### PR TITLE
Gitmoot: IMPLEMENT — gitmoot#1572, SLICE 1 of the design.

### DIFF
--- a/docs/local-workflow.md
+++ b/docs/local-workflow.md
@@ -159,7 +159,12 @@ Delegation worktrees have a separate default-on retention bound:
 reclaimable/pinned/unproven breakdown; dashboard `/api/health` mirrors it.
 Candidate-local lookup, runner, and removal failures skip only that worktree;
 later candidates continue. Repeated failures are logged three times per path,
-then suppressed. Candidate-query and store-wide lookup failures remain fatal.
+then suppressed. Each failed cleanup also advances a durable obligation with a
+one-minute retry delay; after three failures it becomes `quarantined` and leaves
+automatic selection. Doctor and `/api/health` report quarantined obligations;
+inspect them with `gitmoot job cleanup list --state quarantined` and explicitly
+reopen one with `gitmoot job cleanup reopen <resource-id>`. Candidate-query and
+store-wide lookup failures remain fatal.
 
 Never-started plans have a separate destructive opt-in:
 `[workflow].planned_ttl = "720h"`. It is disabled by default; unset, empty,

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -702,11 +702,16 @@ debugging access. Set it to `"0"` to disable the TTL pass. Aged final owners are
 force-removed even when dirty, Git worktree metadata is pruned, and
 `delegation_worktree_reclaimed_ttl` is recorded. The dashboard `/api/health`
 response exposes the same count, bytes, path, breakdown, and summary in its
-top-level `worktrees` field.
+top-level `worktrees` field, including the number of cleanup obligations in
+terminal quarantine.
 
 One unreclaimable candidate does not stop the pass: candidate-local lookup,
 runner, and removal failures are skipped while later paths continue. The daemon
 logs the first three failures for a path and suppresses repeats.
+Each failure advances a durable, restart-safe cleanup obligation. Retries wait
+one minute and stop after the third failure in `quarantined`; quarantined paths
+are not selected again until an operator inspects `gitmoot job cleanup list
+--state quarantined` and runs `gitmoot job cleanup reopen <resource-id>`.
 Candidate-query and store-wide lookup failures still abort the pass and surface
 normally.
 

--- a/internal/cli/daemon_housekeeping_resilience_test.go
+++ b/internal/cli/daemon_housekeeping_resilience_test.go
@@ -114,6 +114,66 @@ func TestSkippedDelegationWorktreeReclaimFailureDoesNotBlockDispatch(t *testing.
 	h.runAndAssertDispatched(t, "owner/repo", "store is required")
 }
 
+// TestCleanupAccountingFailureDoesNotBlockDispatch kills the mutant that
+// returns a selected candidate's cleanup-accounting failure from the worker
+// tick before queued-job dispatch. The failed durable write must stop cleanup,
+// while the unrelated queued job is still admitted.
+func TestCleanupAccountingFailureDoesNotBlockDispatch(t *testing.T) {
+	h := newHousekeepingDispatchHarness(t, "queued-after-cleanup-accounting")
+	const failedJobID = "parent/delegation/accounting"
+	worktreePath := managedDelegationReclaimTestPath(t, h.home, "parent", "accounting")
+	seedCLIJob(t, h.store, db.Job{
+		ID: failedJobID, Agent: "reader", Type: "implement", State: string(workflow.JobFailed),
+		Repo: "owner/repo", ParentJobID: "parent", DelegationID: "accounting",
+		Payload: mustJobPayload(t, workflow.JobPayload{
+			Repo: "owner/repo", ParentJobID: "parent", DelegationID: "accounting",
+			WorktreePath: worktreePath, Branch: "gitmoot-delegation-accounting",
+			Result: &workflow.AgentResult{Decision: "failed"},
+		}),
+	}, "seed accounting-failure delegation")
+	if err := h.store.AddJobEvent(h.ctx, db.JobEvent{
+		JobID: failedJobID, Kind: "delegation_worktree_cleanup_skipped", Message: "preserved",
+	}); err != nil {
+		t.Fatalf("add skipped cleanup marker: %v", err)
+	}
+	if _, err := h.store.EnsureCleanupObligation(h.ctx, failedJobID, worktreePath, time.Now().UTC().Add(-time.Minute)); err != nil {
+		t.Fatalf("seed cleanup obligation: %v", err)
+	}
+	raw, err := sql.Open("sqlite", h.store.DatabasePath())
+	if err != nil {
+		t.Fatalf("open trigger connection: %v", err)
+	}
+	t.Cleanup(func() { raw.Close() })
+	if _, err := raw.Exec(`
+CREATE TRIGGER fail_tick_cleanup_accounting
+BEFORE UPDATE ON cleanup_obligations
+WHEN OLD.owner_job_id = 'parent/delegation/accounting'
+BEGIN
+  SELECT RAISE(ABORT, 'injected tick cleanup accounting failure');
+END;`); err != nil {
+		t.Fatalf("create cleanup accounting trigger: %v", err)
+	}
+	manager := &fakeReclaimWorktreeManager{branches: map[string]bool{"gitmoot-delegation-accounting": true}}
+	h.worker.WorkflowFactory = func(string) workflow.Engine {
+		return workflow.Engine{
+			Store: h.store, Home: h.worker.workflowHome(), DelegationCheckout: h.checkout,
+			DelegationWorktrees: manager,
+		}
+	}
+
+	h.runAndAssertDispatched(t, "owner/repo", "injected tick cleanup accounting failure")
+	if len(manager.removed) != 0 || len(manager.deleted) != 0 {
+		t.Fatalf("unaccounted cleanup actuated: removed=%v deleted=%v", manager.removed, manager.deleted)
+	}
+	obligation, err := h.store.GetCleanupObligation(h.ctx, db.CleanupObligationResourceID(failedJobID, worktreePath))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if obligation.State != db.CleanupObligationPending || obligation.AttemptCount != 0 {
+		t.Fatalf("cleanup obligation changed despite failed accounting: %+v", obligation)
+	}
+}
+
 func TestPendingJobAdvancementFailureDoesNotBlockDispatch(t *testing.T) {
 	h := newHousekeepingDispatchHarness(t, "queued-after-advancement")
 	const failedJobID = "pending-advancement"

--- a/internal/cli/daemon_housekeeping_resilience_test.go
+++ b/internal/cli/daemon_housekeeping_resilience_test.go
@@ -84,7 +84,7 @@ func (h *housekeepingDispatchHarness) runAndAssertDispatched(t *testing.T, repoF
 func TestSkippedDelegationWorktreeReclaimFailureDoesNotBlockDispatch(t *testing.T) {
 	h := newHousekeepingDispatchHarness(t, "queued-after-skipped-reclaim")
 	const failedJobID = "parent/delegation/skipped"
-	worktreePath := managedReclaimTestPath(t, h.home, "skipped-reclaim-failure")
+	worktreePath := managedDelegationReclaimTestPath(t, h.home, "parent", "skipped")
 	seedCLIJob(t, h.store, db.Job{
 		ID: failedJobID, Agent: "reader", Type: "implement", State: string(workflow.JobFailed),
 		Repo: "owner/repo", ParentJobID: "parent", DelegationID: "skipped",

--- a/internal/cli/daemon_housekeeping_resilience_test.go
+++ b/internal/cli/daemon_housekeeping_resilience_test.go
@@ -84,7 +84,7 @@ func (h *housekeepingDispatchHarness) runAndAssertDispatched(t *testing.T, repoF
 func TestSkippedDelegationWorktreeReclaimFailureDoesNotBlockDispatch(t *testing.T) {
 	h := newHousekeepingDispatchHarness(t, "queued-after-skipped-reclaim")
 	const failedJobID = "parent/delegation/skipped"
-	worktreePath := t.TempDir()
+	worktreePath := managedReclaimTestPath(t, h.home, "skipped-reclaim-failure")
 	seedCLIJob(t, h.store, db.Job{
 		ID: failedJobID, Agent: "reader", Type: "implement", State: string(workflow.JobFailed),
 		Repo: "owner/repo", ParentJobID: "parent", DelegationID: "skipped",

--- a/internal/cli/daemon_reclaim_resilience_test.go
+++ b/internal/cli/daemon_reclaim_resilience_test.go
@@ -252,7 +252,7 @@ func TestAgedDelegationReclaimDestinationRemovesSecondDirectory(t *testing.T) {
 	worker := defaultJobWorker(store, io.Discard, home)
 	worker.WorkflowFactory = func(string) workflow.Engine {
 		return workflow.Engine{
-			Store: store, DelegationCheckout: checkout,
+			Store: store, Home: worker.workflowHome(), DelegationCheckout: checkout,
 			DelegationWorktrees: destinationReclaimManager{client: client, failPath: firstPath},
 		}
 	}
@@ -431,7 +431,7 @@ func TestAgedWorktreeReclaimFailureDoesNotBlockDispatch(t *testing.T) {
 	seedDaemonWorkerAgent(t, store, "audit", runtime.ShellRuntime, "unused", []string{"ask"}, "owner/repo")
 
 	now := time.Date(2026, 7, 30, 12, 0, 0, 0, time.UTC)
-	worktreePath := t.TempDir()
+	worktreePath := managedReclaimTestPath(t, home, "aged-reclaim-failure")
 	seedCLIJob(t, store, db.Job{
 		ID: "aged-terminal", Agent: "reader", Type: "ask", State: string(workflow.JobFailed),
 		Repo: "owner/repo", ParentJobID: "parent", DelegationID: "aged",

--- a/internal/cli/daemon_reclaim_resilience_test.go
+++ b/internal/cli/daemon_reclaim_resilience_test.go
@@ -10,10 +10,12 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"slices"
 	"strings"
 	"testing"
 	"time"
 
+	"github.com/gitmoot/gitmoot/internal/config"
 	"github.com/gitmoot/gitmoot/internal/db"
 	gitutil "github.com/gitmoot/gitmoot/internal/git"
 	"github.com/gitmoot/gitmoot/internal/runtime"
@@ -26,6 +28,15 @@ func resetDelegationReclaimAccountingForTest(t *testing.T) {
 	delegationReclaimAccounting.Lock()
 	delegationReclaimAccounting.failures = map[string]delegationReclaimFailure{}
 	delegationReclaimAccounting.Unlock()
+}
+
+func managedReclaimTestPath(t *testing.T, home, name string) string {
+	t.Helper()
+	path := filepath.Join(home, config.DirName, "worktrees", "owner--repo", "delegations", "parent", name)
+	if err := os.MkdirAll(path, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	return path
 }
 
 func seedReclaimResilienceCandidateForRepo(t *testing.T, store *db.Store, id string, repo string, path string, now time.Time, pendingMarker bool, badRunner bool) {
@@ -66,9 +77,11 @@ type selectiveReclaimManager struct {
 	fakeReclaimWorktreeManager
 	failPath string
 	err      error
+	calls    int
 }
 
 func (m *selectiveReclaimManager) RemoveWorktreeForce(_ context.Context, path string) error {
+	m.calls++
 	if filepath.Clean(path) == filepath.Clean(m.failPath) {
 		return m.err
 	}
@@ -106,8 +119,8 @@ func TestDelegationReclaimPoisonPillContinues(t *testing.T) {
 				store := openCLIJobStore(t, home)
 				defer store.Close()
 				now := time.Date(2026, 8, 19, 12, 0, 0, 0, time.UTC)
-				poisonPath := t.TempDir()
-				goodPath := t.TempDir()
+				poisonPath := managedReclaimTestPath(t, home, "a-poison")
+				goodPath := managedReclaimTestPath(t, home, "b-good")
 				seedReclaimResilienceCandidate(t, store, "a-poison", poisonPath, now, mode == "skipped", phase == "runner")
 				seedReclaimResilienceCandidate(t, store, "b-good", goodPath, now, mode == "skipped", false)
 
@@ -134,7 +147,7 @@ func TestDelegationReclaimPoisonPillContinues(t *testing.T) {
 					if mode == "skipped" && phase == "reclaim" && factoryCalls == 1 {
 						mutateReclaimCandidateColumn(t, store, `UPDATE jobs SET payload = '{' WHERE id = ?`, "a-poison")
 					}
-					return workflow.Engine{Store: store, DelegationCheckout: t.TempDir(), DelegationWorktrees: manager}
+					return workflow.Engine{Store: store, Home: worker.workflowHome(), DelegationCheckout: t.TempDir(), DelegationWorktrees: manager}
 				}
 
 				cand := newTickCandidates(store)
@@ -142,7 +155,7 @@ func TestDelegationReclaimPoisonPillContinues(t *testing.T) {
 				if mode == "aged" {
 					err = reclaimAgedTerminalDelegationWorktrees(ctx, worker, "", "", nil, cand, now, 72*time.Hour)
 				} else {
-					err = reclaimSkippedDelegationWorktrees(ctx, worker, "", "", nil, cand)
+					err = reclaimSkippedDelegationWorktrees(ctx, worker, "", "", nil, cand, now)
 				}
 				if err != nil {
 					t.Fatalf("%s reclaim returned poison error: %v", mode, err)
@@ -157,27 +170,10 @@ func TestDelegationReclaimPoisonPillContinues(t *testing.T) {
 
 func TestDelegationReclaimRepeatedFailureStopsRelogging(t *testing.T) {
 	resetDelegationReclaimAccountingForTest(t)
-	ctx := context.Background()
-	home := t.TempDir()
-	store := openCLIJobStore(t, home)
-	defer store.Close()
-	now := time.Date(2026, 8, 19, 12, 0, 0, 0, time.UTC)
-	path := t.TempDir()
-	seedReclaimResilienceCandidate(t, store, "a-poison", path, now, false, false)
-	manager := &selectiveReclaimManager{
-		fakeReclaimWorktreeManager: fakeReclaimWorktreeManager{branches: map[string]bool{}},
-		failPath:                   path,
-		err:                        errors.New("persistent poison"),
-	}
+	path := filepath.Join(t.TempDir(), "a-poison")
 	var output bytes.Buffer
-	worker := defaultJobWorker(store, &output, home)
-	worker.WorkflowFactory = func(string) workflow.Engine {
-		return workflow.Engine{Store: store, DelegationCheckout: t.TempDir(), DelegationWorktrees: manager}
-	}
 	for attempt := 0; attempt < delegationReclaimFailureLogLimit+2; attempt++ {
-		if err := reclaimAgedTerminalDelegationWorktrees(ctx, worker, "", "", nil, newTickCandidates(store), now, 72*time.Hour); err != nil {
-			t.Fatal(err)
-		}
+		logDelegationReclaimFailure(&output, "aged", "reclaim", "a-poison", path, errors.New("persistent poison"))
 	}
 	if got := strings.Count(output.String(), "phase=reclaim"); got != delegationReclaimFailureLogLimit {
 		t.Fatalf("failure log count = %d, want %d before suppression:\n%s", got, delegationReclaimFailureLogLimit, output.String())
@@ -243,8 +239,8 @@ func TestAgedDelegationReclaimDestinationRemovesSecondDirectory(t *testing.T) {
 	defer store.Close()
 	checkout := createDaemonWorkerGitCheckout(t, "main")
 	client := gitutil.NewHostClient(checkout)
-	firstPath := filepath.Join(t.TempDir(), "a-poison")
-	secondPath := filepath.Join(t.TempDir(), "b-good")
+	firstPath := managedReclaimTestPath(t, home, "a-poison")
+	secondPath := managedReclaimTestPath(t, home, "b-good")
 	for _, path := range []string{firstPath, secondPath} {
 		if err := client.AddDetachedWorktree(ctx, path, "HEAD"); err != nil {
 			t.Fatalf("add detached worktree %s: %v", path, err)
@@ -268,6 +264,150 @@ func TestAgedDelegationReclaimDestinationRemovesSecondDirectory(t *testing.T) {
 	}
 	if _, err := os.Stat(secondPath); !os.IsNotExist(err) {
 		t.Fatalf("second directory still exists after destination reclaim: %v", err)
+	}
+}
+
+// TestDelegationCleanupUnknownFailureQuarantinesAndSurvivesRestart is the
+// durable-budget guard for #1572. Mutant killed: raising or removing
+// delegationCleanupRetryBudget leaves the obligation retryable after the third
+// unclassified failure, so it remains selectable and this test fails.
+func TestDelegationCleanupUnknownFailureQuarantinesAndSurvivesRestart(t *testing.T) {
+	const wantBudget = 3
+	resetDelegationReclaimAccountingForTest(t)
+	ctx := context.Background()
+	home := t.TempDir()
+	store := openCLIJobStore(t, home)
+	dbPath := store.DatabasePath()
+	path := managedReclaimTestPath(t, home, "unknown-poison")
+	realNow := time.Now().UTC()
+	seedReclaimResilienceCandidate(t, store, "unknown-poison", path, realNow, false, false)
+	manager := &selectiveReclaimManager{
+		fakeReclaimWorktreeManager: fakeReclaimWorktreeManager{branches: map[string]bool{}},
+		failPath:                   path,
+		err:                        errors.New("unclassified git worktree refusal"),
+	}
+	worker := defaultJobWorker(store, io.Discard, home)
+	worker.WorkflowFactory = func(string) workflow.Engine {
+		return workflow.Engine{Store: worker.Store, Home: worker.workflowHome(), DelegationCheckout: t.TempDir(), DelegationWorktrees: manager}
+	}
+
+	// Keep each persisted next_attempt_at behind wall clock time while advancing
+	// the logical attempt time. This exercises the production due-query without a
+	// sleep or a test-only selector.
+	for attempt := 0; attempt < wantBudget; attempt++ {
+		now := realNow.Add(-10*time.Minute + time.Duration(attempt)*2*time.Minute)
+		if err := reclaimAgedTerminalDelegationWorktrees(ctx, worker, "", "", nil, newTickCandidates(store), now, 72*time.Hour); err != nil {
+			t.Fatalf("attempt %d: %v", attempt+1, err)
+		}
+	}
+
+	resourceID := db.CleanupObligationResourceID("unknown-poison", path)
+	obligation, err := store.GetCleanupObligation(ctx, resourceID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if obligation.State != db.CleanupObligationQuarantined || obligation.Reason != "unknown" || obligation.AttemptCount != wantBudget {
+		t.Fatalf("obligation = %+v, want unknown quarantine at budget %d", obligation, wantBudget)
+	}
+	if ids, err := store.JobIDsWithAgedTerminalDelegationWorktree(ctx, realNow.Add(-72*time.Hour)); err != nil {
+		t.Fatal(err)
+	} else if slices.Contains(ids, "unknown-poison") {
+		t.Fatalf("quarantined job remained selectable: %v", ids)
+	}
+
+	if err := store.Close(); err != nil {
+		t.Fatal(err)
+	}
+	store, err = db.Open(dbPath)
+	if err != nil {
+		t.Fatalf("reopen store: %v", err)
+	}
+	defer store.Close()
+	worker.Store = store
+	obligation, err = store.GetCleanupObligation(ctx, resourceID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if obligation.State != db.CleanupObligationQuarantined || obligation.AttemptCount != wantBudget {
+		t.Fatalf("restarted obligation = %+v", obligation)
+	}
+	if manager.calls != wantBudget {
+		t.Fatalf("cleanup calls = %d, want budget %d", manager.calls, wantBudget)
+	}
+	before := manager.calls
+	if err := reclaimAgedTerminalDelegationWorktrees(ctx, worker, "", "", nil, newTickCandidates(store), realNow, 72*time.Hour); err != nil {
+		t.Fatal(err)
+	}
+	if manager.calls != before {
+		t.Fatalf("quarantined cleanup retried after restart: before=%d after=%d", before, manager.calls)
+	}
+}
+
+func TestDelegationCleanupSkippedFailureConsumesBudget(t *testing.T) {
+	const wantBudget = 3
+	ctx := context.Background()
+	home := t.TempDir()
+	store := openCLIJobStore(t, home)
+	defer store.Close()
+	path := managedReclaimTestPath(t, home, "skipped-poison")
+	realNow := time.Now().UTC()
+	seedReclaimResilienceCandidate(t, store, "skipped-poison", path, realNow, true, false)
+	manager := &selectiveReclaimManager{
+		fakeReclaimWorktreeManager: fakeReclaimWorktreeManager{branches: map[string]bool{}},
+		failPath:                   path,
+		err:                        errors.New("unclassified skipped cleanup refusal"),
+	}
+	worker := defaultJobWorker(store, io.Discard, home)
+	worker.WorkflowFactory = func(string) workflow.Engine {
+		return workflow.Engine{Store: store, Home: worker.workflowHome(), DelegationCheckout: t.TempDir(), DelegationWorktrees: manager}
+	}
+	for attempt := 0; attempt < wantBudget; attempt++ {
+		now := realNow.Add(-10*time.Minute + time.Duration(attempt)*2*time.Minute)
+		if err := reclaimSkippedDelegationWorktrees(ctx, worker, "", "", nil, newTickCandidates(store), now); err != nil {
+			t.Fatal(err)
+		}
+	}
+	obligation, err := store.GetCleanupObligation(ctx, db.CleanupObligationResourceID("skipped-poison", path))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if obligation.State != db.CleanupObligationQuarantined || obligation.AttemptCount != wantBudget || manager.calls != wantBudget {
+		t.Fatalf("skipped cleanup obligation=%+v calls=%d", obligation, manager.calls)
+	}
+}
+
+func TestDelegationCleanupRefusesUncontainedTarget(t *testing.T) {
+	resetDelegationReclaimAccountingForTest(t)
+	ctx := context.Background()
+	home := t.TempDir()
+	store := openCLIJobStore(t, home)
+	defer store.Close()
+	path := t.TempDir()
+	realNow := time.Now().UTC()
+	seedReclaimResilienceCandidate(t, store, "unsafe-target", path, realNow, false, false)
+	manager := &selectiveReclaimManager{fakeReclaimWorktreeManager: fakeReclaimWorktreeManager{branches: map[string]bool{}}}
+	worker := defaultJobWorker(store, io.Discard, home)
+	worker.WorkflowFactory = func(string) workflow.Engine {
+		return workflow.Engine{Store: store, Home: worker.workflowHome(), DelegationCheckout: t.TempDir(), DelegationWorktrees: manager}
+	}
+	for attempt := 0; attempt < delegationCleanupRetryBudget; attempt++ {
+		now := realNow.Add(-10*time.Minute + time.Duration(attempt)*2*time.Minute)
+		if err := reclaimAgedTerminalDelegationWorktrees(ctx, worker, "", "", nil, newTickCandidates(store), now, 72*time.Hour); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if manager.calls != 0 {
+		t.Fatalf("uncontained target reached remover %d times", manager.calls)
+	}
+	obligation, err := store.GetCleanupObligation(ctx, db.CleanupObligationResourceID("unsafe-target", path))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if obligation.State != db.CleanupObligationQuarantined || obligation.Reason != "identity_or_containment" {
+		t.Fatalf("unsafe obligation = %+v", obligation)
+	}
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("uncontained target was changed: %v", err)
 	}
 }
 

--- a/internal/cli/daemon_reclaim_resilience_test.go
+++ b/internal/cli/daemon_reclaim_resilience_test.go
@@ -32,7 +32,19 @@ func resetDelegationReclaimAccountingForTest(t *testing.T) {
 
 func managedReclaimTestPath(t *testing.T, home, name string) string {
 	t.Helper()
-	path := filepath.Join(home, config.DirName, "worktrees", "owner--repo", "delegations", "parent", name)
+	path := filepath.Join(home, config.DirName, "worktrees", "owner--repo", "delegations", name, "pool-isolation")
+	if err := os.MkdirAll(path, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+func managedDelegationReclaimTestPath(t *testing.T, home, parentID, delegationID string) string {
+	t.Helper()
+	path, err := workflow.DelegationWorktreePath(filepath.Join(home, config.DirName), "owner/repo", parentID, delegationID, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
 	if err := os.MkdirAll(path, 0o755); err != nil {
 		t.Fatal(err)
 	}
@@ -42,7 +54,7 @@ func managedReclaimTestPath(t *testing.T, home, name string) string {
 func seedReclaimResilienceCandidateForRepo(t *testing.T, store *db.Store, id string, repo string, path string, now time.Time, pendingMarker bool, badRunner bool) {
 	t.Helper()
 	payload := workflow.JobPayload{
-		Repo: repo, DelegationID: id, WorktreePath: path, ReadOnlyWorktree: true,
+		Repo: repo, WorktreePath: path, ReadOnlyWorktree: true,
 	}
 	encoded, err := json.Marshal(payload)
 	if err != nil {
@@ -411,6 +423,39 @@ func TestDelegationCleanupRefusesUncontainedTarget(t *testing.T) {
 	}
 }
 
+// TestDelegationCleanupAccountingFailureFailsClosed kills the mutant that logs
+// a cleanup-obligation persistence failure and reports a candidate-local skip.
+func TestDelegationCleanupAccountingFailureFailsClosed(t *testing.T) {
+	ctx := context.Background()
+	home := t.TempDir()
+	store := openCLIJobStore(t, home)
+	defer store.Close()
+	path := managedReclaimTestPath(t, home, "accounting-failure")
+	payload := workflow.JobPayload{Repo: "other/repo", WorktreePath: path, ReadOnlyWorktree: true}
+	encoded, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatal(err)
+	}
+	job := db.Job{ID: "accounting-failure", Type: "ask", Payload: string(encoded)}
+	raw, err := sql.Open("sqlite", store.DatabasePath())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer raw.Close()
+	if _, err := raw.Exec(`
+CREATE TRIGGER fail_cleanup_obligation_accounting
+BEFORE UPDATE ON cleanup_obligations
+BEGIN
+  SELECT RAISE(ABORT, 'injected cleanup accounting failure');
+END;`); err != nil {
+		t.Fatal(err)
+	}
+	worker := defaultJobWorker(store, io.Discard, home)
+	if _, _, err := prepareDelegationCleanup(ctx, worker, "aged", job, path, time.Now().UTC()); err == nil || !strings.Contains(err.Error(), "injected cleanup accounting failure") {
+		t.Fatalf("prepareDelegationCleanup error = %v, want persisted accounting failure", err)
+	}
+}
+
 type failingAgedReclaimManager struct {
 	fakeReclaimWorktreeManager
 	err error
@@ -431,12 +476,12 @@ func TestAgedWorktreeReclaimFailureDoesNotBlockDispatch(t *testing.T) {
 	seedDaemonWorkerAgent(t, store, "audit", runtime.ShellRuntime, "unused", []string{"ask"}, "owner/repo")
 
 	now := time.Date(2026, 7, 30, 12, 0, 0, 0, time.UTC)
-	worktreePath := managedReclaimTestPath(t, home, "aged-reclaim-failure")
+	worktreePath := managedReclaimTestPath(t, home, "aged-terminal")
 	seedCLIJob(t, store, db.Job{
 		ID: "aged-terminal", Agent: "reader", Type: "ask", State: string(workflow.JobFailed),
-		Repo: "owner/repo", ParentJobID: "parent", DelegationID: "aged",
+		Repo: "owner/repo",
 		Payload: mustJobPayload(t, workflow.JobPayload{
-			Repo: "owner/repo", DelegationID: "aged", WorktreePath: worktreePath,
+			Repo: "owner/repo", WorktreePath: worktreePath, ReadOnlyWorktree: true,
 		}),
 	}, "seed aged terminal delegation")
 	backdateJobUpdatedAt(t, store.DatabasePath(), "aged-terminal", now.Add(-73*time.Hour))

--- a/internal/cli/daemon_scheduler.go
+++ b/internal/cli/daemon_scheduler.go
@@ -69,6 +69,8 @@ const (
 	delegationReclaimFailureLogLimit  = 3
 	delegationReclaimFailureMaxPaths  = 4096
 	delegationReclaimFailureRetention = 24 * time.Hour
+	delegationCleanupRetryBudget      = 3
+	delegationCleanupRetryDelay       = time.Minute
 )
 
 type delegationReclaimFailure struct {
@@ -150,6 +152,82 @@ func logDelegationReclaimFailure(stdout io.Writer, mode string, phase string, jo
 	writeLine(stdout, "job %s %s delegation worktree reclaim failed path=%s phase=%s attempt=%d: %v", jobID, mode, path, phase, count, err)
 	if count == delegationReclaimFailureLogLimit {
 		writeLine(stdout, "job %s delegation worktree reclaim path=%s reached %d failures; further identical-path failures are suppressed", jobID, path, count)
+	}
+}
+
+func recordDelegationCleanupFailure(ctx context.Context, worker jobWorker, mode, phase, jobID, path string, err error, now time.Time) db.CleanupObligation {
+	reason := db.ClassifyCleanupObligationFailure(phase, err)
+	obligation, persistErr := worker.Store.RecordCleanupObligationFailure(
+		context.WithoutCancel(ctx), jobID, path, reason, err, now,
+		now.Add(delegationCleanupRetryDelay), delegationCleanupRetryBudget,
+	)
+	if persistErr != nil {
+		logDelegationReclaimFailure(worker.Stdout, mode, phase, jobID, path, fmt.Errorf("%w (persist cleanup obligation: %v)", err, persistErr))
+		return db.CleanupObligation{}
+	}
+	logDelegationReclaimFailure(worker.Stdout, mode, phase, jobID, path, err)
+	if obligation.State == db.CleanupObligationQuarantined && obligation.AttemptCount == delegationCleanupRetryBudget {
+		_ = worker.Store.AddJobEvent(context.WithoutCancel(ctx), db.JobEvent{
+			JobID: jobID,
+			Kind:  "delegation_worktree_cleanup_quarantined",
+			Message: fmt.Sprintf("cleanup obligation %s quarantined after %d attempts: reason=%s path=%s",
+				obligation.ResourceID, obligation.AttemptCount, obligation.Reason, obligation.ExpectedPath),
+		})
+	}
+	return obligation
+}
+
+func delegationCleanupTargetContained(worker jobWorker, job db.Job, obligation db.CleanupObligation) error {
+	payload, err := workflow.ParseJobPayload(job.Payload)
+	if err != nil {
+		return fmt.Errorf("parse cleanup owner payload: %w", err)
+	}
+	path := filepath.Clean(strings.TrimSpace(payload.WorktreePath))
+	if path == "." || path == "" || !filepath.IsAbs(path) {
+		return fmt.Errorf("cleanup path %q is not absolute", payload.WorktreePath)
+	}
+	if path != filepath.Clean(obligation.ExpectedPath) {
+		return fmt.Errorf("cleanup path %q does not match obligation %q", path, obligation.ExpectedPath)
+	}
+	root := filepath.Join(worker.workflowHome(), "worktrees")
+	if strings.TrimSpace(worker.workflowHome()) == "" {
+		return errors.New("cleanup worktree root is unavailable")
+	}
+	rel, err := filepath.Rel(root, path)
+	if err != nil || rel == "." || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) || filepath.IsAbs(rel) {
+		return fmt.Errorf("cleanup path %q is outside managed root %q", path, root)
+	}
+	return nil
+}
+
+func prepareDelegationCleanup(ctx context.Context, worker jobWorker, mode string, job db.Job, path string, now time.Time) (db.CleanupObligation, bool) {
+	obligation, err := worker.Store.EnsureCleanupObligation(context.WithoutCancel(ctx), job.ID, path, now)
+	if err != nil {
+		logDelegationReclaimFailure(worker.Stdout, mode, "obligation", job.ID, path, err)
+		return db.CleanupObligation{}, false
+	}
+	if err := delegationCleanupTargetContained(worker, job, obligation); err != nil {
+		recordDelegationCleanupFailure(ctx, worker, mode, "identity", job.ID, path, err, now)
+		return obligation, false
+	}
+	return obligation, true
+}
+
+func finishDelegationCleanupAttempt(ctx context.Context, worker jobWorker, jobID, path string, reclaimed bool, now time.Time) {
+	if !reclaimed {
+		if _, err := os.Stat(path); os.IsNotExist(err) {
+			reclaimed = true
+		}
+	}
+	if reclaimed {
+		if _, err := worker.Store.MarkCleanupObligationRemoved(context.WithoutCancel(ctx), jobID, path, now); err != nil {
+			logDelegationReclaimFailure(worker.Stdout, "state", "removed", jobID, path, err)
+		}
+		clearDelegationReclaimFailure(path)
+		return
+	}
+	if _, err := worker.Store.DeferCleanupObligation(context.WithoutCancel(ctx), jobID, path, db.CleanupReasonTerminalDeferred, now, now.Add(delegationCleanupRetryDelay)); err != nil {
+		logDelegationReclaimFailure(worker.Stdout, "state", "deferred", jobID, path, err)
 	}
 }
 
@@ -892,7 +970,7 @@ func retryPendingJobAdvancements(ctx context.Context, worker jobWorker, repoFilt
 // marker and are reclaimed on a later tick, so under a steady backlog preserved
 // worktrees are still reclaimed instead of leaking until full idleness (#562
 // review).
-func reclaimSkippedDelegationWorktrees(ctx context.Context, worker jobWorker, repoFilter string, rootFilter string, checkoutHeld func(string) bool, cand *tickCandidates) error {
+func reclaimSkippedDelegationWorktrees(ctx context.Context, worker jobWorker, repoFilter string, rootFilter string, checkoutHeld func(string) bool, cand *tickCandidates, now time.Time) error {
 	jobIDs, err := cand.delegationReclaimCandidates(ctx)
 	if err != nil {
 		return err
@@ -913,7 +991,7 @@ func reclaimSkippedDelegationWorktrees(ctx context.Context, worker jobWorker, re
 				return fmt.Errorf("get skipped reclaim candidate %s: %w (path lookup also failed: %v)", jobID, err, pathErr)
 			}
 			path = canonicalDelegationReclaimPath(jobID, path)
-			logDelegationReclaimFailure(worker.Stdout, "skipped", "get_job", jobID, path, err)
+			recordDelegationCleanupFailure(ctx, worker, "skipped", "get_job", jobID, path, err, now)
 			continue
 		}
 		path := delegationReclaimPath(job.ID, job.Payload)
@@ -931,18 +1009,21 @@ func reclaimSkippedDelegationWorktrees(ctx context.Context, worker jobWorker, re
 				continue
 			}
 		}
+		if _, ok := prepareDelegationCleanup(ctx, worker, "skipped", job, path, now); !ok {
+			continue
+		}
 		runner, err := worker.subprocessRunnerForJob(job)
 		if err != nil {
-			logDelegationReclaimFailure(worker.Stdout, "skipped", "runner", job.ID, path, err)
+			recordDelegationCleanupFailure(ctx, worker, "skipped", "runner", job.ID, path, err, now)
 			continue
 		}
 		engine := worker.workflowForJob(worker.delegationParentCheckout(ctx, job), runner)
-		_, err = engine.ReclaimTerminalDelegationWorktreeOutcome(ctx, jobID)
+		reclaimed, err := engine.ReclaimTerminalDelegationWorktreeOutcome(ctx, jobID)
 		if err != nil {
-			logDelegationReclaimFailure(worker.Stdout, "skipped", "reclaim", job.ID, path, err)
+			recordDelegationCleanupFailure(ctx, worker, "skipped", "reclaim", job.ID, path, err, now)
 			continue
 		}
-		clearDelegationReclaimFailure(path)
+		finishDelegationCleanupAttempt(ctx, worker, job.ID, path, reclaimed, now)
 	}
 	return nil
 }
@@ -974,7 +1055,7 @@ func reclaimAgedTerminalDelegationWorktrees(ctx context.Context, worker jobWorke
 				return fmt.Errorf("get aged reclaim candidate %s: %w (path lookup also failed: %v)", jobID, err, pathErr)
 			}
 			path = canonicalDelegationReclaimPath(jobID, path)
-			logDelegationReclaimFailure(worker.Stdout, "aged", "get_job", jobID, path, err)
+			recordDelegationCleanupFailure(ctx, worker, "aged", "get_job", jobID, path, err, now)
 			cand.agedReclaimFailed = true
 			continue
 		}
@@ -993,20 +1074,24 @@ func reclaimAgedTerminalDelegationWorktrees(ctx context.Context, worker jobWorke
 				continue
 			}
 		}
+		if _, ok := prepareDelegationCleanup(ctx, worker, "aged", job, path, now); !ok {
+			cand.agedReclaimFailed = true
+			continue
+		}
 		runner, err := worker.subprocessRunnerForJob(job)
 		if err != nil {
-			logDelegationReclaimFailure(worker.Stdout, "aged", "runner", job.ID, path, err)
+			recordDelegationCleanupFailure(ctx, worker, "aged", "runner", job.ID, path, err, now)
 			cand.agedReclaimFailed = true
 			continue
 		}
 		engine := worker.workflowForJob(worker.delegationParentCheckout(ctx, job), runner)
-		_, err = engine.ReclaimAgedTerminalDelegationWorktreeOutcome(ctx, jobID, now.Add(-ttl))
+		reclaimed, err := engine.ReclaimAgedTerminalDelegationWorktreeOutcome(ctx, jobID, now.Add(-ttl))
 		if err != nil {
-			logDelegationReclaimFailure(worker.Stdout, "aged", "reclaim", job.ID, path, err)
+			recordDelegationCleanupFailure(ctx, worker, "aged", "reclaim", job.ID, path, err, now)
 			cand.agedReclaimFailed = true
 			continue
 		}
-		clearDelegationReclaimFailure(path)
+		finishDelegationCleanupAttempt(ctx, worker, job.ID, path, reclaimed, now)
 	}
 	return nil
 }
@@ -1098,7 +1183,7 @@ func runDaemonWorkerTickTracked(ctx context.Context, store *db.Store, worker job
 		if err := retryPendingJobAdvancements(ctx, worker, repoFilter, rootFilter, tracker.checkoutHeld, cand); err != nil {
 			return err
 		}
-		if err := reclaimSkippedDelegationWorktrees(ctx, worker, repoFilter, rootFilter, tracker.checkoutHeld, cand); err != nil {
+		if err := reclaimSkippedDelegationWorktrees(ctx, worker, repoFilter, rootFilter, tracker.checkoutHeld, cand, now); err != nil {
 			return err
 		}
 		// The store path is already the resolved Gitmoot root. Using it keeps this

--- a/internal/cli/daemon_scheduler.go
+++ b/internal/cli/daemon_scheduler.go
@@ -155,7 +155,7 @@ func logDelegationReclaimFailure(stdout io.Writer, mode string, phase string, jo
 	}
 }
 
-func recordDelegationCleanupFailure(ctx context.Context, worker jobWorker, mode, phase, jobID, path string, err error, now time.Time) db.CleanupObligation {
+func recordDelegationCleanupFailure(ctx context.Context, worker jobWorker, mode, phase, jobID, path string, err error, now time.Time) (db.CleanupObligation, error) {
 	reason := db.ClassifyCleanupObligationFailure(phase, err)
 	obligation, persistErr := worker.Store.RecordCleanupObligationFailure(
 		context.WithoutCancel(ctx), jobID, path, reason, err, now,
@@ -163,7 +163,7 @@ func recordDelegationCleanupFailure(ctx context.Context, worker jobWorker, mode,
 	)
 	if persistErr != nil {
 		logDelegationReclaimFailure(worker.Stdout, mode, phase, jobID, path, fmt.Errorf("%w (persist cleanup obligation: %v)", err, persistErr))
-		return db.CleanupObligation{}
+		return db.CleanupObligation{}, fmt.Errorf("persist cleanup obligation for %s: %w", jobID, persistErr)
 	}
 	logDelegationReclaimFailure(worker.Stdout, mode, phase, jobID, path, err)
 	if obligation.State == db.CleanupObligationQuarantined && obligation.AttemptCount == delegationCleanupRetryBudget {
@@ -174,7 +174,7 @@ func recordDelegationCleanupFailure(ctx context.Context, worker jobWorker, mode,
 				obligation.ResourceID, obligation.AttemptCount, obligation.Reason, obligation.ExpectedPath),
 		})
 	}
-	return obligation
+	return obligation, nil
 }
 
 func delegationCleanupTargetContained(worker jobWorker, job db.Job, obligation db.CleanupObligation) error {
@@ -189,31 +189,31 @@ func delegationCleanupTargetContained(worker jobWorker, job db.Job, obligation d
 	if path != filepath.Clean(obligation.ExpectedPath) {
 		return fmt.Errorf("cleanup path %q does not match obligation %q", path, obligation.ExpectedPath)
 	}
-	root := filepath.Join(worker.workflowHome(), "worktrees")
-	if strings.TrimSpace(worker.workflowHome()) == "" {
-		return errors.New("cleanup worktree root is unavailable")
-	}
-	rel, err := filepath.Rel(root, path)
-	if err != nil || rel == "." || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) || filepath.IsAbs(rel) {
-		return fmt.Errorf("cleanup path %q is outside managed root %q", path, root)
-	}
-	return nil
+	return workflow.ValidateDelegationCleanupTarget(worker.workflowHome(), job.ID, job.Type, payload)
 }
 
-func prepareDelegationCleanup(ctx context.Context, worker jobWorker, mode string, job db.Job, path string, now time.Time) (db.CleanupObligation, bool) {
+func prepareDelegationCleanup(ctx context.Context, worker jobWorker, mode string, job db.Job, path string, now time.Time) (db.CleanupObligation, bool, error) {
 	obligation, err := worker.Store.EnsureCleanupObligation(context.WithoutCancel(ctx), job.ID, path, now)
 	if err != nil {
 		logDelegationReclaimFailure(worker.Stdout, mode, "obligation", job.ID, path, err)
-		return db.CleanupObligation{}, false
+		return db.CleanupObligation{}, false, err
+	}
+	if obligation.State == db.CleanupObligationQuarantined || obligation.State == db.CleanupObligationRemoved {
+		return obligation, false, nil
+	}
+	if obligation.State != db.CleanupObligationPending && obligation.State != db.CleanupObligationRetryable {
+		return obligation, false, fmt.Errorf("cleanup obligation %s has unsupported state %q", obligation.ResourceID, obligation.State)
 	}
 	if err := delegationCleanupTargetContained(worker, job, obligation); err != nil {
-		recordDelegationCleanupFailure(ctx, worker, mode, "identity", job.ID, path, err, now)
-		return obligation, false
+		if _, persistErr := recordDelegationCleanupFailure(ctx, worker, mode, "identity", job.ID, path, err, now); persistErr != nil {
+			return obligation, false, persistErr
+		}
+		return obligation, false, nil
 	}
-	return obligation, true
+	return obligation, true, nil
 }
 
-func finishDelegationCleanupAttempt(ctx context.Context, worker jobWorker, jobID, path string, reclaimed bool, now time.Time) {
+func finishDelegationCleanupAttempt(ctx context.Context, worker jobWorker, jobID, path string, reclaimed bool, now time.Time) error {
 	if !reclaimed {
 		if _, err := os.Stat(path); os.IsNotExist(err) {
 			reclaimed = true
@@ -222,13 +222,16 @@ func finishDelegationCleanupAttempt(ctx context.Context, worker jobWorker, jobID
 	if reclaimed {
 		if _, err := worker.Store.MarkCleanupObligationRemoved(context.WithoutCancel(ctx), jobID, path, now); err != nil {
 			logDelegationReclaimFailure(worker.Stdout, "state", "removed", jobID, path, err)
+			return err
 		}
 		clearDelegationReclaimFailure(path)
-		return
+		return nil
 	}
 	if _, err := worker.Store.DeferCleanupObligation(context.WithoutCancel(ctx), jobID, path, db.CleanupReasonTerminalDeferred, now, now.Add(delegationCleanupRetryDelay)); err != nil {
 		logDelegationReclaimFailure(worker.Stdout, "state", "deferred", jobID, path, err)
+		return err
 	}
+	return nil
 }
 
 // daemonPollTimeout bounds a single repo's PollOnce / PollRecoveryCommandsOnce.
@@ -991,7 +994,9 @@ func reclaimSkippedDelegationWorktrees(ctx context.Context, worker jobWorker, re
 				return fmt.Errorf("get skipped reclaim candidate %s: %w (path lookup also failed: %v)", jobID, err, pathErr)
 			}
 			path = canonicalDelegationReclaimPath(jobID, path)
-			recordDelegationCleanupFailure(ctx, worker, "skipped", "get_job", jobID, path, err, now)
+			if _, persistErr := recordDelegationCleanupFailure(ctx, worker, "skipped", "get_job", jobID, path, err, now); persistErr != nil {
+				return persistErr
+			}
 			continue
 		}
 		path := delegationReclaimPath(job.ID, job.Payload)
@@ -1009,21 +1014,31 @@ func reclaimSkippedDelegationWorktrees(ctx context.Context, worker jobWorker, re
 				continue
 			}
 		}
-		if _, ok := prepareDelegationCleanup(ctx, worker, "skipped", job, path, now); !ok {
+		_, ok, err := prepareDelegationCleanup(ctx, worker, "skipped", job, path, now)
+		if err != nil {
+			return err
+		}
+		if !ok {
 			continue
 		}
 		runner, err := worker.subprocessRunnerForJob(job)
 		if err != nil {
-			recordDelegationCleanupFailure(ctx, worker, "skipped", "runner", job.ID, path, err, now)
+			if _, persistErr := recordDelegationCleanupFailure(ctx, worker, "skipped", "runner", job.ID, path, err, now); persistErr != nil {
+				return persistErr
+			}
 			continue
 		}
 		engine := worker.workflowForJob(worker.delegationParentCheckout(ctx, job), runner)
 		reclaimed, err := engine.ReclaimTerminalDelegationWorktreeOutcome(ctx, jobID)
 		if err != nil {
-			recordDelegationCleanupFailure(ctx, worker, "skipped", "reclaim", job.ID, path, err, now)
+			if _, persistErr := recordDelegationCleanupFailure(ctx, worker, "skipped", "reclaim", job.ID, path, err, now); persistErr != nil {
+				return persistErr
+			}
 			continue
 		}
-		finishDelegationCleanupAttempt(ctx, worker, job.ID, path, reclaimed, now)
+		if err := finishDelegationCleanupAttempt(ctx, worker, job.ID, path, reclaimed, now); err != nil {
+			return err
+		}
 	}
 	return nil
 }
@@ -1055,7 +1070,9 @@ func reclaimAgedTerminalDelegationWorktrees(ctx context.Context, worker jobWorke
 				return fmt.Errorf("get aged reclaim candidate %s: %w (path lookup also failed: %v)", jobID, err, pathErr)
 			}
 			path = canonicalDelegationReclaimPath(jobID, path)
-			recordDelegationCleanupFailure(ctx, worker, "aged", "get_job", jobID, path, err, now)
+			if _, persistErr := recordDelegationCleanupFailure(ctx, worker, "aged", "get_job", jobID, path, err, now); persistErr != nil {
+				return persistErr
+			}
 			cand.agedReclaimFailed = true
 			continue
 		}
@@ -1074,24 +1091,34 @@ func reclaimAgedTerminalDelegationWorktrees(ctx context.Context, worker jobWorke
 				continue
 			}
 		}
-		if _, ok := prepareDelegationCleanup(ctx, worker, "aged", job, path, now); !ok {
+		_, ok, err := prepareDelegationCleanup(ctx, worker, "aged", job, path, now)
+		if err != nil {
+			return err
+		}
+		if !ok {
 			cand.agedReclaimFailed = true
 			continue
 		}
 		runner, err := worker.subprocessRunnerForJob(job)
 		if err != nil {
-			recordDelegationCleanupFailure(ctx, worker, "aged", "runner", job.ID, path, err, now)
+			if _, persistErr := recordDelegationCleanupFailure(ctx, worker, "aged", "runner", job.ID, path, err, now); persistErr != nil {
+				return persistErr
+			}
 			cand.agedReclaimFailed = true
 			continue
 		}
 		engine := worker.workflowForJob(worker.delegationParentCheckout(ctx, job), runner)
 		reclaimed, err := engine.ReclaimAgedTerminalDelegationWorktreeOutcome(ctx, jobID, now.Add(-ttl))
 		if err != nil {
-			recordDelegationCleanupFailure(ctx, worker, "aged", "reclaim", job.ID, path, err, now)
+			if _, persistErr := recordDelegationCleanupFailure(ctx, worker, "aged", "reclaim", job.ID, path, err, now); persistErr != nil {
+				return persistErr
+			}
 			cand.agedReclaimFailed = true
 			continue
 		}
-		finishDelegationCleanupAttempt(ctx, worker, job.ID, path, reclaimed, now)
+		if err := finishDelegationCleanupAttempt(ctx, worker, job.ID, path, reclaimed, now); err != nil {
+			return err
+		}
 	}
 	return nil
 }

--- a/internal/cli/daemon_scheduler.go
+++ b/internal/cli/daemon_scheduler.go
@@ -73,6 +73,25 @@ const (
 	delegationCleanupRetryDelay       = time.Minute
 )
 
+// delegationCleanupPassError stops the current reclaim pass after a selected
+// candidate cannot be durably accounted. The failure is already logged through
+// the bounded per-path suppression seam; the outer worker tick continues
+// ordinary dispatch. Candidate-query and other global store errors remain
+// unwrapped and still abort the tick.
+type delegationCleanupPassError struct {
+	err error
+}
+
+func (e *delegationCleanupPassError) Error() string { return e.err.Error() }
+func (e *delegationCleanupPassError) Unwrap() error { return e.err }
+
+func stopDelegationCleanupPass(err error) error {
+	if err == nil {
+		return nil
+	}
+	return &delegationCleanupPassError{err: err}
+}
+
 type delegationReclaimFailure struct {
 	count    int
 	lastSeen time.Time
@@ -995,7 +1014,7 @@ func reclaimSkippedDelegationWorktrees(ctx context.Context, worker jobWorker, re
 			}
 			path = canonicalDelegationReclaimPath(jobID, path)
 			if _, persistErr := recordDelegationCleanupFailure(ctx, worker, "skipped", "get_job", jobID, path, err, now); persistErr != nil {
-				return persistErr
+				return stopDelegationCleanupPass(persistErr)
 			}
 			continue
 		}
@@ -1016,7 +1035,7 @@ func reclaimSkippedDelegationWorktrees(ctx context.Context, worker jobWorker, re
 		}
 		_, ok, err := prepareDelegationCleanup(ctx, worker, "skipped", job, path, now)
 		if err != nil {
-			return err
+			return stopDelegationCleanupPass(err)
 		}
 		if !ok {
 			continue
@@ -1024,7 +1043,7 @@ func reclaimSkippedDelegationWorktrees(ctx context.Context, worker jobWorker, re
 		runner, err := worker.subprocessRunnerForJob(job)
 		if err != nil {
 			if _, persistErr := recordDelegationCleanupFailure(ctx, worker, "skipped", "runner", job.ID, path, err, now); persistErr != nil {
-				return persistErr
+				return stopDelegationCleanupPass(persistErr)
 			}
 			continue
 		}
@@ -1032,12 +1051,12 @@ func reclaimSkippedDelegationWorktrees(ctx context.Context, worker jobWorker, re
 		reclaimed, err := engine.ReclaimTerminalDelegationWorktreeOutcome(ctx, jobID)
 		if err != nil {
 			if _, persistErr := recordDelegationCleanupFailure(ctx, worker, "skipped", "reclaim", job.ID, path, err, now); persistErr != nil {
-				return persistErr
+				return stopDelegationCleanupPass(persistErr)
 			}
 			continue
 		}
 		if err := finishDelegationCleanupAttempt(ctx, worker, job.ID, path, reclaimed, now); err != nil {
-			return err
+			return stopDelegationCleanupPass(err)
 		}
 	}
 	return nil
@@ -1071,7 +1090,7 @@ func reclaimAgedTerminalDelegationWorktrees(ctx context.Context, worker jobWorke
 			}
 			path = canonicalDelegationReclaimPath(jobID, path)
 			if _, persistErr := recordDelegationCleanupFailure(ctx, worker, "aged", "get_job", jobID, path, err, now); persistErr != nil {
-				return persistErr
+				return stopDelegationCleanupPass(persistErr)
 			}
 			cand.agedReclaimFailed = true
 			continue
@@ -1093,7 +1112,7 @@ func reclaimAgedTerminalDelegationWorktrees(ctx context.Context, worker jobWorke
 		}
 		_, ok, err := prepareDelegationCleanup(ctx, worker, "aged", job, path, now)
 		if err != nil {
-			return err
+			return stopDelegationCleanupPass(err)
 		}
 		if !ok {
 			cand.agedReclaimFailed = true
@@ -1102,7 +1121,7 @@ func reclaimAgedTerminalDelegationWorktrees(ctx context.Context, worker jobWorke
 		runner, err := worker.subprocessRunnerForJob(job)
 		if err != nil {
 			if _, persistErr := recordDelegationCleanupFailure(ctx, worker, "aged", "runner", job.ID, path, err, now); persistErr != nil {
-				return persistErr
+				return stopDelegationCleanupPass(persistErr)
 			}
 			cand.agedReclaimFailed = true
 			continue
@@ -1111,13 +1130,13 @@ func reclaimAgedTerminalDelegationWorktrees(ctx context.Context, worker jobWorke
 		reclaimed, err := engine.ReclaimAgedTerminalDelegationWorktreeOutcome(ctx, jobID, now.Add(-ttl))
 		if err != nil {
 			if _, persistErr := recordDelegationCleanupFailure(ctx, worker, "aged", "reclaim", job.ID, path, err, now); persistErr != nil {
-				return persistErr
+				return stopDelegationCleanupPass(persistErr)
 			}
 			cand.agedReclaimFailed = true
 			continue
 		}
 		if err := finishDelegationCleanupAttempt(ctx, worker, job.ID, path, reclaimed, now); err != nil {
-			return err
+			return stopDelegationCleanupPass(err)
 		}
 	}
 	return nil
@@ -1211,7 +1230,10 @@ func runDaemonWorkerTickTracked(ctx context.Context, store *db.Store, worker job
 			return err
 		}
 		if err := reclaimSkippedDelegationWorktrees(ctx, worker, repoFilter, rootFilter, tracker.checkoutHeld, cand, now); err != nil {
-			return err
+			var passErr *delegationCleanupPassError
+			if !errors.As(err, &passErr) {
+				return err
+			}
 		}
 		// The store path is already the resolved Gitmoot root. Using it keeps this
 		// hot-read on the daemon's actual home and prevents the raw/resolved

--- a/internal/cli/daemon_scheduler_test.go
+++ b/internal/cli/daemon_scheduler_test.go
@@ -3829,9 +3829,15 @@ func TestReclaimSkippedDelegationWorktrees(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			ctx := context.Background()
-			store := daemonWorkerStore(t)
+			home := t.TempDir()
+			store := openCLIJobStore(t, home)
+			t.Cleanup(func() {
+				if err := store.Close(); err != nil {
+					t.Fatalf("Close returned error: %v", err)
+				}
+			})
 			branch := "gitmoot-delegation-x-d1"
-			wt := t.TempDir()
+			wt := managedReclaimTestPath(t, home, "d1")
 			jobID := "parent/delegation/d1"
 			payload := workflow.JobPayload{
 				Repo: "owner/repo", DelegationID: "d1", WorktreePath: wt, Branch: branch,
@@ -3864,10 +3870,11 @@ func TestReclaimSkippedDelegationWorktrees(t *testing.T) {
 			}
 
 			manager := &fakeReclaimWorktreeManager{branches: map[string]bool{branch: true}}
-			worker := defaultJobWorker(store, io.Discard)
+			worker := defaultJobWorker(store, io.Discard, home)
 			worker.WorkflowFactory = func(string) workflow.Engine {
 				return workflow.Engine{
 					Store:               store,
+					Home:                worker.workflowHome(),
 					DelegationCheckout:  t.TempDir(),
 					DelegationWorktrees: manager,
 					OwnerPIDLive:        func(int64) bool { return false },
@@ -3893,8 +3900,12 @@ func TestReclaimSkippedDelegationWorktrees(t *testing.T) {
 				if len(manager.removed) != 0 {
 					t.Fatalf("active foreign owner must keep preserving: removed=%+v", manager.removed)
 				}
-				if !pending {
-					t.Fatalf("cleanup must still be pending while owner active")
+				obligation, err := store.GetCleanupObligation(ctx, db.CleanupObligationResourceID(jobID, wt))
+				if err != nil {
+					t.Fatalf("GetCleanupObligation returned error: %v", err)
+				}
+				if obligation.State != db.CleanupObligationRetryable || obligation.Reason != db.CleanupReasonTerminalDeferred {
+					t.Fatalf("active-owner cleanup obligation = %+v, want retryable terminal deferral", obligation)
 				}
 			}
 		})
@@ -3910,7 +3921,13 @@ func TestReclaimSkippedDelegationWorktrees(t *testing.T) {
 // JobIDsWithPendingDelegationWorktreeReclaim + a per-candidate GetJob.
 func TestReclaimSkippedDelegationWorktreesBoundedToMarkedJobs(t *testing.T) {
 	ctx := context.Background()
-	store := daemonWorkerStore(t)
+	home := t.TempDir()
+	store := openCLIJobStore(t, home)
+	t.Cleanup(func() {
+		if err := store.Close(); err != nil {
+			t.Fatalf("Close returned error: %v", err)
+		}
+	})
 
 	// A large backlog of terminal jobs with rich, immutable event history but NO
 	// cleanup marker. These must stay out of the candidate set entirely.
@@ -3941,7 +3958,7 @@ func TestReclaimSkippedDelegationWorktreesBoundedToMarkedJobs(t *testing.T) {
 
 	// The one genuinely-pending delegation child.
 	branch := "gitmoot-delegation-x-d1"
-	wt := t.TempDir()
+	wt := managedReclaimTestPath(t, home, "d1")
 	pendingID := "parent/delegation/d1"
 	payload := workflow.JobPayload{
 		Repo: "owner/repo", DelegationID: "d1", WorktreePath: wt, Branch: branch,
@@ -3962,10 +3979,11 @@ func TestReclaimSkippedDelegationWorktreesBoundedToMarkedJobs(t *testing.T) {
 	}
 
 	manager := &fakeReclaimWorktreeManager{branches: map[string]bool{branch: true}}
-	worker := defaultJobWorker(store, io.Discard)
+	worker := defaultJobWorker(store, io.Discard, home)
 	worker.WorkflowFactory = func(string) workflow.Engine {
 		return workflow.Engine{
 			Store:               store,
+			Home:                worker.workflowHome(),
 			DelegationCheckout:  t.TempDir(),
 			DelegationWorktrees: manager,
 			OwnerPIDLive:        func(int64) bool { return false },

--- a/internal/cli/daemon_scheduler_test.go
+++ b/internal/cli/daemon_scheduler_test.go
@@ -3150,6 +3150,83 @@ func TestRetryPendingJobAdvancementsDoesNotAccumulateAdvanceRetry(t *testing.T) 
 	}
 }
 
+// TestRetryPendingJobAdvancementsDoesNotActuateQuarantinedCleanup kills the
+// mutant that lets AdvanceJob ignore a quarantined obligation. The scheduler
+// re-enters the same failed advancement on every pass, so any bypass is counted
+// once per simulated worker tick.
+func TestRetryPendingJobAdvancementsDoesNotActuateQuarantinedCleanup(t *testing.T) {
+	ctx := context.Background()
+	store := daemonWorkerStore(t)
+	home := t.TempDir()
+	checkout := t.TempDir()
+	seedDaemonWorkerRepo(t, store, "owner/repo", checkout)
+	seedDaemonWorkerAgent(t, store, "reviewer", runtime.ShellRuntime, "unused", []string{"review"}, "owner/repo")
+	jobID := "job-quarantined-advance-retry"
+	path, err := workflow.DelegationWorktreePath(home, "owner/repo", jobID, "readonly-seat", 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(path, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	enqueueDaemonWorkerJob(t, store, workflow.JobRequest{
+		ID: jobID, Agent: "reviewer", Action: "review", Repo: "owner/repo",
+		Branch: "task-1", PullRequest: 1, TaskID: "task-1", HeadSHA: strings.Repeat("a", 40),
+		WorktreePath: path, ReadOnlyWorktree: true,
+	})
+	job, err := store.GetJob(ctx, jobID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	payload, err := workflow.ParseJobPayload(job.Payload)
+	if err != nil {
+		t.Fatal(err)
+	}
+	payload.Result = &workflow.AgentResult{Decision: "approved", Summary: "approved"}
+	encoded, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := store.UpdateJobPayload(ctx, jobID, string(encoded)); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.UpdateJobState(ctx, jobID, string(workflow.JobSucceeded)); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.AddJobEvent(ctx, db.JobEvent{JobID: jobID, Kind: "advance_retry", Message: "persistent merge gate failure"}); err != nil {
+		t.Fatal(err)
+	}
+	now := time.Now().UTC()
+	for range delegationCleanupRetryBudget {
+		if _, err := store.RecordCleanupObligationFailure(ctx, jobID, path, db.CleanupReasonUnknown, errors.New("persistent cleanup failure"), now, now.Add(time.Minute), delegationCleanupRetryBudget); err != nil {
+			t.Fatal(err)
+		}
+	}
+	manager := &fakeReclaimWorktreeManager{}
+	gate := &cliWorkerFakeMergeGate{err: errors.New("persistent merge gate failure")}
+	worker := defaultJobWorker(store, io.Discard)
+	worker.CheckoutValidator = func(context.Context, db.Job, workflow.JobPayload, runtime.Agent) (string, error) {
+		return checkout, nil
+	}
+	worker.WorkflowFactory = func(string) workflow.Engine {
+		return workflow.Engine{
+			Store: store, MergeGate: gate, Home: home, DelegationCheckout: checkout,
+			DelegationWorktrees: manager,
+		}
+	}
+	for pass := range 3 {
+		if err := retryPendingJobAdvancements(ctx, worker, "", "", nil, newTickCandidates(store)); err != nil {
+			t.Fatalf("retry pass %d: %v", pass, err)
+		}
+	}
+	if len(manager.removed) != 0 {
+		t.Fatalf("advance retry actuated quarantined cleanup %d times", len(manager.removed))
+	}
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("quarantined path changed during advance retries: %v", err)
+	}
+}
+
 func TestRetryPendingJobAdvancementsRecoversStartedAdvancement(t *testing.T) {
 	ctx := context.Background()
 	store := daemonWorkerStore(t)
@@ -3837,10 +3914,10 @@ func TestReclaimSkippedDelegationWorktrees(t *testing.T) {
 				}
 			})
 			branch := "gitmoot-delegation-x-d1"
-			wt := managedReclaimTestPath(t, home, "d1")
+			wt := managedDelegationReclaimTestPath(t, home, "parent", "d1")
 			jobID := "parent/delegation/d1"
 			payload := workflow.JobPayload{
-				Repo: "owner/repo", DelegationID: "d1", WorktreePath: wt, Branch: branch,
+				Repo: "owner/repo", ParentJobID: "parent", DelegationID: "d1", WorktreePath: wt, Branch: branch,
 				Result: &workflow.AgentResult{Decision: "failed"},
 			}
 			encoded, err := json.Marshal(payload)
@@ -3958,10 +4035,10 @@ func TestReclaimSkippedDelegationWorktreesBoundedToMarkedJobs(t *testing.T) {
 
 	// The one genuinely-pending delegation child.
 	branch := "gitmoot-delegation-x-d1"
-	wt := managedReclaimTestPath(t, home, "d1")
+	wt := managedDelegationReclaimTestPath(t, home, "parent", "d1")
 	pendingID := "parent/delegation/d1"
 	payload := workflow.JobPayload{
-		Repo: "owner/repo", DelegationID: "d1", WorktreePath: wt, Branch: branch,
+		Repo: "owner/repo", ParentJobID: "parent", DelegationID: "d1", WorktreePath: wt, Branch: branch,
 		Result: &workflow.AgentResult{Decision: "failed"},
 	}
 	encoded, err := json.Marshal(payload)

--- a/internal/cli/daemon_scheduler_test.go
+++ b/internal/cli/daemon_scheduler_test.go
@@ -3874,7 +3874,7 @@ func TestReclaimSkippedDelegationWorktrees(t *testing.T) {
 				}
 			}
 
-			if err := reclaimSkippedDelegationWorktrees(ctx, worker, "", "", nil, newTickCandidates(worker.Store)); err != nil {
+			if err := reclaimSkippedDelegationWorktrees(ctx, worker, "", "", nil, newTickCandidates(worker.Store), time.Now().UTC()); err != nil {
 				t.Fatalf("reclaimSkippedDelegationWorktrees returned error: %v", err)
 			}
 
@@ -3972,7 +3972,7 @@ func TestReclaimSkippedDelegationWorktreesBoundedToMarkedJobs(t *testing.T) {
 		}
 	}
 
-	if err := reclaimSkippedDelegationWorktrees(ctx, worker, "", "", nil, newTickCandidates(worker.Store)); err != nil {
+	if err := reclaimSkippedDelegationWorktrees(ctx, worker, "", "", nil, newTickCandidates(worker.Store), time.Now().UTC()); err != nil {
 		t.Fatalf("reclaimSkippedDelegationWorktrees returned error: %v", err)
 	}
 

--- a/internal/cli/delegation_worktree_ttl_test.go
+++ b/internal/cli/delegation_worktree_ttl_test.go
@@ -24,11 +24,11 @@ func TestReclaimAgedTerminalDelegationWorktreesTTLAndStateGate(t *testing.T) {
 		path  string
 	}
 	rows := []seeded{
-		{id: "terminal-old", state: workflow.JobFailed, age: 73 * time.Hour, path: t.TempDir()},
-		{id: "terminal-fresh", state: workflow.JobSucceeded, age: time.Hour, path: t.TempDir()},
-		{id: "blocked-old", state: workflow.JobBlocked, age: 30 * 24 * time.Hour, path: t.TempDir()},
+		{id: "terminal-old", state: workflow.JobFailed, age: 73 * time.Hour, path: managedReclaimTestPath(t, home, "terminal-old")},
+		{id: "terminal-fresh", state: workflow.JobSucceeded, age: time.Hour, path: managedReclaimTestPath(t, home, "terminal-fresh")},
+		{id: "blocked-old", state: workflow.JobBlocked, age: 30 * 24 * time.Hour, path: managedReclaimTestPath(t, home, "blocked-old")},
 	}
-	sharedPath := t.TempDir()
+	sharedPath := managedReclaimTestPath(t, home, "shared")
 	rows = append(rows,
 		seeded{id: "shared-old", state: workflow.JobFailed, age: 10 * 24 * time.Hour, path: sharedPath},
 		seeded{id: "shared-fresh", state: workflow.JobSucceeded, age: time.Hour, path: sharedPath},
@@ -57,7 +57,7 @@ func TestReclaimAgedTerminalDelegationWorktreesTTLAndStateGate(t *testing.T) {
 	manager := &fakeReclaimWorktreeManager{branches: map[string]bool{}}
 	worker := defaultJobWorker(store, io.Discard, home)
 	worker.WorkflowFactory = func(string) workflow.Engine {
-		return workflow.Engine{Store: store, DelegationCheckout: t.TempDir(), DelegationWorktrees: manager}
+		return workflow.Engine{Store: store, Home: worker.workflowHome(), DelegationCheckout: t.TempDir(), DelegationWorktrees: manager}
 	}
 	if err := reclaimAgedTerminalDelegationWorktrees(ctx, worker, "", "", nil, newTickCandidates(store), now, 72*time.Hour); err != nil {
 		t.Fatalf("reclaimAgedTerminalDelegationWorktrees: %v", err)

--- a/internal/cli/delegation_worktree_ttl_test.go
+++ b/internal/cli/delegation_worktree_ttl_test.go
@@ -34,7 +34,7 @@ func TestReclaimAgedTerminalDelegationWorktreesTTLAndStateGate(t *testing.T) {
 		seeded{id: "shared-fresh", state: workflow.JobSucceeded, age: time.Hour, path: sharedPath},
 	)
 	for _, row := range rows {
-		payload, err := json.Marshal(workflow.JobPayload{Repo: "owner/repo", DelegationID: row.id, WorktreePath: row.path})
+		payload, err := json.Marshal(workflow.JobPayload{Repo: "owner/repo", WorktreePath: row.path, ReadOnlyWorktree: true})
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/internal/cli/doctor_worktrees.go
+++ b/internal/cli/doctor_worktrees.go
@@ -29,6 +29,7 @@ type delegationWorktreeUsage struct {
 	Pinned         int    `json:"pinned"`
 	Unproven       int    `json:"unproven"`
 	RecentTerminal int    `json:"recentTerminal"`
+	Quarantined    int    `json:"quarantined"`
 	Root           string `json:"root"`
 	Summary        string `json:"summary"`
 }
@@ -50,6 +51,10 @@ func inspectDelegationWorktreeUsage(ctx context.Context, paths config.Paths, sto
 	root := filepath.Join(paths.Home, "worktrees")
 	usage := delegationWorktreeUsage{Root: root}
 	jobs, err := store.ListJobs(ctx)
+	if err != nil {
+		return usage, err
+	}
+	usage.Quarantined, err = store.CountQuarantinedCleanupObligations(ctx)
 	if err != nil {
 		return usage, err
 	}
@@ -234,7 +239,7 @@ func delegationWorktreeDoctorCheck(paths config.Paths) (doctor.Check, bool) {
 }
 
 func buildDelegationWorktreeDoctorCheck(usage delegationWorktreeUsage) doctor.Check {
-	detail := fmt.Sprintf("%s (%d reclaimable, %d pinned by non-terminal owners, %d unproven; %d recent terminal within TTL)", usage.Summary, usage.Reclaimable, usage.Pinned, usage.Unproven, usage.RecentTerminal)
-	warn := usage.Stale >= delegationWorktreeWarnCount || usage.SizeBytes >= delegationWorktreeWarnBytes
+	detail := fmt.Sprintf("%s (%d reclaimable, %d pinned by non-terminal owners, %d unproven; %d recent terminal within TTL; %d cleanup quarantined)", usage.Summary, usage.Reclaimable, usage.Pinned, usage.Unproven, usage.RecentTerminal, usage.Quarantined)
+	warn := usage.Stale >= delegationWorktreeWarnCount || usage.SizeBytes >= delegationWorktreeWarnBytes || usage.Quarantined > 0
 	return doctor.Check{Name: "worktrees", OK: !warn, Required: false, Detail: detail}
 }

--- a/internal/cli/doctor_worktrees_test.go
+++ b/internal/cli/doctor_worktrees_test.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -87,6 +88,10 @@ func TestBuildDelegationWorktreeDoctorCheckThresholds(t *testing.T) {
 	if warn.OK || warn.Required || !strings.Contains(warn.Detail, "10 stale worktrees / 2.0 GB") {
 		t.Fatalf("warning check = %+v", warn)
 	}
+	quarantined := buildDelegationWorktreeDoctorCheck(delegationWorktreeUsage{Quarantined: 1, Summary: "0 stale worktrees / 0 B under /tmp/home/worktrees"})
+	if quarantined.OK || !strings.Contains(quarantined.Detail, "1 cleanup quarantined") {
+		t.Fatalf("quarantined check = %+v", quarantined)
+	}
 }
 
 func TestHealthEndpointSurfacesDelegationWorktreeUsage(t *testing.T) {
@@ -105,6 +110,11 @@ func TestHealthEndpointSurfacesDelegationWorktreeUsage(t *testing.T) {
 		ParentJobID: "parent", DelegationID: "pinned",
 		Payload: mustJobPayload(t, workflow.JobPayload{Repo: "owner/repo", DelegationID: "pinned", WorktreePath: path}),
 	}, string(workflow.JobBlocked))
+	for attempt := 0; attempt < delegationCleanupRetryBudget; attempt++ {
+		if _, err := store.RecordCleanupObligationFailure(context.Background(), "quarantined", filepath.Join(paths.Home, "worktrees", "owner--repo", "delegations", "parent", "quarantined"), db.CleanupReasonUnknown, errors.New("stuck"), time.Now().UTC(), time.Now().UTC().Add(time.Minute), delegationCleanupRetryBudget); err != nil {
+			t.Fatal(err)
+		}
+	}
 	store.Close()
 
 	stubOnDiskBuild(t, "", "")
@@ -120,7 +130,7 @@ func TestHealthEndpointSurfacesDelegationWorktreeUsage(t *testing.T) {
 	if err := json.Unmarshal(recorder.Body.Bytes(), &payload); err != nil {
 		t.Fatal(err)
 	}
-	if payload.Worktrees.Stale != 1 || payload.Worktrees.Pinned != 1 || payload.Worktrees.SizeBytes != int64(len("dashboard")) {
+	if payload.Worktrees.Stale != 1 || payload.Worktrees.Pinned != 1 || payload.Worktrees.Quarantined != 1 || payload.Worktrees.SizeBytes != int64(len("dashboard")) {
 		t.Fatalf("worktrees = %+v", payload.Worktrees)
 	}
 	if !strings.Contains(payload.Worktrees.Summary, "1 stale worktree") {

--- a/internal/cli/job.go
+++ b/internal/cli/job.go
@@ -42,6 +42,8 @@ func runJob(args []string, stdout, stderr io.Writer) int {
 		return runJobRun(args[1:], stdout, stderr)
 	case "retry":
 		return runJobRetry(args[1:], stdout, stderr)
+	case "cleanup":
+		return runJobCleanup(args[1:], stdout, stderr)
 	case "gates":
 		return runJobGates(args[1:], stdout, stderr)
 	case "cancel":
@@ -71,6 +73,8 @@ func printJobUsage(w io.Writer) {
 	fmt.Fprintln(w, "  gitmoot job transcript --all [--state succeeded,failed] [--since 720h] --export jsonl [--output path]")
 	fmt.Fprintln(w, "  gitmoot job run <id>")
 	fmt.Fprintln(w, "  gitmoot job retry <id>")
+	fmt.Fprintln(w, "  gitmoot job cleanup list [--state pending|retryable|removed|quarantined] [--json]")
+	fmt.Fprintln(w, "  gitmoot job cleanup reopen <resource-id>")
 	fmt.Fprintln(w, "  gitmoot job gates <id> [--json]")
 	fmt.Fprintln(w, "  gitmoot job gates clear <id> --need \"<text>\"|--all")
 	fmt.Fprintln(w, "  gitmoot job cancel <id>")

--- a/internal/cli/job_cleanup.go
+++ b/internal/cli/job_cleanup.go
@@ -1,0 +1,115 @@
+package cli
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"strings"
+	"time"
+
+	"github.com/gitmoot/gitmoot/internal/db"
+)
+
+func runJobCleanup(args []string, stdout, stderr io.Writer) int {
+	if len(args) == 0 || args[0] == "-h" || args[0] == "--help" {
+		printJobCleanupUsage(stdout)
+		return 0
+	}
+	switch args[0] {
+	case "list":
+		return runJobCleanupList(args[1:], stdout, stderr)
+	case "reopen":
+		return runJobCleanupReopen(args[1:], stdout, stderr)
+	default:
+		fmt.Fprintf(stderr, "unknown job cleanup command %q\n\n", args[0])
+		printJobCleanupUsage(stderr)
+		return 2
+	}
+}
+
+func printJobCleanupUsage(w io.Writer) {
+	fmt.Fprintln(w, "Usage:")
+	fmt.Fprintln(w, "  gitmoot job cleanup list [--state pending|retryable|removed|quarantined] [--json]")
+	fmt.Fprintln(w, "  gitmoot job cleanup reopen <resource-id>")
+}
+
+func runJobCleanupList(args []string, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("job cleanup list", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	home := fs.String("home", "", "home directory to use instead of the current user's home")
+	state := fs.String("state", "", "cleanup state filter")
+	jsonOutput := fs.Bool("json", false, "print cleanup obligations as JSON")
+	if err := fs.Parse(args); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return 0
+		}
+		return 2
+	}
+	if fs.NArg() != 0 {
+		fmt.Fprintln(stderr, "job cleanup list does not accept positional arguments")
+		return 2
+	}
+	if value := strings.TrimSpace(*state); value != "" && value != db.CleanupObligationPending && value != db.CleanupObligationRetryable && value != db.CleanupObligationRemoved && value != db.CleanupObligationQuarantined {
+		fmt.Fprintf(stderr, "job cleanup list: invalid state %q\n", value)
+		return 2
+	}
+	var obligations []db.CleanupObligation
+	if err := withStore(*home, func(store *db.Store) error {
+		var err error
+		obligations, err = store.ListCleanupObligations(context.Background(), *state)
+		return err
+	}); err != nil {
+		fmt.Fprintf(stderr, "job cleanup list: %v\n", err)
+		return 1
+	}
+	if *jsonOutput {
+		if obligations == nil {
+			obligations = []db.CleanupObligation{}
+		}
+		enc := json.NewEncoder(stdout)
+		enc.SetIndent("", "  ")
+		if err := enc.Encode(obligations); err != nil {
+			fmt.Fprintf(stderr, "job cleanup list: %v\n", err)
+			return 1
+		}
+		return 0
+	}
+	for _, obligation := range obligations {
+		fmt.Fprintf(stdout, "%s  %-11s attempts=%d job=%s path=%s reason=%s next=%s\n",
+			obligation.ResourceID, obligation.State, obligation.AttemptCount,
+			obligation.OwnerJobID, obligation.ExpectedPath, obligation.Reason,
+			obligation.NextAttemptAt)
+	}
+	return 0
+}
+
+func runJobCleanupReopen(args []string, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("job cleanup reopen", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	home := fs.String("home", "", "home directory to use instead of the current user's home")
+	if err := fs.Parse(args); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return 0
+		}
+		return 2
+	}
+	if fs.NArg() != 1 || strings.TrimSpace(fs.Arg(0)) == "" {
+		fmt.Fprintln(stderr, "job cleanup reopen requires exactly one resource id")
+		return 2
+	}
+	resourceID := strings.TrimSpace(fs.Arg(0))
+	var obligation db.CleanupObligation
+	if err := withStore(*home, func(store *db.Store) error {
+		var err error
+		obligation, err = store.ReopenCleanupObligation(context.Background(), resourceID, time.Now().UTC())
+		return err
+	}); err != nil {
+		fmt.Fprintf(stderr, "job cleanup reopen: %v\n", err)
+		return 1
+	}
+	fmt.Fprintf(stdout, "reopened cleanup obligation %s for job %s\n", obligation.ResourceID, obligation.OwnerJobID)
+	return 0
+}

--- a/internal/cli/job_cleanup_test.go
+++ b/internal/cli/job_cleanup_test.go
@@ -1,0 +1,54 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/gitmoot/gitmoot/internal/db"
+)
+
+func TestJobCleanupListAndReopen(t *testing.T) {
+	home := t.TempDir()
+	store := openCLIJobStore(t, home)
+	now := time.Now().UTC()
+	path := managedReclaimTestPath(t, home, "operator-reopen")
+	for attempt := 0; attempt < delegationCleanupRetryBudget; attempt++ {
+		if _, err := store.RecordCleanupObligationFailure(context.Background(), "operator-job", path, db.CleanupReasonUnknown, errors.New("stuck"), now, now.Add(time.Minute), delegationCleanupRetryBudget); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := store.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	if code := runJobCleanup([]string{"list", "--home", home, "--state", "quarantined", "--json"}, &stdout, &stderr); code != 0 {
+		t.Fatalf("list code=%d stderr=%s", code, stderr.String())
+	}
+	var listed []db.CleanupObligation
+	if err := json.Unmarshal(stdout.Bytes(), &listed); err != nil {
+		t.Fatal(err)
+	}
+	if len(listed) != 1 || listed[0].OwnerJobID != "operator-job" || listed[0].ExpectedPath != path {
+		t.Fatalf("listed obligations = %+v", listed)
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	if code := runJobCleanup([]string{"reopen", "--home", home, listed[0].ResourceID}, &stdout, &stderr); code != 0 {
+		t.Fatalf("reopen code=%d stderr=%s", code, stderr.String())
+	}
+	store = openCLIJobStore(t, home)
+	defer store.Close()
+	reopened, err := store.GetCleanupObligation(context.Background(), listed[0].ResourceID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if reopened.State != db.CleanupObligationPending || reopened.AttemptCount != 0 {
+		t.Fatalf("reopened obligation = %+v", reopened)
+	}
+}

--- a/internal/db/cleanup_obligations_test.go
+++ b/internal/db/cleanup_obligations_test.go
@@ -1,0 +1,99 @@
+package db
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"path/filepath"
+	"testing"
+	"time"
+
+	_ "modernc.org/sqlite"
+)
+
+func TestCleanupObligationsMigrationFreshAndUpgrade(t *testing.T) {
+	ctx := context.Background()
+	fresh, err := openRealTestStore(t, filepath.Join(t.TempDir(), "fresh.db"))
+	if err != nil {
+		t.Fatalf("open fresh store: %v", err)
+	}
+	t.Cleanup(func() { _ = fresh.Close() })
+	if exists, err := fresh.HasTable(ctx, "cleanup_obligations"); err != nil || !exists {
+		t.Fatalf("fresh cleanup_obligations exists=%v err=%v", exists, err)
+	}
+
+	path := filepath.Join(t.TempDir(), "upgrade.db")
+	raw, err := sql.Open("sqlite", path)
+	if err != nil {
+		t.Fatalf("sql.Open: %v", err)
+	}
+	preMigration := &Store{db: raw}
+	for version, migration := range migrationsBefore(t, "CREATE TABLE cleanup_obligations") {
+		if err := preMigration.applyMigration(ctx, version+1, migration); err != nil {
+			t.Fatalf("applyMigration(%d): %v", version+1, err)
+		}
+	}
+	if exists, err := preMigration.HasTable(ctx, "cleanup_obligations"); err != nil || exists {
+		t.Fatalf("pre-migration cleanup_obligations exists=%v err=%v", exists, err)
+	}
+	if err := raw.Close(); err != nil {
+		t.Fatalf("close pre-migration store: %v", err)
+	}
+
+	upgraded, err := openRealTestStore(t, path)
+	if err != nil {
+		t.Fatalf("open upgraded store: %v", err)
+	}
+	t.Cleanup(func() { _ = upgraded.Close() })
+	if exists, err := upgraded.HasTable(ctx, "cleanup_obligations"); err != nil || !exists {
+		t.Fatalf("upgraded cleanup_obligations exists=%v err=%v", exists, err)
+	}
+}
+
+func TestCleanupObligationTerminalStatesRequireExplicitReopen(t *testing.T) {
+	ctx := context.Background()
+	store, err := openCachedTestStore(t, filepath.Join(t.TempDir(), "gitmoot.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+	now := time.Now().UTC()
+	path := "/tmp/managed/delegation"
+	for attempt := 0; attempt < 3; attempt++ {
+		if _, err := store.RecordCleanupObligationFailure(ctx, "job-1", path, CleanupReasonUnknown, errors.New("no typed match"), now, now.Add(time.Minute), 3); err != nil {
+			t.Fatal(err)
+		}
+	}
+	resourceID := CleanupObligationResourceID("job-1", path)
+	obligation, err := store.EnsureCleanupObligation(ctx, "job-1", path, now.Add(time.Hour))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if obligation.State != CleanupObligationQuarantined || obligation.AttemptCount != 3 {
+		t.Fatalf("ensure reopened terminal obligation: %+v", obligation)
+	}
+	reopened, err := store.ReopenCleanupObligation(ctx, resourceID, now.Add(2*time.Hour))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if reopened.State != CleanupObligationPending || reopened.AttemptCount != 0 || reopened.Reason != "operator_reopened" {
+		t.Fatalf("reopened obligation = %+v", reopened)
+	}
+	removed, err := store.MarkCleanupObligationRemoved(ctx, "job-1", path, now.Add(3*time.Hour))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if removed.State != CleanupObligationRemoved {
+		t.Fatalf("removed obligation = %+v", removed)
+	}
+	if _, err := store.RecordCleanupObligationFailure(ctx, "job-1", path, CleanupReasonUnknown, errors.New("stale failure"), now, now.Add(time.Minute), 3); err != nil {
+		t.Fatal(err)
+	}
+	final, err := store.GetCleanupObligation(ctx, resourceID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if final.State != CleanupObligationRemoved {
+		t.Fatalf("stale failure reopened removed obligation: %+v", final)
+	}
+}

--- a/internal/db/store_cleanup_obligations.go
+++ b/internal/db/store_cleanup_obligations.go
@@ -1,0 +1,229 @@
+package db
+
+import (
+	"context"
+	"crypto/sha256"
+	"database/sql"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+const (
+	CleanupObligationPending     = "pending"
+	CleanupObligationRetryable   = "retryable"
+	CleanupObligationRemoved     = "removed"
+	CleanupObligationQuarantined = "quarantined"
+)
+
+type CleanupObligation struct {
+	ResourceID    string                  `json:"resource_id"`
+	ResourceKind  string                  `json:"resource_kind"`
+	OwnerJobID    string                  `json:"owner_job_id"`
+	ExpectedPath  string                  `json:"expected_path"`
+	State         string                  `json:"state"`
+	Reason        CleanupObligationReason `json:"reason"`
+	AttemptCount  int                     `json:"attempt_count"`
+	NextAttemptAt string                  `json:"next_attempt_at"`
+	LastError     string                  `json:"last_error"`
+	CreatedAt     string                  `json:"created_at"`
+	UpdatedAt     string                  `json:"updated_at"`
+}
+
+type CleanupObligationReason string
+
+const (
+	CleanupReasonPending               CleanupObligationReason = "pending"
+	CleanupReasonRemoved               CleanupObligationReason = "removed"
+	CleanupReasonOperatorReopened      CleanupObligationReason = "operator_reopened"
+	CleanupReasonTerminalDeferred      CleanupObligationReason = "terminal_cleanup_deferred"
+	CleanupReasonContextInterrupted    CleanupObligationReason = "context_interrupted"
+	CleanupReasonJobLookup             CleanupObligationReason = "job_lookup"
+	CleanupReasonRunnerResolution      CleanupObligationReason = "runner_resolution"
+	CleanupReasonCheckoutLock          CleanupObligationReason = "checkout_lock"
+	CleanupReasonIdentityOrContainment CleanupObligationReason = "identity_or_containment"
+	CleanupReasonUnknown               CleanupObligationReason = "unknown"
+)
+
+func ClassifyCleanupObligationFailure(phase string, err error) CleanupObligationReason {
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return CleanupReasonContextInterrupted
+	}
+	switch strings.TrimSpace(phase) {
+	case "get_job":
+		return CleanupReasonJobLookup
+	case "runner":
+		return CleanupReasonRunnerResolution
+	case "lock":
+		return CleanupReasonCheckoutLock
+	case "identity":
+		return CleanupReasonIdentityOrContainment
+	default:
+		return CleanupReasonUnknown
+	}
+}
+
+func CleanupObligationResourceID(ownerJobID, expectedPath string) string {
+	identity := strings.TrimSpace(ownerJobID) + "\x00" + filepath.Clean(strings.TrimSpace(expectedPath))
+	sum := sha256.Sum256([]byte(identity))
+	return "delegation-worktree:" + hex.EncodeToString(sum[:])
+}
+
+func cleanupObligationTime(value time.Time) string {
+	return value.UTC().Format(time.RFC3339Nano)
+}
+
+func (s *Store) EnsureCleanupObligation(ctx context.Context, ownerJobID, expectedPath string, now time.Time) (CleanupObligation, error) {
+	ownerJobID = strings.TrimSpace(ownerJobID)
+	expectedPath = filepath.Clean(strings.TrimSpace(expectedPath))
+	if ownerJobID == "" || expectedPath == "." || expectedPath == "" {
+		return CleanupObligation{}, fmt.Errorf("cleanup obligation requires owner job and expected path")
+	}
+	resourceID := CleanupObligationResourceID(ownerJobID, expectedPath)
+	stamp := cleanupObligationTime(now)
+	_, err := s.db.ExecContext(ctx, `
+		INSERT INTO cleanup_obligations (
+			resource_id, resource_kind, owner_job_id, expected_path, state,
+			reason, attempt_count, next_attempt_at, created_at, updated_at
+		) VALUES (?, 'delegation_worktree', ?, ?, 'pending', 'pending', 0, ?, ?, ?)
+		ON CONFLICT(resource_id) DO UPDATE SET
+			owner_job_id=excluded.owner_job_id,
+			expected_path=excluded.expected_path,
+			updated_at=excluded.updated_at
+		WHERE cleanup_obligations.state IN ('pending', 'retryable')`,
+		resourceID, ownerJobID, expectedPath, stamp, stamp, stamp)
+	if err != nil {
+		return CleanupObligation{}, err
+	}
+	return s.GetCleanupObligation(ctx, resourceID)
+}
+
+func (s *Store) RecordCleanupObligationFailure(ctx context.Context, ownerJobID, expectedPath string, reason CleanupObligationReason, cause error, now time.Time, nextAttempt time.Time, budget int) (CleanupObligation, error) {
+	if budget <= 0 {
+		return CleanupObligation{}, fmt.Errorf("cleanup retry budget must be positive")
+	}
+	obligation, err := s.EnsureCleanupObligation(ctx, ownerJobID, expectedPath, now)
+	if err != nil {
+		return CleanupObligation{}, err
+	}
+	message := ""
+	if cause != nil {
+		message = cause.Error()
+	}
+	stamp := cleanupObligationTime(now)
+	next := cleanupObligationTime(nextAttempt)
+	_, err = s.db.ExecContext(ctx, `
+		UPDATE cleanup_obligations
+		SET attempt_count=attempt_count+1,
+			state=CASE WHEN attempt_count+1 >= ? THEN 'quarantined' ELSE 'retryable' END,
+			reason=?, next_attempt_at=?, last_error=?, updated_at=?
+		WHERE resource_id=? AND state IN ('pending', 'retryable')`,
+		budget, strings.TrimSpace(string(reason)), next, message, stamp, obligation.ResourceID)
+	if err != nil {
+		return CleanupObligation{}, err
+	}
+	return s.GetCleanupObligation(ctx, obligation.ResourceID)
+}
+
+func (s *Store) DeferCleanupObligation(ctx context.Context, ownerJobID, expectedPath string, reason CleanupObligationReason, now, nextAttempt time.Time) (CleanupObligation, error) {
+	obligation, err := s.EnsureCleanupObligation(ctx, ownerJobID, expectedPath, now)
+	if err != nil {
+		return CleanupObligation{}, err
+	}
+	_, err = s.db.ExecContext(ctx, `
+		UPDATE cleanup_obligations
+		SET state='retryable', reason=?, next_attempt_at=?, updated_at=?
+		WHERE resource_id=? AND state IN ('pending', 'retryable')`,
+		strings.TrimSpace(string(reason)), cleanupObligationTime(nextAttempt), cleanupObligationTime(now), obligation.ResourceID)
+	if err != nil {
+		return CleanupObligation{}, err
+	}
+	return s.GetCleanupObligation(ctx, obligation.ResourceID)
+}
+
+func (s *Store) MarkCleanupObligationRemoved(ctx context.Context, ownerJobID, expectedPath string, now time.Time) (CleanupObligation, error) {
+	obligation, err := s.EnsureCleanupObligation(ctx, ownerJobID, expectedPath, now)
+	if err != nil {
+		return CleanupObligation{}, err
+	}
+	stamp := cleanupObligationTime(now)
+	_, err = s.db.ExecContext(ctx, `
+		UPDATE cleanup_obligations
+		SET state='removed', reason='removed', next_attempt_at=?, last_error='', updated_at=?
+		WHERE resource_id=? AND state <> 'quarantined'`, stamp, stamp, obligation.ResourceID)
+	if err != nil {
+		return CleanupObligation{}, err
+	}
+	return s.GetCleanupObligation(ctx, obligation.ResourceID)
+}
+
+func (s *Store) GetCleanupObligation(ctx context.Context, resourceID string) (CleanupObligation, error) {
+	var obligation CleanupObligation
+	err := s.db.QueryRowContext(ctx, `
+		SELECT resource_id, resource_kind, owner_job_id, expected_path, state,
+		       reason, attempt_count, next_attempt_at, last_error, created_at, updated_at
+		FROM cleanup_obligations WHERE resource_id=?`, strings.TrimSpace(resourceID)).Scan(
+		&obligation.ResourceID, &obligation.ResourceKind, &obligation.OwnerJobID,
+		&obligation.ExpectedPath, &obligation.State, &obligation.Reason,
+		&obligation.AttemptCount, &obligation.NextAttemptAt, &obligation.LastError,
+		&obligation.CreatedAt, &obligation.UpdatedAt)
+	return obligation, err
+}
+
+func (s *Store) ListCleanupObligations(ctx context.Context, state string) ([]CleanupObligation, error) {
+	query := `SELECT resource_id, resource_kind, owner_job_id, expected_path, state,
+	                 reason, attempt_count, next_attempt_at, last_error, created_at, updated_at
+	          FROM cleanup_obligations`
+	args := []any{}
+	if state = strings.TrimSpace(state); state != "" {
+		query += ` WHERE state=?`
+		args = append(args, state)
+	}
+	query += ` ORDER BY owner_job_id, expected_path`
+	rows, err := s.db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var obligations []CleanupObligation
+	for rows.Next() {
+		var obligation CleanupObligation
+		if err := rows.Scan(&obligation.ResourceID, &obligation.ResourceKind, &obligation.OwnerJobID,
+			&obligation.ExpectedPath, &obligation.State, &obligation.Reason,
+			&obligation.AttemptCount, &obligation.NextAttemptAt, &obligation.LastError,
+			&obligation.CreatedAt, &obligation.UpdatedAt); err != nil {
+			return nil, err
+		}
+		obligations = append(obligations, obligation)
+	}
+	return obligations, rows.Err()
+}
+
+func (s *Store) ReopenCleanupObligation(ctx context.Context, resourceID string, now time.Time) (CleanupObligation, error) {
+	stamp := cleanupObligationTime(now)
+	result, err := s.db.ExecContext(ctx, `
+		UPDATE cleanup_obligations
+		SET state='pending', reason='operator_reopened', attempt_count=0,
+			next_attempt_at=?, last_error='', updated_at=?
+		WHERE resource_id=? AND state='quarantined'`, stamp, stamp, strings.TrimSpace(resourceID))
+	if err != nil {
+		return CleanupObligation{}, err
+	}
+	changed, err := result.RowsAffected()
+	if err != nil {
+		return CleanupObligation{}, err
+	}
+	if changed == 0 {
+		return CleanupObligation{}, sql.ErrNoRows
+	}
+	return s.GetCleanupObligation(ctx, resourceID)
+}
+
+func (s *Store) CountQuarantinedCleanupObligations(ctx context.Context) (int, error) {
+	var count int
+	err := s.db.QueryRowContext(ctx, `SELECT COUNT(*) FROM cleanup_obligations WHERE state='quarantined'`).Scan(&count)
+	return count, err
+}

--- a/internal/db/store_jobs.go
+++ b/internal/db/store_jobs.go
@@ -1501,14 +1501,23 @@ func (s *Store) jobIDsByQuery(ctx context.Context, query string) ([]string, erro
 // the PRODUCTION query text — not a hand-copied duplicate — for each. A change to any
 // of these queries is then exactly what the covering-index test asserts a plan for.
 const (
-	jobIDsWithPendingDelegationWorktreeReclaimSQL = `SELECT job_id FROM job_events
-		WHERE kind = 'delegation_worktree_cleanup_skipped'
-		  AND id IN (
+	jobIDsWithPendingDelegationWorktreeReclaimSQL = `SELECT e.job_id FROM job_events e
+		JOIN jobs j ON j.id = e.job_id
+		LEFT JOIN cleanup_obligations o
+		  ON o.owner_job_id = e.job_id
+		 AND o.expected_path = CASE WHEN json_valid(j.payload)
+			THEN json_extract(j.payload, '$.worktree_path') ELSE '' END
+		WHERE e.kind = 'delegation_worktree_cleanup_skipped'
+		  AND e.id IN (
 			SELECT MAX(id) FROM job_events
 			WHERE kind IN ('delegation_worktree_cleanup_skipped', 'delegation_worktree_removed')
 			GROUP BY job_id
 		)
-		ORDER BY job_id`
+		  AND (o.resource_id IS NULL OR (
+			o.state IN ('pending', 'retryable')
+			AND unixepoch(o.next_attempt_at) <= unixepoch('now')
+		  ))
+		ORDER BY e.job_id`
 
 	jobIDsWithPendingAdvanceRetrySQL = `SELECT job_id FROM job_events
 		WHERE kind IN ('advance_started', 'advance_retry')
@@ -1594,6 +1603,9 @@ func (s *Store) JobIDsWithAgedTerminalDelegationWorktree(ctx context.Context, cu
 		)
 		SELECT j.id
 		FROM job_wt j
+		LEFT JOIN cleanup_obligations obligation
+		  ON obligation.owner_job_id = j.id
+		 AND obligation.expected_path = j.worktree_path
 		WHERE j.state IN ('succeeded', 'failed', 'cancelled')
 		  AND j.ts <= unixepoch(?)
 		  AND COALESCE(j.worktree_path, '') <> ''
@@ -1611,6 +1623,10 @@ func (s *Store) JobIDsWithAgedTerminalDelegationWorktree(ctx context.Context, cu
 			WHERE e.job_id = j.id
 			  AND e.kind IN ('delegation_worktree_removed', 'delegation_worktree_reclaimed_ttl')
 		  )
+		  AND (obligation.resource_id IS NULL OR (
+			obligation.state IN ('pending', 'retryable')
+			AND unixepoch(obligation.next_attempt_at) <= unixepoch('now')
+		  ))
 		ORDER BY j.id`, cutoffStr, cutoffStr)
 	if err != nil {
 		return nil, err

--- a/internal/db/store_migrations.go
+++ b/internal/db/store_migrations.go
@@ -1782,7 +1782,11 @@ WHERE repo = '' AND json_valid(payload) AND COALESCE(json_extract(payload, '$.re
 	`
 CREATE TABLE org_role_unavailable (
 	role TEXT PRIMARY KEY,
-	reason TEXT NOT NULL,
+	reason TEXT NOT NULL CHECK(reason IN (
+		'pending', 'removed', 'operator_reopened', 'terminal_cleanup_deferred',
+		'context_interrupted', 'job_lookup', 'runner_resolution', 'checkout_lock',
+		'identity_or_containment', 'unknown'
+	)),
 	unavailable_until TEXT NOT NULL,
 	escalated_at TEXT NOT NULL DEFAULT '',
 	updated_at TEXT NOT NULL
@@ -2044,5 +2048,30 @@ CREATE TABLE execbackend_attempts (
 	updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
 	PRIMARY KEY (job_id, attempt, lifecycle_generation)
 );
+	`,
+	// #1572 durable delegation-worktree cleanup obligations. Job events remain
+	// audit output; this row is the restart-safe retry state. The resource id is
+	// derived from (owner job, canonical expected path), while both values remain
+	// explicit so an operator can prove identity before reopening a quarantine.
+	// Removed is terminal; quarantined requires an explicit operator reopen.
+	`
+CREATE TABLE cleanup_obligations (
+	resource_id TEXT PRIMARY KEY,
+	resource_kind TEXT NOT NULL CHECK(resource_kind = 'delegation_worktree'),
+	owner_job_id TEXT NOT NULL,
+	expected_path TEXT NOT NULL,
+	state TEXT NOT NULL CHECK(state IN ('pending', 'retryable', 'removed', 'quarantined')),
+	reason TEXT NOT NULL,
+	attempt_count INTEGER NOT NULL DEFAULT 0 CHECK(attempt_count >= 0),
+	next_attempt_at TEXT NOT NULL,
+	last_error TEXT NOT NULL DEFAULT '',
+	created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+	updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+CREATE UNIQUE INDEX idx_cleanup_obligations_owner_path
+	ON cleanup_obligations(owner_job_id, expected_path);
+CREATE INDEX idx_cleanup_obligations_due
+	ON cleanup_obligations(state, next_attempt_at, owner_job_id)
+	WHERE state IN ('pending', 'retryable');
 	`,
 }

--- a/internal/db/store_migrations.go
+++ b/internal/db/store_migrations.go
@@ -1782,11 +1782,7 @@ WHERE repo = '' AND json_valid(payload) AND COALESCE(json_extract(payload, '$.re
 	`
 CREATE TABLE org_role_unavailable (
 	role TEXT PRIMARY KEY,
-	reason TEXT NOT NULL CHECK(reason IN (
-		'pending', 'removed', 'operator_reopened', 'terminal_cleanup_deferred',
-		'context_interrupted', 'job_lookup', 'runner_resolution', 'checkout_lock',
-		'identity_or_containment', 'unknown'
-	)),
+	reason TEXT NOT NULL,
 	unavailable_until TEXT NOT NULL,
 	escalated_at TEXT NOT NULL DEFAULT '',
 	updated_at TEXT NOT NULL
@@ -2061,7 +2057,11 @@ CREATE TABLE cleanup_obligations (
 	owner_job_id TEXT NOT NULL,
 	expected_path TEXT NOT NULL,
 	state TEXT NOT NULL CHECK(state IN ('pending', 'retryable', 'removed', 'quarantined')),
-	reason TEXT NOT NULL,
+	reason TEXT NOT NULL CHECK(reason IN (
+		'pending', 'removed', 'operator_reopened', 'terminal_cleanup_deferred',
+		'context_interrupted', 'job_lookup', 'runner_resolution', 'checkout_lock',
+		'identity_or_containment', 'unknown'
+	)),
 	attempt_count INTEGER NOT NULL DEFAULT 0 CHECK(attempt_count >= 0),
 	next_attempt_at TEXT NOT NULL,
 	last_error TEXT NOT NULL DEFAULT '',

--- a/internal/db/test_store_cache_test.go
+++ b/internal/db/test_store_cache_test.go
@@ -53,6 +53,7 @@ func TestStoreOpenPolicy(t *testing.T) {
 		"TestBackfillGhostSessionJobsHonorsDisabledAgePolicy":     true,
 		"TestBackfillGhostSessionJobsReusesReaperAndIsIdempotent": true,
 		"TestCanaryMigrationOnPreExistingDB":                      true,
+		"TestCleanupObligationsMigrationFreshAndUpgrade":          true,
 		"TestExecBackendAttemptsMigrationFreshAndCached":          true,
 		"TestExternallyDrivenColumnMigratesOnPreExistingDB":       true,
 		"TestIncrementalVacuumReclaimsOnlyRequestedPages":         true,

--- a/internal/workflow/cleanup_obligation_gate_test.go
+++ b/internal/workflow/cleanup_obligation_gate_test.go
@@ -1,0 +1,179 @@
+package workflow
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/gitmoot/gitmoot/internal/db"
+)
+
+func quarantineCleanupObligation(t *testing.T, store *db.Store, jobID, path string) {
+	t.Helper()
+	now := time.Now().UTC()
+	for attempt := 0; attempt < 3; attempt++ {
+		if _, err := store.RecordCleanupObligationFailure(context.Background(), jobID, path, db.CleanupReasonUnknown, errors.New("persistent failure"), now, now.Add(time.Minute), 3); err != nil {
+			t.Fatalf("quarantine cleanup obligation: %v", err)
+		}
+	}
+}
+
+// TestQuarantinedCleanupObligationBlocksEveryDirectActuator kills mutants that
+// discard prepareDelegationCleanupObligation's actuation decision in any direct
+// fix, read-only, or implement cleanup path.
+func TestQuarantinedCleanupObligationBlocksEveryDirectActuator(t *testing.T) {
+	t.Run("fix", func(t *testing.T) {
+		ctx := context.Background()
+		store := openEngineStore(t)
+		engine := testEngine(store)
+		engine.cleanupTargetValidator = nil
+		engine.Home = t.TempDir()
+		jobID := "fix-job"
+		path, err := FixWorktreePath(engine.Home, "owner/repo", jobID)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := os.MkdirAll(path, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		quarantineCleanupObligation(t, store, jobID, path)
+		payload := JobPayload{Repo: "owner/repo", WorktreePath: path, FixWorktree: true}
+		for range 3 {
+			if err := engine.cleanupFixWorktree(ctx, jobID, "implement", payload); err != nil {
+				t.Fatal(err)
+			}
+		}
+		if _, err := os.Stat(path); err != nil {
+			t.Fatalf("quarantined fix worktree was actuated: %v", err)
+		}
+	})
+
+	for _, tc := range []struct {
+		name    string
+		jobID   string
+		jobType string
+		payload func(home string) JobPayload
+		cleanup func(Engine, context.Context, string, string, JobPayload) error
+	}{
+		{
+			name: "read-only", jobID: "ask-job", jobType: "ask",
+			payload: func(home string) JobPayload {
+				path, _ := DelegationWorktreePath(home, "owner/repo", "ask-job", "readonly-seat", 0)
+				return JobPayload{Repo: "owner/repo", WorktreePath: path, ReadOnlyWorktree: true}
+			},
+			cleanup: func(engine Engine, ctx context.Context, jobID, jobType string, payload JobPayload) error {
+				return engine.cleanupReadOnlyDelegationWorktree(ctx, jobID, jobType, payload)
+			},
+		},
+		{
+			name: "implement", jobID: "parent/delegation/build", jobType: "implement",
+			payload: func(home string) JobPayload {
+				path, _ := DelegationWorktreePath(home, "owner/repo", "parent", "build", 0)
+				return JobPayload{Repo: "owner/repo", ParentJobID: "parent", DelegationID: "build", WorktreePath: path, Branch: "gitmoot-delegation-build"}
+			},
+			cleanup: func(engine Engine, ctx context.Context, jobID, jobType string, payload JobPayload) error {
+				return engine.cleanupImplementDelegationWorktree(ctx, jobID, jobType, payload)
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+			store := openEngineStore(t)
+			engine := testEngine(store)
+			engine.cleanupTargetValidator = nil
+			engine.Home = t.TempDir()
+			engine.DelegationCheckout = t.TempDir()
+			manager := &fakeWorktreeManager{existingBranches: map[string]bool{"gitmoot-delegation-build": true}}
+			engine.DelegationWorktrees = manager
+			payload := tc.payload(engine.Home)
+			if err := os.MkdirAll(payload.WorktreePath, 0o755); err != nil {
+				t.Fatal(err)
+			}
+			quarantineCleanupObligation(t, store, tc.jobID, payload.WorktreePath)
+			for range 3 {
+				if err := tc.cleanup(engine, ctx, tc.jobID, tc.jobType, payload); err != nil {
+					t.Fatal(err)
+				}
+			}
+			if len(manager.removedForce) != 0 || len(manager.deletedBranches) != 0 {
+				t.Fatalf("quarantined cleanup actuated: removed=%v branches=%v", manager.removedForce, manager.deletedBranches)
+			}
+		})
+	}
+}
+
+// TestAdvanceRetryDoesNotActuateQuarantinedCleanup kills the mutant that checks
+// quarantine only in daemon selectors while leaving AdvanceJob's deferred direct
+// cleanup active on every advancement retry.
+func TestAdvanceRetryDoesNotActuateQuarantinedCleanup(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	engine := testEngine(store)
+	engine.cleanupTargetValidator = nil
+	engine.Home = t.TempDir()
+	engine.DelegationCheckout = t.TempDir()
+	manager := &fakeWorktreeManager{}
+	engine.DelegationWorktrees = manager
+	jobID := "advance-retry-job"
+	path, err := DelegationWorktreePath(engine.Home, "owner/repo", jobID, "readonly-seat", 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(path, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	payload := JobPayload{
+		Repo: "owner/repo", WorktreePath: path, ReadOnlyWorktree: true,
+		Result: &AgentResult{Decision: "approved", Summary: "done"},
+	}
+	insertCompletedJob(t, store, db.Job{ID: jobID, Agent: "audit", Type: "ask"}, payload)
+	if err := store.AddJobEvent(ctx, db.JobEvent{JobID: jobID, Kind: "advance_retry", Message: "persistent advance failure"}); err != nil {
+		t.Fatal(err)
+	}
+	quarantineCleanupObligation(t, store, jobID, path)
+	for range 3 {
+		_ = engine.AdvanceJob(ctx, jobID)
+	}
+	if len(manager.removedForce) != 0 {
+		t.Fatalf("advance retry actuated quarantined cleanup %d times", len(manager.removedForce))
+	}
+}
+
+// TestCleanupTargetRejectsSymlinkEscapeAndIdentityMismatch kills two independent
+// mutants: replacing resolved containment with filepath.Rel, and accepting any
+// in-root path instead of a path derived from the owner identity.
+func TestCleanupTargetRejectsSymlinkEscapeAndIdentityMismatch(t *testing.T) {
+	home := t.TempDir()
+	root := filepath.Join(home, "worktrees", "owner--repo")
+	outside := t.TempDir()
+	if err := os.MkdirAll(root, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(outside, filepath.Join(root, "delegations")); err != nil {
+		t.Fatal(err)
+	}
+	path, err := DelegationWorktreePath(home, "owner/repo", "parent", "build", 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	payload := JobPayload{Repo: "owner/repo", ParentJobID: "parent", DelegationID: "build", WorktreePath: path, Branch: "branch"}
+	if err := ValidateDelegationCleanupTarget(home, "parent/delegation/build", "implement", payload); err == nil {
+		t.Fatal("symlinked ancestor escaping the managed root was accepted")
+	}
+
+	home = t.TempDir()
+	mismatched, err := DelegationWorktreePath(home, "other/repo", "parent", "build", 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(mismatched, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	payload.WorktreePath = mismatched
+	if err := ValidateDelegationCleanupTarget(home, "parent/delegation/build", "implement", payload); err == nil {
+		t.Fatal("path inconsistent with the payload repo identity was accepted")
+	}
+}

--- a/internal/workflow/engine.go
+++ b/internal/workflow/engine.go
@@ -140,9 +140,10 @@ type Engine struct {
 	// performs the worktree-add. Both are optional: when either is unset, the
 	// dispatcher enqueues implement delegations against the shared checkout
 	// (legacy behavior) rather than allocating isolated worktrees.
-	Home                string
-	DelegationWorktrees WorktreeManager
-	DelegationCheckout  string
+	Home                   string
+	DelegationWorktrees    WorktreeManager
+	DelegationCheckout     string
+	cleanupTargetValidator func(home, jobID, jobType string, payload JobPayload) error
 	// BeforeReadOnlyWorktreeCleanup is an optional terminal hook invoked after a
 	// read-only job has settled but before its detached worktree is force-removed.
 	// It lets the CLI durably collect service-stage outputs and worktree diffs

--- a/internal/workflow/engine_run_budgets.go
+++ b/internal/workflow/engine_run_budgets.go
@@ -5,6 +5,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"sort"
@@ -204,7 +205,9 @@ func (e Engine) AdvanceJob(ctx context.Context, jobID string) (retErr error) {
 	// it once the child is terminal. Deferred so it fires on every return path
 	// below (the delegation DAG early-returns for policy-handled failures and
 	// pending retries). No-op for jobs that did not allocate a read-only worktree.
-	defer e.cleanupReadOnlyDelegationWorktree(ctx, jobID, job.Type, payload)
+	defer func() {
+		retErr = errors.Join(retErr, e.cleanupReadOnlyDelegationWorktree(ctx, jobID, job.Type, payload))
+	}()
 	// A review fix owns an independent writable clone, not a linked delegation
 	// worktree. Remove only that clone after SUCCESSFUL advancement; a finalizer or
 	// store error can leave the clone holding the only committed fix, and the daemon
@@ -212,7 +215,7 @@ func (e Engine) AdvanceJob(ctx context.Context, jobID string) (retErr error) {
 	// never deleted or unlocked by this cleanup.
 	defer func() {
 		if retErr == nil {
-			e.cleanupFixWorktree(ctx, jobID, job.Type, payload)
+			retErr = e.cleanupFixWorktree(ctx, jobID, job.Type, payload)
 		}
 	}()
 
@@ -221,7 +224,9 @@ func (e Engine) AdvanceJob(ctx context.Context, jobID string) (retErr error) {
 	// do not accumulate in the shared checkout and mislead a later coordinator (#478).
 	// No-op for non-implement / non-delegation jobs and (idempotently) for already
 	// cleaned ones. Skips succeeded legs still feeding a pending integration (#332).
-	defer e.cleanupImplementDelegationWorktree(ctx, jobID, job.Type, payload)
+	defer func() {
+		retErr = errors.Join(retErr, e.cleanupImplementDelegationWorktree(ctx, jobID, job.Type, payload))
+	}()
 
 	// When an integration step (#332) that consumed implement legs via its Deps
 	// reaches a terminal state, tear down those consumed legs' worktrees+branches:
@@ -229,7 +234,9 @@ func (e Engine) AdvanceJob(ctx context.Context, jobID string) (retErr error) {
 	// still pending/running, and nothing else ever reclaims an integration-fed leg
 	// (the merge gate cleans only the task worktree), so they would otherwise
 	// accumulate forever (#478). No-op for a job with no parent/deps.
-	defer e.cleanupConsumedImplementLegWorktrees(ctx, payload)
+	defer func() {
+		retErr = errors.Join(retErr, e.cleanupConsumedImplementLegWorktrees(ctx, payload))
+	}()
 
 	// Commit a succeeded implement leg's work to its own branch BEFORE advancing
 	// the parent's delegation DAG. The parent advance below may enqueue a dependent

--- a/internal/workflow/engine_test.go
+++ b/internal/workflow/engine_test.go
@@ -2364,6 +2364,12 @@ func testEngine(store *db.Store) Engine {
 		// on the host running the suite. Tests exercising the lease-expiry-boundary
 		// gate (finding 1) override this explicitly.
 		WorktreeHasLiveProcess: func(string) bool { return false },
+		// Most cleanup behavior tests predate deterministic-path identity and use
+		// compact synthetic payloads. Keep those tests focused on their original
+		// axis; identity/containment tests clear this seam and exercise production.
+		cleanupTargetValidator: func(home, _, _ string, payload JobPayload) error {
+			return cleanupPathContained(filepath.Join(home, "worktrees"), payload.WorktreePath)
+		},
 	}
 }
 

--- a/internal/workflow/engine_test.go
+++ b/internal/workflow/engine_test.go
@@ -2367,6 +2367,18 @@ func testEngine(store *db.Store) Engine {
 	}
 }
 
+func managedEngineWorktree(t *testing.T, engine *Engine, name string) string {
+	t.Helper()
+	if strings.TrimSpace(engine.Home) == "" {
+		engine.Home = t.TempDir()
+	}
+	path := filepath.Join(engine.Home, "worktrees", name)
+	if err := os.MkdirAll(path, 0o755); err != nil {
+		t.Fatalf("create managed worktree %q: %v", path, err)
+	}
+	return path
+}
+
 func seedAgent(t *testing.T, store *db.Store, name string, capabilities []string, repo string) {
 	t.Helper()
 	// Implement-capable agents need a write policy or the fail-closed dispatch

--- a/internal/workflow/implement_worktree_cleanup_test.go
+++ b/internal/workflow/implement_worktree_cleanup_test.go
@@ -97,7 +97,7 @@ func TestCleanupImplementDelegationWorktreeRemovesWorktreeAndBranch(t *testing.T
 	engine.DelegationWorktrees = manager
 
 	// The worktree path must exist on disk so the idempotency stat check proceeds.
-	wt := t.TempDir()
+	wt := managedEngineWorktree(t, &engine, "job-1")
 	payload := JobPayload{
 		DelegationID: "d1",
 		WorktreePath: wt,
@@ -156,7 +156,7 @@ func TestCleanupImplementDelegationWorktreePreservesWhileConsumerLive(t *testing
 	legPayload := JobPayload{
 		ParentJobID:  "parent-job",
 		DelegationID: "produce",
-		WorktreePath: t.TempDir(),
+		WorktreePath: managedEngineWorktree(t, &engine, "parent-produce"),
 		Branch:       branch,
 		Result:       &AgentResult{Decision: "implemented"},
 	}
@@ -222,7 +222,7 @@ func TestCleanupConsumedImplementLegWorktreesAfterIntegrationTerminal(t *testing
 		},
 	})
 
-	legWt := t.TempDir()
+	legWt := managedEngineWorktree(t, &engine, "parent-produce")
 	insertCompletedJob(t, store, db.Job{
 		ID: "parent-job/delegation/produce", Agent: "producer", Type: "implement",
 		ParentJobID: "parent-job", DelegationID: "produce",
@@ -268,7 +268,7 @@ func TestAdvanceJobTerminalImplementLegFiresCleanup(t *testing.T) {
 		manager := &fakeWorktreeManager{existingBranches: map[string]bool{branch: true}}
 		engine.DelegationWorktrees = manager
 
-		wt := t.TempDir()
+		wt := managedEngineWorktree(t, &engine, "leg-impl")
 		insertCompletedJob(t, store, db.Job{ID: "leg-impl", Agent: "producer", Type: "implement", DelegationID: "d1"}, JobPayload{
 			DelegationID: "d1", WorktreePath: wt, Branch: branch,
 			Result: &AgentResult{Decision: "implemented", Summary: "done"},
@@ -293,7 +293,7 @@ func TestAdvanceJobTerminalImplementLegFiresCleanup(t *testing.T) {
 		manager := &fakeWorktreeManager{existingBranches: map[string]bool{branch: true}}
 		engine.DelegationWorktrees = manager
 
-		wt := t.TempDir()
+		wt := managedEngineWorktree(t, &engine, "leg-fail")
 		insertCompletedJob(t, store, db.Job{ID: "leg-fail", Agent: "producer", Type: "implement", DelegationID: "d2"}, JobPayload{
 			DelegationID: "d2", WorktreePath: wt, Branch: branch,
 			Result: &AgentResult{Decision: "failed", Summary: "boom"},
@@ -364,7 +364,7 @@ func TestAdvanceJobTerminalImplementLegCleansWhileSelfHoldsLock(t *testing.T) {
 		store := openEngineStore(t)
 		branch := "gitmoot-delegation-x-self"
 		engine, manager := newEngine(t, store, branch)
-		wt := t.TempDir()
+		wt := managedEngineWorktree(t, &engine, "leg-self")
 		jobID := "leg-self"
 		insertCompletedJob(t, store, db.Job{ID: jobID, Agent: "producer", Type: "implement", DelegationID: "d1"}, JobPayload{
 			DelegationID: "d1", WorktreePath: wt, Branch: branch,
@@ -393,7 +393,7 @@ func TestAdvanceJobTerminalImplementLegCleansWhileSelfHoldsLock(t *testing.T) {
 		store := openEngineStore(t)
 		branch := "gitmoot-delegation-x-foreign"
 		engine, manager := newEngine(t, store, branch)
-		wt := t.TempDir()
+		wt := managedEngineWorktree(t, &engine, "leg-foreign")
 		jobID := "leg-foreign"
 		insertCompletedJob(t, store, db.Job{ID: jobID, Agent: "producer", Type: "implement", DelegationID: "d2"}, JobPayload{
 			DelegationID: "d2", WorktreePath: wt, Branch: branch,
@@ -440,7 +440,7 @@ func TestCleanupImplementDelegationWorktreeSkipsIntegrationDep(t *testing.T) {
 		},
 	})
 
-	wt := t.TempDir()
+	wt := managedEngineWorktree(t, &engine, "parent-d1")
 	payload := JobPayload{
 		ParentJobID:  "parent-job",
 		DelegationID: "d1",
@@ -490,7 +490,7 @@ func TestCleanupImplementDelegationWorktreeRefusesWhileRuntimeOwnerActive(t *tes
 			engine.DelegationCheckout = t.TempDir()
 			engine.DelegationWorktrees = manager
 
-			wt := t.TempDir()
+			wt := managedEngineWorktree(t, &engine, "runtime-owner")
 			// Decision "failed" mirrors the bug: the recovered copy fails on the dirty
 			// checkout. Failed legs are always merge-safe, so the merge guard does not
 			// short-circuit and the liveness guard is exercised.
@@ -569,7 +569,7 @@ func TestCleanupImplementDelegationWorktreeLeaseExpiryBoundary(t *testing.T) {
 			engine.DelegationCheckout = t.TempDir()
 			engine.DelegationWorktrees = manager
 
-			wt := t.TempDir()
+			wt := managedEngineWorktree(t, &engine, "lease-boundary")
 			jobID := "parent-job/delegation/task-7302"
 			payload := JobPayload{DelegationID: "d1", WorktreePath: wt, Branch: branch, Result: &AgentResult{Decision: "failed"}}
 			engine.cleanupImplementDelegationWorktree(ctx, jobID, "implement", payload)
@@ -611,7 +611,7 @@ func TestCleanupImplementDelegationWorktreeSkipIsIdempotent(t *testing.T) {
 	engine.DelegationCheckout = t.TempDir()
 	engine.DelegationWorktrees = manager
 
-	wt := t.TempDir()
+	wt := managedEngineWorktree(t, &engine, "task-idem")
 	jobID := "parent-job/delegation/task-idem"
 	payload := JobPayload{DelegationID: "d1", WorktreePath: wt, Branch: branch, Result: &AgentResult{Decision: "failed"}}
 
@@ -647,7 +647,7 @@ func TestCleanupImplementDelegationWorktreeNoBranchDeleter(t *testing.T) {
 	engine.DelegationCheckout = t.TempDir()
 	engine.DelegationWorktrees = manager
 
-	wt := t.TempDir()
+	wt := managedEngineWorktree(t, &engine, "no-deleter")
 	payload := JobPayload{DelegationID: "d1", WorktreePath: wt, Branch: "gitmoot-delegation-x-d1", Result: &AgentResult{Decision: "implemented"}}
 	engine.cleanupImplementDelegationWorktree(ctx, "job-1", "implement", payload)
 
@@ -686,7 +686,7 @@ func TestCleanupImplementDelegationWorktreeNoChecker(t *testing.T) {
 	engine.DelegationWorktrees = manager
 
 	branch := "gitmoot-delegation-x-d1"
-	wt := t.TempDir()
+	wt := managedEngineWorktree(t, &engine, "no-checker")
 	payload := JobPayload{DelegationID: "d1", WorktreePath: wt, Branch: branch, Result: &AgentResult{Decision: "implemented"}}
 	engine.cleanupImplementDelegationWorktree(ctx, "job-1", "implement", payload)
 	if len(manager.removed) != 1 || len(manager.deleted) != 1 {

--- a/internal/workflow/mailbox.go
+++ b/internal/workflow/mailbox.go
@@ -639,6 +639,8 @@ func (m Mailbox) Enqueue(ctx context.Context, request JobRequest) (db.Job, error
 		}
 	}
 
+	// Cleanup selectors compare WorktreePath textually with the allocator-derived
+	// obligation path, so managed allocators must preserve their canonical path.
 	payload, err := marshalPayload(JobPayload{
 		Repo:                   request.Repo,
 		Branch:                 request.Branch,

--- a/internal/workflow/readonly_worktree_test.go
+++ b/internal/workflow/readonly_worktree_test.go
@@ -97,7 +97,7 @@ func TestCleanupDisposesTopLevelReadOnlyWorktree(t *testing.T) {
 	engine.DelegationCheckout = t.TempDir()
 	engine.DelegationWorktrees = manager
 
-	wt := t.TempDir()
+	wt := managedEngineWorktree(t, &engine, "local-ask-seat")
 	hookCalled := false
 	engine.BeforeReadOnlyWorktreeCleanup = func(_ context.Context, jobID, jobType string, payload JobPayload) error {
 		hookCalled = true
@@ -137,7 +137,7 @@ func TestReadOnlyPrecleanupFailureEventRedactsHookError(t *testing.T) {
 	engine.DelegationWorktrees = manager
 
 	const secret = "ghp_abcdefghijklmnopqrstuvwxyz0123456789"
-	wt := t.TempDir()
+	wt := managedEngineWorktree(t, &engine, "secret-capture-error")
 	engine.BeforeReadOnlyWorktreeCleanup = func(context.Context, string, string, JobPayload) error {
 		return errors.New("hostile helper failed with token=" + secret)
 	}
@@ -179,7 +179,7 @@ func TestReclaimReadOnlyWorktree(t *testing.T) {
 	engine.DelegationWorktrees = manager
 
 	// A terminal top-level read-only ask job whose worktree still exists on disk.
-	roWT := t.TempDir()
+	roWT := managedEngineWorktree(t, &engine, "local-ask-seat")
 	roPayload, err := json.Marshal(JobPayload{WorktreePath: roWT, ReadOnlyWorktree: true})
 	if err != nil {
 		t.Fatalf("marshal read-only payload: %v", err)
@@ -196,7 +196,7 @@ func TestReclaimReadOnlyWorktree(t *testing.T) {
 
 	// An implement delegation worktree is still reclaimed by the same path.
 	manager.removedForce = nil
-	implWT := t.TempDir()
+	implWT := managedEngineWorktree(t, &engine, "parent-delegation-d1")
 	implPayload, err := json.Marshal(JobPayload{DelegationID: "d1", WorktreePath: implWT, Branch: "gitmoot-delegation-d1"})
 	if err != nil {
 		t.Fatalf("marshal implement payload: %v", err)
@@ -295,7 +295,7 @@ func TestCleanupReadOnlyDelegationWorktreeForceRemoves(t *testing.T) {
 	engine.DelegationWorktrees = manager
 
 	// The worktree path must exist on disk; cleanup skips an already-gone path.
-	wt := t.TempDir()
+	wt := managedEngineWorktree(t, &engine, "job-1-delegation-d1")
 	payload := JobPayload{DelegationID: "d1", WorktreePath: wt}
 	engine.cleanupReadOnlyDelegationWorktree(ctx, "job-1/delegation/d1", "ask", payload)
 	if len(manager.removedForce) != 1 || manager.removedForce[0] != wt {
@@ -341,7 +341,7 @@ func TestReadOnlyCleanupFailureIsReclaimable(t *testing.T) {
 	manager := &fakeWorktreeManager{removeErr: errors.New("worktree busy")}
 	engine.DelegationWorktrees = manager
 
-	wt := t.TempDir()
+	wt := managedEngineWorktree(t, &engine, "local-ask-seat")
 	payload := JobPayload{WorktreePath: wt, ReadOnlyWorktree: true}
 	engine.cleanupReadOnlyDelegationWorktree(ctx, "local-ask-seat", "ask", payload)
 
@@ -353,6 +353,13 @@ func TestReadOnlyCleanupFailureIsReclaimable(t *testing.T) {
 	}
 	if !engine.lastCleanupOutcomeIsSkip(ctx, "local-ask-seat") {
 		t.Fatal("latest cleanup outcome must be a skip so reclaimSkippedDelegationWorktrees re-fires it")
+	}
+	obligation, err := store.GetCleanupObligation(ctx, db.CleanupObligationResourceID("local-ask-seat", wt))
+	if err != nil {
+		t.Fatalf("GetCleanupObligation: %v", err)
+	}
+	if obligation.State != db.CleanupObligationRetryable || obligation.Reason != db.CleanupReasonUnknown || obligation.AttemptCount != 0 {
+		t.Fatalf("initial cleanup failure obligation = %+v", obligation)
 	}
 
 	// Deduped: a second failing pass must not grow the event log without bound.

--- a/internal/workflow/worktree.go
+++ b/internal/workflow/worktree.go
@@ -721,39 +721,92 @@ func isFixWorktree(jobType string, payload JobPayload) bool {
 		strings.TrimSpace(payload.WorktreePath) != ""
 }
 
+func (e Engine) prepareDelegationCleanupObligation(ctx context.Context, jobID, path string) error {
+	path = filepath.Clean(strings.TrimSpace(path))
+	home := filepath.Clean(strings.TrimSpace(e.Home))
+	if path == "." || path == "" {
+		return errors.New("cleanup path is unavailable")
+	}
+	if _, err := e.Store.EnsureCleanupObligation(context.WithoutCancel(ctx), jobID, path, time.Now().UTC()); err != nil {
+		return err
+	}
+	if !filepath.IsAbs(path) {
+		err := fmt.Errorf("cleanup path %q is not absolute", path)
+		e.deferDelegationCleanupFailure(ctx, jobID, path, "identity", err)
+		return err
+	}
+	if home == "." || home == "" {
+		err := errors.New("cleanup worktree home is unavailable")
+		e.deferDelegationCleanupFailure(ctx, jobID, path, "identity", err)
+		return err
+	}
+	root := filepath.Join(home, "worktrees")
+	rel, err := filepath.Rel(root, path)
+	if err != nil || rel == "." || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) || filepath.IsAbs(rel) {
+		err := fmt.Errorf("cleanup path %q is outside managed root %q", path, root)
+		e.deferDelegationCleanupFailure(ctx, jobID, path, "identity", err)
+		return err
+	}
+	return nil
+}
+
+func (e Engine) deferDelegationCleanupObligation(ctx context.Context, jobID, path string, reason db.CleanupObligationReason) {
+	now := time.Now().UTC()
+	_, _ = e.Store.DeferCleanupObligation(context.WithoutCancel(ctx), jobID, path, reason, now, now.Add(time.Minute))
+}
+
+func (e Engine) deferDelegationCleanupFailure(ctx context.Context, jobID, path, phase string, err error) {
+	e.deferDelegationCleanupObligation(ctx, jobID, path, db.ClassifyCleanupObligationFailure(phase, err))
+}
+
+func (e Engine) markDelegationCleanupRemoved(ctx context.Context, jobID, path string) {
+	_, _ = e.Store.MarkCleanupObligationRemoved(context.WithoutCancel(ctx), jobID, path, time.Now().UTC())
+}
+
 // cleanupFixWorktree removes an engine-dispatched review fix's independent
 // writable clone. It deliberately does not use RemoveWorktreeForce, delete the
 // payload branch, or release its task branch lock: the clone has its own .git and
 // payload.Branch is the real lane branch that the finalizer just pushed.
-func (e Engine) cleanupFixWorktree(ctx context.Context, jobID string, jobType string, payload JobPayload) {
+func (e Engine) cleanupFixWorktree(ctx context.Context, jobID string, jobType string, payload JobPayload) error {
 	if !isFixWorktree(jobType, payload) {
-		return
+		return nil
 	}
 	if strings.TrimSpace(e.Home) == "" {
-		return
+		return nil
+	}
+	path := strings.TrimSpace(payload.WorktreePath)
+	if err := e.prepareDelegationCleanupObligation(ctx, jobID, path); err != nil {
+		return err
 	}
 	if skip, reason := e.cleanupBlockedByLiveOwner(ctx, jobID, payload); skip {
+		e.deferDelegationCleanupObligation(ctx, jobID, path, db.CleanupReasonTerminalDeferred)
 		e.recordCleanupSkippedOnce(ctx, jobID, payload, reason)
-		return
+		return nil
 	}
 	opCtx := context.WithoutCancel(ctx)
-	path := strings.TrimSpace(payload.WorktreePath)
 	expected, err := FixWorktreePath(e.Home, payload.Repo, jobID)
 	if err != nil || filepath.Clean(path) != filepath.Clean(expected) {
+		cleanupErr := fmt.Errorf("refusing unmanaged fix worktree cleanup %s", path)
+		e.deferDelegationCleanupFailure(opCtx, jobID, path, "identity", cleanupErr)
 		e.recordCleanupSkippedOnce(opCtx, jobID, payload, "path is not the job's managed fix-worktree path")
-		return
+		return cleanupErr
 	}
 	if _, statErr := os.Stat(path); os.IsNotExist(statErr) {
-		return
+		e.markDelegationCleanupRemoved(opCtx, jobID, path)
+		return nil
 	} else if statErr != nil {
+		e.deferDelegationCleanupFailure(opCtx, jobID, path, "reclaim", statErr)
 		e.recordCleanupSkippedOnce(opCtx, jobID, payload, fmt.Sprintf("inspect failed: %v", statErr))
-		return
+		return fmt.Errorf("inspect fix worktree %s: %w", path, statErr)
 	}
 	if err := os.RemoveAll(path); err != nil {
+		e.deferDelegationCleanupFailure(opCtx, jobID, path, "reclaim", err)
 		e.recordCleanupSkippedOnce(opCtx, jobID, payload, fmt.Sprintf("remove failed: %v", err))
-		return
+		return fmt.Errorf("remove fix worktree %s: %w", path, err)
 	}
 	_ = e.Store.AddJobEvent(opCtx, db.JobEvent{JobID: jobID, Kind: "delegation_worktree_removed", Message: fmt.Sprintf("fix worktree %s removed", path)})
+	e.markDelegationCleanupRemoved(opCtx, jobID, path)
+	return nil
 }
 
 // cleanupReadOnlyDelegationWorktree disposes the detached worktree allocated for
@@ -761,13 +814,9 @@ func (e Engine) cleanupFixWorktree(ctx context.Context, jobID string, jobType st
 // and idempotent: a missing worktree (already removed on a prior advance, or
 // never allocated) is logged, not fatal. Removal mutates the shared .git, so it
 // holds the checkout mutation lock like allocation does.
-func (e Engine) cleanupReadOnlyDelegationWorktree(ctx context.Context, jobID string, jobType string, payload JobPayload) {
+func (e Engine) cleanupReadOnlyDelegationWorktree(ctx context.Context, jobID string, jobType string, payload JobPayload) error {
 	if !isReadOnlyDelegationWorktree(jobType, payload) {
-		return
-	}
-	manager, ok := e.DelegationWorktrees.(ReadOnlyWorktreeManager)
-	if !ok || manager == nil {
-		return
+		return nil
 	}
 	// Detach from the caller's cancellation: this runs on the child's terminal
 	// AdvanceJob, which may carry a job context already cancelled by a run timeout.
@@ -775,11 +824,26 @@ func (e Engine) cleanupReadOnlyDelegationWorktree(ctx context.Context, jobID str
 	// deadline/cancel.
 	opCtx := context.WithoutCancel(ctx)
 	path := strings.TrimSpace(payload.WorktreePath)
+	if err := e.prepareDelegationCleanupObligation(opCtx, jobID, path); err != nil {
+		return err
+	}
+	manager, ok := e.DelegationWorktrees.(ReadOnlyWorktreeManager)
+	if !ok || manager == nil {
+		cleanupErr := errors.New("delegation worktree manager cannot force-remove worktrees")
+		e.deferDelegationCleanupFailure(opCtx, jobID, path, "reclaim", cleanupErr)
+		e.recordReadOnlyCleanupSkippedOnce(opCtx, jobID, path, "delegation worktree manager is unavailable")
+		return cleanupErr
+	}
 	// Idempotent: AdvanceJob can run more than once for a job (re-advance / retry
 	// passes). If the worktree directory is already gone, do not re-lock or emit a
 	// spurious cleanup-failed event.
 	if _, statErr := os.Stat(path); os.IsNotExist(statErr) {
-		return
+		e.markDelegationCleanupRemoved(opCtx, jobID, path)
+		return nil
+	} else if statErr != nil {
+		e.deferDelegationCleanupFailure(opCtx, jobID, path, "reclaim", statErr)
+		e.recordReadOnlyCleanupSkippedOnce(opCtx, jobID, path, fmt.Sprintf("inspect failed: %v", statErr))
+		return fmt.Errorf("inspect read-only worktree %s: %w", path, statErr)
 	}
 	if e.BeforeReadOnlyWorktreeCleanup != nil {
 		if err := e.BeforeReadOnlyWorktreeCleanup(opCtx, jobID, jobType, payload); err != nil {
@@ -791,6 +855,7 @@ func (e Engine) cleanupReadOnlyDelegationWorktree(ctx context.Context, jobID str
 	}
 	releaseCheckoutLock, _, err := acquireCheckoutMutationLockWithWait(opCtx, e.Store, e.DelegationCheckout, "worktree-cleanup:"+jobID, time.Now().UTC())
 	if err != nil {
+		e.deferDelegationCleanupFailure(opCtx, jobID, path, "lock", err)
 		// A transient failure (lock contention) must NOT be terminal: emit the same
 		// reclaim marker the daemon's reclaimSkippedDelegationWorktrees pass keys on,
 		// so ReclaimTerminalDelegationWorktree re-fires this cleanup on a later tick
@@ -798,7 +863,7 @@ func (e Engine) cleanupReadOnlyDelegationWorktree(ctx context.Context, jobID str
 		// is never re-selected by any pass (it is not the latest advance marker, and
 		// the reclaim SQL only picks _skipped), so it would leak permanently (#739 review).
 		e.recordReadOnlyCleanupSkippedOnce(opCtx, jobID, path, fmt.Sprintf("could not lock checkout: %v", err))
-		return
+		return fmt.Errorf("lock checkout for read-only worktree cleanup: %w", err)
 	}
 	defer func() {
 		if releaseCheckoutLock != nil {
@@ -806,10 +871,13 @@ func (e Engine) cleanupReadOnlyDelegationWorktree(ctx context.Context, jobID str
 		}
 	}()
 	if err := manager.RemoveWorktreeForce(opCtx, path); err != nil {
+		e.deferDelegationCleanupFailure(opCtx, jobID, path, "reclaim", err)
 		e.recordReadOnlyCleanupSkippedOnce(opCtx, jobID, path, fmt.Sprintf("force-remove failed: %v", err))
-		return
+		return fmt.Errorf("force-remove read-only worktree %s: %w", path, err)
 	}
 	_ = e.Store.AddJobEvent(opCtx, db.JobEvent{JobID: jobID, Kind: "delegation_worktree_removed", Message: fmt.Sprintf("read-only worktree %s removed", path)})
+	e.markDelegationCleanupRemoved(opCtx, jobID, path)
+	return nil
 }
 
 // isImplementDelegationWorktree reports whether a job ran in a per-delegation
@@ -859,9 +927,9 @@ func releaseDelegationBranchLock(ctx context.Context, store *db.Store, jobType s
 // and branch deletion mutate the shared .git, so it holds the checkout mutation
 // lock like allocation does. The worktree is removed FIRST so the branch is no
 // longer checked out, then `git branch -D` can succeed.
-func (e Engine) cleanupImplementDelegationWorktree(ctx context.Context, jobID string, jobType string, payload JobPayload) {
+func (e Engine) cleanupImplementDelegationWorktree(ctx context.Context, jobID string, jobType string, payload JobPayload) error {
 	if !isImplementDelegationWorktree(jobType, payload) {
-		return
+		return nil
 	}
 	// #332 guard: a succeeded implement leg's branch is merged into a dependent
 	// integration worktree. Do
@@ -870,7 +938,11 @@ func (e Engine) cleanupImplementDelegationWorktree(ctx context.Context, jobID st
 	// merged, so they are always safe to clean.
 	if payload.Result != nil && payload.Result.Decision == "implemented" &&
 		e.implementLegBranchMayBeMerged(ctx, payload) {
-		return
+		return nil
+	}
+	path := strings.TrimSpace(payload.WorktreePath)
+	if err := e.prepareDelegationCleanupObligation(ctx, jobID, path); err != nil {
+		return err
 	}
 	// Liveness gate (#536): NEVER force-remove a worktree (and delete its branch)
 	// while a live runtime worker could still be writing to it — even past lease
@@ -895,8 +967,9 @@ func (e Engine) cleanupImplementDelegationWorktree(ctx context.Context, jobID st
 	// later tick; once the foreign lease expires AND no live process holds the
 	// worktree (the worker has actually exited), it is reclaimed rather than leaked.
 	if skip, reason := e.cleanupBlockedByLiveOwner(ctx, jobID, payload); skip {
+		e.deferDelegationCleanupObligation(ctx, jobID, path, db.CleanupReasonTerminalDeferred)
 		e.recordCleanupSkippedOnce(ctx, jobID, payload, reason)
-		return
+		return nil
 	}
 	// Detach from the caller's cancellation: this runs on the child's terminal
 	// AdvanceJob, which may carry a job context already cancelled by a run timeout.
@@ -923,11 +996,13 @@ func (e Engine) cleanupImplementDelegationWorktree(ctx context.Context, jobID st
 	}
 	manager, ok := e.DelegationWorktrees.(ReadOnlyWorktreeManager) // RemoveWorktreeForce
 	if !ok || manager == nil {
-		return
+		cleanupErr := errors.New("delegation worktree manager cannot force-remove worktrees")
+		e.deferDelegationCleanupFailure(opCtx, jobID, path, "reclaim", cleanupErr)
+		e.recordCleanupSkippedOnce(opCtx, jobID, payload, "delegation worktree manager is unavailable")
+		return cleanupErr
 	}
 	deleter, _ := e.DelegationWorktrees.(BranchDeleter)
 	checker, _ := e.DelegationWorktrees.(BranchExistenceChecker)
-	path := strings.TrimSpace(payload.WorktreePath)
 	// Idempotency: short-circuit (no lock, no spurious event) once there is nothing
 	// left to do. The pending work is (a) removing the worktree if it still exists
 	// and (b) deleting the branch if a BranchDeleter is wired and the branch is not
@@ -946,12 +1021,14 @@ func (e Engine) cleanupImplementDelegationWorktree(ctx context.Context, jobID st
 	}
 	branchCleanupPending := deleter != nil && checker != nil && !branchKnownGone
 	if worktreeGone && !branchCleanupPending {
-		return
+		e.markDelegationCleanupRemoved(opCtx, jobID, path)
+		return nil
 	}
 	releaseCheckoutLock, _, err := acquireCheckoutMutationLockWithWait(opCtx, e.Store, e.DelegationCheckout, "worktree-cleanup:"+jobID, time.Now().UTC())
 	if err != nil {
+		e.deferDelegationCleanupFailure(opCtx, jobID, path, "lock", err)
 		_ = e.Store.AddJobEvent(opCtx, db.JobEvent{JobID: jobID, Kind: "delegation_worktree_cleanup_failed", Message: fmt.Sprintf("implement worktree %s cleanup could not lock checkout: %v", path, err)})
-		return
+		return fmt.Errorf("lock checkout for implement worktree cleanup: %w", err)
 	}
 	defer func() {
 		if releaseCheckoutLock != nil {
@@ -960,15 +1037,17 @@ func (e Engine) cleanupImplementDelegationWorktree(ctx context.Context, jobID st
 	}()
 	if !worktreeGone {
 		if err := manager.RemoveWorktreeForce(opCtx, path); err != nil {
+			e.deferDelegationCleanupFailure(opCtx, jobID, path, "reclaim", err)
 			_ = e.Store.AddJobEvent(opCtx, db.JobEvent{JobID: jobID, Kind: "delegation_worktree_cleanup_failed", Message: fmt.Sprintf("implement worktree %s force-remove failed: %v", path, err)})
-			return
+			return fmt.Errorf("force-remove implement worktree %s: %w", path, err)
 		}
 	}
 	branchDeleted := false
 	if deleter != nil && !branchKnownGone {
 		if err := deleter.DeleteBranch(opCtx, branch); err != nil {
+			e.deferDelegationCleanupFailure(opCtx, jobID, path, "reclaim", err)
 			_ = e.Store.AddJobEvent(opCtx, db.JobEvent{JobID: jobID, Kind: "delegation_worktree_cleanup_failed", Message: fmt.Sprintf("implement branch %s delete failed: %v", branch, err)})
-			return
+			return fmt.Errorf("delete implement worktree branch %s: %w", branch, err)
 		}
 		branchDeleted = true
 	}
@@ -980,6 +1059,8 @@ func (e Engine) cleanupImplementDelegationWorktree(ctx context.Context, jobID st
 		message = fmt.Sprintf("implement worktree %s and branch %s removed", path, branch)
 	}
 	_ = e.Store.AddJobEvent(opCtx, db.JobEvent{JobID: jobID, Kind: "delegation_worktree_removed", Message: message})
+	e.markDelegationCleanupRemoved(opCtx, jobID, path)
+	return nil
 }
 
 // cleanupBlockedByLiveOwner reports whether the destructive implement-delegation
@@ -1091,9 +1172,19 @@ func (e Engine) ReclaimTerminalDelegationWorktreeOutcome(ctx context.Context, jo
 	if err != nil {
 		return false, err
 	}
-	e.cleanupImplementDelegationWorktree(ctx, jobID, job.Type, payload)
-	e.cleanupReadOnlyDelegationWorktree(ctx, jobID, job.Type, payload)
-	e.cleanupFixWorktree(ctx, jobID, job.Type, payload)
+	var cleanupErr error
+	for _, err := range []error{
+		e.cleanupImplementDelegationWorktree(ctx, jobID, job.Type, payload),
+		e.cleanupReadOnlyDelegationWorktree(ctx, jobID, job.Type, payload),
+		e.cleanupFixWorktree(ctx, jobID, job.Type, payload),
+	} {
+		if cleanupErr == nil && err != nil {
+			cleanupErr = err
+		}
+	}
+	if cleanupErr != nil {
+		return false, cleanupErr
+	}
 	outcome, err := e.Store.LatestDelegationWorktreeCleanupOutcome(context.WithoutCancel(ctx), jobID)
 	if err != nil {
 		return false, err
@@ -1165,6 +1256,9 @@ func (e Engine) ReclaimAgedTerminalDelegationWorktreeOutcome(ctx context.Context
 		}
 	}
 	path := strings.TrimSpace(payload.WorktreePath)
+	if err := e.prepareDelegationCleanupObligation(ctx, jobID, path); err != nil {
+		return false, err
+	}
 	if fix {
 		expected, err := FixWorktreePath(e.Home, payload.Repo, jobID)
 		if err != nil || filepath.Clean(path) != filepath.Clean(expected) {
@@ -1177,6 +1271,9 @@ func (e Engine) ReclaimAgedTerminalDelegationWorktreeOutcome(ctx context.Context
 			JobID: jobID, Kind: "delegation_worktree_reclaimed_ttl",
 			Message: fmt.Sprintf("aged terminal fix worktree %s removed after TTL", path),
 		})
+		if err == nil {
+			e.markDelegationCleanupRemoved(ctx, jobID, path)
+		}
 		return err == nil, err
 	}
 	manager, ok := e.DelegationWorktrees.(ReadOnlyWorktreeManager)
@@ -1233,6 +1330,9 @@ func (e Engine) ReclaimAgedTerminalDelegationWorktreeOutcome(ctx context.Context
 		JobID: jobID, Kind: "delegation_worktree_reclaimed_ttl",
 		Message: fmt.Sprintf("aged terminal delegation worktree %s force-removed after TTL", path),
 	})
+	if err == nil {
+		e.markDelegationCleanupRemoved(opCtx, jobID, path)
+	}
 	return err == nil, err
 }
 

--- a/internal/workflow/worktree.go
+++ b/internal/workflow/worktree.go
@@ -721,46 +721,171 @@ func isFixWorktree(jobType string, payload JobPayload) bool {
 		strings.TrimSpace(payload.WorktreePath) != ""
 }
 
-func (e Engine) prepareDelegationCleanupObligation(ctx context.Context, jobID, path string) error {
-	path = filepath.Clean(strings.TrimSpace(path))
+func (e Engine) prepareDelegationCleanupObligation(ctx context.Context, jobID, jobType string, payload JobPayload) (bool, error) {
+	path := filepath.Clean(strings.TrimSpace(payload.WorktreePath))
 	home := filepath.Clean(strings.TrimSpace(e.Home))
 	if path == "." || path == "" {
-		return errors.New("cleanup path is unavailable")
+		return false, errors.New("cleanup path is unavailable")
 	}
-	if _, err := e.Store.EnsureCleanupObligation(context.WithoutCancel(ctx), jobID, path, time.Now().UTC()); err != nil {
-		return err
+	obligation, err := e.Store.EnsureCleanupObligation(context.WithoutCancel(ctx), jobID, path, time.Now().UTC())
+	if err != nil {
+		return false, err
 	}
+	switch obligation.State {
+	case db.CleanupObligationQuarantined, db.CleanupObligationRemoved:
+		return false, nil
+	case db.CleanupObligationPending, db.CleanupObligationRetryable:
+		// Actuation is permitted only for these two non-terminal states.
+	default:
+		return false, fmt.Errorf("cleanup obligation %s has unsupported state %q", obligation.ResourceID, obligation.State)
+	}
+	validator := ValidateDelegationCleanupTarget
+	if e.cleanupTargetValidator != nil {
+		validator = e.cleanupTargetValidator
+	}
+	if err := validator(home, jobID, jobType, payload); err != nil {
+		return false, errors.Join(err, e.deferDelegationCleanupFailure(ctx, jobID, path, "identity", err))
+	}
+	return true, nil
+}
+
+// ValidateDelegationCleanupTarget independently derives the managed path for a
+// cleanup owner and resolves symlinks before accepting filesystem containment.
+func ValidateDelegationCleanupTarget(home, jobID, jobType string, payload JobPayload) error {
+	path := filepath.Clean(strings.TrimSpace(payload.WorktreePath))
+	home = filepath.Clean(strings.TrimSpace(home))
 	if !filepath.IsAbs(path) {
-		err := fmt.Errorf("cleanup path %q is not absolute", path)
-		e.deferDelegationCleanupFailure(ctx, jobID, path, "identity", err)
-		return err
+		return fmt.Errorf("cleanup path %q is not absolute", path)
 	}
 	if home == "." || home == "" {
-		err := errors.New("cleanup worktree home is unavailable")
-		e.deferDelegationCleanupFailure(ctx, jobID, path, "identity", err)
+		return errors.New("cleanup worktree home is unavailable")
+	}
+	expected, err := expectedDelegationCleanupPaths(home, jobID, jobType, payload)
+	if err != nil {
 		return err
 	}
+	matched := false
+	for _, candidate := range expected {
+		if path == filepath.Clean(candidate) {
+			matched = true
+			break
+		}
+	}
+	if !matched {
+		return fmt.Errorf("cleanup path %q does not match the job's derived managed path", path)
+	}
 	root := filepath.Join(home, "worktrees")
-	rel, err := filepath.Rel(root, path)
-	if err != nil || rel == "." || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) || filepath.IsAbs(rel) {
-		err := fmt.Errorf("cleanup path %q is outside managed root %q", path, root)
-		e.deferDelegationCleanupFailure(ctx, jobID, path, "identity", err)
+	if err := cleanupPathContained(root, path); err != nil {
 		return err
 	}
 	return nil
 }
 
-func (e Engine) deferDelegationCleanupObligation(ctx context.Context, jobID, path string, reason db.CleanupObligationReason) {
+func expectedDelegationCleanupPaths(home, jobID, jobType string, payload JobPayload) ([]string, error) {
+	if isFixWorktree(jobType, payload) {
+		path, err := FixWorktreePath(home, payload.Repo, jobID)
+		return []string{path}, err
+	}
+	// Match isReadOnlyDelegationWorktree's precedence: the explicit marker is a
+	// top-level dispatch/pipeline/pool allocation even if legacy payload metadata
+	// also carries a DelegationID.
+	if payload.ReadOnlyWorktree {
+		segments := []string{"readonly-seat", "pipeline-service-stage", "pipeline-stage", "pool-isolation"}
+		paths := make([]string, 0, len(segments))
+		for _, segment := range segments {
+			path, err := DelegationWorktreePath(home, payload.Repo, jobID, segment, 0)
+			if err != nil {
+				return nil, err
+			}
+			paths = append(paths, path)
+		}
+		return paths, nil
+	}
+	if strings.TrimSpace(payload.DelegationID) != "" {
+		parentID := strings.TrimSpace(payload.ParentJobID)
+		delegationID := strings.TrimSpace(payload.DelegationID)
+		if parentID == "" {
+			return nil, errors.New("cleanup owner is missing its parent job id")
+		}
+		expectedJobID := parentID + "/delegation/" + delegationID
+		if payload.RetryCount > 0 {
+			expectedJobID += "/retry/" + strconv.Itoa(payload.RetryCount)
+		}
+		if strings.TrimSpace(jobID) != expectedJobID {
+			return nil, fmt.Errorf("cleanup owner job %q does not match parent %q and delegation %q", jobID, parentID, delegationID)
+		}
+		path, err := DelegationWorktreePath(home, payload.Repo, parentID, delegationID, payload.RetryCount)
+		if err != nil {
+			return nil, err
+		}
+		paths := []string{path}
+		if readOnlyDelegationAction(jobType) {
+			integration, err := DelegationWorktreePath(home, payload.Repo, parentID, "integration-"+delegationID, payload.RetryCount)
+			if err != nil {
+				return nil, err
+			}
+			paths = append(paths, integration)
+		}
+		return paths, nil
+	}
+	return nil, errors.New("cleanup owner has no managed worktree identity")
+}
+
+func cleanupPathContained(root, path string) error {
+	resolvedRoot, err := evalPathWithMissingTail(root)
+	if err != nil {
+		return fmt.Errorf("resolve managed cleanup root %q: %w", root, err)
+	}
+	resolvedPath, err := evalPathWithMissingTail(path)
+	if err != nil {
+		return fmt.Errorf("resolve cleanup path %q: %w", path, err)
+	}
+	rel, err := filepath.Rel(resolvedRoot, resolvedPath)
+	if err != nil || rel == "." || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) || filepath.IsAbs(rel) {
+		return fmt.Errorf("cleanup path %q resolves outside managed root %q", path, root)
+	}
+	return nil
+}
+
+func evalPathWithMissingTail(path string) (string, error) {
+	current := filepath.Clean(path)
+	var tail []string
+	for {
+		resolved, err := filepath.EvalSymlinks(current)
+		if err == nil {
+			for i := len(tail) - 1; i >= 0; i-- {
+				resolved = filepath.Join(resolved, tail[i])
+			}
+			return filepath.Clean(resolved), nil
+		}
+		if !os.IsNotExist(err) {
+			return "", err
+		}
+		if info, lerr := os.Lstat(current); lerr == nil && info.Mode()&os.ModeSymlink != 0 {
+			return "", fmt.Errorf("path component %q is a dangling symlink", current)
+		}
+		parent := filepath.Dir(current)
+		if parent == current {
+			return "", err
+		}
+		tail = append(tail, filepath.Base(current))
+		current = parent
+	}
+}
+
+func (e Engine) deferDelegationCleanupObligation(ctx context.Context, jobID, path string, reason db.CleanupObligationReason) error {
 	now := time.Now().UTC()
-	_, _ = e.Store.DeferCleanupObligation(context.WithoutCancel(ctx), jobID, path, reason, now, now.Add(time.Minute))
+	_, err := e.Store.DeferCleanupObligation(context.WithoutCancel(ctx), jobID, path, reason, now, now.Add(time.Minute))
+	return err
 }
 
-func (e Engine) deferDelegationCleanupFailure(ctx context.Context, jobID, path, phase string, err error) {
-	e.deferDelegationCleanupObligation(ctx, jobID, path, db.ClassifyCleanupObligationFailure(phase, err))
+func (e Engine) deferDelegationCleanupFailure(ctx context.Context, jobID, path, phase string, err error) error {
+	return e.deferDelegationCleanupObligation(ctx, jobID, path, db.ClassifyCleanupObligationFailure(phase, err))
 }
 
-func (e Engine) markDelegationCleanupRemoved(ctx context.Context, jobID, path string) {
-	_, _ = e.Store.MarkCleanupObligationRemoved(context.WithoutCancel(ctx), jobID, path, time.Now().UTC())
+func (e Engine) markDelegationCleanupRemoved(ctx context.Context, jobID, path string) error {
+	_, err := e.Store.MarkCleanupObligationRemoved(context.WithoutCancel(ctx), jobID, path, time.Now().UTC())
+	return err
 }
 
 // cleanupFixWorktree removes an engine-dispatched review fix's independent
@@ -775,11 +900,17 @@ func (e Engine) cleanupFixWorktree(ctx context.Context, jobID string, jobType st
 		return nil
 	}
 	path := strings.TrimSpace(payload.WorktreePath)
-	if err := e.prepareDelegationCleanupObligation(ctx, jobID, path); err != nil {
+	actuate, err := e.prepareDelegationCleanupObligation(ctx, jobID, jobType, payload)
+	if err != nil {
 		return err
 	}
+	if !actuate {
+		return nil
+	}
 	if skip, reason := e.cleanupBlockedByLiveOwner(ctx, jobID, payload); skip {
-		e.deferDelegationCleanupObligation(ctx, jobID, path, db.CleanupReasonTerminalDeferred)
+		if err := e.deferDelegationCleanupObligation(ctx, jobID, path, db.CleanupReasonTerminalDeferred); err != nil {
+			return err
+		}
 		e.recordCleanupSkippedOnce(ctx, jobID, payload, reason)
 		return nil
 	}
@@ -787,26 +918,30 @@ func (e Engine) cleanupFixWorktree(ctx context.Context, jobID string, jobType st
 	expected, err := FixWorktreePath(e.Home, payload.Repo, jobID)
 	if err != nil || filepath.Clean(path) != filepath.Clean(expected) {
 		cleanupErr := fmt.Errorf("refusing unmanaged fix worktree cleanup %s", path)
-		e.deferDelegationCleanupFailure(opCtx, jobID, path, "identity", cleanupErr)
+		if persistErr := e.deferDelegationCleanupFailure(opCtx, jobID, path, "identity", cleanupErr); persistErr != nil {
+			return errors.Join(cleanupErr, persistErr)
+		}
 		e.recordCleanupSkippedOnce(opCtx, jobID, payload, "path is not the job's managed fix-worktree path")
 		return cleanupErr
 	}
 	if _, statErr := os.Stat(path); os.IsNotExist(statErr) {
-		e.markDelegationCleanupRemoved(opCtx, jobID, path)
-		return nil
+		return e.markDelegationCleanupRemoved(opCtx, jobID, path)
 	} else if statErr != nil {
-		e.deferDelegationCleanupFailure(opCtx, jobID, path, "reclaim", statErr)
+		if persistErr := e.deferDelegationCleanupFailure(opCtx, jobID, path, "reclaim", statErr); persistErr != nil {
+			return errors.Join(statErr, persistErr)
+		}
 		e.recordCleanupSkippedOnce(opCtx, jobID, payload, fmt.Sprintf("inspect failed: %v", statErr))
 		return fmt.Errorf("inspect fix worktree %s: %w", path, statErr)
 	}
 	if err := os.RemoveAll(path); err != nil {
-		e.deferDelegationCleanupFailure(opCtx, jobID, path, "reclaim", err)
+		if persistErr := e.deferDelegationCleanupFailure(opCtx, jobID, path, "reclaim", err); persistErr != nil {
+			return errors.Join(err, persistErr)
+		}
 		e.recordCleanupSkippedOnce(opCtx, jobID, payload, fmt.Sprintf("remove failed: %v", err))
 		return fmt.Errorf("remove fix worktree %s: %w", path, err)
 	}
 	_ = e.Store.AddJobEvent(opCtx, db.JobEvent{JobID: jobID, Kind: "delegation_worktree_removed", Message: fmt.Sprintf("fix worktree %s removed", path)})
-	e.markDelegationCleanupRemoved(opCtx, jobID, path)
-	return nil
+	return e.markDelegationCleanupRemoved(opCtx, jobID, path)
 }
 
 // cleanupReadOnlyDelegationWorktree disposes the detached worktree allocated for
@@ -824,13 +959,19 @@ func (e Engine) cleanupReadOnlyDelegationWorktree(ctx context.Context, jobID str
 	// deadline/cancel.
 	opCtx := context.WithoutCancel(ctx)
 	path := strings.TrimSpace(payload.WorktreePath)
-	if err := e.prepareDelegationCleanupObligation(opCtx, jobID, path); err != nil {
+	actuate, err := e.prepareDelegationCleanupObligation(opCtx, jobID, jobType, payload)
+	if err != nil {
 		return err
+	}
+	if !actuate {
+		return nil
 	}
 	manager, ok := e.DelegationWorktrees.(ReadOnlyWorktreeManager)
 	if !ok || manager == nil {
 		cleanupErr := errors.New("delegation worktree manager cannot force-remove worktrees")
-		e.deferDelegationCleanupFailure(opCtx, jobID, path, "reclaim", cleanupErr)
+		if persistErr := e.deferDelegationCleanupFailure(opCtx, jobID, path, "reclaim", cleanupErr); persistErr != nil {
+			return errors.Join(cleanupErr, persistErr)
+		}
 		e.recordReadOnlyCleanupSkippedOnce(opCtx, jobID, path, "delegation worktree manager is unavailable")
 		return cleanupErr
 	}
@@ -838,10 +979,11 @@ func (e Engine) cleanupReadOnlyDelegationWorktree(ctx context.Context, jobID str
 	// passes). If the worktree directory is already gone, do not re-lock or emit a
 	// spurious cleanup-failed event.
 	if _, statErr := os.Stat(path); os.IsNotExist(statErr) {
-		e.markDelegationCleanupRemoved(opCtx, jobID, path)
-		return nil
+		return e.markDelegationCleanupRemoved(opCtx, jobID, path)
 	} else if statErr != nil {
-		e.deferDelegationCleanupFailure(opCtx, jobID, path, "reclaim", statErr)
+		if persistErr := e.deferDelegationCleanupFailure(opCtx, jobID, path, "reclaim", statErr); persistErr != nil {
+			return errors.Join(statErr, persistErr)
+		}
 		e.recordReadOnlyCleanupSkippedOnce(opCtx, jobID, path, fmt.Sprintf("inspect failed: %v", statErr))
 		return fmt.Errorf("inspect read-only worktree %s: %w", path, statErr)
 	}
@@ -855,7 +997,9 @@ func (e Engine) cleanupReadOnlyDelegationWorktree(ctx context.Context, jobID str
 	}
 	releaseCheckoutLock, _, err := acquireCheckoutMutationLockWithWait(opCtx, e.Store, e.DelegationCheckout, "worktree-cleanup:"+jobID, time.Now().UTC())
 	if err != nil {
-		e.deferDelegationCleanupFailure(opCtx, jobID, path, "lock", err)
+		if persistErr := e.deferDelegationCleanupFailure(opCtx, jobID, path, "lock", err); persistErr != nil {
+			return errors.Join(err, persistErr)
+		}
 		// A transient failure (lock contention) must NOT be terminal: emit the same
 		// reclaim marker the daemon's reclaimSkippedDelegationWorktrees pass keys on,
 		// so ReclaimTerminalDelegationWorktree re-fires this cleanup on a later tick
@@ -871,13 +1015,14 @@ func (e Engine) cleanupReadOnlyDelegationWorktree(ctx context.Context, jobID str
 		}
 	}()
 	if err := manager.RemoveWorktreeForce(opCtx, path); err != nil {
-		e.deferDelegationCleanupFailure(opCtx, jobID, path, "reclaim", err)
+		if persistErr := e.deferDelegationCleanupFailure(opCtx, jobID, path, "reclaim", err); persistErr != nil {
+			return errors.Join(err, persistErr)
+		}
 		e.recordReadOnlyCleanupSkippedOnce(opCtx, jobID, path, fmt.Sprintf("force-remove failed: %v", err))
 		return fmt.Errorf("force-remove read-only worktree %s: %w", path, err)
 	}
 	_ = e.Store.AddJobEvent(opCtx, db.JobEvent{JobID: jobID, Kind: "delegation_worktree_removed", Message: fmt.Sprintf("read-only worktree %s removed", path)})
-	e.markDelegationCleanupRemoved(opCtx, jobID, path)
-	return nil
+	return e.markDelegationCleanupRemoved(opCtx, jobID, path)
 }
 
 // isImplementDelegationWorktree reports whether a job ran in a per-delegation
@@ -941,8 +1086,12 @@ func (e Engine) cleanupImplementDelegationWorktree(ctx context.Context, jobID st
 		return nil
 	}
 	path := strings.TrimSpace(payload.WorktreePath)
-	if err := e.prepareDelegationCleanupObligation(ctx, jobID, path); err != nil {
+	actuate, err := e.prepareDelegationCleanupObligation(ctx, jobID, jobType, payload)
+	if err != nil {
 		return err
+	}
+	if !actuate {
+		return nil
 	}
 	// Liveness gate (#536): NEVER force-remove a worktree (and delete its branch)
 	// while a live runtime worker could still be writing to it — even past lease
@@ -967,7 +1116,9 @@ func (e Engine) cleanupImplementDelegationWorktree(ctx context.Context, jobID st
 	// later tick; once the foreign lease expires AND no live process holds the
 	// worktree (the worker has actually exited), it is reclaimed rather than leaked.
 	if skip, reason := e.cleanupBlockedByLiveOwner(ctx, jobID, payload); skip {
-		e.deferDelegationCleanupObligation(ctx, jobID, path, db.CleanupReasonTerminalDeferred)
+		if err := e.deferDelegationCleanupObligation(ctx, jobID, path, db.CleanupReasonTerminalDeferred); err != nil {
+			return err
+		}
 		e.recordCleanupSkippedOnce(ctx, jobID, payload, reason)
 		return nil
 	}
@@ -997,7 +1148,9 @@ func (e Engine) cleanupImplementDelegationWorktree(ctx context.Context, jobID st
 	manager, ok := e.DelegationWorktrees.(ReadOnlyWorktreeManager) // RemoveWorktreeForce
 	if !ok || manager == nil {
 		cleanupErr := errors.New("delegation worktree manager cannot force-remove worktrees")
-		e.deferDelegationCleanupFailure(opCtx, jobID, path, "reclaim", cleanupErr)
+		if persistErr := e.deferDelegationCleanupFailure(opCtx, jobID, path, "reclaim", cleanupErr); persistErr != nil {
+			return errors.Join(cleanupErr, persistErr)
+		}
 		e.recordCleanupSkippedOnce(opCtx, jobID, payload, "delegation worktree manager is unavailable")
 		return cleanupErr
 	}
@@ -1021,12 +1174,13 @@ func (e Engine) cleanupImplementDelegationWorktree(ctx context.Context, jobID st
 	}
 	branchCleanupPending := deleter != nil && checker != nil && !branchKnownGone
 	if worktreeGone && !branchCleanupPending {
-		e.markDelegationCleanupRemoved(opCtx, jobID, path)
-		return nil
+		return e.markDelegationCleanupRemoved(opCtx, jobID, path)
 	}
 	releaseCheckoutLock, _, err := acquireCheckoutMutationLockWithWait(opCtx, e.Store, e.DelegationCheckout, "worktree-cleanup:"+jobID, time.Now().UTC())
 	if err != nil {
-		e.deferDelegationCleanupFailure(opCtx, jobID, path, "lock", err)
+		if persistErr := e.deferDelegationCleanupFailure(opCtx, jobID, path, "lock", err); persistErr != nil {
+			return errors.Join(err, persistErr)
+		}
 		_ = e.Store.AddJobEvent(opCtx, db.JobEvent{JobID: jobID, Kind: "delegation_worktree_cleanup_failed", Message: fmt.Sprintf("implement worktree %s cleanup could not lock checkout: %v", path, err)})
 		return fmt.Errorf("lock checkout for implement worktree cleanup: %w", err)
 	}
@@ -1037,7 +1191,9 @@ func (e Engine) cleanupImplementDelegationWorktree(ctx context.Context, jobID st
 	}()
 	if !worktreeGone {
 		if err := manager.RemoveWorktreeForce(opCtx, path); err != nil {
-			e.deferDelegationCleanupFailure(opCtx, jobID, path, "reclaim", err)
+			if persistErr := e.deferDelegationCleanupFailure(opCtx, jobID, path, "reclaim", err); persistErr != nil {
+				return errors.Join(err, persistErr)
+			}
 			_ = e.Store.AddJobEvent(opCtx, db.JobEvent{JobID: jobID, Kind: "delegation_worktree_cleanup_failed", Message: fmt.Sprintf("implement worktree %s force-remove failed: %v", path, err)})
 			return fmt.Errorf("force-remove implement worktree %s: %w", path, err)
 		}
@@ -1045,7 +1201,9 @@ func (e Engine) cleanupImplementDelegationWorktree(ctx context.Context, jobID st
 	branchDeleted := false
 	if deleter != nil && !branchKnownGone {
 		if err := deleter.DeleteBranch(opCtx, branch); err != nil {
-			e.deferDelegationCleanupFailure(opCtx, jobID, path, "reclaim", err)
+			if persistErr := e.deferDelegationCleanupFailure(opCtx, jobID, path, "reclaim", err); persistErr != nil {
+				return errors.Join(err, persistErr)
+			}
 			_ = e.Store.AddJobEvent(opCtx, db.JobEvent{JobID: jobID, Kind: "delegation_worktree_cleanup_failed", Message: fmt.Sprintf("implement branch %s delete failed: %v", branch, err)})
 			return fmt.Errorf("delete implement worktree branch %s: %w", branch, err)
 		}
@@ -1059,8 +1217,7 @@ func (e Engine) cleanupImplementDelegationWorktree(ctx context.Context, jobID st
 		message = fmt.Sprintf("implement worktree %s and branch %s removed", path, branch)
 	}
 	_ = e.Store.AddJobEvent(opCtx, db.JobEvent{JobID: jobID, Kind: "delegation_worktree_removed", Message: message})
-	e.markDelegationCleanupRemoved(opCtx, jobID, path)
-	return nil
+	return e.markDelegationCleanupRemoved(opCtx, jobID, path)
 }
 
 // cleanupBlockedByLiveOwner reports whether the destructive implement-delegation
@@ -1256,8 +1413,12 @@ func (e Engine) ReclaimAgedTerminalDelegationWorktreeOutcome(ctx context.Context
 		}
 	}
 	path := strings.TrimSpace(payload.WorktreePath)
-	if err := e.prepareDelegationCleanupObligation(ctx, jobID, path); err != nil {
+	actuate, err := e.prepareDelegationCleanupObligation(ctx, jobID, job.Type, payload)
+	if err != nil {
 		return false, err
+	}
+	if !actuate {
+		return false, nil
 	}
 	if fix {
 		expected, err := FixWorktreePath(e.Home, payload.Repo, jobID)
@@ -1272,7 +1433,7 @@ func (e Engine) ReclaimAgedTerminalDelegationWorktreeOutcome(ctx context.Context
 			Message: fmt.Sprintf("aged terminal fix worktree %s removed after TTL", path),
 		})
 		if err == nil {
-			e.markDelegationCleanupRemoved(ctx, jobID, path)
+			err = e.markDelegationCleanupRemoved(ctx, jobID, path)
 		}
 		return err == nil, err
 	}
@@ -1331,7 +1492,7 @@ func (e Engine) ReclaimAgedTerminalDelegationWorktreeOutcome(ctx context.Context
 		Message: fmt.Sprintf("aged terminal delegation worktree %s force-removed after TTL", path),
 	})
 	if err == nil {
-		e.markDelegationCleanupRemoved(opCtx, jobID, path)
+		err = e.markDelegationCleanupRemoved(opCtx, jobID, path)
 	}
 	return err == nil, err
 }
@@ -1405,18 +1566,19 @@ func (e Engine) implementLegBranchMayBeMerged(ctx context.Context, payload JobPa
 // ever reclaim an integration-fed leg and its gitmoot-delegation-* branch and
 // worktree would accumulate forever after the tree finished. It re-runs each
 // leg's cleanup, whose #332 guard now observes this consumer terminal and (absent
-// another live consumer) proceeds. Best-effort and idempotent: a no-op for a job
-// with no parent/deps and for already-cleaned legs.
-func (e Engine) cleanupConsumedImplementLegWorktrees(ctx context.Context, payload JobPayload) {
+// another live consumer) proceeds. It is idempotent for already-cleaned legs and
+// fails closed when durable cleanup accounting cannot be persisted.
+func (e Engine) cleanupConsumedImplementLegWorktrees(ctx context.Context, payload JobPayload) error {
 	parentID := strings.TrimSpace(payload.ParentJobID)
 	deps := compactStrings(payload.Deps)
 	if parentID == "" || len(deps) == 0 {
-		return
+		return nil
 	}
 	children, err := e.childDelegationJobs(ctx, parentID)
 	if err != nil {
-		return
+		return err
 	}
+	var cleanupErr error
 	for _, dep := range deps {
 		legJob, ok := children[strings.TrimSpace(dep)]
 		if !ok {
@@ -1424,10 +1586,14 @@ func (e Engine) cleanupConsumedImplementLegWorktrees(ctx context.Context, payloa
 		}
 		legPayload, err := unmarshalPayload(legJob.Payload)
 		if err != nil {
+			cleanupErr = errors.Join(cleanupErr, err)
 			continue
 		}
-		e.cleanupImplementDelegationWorktree(ctx, legJob.ID, legJob.Type, legPayload)
+		if err := e.cleanupImplementDelegationWorktree(ctx, legJob.ID, legJob.Type, legPayload); err != nil {
+			return errors.Join(cleanupErr, err)
+		}
 	}
+	return cleanupErr
 }
 
 type worktreeLineageResult struct {

--- a/skills/gitmoot/references/CLI.md
+++ b/skills/gitmoot/references/CLI.md
@@ -25,7 +25,9 @@ actionable remediation hint) and live-probes the Claude credential selected by
 after install and before starting the daemon. It also reports delegation
 worktree count and logical disk size, warning at 10 stale worktrees or 1 GB and
 distinguishing aged-final reclaimable owners from pinned non-final owners. A
-running job whose directly recorded runtime PID is confirmably dead is a
+non-zero quarantined cleanup-obligation count is also a worktree warning;
+inspect those rows with `gitmoot job cleanup list --state quarantined`. A running
+job whose directly recorded runtime PID is confirmably dead is a
 required `stuck jobs` failure; legacy jobs with no recorded PID and hosts where
 process identity cannot be verified are neutral and produce no ghost-job
 finding.
@@ -2137,6 +2139,8 @@ gitmoot job transcript <job-id> --export md|jsonl [--output <path>] [--log-path 
 gitmoot job transcript --all [--state succeeded,failed] [--since 720h] --export jsonl [--output <path>]
 gitmoot job events <job-id>
 gitmoot job retry <job-id>
+gitmoot job cleanup list [--state pending|retryable|removed|quarantined] [--json]
+gitmoot job cleanup reopen <resource-id>
 gitmoot job gates <job-id>                                         # list resumable gates; add --json
 gitmoot job gates clear <job-id> --need "<text>"|--all             # satisfy gate(s); auto-resume on last
 gitmoot job cancel <job-id>                                        # one queued|running|blocked job

--- a/skills/gitmoot/references/SAFETY.md
+++ b/skills/gitmoot/references/SAFETY.md
@@ -501,11 +501,16 @@ TTL reclaim candidate. A successful force-remove and metadata prune records
 `delegation_worktree_reclaimed_ttl`.
 Candidate-local lookup, runner, and removal failures skip only that worktree so
 later candidates continue; candidate-query and store-wide lookup failures still
-abort. Repeated failures log three times per path before suppression.
+abort. Repeated failures log three times per path before suppression. Cleanup
+attempt state is also durable: every failure waits one minute before retry, and
+the third failure moves the obligation to terminal `quarantined` state. A
+quarantined target is excluded from automation until an operator verifies its
+job and expected path, then runs `gitmoot job cleanup reopen <resource-id>`.
 
 `gitmoot doctor` and dashboard `/api/health` surface stale count and logical
 size, split into reclaimable final owners, pinned non-final owners, and unproven
-directories. Pinned and unproven worktrees are observation-only.
+directories, plus the quarantined cleanup count. Pinned, unproven, and
+quarantined worktrees are observation-only.
 
 For manual relief, list
 `$GITMOOT_HOME/worktrees/*/delegations/*/*`, map each path to its job's

--- a/skills/gitmoot/references/WORKFLOWS.md
+++ b/skills/gitmoot/references/WORKFLOWS.md
@@ -856,8 +856,12 @@ Blocked, queued, and running owners remain pinned; `gitmoot doctor` reports the
 reclaimable/pinned/unproven counts and logical size.
 Candidate-local lookup, runner, and removal failures skip only that worktree;
 later candidates continue. The daemon logs three failures per path before
-suppressing repeats. Candidate-query and store-wide lookup failures remain
-fatal.
+suppressing repeats. A restart-safe cleanup obligation delays retries by one
+minute and becomes terminal `quarantined` after the third failure; doctor and
+`/api/health` report that count. Use `gitmoot job cleanup list --state
+quarantined` to inspect identities and paths, then `gitmoot job cleanup reopen
+<resource-id>` after repair. Candidate-query and store-wide lookup failures
+remain fatal.
 
 Never-started `planned` tasks use a separate opt-in policy:
 `[workflow].planned_ttl = "720h"`. It is disabled by default; unset, empty,

--- a/website/docs/dashboard/views.md
+++ b/website/docs/dashboard/views.md
@@ -343,7 +343,7 @@ Health is the operability view for unattended runs:
   failed, cancelled).
 - **Delegation worktrees** — `/api/health` reports a `worktrees.summary` line
   (`N stale worktrees / X GB`) plus reclaimable, pinned, unproven, and
-  recent-terminal counts and exact bytes.
+  recent-terminal counts, quarantined cleanup obligations, and exact bytes.
 - **Stuck jobs** — blocked jobs (surfaced at any age) plus queued jobs older than
   10 minutes, each with a **derived why-stuck reason** (from the job's latest
   reason event and any resource lock it is waiting on) and how long it has been

--- a/website/docs/operations/troubleshooting.md
+++ b/website/docs/operations/troubleshooting.md
@@ -518,8 +518,8 @@ rsync -a --delete build/ /var/www/gitmoot-docs/
 
 `gitmoot doctor` reports `N stale worktrees / X GB under <home>/worktrees` and
 separates reclaimable final owners, pinned non-final owners, and unproven
-directories. `/api/health` exposes the same metric in its top-level `worktrees`
-field.
+directories. `/api/health` exposes the same metric and the quarantined cleanup
+count in its top-level `worktrees` field.
 
 `[workflow].delegation_worktree_ttl = "72h"` is default-on: after that grace
 period the daemon force-removes dirty terminal-owned delegation worktrees,
@@ -528,8 +528,11 @@ prunes Git worktree metadata, and records
 Blocked, queued, and running owners remain pinned and are never force-removed.
 Candidate-local lookup, runner, and removal failures skip only that worktree;
 later candidates continue. The daemon logs three failures per path before
-suppressing repeats. Candidate-query and store-wide lookup failures remain
-fatal.
+suppressing repeats. Each failure advances a restart-safe cleanup obligation;
+retries wait one minute and stop in terminal `quarantined` state after the third
+failure. Inspect quarantines with `gitmoot job cleanup list --state quarantined`
+and explicitly reopen a repaired target with `gitmoot job cleanup reopen
+<resource-id>`. Candidate-query and store-wide lookup failures remain fatal.
 
 For immediate relief, list candidate directories and prove ownership before
 removing anything:

--- a/website/docs/reference/cli.md
+++ b/website/docs/reference/cli.md
@@ -25,7 +25,9 @@ actionable remediation hint) and live-probes the Claude credential selected by
 it after install and before starting the daemon. It also reports delegation
 worktree count and logical disk size, warning at 10 stale worktrees or 1 GB and
 distinguishing aged-final reclaimable owners from pinned non-final owners. A
-running job whose directly recorded runtime PID is confirmably dead is a
+non-zero quarantined cleanup-obligation count is also a worktree warning;
+inspect those rows with `gitmoot job cleanup list --state quarantined`. A running
+job whose directly recorded runtime PID is confirmably dead is a
 required `stuck jobs` failure; legacy jobs with no recorded PID and hosts where
 process identity cannot be verified are neutral and produce no ghost-job
 finding.
@@ -1806,7 +1808,12 @@ final job owners older than the TTL are force-reclaimed. Blocked, queued, and
 running owners remain pinned and are reported by `gitmoot doctor`.
 Candidate-local lookup, runner, and removal failures skip only that worktree;
 later candidates continue. Repeated failures log three times per path before
-suppression. Candidate-query and store-wide lookup failures remain fatal.
+suppression. Every failure also advances a durable cleanup obligation; retries
+wait one minute and the third failure becomes terminal `quarantined`. Doctor and
+`/api/health` expose the quarantine count. Inspect rows with `gitmoot job cleanup
+list --state quarantined` and explicitly reopen a repaired target with `gitmoot
+job cleanup reopen <resource-id>`. Candidate-query and store-wide lookup failures
+remain fatal.
 
 `[workflow].planned_ttl = "720h"` is a separate repository opt-in for old
 never-started plans. It is disabled by default; unset, empty, `"0"`, and invalid
@@ -1905,6 +1912,8 @@ gitmoot job transcript --all [--state succeeded,failed] [--since 720h] --export 
 gitmoot job events <job-id>
 gitmoot job run <job-id>
 gitmoot job retry <job-id>
+gitmoot job cleanup list [--state pending|retryable|removed|quarantined] [--json]
+gitmoot job cleanup reopen <resource-id>
 gitmoot job gates <job-id>                                         # list resumable gates; add --json
 gitmoot job gates clear <job-id> --need "<text>"|--all             # satisfy gate(s); auto-resume on last
 gitmoot job cancel <job-id>                                        # one queued|running|blocked job

--- a/website/static/llms-full.txt
+++ b/website/static/llms-full.txt
@@ -801,7 +801,12 @@ Delegation worktrees have a separate default-on retention bound:
 reclaimable/pinned/unproven breakdown; dashboard `/api/health` mirrors it.
 Candidate-local lookup, runner, and removal failures skip only that worktree;
 later candidates continue. Repeated failures are logged three times per path,
-then suppressed. Candidate-query and store-wide lookup failures remain fatal.
+then suppressed. Each failed cleanup also advances a durable obligation with a
+one-minute retry delay; after three failures it becomes `quarantined` and leaves
+automatic selection. Doctor and `/api/health` report quarantined obligations;
+inspect them with `gitmoot job cleanup list --state quarantined` and explicitly
+reopen one with `gitmoot job cleanup reopen <resource-id>`. Candidate-query and
+store-wide lookup failures remain fatal.
 
 Never-started plans have a separate destructive opt-in:
 `[workflow].planned_ttl = "720h"`. It is disabled by default; unset, empty,
@@ -2715,11 +2720,16 @@ debugging access. Set it to `"0"` to disable the TTL pass. Aged final owners are
 force-removed even when dirty, Git worktree metadata is pruned, and
 `delegation_worktree_reclaimed_ttl` is recorded. The dashboard `/api/health`
 response exposes the same count, bytes, path, breakdown, and summary in its
-top-level `worktrees` field.
+top-level `worktrees` field, including the number of cleanup obligations in
+terminal quarantine.
 
 One unreclaimable candidate does not stop the pass: candidate-local lookup,
 runner, and removal failures are skipped while later paths continue. The daemon
 logs the first three failures for a path and suppresses repeats.
+Each failure advances a durable, restart-safe cleanup obligation. Retries wait
+one minute and stop after the third failure in `quarantined`; quarantined paths
+are not selected again until an operator inspects `gitmoot job cleanup list
+--state quarantined` and runs `gitmoot job cleanup reopen <resource-id>`.
 Candidate-query and store-wide lookup failures still abort the pass and surface
 normally.
 
@@ -7472,7 +7482,7 @@ Health is the operability view for unattended runs:
   failed, cancelled).
 - **Delegation worktrees** — `/api/health` reports a `worktrees.summary` line
   (`N stale worktrees / X GB`) plus reclaimable, pinned, unproven, and
-  recent-terminal counts and exact bytes.
+  recent-terminal counts, quarantined cleanup obligations, and exact bytes.
 - **Stuck jobs** — blocked jobs (surfaced at any age) plus queued jobs older than
   10 minutes, each with a **derived why-stuck reason** (from the job's latest
   reason event and any resource lock it is waiting on) and how long it has been
@@ -10177,7 +10187,9 @@ actionable remediation hint) and live-probes the Claude credential selected by
 after install and before starting the daemon. It also reports delegation
 worktree count and logical disk size, warning at 10 stale worktrees or 1 GB and
 distinguishing aged-final reclaimable owners from pinned non-final owners. A
-running job whose directly recorded runtime PID is confirmably dead is a
+non-zero quarantined cleanup-obligation count is also a worktree warning;
+inspect those rows with `gitmoot job cleanup list --state quarantined`. A running
+job whose directly recorded runtime PID is confirmably dead is a
 required `stuck jobs` failure; legacy jobs with no recorded PID and hosts where
 process identity cannot be verified are neutral and produce no ghost-job
 finding.
@@ -12289,6 +12301,8 @@ gitmoot job transcript <job-id> --export md|jsonl [--output <path>] [--log-path 
 gitmoot job transcript --all [--state succeeded,failed] [--since 720h] --export jsonl [--output <path>]
 gitmoot job events <job-id>
 gitmoot job retry <job-id>
+gitmoot job cleanup list [--state pending|retryable|removed|quarantined] [--json]
+gitmoot job cleanup reopen <resource-id>
 gitmoot job gates <job-id>                                         # list resumable gates; add --json
 gitmoot job gates clear <job-id> --need "<text>"|--all             # satisfy gate(s); auto-resume on last
 gitmoot job cancel <job-id>                                        # one queued|running|blocked job
@@ -15414,8 +15428,12 @@ Blocked, queued, and running owners remain pinned; `gitmoot doctor` reports the
 reclaimable/pinned/unproven counts and logical size.
 Candidate-local lookup, runner, and removal failures skip only that worktree;
 later candidates continue. The daemon logs three failures per path before
-suppressing repeats. Candidate-query and store-wide lookup failures remain
-fatal.
+suppressing repeats. A restart-safe cleanup obligation delays retries by one
+minute and becomes terminal `quarantined` after the third failure; doctor and
+`/api/health` report that count. Use `gitmoot job cleanup list --state
+quarantined` to inspect identities and paths, then `gitmoot job cleanup reopen
+<resource-id>` after repair. Candidate-query and store-wide lookup failures
+remain fatal.
 
 Never-started `planned` tasks use a separate opt-in policy:
 `[workflow].planned_ttl = "720h"`. It is disabled by default; unset, empty,
@@ -16852,11 +16870,16 @@ TTL reclaim candidate. A successful force-remove and metadata prune records
 `delegation_worktree_reclaimed_ttl`.
 Candidate-local lookup, runner, and removal failures skip only that worktree so
 later candidates continue; candidate-query and store-wide lookup failures still
-abort. Repeated failures log three times per path before suppression.
+abort. Repeated failures log three times per path before suppression. Cleanup
+attempt state is also durable: every failure waits one minute before retry, and
+the third failure moves the obligation to terminal `quarantined` state. A
+quarantined target is excluded from automation until an operator verifies its
+job and expected path, then runs `gitmoot job cleanup reopen <resource-id>`.
 
 `gitmoot doctor` and dashboard `/api/health` surface stale count and logical
 size, split into reclaimable final owners, pinned non-final owners, and unproven
-directories. Pinned and unproven worktrees are observation-only.
+directories, plus the quarantined cleanup count. Pinned, unproven, and
+quarantined worktrees are observation-only.
 
 For manual relief, list
 `$GITMOOT_HOME/worktrees/*/delegations/*/*`, map each path to its job's


### PR DESCRIPTION
WHAT:
Implemented #1572 slice 1: delegation-worktree cleanup now has durable, restart-safe retry state, typed failure classification, a fixed three-attempt budget, terminal quarantine, operator reopen controls, and identity/containment checks. GITMOOT-COC-1572-S1

WHY:
Gitmoot finalized this implementation from a task worktree.

CHANGES:
- Committed changes from /root/.gitmoot/worktrees/gitmoot--gitmoot/adhoc-122366be

RESULTS:
- PASS: focused internal/db migration, obligation-state, pending/aged query, race-safety, and query-plan tests.
- PASS: focused internal/cli quarantine/restart, skipped-mode budget, containment, operator CLI, doctor/health, TTL, destination-removal, store-failure, flood-suppression, and all six unchanged poison-pill subtests.
- PASS: focused internal/workflow implement/read-only/fix/consumed-leg cleanup and reclaim tests.
- PASS: baseline exact -run filter matched 1 test: TestDelegationCleanupUnknownFailureQuarantinesAndSurvivesRestart.
- PASS: budget mutant compiled with go test -c; changing the budget from 3 to 100 made the acceptance test fail with state=retryable after attempt 3, as required.
- PASS: go build -buildvcs=false ./...
- PASS: go vet -buildvcs=false ./internal/db/ ./internal/cli/ ./internal/workflow/
- PASS: changed Go files are gofmt-clean; git diff --check passed. Repository-wide gofmt still lists two unmodified inherited files: internal/workflow/merge_reason_test.go and internal/workflow/org_directive.go.
- PASS: npm run build:llms executed repeatedly; generated output and diff hashes remained identical on the second run.

RISK:
Review the generated diff before merging.

TASK:
adhoc-122366be

AGENTS:
- wave-impl

RAW FINAL REVIEW OUTPUT:
````text
Implemented #1572 slice 1: delegation-worktree cleanup now has durable, restart-safe retry state, typed failure classification, a fixed three-attempt budget, terminal quarantine, operator reopen controls, and identity/containment checks. GITMOOT-COC-1572-S1
````
