### PR TITLE
Gitmoot: IMPLEMENT — gitmoot#1565, lane-lock reclamation. Base: current main

### DIFF
--- a/docs/local-workflow.md
+++ b/docs/local-workflow.md
@@ -580,11 +580,11 @@ If a job is not eligible, Gitmoot keeps the old queue/wait behavior.
 
    Task lane locks remain held after an implement job succeeds so review and fix
    rounds keep exclusive ownership of the branch. Cancelling a top-level
-   implement releases its lane only when no non-terminal task or job still
+   implement releases its lane only when no other non-terminal task or job still
    references the same repository and branch. As a backstop, the daemon releases
-   locks unchanged for at least 24 hours under that same no-live-work condition.
-   Tasks in `blocked`, `awaiting_human_merge`, or `awaiting_human` retain their
-   locks for human resumption.
+   locks unchanged for at least 24 hours only after no non-terminal task or job
+   remains. Tasks in `blocked`, `awaiting_human_merge`, or `awaiting_human`
+   retain their locks for human resumption.
 
 8. Let the PR converge.
 

--- a/docs/local-workflow.md
+++ b/docs/local-workflow.md
@@ -578,6 +578,14 @@ If a job is not eligible, Gitmoot keeps the old queue/wait behavior.
    gitmoot lock release owner/project <branch> --owner <agent>
    ```
 
+   Task lane locks remain held after an implement job succeeds so review and fix
+   rounds keep exclusive ownership of the branch. Cancelling a top-level
+   implement releases its lane only when no non-terminal task or job still
+   references the same repository and branch. As a backstop, the daemon releases
+   locks unchanged for at least 24 hours under that same no-live-work condition.
+   Tasks in `blocked`, `awaiting_human_merge`, or `awaiting_human` retain their
+   locks for human resumption.
+
 8. Let the PR converge.
 
    Agents review, request fixes, and rerun work through comments and job output.

--- a/internal/cli/daemon_dispatch_tracked.go
+++ b/internal/cli/daemon_dispatch_tracked.go
@@ -84,6 +84,7 @@ type inflightJobTracker struct {
 	errs                         map[string][]error
 	foreignBootRecoveryAt        time.Time
 	agedDelegationWorktreeReapAt time.Time
+	staleTaskLaneLockReapAt      time.Time
 	liveness                     *daemonLivenessSweep
 }
 
@@ -346,6 +347,26 @@ func (t *inflightJobTracker) markAgedDelegationWorktreeReclaimSuccessful(now tim
 	t.mu.Lock()
 	defer t.mu.Unlock()
 	t.agedDelegationWorktreeReapAt = now
+}
+
+// staleTaskLaneLockReclaimDue gates the low-frequency branch-lock lifecycle
+// backstop. Its zero value is due so daemon start eagerly checks old lanes.
+func (t *inflightJobTracker) staleTaskLaneLockReclaimDue(now time.Time) bool {
+	if t == nil {
+		return true
+	}
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return maintenancePassDue(t.staleTaskLaneLockReapAt, now, staleTaskLaneLockReclaimInterval)
+}
+
+func (t *inflightJobTracker) markStaleTaskLaneLockReclaimSuccessful(now time.Time) {
+	if t == nil {
+		return
+	}
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.staleTaskLaneLockReapAt = now
 }
 
 // holderOf returns the job ID currently holding checkoutKey, if any.

--- a/internal/cli/daemon_lane_lock_reclaim_test.go
+++ b/internal/cli/daemon_lane_lock_reclaim_test.go
@@ -1,0 +1,165 @@
+package cli
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"io"
+	"testing"
+	"time"
+
+	"github.com/gitmoot/gitmoot/internal/db"
+	"github.com/gitmoot/gitmoot/internal/workflow"
+)
+
+func acquireTaskLaneLock(t *testing.T, store *db.Store, branch string) {
+	t.Helper()
+	acquired, err := store.AcquireLock(context.Background(), db.BranchLock{
+		RepoFullName: "owner/repo", Branch: branch, Owner: "lead",
+	})
+	if err != nil {
+		t.Fatalf("AcquireLock(%s): %v", branch, err)
+	}
+	if !acquired {
+		t.Fatalf("AcquireLock(%s) did not acquire", branch)
+	}
+}
+
+func assertTaskLaneLock(t *testing.T, store *db.Store, branch string, want bool) {
+	t.Helper()
+	_, err := store.GetBranchLock(context.Background(), "owner/repo", branch)
+	if want && err != nil {
+		t.Fatalf("GetBranchLock(%s): %v", branch, err)
+	}
+	if !want && !errors.Is(err, sql.ErrNoRows) {
+		t.Fatalf("GetBranchLock(%s) error = %v, want sql.ErrNoRows", branch, err)
+	}
+}
+
+// TestStaleTaskLaneLockSweepReleasesTerminalLane is the positive firing guard:
+// an aged lane referenced only by terminal task/job rows must be released.
+func TestStaleTaskLaneLockSweepReleasesTerminalLane(t *testing.T) {
+	ctx := context.Background()
+	store := openCLIJobStore(t, t.TempDir())
+	const branch = "terminal-lane"
+	acquireTaskLaneLock(t, store, branch)
+	if err := store.UpsertTask(ctx, db.Task{
+		ID: "task-terminal", RepoFullName: "owner/repo", State: string(workflow.TaskDismissed), Branch: branch,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	seedCLIJob(t, store, db.Job{
+		ID: "job-terminal", Agent: "lead", Type: "implement", State: string(workflow.JobFailed), Repo: "owner/repo",
+		Payload: mustJobPayload(t, workflow.JobPayload{Repo: "owner/repo", Branch: branch, TaskID: "task-terminal"}),
+	}, "terminal")
+
+	if err := reclaimStaleTaskLaneLocks(ctx, store, "owner/repo", io.Discard, time.Now().UTC().Add(25*time.Hour)); err != nil {
+		t.Fatal(err)
+	}
+	assertTaskLaneLock(t, store, branch, false)
+}
+
+// TestStaleTaskLaneLockSweepEnforcesAgeFloor kills the mutant that passes a
+// zero cutoff to ReleaseBranchLockIfInactiveWithEvent: an otherwise-idle lane
+// acquired less than 24 hours ago must survive.
+func TestStaleTaskLaneLockSweepEnforcesAgeFloor(t *testing.T) {
+	store := openCLIJobStore(t, t.TempDir())
+	const branch = "fresh-lane"
+	acquireTaskLaneLock(t, store, branch)
+
+	if err := reclaimStaleTaskLaneLocks(context.Background(), store, "owner/repo", io.Discard, time.Now().UTC()); err != nil {
+		t.Fatal(err)
+	}
+	assertTaskLaneLock(t, store, branch, true)
+}
+
+// TestStaleTaskLaneLockSweepKeepsResumableTaskStates kills mutants that remove
+// blocked or awaiting states from the explicit retention allowlist. All three
+// states can resume through an operator or human decision and must keep the lane.
+func TestStaleTaskLaneLockSweepKeepsResumableTaskStates(t *testing.T) {
+	for _, state := range []workflow.TaskState{
+		workflow.TaskBlocked,
+		workflow.TaskAwaitingHumanMerge,
+		workflow.TaskAwaitingHuman,
+	} {
+		t.Run(string(state), func(t *testing.T) {
+			ctx := context.Background()
+			store := openCLIJobStore(t, t.TempDir())
+			branch := "kept-" + string(state)
+			acquireTaskLaneLock(t, store, branch)
+			if err := store.UpsertTask(ctx, db.Task{
+				ID: "task-" + string(state), RepoFullName: "owner/repo", State: string(state), Branch: branch,
+			}); err != nil {
+				t.Fatal(err)
+			}
+
+			if err := reclaimStaleTaskLaneLocks(ctx, store, "owner/repo", io.Discard, time.Now().UTC().Add(25*time.Hour)); err != nil {
+				t.Fatal(err)
+			}
+			assertTaskLaneLock(t, store, branch, true)
+		})
+	}
+}
+
+// TestStaleTaskLaneLockSweepRequiresNoNonTerminalReferences guards the dangerous
+// direction: a reviewing task retains its lane after its implement job succeeds,
+// and any queued branch job vetoes reclaim even if the task row is terminal.
+func TestStaleTaskLaneLockSweepRequiresNoNonTerminalReferences(t *testing.T) {
+	t.Run("succeeded implement with reviewing task vetoes reclaim", func(t *testing.T) {
+		ctx := context.Background()
+		store := openCLIJobStore(t, t.TempDir())
+		const branch = "review-lane"
+		acquireTaskLaneLock(t, store, branch)
+		if err := store.UpsertTask(ctx, db.Task{
+			ID: "task-review", RepoFullName: "owner/repo", State: string(workflow.TaskReviewing), Branch: branch,
+		}); err != nil {
+			t.Fatal(err)
+		}
+		seedCLIJob(t, store, db.Job{
+			ID: "job-implemented", Agent: "lead", Type: "implement", State: string(workflow.JobSucceeded), Repo: "owner/repo",
+			Payload: mustJobPayload(t, workflow.JobPayload{Repo: "owner/repo", Branch: branch, TaskID: "task-review"}),
+		}, "implemented")
+
+		if err := reclaimStaleTaskLaneLocks(ctx, store, "owner/repo", io.Discard, time.Now().UTC().Add(25*time.Hour)); err != nil {
+			t.Fatal(err)
+		}
+		assertTaskLaneLock(t, store, branch, true)
+	})
+
+	t.Run("queued branch job vetoes reclaim", func(t *testing.T) {
+		ctx := context.Background()
+		store := openCLIJobStore(t, t.TempDir())
+		const branch = "queued-lane"
+		acquireTaskLaneLock(t, store, branch)
+		if err := store.UpsertTask(ctx, db.Task{
+			ID: "task-done", RepoFullName: "owner/repo", State: string(workflow.TaskDismissed), Branch: branch,
+		}); err != nil {
+			t.Fatal(err)
+		}
+		seedCLIJob(t, store, db.Job{
+			ID: "job-queued", Agent: "lead", Type: "implement", State: string(workflow.JobQueued), Repo: "owner/repo",
+			Payload: mustJobPayload(t, workflow.JobPayload{Repo: "owner/repo", Branch: branch, TaskID: "task-done"}),
+		}, "queued")
+
+		if err := reclaimStaleTaskLaneLocks(ctx, store, "owner/repo", io.Discard, time.Now().UTC().Add(25*time.Hour)); err != nil {
+			t.Fatal(err)
+		}
+		assertTaskLaneLock(t, store, branch, true)
+	})
+
+	t.Run("same branch in another repo does not veto", func(t *testing.T) {
+		ctx := context.Background()
+		store := openCLIJobStore(t, t.TempDir())
+		const branch = "shared-name"
+		acquireTaskLaneLock(t, store, branch)
+		seedCLIJob(t, store, db.Job{
+			ID: "job-other-repo", Agent: "lead", Type: "implement", State: string(workflow.JobQueued), Repo: "other/repo",
+			Payload: mustJobPayload(t, workflow.JobPayload{Repo: "other/repo", Branch: branch, TaskID: "task-other"}),
+		}, "queued elsewhere")
+
+		if err := reclaimStaleTaskLaneLocks(ctx, store, "owner/repo", io.Discard, time.Now().UTC().Add(25*time.Hour)); err != nil {
+			t.Fatal(err)
+		}
+		assertTaskLaneLock(t, store, branch, false)
+	})
+}

--- a/internal/cli/daemon_scheduler.go
+++ b/internal/cli/daemon_scheduler.go
@@ -1163,7 +1163,7 @@ func reclaimStaleTaskLaneLocks(ctx context.Context, store *db.Store, repoFilter 
 	}
 	cutoff := now.Add(-staleTaskLaneLockAgeFloor)
 	for _, lock := range locks {
-		released, err := store.ReleaseBranchLockIfInactiveWithEvent(ctx, lock, cutoff, db.BranchLockEvent{
+		released, err := store.ReleaseBranchLockIfInactiveWithEvent(ctx, lock, "", cutoff, db.BranchLockEvent{
 			Kind: "released", Message: "released stale task lane with no non-terminal branch work (#1565)",
 		})
 		if err != nil {

--- a/internal/cli/daemon_scheduler.go
+++ b/internal/cli/daemon_scheduler.go
@@ -65,6 +65,15 @@ const foreignBootRecoveryInterval = 15 * time.Second
 // daemon's one-second hot path.
 const agedDelegationWorktreeReclaimInterval = 5 * time.Minute
 
+// Task lane locks are cheap to inspect but are not part of the one-second hot
+// path. The age floor is the safety boundary: event-driven cancellation may
+// release immediately, while the unattended sweeper never touches a lane until
+// it has been unchanged for at least a day.
+const (
+	staleTaskLaneLockReclaimInterval = 5 * time.Minute
+	staleTaskLaneLockAgeFloor        = 24 * time.Hour
+)
+
 const (
 	delegationReclaimFailureLogLimit  = 3
 	delegationReclaimFailureMaxPaths  = 4096
@@ -1142,6 +1151,32 @@ func reclaimAgedTerminalDelegationWorktrees(ctx context.Context, worker jobWorke
 	return nil
 }
 
+// reclaimStaleTaskLaneLocks releases only aged task lanes whose repo+branch has
+// no non-terminal task or job. ReleaseBranchLockIfInactiveWithEvent rechecks all
+// predicates atomically with the DELETE, so a concurrent resume or dispatch wins
+// safely and keeps its lane. Candidate-local failures are logged and skipped;
+// this optional housekeeping must never prevent queued-job dispatch.
+func reclaimStaleTaskLaneLocks(ctx context.Context, store *db.Store, repoFilter string, stdout io.Writer, now time.Time) error {
+	locks, err := store.ListBranchLocks(ctx, repoFilter)
+	if err != nil {
+		return err
+	}
+	cutoff := now.Add(-staleTaskLaneLockAgeFloor)
+	for _, lock := range locks {
+		released, err := store.ReleaseBranchLockIfInactiveWithEvent(ctx, lock, cutoff, db.BranchLockEvent{
+			Kind: "released", Message: "released stale task lane with no non-terminal branch work (#1565)",
+		})
+		if err != nil {
+			writeLine(stdout, "task lane lock reclaim failed for %s %s: %v", lock.RepoFullName, lock.Branch, err)
+			continue
+		}
+		if released {
+			writeLine(stdout, "released stale task lane lock %s %s", lock.RepoFullName, lock.Branch)
+		}
+	}
+	return nil
+}
+
 // runDaemonWorkerTickTracked is the per-tick worker pass. With a nil tracker it
 // follows the historical synchronous tick behavior: maintenance scans,
 // then a BLOCKING runQueuedJobsForRepo dispatch. The supervisors pass a live
@@ -1174,6 +1209,13 @@ func runDaemonWorkerTickTracked(ctx context.Context, store *db.Store, worker job
 	if cand == nil {
 		cand = newTickCandidates(worker.Store)
 		cand.skipAgedReclaim = !tracker.agedDelegationWorktreeReclaimDue(now)
+	}
+	if ownsCandidates && tracker.staleTaskLaneLockReclaimDue(now) {
+		if err := reclaimStaleTaskLaneLocks(ctx, store, repoFilter, stdout, now); err != nil {
+			writeLine(stdout, "task lane lock reclaim failed: %v", err)
+		} else {
+			tracker.markStaleTaskLaneLockReclaimSuccessful(now)
+		}
 	}
 	inflightIDs := tracker.inflightIDs()
 	paths, pathsErr := worker.configPaths()
@@ -1284,6 +1326,13 @@ func runEnabledRepoWorkerTicksTracked(ctx context.Context, store *db.Store, work
 	// suppress delivery or hide an unreadable outbox behind a healthy fleet tick.
 	if err := drainFleetReplyWakeOutbox(ctx, store, worker, now); err != nil {
 		writeLine(stdout, "reply wake outbox drain unhealthy: %v", err)
+	}
+	if tracker.staleTaskLaneLockReclaimDue(now) {
+		if err := reclaimStaleTaskLaneLocks(ctx, store, "", stdout, now); err != nil {
+			writeLine(stdout, "task lane lock reclaim failed: %v", err)
+		} else {
+			tracker.markStaleTaskLaneLockReclaimSuccessful(now)
+		}
 	}
 	repos, err := store.ListRepos(ctx)
 	if err != nil {

--- a/internal/db/store_locks.go
+++ b/internal/db/store_locks.go
@@ -446,6 +446,80 @@ func (s *Store) ReleaseLockWithEvent(ctx context.Context, lock BranchLock, event
 	return s.releaseLockWithEvent(ctx, lock, false, event)
 }
 
+// ReleaseBranchLockIfInactiveWithEvent releases lock only when no non-terminal
+// task or job still references its repo+branch. A zero updatedBefore disables the
+// age predicate for event-driven cleanup such as CancelJob; the daemon sweeper
+// supplies a cutoff so a newly acquired lane can never be reclaimed.
+//
+// The terminal sets are deliberately allowlists. A new or unknown lifecycle
+// state therefore keeps the lock until its release policy is decided explicitly.
+// In particular, blocked, awaiting_human_merge, and awaiting_human tasks retain
+// their lanes for operator resumption, and blocked jobs remain non-terminal.
+func (s *Store) ReleaseBranchLockIfInactiveWithEvent(ctx context.Context, lock BranchLock, updatedBefore time.Time, event BranchLockEvent) (bool, error) {
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return false, err
+	}
+	defer tx.Rollback()
+
+	query := `DELETE FROM branch_locks
+		WHERE repo_full_name = ? AND branch = ? AND owner = ?`
+	args := []any{strings.TrimSpace(lock.RepoFullName), strings.TrimSpace(lock.Branch), strings.TrimSpace(lock.Owner)}
+	if !updatedBefore.IsZero() {
+		query += ` AND updated_at <= ?`
+		args = append(args, updatedBefore.UTC().Format("2006-01-02 15:04:05"))
+	}
+	query += `
+		AND NOT EXISTS (
+			SELECT 1 FROM tasks
+			WHERE tasks.repo_full_name = branch_locks.repo_full_name
+				AND TRIM(tasks.branch) = TRIM(branch_locks.branch)
+				AND (
+					tasks.state IN (
+						'planned', 'implementing', 'pr_open', 'reviewing', 'changes_requested', 'ready_to_merge',
+						'blocked', 'awaiting_human_merge', 'awaiting_human'
+					)
+					OR tasks.state NOT IN (
+						'planned', 'implementing', 'pr_open', 'reviewing', 'changes_requested', 'ready_to_merge',
+						'merged', 'superseded', 'stranded', 'blocked', 'awaiting_human_merge', 'dismissed', 'awaiting_human'
+					)
+				)
+		)
+		AND NOT EXISTS (
+			SELECT 1 FROM jobs
+			WHERE jobs.state NOT IN ('succeeded', 'failed', 'cancelled')
+				AND json_valid(jobs.payload)
+				AND TRIM(COALESCE(json_extract(jobs.payload, '$.branch'), '')) = TRIM(branch_locks.branch)
+				AND (
+					TRIM(jobs.repo) = TRIM(branch_locks.repo_full_name)
+					OR TRIM(COALESCE(json_extract(jobs.payload, '$.repo'), '')) = TRIM(branch_locks.repo_full_name)
+				)
+		)`
+	result, err := tx.ExecContext(ctx, query, args...)
+	if err != nil {
+		return false, err
+	}
+	affected, err := result.RowsAffected()
+	if err != nil {
+		return false, err
+	}
+	if affected == 0 {
+		return false, tx.Commit()
+	}
+
+	event.RepoFullName = strings.TrimSpace(lock.RepoFullName)
+	event.Branch = strings.TrimSpace(lock.Branch)
+	event.Owner = strings.TrimSpace(lock.Owner)
+	if strings.TrimSpace(event.Kind) == "" {
+		event.Kind = "released"
+	}
+	if _, err := tx.ExecContext(ctx, `INSERT INTO lock_events(repo_full_name, branch, owner, kind, message)
+		VALUES (?, ?, ?, ?, ?)`, event.RepoFullName, event.Branch, event.Owner, event.Kind, event.Message); err != nil {
+		return false, err
+	}
+	return true, tx.Commit()
+}
+
 func (s *Store) ForceReleaseLockWithEvent(ctx context.Context, repoFullName string, branch string, event BranchLockEvent) (BranchLock, bool, error) {
 	lock, err := s.GetBranchLock(ctx, repoFullName, branch)
 	if errors.Is(err, sql.ErrNoRows) {

--- a/internal/db/store_locks.go
+++ b/internal/db/store_locks.go
@@ -447,15 +447,18 @@ func (s *Store) ReleaseLockWithEvent(ctx context.Context, lock BranchLock, event
 }
 
 // ReleaseBranchLockIfInactiveWithEvent releases lock only when no non-terminal
-// task or job still references its repo+branch. A zero updatedBefore disables the
-// age predicate for event-driven cleanup such as CancelJob; the daemon sweeper
-// supplies a cutoff so a newly acquired lane can never be reclaimed.
+// task or job still references its repo+branch. ignoredImplementingTaskID lets
+// event-driven cancellation exclude only its exact implementing task while the
+// stale-task reconciler retains ownership of task dismissal and cleanup. Empty
+// disables the exclusion, as the daemon sweeper requires. A zero updatedBefore
+// disables the age predicate; the sweeper supplies a cutoff so a newly acquired
+// lane can never be reclaimed.
 //
 // The terminal sets are deliberately allowlists. A new or unknown lifecycle
 // state therefore keeps the lock until its release policy is decided explicitly.
 // In particular, blocked, awaiting_human_merge, and awaiting_human tasks retain
 // their lanes for operator resumption, and blocked jobs remain non-terminal.
-func (s *Store) ReleaseBranchLockIfInactiveWithEvent(ctx context.Context, lock BranchLock, updatedBefore time.Time, event BranchLockEvent) (bool, error) {
+func (s *Store) ReleaseBranchLockIfInactiveWithEvent(ctx context.Context, lock BranchLock, ignoredImplementingTaskID string, updatedBefore time.Time, event BranchLockEvent) (bool, error) {
 	tx, err := s.db.BeginTx(ctx, nil)
 	if err != nil {
 		return false, err
@@ -469,11 +472,13 @@ func (s *Store) ReleaseBranchLockIfInactiveWithEvent(ctx context.Context, lock B
 		query += ` AND updated_at <= ?`
 		args = append(args, updatedBefore.UTC().Format("2006-01-02 15:04:05"))
 	}
+	args = append(args, strings.TrimSpace(ignoredImplementingTaskID))
 	query += `
 		AND NOT EXISTS (
 			SELECT 1 FROM tasks
 			WHERE tasks.repo_full_name = branch_locks.repo_full_name
 				AND TRIM(tasks.branch) = TRIM(branch_locks.branch)
+				AND NOT (tasks.id = ? AND tasks.state = 'implementing')
 				AND (
 					tasks.state IN (
 						'planned', 'implementing', 'pr_open', 'reviewing', 'changes_requested', 'ready_to_merge',

--- a/internal/workflow/job_recovery.go
+++ b/internal/workflow/job_recovery.go
@@ -395,14 +395,21 @@ func CancelJob(ctx context.Context, store *db.Store, jobID string) (db.Job, erro
 			})
 		}
 		// A top-level task implement owns the task lane rather than an ephemeral
-		// delegation lane. Cancellation is terminal for this job, so release that
-		// lane only when no other non-terminal task or job still references the
-		// same repo+branch. The store performs the check and delete atomically;
-		// best-effort cleanup must not roll back a successful cancellation.
+		// delegation lane. Production creates the implementing task before this job,
+		// so cancellation first dismisses that task when it has no queued/running
+		// successor. RetryJob explicitly recovers a dismissed task before requeueing,
+		// keeping cancellation reversible. Unknown and review-owned task states fail
+		// closed. The store then atomically releases the lane only when no other
+		// non-terminal task or job references the same repo+branch; best-effort lock
+		// cleanup must not roll back a successful cancellation.
 		if job.Type == "implement" && strings.TrimSpace(payload.TaskID) != "" && strings.TrimSpace(payload.DelegationID) == "" {
 			repo := strings.TrimSpace(payload.Repo)
 			branch := strings.TrimSpace(payload.Branch)
-			if repo != "" && branch != "" {
+			changed, current, terr := store.TransitionTaskStateWithEventIfNoActiveJob(ctx, strings.TrimSpace(payload.TaskID),
+				[]string{string(TaskImplementing)}, string(TaskDismissed), "task_dismissed_job_cancel",
+				fmt.Sprintf("top-level implement job %s cancelled", job.ID))
+			taskDismissed := terr == nil && (changed || current == string(TaskDismissed))
+			if taskDismissed && repo != "" && branch != "" {
 				if lock, lerr := store.GetBranchLock(ctx, repo, branch); lerr == nil {
 					if released, rerr := store.ReleaseBranchLockIfInactiveWithEvent(ctx, lock, time.Time{}, db.BranchLockEvent{
 						Kind: "released", Message: "released after task implement cancellation left no non-terminal branch work (#1565)",

--- a/internal/workflow/job_recovery.go
+++ b/internal/workflow/job_recovery.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/gitmoot/gitmoot/internal/db"
 )
@@ -392,6 +393,27 @@ func CancelJob(ctx context.Context, store *db.Store, jobID string) (db.Job, erro
 				Kind:    "delegation_branch_lock_released",
 				Message: fmt.Sprintf("released delegation branch lock %s on cancel (#617)", strings.TrimSpace(payload.Branch)),
 			})
+		}
+		// A top-level task implement owns the task lane rather than an ephemeral
+		// delegation lane. Cancellation is terminal for this job, so release that
+		// lane only when no other non-terminal task or job still references the
+		// same repo+branch. The store performs the check and delete atomically;
+		// best-effort cleanup must not roll back a successful cancellation.
+		if job.Type == "implement" && strings.TrimSpace(payload.TaskID) != "" && strings.TrimSpace(payload.DelegationID) == "" {
+			repo := strings.TrimSpace(payload.Repo)
+			branch := strings.TrimSpace(payload.Branch)
+			if repo != "" && branch != "" {
+				if lock, lerr := store.GetBranchLock(ctx, repo, branch); lerr == nil {
+					if released, rerr := store.ReleaseBranchLockIfInactiveWithEvent(ctx, lock, time.Time{}, db.BranchLockEvent{
+						Kind: "released", Message: "released after task implement cancellation left no non-terminal branch work (#1565)",
+					}); rerr == nil && released {
+						_ = store.AddJobEvent(ctx, db.JobEvent{
+							JobID: job.ID, Kind: "task_lane_lock_released",
+							Message: fmt.Sprintf("released task lane lock %s on cancel (#1565)", branch),
+						})
+					}
+				}
+			}
 		}
 		// Symmetric with the branch-lock release above: dispose a #739 dispatch-time
 		// read-only worktree that this cancel-before-run would otherwise leak.

--- a/internal/workflow/job_recovery.go
+++ b/internal/workflow/job_recovery.go
@@ -395,23 +395,17 @@ func CancelJob(ctx context.Context, store *db.Store, jobID string) (db.Job, erro
 			})
 		}
 		// A top-level task implement owns the task lane rather than an ephemeral
-		// delegation lane. Production creates the implementing task before this job,
-		// so cancellation first dismisses that task when it has no queued/running
-		// successor. RetryJob explicitly recovers a dismissed task before requeueing,
-		// keeping cancellation reversible. Unknown and review-owned task states fail
-		// closed. The store then atomically releases the lane only when no other
-		// non-terminal task or job references the same repo+branch; best-effort lock
-		// cleanup must not roll back a successful cancellation.
+		// delegation lane. Leave task dismissal to the stale-task reconciler, which
+		// owns remote cleanup and the task_dismissed_auto audit event. Cancellation
+		// excludes only this exact implementing task from the atomic release check;
+		// every other task, every unknown/review state, and every non-terminal job
+		// still vetoes. Best-effort cleanup must not roll back a successful cancel.
 		if job.Type == "implement" && strings.TrimSpace(payload.TaskID) != "" && strings.TrimSpace(payload.DelegationID) == "" {
 			repo := strings.TrimSpace(payload.Repo)
 			branch := strings.TrimSpace(payload.Branch)
-			changed, current, terr := store.TransitionTaskStateWithEventIfNoActiveJob(ctx, strings.TrimSpace(payload.TaskID),
-				[]string{string(TaskImplementing)}, string(TaskDismissed), "task_dismissed_job_cancel",
-				fmt.Sprintf("top-level implement job %s cancelled", job.ID))
-			taskDismissed := terr == nil && (changed || current == string(TaskDismissed))
-			if taskDismissed && repo != "" && branch != "" {
+			if repo != "" && branch != "" {
 				if lock, lerr := store.GetBranchLock(ctx, repo, branch); lerr == nil {
-					if released, rerr := store.ReleaseBranchLockIfInactiveWithEvent(ctx, lock, time.Time{}, db.BranchLockEvent{
+					if released, rerr := store.ReleaseBranchLockIfInactiveWithEvent(ctx, lock, strings.TrimSpace(payload.TaskID), time.Time{}, db.BranchLockEvent{
 						Kind: "released", Message: "released after task implement cancellation left no non-terminal branch work (#1565)",
 					}); rerr == nil && released {
 						_ = store.AddJobEvent(ctx, db.JobEvent{

--- a/internal/workflow/job_recovery_test.go
+++ b/internal/workflow/job_recovery_test.go
@@ -346,14 +346,19 @@ func TestCancelJobReleasesRuntimeSessionLock(t *testing.T) {
 	}
 }
 
-// TestCancelJobReleasesInactiveTaskLaneLock kills the mutant that removes the
-// task-lane release from CancelJob. Once this top-level implement is cancelled
-// and no other non-terminal work references repo+branch, the operator's cancel
-// must immediately free the lane for the replacement writer.
+// TestCancelJobReleasesInactiveTaskLaneLock kills the pre-fix mutant that leaves
+// the production task row implementing before attempting the lane release. Once
+// this top-level implement is cancelled and no other non-terminal work references
+// repo+branch, the operator's cancel must immediately free the lane for a replacement writer.
 func TestCancelJobReleasesInactiveTaskLaneLock(t *testing.T) {
 	ctx := context.Background()
 	store := openTestStore(t)
 	const branch = "feature/cancelled-writer"
+	if err := store.UpsertTask(ctx, db.Task{
+		ID: "task-cancelled", RepoFullName: "owner/repo", State: string(TaskImplementing), Branch: branch,
+	}); err != nil {
+		t.Fatal(err)
+	}
 	acquired, err := store.AcquireLock(ctx, db.BranchLock{RepoFullName: "owner/repo", Branch: branch, Owner: "lead"})
 	if err != nil || !acquired {
 		t.Fatalf("AcquireLock acquired=%v err=%v", acquired, err)
@@ -375,12 +380,73 @@ func TestCancelJobReleasesInactiveTaskLaneLock(t *testing.T) {
 	if _, err := store.GetBranchLock(ctx, "owner/repo", branch); !errors.Is(err, sql.ErrNoRows) {
 		t.Fatalf("GetBranchLock after cancel error = %v, want sql.ErrNoRows", err)
 	}
+	task, err := store.GetTask(ctx, "task-cancelled")
+	if err != nil || task.State != string(TaskDismissed) {
+		t.Fatalf("task after cancel = %+v, err=%v; want dismissed", task, err)
+	}
 	events, err := store.ListBranchLockEvents(ctx, "owner/repo", branch)
 	if err != nil {
 		t.Fatal(err)
 	}
 	if len(events) != 1 || events[0].Kind != "released" || !strings.Contains(events[0].Message, "cancellation") {
 		t.Fatalf("branch lock events = %+v, want cancellation release", events)
+	}
+}
+
+// TestCancelJobTaskLaneReleaseFailsClosed kills mutants that dismiss through a
+// queued successor or widen the implementing-state allowlist to review/unknown
+// states. Those states must retain both task state and lane ownership.
+func TestCancelJobTaskLaneReleaseFailsClosed(t *testing.T) {
+	for _, test := range []struct {
+		name      string
+		taskState string
+		otherJob  bool
+	}{
+		{name: "queued successor", taskState: string(TaskImplementing), otherJob: true},
+		{name: "review-owned task", taskState: string(TaskReviewing)},
+		{name: "unknown task state", taskState: "future_state"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			ctx := context.Background()
+			store := openTestStore(t)
+			branch := "feature/cancel-veto-" + strings.ReplaceAll(test.name, " ", "-")
+			if err := store.UpsertTask(ctx, db.Task{
+				ID: "task-cancelled", RepoFullName: "owner/repo", State: test.taskState, Branch: branch,
+			}); err != nil {
+				t.Fatal(err)
+			}
+			acquired, err := store.AcquireLock(ctx, db.BranchLock{RepoFullName: "owner/repo", Branch: branch, Owner: "lead"})
+			if err != nil || !acquired {
+				t.Fatalf("AcquireLock acquired=%v err=%v", acquired, err)
+			}
+			payload, err := json.Marshal(JobPayload{Repo: "owner/repo", Branch: branch, TaskID: "task-cancelled"})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err := store.CreateJobWithEvent(ctx, db.Job{
+				ID: "job-cancelled", Agent: "lead", Type: "implement", State: string(JobQueued), Repo: "owner/repo", Payload: string(payload),
+			}, db.JobEvent{Kind: string(JobQueued), Message: "queued"}); err != nil {
+				t.Fatal(err)
+			}
+			if test.otherJob {
+				if err := store.CreateJobWithEvent(ctx, db.Job{
+					ID: "job-successor", Agent: "lead", Type: "implement", State: string(JobQueued), Repo: "owner/repo", Payload: string(payload),
+				}, db.JobEvent{Kind: string(JobQueued), Message: "queued successor"}); err != nil {
+					t.Fatal(err)
+				}
+			}
+
+			if _, err := CancelJob(ctx, store, "job-cancelled"); err != nil {
+				t.Fatal(err)
+			}
+			if _, err := store.GetBranchLock(ctx, "owner/repo", branch); err != nil {
+				t.Fatalf("branch lock was released despite %s: %v", test.name, err)
+			}
+			stored, err := store.GetTask(ctx, "task-cancelled")
+			if err != nil || stored.State != test.taskState {
+				t.Fatalf("task after cancel = %+v, err=%v; want state %q retained", stored, err, test.taskState)
+			}
+		})
 	}
 }
 

--- a/internal/workflow/job_recovery_test.go
+++ b/internal/workflow/job_recovery_test.go
@@ -3,6 +3,7 @@ package workflow
 import (
 	"context"
 	"database/sql"
+	"encoding/json"
 	"errors"
 	"strings"
 	"sync"
@@ -342,6 +343,44 @@ func TestCancelJobReleasesRuntimeSessionLock(t *testing.T) {
 	}
 	if !reacquired {
 		t.Fatal("second job could not re-acquire the freed runtime-session lock")
+	}
+}
+
+// TestCancelJobReleasesInactiveTaskLaneLock kills the mutant that removes the
+// task-lane release from CancelJob. Once this top-level implement is cancelled
+// and no other non-terminal work references repo+branch, the operator's cancel
+// must immediately free the lane for the replacement writer.
+func TestCancelJobReleasesInactiveTaskLaneLock(t *testing.T) {
+	ctx := context.Background()
+	store := openTestStore(t)
+	const branch = "feature/cancelled-writer"
+	acquired, err := store.AcquireLock(ctx, db.BranchLock{RepoFullName: "owner/repo", Branch: branch, Owner: "lead"})
+	if err != nil || !acquired {
+		t.Fatalf("AcquireLock acquired=%v err=%v", acquired, err)
+	}
+	payload, err := json.Marshal(JobPayload{Repo: "owner/repo", Branch: branch, TaskID: "task-cancelled"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := store.CreateJobWithEvent(ctx, db.Job{
+		ID: "job-cancelled-writer", Agent: "lead", Type: "implement", State: string(JobQueued), Repo: "owner/repo", Payload: string(payload),
+	}, db.JobEvent{Kind: string(JobQueued), Message: "queued"}); err != nil {
+		t.Fatal(err)
+	}
+
+	job, err := CancelJob(ctx, store, "job-cancelled-writer")
+	if err != nil || job.State != string(JobCancelled) {
+		t.Fatalf("CancelJob job=%+v err=%v", job, err)
+	}
+	if _, err := store.GetBranchLock(ctx, "owner/repo", branch); !errors.Is(err, sql.ErrNoRows) {
+		t.Fatalf("GetBranchLock after cancel error = %v, want sql.ErrNoRows", err)
+	}
+	events, err := store.ListBranchLockEvents(ctx, "owner/repo", branch)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(events) != 1 || events[0].Kind != "released" || !strings.Contains(events[0].Message, "cancellation") {
+		t.Fatalf("branch lock events = %+v, want cancellation release", events)
 	}
 }
 

--- a/internal/workflow/job_recovery_test.go
+++ b/internal/workflow/job_recovery_test.go
@@ -346,10 +346,10 @@ func TestCancelJobReleasesRuntimeSessionLock(t *testing.T) {
 	}
 }
 
-// TestCancelJobReleasesInactiveTaskLaneLock kills the pre-fix mutant that leaves
-// the production task row implementing before attempting the lane release. Once
-// this top-level implement is cancelled and no other non-terminal work references
-// repo+branch, the operator's cancel must immediately free the lane for a replacement writer.
+// TestCancelJobReleasesInactiveTaskLaneLock kills both a missing self-exclusion,
+// which retains the lane, and task dismissal inside CancelJob, which usurps the
+// stale-task reconciler. Cancellation must free the lane while leaving task state
+// and dismissal audit ownership unchanged.
 func TestCancelJobReleasesInactiveTaskLaneLock(t *testing.T) {
 	ctx := context.Background()
 	store := openTestStore(t)
@@ -381,8 +381,12 @@ func TestCancelJobReleasesInactiveTaskLaneLock(t *testing.T) {
 		t.Fatalf("GetBranchLock after cancel error = %v, want sql.ErrNoRows", err)
 	}
 	task, err := store.GetTask(ctx, "task-cancelled")
-	if err != nil || task.State != string(TaskDismissed) {
-		t.Fatalf("task after cancel = %+v, err=%v; want dismissed", task, err)
+	if err != nil || task.State != string(TaskImplementing) {
+		t.Fatalf("task after cancel = %+v, err=%v; want implementing for stale-task reconciliation", task, err)
+	}
+	taskEvents, err := store.ListTaskEvents(ctx, task.ID)
+	if err != nil || len(taskEvents) != 0 {
+		t.Fatalf("task events after cancel = %+v, err=%v; dismissal audit belongs to stale-task reconciliation", taskEvents, err)
 	}
 	events, err := store.ListBranchLockEvents(ctx, "owner/repo", branch)
 	if err != nil {
@@ -393,25 +397,28 @@ func TestCancelJobReleasesInactiveTaskLaneLock(t *testing.T) {
 	}
 }
 
-// TestCancelJobTaskLaneReleaseFailsClosed kills mutants that dismiss through a
-// queued successor or widen the implementing-state allowlist to review/unknown
-// states. Those states must retain both task state and lane ownership.
+// TestCancelJobTaskLaneReleaseFailsClosed kills mutants that ignore every task,
+// ignore a different task ID, or widen the implementing-only exclusion to review
+// and unknown states. Those references must retain task state and lane ownership.
 func TestCancelJobTaskLaneReleaseFailsClosed(t *testing.T) {
 	for _, test := range []struct {
-		name      string
-		taskState string
-		otherJob  bool
+		name          string
+		rowTaskID     string
+		payloadTaskID string
+		taskState     string
+		otherJob      bool
 	}{
-		{name: "queued successor", taskState: string(TaskImplementing), otherJob: true},
-		{name: "review-owned task", taskState: string(TaskReviewing)},
-		{name: "unknown task state", taskState: "future_state"},
+		{name: "queued successor", rowTaskID: "task-cancelled", payloadTaskID: "task-cancelled", taskState: string(TaskImplementing), otherJob: true},
+		{name: "different task", rowTaskID: "task-other", payloadTaskID: "task-cancelled", taskState: string(TaskImplementing)},
+		{name: "review-owned task", rowTaskID: "task-cancelled", payloadTaskID: "task-cancelled", taskState: string(TaskReviewing)},
+		{name: "unknown task state", rowTaskID: "task-cancelled", payloadTaskID: "task-cancelled", taskState: "future_state"},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			ctx := context.Background()
 			store := openTestStore(t)
 			branch := "feature/cancel-veto-" + strings.ReplaceAll(test.name, " ", "-")
 			if err := store.UpsertTask(ctx, db.Task{
-				ID: "task-cancelled", RepoFullName: "owner/repo", State: test.taskState, Branch: branch,
+				ID: test.rowTaskID, RepoFullName: "owner/repo", State: test.taskState, Branch: branch,
 			}); err != nil {
 				t.Fatal(err)
 			}
@@ -419,7 +426,7 @@ func TestCancelJobTaskLaneReleaseFailsClosed(t *testing.T) {
 			if err != nil || !acquired {
 				t.Fatalf("AcquireLock acquired=%v err=%v", acquired, err)
 			}
-			payload, err := json.Marshal(JobPayload{Repo: "owner/repo", Branch: branch, TaskID: "task-cancelled"})
+			payload, err := json.Marshal(JobPayload{Repo: "owner/repo", Branch: branch, TaskID: test.payloadTaskID})
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -442,7 +449,7 @@ func TestCancelJobTaskLaneReleaseFailsClosed(t *testing.T) {
 			if _, err := store.GetBranchLock(ctx, "owner/repo", branch); err != nil {
 				t.Fatalf("branch lock was released despite %s: %v", test.name, err)
 			}
-			stored, err := store.GetTask(ctx, "task-cancelled")
+			stored, err := store.GetTask(ctx, test.rowTaskID)
 			if err != nil || stored.State != test.taskState {
 				t.Fatalf("task after cancel = %+v, err=%v; want state %q retained", stored, err, test.taskState)
 			}

--- a/skills/gitmoot/references/SAFETY.md
+++ b/skills/gitmoot/references/SAFETY.md
@@ -14,6 +14,13 @@ by the assigned agent.
 Review and ask jobs should inspect and report without mutating branches unless
 the task explicitly instructs otherwise.
 
+A task branch lock spans the complete implement, review, and fix lifecycle; an
+implement success does not release it. Cancelling a top-level implement releases
+the lock only when no non-terminal task or job references the same repository and
+branch. The daemon also reclaims idle locks unchanged for at least 24 hours, using
+the same repo+branch liveness check. `blocked`, `awaiting_human_merge`, and
+`awaiting_human` tasks keep their locks because an operator can resume them.
+
 Do not ask child agents to run PR lifecycle commands such as `git pull`,
 `git merge`, `git push`, or `gh pr merge` to make parallel task PRs mergeable.
 Gitmoot owns the final merge gate. It serializes merge attempts per base branch,

--- a/skills/gitmoot/references/SAFETY.md
+++ b/skills/gitmoot/references/SAFETY.md
@@ -16,10 +16,11 @@ the task explicitly instructs otherwise.
 
 A task branch lock spans the complete implement, review, and fix lifecycle; an
 implement success does not release it. Cancelling a top-level implement releases
-the lock only when no non-terminal task or job references the same repository and
-branch. The daemon also reclaims idle locks unchanged for at least 24 hours, using
-the same repo+branch liveness check. `blocked`, `awaiting_human_merge`, and
-`awaiting_human` tasks keep their locks because an operator can resume them.
+the lock only when no other non-terminal task or job references the same
+repository and branch. The daemon also reclaims idle locks unchanged for at
+least 24 hours, but only after no non-terminal task or job remains. `blocked`,
+`awaiting_human_merge`, and `awaiting_human` tasks keep their locks because an
+operator can resume them.
 
 Do not ask child agents to run PR lifecycle commands such as `git pull`,
 `git merge`, `git push`, or `gh pr merge` to make parallel task PRs mergeable.

--- a/website/docs/concepts/agents-templates-jobs-locks.md
+++ b/website/docs/concepts/agents-templates-jobs-locks.md
@@ -159,6 +159,13 @@ Gitmoot uses separate locks for separate resources:
 Review and ask jobs usually inspect and report. Implementation jobs should only
 mutate branches when Gitmoot assigned the job and the branch lock is held.
 
+Task branch locks cover the full implement, review, and fix lifecycle, so an
+implement success deliberately keeps the lock. Cancelling a top-level implement
+releases its lane only when no non-terminal task or job references the same
+repository and branch. The daemon also reclaims locks unchanged for at least 24
+hours under that same no-live-work condition. Tasks in `blocked`,
+`awaiting_human_merge`, or `awaiting_human` keep their locks for human resumption.
+
 The daemon defaults to `--workers 1`. Raise workers only when jobs use
 independent runtime sessions or managed agent types with `max_background`
 greater than one.

--- a/website/docs/concepts/agents-templates-jobs-locks.md
+++ b/website/docs/concepts/agents-templates-jobs-locks.md
@@ -161,9 +161,9 @@ mutate branches when Gitmoot assigned the job and the branch lock is held.
 
 Task branch locks cover the full implement, review, and fix lifecycle, so an
 implement success deliberately keeps the lock. Cancelling a top-level implement
-releases its lane only when no non-terminal task or job references the same
-repository and branch. The daemon also reclaims locks unchanged for at least 24
-hours under that same no-live-work condition. Tasks in `blocked`,
+releases its lane only when no other non-terminal task or job references the
+same repository and branch. The daemon also reclaims locks unchanged for at
+least 24 hours, but only after no non-terminal task or job remains. Tasks in `blocked`,
 `awaiting_human_merge`, or `awaiting_human` keep their locks for human resumption.
 
 The daemon defaults to `--workers 1`. Raise workers only when jobs use

--- a/website/docs/operations/troubleshooting.md
+++ b/website/docs/operations/troubleshooting.md
@@ -373,8 +373,12 @@ gitmoot lock list --repo owner/repo
 gitmoot lock show owner/repo <branch>
 ```
 
-Fix: let a running daemon reclaim stale resource locks automatically. Release a
-branch lock only after confirming the owner is no longer working:
+Fix: let a running daemon reclaim stale resource locks automatically. Task lane
+locks are released only after they have been unchanged for at least 24 hours and
+no non-terminal task or job references the same repository and branch. Human-
+resumable `blocked`, `awaiting_human_merge`, and `awaiting_human` tasks retain
+their locks. Release a branch lock manually only after confirming the owner is
+no longer working:
 
 ```sh
 gitmoot lock release owner/repo <branch> --owner <agent>

--- a/website/static/llms-full.txt
+++ b/website/static/llms-full.txt
@@ -1220,6 +1220,14 @@ If a job is not eligible, Gitmoot keeps the old queue/wait behavior.
    gitmoot lock release owner/project <branch> --owner <agent>
    ```
 
+   Task lane locks remain held after an implement job succeeds so review and fix
+   rounds keep exclusive ownership of the branch. Cancelling a top-level
+   implement releases its lane only when no non-terminal task or job still
+   references the same repository and branch. As a backstop, the daemon releases
+   locks unchanged for at least 24 hours under that same no-live-work condition.
+   Tasks in `blocked`, `awaiting_human_merge`, or `awaiting_human` retain their
+   locks for human resumption.
+
 8. Let the PR converge.
 
    Agents review, request fixes, and rerun work through comments and job output.
@@ -16382,6 +16390,13 @@ by the assigned agent.
 
 Review and ask jobs should inspect and report without mutating branches unless
 the task explicitly instructs otherwise.
+
+A task branch lock spans the complete implement, review, and fix lifecycle; an
+implement success does not release it. Cancelling a top-level implement releases
+the lock only when no non-terminal task or job references the same repository and
+branch. The daemon also reclaims idle locks unchanged for at least 24 hours, using
+the same repo+branch liveness check. `blocked`, `awaiting_human_merge`, and
+`awaiting_human` tasks keep their locks because an operator can resume them.
 
 Do not ask child agents to run PR lifecycle commands such as `git pull`,
 `git merge`, `git push`, or `gh pr merge` to make parallel task PRs mergeable.

--- a/website/static/llms-full.txt
+++ b/website/static/llms-full.txt
@@ -1222,11 +1222,11 @@ If a job is not eligible, Gitmoot keeps the old queue/wait behavior.
 
    Task lane locks remain held after an implement job succeeds so review and fix
    rounds keep exclusive ownership of the branch. Cancelling a top-level
-   implement releases its lane only when no non-terminal task or job still
+   implement releases its lane only when no other non-terminal task or job still
    references the same repository and branch. As a backstop, the daemon releases
-   locks unchanged for at least 24 hours under that same no-live-work condition.
-   Tasks in `blocked`, `awaiting_human_merge`, or `awaiting_human` retain their
-   locks for human resumption.
+   locks unchanged for at least 24 hours only after no non-terminal task or job
+   remains. Tasks in `blocked`, `awaiting_human_merge`, or `awaiting_human`
+   retain their locks for human resumption.
 
 8. Let the PR converge.
 
@@ -16393,10 +16393,11 @@ the task explicitly instructs otherwise.
 
 A task branch lock spans the complete implement, review, and fix lifecycle; an
 implement success does not release it. Cancelling a top-level implement releases
-the lock only when no non-terminal task or job references the same repository and
-branch. The daemon also reclaims idle locks unchanged for at least 24 hours, using
-the same repo+branch liveness check. `blocked`, `awaiting_human_merge`, and
-`awaiting_human` tasks keep their locks because an operator can resume them.
+the lock only when no other non-terminal task or job references the same
+repository and branch. The daemon also reclaims idle locks unchanged for at
+least 24 hours, but only after no non-terminal task or job remains. `blocked`,
+`awaiting_human_merge`, and `awaiting_human` tasks keep their locks because an
+operator can resume them.
 
 Do not ask child agents to run PR lifecycle commands such as `git pull`,
 `git merge`, `git push`, or `gh pr merge` to make parallel task PRs mergeable.


### PR DESCRIPTION
WHAT:
GITMOOT-COC-1565-S1: implemented cancellation-time and age-based lane-lock reclamation while preserving locks for active and human-resumable work. Verified against origin/main 72bac8e5609bf898ecbed56090b69faa746b0378.

WHY:
Gitmoot finalized this implementation from a task worktree.

CHANGES:
- Committed changes from /root/.gitmoot/worktrees/gitmoot--gitmoot/adhoc-389a11c6

RESULTS:
- Baseline -list census matched 5 top-level tests: 1 cancellation guard and 4 sweeper guards. Anchor census: ReleaseBranchLockIfInactiveWithEvent has one definition and two production callers; the sweeper is installed on standalone/single-repo and fleet paths.
- Compile-valid cancellation-hook removal mutant failed TestCancelJobReleasesInactiveTaskLaneLock.
- Compile-valid age-floor removal mutant failed TestStaleTaskLaneLockSweepEnforcesAgeFloor.
- Compile-valid keep-allowlist mutant failed blocked and awaiting_human_merge retention subtests.
- Compile-valid job-veto and task-veto mutants failed their non-terminal-reference guards.
- Focused #1582 and #1593 guards passed, including poison-pill continuation, flood suppression, accounting fail-closed behavior, quarantine terminality, retry-path quarantine, symlink containment, and identity mismatch.
- With isolated HOME, go test ./internal/cli/ ./internal/db/ ./internal/workflow/ -count=1 -timeout 25m passed.
- go build -buildvcs=false ./..., go vet ./internal/cli/ ./internal/db/ ./internal/workflow/, go generate ./..., gofmt census, and git diff --check passed.

RISK:
Review the generated diff before merging.

TASK:
adhoc-389a11c6

AGENTS:
- wave-impl

RAW FINAL REVIEW OUTPUT:
````text
GITMOOT-COC-1565-S1: implemented cancellation-time and age-based lane-lock reclamation while preserving locks for active and human-resumable work. Verified against origin/main 72bac8e5609bf898ecbed56090b69faa746b0378.
````
