### PR TITLE
Gitmoot: IMPLEMENT gitmoot#1526 — three internal/cli tests read the

### DIFF
--- a/internal/cli/daemon_home_shape_test.go
+++ b/internal/cli/daemon_home_shape_test.go
@@ -147,6 +147,11 @@ func TestResolveEscalationTTLTable(t *testing.T) {
 // invariant the #446/#459 seam shares: a raw --home and the already-resolved
 // <home>/.gitmoot root resolve identically with no phantom doubled home.
 func TestResolveBlockedTTLShapeTolerantNoPhantom(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	if _, err := config.DefaultPaths(); err != nil {
+		t.Fatal(err)
+	}
+
 	// A positive TTL resolves identically for BOTH the raw --home and the resolved
 	// <home>/.gitmoot root, creating no phantom in either case.
 	positive := initHomeWithBlockedTTL(t, "48h")

--- a/internal/cli/merge_gate_policy_test.go
+++ b/internal/cli/merge_gate_policy_test.go
@@ -118,6 +118,11 @@ require_external_ci = true
 }
 
 func TestApplyMergeGatePolicyEmptyHomeIsNoop(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	if _, err := config.DefaultPaths(); err != nil {
+		t.Fatal(err)
+	}
+
 	gate := workflow.PolicyMergeGate{}
 	applyMergeGatePolicy(&gate, "", "jerryfane/noted")
 	if gate.AutoMerge || gate.RequireExternalCI || gate.MinCIWait != 0 || gate.MaxCIWait != 0 {

--- a/internal/cli/trace_harvest_daemon_test.go
+++ b/internal/cli/trace_harvest_daemon_test.go
@@ -97,6 +97,11 @@ func TestDaemonOutcomeHarvesterFailSafeOnBadConfig(t *testing.T) {
 // leaves OutcomeHarvester nil with no [skillopt] config, so the engine constructs
 // no Outcome and harvests nothing (byte-identical default).
 func TestDaemonWorkflowEngineNilHarvesterByDefault(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	if _, err := config.DefaultPaths(); err != nil {
+		t.Fatal(err)
+	}
+
 	store := openHarvestStore(t)
 	engine := daemonWorkflowEngine(store, github.NoopClient{}, "/tmp/gitmoot-checkout", "")
 	if engine.OutcomeHarvester != nil {


### PR DESCRIPTION
WHAT:
GITMOOT-COC — Isolated all three empty-home tests from the operator's live configuration using per-test temporary HOME directories.

WHY:
Gitmoot finalized this implementation from a task worktree.

CHANGES:
- Committed changes from /root/.gitmoot/worktrees/gitmoot--gitmoot/adhoc-877f2a9d

RESULTS:
- Baseline `-list` filter matched exactly 3 top-level tests.
- Pre-fix control ran the unmodified tests against a safe temporary HOME containing equivalent non-default settings; all 3 failed: `resolveBlockedTTL("") = 720h0m0s, want 0`, `empty home must leave the gate untouched` with AutoMerge=true, and `daemonWorkflowEngine must wire a nil OutcomeHarvester`. This reproduced the ambient-home defect without reading /root/.gitmoot.
- Post-fix ambient invocation: the exact 3-test filter passed.
- Post-fix externally isolated HOME invocation: the exact 3-test filter passed.
- `gofmt` and `git diff --check` passed; only the three requested `_test.go` files are modified.

RISK:
Review the generated diff before merging.

TASK:
adhoc-877f2a9d

AGENTS:
- wave-impl

RAW FINAL REVIEW OUTPUT:
````text
GITMOOT-COC — Isolated all three empty-home tests from the operator's live configuration using per-test temporary HOME directories.
````
