### PR TITLE
Gitmoot: IMPLEMENT gitmoot#1580 (part of epic #1529). Base: current

### DIFF
--- a/docs/remote-exec.md
+++ b/docs/remote-exec.md
@@ -41,8 +41,13 @@ dedicated directory beneath a suitable operator-managed parent such as
 `/var/tmp`. A filesystem root is rejected. Gitmoot keeps its backend root and
 per-instance roots owned by the daemon, assigns their group to `local_gid`, and
 uses mode `0710` so the configured command group can traverse them without an
-execute bit for the Unix `other` class. With no uid/gid configured, local
-execution retains the daemon identity for backward compatibility.
+execute bit for the Unix `other` class. This is a group boundary: every process
+carrying `local_gid` can traverse, so use a dedicated group whose only member is
+the configured execution account when unrelated local users must be excluded.
+Gitmoot validates that the numeric UID/GID are paired and non-zero, but cannot
+portably prove group exclusivity across host account databases, NSS, or
+containers. With no uid/gid configured, local execution retains the daemon
+identity for backward compatibility.
 
 The runtime executable and any child-readable file-backed state must also be
 reachable by the configured identity. In particular, a root daemon whose

--- a/docs/remote-exec.md
+++ b/docs/remote-exec.md
@@ -34,14 +34,15 @@ reclaiming the clone for Git's ownership check, and import creates host files as
 the daemon user. Credential-application errors fail the command and never retry
 as the daemon user.
 
-The configured identity must be able to traverse every parent of the local
-backend root. The default root is below the Gitmoot home, so a root daemon whose
-home is under `/root` should also set absolute `local_root` to a dedicated
-directory beneath a suitable operator-managed parent such as `/var/tmp`. A
-filesystem root is rejected. Gitmoot makes its backend root and
-per-instance roots execute-only for traversal while leaving lifecycle metadata
-owned by the daemon. With no uid/gid configured, local execution retains the
-daemon identity for backward compatibility.
+The configured identity must be able to traverse every operator-managed parent
+of the local backend root. The default root is below the Gitmoot home, so a root
+daemon whose home is under `/root` should also set absolute `local_root` to a
+dedicated directory beneath a suitable operator-managed parent such as
+`/var/tmp`. A filesystem root is rejected. Gitmoot keeps its backend root and
+per-instance roots owned by the daemon, assigns their group to `local_gid`, and
+uses mode `0710` so the configured command group can traverse them without an
+execute bit for the Unix `other` class. With no uid/gid configured, local
+execution retains the daemon identity for backward compatibility.
 
 The runtime executable and any child-readable file-backed state must also be
 reachable by the configured identity. In particular, a root daemon whose

--- a/internal/config/init.go
+++ b/internal/config/init.go
@@ -135,7 +135,7 @@ artifact_blobs = %q
 # [remote_exec]
 # backend = "local"
 # local_uid = 1000 # optional; configure together with non-root local_gid
-# local_gid = 1000
+# local_gid = 1000 # use a dedicated group when unrelated local users must be excluded
 # local_root = "/var/tmp/gitmoot-local" # absolute; parents must be traversable by local_uid
 
 # [transcripts] is ON by default. Raw unredacted runtime output

--- a/internal/execbackend/lifecycle.go
+++ b/internal/execbackend/lifecycle.go
@@ -318,13 +318,13 @@ func (b *LocalBackend) handoffWorkspace(instance *Instance) error {
 		return fmt.Errorf("assign local execution-backend root to gid %d: %w", b.identity.GID, err)
 	}
 	if err := os.Chmod(b.root, 0o710); err != nil {
-		return fmt.Errorf("make local execution-backend root traversable for uid %d: %w", b.identity.UID, err)
+		return fmt.Errorf("make local execution-backend root traversable for gid %d: %w", b.identity.GID, err)
 	}
 	if err := b.chown(instance.root, -1, int(b.identity.GID)); err != nil {
 		return fmt.Errorf("assign local execution instance %q to gid %d: %w", instance.ID, b.identity.GID, err)
 	}
 	if err := os.Chmod(instance.root, 0o710); err != nil {
-		return fmt.Errorf("make local execution instance %q traversable for uid %d: %w", instance.ID, b.identity.UID, err)
+		return fmt.Errorf("make local execution instance %q traversable for gid %d: %w", instance.ID, b.identity.GID, err)
 	}
 	if err := chownLocalWorkspace(instance.Workspace, b.identity.UID, b.identity.GID); err != nil {
 		return fmt.Errorf("hand local execution workspace to uid %d gid %d: %w", b.identity.UID, b.identity.GID, err)

--- a/internal/execbackend/lifecycle.go
+++ b/internal/execbackend/lifecycle.go
@@ -121,6 +121,7 @@ type LocalIdentity struct {
 type LocalBackend struct {
 	root     string
 	identity *LocalIdentity
+	chown    func(string, int, int) error
 
 	mu     sync.Mutex
 	active map[string]map[*localExec]struct{}
@@ -152,7 +153,7 @@ func NewLocalBackend(root string, identity *LocalIdentity) (*LocalBackend, error
 		}
 		identity = &LocalIdentity{UID: identity.UID, GID: identity.GID}
 	}
-	return &LocalBackend{root: absolute, identity: identity, active: make(map[string]map[*localExec]struct{})}, nil
+	return &LocalBackend{root: absolute, identity: identity, chown: os.Chown, active: make(map[string]map[*localExec]struct{})}, nil
 }
 
 func (b *LocalBackend) Name() Backend { return Local }
@@ -309,16 +310,17 @@ func (b *LocalBackend) handoffWorkspace(instance *Instance) error {
 		return nil
 	}
 	// Keep backend and instance roots owned by the daemon, assign their group to
-	// the configured execution gid, and grant traverse only to that group. The
-	// operator-managed parent of b.root must already be traversable by the
-	// configured identity.
-	if err := os.Chown(b.root, -1, int(b.identity.GID)); err != nil {
+	// the configured execution gid, and grant traverse to that group. The
+	// operator-managed parent of b.root must already be traversable by the same
+	// group; local_gid must be dedicated when unrelated local users must not
+	// share access.
+	if err := b.chown(b.root, -1, int(b.identity.GID)); err != nil {
 		return fmt.Errorf("assign local execution-backend root to gid %d: %w", b.identity.GID, err)
 	}
 	if err := os.Chmod(b.root, 0o710); err != nil {
 		return fmt.Errorf("make local execution-backend root traversable for uid %d: %w", b.identity.UID, err)
 	}
-	if err := os.Chown(instance.root, -1, int(b.identity.GID)); err != nil {
+	if err := b.chown(instance.root, -1, int(b.identity.GID)); err != nil {
 		return fmt.Errorf("assign local execution instance %q to gid %d: %w", instance.ID, b.identity.GID, err)
 	}
 	if err := os.Chmod(instance.root, 0o710); err != nil {

--- a/internal/execbackend/lifecycle.go
+++ b/internal/execbackend/lifecycle.go
@@ -308,14 +308,20 @@ func (b *LocalBackend) handoffWorkspace(instance *Instance) error {
 	if b.identity == nil {
 		return nil
 	}
-	// Keep backend and instance roots owned by the daemon: execute-only access
-	// lets the configured identity traverse to its workspace without exposing
-	// sibling instance names or writable lifecycle metadata. The configured
-	// root's parent must likewise be traversable by that identity.
-	if err := os.Chmod(b.root, 0o711); err != nil {
+	// Keep backend and instance roots owned by the daemon, assign their group to
+	// the configured execution gid, and grant traverse only to that group. The
+	// operator-managed parent of b.root must already be traversable by the
+	// configured identity.
+	if err := os.Chown(b.root, -1, int(b.identity.GID)); err != nil {
+		return fmt.Errorf("assign local execution-backend root to gid %d: %w", b.identity.GID, err)
+	}
+	if err := os.Chmod(b.root, 0o710); err != nil {
 		return fmt.Errorf("make local execution-backend root traversable for uid %d: %w", b.identity.UID, err)
 	}
-	if err := os.Chmod(instance.root, 0o711); err != nil {
+	if err := os.Chown(instance.root, -1, int(b.identity.GID)); err != nil {
+		return fmt.Errorf("assign local execution instance %q to gid %d: %w", instance.ID, b.identity.GID, err)
+	}
+	if err := os.Chmod(instance.root, 0o710); err != nil {
 		return fmt.Errorf("make local execution instance %q traversable for uid %d: %w", instance.ID, b.identity.UID, err)
 	}
 	if err := chownLocalWorkspace(instance.Workspace, b.identity.UID, b.identity.GID); err != nil {

--- a/internal/execbackend/lifecycle_test.go
+++ b/internal/execbackend/lifecycle_test.go
@@ -158,6 +158,80 @@ func TestLocalBackendExecDropsPrivilegesAndImportNormalizesOwnership(t *testing.
 	}
 }
 
+func TestLocalBackendWorkspaceTraverseLimitedToConfiguredIdentity(t *testing.T) {
+	if os.Geteuid() != 0 {
+		t.Skip("workspace traverse identity proof requires a root test process")
+	}
+	identities := testUnprivilegedIdentitiesWithDistinctGIDs(t, 3)
+	configured := LocalIdentity{UID: identities[0].UID, GID: identities[1].GID}
+	third := identities[2]
+
+	host, _, _ := changeSetRepoPair(t)
+	backend := newPrivilegedTestLocalBackend(t, configured)
+	instance, err := backend.Provision(context.Background(), JobScope{JobID: "traverse-boundary"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = backend.Destroy(context.Background(), instance) })
+	if err := backend.SyncIn(context.Background(), instance, Materials{SourceWorktree: host}); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := runAsIdentity(configured, instance.Workspace, "/bin/pwd"); err != nil {
+		t.Fatalf("configured identity uid %d gid %d cannot traverse workspace: %v", configured.UID, configured.GID, err)
+	}
+	if err := runAsIdentity(third, instance.Workspace, "/bin/pwd"); err == nil {
+		t.Fatalf("third identity uid %d gid %d traversed workspace; want permission denied", third.UID, third.GID)
+	}
+
+	for _, path := range []string{backend.root, instance.root} {
+		info, err := os.Stat(path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got := info.Mode().Perm(); got != 0o710 {
+			t.Fatalf("traverse parent %q mode = %#o, want 0710", path, got)
+		}
+		if _, gid := pathOwnership(t, path); gid != configured.GID {
+			t.Fatalf("traverse parent %q gid = %d, want configured gid %d", path, gid, configured.GID)
+		}
+	}
+}
+
+func TestLocalBackendWorkspaceTraverseParentPermissions(t *testing.T) {
+	identity := LocalIdentity{UID: uint32(os.Geteuid()), GID: uint32(os.Getegid())}
+	if identity.UID == 0 || identity.GID == 0 {
+		identity = testUnprivilegedIdentities(t, 1)[0]
+	}
+	backend, err := NewLocalBackend(filepath.Join(t.TempDir(), "instances"), &identity)
+	if err != nil {
+		t.Fatal(err)
+	}
+	instance, err := backend.Provision(context.Background(), JobScope{JobID: "traverse-permissions"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Mkdir(instance.Workspace, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := backend.handoffWorkspace(instance); err != nil {
+		t.Fatal(err)
+	}
+
+	for _, path := range []string{backend.root, instance.root} {
+		info, err := os.Stat(path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got := info.Mode().Perm(); got != 0o710 {
+			t.Fatalf("traverse parent %q mode = %#o, want 0710", path, got)
+		}
+		if _, gid := pathOwnership(t, path); gid != identity.GID {
+			t.Fatalf("traverse parent %q gid = %d, want configured gid %d", path, gid, identity.GID)
+		}
+	}
+}
+
 func TestLocalBackendCuratedScratchUsesConfiguredIdentity(t *testing.T) {
 	identity := testUnprivilegedIdentities(t, 1)[0]
 	host, _, _ := changeSetRepoPair(t)
@@ -575,6 +649,52 @@ func testUnprivilegedIdentities(t *testing.T, count int) []LocalIdentity {
 	}
 	t.Skipf("no unprivileged identity configured: need %d distinct uid/gid pairs, found %d", count, len(identities))
 	return nil
+}
+
+func testUnprivilegedIdentitiesWithDistinctGIDs(t *testing.T, count int) []LocalIdentity {
+	t.Helper()
+	data, err := os.ReadFile("/etc/passwd")
+	if err != nil {
+		t.Skipf("no unprivileged identity configured: read /etc/passwd: %v", err)
+	}
+	identities := make([]LocalIdentity, 0, count)
+	seenUIDs := make(map[uint32]struct{})
+	seenGIDs := make(map[uint32]struct{})
+	for _, line := range strings.Split(string(data), "\n") {
+		fields := strings.Split(line, ":")
+		if len(fields) < 4 {
+			continue
+		}
+		uid, uidErr := strconv.ParseUint(fields[2], 10, 32)
+		gid, gidErr := strconv.ParseUint(fields[3], 10, 32)
+		if uidErr != nil || gidErr != nil || uid == 0 || gid == 0 || uid == uint64(^uint32(0)) || gid == uint64(^uint32(0)) {
+			continue
+		}
+		convertedUID, convertedGID := uint32(uid), uint32(gid)
+		if _, duplicate := seenUIDs[convertedUID]; duplicate {
+			continue
+		}
+		if _, duplicate := seenGIDs[convertedGID]; duplicate {
+			continue
+		}
+		seenUIDs[convertedUID] = struct{}{}
+		seenGIDs[convertedGID] = struct{}{}
+		identities = append(identities, LocalIdentity{UID: convertedUID, GID: convertedGID})
+		if len(identities) == count {
+			return identities
+		}
+	}
+	t.Skipf("no unprivileged identities configured: need %d distinct uid/gid pairs, found %d", count, len(identities))
+	return nil
+}
+
+func runAsIdentity(identity LocalIdentity, dir, name string, args ...string) error {
+	cmd := exec.Command(name, args...)
+	cmd.Dir = dir
+	cmd.SysProcAttr = &syscall.SysProcAttr{Credential: &syscall.Credential{
+		Uid: identity.UID, Gid: identity.GID, Groups: []uint32{},
+	}}
+	return cmd.Run()
 }
 
 func chownTree(t *testing.T, root string, identity LocalIdentity) {

--- a/internal/execbackend/lifecycle_test.go
+++ b/internal/execbackend/lifecycle_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"reflect"
 	"strconv"
 	"strings"
 	"syscall"
@@ -158,7 +159,7 @@ func TestLocalBackendExecDropsPrivilegesAndImportNormalizesOwnership(t *testing.
 	}
 }
 
-func TestLocalBackendWorkspaceTraverseLimitedToConfiguredIdentity(t *testing.T) {
+func TestLocalBackendWorkspaceTraverseLimitedToConfiguredGroup(t *testing.T) {
 	if os.Geteuid() != 0 {
 		t.Skip("workspace traverse identity proof requires a root test process")
 	}
@@ -181,7 +182,11 @@ func TestLocalBackendWorkspaceTraverseLimitedToConfiguredIdentity(t *testing.T) 
 		t.Fatalf("configured identity uid %d gid %d cannot traverse workspace: %v", configured.UID, configured.GID, err)
 	}
 	if err := runAsIdentity(third, instance.Workspace, "/bin/pwd"); err == nil {
-		t.Fatalf("third identity uid %d gid %d traversed workspace; want permission denied", third.UID, third.GID)
+		t.Fatalf("identity outside configured group, uid %d gid %d, traversed workspace; want permission denied", third.UID, third.GID)
+	}
+	sameGroupThird := LocalIdentity{UID: third.UID, GID: configured.GID}
+	if err := runAsIdentity(sameGroupThird, instance.Workspace, "/bin/pwd"); err != nil {
+		t.Fatalf("different uid %d carrying configured gid %d cannot traverse group-scoped workspace: %v", sameGroupThird.UID, sameGroupThird.GID, err)
 	}
 
 	for _, path := range []string{backend.root, instance.root} {
@@ -207,6 +212,15 @@ func TestLocalBackendWorkspaceTraverseParentPermissions(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	type chownCall struct {
+		path     string
+		uid, gid int
+	}
+	var chownCalls []chownCall
+	backend.chown = func(path string, uid, gid int) error {
+		chownCalls = append(chownCalls, chownCall{path: path, uid: uid, gid: gid})
+		return nil
+	}
 	instance, err := backend.Provision(context.Background(), JobScope{JobID: "traverse-permissions"})
 	if err != nil {
 		t.Fatal(err)
@@ -217,6 +231,13 @@ func TestLocalBackendWorkspaceTraverseParentPermissions(t *testing.T) {
 	if err := backend.handoffWorkspace(instance); err != nil {
 		t.Fatal(err)
 	}
+	wantChownCalls := []chownCall{
+		{path: backend.root, uid: -1, gid: int(identity.GID)},
+		{path: instance.root, uid: -1, gid: int(identity.GID)},
+	}
+	if !reflect.DeepEqual(chownCalls, wantChownCalls) {
+		t.Fatalf("traverse-parent chown calls = %+v, want %+v", chownCalls, wantChownCalls)
+	}
 
 	for _, path := range []string{backend.root, instance.root} {
 		info, err := os.Stat(path)
@@ -225,9 +246,6 @@ func TestLocalBackendWorkspaceTraverseParentPermissions(t *testing.T) {
 		}
 		if got := info.Mode().Perm(); got != 0o710 {
 			t.Fatalf("traverse parent %q mode = %#o, want 0710", path, got)
-		}
-		if _, gid := pathOwnership(t, path); gid != identity.GID {
-			t.Fatalf("traverse parent %q gid = %d, want configured gid %d", path, gid, identity.GID)
 		}
 	}
 }

--- a/skills/gitmoot/references/CLI.md
+++ b/skills/gitmoot/references/CLI.md
@@ -296,8 +296,10 @@ collection/import remain daemon-side and imported files therefore retain the
 daemon user's ownership. If the default backend root is below a root-only
 parent (for example a root daemon using `/root/.gitmoot`), set absolute
 `local_root` to a dedicated operator-managed path whose parents the configured
-uid can traverse; filesystem roots are rejected. Omitting uid/gid preserves
-the daemon identity.
+identity can traverse; filesystem roots are rejected. Gitmoot keeps the backend
+and instance roots daemon-owned, assigns them to `local_gid`, and uses mode
+`0710` so the configured command group can traverse without setting execute for
+the Unix `other` class. Omitting uid/gid preserves the daemon identity.
 
 The runtime executable must be traversable by the configured uid too. If a
 root daemon resolves `claude` or `codex` below `/root`, install the runtime at

--- a/skills/gitmoot/references/CLI.md
+++ b/skills/gitmoot/references/CLI.md
@@ -299,7 +299,10 @@ parent (for example a root daemon using `/root/.gitmoot`), set absolute
 identity can traverse; filesystem roots are rejected. Gitmoot keeps the backend
 and instance roots daemon-owned, assigns them to `local_gid`, and uses mode
 `0710` so the configured command group can traverse without setting execute for
-the Unix `other` class. Omitting uid/gid preserves the daemon identity.
+the Unix `other` class. This is a group boundary: use a dedicated `local_gid`
+whose only member is the configured account when unrelated local users must be
+excluded. Gitmoot validates paired, non-zero numeric IDs but cannot portably
+verify host group exclusivity. Omitting uid/gid preserves the daemon identity.
 
 The runtime executable must be traversable by the configured uid too. If a
 root daemon resolves `claude` or `codex` below `/root`, install the runtime at

--- a/website/docs/reference/remote-exec.md
+++ b/website/docs/reference/remote-exec.md
@@ -41,8 +41,13 @@ dedicated directory beneath a suitable operator-managed parent such as
 `/var/tmp`. A filesystem root is rejected. Gitmoot keeps its backend root and
 per-instance roots owned by the daemon, assigns their group to `local_gid`, and
 uses mode `0710` so the configured command group can traverse them without an
-execute bit for the Unix `other` class. With no uid/gid configured, local
-execution retains the daemon identity for backward compatibility.
+execute bit for the Unix `other` class. This is a group boundary: every process
+carrying `local_gid` can traverse, so use a dedicated group whose only member is
+the configured execution account when unrelated local users must be excluded.
+Gitmoot validates that the numeric UID/GID are paired and non-zero, but cannot
+portably prove group exclusivity across host account databases, NSS, or
+containers. With no uid/gid configured, local execution retains the daemon
+identity for backward compatibility.
 
 The runtime executable and any child-readable file-backed state must also be
 reachable by the configured identity. In particular, a root daemon whose

--- a/website/docs/reference/remote-exec.md
+++ b/website/docs/reference/remote-exec.md
@@ -34,14 +34,15 @@ reclaiming the clone for Git's ownership check, and import creates host files as
 the daemon user. Credential-application errors fail the command and never retry
 as the daemon user.
 
-The configured identity must be able to traverse every parent of the local
-backend root. The default root is below the Gitmoot home, so a root daemon whose
-home is under `/root` should also set absolute `local_root` to a dedicated
-directory beneath a suitable operator-managed parent such as `/var/tmp`. A
-filesystem root is rejected. Gitmoot makes its backend root and
-per-instance roots execute-only for traversal while leaving lifecycle metadata
-owned by the daemon. With no uid/gid configured, local execution retains the
-daemon identity for backward compatibility.
+The configured identity must be able to traverse every operator-managed parent
+of the local backend root. The default root is below the Gitmoot home, so a root
+daemon whose home is under `/root` should also set absolute `local_root` to a
+dedicated directory beneath a suitable operator-managed parent such as
+`/var/tmp`. A filesystem root is rejected. Gitmoot keeps its backend root and
+per-instance roots owned by the daemon, assigns their group to `local_gid`, and
+uses mode `0710` so the configured command group can traverse them without an
+execute bit for the Unix `other` class. With no uid/gid configured, local
+execution retains the daemon identity for backward compatibility.
 
 The runtime executable and any child-readable file-backed state must also be
 reachable by the configured identity. In particular, a root daemon whose

--- a/website/static/llms-full.txt
+++ b/website/static/llms-full.txt
@@ -1988,8 +1988,13 @@ dedicated directory beneath a suitable operator-managed parent such as
 `/var/tmp`. A filesystem root is rejected. Gitmoot keeps its backend root and
 per-instance roots owned by the daemon, assigns their group to `local_gid`, and
 uses mode `0710` so the configured command group can traverse them without an
-execute bit for the Unix `other` class. With no uid/gid configured, local
-execution retains the daemon identity for backward compatibility.
+execute bit for the Unix `other` class. This is a group boundary: every process
+carrying `local_gid` can traverse, so use a dedicated group whose only member is
+the configured execution account when unrelated local users must be excluded.
+Gitmoot validates that the numeric UID/GID are paired and non-zero, but cannot
+portably prove group exclusivity across host account databases, NSS, or
+containers. With no uid/gid configured, local execution retains the daemon
+identity for backward compatibility.
 
 The runtime executable and any child-readable file-backed state must also be
 reachable by the configured identity. In particular, a root daemon whose
@@ -10470,7 +10475,10 @@ parent (for example a root daemon using `/root/.gitmoot`), set absolute
 identity can traverse; filesystem roots are rejected. Gitmoot keeps the backend
 and instance roots daemon-owned, assigns them to `local_gid`, and uses mode
 `0710` so the configured command group can traverse without setting execute for
-the Unix `other` class. Omitting uid/gid preserves the daemon identity.
+the Unix `other` class. This is a group boundary: use a dedicated `local_gid`
+whose only member is the configured account when unrelated local users must be
+excluded. Gitmoot validates paired, non-zero numeric IDs but cannot portably
+verify host group exclusivity. Omitting uid/gid preserves the daemon identity.
 
 The runtime executable must be traversable by the configured uid too. If a
 root daemon resolves `claude` or `codex` below `/root`, install the runtime at

--- a/website/static/llms-full.txt
+++ b/website/static/llms-full.txt
@@ -1981,14 +1981,15 @@ reclaiming the clone for Git's ownership check, and import creates host files as
 the daemon user. Credential-application errors fail the command and never retry
 as the daemon user.
 
-The configured identity must be able to traverse every parent of the local
-backend root. The default root is below the Gitmoot home, so a root daemon whose
-home is under `/root` should also set absolute `local_root` to a dedicated
-directory beneath a suitable operator-managed parent such as `/var/tmp`. A
-filesystem root is rejected. Gitmoot makes its backend root and
-per-instance roots execute-only for traversal while leaving lifecycle metadata
-owned by the daemon. With no uid/gid configured, local execution retains the
-daemon identity for backward compatibility.
+The configured identity must be able to traverse every operator-managed parent
+of the local backend root. The default root is below the Gitmoot home, so a root
+daemon whose home is under `/root` should also set absolute `local_root` to a
+dedicated directory beneath a suitable operator-managed parent such as
+`/var/tmp`. A filesystem root is rejected. Gitmoot keeps its backend root and
+per-instance roots owned by the daemon, assigns their group to `local_gid`, and
+uses mode `0710` so the configured command group can traverse them without an
+execute bit for the Unix `other` class. With no uid/gid configured, local
+execution retains the daemon identity for backward compatibility.
 
 The runtime executable and any child-readable file-backed state must also be
 reachable by the configured identity. In particular, a root daemon whose
@@ -10466,8 +10467,10 @@ collection/import remain daemon-side and imported files therefore retain the
 daemon user's ownership. If the default backend root is below a root-only
 parent (for example a root daemon using `/root/.gitmoot`), set absolute
 `local_root` to a dedicated operator-managed path whose parents the configured
-uid can traverse; filesystem roots are rejected. Omitting uid/gid preserves
-the daemon identity.
+identity can traverse; filesystem roots are rejected. Gitmoot keeps the backend
+and instance roots daemon-owned, assigns them to `local_gid`, and uses mode
+`0710` so the configured command group can traverse without setting execute for
+the Unix `other` class. Omitting uid/gid preserves the daemon identity.
 
 The runtime executable must be traversable by the configured uid too. If a
 root daemon resolves `claude` or `codex` below `/root`, install the runtime at


### PR DESCRIPTION
WHAT:
GITMOOT-COC — Local backend parent traversal is now granted through the configured execution GID, with no Unix `other` execute permission.

WHY:
Gitmoot finalized this implementation from a task worktree.

CHANGES:
- Committed changes from /root/.gitmoot/worktrees/gitmoot--gitmoot/adhoc-9271fdef

RESULTS:
- Verified HEAD and GitHub `main` both equal 47802bfbca96b8a376564b17c6392a748bef538d.
- Anchor census: one `handoffWorkspace` definition and two production calls, from SyncIn and Collect.
- Baseline targeted filter matched 4 tests; all passed, including configured-identity, nil-identity, functional traversal, and CI-compatible permission guards.
- Functional traversal filter matched exactly 1 test.
- Compiled overlay mutant changed exactly the two 0710 modes back to 0711 using `go test -c`; the test failed with `third identity uid 3 gid 3 traversed workspace; want permission denied`.
- Ran `npm run build:llms` twice; the second output was byte-identical with SHA-256 daf0f88d784cb65376ae8ebd0e5c86e076a117000985ef9e0232c2f474ff9d92.
- `gofmt` and `git diff --check` passed. Full suite was not run as instructed.

RISK:
Review the generated diff before merging.

TASK:
adhoc-9271fdef

AGENTS:
- wave-impl

RAW FINAL REVIEW OUTPUT:
````text
GITMOOT-COC — Local backend parent traversal is now granted through the configured execution GID, with no Unix `other` execute permission.
````
