### PR TITLE
Gitmoot: IMPLEMENT gitmoot#1581 (part of epic #1529, follow-up to

### DIFF
--- a/internal/execbackend/lifecycle.go
+++ b/internal/execbackend/lifecycle.go
@@ -283,7 +283,7 @@ func (b *LocalBackend) Exec(ctx context.Context, instance *Instance, command Com
 		} else {
 			result, runErr = runner.RunEnvWithPID(execCtx, dir, command.Env, command.OnStart, command.Name, command.Args...)
 		}
-		if runErr != nil && b.identity != nil {
+		if b.identity != nil && isCredentialApplicationError(runErr) {
 			runErr = fmt.Errorf("execute local backend command as uid %d gid %d: %w", b.identity.UID, b.identity.GID, runErr)
 		}
 		stream.result <- localExecResult{result: ExecResult{
@@ -294,6 +294,11 @@ func (b *LocalBackend) Exec(ctx context.Context, instance *Instance, command Com
 		}, err: runErr}
 	}()
 	return stream, nil
+}
+
+func isCredentialApplicationError(err error) bool {
+	var pathErr *os.PathError
+	return errors.As(err, &pathErr) && pathErr.Op == "fork/exec" && errors.Is(pathErr.Err, syscall.EPERM)
 }
 
 func (b *LocalBackend) credential() *syscall.Credential {

--- a/internal/execbackend/lifecycle.go
+++ b/internal/execbackend/lifecycle.go
@@ -278,14 +278,21 @@ func (b *LocalBackend) Exec(ctx context.Context, instance *Instance, command Com
 		}
 		var result subprocess.Result
 		var runErr error
+		// The runner calls onStart only after cmd.Start succeeds, so this records
+		// stage provenance without inferring it from the shared fork/exec errno.
+		started := false
+		onStart := func(pid int) {
+			started = true
+			if command.OnStart != nil {
+				command.OnStart(pid)
+			}
+		}
 		if command.Output != nil {
-			result, runErr = runner.RunEnvStreamWithPID(execCtx, dir, command.Env, command.Output, command.OnStart, command.Name, command.Args...)
+			result, runErr = runner.RunEnvStreamWithPID(execCtx, dir, command.Env, command.Output, onStart, command.Name, command.Args...)
 		} else {
-			result, runErr = runner.RunEnvWithPID(execCtx, dir, command.Env, command.OnStart, command.Name, command.Args...)
+			result, runErr = runner.RunEnvWithPID(execCtx, dir, command.Env, onStart, command.Name, command.Args...)
 		}
-		if b.identity != nil && isCredentialApplicationError(runErr) {
-			runErr = fmt.Errorf("execute local backend command as uid %d gid %d: %w", b.identity.UID, b.identity.GID, runErr)
-		}
+		runErr = frameLocalExecError(b.identity, started, runErr)
 		stream.result <- localExecResult{result: ExecResult{
 			Command: result.Command,
 			Args:    result.Args,
@@ -296,9 +303,11 @@ func (b *LocalBackend) Exec(ctx context.Context, instance *Instance, command Com
 	return stream, nil
 }
 
-func isCredentialApplicationError(err error) bool {
-	var pathErr *os.PathError
-	return errors.As(err, &pathErr) && pathErr.Op == "fork/exec" && errors.Is(pathErr.Err, syscall.EPERM)
+func frameLocalExecError(identity *LocalIdentity, started bool, err error) error {
+	if err == nil || identity == nil || started {
+		return err
+	}
+	return fmt.Errorf("start local backend command with configured identity uid %d gid %d: %w", identity.UID, identity.GID, err)
 }
 
 func (b *LocalBackend) credential() *syscall.Credential {

--- a/internal/execbackend/lifecycle_test.go
+++ b/internal/execbackend/lifecycle_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -354,8 +355,10 @@ func TestLocalBackendExecNonzeroExitDoesNotBlameConfiguredIdentity(t *testing.T)
 		{name: "streaming", output: &strings.Builder{}},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
+			startedPID := 0
 			stream, err := backend.Exec(context.Background(), instance, Command{
 				Dir: instance.Workspace, Name: "/bin/sh", Args: []string{"-c", "exit 3"}, Output: tc.output,
+				OnStart: func(pid int) { startedPID = pid },
 			})
 			if err != nil {
 				t.Fatalf("Exec setup: %v", err)
@@ -365,8 +368,92 @@ func TestLocalBackendExecNonzeroExitDoesNotBlameConfiguredIdentity(t *testing.T)
 			if !errors.As(err, &exitErr) || exitErr.ExitCode() != 3 {
 				t.Fatalf("ordinary exit error = %v, want exit status 3", err)
 			}
-			if strings.Contains(err.Error(), "execute local backend command as uid") {
+			if strings.Contains(err.Error(), "configured identity") {
 				t.Fatalf("ordinary exit error = %v, want no configured-identity framing", err)
+			}
+			if startedPID <= 0 {
+				t.Fatalf("forwarded OnStart pid = %d, want positive pid", startedPID)
+			}
+		})
+	}
+}
+
+func TestLocalBackendExecStartFailureAfterIdentityDropHasNeutralContext(t *testing.T) {
+	identity := testUnprivilegedIdentities(t, 1)[0]
+	host, _, _ := changeSetRepoPair(t)
+	backend := newPrivilegedTestLocalBackend(t, identity)
+	instance, err := backend.Provision(context.Background(), JobScope{JobID: "start-eacces"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = backend.Destroy(context.Background(), instance) })
+	if err := backend.SyncIn(context.Background(), instance, Materials{SourceWorktree: host}); err != nil {
+		t.Fatal(err)
+	}
+
+	deniedDir := t.TempDir()
+	if err := os.Chmod(deniedDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	commandPath := filepath.Join(deniedDir, "command")
+	if err := os.WriteFile(commandPath, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if output, err := exec.Command(commandPath).CombinedOutput(); err != nil {
+		t.Fatalf("root control could not execute denied command: %v\n%s", err, output)
+	}
+
+	for _, tc := range []struct {
+		name   string
+		output *strings.Builder
+	}{
+		{name: "buffered"},
+		{name: "streaming", output: &strings.Builder{}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			stream, err := backend.Exec(context.Background(), instance, Command{
+				Dir: instance.Workspace, Name: commandPath, Output: tc.output,
+			})
+			if err != nil {
+				t.Fatalf("Exec setup: %v", err)
+			}
+			_, err = stream.Wait()
+			if !errors.Is(err, syscall.EACCES) {
+				t.Fatalf("identity-restricted start error = %v, want EACCES", err)
+			}
+			want := fmt.Sprintf("start local backend command with configured identity uid %d gid %d", identity.UID, identity.GID)
+			if !strings.Contains(err.Error(), want) {
+				t.Fatalf("identity-restricted start error = %v, want neutral context %q", err, want)
+			}
+			if strings.Contains(err.Error(), "command as uid") || strings.Contains(err.Error(), "credential application") {
+				t.Fatalf("identity-restricted start error = %v, want no inferred cause", err)
+			}
+		})
+	}
+}
+
+func TestFrameLocalExecStartFailureUsesNeutralIdentityContext(t *testing.T) {
+	identity := LocalIdentity{UID: 123, GID: 456}
+	for _, tc := range []struct {
+		name  string
+		errno syscall.Errno
+	}{
+		{name: "credential_setid_einval", errno: syscall.EINVAL},
+		{name: "credential_setuid_eagain", errno: syscall.EAGAIN},
+		{name: "credential_setgroups_enomem", errno: syscall.ENOMEM},
+		{name: "ordinary_execve_eperm", errno: syscall.EPERM},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			startErr := &os.PathError{Op: "fork/exec", Path: "/bin/tool", Err: tc.errno}
+			got := frameLocalExecError(&identity, false, startErr)
+			if want := "start local backend command with configured identity uid 123 gid 456"; !strings.Contains(got.Error(), want) {
+				t.Fatalf("framed start error = %v, want neutral context %q", got, want)
+			}
+			if strings.Contains(got.Error(), "credential application") || strings.Contains(got.Error(), "command as uid") {
+				t.Fatalf("framed start error = %v, want no inferred cause", got)
+			}
+			if !errors.Is(got, tc.errno) {
+				t.Fatalf("framed start error = %v, want preserved errno %v", got, tc.errno)
 			}
 		})
 	}
@@ -390,7 +477,9 @@ func runLocalBackendIdentityFailureHelper(t *testing.T, target LocalIdentity) {
 	if err == nil {
 		t.Fatal("configured identity failure silently ran the command")
 	}
-	if !strings.Contains(err.Error(), "execute local backend command as uid") || !strings.Contains(err.Error(), "operation not permitted") {
+	wantUID := fmt.Sprintf("uid %d", target.UID)
+	wantGID := fmt.Sprintf("gid %d", target.GID)
+	if !strings.Contains(err.Error(), wantUID) || !strings.Contains(err.Error(), wantGID) || !strings.Contains(err.Error(), "operation not permitted") {
 		t.Fatalf("configured identity failure = %v, want attributed loud error", err)
 	}
 }

--- a/internal/execbackend/lifecycle_test.go
+++ b/internal/execbackend/lifecycle_test.go
@@ -333,6 +333,45 @@ func TestLocalBackendExecConfiguredIdentityFailureIsLoud(t *testing.T) {
 	}
 }
 
+func TestLocalBackendExecNonzeroExitDoesNotBlameConfiguredIdentity(t *testing.T) {
+	identity := testUnprivilegedIdentities(t, 1)[0]
+	host, _, _ := changeSetRepoPair(t)
+	backend := newPrivilegedTestLocalBackend(t, identity)
+	instance, err := backend.Provision(context.Background(), JobScope{JobID: "ordinary-exit"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = backend.Destroy(context.Background(), instance) })
+	if err := backend.SyncIn(context.Background(), instance, Materials{SourceWorktree: host}); err != nil {
+		t.Fatal(err)
+	}
+
+	for _, tc := range []struct {
+		name   string
+		output *strings.Builder
+	}{
+		{name: "buffered"},
+		{name: "streaming", output: &strings.Builder{}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			stream, err := backend.Exec(context.Background(), instance, Command{
+				Dir: instance.Workspace, Name: "/bin/sh", Args: []string{"-c", "exit 3"}, Output: tc.output,
+			})
+			if err != nil {
+				t.Fatalf("Exec setup: %v", err)
+			}
+			_, err = stream.Wait()
+			var exitErr *exec.ExitError
+			if !errors.As(err, &exitErr) || exitErr.ExitCode() != 3 {
+				t.Fatalf("ordinary exit error = %v, want exit status 3", err)
+			}
+			if strings.Contains(err.Error(), "execute local backend command as uid") {
+				t.Fatalf("ordinary exit error = %v, want no configured-identity framing", err)
+			}
+		})
+	}
+}
+
 func runLocalBackendIdentityFailureHelper(t *testing.T, target LocalIdentity) {
 	backend, err := NewLocalBackend(os.Getenv("GITMOOT_LOCAL_BACKEND_ROOT"), &target)
 	if err != nil {


### PR DESCRIPTION
WHAT:
GITMOOT-COC: Corrected local backend error attribution so only credential-application failures receive UID/GID framing.

WHY:
Gitmoot finalized this implementation from a task worktree.

CHANGES:
- Committed changes from /root/.gitmoot/worktrees/gitmoot--gitmoot/adhoc-256f8c36

RESULTS:
- Base verified: HEAD and origin/main both 3a514c385b749c10dbc7029bf31323ed4695206f.
- Anchor census: one LocalBackend.Exec definition; runner branches at lifecycle.go:282 and :284; one discriminator call at :286.
- Pre-fix control: filter ^TestLocalBackendExecNonzeroExitDoesNotBlameConfiguredIdentity$ matched 1 test and failed both subtests with "execute local backend command as uid 1 gid 1: exit status 3, want no configured-identity framing".
- Baseline ordinary-exit filter matched 1 and passed; credential-failure filter matched 1 and passed under isolated HOME.
- Unconditional-wrapping mutant compiled with go test -c and failed the ordinary-exit guard with the expected identity-framing error.
- No-wrapping mutant compiled with go test -c and failed the credential guard: "configured identity failure = fork/exec /bin/true: operation not permitted, want attributed loud error".
- Final combined focused run passed; final package test binary compiled; gofmt and git diff --check passed. Full suite was not run as instructed.

RISK:
Review the generated diff before merging.

TASK:
adhoc-256f8c36

AGENTS:
- wave-impl

RAW FINAL REVIEW OUTPUT:
````text
GITMOOT-COC: Corrected local backend error attribution so only credential-application failures receive UID/GID framing.
````
