### PR TITLE
Gitmoot: IMPLEMENT gitmoot#1584 (part of epic #1529). Base: current

### DIFF
--- a/internal/cli/doctor_remote_exec.go
+++ b/internal/cli/doctor_remote_exec.go
@@ -1,0 +1,37 @@
+package cli
+
+import (
+	"errors"
+	"fmt"
+	"os"
+
+	"github.com/gitmoot/gitmoot/internal/config"
+	"github.com/gitmoot/gitmoot/internal/doctor"
+)
+
+const remoteExecDoctorCheckName = "remote exec config"
+
+func remoteExecDoctorCheck(paths config.Paths) (doctor.Check, bool) {
+	cfg, err := config.LoadRemoteExecConfig(paths)
+	if err == nil {
+		return doctor.Check{
+			Name:     remoteExecDoctorCheckName,
+			OK:       true,
+			Required: true,
+			Detail:   fmt.Sprintf("[remote_exec] configuration valid (backend %s)", cfg.Backend),
+		}, true
+	}
+	if errors.Is(err, os.ErrNotExist) {
+		return doctor.Check{
+			Name:     remoteExecDoctorCheckName,
+			OK:       true,
+			Required: true,
+			Detail:   "[remote_exec] not configured; local backend defaults apply",
+		}, true
+	}
+	return doctor.Check{
+		Name:     remoteExecDoctorCheckName,
+		Required: true,
+		Detail:   fmt.Sprintf("invalid [remote_exec] configuration: %v", err),
+	}, true
+}

--- a/internal/cli/doctor_remote_exec_test.go
+++ b/internal/cli/doctor_remote_exec_test.go
@@ -1,0 +1,122 @@
+package cli
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/gitmoot/gitmoot/internal/config"
+)
+
+func TestRemoteExecDoctorCheck(t *testing.T) {
+	t.Run("section absent", func(t *testing.T) {
+		paths := writeRemoteExecDoctorConfig(t, t.TempDir(), "[daemon]\nworkers = 1\n")
+		check, ok := remoteExecDoctorCheck(paths)
+		if !ok || !check.OK || !check.Required {
+			t.Fatalf("check = %#v, ok = %v, want required pass", check, ok)
+		}
+	})
+
+	t.Run("config file absent", func(t *testing.T) {
+		check, ok := remoteExecDoctorCheck(config.PathsForHome(t.TempDir()))
+		if !ok || !check.OK || !check.Required {
+			t.Fatalf("check = %#v, ok = %v, want required pass", check, ok)
+		}
+	})
+
+	t.Run("valid section", func(t *testing.T) {
+		paths := writeRemoteExecDoctorConfig(t, t.TempDir(), `[remote_exec]
+backend = "local"
+local_uid = 1
+local_gid = 1
+local_root = "/tmp/gitmoot-execbackend"
+`)
+		check, ok := remoteExecDoctorCheck(paths)
+		if !ok || !check.OK || !check.Required {
+			t.Fatalf("check = %#v, ok = %v, want required pass", check, ok)
+		}
+	})
+
+	for _, tc := range []struct {
+		name string
+		body string
+		want string
+	}{
+		{
+			name: "uid without gid",
+			body: "[remote_exec]\nlocal_uid = 1\n",
+			want: "local_uid and [remote_exec].local_gid must be configured together",
+		},
+		{
+			name: "relative local root",
+			body: "[remote_exec]\nlocal_root = \"relative/instances\"\n",
+			want: "local_root must be an absolute path",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			paths := writeRemoteExecDoctorConfig(t, t.TempDir(), tc.body)
+			_, loaderErr := config.LoadRemoteExecConfig(paths)
+			if loaderErr == nil {
+				t.Fatal("loader accepted invalid remote exec fixture")
+			}
+			check, ok := remoteExecDoctorCheck(paths)
+			if !ok || check.OK || !check.Required {
+				t.Fatalf("check = %#v, ok = %v, want required failure", check, ok)
+			}
+			if !strings.Contains(check.Detail, tc.want) {
+				t.Fatalf("detail = %q, want loader error containing %q", check.Detail, tc.want)
+			}
+			if !strings.Contains(check.Detail, loaderErr.Error()) {
+				t.Fatalf("detail = %q, want exact loader error %q", check.Detail, loaderErr)
+			}
+		})
+	}
+}
+
+func TestDoctorHomeSelectsRemoteExecConfig(t *testing.T) {
+	ambientHome := t.TempDir()
+	writeRemoteExecDoctorConfig(t, ambientHome, "[remote_exec]\nlocal_root = \"ambient-relative\"\n")
+	t.Setenv("HOME", ambientHome)
+
+	explicitHome := t.TempDir()
+	explicitPaths := writeRemoteExecDoctorConfig(t, explicitHome, `[remote_exec]
+backend = "local"
+local_uid = 1
+local_gid = 1
+local_root = "/tmp/gitmoot-explicit-home"
+`)
+	var stdout, stderr bytes.Buffer
+	Run([]string{"doctor", "--home", explicitHome, "--json", "--repo", t.TempDir()}, &stdout, &stderr)
+	if strings.Contains(stderr.String(), "flag provided but not defined") {
+		t.Fatalf("doctor rejected --home: %s", stderr.String())
+	}
+	var checks []map[string]any
+	if err := json.Unmarshal(stdout.Bytes(), &checks); err != nil {
+		t.Fatalf("doctor --home JSON: %v\nstdout=%q\nstderr=%q", err, stdout.String(), stderr.String())
+	}
+	check, ok := doctorJSONCheckByName(checks, remoteExecDoctorCheckName)
+	if !ok {
+		t.Fatalf("doctor --home omitted %q check", remoteExecDoctorCheckName)
+	}
+	if got, _ := check["ok"].(bool); !got {
+		t.Fatalf("doctor read ambient config instead of %s: %#v", explicitPaths.ConfigFile, check)
+	}
+	if detail, _ := check["detail"].(string); strings.Contains(detail, "ambient-relative") {
+		t.Fatalf("doctor read ambient config: %q", detail)
+	}
+}
+
+func writeRemoteExecDoctorConfig(t *testing.T, home, body string) config.Paths {
+	t.Helper()
+	paths := config.PathsForHome(home)
+	if err := os.MkdirAll(filepath.Dir(paths.ConfigFile), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(paths.ConfigFile, []byte(body), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return paths
+}

--- a/internal/cli/doctor_remote_exec_test.go
+++ b/internal/cli/doctor_remote_exec_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/gitmoot/gitmoot/internal/config"
+	"github.com/gitmoot/gitmoot/internal/runtime"
 )
 
 func TestRemoteExecDoctorCheck(t *testing.T) {
@@ -78,8 +79,13 @@ local_root = "/tmp/gitmoot-execbackend"
 
 func TestDoctorHomeSelectsRemoteExecConfig(t *testing.T) {
 	ambientHome := t.TempDir()
-	writeRemoteExecDoctorConfig(t, ambientHome, "[remote_exec]\nlocal_root = \"ambient-relative\"\n")
+	ambientPaths := config.PathsForHome(ambientHome)
+	if err := os.MkdirAll(ambientPaths.ConfigFile, 0o700); err != nil {
+		t.Fatalf("create ambient config trap: %v", err)
+	}
 	t.Setenv("HOME", ambientHome)
+	// Make the live Claude probe fail unavailable without consulting host tools.
+	t.Setenv("PATH", t.TempDir())
 
 	explicitHome := t.TempDir()
 	explicitPaths := writeRemoteExecDoctorConfig(t, explicitHome, `[remote_exec]
@@ -88,6 +94,24 @@ local_uid = 1
 local_gid = 1
 local_root = "/tmp/gitmoot-explicit-home"
 `)
+	if err := writeRuntimeAuthFile(runtimeAuthFilePath(explicitPaths.Home), map[string]string{
+		runtime.ClaudeOAuthTokenEnv: testOAuthToken,
+	}); err != nil {
+		t.Fatalf("write explicit runtime auth: %v", err)
+	}
+	oldLookup, oldLogf := runtimeAuthEnvLookup, runtimeAuthLogf
+	runtimeAuthEnvLookup = func(name string) (string, bool) {
+		if name == runtime.AnthropicAPIKeyEnv {
+			return testAPIKey, true
+		}
+		return "", false
+	}
+	runtimeAuthLogf = func(string, ...any) {}
+	t.Cleanup(func() {
+		runtimeAuthEnvLookup = oldLookup
+		runtimeAuthLogf = oldLogf
+	})
+
 	var stdout, stderr bytes.Buffer
 	Run([]string{"doctor", "--home", explicitHome, "--json", "--repo", t.TempDir()}, &stdout, &stderr)
 	if strings.Contains(stderr.String(), "flag provided but not defined") {
@@ -97,6 +121,7 @@ local_root = "/tmp/gitmoot-explicit-home"
 	if err := json.Unmarshal(stdout.Bytes(), &checks); err != nil {
 		t.Fatalf("doctor --home JSON: %v\nstdout=%q\nstderr=%q", err, stdout.String(), stderr.String())
 	}
+	t.Logf("doctor --home returned %d checks", len(checks))
 	check, ok := doctorJSONCheckByName(checks, remoteExecDoctorCheckName)
 	if !ok {
 		t.Fatalf("doctor --home omitted %q check", remoteExecDoctorCheckName)
@@ -104,8 +129,25 @@ local_root = "/tmp/gitmoot-explicit-home"
 	if got, _ := check["ok"].(bool); !got {
 		t.Fatalf("doctor read ambient config instead of %s: %#v", explicitPaths.ConfigFile, check)
 	}
-	if detail, _ := check["detail"].(string); strings.Contains(detail, "ambient-relative") {
-		t.Fatalf("doctor read ambient config: %q", detail)
+	if detail, _ := check["detail"].(string); strings.Contains(detail, ambientPaths.ConfigFile) {
+		t.Fatalf("doctor read ambient config %s: %q", ambientPaths.ConfigFile, detail)
+	}
+	authCheck, ok := doctorJSONCheckByName(checks, "claude auth")
+	if !ok {
+		t.Fatal("doctor --home omitted claude auth check")
+	}
+	authDetail, _ := authCheck["detail"].(string)
+	for _, want := range []string{
+		runtimeAuthFileName,
+		runtime.ClaudeOAuthTokenEnv + "=set",
+		runtime.AnthropicAPIKeyEnv + "=unset",
+	} {
+		if !strings.Contains(authDetail, want) {
+			t.Fatalf("claude auth detail = %q, want %q from explicit home", authDetail, want)
+		}
+	}
+	if _, err := os.Stat(runtimeAuthFilePath(ambientPaths.Home)); !os.IsNotExist(err) {
+		t.Fatalf("doctor --home accessed ambient runtime auth at %s: %v", runtimeAuthFilePath(ambientPaths.Home), err)
 	}
 }
 

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -141,6 +141,7 @@ func runDoctor(args []string, stdout, stderr io.Writer) int {
 	fs := flag.NewFlagSet("doctor", flag.ContinueOnError)
 	fs.SetOutput(stderr)
 	repoDir := fs.String("repo", ".", "repository directory to check")
+	home := fs.String("home", "", "home directory to use instead of the current user's home")
 	jsonOutput := fs.Bool("json", false, "print the checks as a JSON array instead of the text table")
 	if err := fs.Parse(args); err != nil {
 		if errors.Is(err, flag.ErrHelp) {
@@ -156,7 +157,7 @@ func runDoctor(args []string, stdout, stderr io.Writer) int {
 	// Resolve paths best-effort so the daemon-aware claude auth check (#427) can
 	// locate the running daemon. A failure here (no initialized home) just leaves
 	// Paths zero, which skips the daemon check and keeps the shell-local one.
-	paths, _ := config.DefaultPaths()
+	paths, _ := pathsFromFlag(*home)
 	buildStatus := daemonBuildStatus(paths)
 	stuckStatus := stuckJobsStatus(paths)
 	logStatus := daemonLogStatus(paths)
@@ -180,6 +181,9 @@ func runDoctor(args []string, stdout, stderr io.Writer) int {
 		RuntimeContracts:  contractResults,
 	}
 	checks := checker.Run(context.Background())
+	if check, ok := remoteExecDoctorCheck(paths); ok {
+		checks = append(checks, check)
+	}
 	// #631: surface a stale backlog of blocked jobs (each paused awaiting a human)
 	// so an operator knows they can be bulk-dismissed. Best-effort and appended to
 	// both the text table and the --json array; the dashboard's cheaper

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -161,7 +161,7 @@ func runDoctor(args []string, stdout, stderr io.Writer) int {
 	buildStatus := daemonBuildStatus(paths)
 	stuckStatus := stuckJobsStatus(paths)
 	logStatus := daemonLogStatus(paths)
-	probeRunner, authState, authSource, authErr := runtimeJobRunnerWithAuth("", runtime.ClaudeRuntime, nil)
+	probeRunner, authState, authSource, authErr := runtimeJobRunnerWithAuth(*home, runtime.ClaudeRuntime, nil)
 	contractResults := make([]runtime.RuntimeContractResult, 0, len(runtime.BuiltinRuntimeRegistry().All()))
 	for _, meta := range runtime.BuiltinRuntimeRegistry().All() {
 		contractResults = append(contractResults, runtime.DefaultRuntimeContractChecker().Inspect(context.Background(), meta.Name))

--- a/skills/gitmoot/references/CLI.md
+++ b/skills/gitmoot/references/CLI.md
@@ -10,7 +10,7 @@ curl -fsSL https://gitmoot.io/install.sh | sh
 gitmoot version
 gitmoot update --check
 gitmoot update --restart-daemon
-gitmoot doctor [--repo <path>]
+gitmoot doctor [--home <path>] [--repo <path>] [--json]
 ```
 
 Verify GitHub access before PR workflows:
@@ -31,6 +31,11 @@ job whose directly recorded runtime PID is confirmably dead is a
 required `stuck jobs` failure; legacy jobs with no recorded PID and hosts where
 process identity cannot be verified are neutral and produce no ghost-job
 finding.
+Doctor validates `[remote_exec]` through the same configuration loader used by
+job dispatch. An absent section passes because remote execution is opt-in; an
+invalid backend, identity pair, numeric identity, or local root is a required
+failure carrying the loader's exact error. Use `--home /x` to preflight
+`/x/.gitmoot/config.toml` without reading the default home.
 For organization roles with an effective `recycle_after`, doctor also reads the
 durable `org_role_presence.last_seen_at` signal. It warns when a specific role
 has never been observed or has been inactive past that bound; an unreadable,

--- a/website/docs/reference/cli.md
+++ b/website/docs/reference/cli.md
@@ -10,7 +10,7 @@ curl -fsSL https://gitmoot.io/install.sh | sh
 gitmoot version
 gitmoot update --check
 gitmoot update --restart-daemon
-gitmoot doctor [--repo <path>]
+gitmoot doctor [--home <path>] [--repo <path>] [--json]
 ```
 
 Verify GitHub access before PR workflows:
@@ -31,6 +31,11 @@ job whose directly recorded runtime PID is confirmably dead is a
 required `stuck jobs` failure; legacy jobs with no recorded PID and hosts where
 process identity cannot be verified are neutral and produce no ghost-job
 finding.
+Doctor validates `[remote_exec]` through the same configuration loader used by
+job dispatch. An absent section passes because remote execution is opt-in; an
+invalid backend, identity pair, numeric identity, or local root is a required
+failure carrying the loader's exact error. Use `--home /x` to preflight
+`/x/.gitmoot/config.toml` without reading the default home.
 For organization roles with an effective `recycle_after`, doctor also reads the
 durable `org_role_presence.last_seen_at` signal. It warns when a specific role
 has never been observed or has been inactive past that bound; an unreadable,

--- a/website/static/llms-full.txt
+++ b/website/static/llms-full.txt
@@ -10186,7 +10186,7 @@ curl -fsSL https://gitmoot.io/install.sh | sh
 gitmoot version
 gitmoot update --check
 gitmoot update --restart-daemon
-gitmoot doctor [--repo <path>]
+gitmoot doctor [--home <path>] [--repo <path>] [--json]
 ```
 
 Verify GitHub access before PR workflows:
@@ -10207,6 +10207,11 @@ job whose directly recorded runtime PID is confirmably dead is a
 required `stuck jobs` failure; legacy jobs with no recorded PID and hosts where
 process identity cannot be verified are neutral and produce no ghost-job
 finding.
+Doctor validates `[remote_exec]` through the same configuration loader used by
+job dispatch. An absent section passes because remote execution is opt-in; an
+invalid backend, identity pair, numeric identity, or local root is a required
+failure carrying the loader's exact error. Use `--home /x` to preflight
+`/x/.gitmoot/config.toml` without reading the default home.
 For organization roles with an effective `recycle_after`, doctor also reads the
 durable `org_role_presence.last_seen_at` signal. It warns when a specific role
 has never been observed or has been inactive past that bound; an unreadable,


### PR DESCRIPTION
WHAT:
GITMOOT-COC: Added single-sourced remote-exec preflight validation and isolated `doctor --home` support.

WHY:
Gitmoot finalized this implementation from a task worktree.

CHANGES:
- Committed changes from /root/.gitmoot/worktrees/gitmoot--gitmoot/adhoc-973ae1dc

RESULTS:
- Base verified: local HEAD and GitHub main both 7a0a067efa893b86c2f2fad439ede53f440fb720; this managed checkout has no origin remote configured.
- `^TestRemoteExecDoctorCheck$` matched 1 top-level test and passed all absent, valid, and invalid subtests.
- `^TestDoctorHomeSelectsRemoteExecConfig$` matched 1 top-level test and passed.
- Existing `RemoteExec` loader filter matched 8 tests; all passed.
- Wiring mutant removing the append call compiled with go test -c and failed: `doctor --home omitted "remote exec config" check`.
- Final CLI test binary compiled; `go vet ./internal/cli/`, gofmt, and `git diff --check` passed.
- llms-full.txt generation ran twice; both outputs had SHA-256 `65e0cbe0e1b60f9cdf66918b7ce670666018c72de090f93dca12a20d593e5a9c` and byte comparison succeeded.
- Full suite was not run as instructed.

RISK:
Review the generated diff before merging.

TASK:
adhoc-973ae1dc

AGENTS:
- wave-impl

RAW FINAL REVIEW OUTPUT:
````text
GITMOOT-COC: Added single-sourced remote-exec preflight validation and isolated `doctor --home` support.
````
