### PR TITLE
Gitmoot: IMPLEMENT gitmoot#1538 (P3a, epic #1529) — SLICE 1

### DIFF
--- a/internal/credgw/gateway.go
+++ b/internal/credgw/gateway.go
@@ -3,6 +3,8 @@ package credgw
 import (
 	"context"
 	"crypto/rand"
+	"crypto/sha256"
+	"crypto/subtle"
 	"encoding/hex"
 	"errors"
 	"fmt"
@@ -19,6 +21,11 @@ import (
 )
 
 const DefaultAnthropicUpstream = "https://api.anthropic.com"
+
+const (
+	proxyCapabilityBytes = 32
+	proxyCapabilityTTL   = 5 * time.Minute
+)
 
 type CredentialKind string
 
@@ -95,11 +102,13 @@ type entry struct {
 }
 
 type proxyEntry struct {
-	jobID       string
-	placeholder string
-	policy      ProxyPolicy
-	upstream    *url.URL
-	resolver    CredentialResolver
+	jobID               string
+	placeholder         string
+	policy              ProxyPolicy
+	upstream            *url.URL
+	resolver            CredentialResolver
+	capabilityHash      [sha256.Size]byte
+	capabilityExpiresAt time.Time
 }
 
 func Start(logf LogFunc) (*Gateway, error) {
@@ -157,6 +166,10 @@ func (g *Gateway) RegisterProxy(jobID string, policy ProxyPolicy, resolver Crede
 	if err != nil {
 		return nil, err
 	}
+	capability, capabilityHash, err := mintProxyCapability()
+	if err != nil {
+		return nil, err
+	}
 	g.mu.Lock()
 	defer g.mu.Unlock()
 	if g.closed {
@@ -164,9 +177,10 @@ func (g *Gateway) RegisterProxy(jobID string, policy ProxyPolicy, resolver Crede
 	}
 	g.proxyEntries[route] = proxyEntry{
 		jobID: jobID, placeholder: placeholder, policy: validated,
-		upstream: upstream, resolver: resolver,
+		upstream: upstream, resolver: resolver, capabilityHash: capabilityHash,
+		capabilityExpiresAt: time.Now().Add(proxyCapabilityTTL),
 	}
-	return &Lease{gateway: g, placeholder: placeholder, route: route}, nil
+	return &Lease{gateway: g, placeholder: placeholder, route: route, capability: capability}, nil
 }
 
 func (g *Gateway) URL() string {
@@ -320,10 +334,21 @@ func (g *Gateway) serveProxy(w http.ResponseWriter, r *http.Request, route strin
 		g.writeLog(r.Method, registered.upstream.Hostname(), http.StatusBadRequest, registered.jobID)
 		return
 	}
-	suffix, err := proxyRequestSuffix(r.URL.EscapedPath(), route)
+	capability, ok := proxyRequestCapability(r.URL.EscapedPath(), route)
+	if !ok {
+		http.Error(w, "unauthorized", http.StatusUnauthorized)
+		g.writeLog(r.Method, registered.upstream.Hostname(), http.StatusUnauthorized, registered.jobID)
+		return
+	}
+	suffix, err := proxyRequestSuffix(r.URL.EscapedPath(), route+"/"+capability)
 	if err != nil {
 		http.Error(w, "request path refused", http.StatusBadRequest)
 		g.writeLog(r.Method, registered.upstream.Hostname(), http.StatusBadRequest, registered.jobID)
+		return
+	}
+	if !validProxyCapability(capability, registered, time.Now()) {
+		http.Error(w, "unauthorized", http.StatusUnauthorized)
+		g.writeLog(r.Method, registered.upstream.Hostname(), http.StatusUnauthorized, registered.jobID)
 		return
 	}
 	resolved, err := registered.resolver(r.Context())
@@ -459,6 +484,29 @@ func proxyRequestSuffix(escapedPath, route string) (string, error) {
 	return decoded, nil
 }
 
+func proxyRequestCapability(escapedPath, route string) (string, bool) {
+	raw := strings.TrimPrefix(escapedPath, route)
+	if !strings.HasPrefix(raw, "/") {
+		return "", false
+	}
+	capability, _, _ := strings.Cut(strings.TrimPrefix(raw, "/"), "/")
+	if len(capability) != proxyCapabilityBytes*2 {
+		return "", false
+	}
+	decoded, err := hex.DecodeString(capability)
+	return capability, err == nil && len(decoded) == proxyCapabilityBytes
+}
+
+func validProxyCapability(capability string, registered proxyEntry, now time.Time) bool {
+	decoded, err := hex.DecodeString(capability)
+	if err != nil || len(decoded) != proxyCapabilityBytes {
+		return false
+	}
+	presented := sha256.Sum256(decoded)
+	matches := subtle.ConstantTimeCompare(presented[:], registered.capabilityHash[:]) == 1
+	return matches && now.Before(registered.capabilityExpiresAt)
+}
+
 func hasDotPathSegment(value string) bool {
 	for _, segment := range strings.Split(value, "/") {
 		if segment == "." || segment == ".." {
@@ -540,6 +588,14 @@ func mintProxyRoute() (string, error) {
 		return "", fmt.Errorf("mint credential gateway route: %w", err)
 	}
 	return "/_gitmoot/proxy/" + hex.EncodeToString(random), nil
+}
+
+func mintProxyCapability() (string, [sha256.Size]byte, error) {
+	random := make([]byte, proxyCapabilityBytes)
+	if _, err := rand.Read(random); err != nil {
+		return "", [sha256.Size]byte{}, fmt.Errorf("mint credential gateway capability: %w", err)
+	}
+	return hex.EncodeToString(random), sha256.Sum256(random), nil
 }
 
 func proxyRoute(escapedPath string) (string, bool) {

--- a/internal/credgw/gateway_test.go
+++ b/internal/credgw/gateway_test.go
@@ -11,6 +11,7 @@ import (
 	"net/url"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 )
@@ -158,6 +159,160 @@ func TestGatewayAttachesAPIKeyWithoutForwardingPlaceholder(t *testing.T) {
 	}
 }
 
+func TestGenericProxyCapabilityRejectionsNeverResolveCredential(t *testing.T) {
+	tests := []struct {
+		name       string
+		requestURL func(*Gateway, *Lease, *Lease) string
+		expire     bool
+		second     bool
+	}{
+		{
+			name: "missing capability",
+			requestURL: func(gateway *Gateway, lease, _ *Lease) string {
+				return gateway.URL() + lease.route
+			},
+		},
+		{
+			name: "malformed capability",
+			requestURL: func(gateway *Gateway, lease, _ *Lease) string {
+				return gateway.URL() + lease.route + "/not-a-capability"
+			},
+		},
+		{
+			name:   "capability from another job route",
+			second: true,
+			requestURL: func(gateway *Gateway, lease, other *Lease) string {
+				return gateway.URL() + lease.route + "/" + other.capability
+			},
+		},
+		{
+			name:   "expired capability",
+			expire: true,
+			requestURL: func(_ *Gateway, lease, _ *Lease) string {
+				return lease.URL()
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			var upstreamCalls atomic.Int32
+			upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				upstreamCalls.Add(1)
+				w.WriteHeader(http.StatusNoContent)
+			}))
+			defer upstream.Close()
+
+			gateway, err := Start(nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer gateway.Close(context.Background())
+			policy := ProxyPolicy{Upstream: upstream.URL, AuthKind: ProxyAuthBearer, AllowLoopbackHTTP: true}
+			var resolverCalls atomic.Int32
+			lease, err := gateway.RegisterProxy("capability-job", policy, func(context.Context) (ResolvedCredential, error) {
+				resolverCalls.Add(1)
+				return ResolvedCredential{Value: testRealCredential, Upstream: policy.Upstream, AuthKind: policy.AuthKind}, nil
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			var other *Lease
+			if test.second {
+				other, err = gateway.RegisterProxy("other-job", policy, func(context.Context) (ResolvedCredential, error) {
+					return ResolvedCredential{Value: "other-real-credential", Upstream: policy.Upstream, AuthKind: policy.AuthKind}, nil
+				})
+				if err != nil {
+					t.Fatal(err)
+				}
+			}
+			if test.expire {
+				gateway.mu.Lock()
+				entry := gateway.proxyEntries[lease.route]
+				entry.capabilityExpiresAt = time.Now().Add(-time.Second)
+				gateway.proxyEntries[lease.route] = entry
+				gateway.mu.Unlock()
+			}
+
+			request, err := http.NewRequest(http.MethodPost, test.requestURL(gateway, lease, other), nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+			request.Header.Set("Authorization", "Bearer "+lease.Placeholder())
+			response, err := http.DefaultClient.Do(request)
+			if err != nil {
+				t.Fatal(err)
+			}
+			response.Body.Close()
+			if response.StatusCode != http.StatusUnauthorized {
+				t.Fatalf("status = %d, want %d", response.StatusCode, http.StatusUnauthorized)
+			}
+			if got := resolverCalls.Load(); got != 0 {
+				t.Fatalf("credential resolver calls = %d, want 0", got)
+			}
+			if got := upstreamCalls.Load(); got != 0 {
+				t.Fatalf("upstream calls = %d, want 0", got)
+			}
+		})
+	}
+}
+
+func TestGenericProxyCapabilityHappyPathSubstitutesCredential(t *testing.T) {
+	var resolverCalls atomic.Int32
+	var upstreamCalls atomic.Int32
+	var mu sync.Mutex
+	var upstreamAuthorization, upstreamAPIKey, upstreamPath string
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		upstreamCalls.Add(1)
+		mu.Lock()
+		upstreamAuthorization = r.Header.Get("Authorization")
+		upstreamAPIKey = r.Header.Get("X-Api-Key")
+		upstreamPath = r.URL.Path
+		mu.Unlock()
+		w.WriteHeader(http.StatusCreated)
+	}))
+	defer upstream.Close()
+
+	gateway, err := Start(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer gateway.Close(context.Background())
+	policy := ProxyPolicy{Upstream: upstream.URL + "/api/v1", AuthKind: ProxyAuthBearer, AllowLoopbackHTTP: true}
+	lease, err := gateway.RegisterProxy("capability-happy", policy, func(context.Context) (ResolvedCredential, error) {
+		resolverCalls.Add(1)
+		return ResolvedCredential{Value: testRealCredential, Upstream: policy.Upstream, AuthKind: policy.AuthKind}, nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	request, err := http.NewRequest(http.MethodPost, lease.URL()+"/messages", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	request.Header.Set("Authorization", "Bearer "+lease.Placeholder())
+	request.Header.Set("X-Api-Key", lease.Placeholder())
+	response, err := http.DefaultClient.Do(request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	response.Body.Close()
+	if response.StatusCode != http.StatusCreated {
+		t.Fatalf("status = %d, want %d", response.StatusCode, http.StatusCreated)
+	}
+	if got := resolverCalls.Load(); got != 1 {
+		t.Fatalf("credential resolver calls = %d, want 1", got)
+	}
+	if got := upstreamCalls.Load(); got != 1 {
+		t.Fatalf("upstream calls = %d, want 1", got)
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	if upstreamAuthorization != "Bearer "+testRealCredential || upstreamAPIKey != "" || upstreamPath != "/api/v1/messages" {
+		t.Fatalf("upstream authorization=%q api_key=%q path=%q", upstreamAuthorization, upstreamAPIKey, upstreamPath)
+	}
+}
+
 func TestGenericProxyLeaseBearerRotationRevocationAndPathPinning(t *testing.T) {
 	const rotatedCredential = "rotated-real-credential-874"
 	var mu sync.Mutex
@@ -262,7 +417,7 @@ func TestGenericProxyLeaseBearerRotationRevocationAndPathPinning(t *testing.T) {
 	mu.Unlock()
 
 	logged := logs.waitFor(t, "job_id=proxy-job")
-	for _, forbidden := range []string{testRealCredential, rotatedCredential, lease.Placeholder(), testRequestBody, "Authorization", "X-Api-Key"} {
+	for _, forbidden := range []string{testRealCredential, rotatedCredential, lease.Placeholder(), lease.capability, testRequestBody, "Authorization", "X-Api-Key"} {
 		if strings.Contains(logged, forbidden) {
 			t.Fatalf("gateway log leaked %q: %q", forbidden, logged)
 		}

--- a/internal/credgw/runner.go
+++ b/internal/credgw/runner.go
@@ -21,13 +21,18 @@ type Lease struct {
 	gateway     *Gateway
 	placeholder string
 	route       string
+	capability  string
 }
 
 func (l *Lease) URL() string {
 	if l == nil || l.gateway == nil || l.route == "" {
 		return ""
 	}
-	return l.gateway.URL() + l.route
+	url := l.gateway.URL() + l.route
+	if l.capability != "" {
+		url += "/" + l.capability
+	}
+	return url
 }
 
 func (l *Lease) Placeholder() string {


### PR DESCRIPTION
WHAT:
Added a route-bound, expiring capability gate to the existing loopback credential proxy. Invalid capabilities are rejected before credential resolution; no TLS, listener, legacy Register, or Runner changes were made. GITMOOT-COC-1538-S1-IMPL

WHY:
Gitmoot finalized this implementation from a task worktree.

CHANGES:
- Committed changes from /root/.gitmoot/worktrees/gitmoot--gitmoot/adhoc-14aa8916

RESULTS:
- Base verified at f8b18e5083b39c59042b11ffc87b67fbb9106c8a.
- Baseline filter ^TestGenericProxyCapability matched 2 tests; both passed, including four rejection subtests.
- Existing proxy regression filter matched 3 tests; rotation/revocation/path pinning, custom-header/redirect refusal, and concurrent route isolation all passed unchanged.
- Combined focused race run matched 5 top-level tests and passed.
- Ordering mutant compiled with go test -c. Moving resolution before authorization failed all four rejection cases with: credential resolver calls = 1, want 0. Its separate happy-path filter matched 1 and passed.
- No-gate mutant compiled with go test -c. Cross-route and expired cases failed with: status = 204, want 401. Its separate happy-path filter matched 1 and passed.
- gofmt -d and git diff --check were clean.

RISK:
Review the generated diff before merging.

TASK:
adhoc-14aa8916

AGENTS:
- wave-impl

RAW FINAL REVIEW OUTPUT:
````text
Added a route-bound, expiring capability gate to the existing loopback credential proxy. Invalid capabilities are rejected before credential resolution; no TLS, listener, legacy Register, or Runner changes were made. GITMOOT-COC-1538-S1-IMPL
````
