### PR TITLE
Gitmoot: IMPLEMENT gitmoot#1538 (P3a, epic #1529) — SLICE 2

### DIFF
--- a/internal/credgw/gateway.go
+++ b/internal/credgw/gateway.go
@@ -22,9 +22,12 @@ import (
 
 const DefaultAnthropicUpstream = "https://api.anthropic.com"
 
+const CapabilityHeader = "X-Gitmoot-Capability"
+
 const (
-	proxyCapabilityBytes = 32
-	proxyCapabilityTTL   = 5 * time.Minute
+	proxyCapabilityBytes   = 32
+	proxyCapabilityTTL     = 5 * time.Minute
+	proxyCapabilityOverlap = 30 * time.Second
 )
 
 type CredentialKind string
@@ -91,6 +94,8 @@ type Gateway struct {
 	mu           sync.RWMutex
 	entries      map[string]entry
 	proxyEntries map[string]proxyEntry
+	networks     map[*NetworkProxy]struct{}
+	now          func() time.Time
 	closed       bool
 }
 
@@ -102,13 +107,21 @@ type entry struct {
 }
 
 type proxyEntry struct {
-	jobID               string
-	placeholder         string
-	policy              ProxyPolicy
-	upstream            *url.URL
-	resolver            CredentialResolver
-	capabilityHash      [sha256.Size]byte
-	capabilityExpiresAt time.Time
+	jobID            string
+	placeholder      string
+	policy           ProxyPolicy
+	upstream         *url.URL
+	resolver         CredentialResolver
+	capability       proxyCapability
+	previous         proxyCapability
+	absoluteDeadline time.Time
+	clientCertHash   [sha256.Size]byte
+	networkEnabled   bool
+}
+
+type proxyCapability struct {
+	hash      [sha256.Size]byte
+	expiresAt time.Time
 }
 
 func Start(logf LogFunc) (*Gateway, error) {
@@ -127,6 +140,8 @@ func Start(logf LogFunc) (*Gateway, error) {
 		logf:         logf,
 		entries:      make(map[string]entry),
 		proxyEntries: make(map[string]proxyEntry),
+		networks:     make(map[*NetworkProxy]struct{}),
+		now:          time.Now,
 	}
 	gateway.server = &http.Server{
 		Handler:           gateway,
@@ -175,10 +190,11 @@ func (g *Gateway) RegisterProxy(jobID string, policy ProxyPolicy, resolver Crede
 	if g.closed {
 		return nil, errors.New("credential gateway is not running")
 	}
+	now := g.nowTime()
 	g.proxyEntries[route] = proxyEntry{
 		jobID: jobID, placeholder: placeholder, policy: validated,
-		upstream: upstream, resolver: resolver, capabilityHash: capabilityHash,
-		capabilityExpiresAt: time.Now().Add(proxyCapabilityTTL),
+		upstream: upstream, resolver: resolver,
+		capability: proxyCapability{hash: capabilityHash, expiresAt: now.Add(proxyCapabilityTTL)},
 	}
 	return &Lease{gateway: g, placeholder: placeholder, route: route, capability: capability}, nil
 }
@@ -257,8 +273,22 @@ func (g *Gateway) Close(ctx context.Context) error {
 	g.closed = true
 	clear(g.entries)
 	clear(g.proxyEntries)
+	networks := make([]*NetworkProxy, 0, len(g.networks))
+	for network := range g.networks {
+		networks = append(networks, network)
+	}
+	clear(g.networks)
 	g.mu.Unlock()
-	return g.server.Shutdown(ctx)
+	var errs []error
+	for _, network := range networks {
+		if err := network.server.Shutdown(ctx); err != nil {
+			errs = append(errs, err)
+		}
+	}
+	if err := g.server.Shutdown(ctx); err != nil {
+		errs = append(errs, err)
+	}
+	return errors.Join(errs...)
 }
 
 func (g *Gateway) ServeHTTP(w http.ResponseWriter, r *http.Request) {
@@ -316,8 +346,30 @@ func (g *Gateway) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 }
 
 func (g *Gateway) serveProxy(w http.ResponseWriter, r *http.Request, route string) {
+	capability, ok := proxyRequestCapability(r.URL.EscapedPath(), route)
+	if !ok {
+		http.Error(w, "unauthorized", http.StatusUnauthorized)
+		g.writeLog(r.Method, "", http.StatusUnauthorized, "")
+		return
+	}
+	g.serveProxyRequest(w, r, proxyRequestAccess{
+		route: route, capability: capability, suffixRoute: route + "/" + capability,
+		authority: g.listener.Addr().String(),
+	})
+}
+
+type proxyRequestAccess struct {
+	route          string
+	capability     string
+	suffixRoute    string
+	authority      string
+	clientCertHash [sha256.Size]byte
+	network        bool
+}
+
+func (g *Gateway) serveProxyRequest(w http.ResponseWriter, r *http.Request, access proxyRequestAccess) {
 	g.mu.RLock()
-	registered, ok := g.proxyEntries[route]
+	registered, ok := g.proxyEntries[access.route]
 	g.mu.RUnlock()
 	if !ok {
 		http.Error(w, "unauthorized", http.StatusUnauthorized)
@@ -329,24 +381,23 @@ func (g *Gateway) serveProxy(w http.ResponseWriter, r *http.Request, route strin
 		g.writeLog(r.Method, registered.upstream.Hostname(), http.StatusUnauthorized, registered.jobID)
 		return
 	}
-	if r.URL.IsAbs() || r.URL.Host != "" || !strings.EqualFold(r.Host, g.listener.Addr().String()) {
+	if r.URL.IsAbs() || r.URL.Host != "" || !strings.EqualFold(r.Host, access.authority) {
 		http.Error(w, "request target refused", http.StatusBadRequest)
 		g.writeLog(r.Method, registered.upstream.Hostname(), http.StatusBadRequest, registered.jobID)
 		return
 	}
-	capability, ok := proxyRequestCapability(r.URL.EscapedPath(), route)
-	if !ok {
+	if access.network && (!registered.networkEnabled || subtle.ConstantTimeCompare(access.clientCertHash[:], registered.clientCertHash[:]) != 1) {
 		http.Error(w, "unauthorized", http.StatusUnauthorized)
 		g.writeLog(r.Method, registered.upstream.Hostname(), http.StatusUnauthorized, registered.jobID)
 		return
 	}
-	suffix, err := proxyRequestSuffix(r.URL.EscapedPath(), route+"/"+capability)
+	suffix, err := proxyRequestSuffix(r.URL.EscapedPath(), access.suffixRoute)
 	if err != nil {
 		http.Error(w, "request path refused", http.StatusBadRequest)
 		g.writeLog(r.Method, registered.upstream.Hostname(), http.StatusBadRequest, registered.jobID)
 		return
 	}
-	if !validProxyCapability(capability, registered, time.Now()) {
+	if !validProxyCapability(access.capability, registered, g.nowTime()) {
 		http.Error(w, "unauthorized", http.StatusUnauthorized)
 		g.writeLog(r.Method, registered.upstream.Hostname(), http.StatusUnauthorized, registered.jobID)
 		return
@@ -503,8 +554,16 @@ func validProxyCapability(capability string, registered proxyEntry, now time.Tim
 		return false
 	}
 	presented := sha256.Sum256(decoded)
-	matches := subtle.ConstantTimeCompare(presented[:], registered.capabilityHash[:]) == 1
-	return matches && now.Before(registered.capabilityExpiresAt)
+	current := subtle.ConstantTimeCompare(presented[:], registered.capability.hash[:]) == 1 && now.Before(registered.capability.expiresAt)
+	previous := subtle.ConstantTimeCompare(presented[:], registered.previous.hash[:]) == 1 && now.Before(registered.previous.expiresAt)
+	return current || previous
+}
+
+func (g *Gateway) nowTime() time.Time {
+	if g != nil && g.now != nil {
+		return g.now()
+	}
+	return time.Now()
 }
 
 func hasDotPathSegment(value string) bool {
@@ -565,7 +624,7 @@ func proxyRequestPlaceholder(r *http.Request, policy ProxyPolicy) string {
 }
 
 func removeCredentialHeaders(header http.Header, configured string) {
-	for _, name := range []string{"Authorization", "X-Api-Key", "Proxy-Authorization", configured} {
+	for _, name := range []string{"Authorization", "X-Api-Key", "Proxy-Authorization", CapabilityHeader, configured} {
 		if name != "" {
 			header.Del(name)
 		}

--- a/internal/credgw/gateway_test.go
+++ b/internal/credgw/gateway_test.go
@@ -229,7 +229,7 @@ func TestGenericProxyCapabilityRejectionsNeverResolveCredential(t *testing.T) {
 			if test.expire {
 				gateway.mu.Lock()
 				entry := gateway.proxyEntries[lease.route]
-				entry.capabilityExpiresAt = time.Now().Add(-time.Second)
+				entry.capability.expiresAt = time.Now().Add(-time.Second)
 				gateway.proxyEntries[lease.route] = entry
 				gateway.mu.Unlock()
 			}

--- a/internal/credgw/network.go
+++ b/internal/credgw/network.go
@@ -1,0 +1,418 @@
+package credgw
+
+import (
+	"bytes"
+	"context"
+	"crypto"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/sha256"
+	"crypto/subtle"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io"
+	"log"
+	"math/big"
+	"net"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+)
+
+const networkRenewPrefix = "/_gitmoot/renew/"
+
+// NetworkProxyConfig contains the host-owned TLS material for a proxy-only
+// listener. ClientCAKey never leaves the host; it signs one client certificate
+// for each network proxy lease.
+type NetworkProxyConfig struct {
+	Address           string
+	ServerCertificate tls.Certificate
+	ClientCA          *x509.Certificate
+	ClientCAKey       crypto.Signer
+}
+
+// NetworkProxy is a mandatory-mTLS transport over a Gateway's request-time
+// proxy entries. It never dispatches the legacy entries that retain credentials.
+type NetworkProxy struct {
+	gateway  *Gateway
+	listener net.Listener
+	server   *http.Server
+	clientCA *x509.Certificate
+	caKey    crypto.Signer
+}
+
+// NetworkLease carries no provider credential. Its client certificate and
+// rotating capability authorize one route until the absolute deadline.
+type NetworkLease struct {
+	lease       *Lease
+	network     *NetworkProxy
+	certificate tls.Certificate
+	deadline    time.Time
+
+	mu         sync.RWMutex
+	renewMu    sync.Mutex
+	capability string
+}
+
+func (g *Gateway) StartNetworkProxy(config NetworkProxyConfig) (*NetworkProxy, error) {
+	if g == nil {
+		return nil, errors.New("credential gateway is not running")
+	}
+	if strings.TrimSpace(config.Address) == "" {
+		return nil, errors.New("network credential gateway listen address is required")
+	}
+	if len(config.ServerCertificate.Certificate) == 0 || config.ServerCertificate.PrivateKey == nil {
+		return nil, errors.New("network credential gateway server TLS certificate is required")
+	}
+	if err := validateClientCA(config.ClientCA, config.ClientCAKey); err != nil {
+		return nil, err
+	}
+
+	g.mu.RLock()
+	closed := g.closed
+	g.mu.RUnlock()
+	if closed {
+		return nil, errors.New("credential gateway is not running")
+	}
+
+	clientCAs := x509.NewCertPool()
+	clientCAs.AddCert(config.ClientCA)
+	tlsConfig := &tls.Config{
+		Certificates: []tls.Certificate{config.ServerCertificate},
+		ClientAuth:   tls.RequireAndVerifyClientCert,
+		ClientCAs:    clientCAs,
+		MinVersion:   tls.VersionTLS13,
+		Time:         g.nowTime,
+	}
+	listener, err := net.Listen("tcp", config.Address)
+	if err != nil {
+		return nil, fmt.Errorf("listen for network credential gateway: %w", err)
+	}
+	network := &NetworkProxy{
+		gateway: g, listener: listener, clientCA: config.ClientCA, caKey: config.ClientCAKey,
+	}
+	network.server = &http.Server{
+		Handler:           network,
+		ErrorLog:          log.New(io.Discard, "", 0),
+		ReadHeaderTimeout: 5 * time.Second,
+		IdleTimeout:       90 * time.Second,
+		MaxHeaderBytes:    1 << 20,
+	}
+	g.mu.Lock()
+	if g.closed {
+		g.mu.Unlock()
+		_ = listener.Close()
+		return nil, errors.New("credential gateway is not running")
+	}
+	g.networks[network] = struct{}{}
+	g.mu.Unlock()
+	go func() {
+		_ = network.server.Serve(tls.NewListener(listener, tlsConfig))
+	}()
+	return network, nil
+}
+
+func (n *NetworkProxy) URL() string {
+	if n == nil || n.listener == nil {
+		return ""
+	}
+	return "https://" + n.listener.Addr().String()
+}
+
+func (n *NetworkProxy) Close(ctx context.Context) error {
+	if n == nil || n.server == nil {
+		return nil
+	}
+	err := n.server.Shutdown(ctx)
+	if n.gateway != nil {
+		n.gateway.mu.Lock()
+		delete(n.gateway.networks, n)
+		n.gateway.mu.Unlock()
+	}
+	return err
+}
+
+func (n *NetworkProxy) RegisterProxy(jobID string, deadline time.Time, policy ProxyPolicy, resolver CredentialResolver) (*NetworkLease, error) {
+	if n == nil || n.gateway == nil {
+		return nil, errors.New("network credential gateway is not running")
+	}
+	now := n.gateway.nowTime()
+	deadline = deadline.UTC()
+	if !deadline.After(now) {
+		return nil, errors.New("network credential gateway deadline must be in the future")
+	}
+	certificate, certificateHash, err := issueNetworkClientCertificate(n.clientCA, n.caKey, jobID, now, deadline)
+	if err != nil {
+		return nil, err
+	}
+	lease, err := n.gateway.RegisterProxy(jobID, policy, resolver)
+	if err != nil {
+		return nil, err
+	}
+
+	n.gateway.mu.Lock()
+	registered, ok := n.gateway.proxyEntries[lease.route]
+	if !ok || registered.placeholder != lease.placeholder {
+		n.gateway.mu.Unlock()
+		lease.Revoke()
+		return nil, errors.New("network credential gateway lease registration disappeared")
+	}
+	registered.networkEnabled = true
+	registered.clientCertHash = certificateHash
+	registered.absoluteDeadline = deadline
+	registered.capability.expiresAt = earliestTime(registered.capability.expiresAt, deadline)
+	n.gateway.proxyEntries[lease.route] = registered
+	n.gateway.mu.Unlock()
+
+	return &NetworkLease{
+		lease: lease, network: n, certificate: certificate, deadline: deadline,
+		capability: lease.capability,
+	}, nil
+}
+
+func (l *NetworkLease) URL() string {
+	if l == nil || l.network == nil || l.lease == nil {
+		return ""
+	}
+	return l.network.URL() + l.lease.route
+}
+
+func (l *NetworkLease) Placeholder() string {
+	if l == nil || l.lease == nil {
+		return ""
+	}
+	return l.lease.Placeholder()
+}
+
+func (l *NetworkLease) Capability() string {
+	if l == nil {
+		return ""
+	}
+	l.mu.RLock()
+	defer l.mu.RUnlock()
+	return l.capability
+}
+
+func (l *NetworkLease) ClientCertificate() tls.Certificate {
+	if l == nil {
+		return tls.Certificate{}
+	}
+	return l.certificate
+}
+
+func (l *NetworkLease) Deadline() time.Time {
+	if l == nil {
+		return time.Time{}
+	}
+	return l.deadline
+}
+
+func (l *NetworkLease) Revoke() {
+	if l != nil && l.lease != nil {
+		l.lease.Revoke()
+	}
+}
+
+// Renew rotates the capability over the authenticated network transport. The
+// route URL remains stable; callers read Capability again for later requests.
+func (l *NetworkLease) Renew(ctx context.Context, client *http.Client) error {
+	if l == nil || l.network == nil || l.lease == nil || client == nil {
+		return errors.New("network credential gateway renewal requires a lease and client")
+	}
+	l.renewMu.Lock()
+	defer l.renewMu.Unlock()
+	request, err := http.NewRequestWithContext(ctx, http.MethodPost, l.network.URL()+networkRenewPrefix+strings.TrimPrefix(l.lease.route, "/_gitmoot/proxy/"), nil)
+	if err != nil {
+		return err
+	}
+	request.Header.Set(CapabilityHeader, l.Capability())
+	response, err := client.Do(request)
+	if err != nil {
+		return fmt.Errorf("renew network credential gateway capability: %w", err)
+	}
+	defer response.Body.Close()
+	if response.StatusCode != http.StatusOK {
+		return fmt.Errorf("renew network credential gateway capability: status %d", response.StatusCode)
+	}
+	capability, err := io.ReadAll(io.LimitReader(response.Body, proxyCapabilityBytes*2+1))
+	if err != nil {
+		return fmt.Errorf("read renewed network credential gateway capability: %w", err)
+	}
+	value := strings.TrimSpace(string(capability))
+	if !validCapabilityEncoding(value) {
+		return errors.New("renew network credential gateway capability: malformed response")
+	}
+	l.mu.Lock()
+	l.capability = value
+	l.mu.Unlock()
+	return nil
+}
+
+func (n *NetworkProxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	certificateHash, ok := requestClientCertificateHash(r)
+	if !ok {
+		http.Error(w, "unauthorized", http.StatusUnauthorized)
+		return
+	}
+	if route, ok := networkRenewRoute(r.URL.EscapedPath()); ok {
+		n.serveRenewal(w, r, route, certificateHash)
+		return
+	}
+	if route, ok := proxyRoute(r.URL.EscapedPath()); ok {
+		capability := strings.TrimSpace(r.Header.Get(CapabilityHeader))
+		if !validCapabilityEncoding(capability) {
+			http.Error(w, "unauthorized", http.StatusUnauthorized)
+			return
+		}
+		n.gateway.serveProxyRequest(w, r, proxyRequestAccess{
+			route: route, capability: capability, suffixRoute: route,
+			authority: n.listener.Addr().String(), clientCertHash: certificateHash, network: true,
+		})
+		return
+	}
+	http.NotFound(w, r)
+}
+
+func (n *NetworkProxy) serveRenewal(w http.ResponseWriter, r *http.Request, route string, certificateHash [sha256.Size]byte) {
+	if r.Method != http.MethodPost || r.URL.IsAbs() || r.URL.Host != "" || !strings.EqualFold(r.Host, n.listener.Addr().String()) {
+		http.Error(w, "unauthorized", http.StatusUnauthorized)
+		return
+	}
+	capability := strings.TrimSpace(r.Header.Get(CapabilityHeader))
+	if !validCapabilityEncoding(capability) {
+		http.Error(w, "unauthorized", http.StatusUnauthorized)
+		return
+	}
+	renewed, err := n.gateway.renewProxyCapability(route, capability, certificateHash)
+	if err != nil {
+		http.Error(w, "unauthorized", http.StatusUnauthorized)
+		return
+	}
+	w.Header().Set("Cache-Control", "no-store")
+	w.Header().Set("Content-Type", "text/plain")
+	w.WriteHeader(http.StatusOK)
+	_, _ = io.WriteString(w, renewed)
+}
+
+func (g *Gateway) renewProxyCapability(route, capability string, certificateHash [sha256.Size]byte) (string, error) {
+	newCapability, newHash, err := mintProxyCapability()
+	if err != nil {
+		return "", err
+	}
+	now := g.nowTime()
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	registered, ok := g.proxyEntries[route]
+	if !ok || !registered.networkEnabled || subtle.ConstantTimeCompare(certificateHash[:], registered.clientCertHash[:]) != 1 {
+		return "", errors.New("network credential gateway lease is unavailable")
+	}
+	if registered.absoluteDeadline.IsZero() || !now.Before(registered.absoluteDeadline) || !validProxyCapability(capability, registered, now) {
+		return "", errors.New("network credential gateway lease is expired")
+	}
+	previous := registered.capability
+	previous.expiresAt = earliestTime(previous.expiresAt, now.Add(proxyCapabilityOverlap), registered.absoluteDeadline)
+	registered.previous = previous
+	registered.capability = proxyCapability{
+		hash: newHash, expiresAt: earliestTime(now.Add(proxyCapabilityTTL), registered.absoluteDeadline),
+	}
+	g.proxyEntries[route] = registered
+	return newCapability, nil
+}
+
+func requestClientCertificateHash(r *http.Request) ([sha256.Size]byte, bool) {
+	if r == nil || r.TLS == nil || len(r.TLS.PeerCertificates) == 0 {
+		return [sha256.Size]byte{}, false
+	}
+	return sha256.Sum256(r.TLS.PeerCertificates[0].Raw), true
+}
+
+func networkRenewRoute(escapedPath string) (string, bool) {
+	if !strings.HasPrefix(escapedPath, networkRenewPrefix) {
+		return "", false
+	}
+	segment, remainder, _ := strings.Cut(strings.TrimPrefix(escapedPath, networkRenewPrefix), "/")
+	if len(segment) != 32 || remainder != "" {
+		return "", false
+	}
+	return "/_gitmoot/proxy/" + segment, true
+}
+
+func validCapabilityEncoding(capability string) bool {
+	if len(capability) != proxyCapabilityBytes*2 {
+		return false
+	}
+	decoded, err := hex.DecodeString(capability)
+	return err == nil && len(decoded) == proxyCapabilityBytes
+}
+
+func validateClientCA(certificate *x509.Certificate, key crypto.Signer) error {
+	if certificate == nil || !certificate.IsCA || certificate.KeyUsage&x509.KeyUsageCertSign == 0 {
+		return errors.New("network credential gateway client CA certificate is required")
+	}
+	if key == nil {
+		return errors.New("network credential gateway client CA signing key is required")
+	}
+	want, err := x509.MarshalPKIXPublicKey(certificate.PublicKey)
+	if err != nil {
+		return fmt.Errorf("marshal network credential gateway client CA public key: %w", err)
+	}
+	got, err := x509.MarshalPKIXPublicKey(key.Public())
+	if err != nil {
+		return fmt.Errorf("marshal network credential gateway client CA signing key: %w", err)
+	}
+	if !bytes.Equal(want, got) {
+		return errors.New("network credential gateway client CA certificate and signing key do not match")
+	}
+	return nil
+}
+
+func issueNetworkClientCertificate(ca *x509.Certificate, caKey crypto.Signer, jobID string, now, deadline time.Time) (tls.Certificate, [sha256.Size]byte, error) {
+	privateKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		return tls.Certificate{}, [sha256.Size]byte{}, fmt.Errorf("generate network credential gateway client key: %w", err)
+	}
+	serialBytes := make([]byte, 16)
+	if _, err := rand.Read(serialBytes); err != nil {
+		return tls.Certificate{}, [sha256.Size]byte{}, fmt.Errorf("generate network credential gateway client serial: %w", err)
+	}
+	notAfter := earliestTime(deadline, ca.NotAfter)
+	if !notAfter.After(now) {
+		return tls.Certificate{}, [sha256.Size]byte{}, errors.New("network credential gateway client certificate deadline is not usable")
+	}
+	template := &x509.Certificate{
+		SerialNumber: new(big.Int).SetBytes(serialBytes),
+		Subject:      pkix.Name{CommonName: "gitmoot-job:" + jobID, Organization: []string{"gitmoot"}},
+		NotBefore:    now.Add(-time.Minute), NotAfter: notAfter,
+		KeyUsage:    x509.KeyUsageDigitalSignature,
+		ExtKeyUsage: []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
+	}
+	der, err := x509.CreateCertificate(rand.Reader, template, ca, &privateKey.PublicKey, caKey)
+	if err != nil {
+		return tls.Certificate{}, [sha256.Size]byte{}, fmt.Errorf("issue network credential gateway client certificate: %w", err)
+	}
+	leaf, err := x509.ParseCertificate(der)
+	if err != nil {
+		return tls.Certificate{}, [sha256.Size]byte{}, fmt.Errorf("parse network credential gateway client certificate: %w", err)
+	}
+	certificate := tls.Certificate{Certificate: [][]byte{der, ca.Raw}, PrivateKey: privateKey, Leaf: leaf}
+	return certificate, sha256.Sum256(der), nil
+}
+
+func earliestTime(values ...time.Time) time.Time {
+	var earliest time.Time
+	for _, value := range values {
+		if value.IsZero() {
+			continue
+		}
+		if earliest.IsZero() || value.Before(earliest) {
+			earliest = value
+		}
+	}
+	return earliest
+}

--- a/internal/credgw/network_test.go
+++ b/internal/credgw/network_test.go
@@ -1,0 +1,460 @@
+package credgw
+
+import (
+	"bytes"
+	"context"
+	"crypto"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/sha256"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"io"
+	"math/big"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+type controlledClock struct {
+	mu  sync.Mutex
+	now time.Time
+}
+
+func (c *controlledClock) Now() time.Time {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.now
+}
+
+func (c *controlledClock) Advance(delta time.Duration) {
+	c.mu.Lock()
+	c.now = c.now.Add(delta)
+	c.mu.Unlock()
+}
+
+type networkProxyFixture struct {
+	t             *testing.T
+	clock         *controlledClock
+	gateway       *Gateway
+	network       *NetworkProxy
+	serverCA      *x509.Certificate
+	clientCA      *x509.Certificate
+	clientCAKey   crypto.Signer
+	upstream      *httptest.Server
+	upstreamCalls atomic.Int32
+	resolverCalls atomic.Int32
+
+	upstreamMu            sync.Mutex
+	upstreamAuthorization string
+	upstreamCapability    string
+}
+
+func newNetworkProxyFixture(t *testing.T) *networkProxyFixture {
+	t.Helper()
+	now := time.Date(2026, time.August, 25, 12, 0, 0, 0, time.UTC)
+	clock := &controlledClock{now: now}
+	serverCA, serverCAKey := newTestCertificateAuthority(t, now, "server-ca")
+	clientCA, clientCAKey := newTestCertificateAuthority(t, now, "client-ca")
+	serverCertificate := newTestServerCertificate(t, now, serverCA, serverCAKey)
+	gateway, err := Start(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	gateway.now = clock.Now
+	network, err := gateway.StartNetworkProxy(NetworkProxyConfig{
+		Address: "127.0.0.1:0", ServerCertificate: serverCertificate,
+		ClientCA: clientCA, ClientCAKey: clientCAKey,
+	})
+	if err != nil {
+		gateway.Close(context.Background())
+		t.Fatal(err)
+	}
+	fixture := &networkProxyFixture{
+		t: t, clock: clock, gateway: gateway, network: network,
+		serverCA: serverCA, clientCA: clientCA, clientCAKey: clientCAKey,
+	}
+	fixture.upstream = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fixture.upstreamCalls.Add(1)
+		fixture.upstreamMu.Lock()
+		fixture.upstreamAuthorization = r.Header.Get("Authorization")
+		fixture.upstreamCapability = r.Header.Get(CapabilityHeader)
+		fixture.upstreamMu.Unlock()
+		w.WriteHeader(http.StatusOK)
+		_, _ = io.WriteString(w, "proxied")
+	}))
+	t.Cleanup(func() {
+		fixture.upstream.Close()
+		_ = network.Close(context.Background())
+		_ = gateway.Close(context.Background())
+	})
+	return fixture
+}
+
+func (f *networkProxyFixture) register(jobID string, deadline time.Time) *NetworkLease {
+	f.t.Helper()
+	policy := ProxyPolicy{Upstream: f.upstream.URL, AuthKind: ProxyAuthBearer, AllowLoopbackHTTP: true}
+	lease, err := f.network.RegisterProxy(jobID, deadline, policy, func(context.Context) (ResolvedCredential, error) {
+		f.resolverCalls.Add(1)
+		return ResolvedCredential{Value: testRealCredential, Upstream: policy.Upstream, AuthKind: policy.AuthKind}, nil
+	})
+	if err != nil {
+		f.t.Fatal(err)
+	}
+	return lease
+}
+
+func (f *networkProxyFixture) client(certificate tls.Certificate) *http.Client {
+	f.t.Helper()
+	roots := x509.NewCertPool()
+	roots.AddCert(f.serverCA)
+	config := &tls.Config{RootCAs: roots, MinVersion: tls.VersionTLS13, Time: f.clock.Now}
+	if len(certificate.Certificate) != 0 {
+		config.GetClientCertificate = func(*tls.CertificateRequestInfo) (*tls.Certificate, error) {
+			return &certificate, nil
+		}
+	}
+	return &http.Client{Transport: &http.Transport{
+		TLSClientConfig: config, DisableKeepAlives: true,
+	}}
+}
+
+func (f *networkProxyFixture) request(client *http.Client, lease *NetworkLease, capability string) (*http.Response, error) {
+	f.t.Helper()
+	request, err := http.NewRequest(http.MethodPost, lease.URL()+"/v1/messages", nil)
+	if err != nil {
+		return nil, err
+	}
+	request.Header.Set("Authorization", "Bearer "+lease.Placeholder())
+	if capability != "" {
+		request.Header.Set(CapabilityHeader, capability)
+	}
+	return client.Do(request)
+}
+
+func TestNetworkProxyRefusesToStartWithoutTLSMaterial(t *testing.T) {
+	now := time.Date(2026, time.August, 25, 12, 0, 0, 0, time.UTC)
+	clientCA, clientCAKey := newTestCertificateAuthority(t, now, "client-ca")
+	gateway, err := Start(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer gateway.Close(context.Background())
+	_, err = gateway.StartNetworkProxy(NetworkProxyConfig{
+		Address: "127.0.0.1:0", ClientCA: clientCA, ClientCAKey: clientCAKey,
+	})
+	if err == nil || !strings.Contains(err.Error(), "server TLS certificate is required") {
+		t.Fatalf("StartNetworkProxy error = %v", err)
+	}
+}
+
+func TestNetworkProxyTLSHandshakeRejectsMissingWrongAndExpiredClientCertificates(t *testing.T) {
+	fixture := newNetworkProxyFixture(t)
+	lease := fixture.register("tls-job", fixture.clock.Now().Add(10*time.Minute))
+	wrongCA, wrongSigner := newTestCertificateAuthority(t, fixture.clock.Now(), "wrong-client-ca")
+	wrongCertificate, _, err := issueNetworkClientCertificate(wrongCA, wrongSigner, "wrong-ca-job", fixture.clock.Now(), fixture.clock.Now().Add(10*time.Minute))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tests := []struct {
+		name        string
+		certificate tls.Certificate
+	}{
+		{name: "missing client certificate"},
+		{name: "wrong CA client certificate", certificate: wrongCertificate},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			response, err := fixture.request(fixture.client(test.certificate), lease, lease.Capability())
+			if err == nil {
+				response.Body.Close()
+				t.Fatalf("request reached HTTP with status %d; want TLS handshake failure", response.StatusCode)
+			}
+			if got := fixture.resolverCalls.Load(); got != 0 {
+				t.Fatalf("credential resolver calls = %d, want 0", got)
+			}
+		})
+	}
+
+	fixture.clock.Advance(11 * time.Minute)
+	response, err := fixture.request(fixture.client(lease.ClientCertificate()), lease, lease.Capability())
+	if err == nil {
+		response.Body.Close()
+		t.Fatalf("expired certificate reached HTTP with status %d; want TLS handshake failure", response.StatusCode)
+	}
+	if got := fixture.resolverCalls.Load(); got != 0 {
+		t.Fatalf("credential resolver calls after expired certificate = %d, want 0", got)
+	}
+}
+
+func TestNetworkProxyRejectedAuthorizationNeverResolvesCredential(t *testing.T) {
+	tests := []struct {
+		name  string
+		probe func(*networkProxyFixture, *NetworkLease) (*http.Response, error)
+	}{
+		{
+			name: "missing capability",
+			probe: func(f *networkProxyFixture, lease *NetworkLease) (*http.Response, error) {
+				return f.request(f.client(lease.ClientCertificate()), lease, "")
+			},
+		},
+		{
+			name: "malformed capability",
+			probe: func(f *networkProxyFixture, lease *NetworkLease) (*http.Response, error) {
+				return f.request(f.client(lease.ClientCertificate()), lease, "not-a-capability")
+			},
+		},
+		{
+			name: "certificate bound to another job",
+			probe: func(f *networkProxyFixture, lease *NetworkLease) (*http.Response, error) {
+				other := f.register("other-cert-job", f.clock.Now().Add(30*time.Minute))
+				if bytes.Equal(lease.ClientCertificate().Certificate[0], other.ClientCertificate().Certificate[0]) {
+					f.t.Fatal("different jobs received the same client certificate")
+				}
+				return f.request(f.client(other.ClientCertificate()), lease, lease.Capability())
+			},
+		},
+		{
+			name: "expired capability",
+			probe: func(f *networkProxyFixture, lease *NetworkLease) (*http.Response, error) {
+				f.clock.Advance(proxyCapabilityTTL + time.Second)
+				return f.request(f.client(lease.ClientCertificate()), lease, lease.Capability())
+			},
+		},
+		{
+			name: "capability from another route",
+			probe: func(f *networkProxyFixture, lease *NetworkLease) (*http.Response, error) {
+				other := f.register("other-capability-job", f.clock.Now().Add(30*time.Minute))
+				return f.request(f.client(lease.ClientCertificate()), lease, other.Capability())
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			fixture := newNetworkProxyFixture(t)
+			lease := fixture.register("target-job", fixture.clock.Now().Add(30*time.Minute))
+			response, err := test.probe(fixture, lease)
+			if err != nil {
+				t.Fatal(err)
+			}
+			response.Body.Close()
+			if response.StatusCode != http.StatusUnauthorized {
+				t.Fatalf("status = %d, want %d", response.StatusCode, http.StatusUnauthorized)
+			}
+			if got := fixture.resolverCalls.Load(); got != 0 {
+				t.Fatalf("credential resolver calls = %d, want 0", got)
+			}
+			if got := fixture.upstreamCalls.Load(); got != 0 {
+				t.Fatalf("upstream calls = %d, want 0", got)
+			}
+		})
+	}
+}
+
+func TestNetworkProxyValidRequestSubstitutesCredential(t *testing.T) {
+	fixture := newNetworkProxyFixture(t)
+	lease := fixture.register("valid-job", fixture.clock.Now().Add(30*time.Minute))
+	response, err := fixture.request(fixture.client(lease.ClientCertificate()), lease, lease.Capability())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer response.Body.Close()
+	if response.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want %d", response.StatusCode, http.StatusOK)
+	}
+	body, err := io.ReadAll(response.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(body), testRealCredential) || strings.Contains(string(body), lease.Capability()) {
+		t.Fatalf("client response exposed credential material: %q", body)
+	}
+	if got := fixture.resolverCalls.Load(); got != 1 {
+		t.Fatalf("credential resolver calls = %d, want 1", got)
+	}
+	if got := fixture.upstreamCalls.Load(); got != 1 {
+		t.Fatalf("upstream calls = %d, want 1", got)
+	}
+	fixture.upstreamMu.Lock()
+	defer fixture.upstreamMu.Unlock()
+	if fixture.upstreamAuthorization != "Bearer "+testRealCredential || fixture.upstreamCapability != "" {
+		t.Fatalf("upstream authorization=%q capability=%q", fixture.upstreamAuthorization, fixture.upstreamCapability)
+	}
+}
+
+func TestNetworkProxyCapabilityRenewalOverlapAndAbsoluteDeadline(t *testing.T) {
+	fixture := newNetworkProxyFixture(t)
+	deadline := fixture.clock.Now().Add(15 * time.Minute)
+	lease := fixture.register("renew-job", deadline)
+	stableURL := lease.URL()
+	if lease.ClientCertificate().Leaf == nil || lease.ClientCertificate().Leaf.NotAfter.After(deadline) {
+		t.Fatalf("client certificate deadline = %v, want no later than %v", lease.ClientCertificate().Leaf, deadline)
+	}
+	fixture.gateway.mu.RLock()
+	initialEntry := fixture.gateway.proxyEntries[lease.lease.route]
+	fixture.gateway.mu.RUnlock()
+	if initialEntry.capability.expiresAt.After(deadline) {
+		t.Fatalf("initial capability deadline = %v, want no later than %v", initialEntry.capability.expiresAt, deadline)
+	}
+	client := fixture.client(lease.ClientCertificate())
+	oldCapability := lease.Capability()
+	fixture.clock.Advance(4 * time.Minute)
+	if err := lease.Renew(context.Background(), client); err != nil {
+		t.Fatal(err)
+	}
+	newCapability := lease.Capability()
+	if newCapability == oldCapability {
+		t.Fatal("renewal did not rotate the capability")
+	}
+	if lease.URL() != stableURL {
+		t.Fatalf("renewal changed route URL from %q to %q", stableURL, lease.URL())
+	}
+
+	response, err := fixture.request(fixture.client(lease.ClientCertificate()), lease, oldCapability)
+	if err != nil {
+		t.Fatal(err)
+	}
+	response.Body.Close()
+	if response.StatusCode != http.StatusOK {
+		t.Fatalf("previous capability during overlap status = %d, want 200", response.StatusCode)
+	}
+	fixture.clock.Advance(proxyCapabilityOverlap + time.Second)
+	response, err = fixture.request(fixture.client(lease.ClientCertificate()), lease, oldCapability)
+	if err != nil {
+		t.Fatal(err)
+	}
+	response.Body.Close()
+	if response.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("previous capability after overlap status = %d, want 401", response.StatusCode)
+	}
+	response, err = fixture.request(fixture.client(lease.ClientCertificate()), lease, newCapability)
+	if err != nil {
+		t.Fatal(err)
+	}
+	response.Body.Close()
+	if response.StatusCode != http.StatusOK {
+		t.Fatalf("renewed capability status = %d, want 200", response.StatusCode)
+	}
+
+	fixture.clock.Advance(deadline.Sub(fixture.clock.Now()) + time.Second)
+	fixture.gateway.mu.Lock()
+	registered := fixture.gateway.proxyEntries[lease.lease.route]
+	registered.capability.expiresAt = fixture.clock.Now().Add(time.Hour)
+	fixture.gateway.proxyEntries[lease.lease.route] = registered
+	fixture.gateway.mu.Unlock()
+	certificateHash := sha256.Sum256(lease.ClientCertificate().Certificate[0])
+	if _, err := fixture.gateway.renewProxyCapability(lease.lease.route, newCapability, certificateHash); err == nil {
+		t.Fatal("post-deadline renewal succeeded")
+	}
+	response, err = fixture.request(fixture.client(lease.ClientCertificate()), lease, newCapability)
+	if err == nil {
+		response.Body.Close()
+		t.Fatalf("post-deadline certificate reached HTTP with status %d", response.StatusCode)
+	}
+}
+
+func TestNetworkProxyRevocationAndLegacyIsolation(t *testing.T) {
+	fixture := newNetworkProxyFixture(t)
+	lease := fixture.register("revoked-job", fixture.clock.Now().Add(30*time.Minute))
+	client := fixture.client(lease.ClientCertificate())
+	response, err := fixture.request(client, lease, lease.Capability())
+	if err != nil {
+		t.Fatal(err)
+	}
+	response.Body.Close()
+	if response.StatusCode != http.StatusOK {
+		t.Fatalf("initial status = %d, want 200", response.StatusCode)
+	}
+	resolvedBeforeRevoke := fixture.resolverCalls.Load()
+	lease.Revoke()
+	response, err = fixture.request(fixture.client(lease.ClientCertificate()), lease, lease.Capability())
+	if err != nil {
+		t.Fatal(err)
+	}
+	response.Body.Close()
+	if response.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("revoked status = %d, want 401", response.StatusCode)
+	}
+	if got := fixture.resolverCalls.Load(); got != resolvedBeforeRevoke {
+		t.Fatalf("resolver calls after revocation = %d, want %d", got, resolvedBeforeRevoke)
+	}
+
+	legacyPlaceholder, err := fixture.gateway.Register("legacy-job", Credential{Kind: CredentialBearer, Value: testRealCredential}, testPolicy(t, fixture.upstream.URL))
+	if err != nil {
+		t.Fatal(err)
+	}
+	request, err := http.NewRequest(http.MethodPost, fixture.network.URL()+"/v1/messages", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	request.Header.Set("Authorization", "Bearer "+legacyPlaceholder)
+	upstreamBeforeLegacyProbe := fixture.upstreamCalls.Load()
+	response, err = fixture.client(lease.ClientCertificate()).Do(request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	response.Body.Close()
+	if response.StatusCode != http.StatusNotFound {
+		t.Fatalf("legacy route network status = %d, want 404", response.StatusCode)
+	}
+	if got := fixture.upstreamCalls.Load(); got != upstreamBeforeLegacyProbe {
+		t.Fatalf("legacy route reached upstream: calls = %d, want %d", got, upstreamBeforeLegacyProbe)
+	}
+}
+
+func newTestCertificateAuthority(t *testing.T, now time.Time, name string) (*x509.Certificate, crypto.Signer) {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	template := &x509.Certificate{
+		SerialNumber: big.NewInt(time.Now().UnixNano()),
+		Subject:      pkix.Name{CommonName: name},
+		NotBefore:    now.Add(-24 * time.Hour), NotAfter: now.Add(24 * time.Hour),
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageDigitalSignature,
+		BasicConstraintsValid: true, IsCA: true,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, template, template, &key.PublicKey, key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	certificate, err := x509.ParseCertificate(der)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return certificate, key
+}
+
+func newTestServerCertificate(t *testing.T, now time.Time, ca *x509.Certificate, caKey crypto.Signer) tls.Certificate {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	template := &x509.Certificate{
+		SerialNumber: big.NewInt(time.Now().UnixNano()),
+		Subject:      pkix.Name{CommonName: "credential-gateway.test"},
+		NotBefore:    now.Add(-time.Hour), NotAfter: now.Add(time.Hour),
+		KeyUsage:    x509.KeyUsageDigitalSignature,
+		ExtKeyUsage: []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		IPAddresses: []net.IP{net.ParseIP("127.0.0.1")},
+	}
+	der, err := x509.CreateCertificate(rand.Reader, template, ca, &key.PublicKey, caKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	leaf, err := x509.ParseCertificate(der)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return tls.Certificate{Certificate: [][]byte{der, ca.Raw}, PrivateKey: key, Leaf: leaf}
+}


### PR DESCRIPTION
WHAT:
Implemented slice 2: a mandatory-mTLS, proxy-only network listener with route-bound client certificates, renewable short-TTL capabilities, overlap, revocation, and absolute deadlines. Existing loopback behavior remains unchanged. GITMOOT-COC-1538-S2-IMPL

WHY:
Gitmoot finalized this implementation from a task worktree.

CHANGES:
- Committed changes from /root/.gitmoot/worktrees/gitmoot--gitmoot/adhoc-f6fbef83

RESULTS:
- Base verified at 96f3a03e445b0dfa01a6a395abf629f96b228d58.
- Baseline ^TestNetworkProxy filter matched 6 top-level tests and passed.
- Merged loopback filters matched 5 tests; capability rejection, substitution, rotation/revocation/path pinning, redirect refusal, and concurrent isolation remained green.
- Combined focused filter matched 11 tests and passed under go test -race.
- Optional-client-certificate mutant compiled. Its one-test handshake filter failed with: request reached HTTP with status 401; want TLS handshake failure. Authorization and deadline filters each matched 1 and passed independently.
- Late-capability-validation mutant compiled. Its one-test authorization filter failed with: credential resolver calls = 1, want 0 for expired and cross-route capabilities. Handshake and deadline filters each matched 1 and passed independently.
- No-absolute-deadline mutant compiled against the final test. Its one-test renewal filter failed with: post-deadline renewal succeeded. Handshake and authorization filters each matched 1 and passed independently.
- go vet ./internal/credgw, gofmt, and git diff --check were clean.

RISK:
Review the generated diff before merging.

TASK:
adhoc-f6fbef83

AGENTS:
- wave-impl

RAW FINAL REVIEW OUTPUT:
````text
Implemented slice 2: a mandatory-mTLS, proxy-only network listener with route-bound client certificates, renewable short-TTL capabilities, overlap, revocation, and absolute deadlines. Existing loopback behavior remains unchanged. GITMOOT-COC-1538-S2-IMPL
````
