### PR TITLE
Gitmoot: IMPLEMENT gitmoot#1538 (P3a, epic #1529) — SLICE 3a,

### DIFF
--- a/internal/execbackend/credentialplan/plan.go
+++ b/internal/execbackend/credentialplan/plan.go
@@ -4,6 +4,7 @@ package credentialplan
 
 import (
 	"crypto/tls"
+	"crypto/x509"
 	"errors"
 	"fmt"
 	"net/url"
@@ -25,7 +26,15 @@ type brokerCapability string
 type Plan struct {
 	endpoint          url.URL
 	capability        brokerCapability
-	clientCertificate tls.Certificate
+	clientCertificate clientCertificateMaterial
+}
+
+type clientCertificateMaterial struct {
+	certificateDER               [][]byte
+	privateKeyPKCS8              []byte
+	ocspStaple                   []byte
+	signedCertificateTimestamps  [][]byte
+	supportedSignatureAlgorithms []tls.SignatureScheme
 }
 
 // New constructs a Plan exclusively from a gateway-issued lease. No runtime
@@ -35,6 +44,10 @@ func New(runtimeName string, lease *credgw.NetworkLease) (Plan, error) {
 	if err := RequireCloudRuntimeSupport(runtimeName); err != nil {
 		return Plan{}, err
 	}
+	return newFromNetworkLease(lease)
+}
+
+func newFromNetworkLease(lease *credgw.NetworkLease) (Plan, error) {
 	if lease == nil {
 		return Plan{}, errors.New("remote credential plan requires a broker lease")
 	}
@@ -42,10 +55,14 @@ func New(runtimeName string, lease *credgw.NetworkLease) (Plan, error) {
 	if err != nil {
 		return Plan{}, fmt.Errorf("parse broker lease endpoint: %w", err)
 	}
+	certificate, err := freezeClientCertificate(lease.ClientCertificate())
+	if err != nil {
+		return Plan{}, fmt.Errorf("freeze broker lease client certificate: %w", err)
+	}
 	return Plan{
 		endpoint:          *endpoint,
 		capability:        brokerCapability(lease.Capability()),
-		clientCertificate: cloneCertificate(lease.ClientCertificate()),
+		clientCertificate: certificate,
 	}, nil
 }
 
@@ -59,23 +76,73 @@ func (p Plan) Capability() string {
 	return string(p.capability)
 }
 
-// ClientCertificate returns a copy of the per-job mTLS client certificate.
-func (p Plan) ClientCertificate() tls.Certificate {
-	return cloneCertificate(p.clientCertificate)
+// ClientTLSConfig returns a TLS configuration that can use the per-job client
+// identity without exposing the plan's stored key material. Each handshake
+// receives independently parsed certificate and private-key objects.
+func (p Plan) ClientTLSConfig() (*tls.Config, error) {
+	serverName := p.endpoint.Hostname()
+	if serverName == "" {
+		return nil, errors.New("broker endpoint has no TLS server name")
+	}
+	material := p.clientCertificate
+	if _, err := material.certificate(); err != nil {
+		return nil, fmt.Errorf("prepare broker client certificate: %w", err)
+	}
+	return &tls.Config{
+		MinVersion: tls.VersionTLS13,
+		ServerName: serverName,
+		GetClientCertificate: func(*tls.CertificateRequestInfo) (*tls.Certificate, error) {
+			return material.certificate()
+		},
+	}, nil
 }
 
-func cloneCertificate(certificate tls.Certificate) tls.Certificate {
-	clone := certificate
-	clone.Certificate = make([][]byte, len(certificate.Certificate))
-	for i, der := range certificate.Certificate {
-		clone.Certificate[i] = append([]byte(nil), der...)
+func freezeClientCertificate(certificate tls.Certificate) (clientCertificateMaterial, error) {
+	if len(certificate.Certificate) == 0 || certificate.PrivateKey == nil {
+		return clientCertificateMaterial{}, errors.New("client certificate is incomplete")
 	}
-	clone.OCSPStaple = append([]byte(nil), certificate.OCSPStaple...)
-	clone.SignedCertificateTimestamps = make([][]byte, len(certificate.SignedCertificateTimestamps))
-	for i, timestamp := range certificate.SignedCertificateTimestamps {
-		clone.SignedCertificateTimestamps[i] = append([]byte(nil), timestamp...)
+	privateKeyPKCS8, err := x509.MarshalPKCS8PrivateKey(certificate.PrivateKey)
+	if err != nil {
+		return clientCertificateMaterial{}, fmt.Errorf("marshal client private key: %w", err)
 	}
-	clone.SupportedSignatureAlgorithms = append([]tls.SignatureScheme(nil), certificate.SupportedSignatureAlgorithms...)
+	material := clientCertificateMaterial{
+		certificateDER:               cloneByteSlices(certificate.Certificate),
+		privateKeyPKCS8:              append([]byte(nil), privateKeyPKCS8...),
+		ocspStaple:                   append([]byte(nil), certificate.OCSPStaple...),
+		signedCertificateTimestamps:  cloneByteSlices(certificate.SignedCertificateTimestamps),
+		supportedSignatureAlgorithms: append([]tls.SignatureScheme(nil), certificate.SupportedSignatureAlgorithms...),
+	}
+	return material, nil
+}
+
+func (m clientCertificateMaterial) certificate() (*tls.Certificate, error) {
+	if len(m.certificateDER) == 0 || len(m.privateKeyPKCS8) == 0 {
+		return nil, errors.New("client certificate material is incomplete")
+	}
+	privateKey, err := x509.ParsePKCS8PrivateKey(m.privateKeyPKCS8)
+	if err != nil {
+		return nil, fmt.Errorf("parse client private key: %w", err)
+	}
+	certificateDER := cloneByteSlices(m.certificateDER)
+	leaf, err := x509.ParseCertificate(certificateDER[0])
+	if err != nil {
+		return nil, fmt.Errorf("parse client leaf certificate: %w", err)
+	}
+	return &tls.Certificate{
+		Certificate:                  certificateDER,
+		PrivateKey:                   privateKey,
+		OCSPStaple:                   append([]byte(nil), m.ocspStaple...),
+		SignedCertificateTimestamps:  cloneByteSlices(m.signedCertificateTimestamps),
+		Leaf:                         leaf,
+		SupportedSignatureAlgorithms: append([]tls.SignatureScheme(nil), m.supportedSignatureAlgorithms...),
+	}, nil
+}
+
+func cloneByteSlices(values [][]byte) [][]byte {
+	clone := make([][]byte, len(values))
+	for i, value := range values {
+		clone[i] = append([]byte(nil), value...)
+	}
 	return clone
 }
 

--- a/internal/execbackend/credentialplan/plan.go
+++ b/internal/execbackend/credentialplan/plan.go
@@ -1,0 +1,106 @@
+// Package credentialplan owns the opaque credential shape available to a
+// future remote execution backend.
+package credentialplan
+
+import (
+	"crypto/tls"
+	"errors"
+	"fmt"
+	"net/url"
+	"strings"
+
+	"github.com/gitmoot/gitmoot/internal/credgw"
+	"github.com/gitmoot/gitmoot/internal/runtime"
+)
+
+// ErrCloudRuntimeUnsupported means a runtime has been deliberately classified
+// as unable to consume brokered credentials from a remote execution backend.
+var ErrCloudRuntimeUnsupported = errors.New("cloud runtime does not support brokered credentials")
+
+type brokerCapability string
+
+// Plan is the complete credential material a future remote backend may
+// receive. Its fields are owned by this package so backend implementations in
+// package execbackend cannot construct or mutate them directly.
+type Plan struct {
+	endpoint          url.URL
+	capability        brokerCapability
+	clientCertificate tls.Certificate
+}
+
+// New constructs a Plan exclusively from a gateway-issued lease. No runtime
+// is supported until a compatibility spike proves it can target the mTLS
+// broker directly.
+func New(runtimeName string, lease *credgw.NetworkLease) (Plan, error) {
+	if err := RequireCloudRuntimeSupport(runtimeName); err != nil {
+		return Plan{}, err
+	}
+	if lease == nil {
+		return Plan{}, errors.New("remote credential plan requires a broker lease")
+	}
+	endpoint, err := url.Parse(lease.URL())
+	if err != nil {
+		return Plan{}, fmt.Errorf("parse broker lease endpoint: %w", err)
+	}
+	return Plan{
+		endpoint:          *endpoint,
+		capability:        brokerCapability(lease.Capability()),
+		clientCertificate: cloneCertificate(lease.ClientCertificate()),
+	}, nil
+}
+
+// Endpoint returns a copy of the broker route URL.
+func (p Plan) Endpoint() url.URL {
+	return p.endpoint
+}
+
+// Capability returns the short-lived credential-gateway capability.
+func (p Plan) Capability() string {
+	return string(p.capability)
+}
+
+// ClientCertificate returns a copy of the per-job mTLS client certificate.
+func (p Plan) ClientCertificate() tls.Certificate {
+	return cloneCertificate(p.clientCertificate)
+}
+
+func cloneCertificate(certificate tls.Certificate) tls.Certificate {
+	clone := certificate
+	clone.Certificate = make([][]byte, len(certificate.Certificate))
+	for i, der := range certificate.Certificate {
+		clone.Certificate[i] = append([]byte(nil), der...)
+	}
+	clone.OCSPStaple = append([]byte(nil), certificate.OCSPStaple...)
+	clone.SignedCertificateTimestamps = make([][]byte, len(certificate.SignedCertificateTimestamps))
+	for i, timestamp := range certificate.SignedCertificateTimestamps {
+		clone.SignedCertificateTimestamps[i] = append([]byte(nil), timestamp...)
+	}
+	clone.SupportedSignatureAlgorithms = append([]tls.SignatureScheme(nil), certificate.SupportedSignatureAlgorithms...)
+	return clone
+}
+
+// RequireCloudRuntimeSupport is a closed classification switch over Gitmoot's
+// compiled runtimes. There is intentionally no default arm: an absent runtime
+// is unclassified rather than inheriting support or an existing decision.
+func RequireCloudRuntimeSupport(runtimeName string) error {
+	runtimeName = strings.TrimSpace(runtimeName)
+	switch runtimeName {
+	case runtime.CodexRuntime:
+		return unsupportedCloudRuntime(runtimeName)
+	case runtime.ClaudeRuntime:
+		return unsupportedCloudRuntime(runtimeName)
+	case runtime.KimiRuntime:
+		return unsupportedCloudRuntime(runtimeName)
+	case runtime.KimiCLIRuntime:
+		return unsupportedCloudRuntime(runtimeName)
+	case runtime.OmpRuntime:
+		return unsupportedCloudRuntime(runtimeName)
+	case runtime.ShellRuntime:
+		return unsupportedCloudRuntime(runtimeName)
+	}
+	return fmt.Errorf("cloud runtime %q has no broker credential classification", runtimeName)
+}
+
+func unsupportedCloudRuntime(runtimeName string) error {
+	return fmt.Errorf("%w: runtime %q has not passed broker compatibility verification", ErrCloudRuntimeUnsupported, runtimeName)
+}

--- a/internal/execbackend/credentialplan/plan_test.go
+++ b/internal/execbackend/credentialplan/plan_test.go
@@ -1,0 +1,193 @@
+package credentialplan
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"math/big"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/gitmoot/gitmoot/internal/credgw"
+)
+
+func TestPlanClientTLSConfigIsolatesCertificateState(t *testing.T) {
+	lease := testNetworkLease(t)
+	source := lease.ClientCertificate()
+	sourceLeaf := source.Leaf
+	sourceKey := source.PrivateKey.(*ecdsa.PrivateKey)
+	originalCommonName := sourceLeaf.Subject.CommonName
+	originalRaw := append([]byte(nil), sourceLeaf.Raw...)
+	originalD := new(big.Int).Set(sourceKey.D)
+
+	plan, err := newFromNetworkLease(lease)
+	if err != nil {
+		t.Fatalf("newFromNetworkLease: %v", err)
+	}
+
+	config, err := plan.ClientTLSConfig()
+	if err != nil {
+		t.Fatalf("ClientTLSConfig: %v", err)
+	}
+
+	t.Run("ingress", func(t *testing.T) {
+		// Mutate the lease-side certificate after plan construction. The frozen
+		// plan must retain the original leaf and key.
+		sourceLeaf.Subject.CommonName = "lease-side-marker"
+		sourceLeaf.Raw[0] ^= 0xff
+		sourceKey.D.SetInt64(1)
+
+		certificate := getClientCertificate(t, config)
+		if certificate.Leaf == sourceLeaf {
+			t.Error("TLS client certificate Leaf shares the ingress pointer")
+		}
+		if certificate.PrivateKey.(*ecdsa.PrivateKey) == sourceKey {
+			t.Error("TLS client certificate PrivateKey shares the ingress pointer")
+		}
+		assertCertificateState(t, certificate, originalCommonName, originalRaw, originalD)
+	})
+
+	t.Run("pointer_identity", func(t *testing.T) {
+		first := getClientCertificate(t, config)
+		second := getClientCertificate(t, config)
+		if second.Leaf == first.Leaf {
+			t.Error("successive TLS client certificates share a Leaf pointer")
+		}
+		if second.PrivateKey.(*ecdsa.PrivateKey) == first.PrivateKey.(*ecdsa.PrivateKey) {
+			t.Error("successive TLS client certificates share a PrivateKey pointer")
+		}
+	})
+
+	t.Run("consumer_mutation", func(t *testing.T) {
+		first := getClientCertificate(t, config)
+		first.Leaf.Subject.CommonName = "consumer-side-marker"
+		first.Leaf.Raw[0] ^= 0xff
+		first.PrivateKey.(*ecdsa.PrivateKey).D.SetInt64(2)
+
+		second := getClientCertificate(t, config)
+		assertCertificateState(t, second, originalCommonName, originalRaw, originalD)
+	})
+}
+
+func getClientCertificate(t *testing.T, config *tls.Config) *tls.Certificate {
+	t.Helper()
+	certificate, err := config.GetClientCertificate(nil)
+	if err != nil {
+		t.Fatalf("GetClientCertificate: %v", err)
+	}
+	return certificate
+}
+
+func assertCertificateState(t *testing.T, certificate *tls.Certificate, commonName string, raw []byte, d *big.Int) {
+	t.Helper()
+	if certificate.Leaf.Subject.CommonName != commonName {
+		t.Fatalf("leaf common name = %q, want %q", certificate.Leaf.Subject.CommonName, commonName)
+	}
+	if string(certificate.Leaf.Raw) != string(raw) {
+		t.Fatal("leaf raw bytes changed through shared state")
+	}
+	key := certificate.PrivateKey.(*ecdsa.PrivateKey)
+	if key.D.Cmp(d) != 0 {
+		t.Fatalf("private key D = %s, want %s", key.D, d)
+	}
+}
+
+func testNetworkLease(t *testing.T) *credgw.NetworkLease {
+	t.Helper()
+	now := time.Now().UTC()
+	serverCA, serverCAKey := testCertificateAuthority(t, now, "server-ca")
+	clientCA, clientCAKey := testCertificateAuthority(t, now, "client-ca")
+	serverCertificate := testServerCertificate(t, now, serverCA, serverCAKey)
+	gateway, err := credgw.Start(nil)
+	if err != nil {
+		t.Fatalf("start credential gateway: %v", err)
+	}
+	network, err := gateway.StartNetworkProxy(credgw.NetworkProxyConfig{
+		Address:             "127.0.0.1:0",
+		AdvertisedAuthority: "127.0.0.1",
+		ServerCertificate:   serverCertificate,
+		ClientCA:            clientCA,
+		ClientCAKey:         clientCAKey,
+	})
+	if err != nil {
+		_ = gateway.Close(context.Background())
+		t.Fatalf("start network credential gateway: %v", err)
+	}
+	upstream := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+	t.Cleanup(func() {
+		upstream.Close()
+		_ = network.Close(context.Background())
+		_ = gateway.Close(context.Background())
+	})
+	policy := credgw.ProxyPolicy{
+		Upstream:          upstream.URL,
+		AuthKind:          credgw.ProxyAuthBearer,
+		AllowLoopbackHTTP: true,
+	}
+	lease, err := network.RegisterProxy("certificate-isolation-job", now.Add(10*time.Minute), policy, func(context.Context) (credgw.ResolvedCredential, error) {
+		return credgw.ResolvedCredential{Value: "unused", Upstream: policy.Upstream, AuthKind: policy.AuthKind}, nil
+	})
+	if err != nil {
+		t.Fatalf("register network credential lease: %v", err)
+	}
+	return lease
+}
+
+func testCertificateAuthority(t *testing.T, now time.Time, commonName string) (*x509.Certificate, *ecdsa.PrivateKey) {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("generate CA key: %v", err)
+	}
+	template := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: commonName},
+		NotBefore:             now.Add(-time.Hour),
+		NotAfter:              now.Add(time.Hour),
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageDigitalSignature,
+		IsCA:                  true,
+		BasicConstraintsValid: true,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, template, template, &key.PublicKey, key)
+	if err != nil {
+		t.Fatalf("create CA certificate: %v", err)
+	}
+	certificate, err := x509.ParseCertificate(der)
+	if err != nil {
+		t.Fatalf("parse CA certificate: %v", err)
+	}
+	return certificate, key
+}
+
+func testServerCertificate(t *testing.T, now time.Time, ca *x509.Certificate, caKey *ecdsa.PrivateKey) tls.Certificate {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("generate server key: %v", err)
+	}
+	template := &x509.Certificate{
+		SerialNumber: big.NewInt(2),
+		Subject:      pkix.Name{CommonName: "127.0.0.1"},
+		NotBefore:    now.Add(-time.Hour),
+		NotAfter:     now.Add(time.Hour),
+		KeyUsage:     x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		IPAddresses:  []net.IP{net.ParseIP("127.0.0.1")},
+	}
+	der, err := x509.CreateCertificate(rand.Reader, template, ca, &key.PublicKey, caKey)
+	if err != nil {
+		t.Fatalf("create server certificate: %v", err)
+	}
+	leaf, err := x509.ParseCertificate(der)
+	if err != nil {
+		t.Fatalf("parse server certificate: %v", err)
+	}
+	return tls.Certificate{Certificate: [][]byte{der, ca.Raw}, PrivateKey: key, Leaf: leaf}
+}

--- a/internal/execbackend/credentials.go
+++ b/internal/execbackend/credentials.go
@@ -1,0 +1,78 @@
+package execbackend
+
+import (
+	"crypto/tls"
+	"errors"
+	"fmt"
+	"net/url"
+	"strings"
+
+	"github.com/gitmoot/gitmoot/internal/credgw"
+	"github.com/gitmoot/gitmoot/internal/runtime"
+)
+
+// ErrCloudRuntimeUnsupported means a runtime has been deliberately classified
+// as unable to consume brokered credentials from a remote execution backend.
+var ErrCloudRuntimeUnsupported = errors.New("cloud runtime does not support brokered credentials")
+
+// BrokerCapability is a short-lived credential-gateway capability.
+type BrokerCapability string
+
+// RemoteCredentialPlan is the complete credential material a future remote
+// backend may receive. Its unexported shape and constructor deliberately leave
+// no field or parameter for a raw provider credential.
+type RemoteCredentialPlan struct {
+	endpoint          url.URL
+	capability        BrokerCapability
+	clientCertificate tls.Certificate
+}
+
+// NewRemoteCredentialPlan constructs the only credential shape a future remote
+// backend may consume. Accepting only a gateway-issued lease prevents callers
+// from substituting a raw provider credential for broker material. No runtime
+// is supported until a compatibility spike proves that runtime can target the
+// mTLS broker directly.
+func NewRemoteCredentialPlan(runtimeName string, lease *credgw.NetworkLease) (RemoteCredentialPlan, error) {
+	if err := RequireCloudRuntimeCredentialSupport(runtimeName); err != nil {
+		return RemoteCredentialPlan{}, err
+	}
+	if lease == nil {
+		return RemoteCredentialPlan{}, errors.New("remote credential plan requires a broker lease")
+	}
+	endpoint, err := url.Parse(lease.URL())
+	if err != nil {
+		return RemoteCredentialPlan{}, fmt.Errorf("parse broker lease endpoint: %w", err)
+	}
+	return RemoteCredentialPlan{
+		endpoint:          *endpoint,
+		capability:        BrokerCapability(lease.Capability()),
+		clientCertificate: lease.ClientCertificate(),
+	}, nil
+}
+
+// RequireCloudRuntimeCredentialSupport is a closed classification switch over
+// Gitmoot's compiled runtimes. There is intentionally no default arm: a runtime
+// absent from the switch is unclassified, which is distinct from an explicit
+// unsupported decision and makes the registry-enumeration test fail.
+func RequireCloudRuntimeCredentialSupport(runtimeName string) error {
+	runtimeName = strings.TrimSpace(runtimeName)
+	switch runtimeName {
+	case runtime.CodexRuntime:
+		return unsupportedCloudRuntime(runtimeName)
+	case runtime.ClaudeRuntime:
+		return unsupportedCloudRuntime(runtimeName)
+	case runtime.KimiRuntime:
+		return unsupportedCloudRuntime(runtimeName)
+	case runtime.KimiCLIRuntime:
+		return unsupportedCloudRuntime(runtimeName)
+	case runtime.OmpRuntime:
+		return unsupportedCloudRuntime(runtimeName)
+	case runtime.ShellRuntime:
+		return unsupportedCloudRuntime(runtimeName)
+	}
+	return fmt.Errorf("cloud runtime %q has no broker credential classification", runtimeName)
+}
+
+func unsupportedCloudRuntime(runtimeName string) error {
+	return fmt.Errorf("%w: runtime %q has not passed broker compatibility verification", ErrCloudRuntimeUnsupported, runtimeName)
+}

--- a/internal/execbackend/credentials.go
+++ b/internal/execbackend/credentials.go
@@ -1,31 +1,18 @@
 package execbackend
 
 import (
-	"crypto/tls"
-	"errors"
-	"fmt"
-	"net/url"
-	"strings"
-
 	"github.com/gitmoot/gitmoot/internal/credgw"
-	"github.com/gitmoot/gitmoot/internal/runtime"
+	"github.com/gitmoot/gitmoot/internal/execbackend/credentialplan"
 )
 
 // ErrCloudRuntimeUnsupported means a runtime has been deliberately classified
 // as unable to consume brokered credentials from a remote execution backend.
-var ErrCloudRuntimeUnsupported = errors.New("cloud runtime does not support brokered credentials")
-
-// BrokerCapability is a short-lived credential-gateway capability.
-type BrokerCapability string
+var ErrCloudRuntimeUnsupported = credentialplan.ErrCloudRuntimeUnsupported
 
 // RemoteCredentialPlan is the complete credential material a future remote
-// backend may receive. Its unexported shape and constructor deliberately leave
-// no field or parameter for a raw provider credential.
-type RemoteCredentialPlan struct {
-	endpoint          url.URL
-	capability        BrokerCapability
-	clientCertificate tls.Certificate
-}
+// backend may receive. Its defining package is separate from backend
+// implementations, so they cannot populate or mutate its fields directly.
+type RemoteCredentialPlan = credentialplan.Plan
 
 // NewRemoteCredentialPlan constructs the only credential shape a future remote
 // backend may consume. Accepting only a gateway-issued lease prevents callers
@@ -33,21 +20,7 @@ type RemoteCredentialPlan struct {
 // is supported until a compatibility spike proves that runtime can target the
 // mTLS broker directly.
 func NewRemoteCredentialPlan(runtimeName string, lease *credgw.NetworkLease) (RemoteCredentialPlan, error) {
-	if err := RequireCloudRuntimeCredentialSupport(runtimeName); err != nil {
-		return RemoteCredentialPlan{}, err
-	}
-	if lease == nil {
-		return RemoteCredentialPlan{}, errors.New("remote credential plan requires a broker lease")
-	}
-	endpoint, err := url.Parse(lease.URL())
-	if err != nil {
-		return RemoteCredentialPlan{}, fmt.Errorf("parse broker lease endpoint: %w", err)
-	}
-	return RemoteCredentialPlan{
-		endpoint:          *endpoint,
-		capability:        BrokerCapability(lease.Capability()),
-		clientCertificate: lease.ClientCertificate(),
-	}, nil
+	return credentialplan.New(runtimeName, lease)
 }
 
 // RequireCloudRuntimeCredentialSupport is a closed classification switch over
@@ -55,24 +28,5 @@ func NewRemoteCredentialPlan(runtimeName string, lease *credgw.NetworkLease) (Re
 // absent from the switch is unclassified, which is distinct from an explicit
 // unsupported decision and makes the registry-enumeration test fail.
 func RequireCloudRuntimeCredentialSupport(runtimeName string) error {
-	runtimeName = strings.TrimSpace(runtimeName)
-	switch runtimeName {
-	case runtime.CodexRuntime:
-		return unsupportedCloudRuntime(runtimeName)
-	case runtime.ClaudeRuntime:
-		return unsupportedCloudRuntime(runtimeName)
-	case runtime.KimiRuntime:
-		return unsupportedCloudRuntime(runtimeName)
-	case runtime.KimiCLIRuntime:
-		return unsupportedCloudRuntime(runtimeName)
-	case runtime.OmpRuntime:
-		return unsupportedCloudRuntime(runtimeName)
-	case runtime.ShellRuntime:
-		return unsupportedCloudRuntime(runtimeName)
-	}
-	return fmt.Errorf("cloud runtime %q has no broker credential classification", runtimeName)
-}
-
-func unsupportedCloudRuntime(runtimeName string) error {
-	return fmt.Errorf("%w: runtime %q has not passed broker compatibility verification", ErrCloudRuntimeUnsupported, runtimeName)
+	return credentialplan.RequireCloudRuntimeSupport(runtimeName)
 }

--- a/internal/execbackend/credentials_test.go
+++ b/internal/execbackend/credentials_test.go
@@ -1,0 +1,53 @@
+package execbackend
+
+import (
+	"crypto/tls"
+	"errors"
+	"net/url"
+	"reflect"
+	"testing"
+
+	"github.com/gitmoot/gitmoot/internal/credgw"
+	"github.com/gitmoot/gitmoot/internal/runtime"
+)
+
+// This unkeyed compile-time assertion pins the plan to exactly these three
+// broker-material fields. Adding a raw-key field makes this package fail to
+// compile instead of silently widening the remote credential surface.
+var _ = RemoteCredentialPlan{url.URL{}, BrokerCapability("capability"), tls.Certificate{}}
+var _ func(string, *credgw.NetworkLease) (RemoteCredentialPlan, error) = NewRemoteCredentialPlan
+
+func TestRemoteCredentialPlanCarriesOnlyBrokerMaterial(t *testing.T) {
+	typeOfPlan := reflect.TypeFor[RemoteCredentialPlan]()
+	want := []string{"endpoint", "capability", "clientCertificate"}
+	if typeOfPlan.NumField() != len(want) {
+		t.Fatalf("RemoteCredentialPlan fields = %d, want exactly %d broker fields", typeOfPlan.NumField(), len(want))
+	}
+	for i, name := range want {
+		if got := typeOfPlan.Field(i).Name; got != name {
+			t.Fatalf("RemoteCredentialPlan field %d = %q, want %q", i, got, name)
+		}
+	}
+}
+
+func TestCloudCredentialSupportClassifiesEveryRegisteredRuntime(t *testing.T) {
+	runtimes := runtime.SupportedRuntimes()
+	if len(runtimes) == 0 {
+		t.Fatal("runtime registry is empty")
+	}
+	for _, runtimeName := range runtimes {
+		err := RequireCloudRuntimeCredentialSupport(runtimeName)
+		if !errors.Is(err, ErrCloudRuntimeUnsupported) {
+			t.Errorf("runtime %q classification error = %v; want ErrCloudRuntimeUnsupported", runtimeName, err)
+		}
+	}
+}
+
+func TestRemoteCredentialPlanRejectsUnsupportedAndUnclassifiedRuntimes(t *testing.T) {
+	if _, err := NewRemoteCredentialPlan(runtime.ClaudeRuntime, nil); !errors.Is(err, ErrCloudRuntimeUnsupported) {
+		t.Fatalf("Claude remote credential plan error = %v, want ErrCloudRuntimeUnsupported", err)
+	}
+	if _, err := NewRemoteCredentialPlan("future-runtime", nil); err == nil || errors.Is(err, ErrCloudRuntimeUnsupported) {
+		t.Fatalf("unclassified remote credential plan error = %v, want distinct fail-closed classification error", err)
+	}
+}

--- a/internal/execbackend/credentials_test.go
+++ b/internal/execbackend/credentials_test.go
@@ -1,9 +1,7 @@
 package execbackend
 
 import (
-	"crypto/tls"
 	"errors"
-	"net/url"
 	"reflect"
 	"testing"
 
@@ -11,21 +9,25 @@ import (
 	"github.com/gitmoot/gitmoot/internal/runtime"
 )
 
-// This unkeyed compile-time assertion pins the plan to exactly these three
-// broker-material fields. Adding a raw-key field makes this package fail to
-// compile instead of silently widening the remote credential surface.
-var _ = RemoteCredentialPlan{url.URL{}, BrokerCapability("capability"), tls.Certificate{}}
 var _ func(string, *credgw.NetworkLease) (RemoteCredentialPlan, error) = NewRemoteCredentialPlan
 
 func TestRemoteCredentialPlanCarriesOnlyBrokerMaterial(t *testing.T) {
 	typeOfPlan := reflect.TypeFor[RemoteCredentialPlan]()
 	want := []string{"endpoint", "capability", "clientCertificate"}
+	const owner = "github.com/gitmoot/gitmoot/internal/execbackend/credentialplan"
+	if got := typeOfPlan.PkgPath(); got != owner {
+		t.Fatalf("RemoteCredentialPlan owner = %q, want isolated package %q", got, owner)
+	}
 	if typeOfPlan.NumField() != len(want) {
 		t.Fatalf("RemoteCredentialPlan fields = %d, want exactly %d broker fields", typeOfPlan.NumField(), len(want))
 	}
 	for i, name := range want {
-		if got := typeOfPlan.Field(i).Name; got != name {
+		field := typeOfPlan.Field(i)
+		if got := field.Name; got != name {
 			t.Fatalf("RemoteCredentialPlan field %d = %q, want %q", i, got, name)
+		}
+		if field.PkgPath != owner {
+			t.Fatalf("RemoteCredentialPlan field %q is exported or owned by %q, want private owner %q", name, field.PkgPath, owner)
 		}
 	}
 }


### PR DESCRIPTION
WHAT:
Implemented #1538 slice 3a structural enforcement on verified base 8947846fa4cbefcc527fb22f0c87518c86dd2f9f. Signed GITMOOT-COC-1538-S3A.

WHY:
Gitmoot finalized this implementation from a task worktree.

CHANGES:
- Committed changes from /root/.gitmoot/worktrees/gitmoot--gitmoot/adhoc-11513a6e

RESULTS:
- New structural filter matched 3 tests and passed: ^Test(RemoteCredentialPlanCarriesOnlyBrokerMaterial|CloudCredentialSupportClassifiesEveryRegisteredRuntime|RemoteCredentialPlanRejectsUnsupportedAndUnclassifiedRuntimes)$.
- Runtime registry filter matched 2 tests and passed: ^Test(SupportedRuntimesMatchFactory|BuiltinRegistryMatchesSupportedRuntimes)$.
- Existing local credential filter matched 12 tests and passed under an isolated HOME: ^Test(RuntimeJobRunner|RuntimeAuth).
- Hypothetical dispatchable-runtime mutant compiled with go test -c, then failed the derived guard: runtime "future-cloud-runtime" classification error = cloud runtime "future-cloud-runtime" has no broker credential classification; want ErrCloudRuntimeUnsupported.
- Mutant independence: TestRemoteCredentialPlanCarriesOnlyBrokerMaterial passed separately, and three existing model-gateway local-auth guards passed separately while the classification mutant was active.
- Final go test -c ./internal/execbackend passed; gofmt produced no diff; whitespace checks passed. Anchor census: one plan type, one constructor, one support switch with six explicit cases, and one SupportedRuntimes registry derivation.

RISK:
Review the generated diff before merging.

TASK:
adhoc-11513a6e

AGENTS:
- wave-impl

RAW FINAL REVIEW OUTPUT:
````text
Implemented #1538 slice 3a structural enforcement on verified base 8947846fa4cbefcc527fb22f0c87518c86dd2f9f. Signed GITMOOT-COC-1538-S3A.
````
