### PR TITLE
feat(execbackend): gate remote provisioning on runtime credential classification (#1538 slice 3b)

### DIFF
--- a/internal/cli/daemon_worker.go
+++ b/internal/cli/daemon_worker.go
@@ -593,7 +593,7 @@ func (w jobWorker) run(ctx context.Context, job db.Job) error {
 	// delivery and is destroyed synchronously on every return path. Host checkout,
 	// git, observation, and finalization remain on checkout/jobRunner; only runtime
 	// delivery executes in the distinct backend workspace.
-	lifecycle, instance, lifecycleErr := w.provisionExecutionBackend(ctx, execBackend, job, checkout)
+	lifecycle, instance, lifecycleErr := w.provisionExecutionBackend(ctx, execBackend, agent.Runtime, job, checkout)
 	if instance != nil {
 		defer w.destroyExecutionBackend(job.ID, lifecycle, instance)
 	}

--- a/internal/cli/execbackend_lifecycle.go
+++ b/internal/cli/execbackend_lifecycle.go
@@ -70,10 +70,6 @@ func (w jobWorker) provisionExecutionBackend(ctx context.Context, backend execba
 	if w.ExecutionBackendFactory == nil {
 		return nil, nil, nil
 	}
-	lifecycle, err := w.ExecutionBackendFactory(backend)
-	if err != nil {
-		return nil, nil, fmt.Errorf("construct %s execution backend: %w", backend, err)
-	}
 	requiresBrokeredCredentials, err := execbackend.RequiresBrokeredCredentials(backend)
 	if err != nil {
 		return nil, nil, err
@@ -82,6 +78,10 @@ func (w jobWorker) provisionExecutionBackend(ctx context.Context, backend execba
 		if err := execbackend.RequireCloudRuntimeCredentialSupport(runtimeName); err != nil {
 			return nil, nil, fmt.Errorf("provision %s execution backend with runtime %q: %w", backend, runtimeName, err)
 		}
+	}
+	lifecycle, err := w.ExecutionBackendFactory(backend)
+	if err != nil {
+		return nil, nil, fmt.Errorf("construct %s execution backend: %w", backend, err)
 	}
 	instance, err := lifecycle.Provision(ctx, execbackend.JobScope{JobID: job.ID, LifecycleGeneration: job.LifecycleGeneration})
 	if err != nil {

--- a/internal/cli/execbackend_lifecycle.go
+++ b/internal/cli/execbackend_lifecycle.go
@@ -66,13 +66,22 @@ func (w jobWorker) defaultExecutionBackend(backend execbackend.Backend) (execbac
 	})
 }
 
-func (w jobWorker) provisionExecutionBackend(ctx context.Context, backend execbackend.Backend, job db.Job, checkout string) (execbackend.ExecutionBackend, *execbackend.Instance, error) {
+func (w jobWorker) provisionExecutionBackend(ctx context.Context, backend execbackend.Backend, runtimeName string, job db.Job, checkout string) (execbackend.ExecutionBackend, *execbackend.Instance, error) {
 	if w.ExecutionBackendFactory == nil {
 		return nil, nil, nil
 	}
 	lifecycle, err := w.ExecutionBackendFactory(backend)
 	if err != nil {
 		return nil, nil, fmt.Errorf("construct %s execution backend: %w", backend, err)
+	}
+	requiresBrokeredCredentials, err := execbackend.RequiresBrokeredCredentials(backend)
+	if err != nil {
+		return nil, nil, err
+	}
+	if requiresBrokeredCredentials {
+		if err := execbackend.RequireCloudRuntimeCredentialSupport(runtimeName); err != nil {
+			return nil, nil, fmt.Errorf("provision %s execution backend with runtime %q: %w", backend, runtimeName, err)
+		}
 	}
 	instance, err := lifecycle.Provision(ctx, execbackend.JobScope{JobID: job.ID, LifecycleGeneration: job.LifecycleGeneration})
 	if err != nil {

--- a/internal/cli/execbackend_lifecycle_e2e_test.go
+++ b/internal/cli/execbackend_lifecycle_e2e_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -21,6 +22,109 @@ import (
 	"github.com/gitmoot/gitmoot/internal/subprocess"
 	"github.com/gitmoot/gitmoot/internal/workflow"
 )
+
+type credentialGateBackend struct {
+	name           execbackend.Backend
+	provisionCalls int
+	syncInCalls    int
+	scope          execbackend.JobScope
+	materials      execbackend.Materials
+	instance       *execbackend.Instance
+}
+
+func (b *credentialGateBackend) Name() execbackend.Backend { return b.name }
+
+func (b *credentialGateBackend) Provision(_ context.Context, scope execbackend.JobScope) (*execbackend.Instance, error) {
+	b.provisionCalls++
+	b.scope = scope
+	if b.instance == nil {
+		b.instance = &execbackend.Instance{ID: "credential-gate", JobID: scope.JobID, LifecycleGeneration: scope.LifecycleGeneration, Workspace: "/credential-gate"}
+	}
+	return b.instance, nil
+}
+
+func (*credentialGateBackend) Attach(context.Context, string) (*execbackend.Instance, error) {
+	return nil, nil
+}
+
+func (b *credentialGateBackend) SyncIn(_ context.Context, _ *execbackend.Instance, materials execbackend.Materials) error {
+	b.syncInCalls++
+	b.materials = materials
+	return nil
+}
+
+func (*credentialGateBackend) Exec(context.Context, *execbackend.Instance, execbackend.Command) (execbackend.Stream, error) {
+	return nil, nil
+}
+
+func (*credentialGateBackend) Collect(context.Context, *execbackend.Instance) (execbackend.ChangeSet, error) {
+	return execbackend.ChangeSet{}, nil
+}
+
+func (*credentialGateBackend) Cancel(context.Context, *execbackend.Instance) error { return nil }
+
+func (*credentialGateBackend) Destroy(context.Context, *execbackend.Instance) error { return nil }
+
+func TestProvisionExecutionBackendRefusesUnsupportedBrokeredRuntimesBeforeProvision(t *testing.T) {
+	for _, runtimeName := range []string{runtime.CodexRuntime, runtime.ShellRuntime} {
+		t.Run(runtimeName, func(t *testing.T) {
+			backend := &credentialGateBackend{name: execbackend.Remote}
+			factoryCalls := 0
+			worker := jobWorker{ExecutionBackendFactory: func(got execbackend.Backend) (execbackend.ExecutionBackend, error) {
+				factoryCalls++
+				if got != execbackend.Remote {
+					t.Fatalf("factory backend = %q, want %q", got, execbackend.Remote)
+				}
+				return backend, nil
+			}}
+
+			lifecycle, instance, err := worker.provisionExecutionBackend(context.Background(), execbackend.Remote, runtimeName, db.Job{ID: "remote-credential-gate", LifecycleGeneration: 3}, "/checkout")
+			if backend.provisionCalls != 0 {
+				t.Fatalf("Provision calls = %d, want 0 before unsupported runtime refusal", backend.provisionCalls)
+			}
+			if backend.syncInCalls != 0 {
+				t.Fatalf("SyncIn calls = %d, want 0 before unsupported runtime refusal", backend.syncInCalls)
+			}
+			if !errors.Is(err, execbackend.ErrCloudRuntimeUnsupported) {
+				t.Fatalf("provisionExecutionBackend(%s) error = %v, want ErrCloudRuntimeUnsupported", runtimeName, err)
+			}
+			if lifecycle != nil || instance != nil {
+				t.Fatalf("refused lifecycle = %T, instance = %+v; want nil, nil", lifecycle, instance)
+			}
+			if factoryCalls != 1 {
+				t.Fatalf("factory calls = %d, want 1 through the injectable seam", factoryCalls)
+			}
+		})
+	}
+}
+
+func TestProvisionExecutionBackendLocalBehaviorUnchanged(t *testing.T) {
+	backend := &credentialGateBackend{name: execbackend.Local}
+	worker := jobWorker{ExecutionBackendFactory: func(got execbackend.Backend) (execbackend.ExecutionBackend, error) {
+		if got != execbackend.Local {
+			t.Fatalf("factory backend = %q, want %q", got, execbackend.Local)
+		}
+		return backend, nil
+	}}
+	job := db.Job{ID: "local-credential-gate", LifecycleGeneration: 4}
+
+	lifecycle, instance, err := worker.provisionExecutionBackend(context.Background(), execbackend.Local, runtime.ShellRuntime, job, "/checkout")
+	if err != nil {
+		t.Fatalf("provisionExecutionBackend(local): %v", err)
+	}
+	if lifecycle != backend || instance != backend.instance {
+		t.Fatalf("local lifecycle = %T, instance = %+v; want injected backend and its instance", lifecycle, instance)
+	}
+	if backend.provisionCalls != 1 || backend.syncInCalls != 1 {
+		t.Fatalf("local Provision calls = %d, SyncIn calls = %d; want 1, 1", backend.provisionCalls, backend.syncInCalls)
+	}
+	if backend.scope.JobID != job.ID || backend.scope.LifecycleGeneration != job.LifecycleGeneration {
+		t.Fatalf("local provision scope = %+v, want job id %q generation %d", backend.scope, job.ID, job.LifecycleGeneration)
+	}
+	if backend.materials.SourceWorktree != "/checkout" {
+		t.Fatalf("local SyncIn source = %q, want /checkout", backend.materials.SourceWorktree)
+	}
+}
 
 func TestExecutionChangeSetCollectorRequiresLiveOwnedInstance(t *testing.T) {
 	backend, err := execbackend.NewLocalBackend(filepath.Join(t.TempDir(), "instances"), nil)

--- a/internal/cli/execbackend_lifecycle_e2e_test.go
+++ b/internal/cli/execbackend_lifecycle_e2e_test.go
@@ -91,10 +91,29 @@ func TestProvisionExecutionBackendRefusesUnsupportedBrokeredRuntimesBeforeProvis
 			if lifecycle != nil || instance != nil {
 				t.Fatalf("refused lifecycle = %T, instance = %+v; want nil, nil", lifecycle, instance)
 			}
-			if factoryCalls != 1 {
-				t.Fatalf("factory calls = %d, want 1 through the injectable seam", factoryCalls)
+			if factoryCalls != 0 {
+				t.Fatalf("factory calls = %d, want 0 before unsupported runtime refusal", factoryCalls)
 			}
 		})
+	}
+}
+
+func TestProvisionExecutionBackendRejectsUnclassifiedBeforeFactory(t *testing.T) {
+	factoryCalls := 0
+	worker := jobWorker{ExecutionBackendFactory: func(execbackend.Backend) (execbackend.ExecutionBackend, error) {
+		factoryCalls++
+		return &credentialGateBackend{}, nil
+	}}
+
+	lifecycle, instance, err := worker.provisionExecutionBackend(context.Background(), execbackend.Backend("future-backend"), runtime.CodexRuntime, db.Job{ID: "unclassified-credential-gate"}, "/checkout")
+	if err == nil || !strings.Contains(err.Error(), "no brokered credential classification") {
+		t.Fatalf("provisionExecutionBackend(unclassified) error = %v, want classification error", err)
+	}
+	if lifecycle != nil || instance != nil {
+		t.Fatalf("unclassified lifecycle = %T, instance = %+v; want nil, nil", lifecycle, instance)
+	}
+	if factoryCalls != 0 {
+		t.Fatalf("factory calls = %d, want 0 before unclassified backend refusal", factoryCalls)
 	}
 }
 

--- a/internal/execbackend/execbackend.go
+++ b/internal/execbackend/execbackend.go
@@ -37,12 +37,29 @@ const (
 	// implemented execution backend. It resolves to today's behaviour exactly:
 	// the existing runner composition with subprocess.GroupRunner{} innermost.
 	Local Backend = "local"
+	// Remote reserves the brokered-credential classification for a future
+	// execution backend. It is intentionally absent from AllowedNames until an
+	// implementation exists, so Parse continues to reject it.
+	Remote Backend = "remote"
 )
 
 // AllowedNames is the canonical allowed set of backend names, in the order
 // error messages render them. Parse accepts names exclusively from this list,
 // so a backend cannot be accepted without also being advertised.
 var AllowedNames = []string{string(Local)}
+
+// RequiresBrokeredCredentials classifies every declared execution backend.
+// There is intentionally no default arm: a newly declared backend is
+// unclassified until its credential handling is explicitly decided.
+func RequiresBrokeredCredentials(backend Backend) (bool, error) {
+	switch backend {
+	case Local:
+		return false, nil
+	case Remote:
+		return true, nil
+	}
+	return false, fmt.Errorf("execution backend %q has no brokered credential classification", backend)
+}
 
 // Allowed renders the allowed set for error messages (e.g. "local").
 func Allowed() string {

--- a/internal/execbackend/execbackend.go
+++ b/internal/execbackend/execbackend.go
@@ -58,7 +58,7 @@ func RequiresBrokeredCredentials(backend Backend) (bool, error) {
 	case Remote:
 		return true, nil
 	}
-	return false, fmt.Errorf("execution backend %q has no brokered credential classification", backend)
+	return true, fmt.Errorf("execution backend %q has no brokered credential classification", backend)
 }
 
 // Allowed renders the allowed set for error messages (e.g. "local").

--- a/internal/execbackend/execbackend_test.go
+++ b/internal/execbackend/execbackend_test.go
@@ -81,6 +81,31 @@ func TestAllowedNamesMatchesParse(t *testing.T) {
 	}
 }
 
+func TestBackendBrokeredCredentialRequirementIsClosed(t *testing.T) {
+	for _, test := range []struct {
+		name    string
+		backend Backend
+		want    bool
+	}{
+		{name: "local", backend: Local, want: false},
+		{name: "remote", backend: Remote, want: true},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			got, err := RequiresBrokeredCredentials(test.backend)
+			if err != nil || got != test.want {
+				t.Fatalf("RequiresBrokeredCredentials(%q) = %t, %v; want %t, nil", test.backend, got, err, test.want)
+			}
+		})
+	}
+
+	if got, err := RequiresBrokeredCredentials(Backend("future-backend")); err == nil || got {
+		t.Fatalf("RequiresBrokeredCredentials(future-backend) = %t, %v; want false and an unclassified error", got, err)
+	}
+	if _, err := Parse(string(Remote)); err == nil {
+		t.Fatal("reserved remote backend became user-selectable before it has an implementation")
+	}
+}
+
 func TestAdvertisedBackendWithoutImplementationFailsLoud(t *testing.T) {
 	original := append([]string(nil), AllowedNames...)
 	defer func() { AllowedNames = original }()

--- a/internal/execbackend/execbackend_test.go
+++ b/internal/execbackend/execbackend_test.go
@@ -98,8 +98,8 @@ func TestBackendBrokeredCredentialRequirementIsClosed(t *testing.T) {
 		})
 	}
 
-	if got, err := RequiresBrokeredCredentials(Backend("future-backend")); err == nil || got {
-		t.Fatalf("RequiresBrokeredCredentials(future-backend) = %t, %v; want false and an unclassified error", got, err)
+	if got, err := RequiresBrokeredCredentials(Backend("future-backend")); err == nil || !got {
+		t.Fatalf("RequiresBrokeredCredentials(future-backend) = %t, %v; want true and an unclassified error", got, err)
 	}
 	if _, err := Parse(string(Remote)); err == nil {
 		t.Fatal("reserved remote backend became user-selectable before it has an implementation")


### PR DESCRIPTION
## What

#1538 slice 3b — give the P3a credential stack its **first production consumer**.

P3a has shipped three layers that nothing in production calls. Measured on main at `c3aa13e4`, two
agreeing instruments (grep, and renaming the entry point then `go build ./...` → exit 0):

| symbol | non-test callers |
|---|---|
| `StartNetworkProxy` | 0 |
| `NetworkProxyConfig` / `ServerCertificate` | 0 producers |
| `NewRemoteCredentialPlan` | **0** |

This slice makes the already-shipped runtime classification load-bearing instead of decorative.

## Changes

- `internal/execbackend/execbackend.go` — a `Remote` backend constant, deliberately **absent from
  `AllowedNames`** so `Parse` keeps rejecting it, plus `RequiresBrokeredCredentials`: a
  classification switch with **no default arm**, returning an error for an unclassified backend.
- `internal/cli/execbackend_lifecycle.go` — `provisionExecutionBackend` takes the runtime and, for a
  backend requiring brokering, requires `RequireCloudRuntimeCredentialSupport` to pass **before**
  `lifecycle.Provision` runs.
- `internal/cli/daemon_worker.go:596` — passes `agent.Runtime`, the effective runtime persisted at
  :553 (not an agent default).
- Tests: a fake backend asserting `Provision`/`SyncIn` call counts are **0** on the refusal path,
  driven with two runtimes; plus classification and `Parse`-rejection tests.

## Stated property

For a backend requiring brokered credentials, an unsupported runtime is refused **before any
provisioning happens**, and local behaviour is unchanged. Every runtime is classified unsupported
today, so the remote arm refuses for all of them — that is intended.

## Not in scope

Certificate issuance, trust roots and `RootCAs` are **not** here. See #1614, which I re-scoped
after measuring that the CA it asks to plumb has no producer anywhere in the tree; it is an
acceptance criterion on whichever slice first mints a server certificate, not separately fixable.

## Deploy notes

Internal only — no user-facing surface, no docs change. Local backend behaviour unchanged.

Draft until a two-family review panel approves at one head.

Part of #1529.

-- GITMOOT-COC
