### PR TITLE
Gitmoot: # IMPLEMENT — gitmoot #1620: surface the runtime's

### DIFF
--- a/internal/cli/daemon_result.go
+++ b/internal/cli/daemon_result.go
@@ -289,17 +289,21 @@ func (w jobWorker) finalizeTimedOutJob(ctx context.Context, job db.Job, payload 
 		elapsed = time.Since(evidence.Started).Round(time.Millisecond)
 	}
 	stderrTail := ""
+	deliveryError := ""
 	if payload.FailureDiagnostics != nil {
 		stderrTail = payload.FailureDiagnostics.StderrTail
+		deliveryError = payload.FailureDiagnostics.DeliveryError
 	}
 	detailBytes, _ := json.Marshal(struct {
-		Deadline   string `json:"deadline"`
-		Elapsed    string `json:"elapsed"`
-		StderrTail string `json:"stderr_tail,omitempty"`
+		Deadline      string `json:"deadline"`
+		Elapsed       string `json:"elapsed"`
+		StderrTail    string `json:"stderr_tail,omitempty"`
+		DeliveryError string `json:"delivery_error,omitempty"`
 	}{
-		Deadline:   deadline.Format(time.RFC3339Nano),
-		Elapsed:    elapsed.String(),
-		StderrTail: stderrTail,
+		Deadline:      deadline.Format(time.RFC3339Nano),
+		Elapsed:       elapsed.String(),
+		StderrTail:    stderrTail,
+		DeliveryError: deliveryError,
 	})
 	reason := fmt.Sprintf("job %s exceeded its run deadline: %v", job.ID, cause)
 	writeCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 30*time.Second)
@@ -369,6 +373,52 @@ type jobLifecycle struct {
 
 func observedJobLifecycle(job db.Job) jobLifecycle {
 	return jobLifecycle{state: job.State, generation: job.LifecycleGeneration}
+}
+
+// recordDeliveryFailureDiagnostics carries the engine's terminal delivery error
+// onto the job row's failure diagnostics (#1620), so `job show` shows the same
+// line the daemon writes to its journal as "job <id> failed: <err>" instead of
+// leaving the runtime's real error ("400 invalid_request_error: ... requires a
+// newer version of Codex", a compaction-endpoint 404) journal-only. It is purely
+// additive: the terminal state, its events, and the journal line are all
+// unchanged, and an existing StderrTail/phase/exit_code is preserved.
+//
+// Best-effort by design, exactly like Mailbox.storeFailureDiagnostics — the row
+// is already terminally settled by the time this runs, so a load or persist
+// failure must never change the failure path.
+//
+// atGeneration is the lifecycle the run OWNED. A retry claimed between the run
+// error and this write bumps the generation and clears diagnostics for its own
+// run, so writing then would stamp a live run's payload with a dead run's error;
+// the guard drops the write instead. It mirrors handleRunJobError's superseded
+// check, and for the same reason.
+func (w jobWorker) recordDeliveryFailureDiagnostics(ctx context.Context, jobID string, atGeneration int64, cause error) {
+	if cause == nil || strings.TrimSpace(cause.Error()) == "" {
+		return
+	}
+	writeCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 30*time.Second)
+	defer cancel()
+	latest, err := w.Store.GetJob(writeCtx, jobID)
+	if err != nil || latest.LifecycleGeneration != atGeneration {
+		return
+	}
+	// ParseJobPayload, not daemonJobPayload: this is a read-MODIFY-write, and the
+	// legacy-tolerant decoder is what keeps a payload still carrying the legacy
+	// preset_* keys from losing them on the way back out.
+	payload, err := workflow.ParseJobPayload(latest.Payload)
+	if err != nil {
+		return
+	}
+	updated := workflow.WithDeliveryError(payload.FailureDiagnostics, cause.Error())
+	if updated == nil {
+		return
+	}
+	payload.FailureDiagnostics = updated
+	encoded, err := json.Marshal(payload)
+	if err != nil {
+		return
+	}
+	_ = w.Store.UpdateJobPayload(writeCtx, jobID, string(encoded))
 }
 
 // matches reports whether the row read back is still the run this lifecycle identified.

--- a/internal/cli/daemon_result.go
+++ b/internal/cli/daemon_result.go
@@ -392,6 +392,16 @@ func observedJobLifecycle(job db.Job) jobLifecycle {
 // run, so writing then would stamp a live run's payload with a dead run's error;
 // the guard drops the write instead. It mirrors handleRunJobError's superseded
 // check, and for the same reason.
+//
+// The generation is checked TWICE, and the second check is the load-bearing one.
+// The read below only establishes what to write; a retry can still claim the row
+// between that read and the write, and an observer that then wrote
+// unconditionally would clobber the live generation's payload — a diagnostic
+// given authority over the lifecycle it observes, which is the exact inversion the
+// generation anchor exists to prevent. The write is therefore
+// UpdateJobPayloadAtGeneration, whose compare-and-swap makes losing that race a
+// no-op instead of an overwrite. The early check is kept anyway: it is free and
+// skips the read-modify-write entirely in the common superseded case.
 func (w jobWorker) recordDeliveryFailureDiagnostics(ctx context.Context, jobID string, atGeneration int64, cause error) {
 	if cause == nil || strings.TrimSpace(cause.Error()) == "" {
 		return
@@ -399,7 +409,11 @@ func (w jobWorker) recordDeliveryFailureDiagnostics(ctx context.Context, jobID s
 	writeCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 30*time.Second)
 	defer cancel()
 	latest, err := w.Store.GetJob(writeCtx, jobID)
-	if err != nil || latest.LifecycleGeneration != atGeneration {
+	if err != nil {
+		w.reportDeliveryDiagnosticsLoss(jobID, cause, err)
+		return
+	}
+	if latest.LifecycleGeneration != atGeneration {
 		return
 	}
 	// ParseJobPayload, not daemonJobPayload: this is a read-MODIFY-write, and the
@@ -407,6 +421,7 @@ func (w jobWorker) recordDeliveryFailureDiagnostics(ctx context.Context, jobID s
 	// preset_* keys from losing them on the way back out.
 	payload, err := workflow.ParseJobPayload(latest.Payload)
 	if err != nil {
+		w.reportDeliveryDiagnosticsLoss(jobID, cause, err)
 		return
 	}
 	updated := workflow.WithDeliveryError(payload.FailureDiagnostics, cause.Error())
@@ -416,9 +431,42 @@ func (w jobWorker) recordDeliveryFailureDiagnostics(ctx context.Context, jobID s
 	payload.FailureDiagnostics = updated
 	encoded, err := json.Marshal(payload)
 	if err != nil {
+		w.reportDeliveryDiagnosticsLoss(jobID, cause, err)
 		return
 	}
-	_ = w.Store.UpdateJobPayload(writeCtx, jobID, string(encoded))
+	if w.beforeDeliveryDiagnosticsWrite != nil {
+		w.beforeDeliveryDiagnosticsWrite()
+	}
+	// A LOST CAS is the superseded case arriving at the write instead of at the
+	// check, so it stays exactly as quiet — the discarded bool is the whole point,
+	// not an oversight. Only a genuine persistence FAULT is reported.
+	if _, err := w.Store.UpdateJobPayloadAtGeneration(writeCtx, jobID, string(encoded), atGeneration); err != nil {
+		w.reportDeliveryDiagnosticsLoss(jobID, cause, err)
+	}
+}
+
+// reportDeliveryDiagnosticsLoss says on the daemon journal that the delivery
+// error never reached the job row.
+//
+// The distinction it draws is the whole reason it exists. A SUPERSEDED generation
+// is an expected drop — the write was supposed to be discarded — and stays silent;
+// saying so on every retry would be noise that trains operators to ignore the
+// line. A FAULT (the row would not load, its payload would not parse or re-encode,
+// the write itself failed) is not expected: the row then carries no delivery_error
+// and nothing anywhere says why, which re-creates one level up the exact
+// journal-versus-row blindness #1620 exists to end.
+//
+// Both the fault and the delivery error are redacted through the same
+// RedactCommentText path the stored field uses, because either can quote a
+// provider URL, a request id, or a token, and this text is written to the journal.
+// It remains best-effort: reporting is all it does, and the job's outcome is
+// unchanged.
+func (w jobWorker) reportDeliveryDiagnosticsLoss(jobID string, cause error, fault error) {
+	if w.Stdout == nil {
+		return
+	}
+	writeLine(w.Stdout, "job %s delivery-error diagnostics not recorded: %s", jobID,
+		workflow.RedactCommentText(fmt.Sprintf("%v (delivery error: %v)", fault, cause)))
 }
 
 // matches reports whether the row read back is still the run this lifecycle identified.

--- a/internal/cli/daemon_worker.go
+++ b/internal/cli/daemon_worker.go
@@ -858,6 +858,12 @@ func (w jobWorker) run(ctx context.Context, job db.Job) error {
 			}
 		}
 		_ = w.postJobResultComment(ctx, job.ID, agent, checkout, commentErr)
+		// Record the SAME err the journal line below prints, so the job row can
+		// distinguish faults the row otherwise collapses into one exit_code: 1
+		// (#1620). commentErr is deliberately not used here: it can be swapped for
+		// the permission-blocked operator message, and this field means "what the
+		// engine actually failed with".
+		w.recordDeliveryFailureDiagnostics(ctx, job.ID, job.LifecycleGeneration, err)
 		writeLine(w.Stdout, "job %s failed: %v", job.ID, err)
 		return nil
 	}
@@ -2122,6 +2128,10 @@ func (w jobWorker) runWithTempWorker(ctx context.Context, job db.Job, payload wo
 			return reconcileErr
 		}
 		_ = w.postJobResultComment(ctx, delegatedJob.ID, started.Agent, checkout, err)
+		// Same record as the ordinary path (#1620) — a delegated run's runtime
+		// error was journal-only too, and the temp-worker row is exactly where an
+		// operator looks first.
+		w.recordDeliveryFailureDiagnostics(ctx, delegatedJob.ID, delegatedJob.LifecycleGeneration, err)
 		writeLine(w.Stdout, "job %s failed: %v", delegatedJob.ID, err)
 		return nil
 	}

--- a/internal/cli/daemon_worker.go
+++ b/internal/cli/daemon_worker.go
@@ -67,7 +67,13 @@ type jobWorker struct {
 	// ReclaimJobLookup is a test seam for candidate-local GetJob failures. The
 	// production path is always Store.GetJob.
 	ReclaimJobLookup func(context.Context, string) (db.Job, error)
-	CommenterFactory func(string) github.Client
+	// beforeDeliveryDiagnosticsWrite fires inside recordDeliveryFailureDiagnostics
+	// between the lifecycle read and the generation-conditioned payload write —
+	// i.e. inside the window the compare-and-swap exists to close. It is the only
+	// way to drive that window deterministically, since the two operations are
+	// otherwise adjacent. Production leaves it nil.
+	beforeDeliveryDiagnosticsWrite func()
+	CommenterFactory               func(string) github.Client
 	// UsePool selects the opt-in continuous worker-pool scheduler (#394,
 	// --scheduler=pool) over the default per-tick wg.Wait() barrier.
 	UsePool bool

--- a/internal/cli/delivery_error_diagnostics_test.go
+++ b/internal/cli/delivery_error_diagnostics_test.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -255,6 +256,11 @@ func TestRecordDeliveryFailureDiagnosticsIgnoresEmptyError(t *testing.T) {
 // A retry that claimed the row between the run error and this write owns a NEWER
 // generation and has already cleared diagnostics for its own run; stamping the
 // dead run's error onto it would be a live-row corruption, so the write drops.
+//
+// It drops SILENTLY, and that is asserted here rather than left implicit: a
+// superseded write is the expected outcome of an ordinary retry, and announcing it
+// on the journal every time would be the noise that teaches operators to skip the
+// line the persistence-failure case needs them to read.
 func TestRecordDeliveryFailureDiagnosticsSkipsSupersededGeneration(t *testing.T) {
 	ctx := context.Background()
 	store := daemonWorkerStore(t)
@@ -263,11 +269,156 @@ func TestRecordDeliveryFailureDiagnosticsSkipsSupersededGeneration(t *testing.T)
 		ID: "job-superseded-delivery-error", Agent: "audit", Action: "ask", Repo: "owner/repo", Branch: "main",
 	})
 	job := mustWorkerJob(t, store, "job-superseded-delivery-error")
-	worker := defaultJobWorker(store, io.Discard, t.TempDir())
+	stdout := &lockedBuffer{}
+	worker := defaultJobWorker(store, stdout, t.TempDir())
 
 	worker.recordDeliveryFailureDiagnostics(ctx, job.ID, job.LifecycleGeneration-1, errors.New(deliveryErrorFixture))
 
 	if diag := deliveryErrorDiagnostics(t, store, job.ID); diag != nil {
 		t.Fatalf("FailureDiagnostics = %+v, want none: a superseded run must not write", diag)
+	}
+	if out := stdout.String(); strings.Contains(out, deliveryDiagnosticsLossPrefix) {
+		t.Fatalf("stdout = %q, want silence: a superseded generation is an EXPECTED drop", out)
+	}
+}
+
+// deliveryDiagnosticsLossPrefix is the journal marker for "the delivery error
+// never reached the row". Both the silence assertion above and the fault
+// assertions below key off it.
+const deliveryDiagnosticsLossPrefix = "delivery-error diagnostics not recorded"
+
+// liveGenerationTail marks the payload a RETRY installed for its own run. The
+// stale observer must leave it exactly as found.
+const liveGenerationTail = "live generation stderr"
+
+// TestRecordDeliveryFailureDiagnosticsLosesTheRaceToANewGeneration is the probe
+// for the defect this round closes: the generation check and the payload write
+// were two statements, so a retry landing BETWEEN them left a stale observer
+// overwriting the new generation's row.
+//
+// The superseded-generation test above cannot catch that. It advances the
+// generation BEFORE the call, so the early check rejects it and the write is never
+// reached — an unconditional write passes that test. Only a retry that lands
+// INSIDE the check-to-write window discriminates, which is what the
+// beforeDeliveryDiagnosticsWrite seam exists to stage. Reverting the write to the
+// unconditional UpdateJobPayload turns this test RED and nothing else.
+func TestRecordDeliveryFailureDiagnosticsLosesTheRaceToANewGeneration(t *testing.T) {
+	ctx := context.Background()
+	store := daemonWorkerStore(t)
+	seedDaemonWorkerAgent(t, store, "audit", runtime.ShellRuntime, "", []string{"ask"}, "owner/repo")
+	enqueueDaemonWorkerJob(t, store, workflow.JobRequest{
+		ID: "job-raced-delivery-error", Agent: "audit", Action: "ask", Repo: "owner/repo", Branch: "main",
+	})
+	// queued -> running -> failed leaves the generation alone (only entry to queued
+	// is a new run), so the observer below genuinely holds the run that failed.
+	for _, step := range [][2]string{{"queued", "running"}, {"running", "failed"}} {
+		transitioned, err := store.TransitionJobState(ctx, "job-raced-delivery-error", step[0], step[1])
+		if err != nil {
+			t.Fatalf("TransitionJobState(%s->%s) returned error: %v", step[0], step[1], err)
+		}
+		if !transitioned {
+			t.Fatalf("TransitionJobState(%s->%s) did not transition; the fixture is not in the shape this probe needs", step[0], step[1])
+		}
+	}
+	observed := mustWorkerJob(t, store, "job-raced-delivery-error")
+
+	// What the retry installs for ITS run: its own diagnostics, no delivery_error.
+	livePayload, err := workflow.ParseJobPayload(observed.Payload)
+	if err != nil {
+		t.Fatalf("ParseJobPayload returned error: %v", err)
+	}
+	livePayload.FailureDiagnostics = &workflow.FailureDiagnostics{
+		Phase: workflow.FailurePhaseLaunched, StderrTail: liveGenerationTail,
+	}
+	liveEncoded, err := json.Marshal(livePayload)
+	if err != nil {
+		t.Fatalf("Marshal(live payload) returned error: %v", err)
+	}
+
+	stdout := &lockedBuffer{}
+	worker := defaultJobWorker(store, stdout, t.TempDir())
+	fired := false
+	worker.beforeDeliveryDiagnosticsWrite = func() {
+		fired = true
+		// failed -> queued is the operator retry: it bumps the generation and
+		// installs the new run's payload, all after the observer's check passed.
+		if err := store.UpdateJobPayloadAndStateWithEvent(ctx, observed.ID, string(liveEncoded), "queued",
+			db.JobEvent{JobID: observed.ID, Kind: "queued", Message: "retry"}); err != nil {
+			t.Errorf("UpdateJobPayloadAndStateWithEvent(retry) returned error: %v", err)
+		}
+	}
+
+	worker.recordDeliveryFailureDiagnostics(ctx, observed.ID, observed.LifecycleGeneration, errors.New(deliveryErrorFixture))
+
+	if !fired {
+		t.Fatal("the race window never opened; the probe proves nothing")
+	}
+	after := mustWorkerJob(t, store, observed.ID)
+	if after.LifecycleGeneration != observed.LifecycleGeneration+1 {
+		t.Fatalf("generation = %d, want %d (the retry did not arm)", after.LifecycleGeneration, observed.LifecycleGeneration+1)
+	}
+	// Byte equality, because "unmodified" is the claim: the stale write must not
+	// have touched ANY part of the live generation's payload.
+	if after.Payload != string(liveEncoded) {
+		t.Fatalf("payload = %q, want the live generation's own payload %q -- a stale observer overwrote a live run",
+			after.Payload, string(liveEncoded))
+	}
+	diag := deliveryErrorDiagnostics(t, store, observed.ID)
+	if diag == nil || diag.StderrTail != liveGenerationTail {
+		t.Fatalf("FailureDiagnostics = %+v, want the live run's own diagnostics kept", diag)
+	}
+	if diag.DeliveryError != "" {
+		t.Fatalf("delivery_error = %q, want empty: a dead run's error must not land on a live run's row", diag.DeliveryError)
+	}
+	// The lost CAS is the superseded case arriving at the write, so it is as quiet
+	// as the check is.
+	if out := stdout.String(); strings.Contains(out, deliveryDiagnosticsLossPrefix) {
+		t.Fatalf("stdout = %q, want silence: losing the CAS is an EXPECTED drop", out)
+	}
+}
+
+// The other half of the split: a persistence FAULT is not expected, so dropping it
+// silently would leave the row with no delivery_error and no explanation anywhere
+// — the journal-versus-row blindness of #1620, one level up. The store is closed
+// inside the write window so the CAS itself fails, which is the arm that matters:
+// the read, the parse and the marshal have all already succeeded.
+func TestRecordDeliveryFailureDiagnosticsReportsPersistenceFailure(t *testing.T) {
+	ctx := context.Background()
+	store := daemonWorkerStore(t)
+	seedDaemonWorkerAgent(t, store, "audit", runtime.ShellRuntime, "", []string{"ask"}, "owner/repo")
+	enqueueDaemonWorkerJob(t, store, workflow.JobRequest{
+		ID: "job-unpersisted-delivery-error", Agent: "audit", Action: "ask", Repo: "owner/repo", Branch: "main",
+	})
+	job := mustWorkerJob(t, store, "job-unpersisted-delivery-error")
+
+	stdout := &lockedBuffer{}
+	worker := defaultJobWorker(store, stdout, t.TempDir())
+	worker.beforeDeliveryDiagnosticsWrite = func() {
+		// A closed store is a persistence fault the write cannot survive, injected
+		// after every earlier step has already succeeded.
+		if err := store.Close(); err != nil {
+			t.Errorf("Close returned error: %v", err)
+		}
+	}
+
+	worker.recordDeliveryFailureDiagnostics(ctx, job.ID, job.LifecycleGeneration, errors.New(deliveryErrorSecretFixture))
+
+	out := stdout.String()
+	if !strings.Contains(out, deliveryDiagnosticsLossPrefix) {
+		t.Fatalf("stdout = %q, want the %q diagnostic for a persistence fault", out, deliveryDiagnosticsLossPrefix)
+	}
+	if !strings.Contains(out, job.ID) {
+		t.Fatalf("stdout = %q, want the job id so an operator can find the row", out)
+	}
+	// The journal line quotes the delivery error, so it is a leak surface exactly
+	// like the stored field. Same redaction, not a second weaker path.
+	if strings.Contains(out, deliveryErrorSecret) {
+		t.Fatalf("the diagnostic leaked the token: %q", out)
+	}
+	if !strings.Contains(out, "[REDACTED]") {
+		t.Fatalf("stdout = %q, want the redaction marker", out)
+	}
+	if !strings.Contains(out, "unexpected status 404 Not Found") {
+		t.Fatalf("stdout = %q, want the triage-bearing text kept", out)
 	}
 }

--- a/internal/cli/delivery_error_diagnostics_test.go
+++ b/internal/cli/delivery_error_diagnostics_test.go
@@ -1,0 +1,273 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/gitmoot/gitmoot/internal/config"
+	"github.com/gitmoot/gitmoot/internal/db"
+	"github.com/gitmoot/gitmoot/internal/execbackend"
+	"github.com/gitmoot/gitmoot/internal/runtime"
+	"github.com/gitmoot/gitmoot/internal/workflow"
+)
+
+// #1620: when a runtime fails, the job row used to report only
+// `phase: streaming, exit_code: 1` plus a stderr tail echoing the skill prompt.
+// The runtime's REAL error line ("...requires a newer version of Codex", a
+// compaction-endpoint 404) existed solely in `journalctl -u gitmoot-daemon`, so
+// two genuinely different faults were indistinguishable on the record and
+// operators re-dispatched instead of triaging. These tests bind the daemon's
+// journal line to the job row at BOTH terminal-failure call sites.
+
+// A representative provider error that is NOT an operational blocker: it carries
+// no 401/429, no quota/rate-limit wording, and no transient-network signature,
+// so classifyOperationalBlocker leaves it alone and the run takes the ordinary
+// terminal path rather than the #532 pre-terminal deferral.
+const deliveryErrorFixture = "400 invalid_request_error: The 'gpt-5.6-sol' model requires a newer version of Codex."
+
+// deliveryErrorSecretFixture puts a token-shaped string in the SAME provider
+// error an operator would read. It deliberately avoids "auth"/"invalid"
+// co-location so classifyAuthQuotaStrict still declines to classify it.
+var deliveryErrorSecretFixture = "Error running remote compact task: unexpected status 404 Not Found, url: https://chatgpt.com/backend-api/codex/responses/compact?secret=" + deliveryErrorSecret
+
+var deliveryErrorSecret = "ghp_" + strings.Repeat("A", 36)
+
+// lockedBuffer is a race-safe stdout sink: the worker's writeLine calls are the
+// daemon's journal lines, and this test reads them back to prove the row carries
+// the same text.
+type lockedBuffer struct {
+	mu  sync.Mutex
+	buf bytes.Buffer
+}
+
+func (b *lockedBuffer) Write(p []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.Write(p)
+}
+
+func (b *lockedBuffer) String() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.String()
+}
+
+// journalFailureText extracts what the daemon logged as "job <id> failed: <err>"
+// — the string this feature exists to stop losing.
+func journalFailureText(t *testing.T, stdout string, jobID string) string {
+	t.Helper()
+	prefix := fmt.Sprintf("job %s failed: ", jobID)
+	for _, line := range strings.Split(stdout, "\n") {
+		if strings.HasPrefix(line, prefix) {
+			return strings.TrimPrefix(line, prefix)
+		}
+	}
+	t.Fatalf("daemon stdout has no %q line:\n%s", prefix, stdout)
+	return ""
+}
+
+func deliveryErrorDiagnostics(t *testing.T, store *db.Store, jobID string) *workflow.FailureDiagnostics {
+	t.Helper()
+	job, err := store.GetJob(context.Background(), jobID)
+	if err != nil {
+		t.Fatalf("GetJob(%s) returned error: %v", jobID, err)
+	}
+	payload, err := daemonJobPayload(job)
+	if err != nil {
+		t.Fatalf("daemonJobPayload(%s) returned error: %v", jobID, err)
+	}
+	return payload.FailureDiagnostics
+}
+
+// runFailingDelivery drives the ORDINARY worker path (daemon_worker.go's run)
+// to a terminal failure with a caller-chosen delivery error, returning the
+// daemon's own journal line for it.
+func runFailingDelivery(t *testing.T, store *db.Store, home string, jobID string, deliveryErr error) string {
+	t.Helper()
+	seedDaemonWorkerAgent(t, store, "audit", runtime.ShellRuntime, "", []string{"ask"}, "owner/repo")
+	enqueueDaemonWorkerJob(t, store, workflow.JobRequest{
+		ID: jobID, Agent: "audit", Action: "ask", Repo: "owner/repo", Branch: "main",
+	})
+	job := mustWorkerJob(t, store, jobID)
+
+	stdout := &lockedBuffer{}
+	worker := defaultJobWorker(store, stdout, home)
+	worker.CheckoutValidator = func(context.Context, db.Job, workflow.JobPayload, runtime.Agent) (string, error) {
+		return t.TempDir(), nil
+	}
+	worker.AdapterFactory = func(runtime.Agent, string) (workflow.DeliveryAdapter, error) {
+		return &cliWorkerFakeAdapter{err: deliveryErr}, nil
+	}
+	if err := worker.run(context.Background(), job); err != nil {
+		t.Fatalf("worker.run returned error: %v", err)
+	}
+	after := mustWorkerJob(t, store, jobID)
+	if after.State != string(workflow.JobFailed) {
+		t.Fatalf("state = %q, want failed (a deferral or block would make this test vacuous)", after.State)
+	}
+	return journalFailureText(t, stdout.String(), jobID)
+}
+
+func TestRunRecordsDeliveryErrorOnTheJobRow(t *testing.T) {
+	store := daemonWorkerStore(t)
+	journal := runFailingDelivery(t, store, t.TempDir(), "job-delivery-error", errors.New(deliveryErrorFixture))
+
+	diag := deliveryErrorDiagnostics(t, store, "job-delivery-error")
+	if diag == nil {
+		t.Fatal("FailureDiagnostics = nil, want the delivery error recorded on the row")
+	}
+	if !strings.Contains(diag.DeliveryError, deliveryErrorFixture) {
+		t.Fatalf("delivery_error = %q, want it to carry the runtime's own error", diag.DeliveryError)
+	}
+	// The whole point: the row now says what the journal said. Substring, not
+	// equality, so a future wrapper adding context to the error keeps the binding
+	// meaningful instead of turning it into a churn magnet.
+	if !strings.Contains(diag.DeliveryError, journal) {
+		t.Fatalf("delivery_error = %q, want it to carry the daemon's journal text %q", diag.DeliveryError, journal)
+	}
+
+	var buf bytes.Buffer
+	printFailureDiagnostics(&buf, diag)
+	out := buf.String()
+	if !strings.Contains(out, "  delivery_error:") || !strings.Contains(out, deliveryErrorFixture) {
+		t.Fatalf("job show output missing the delivery error:\n%s", out)
+	}
+}
+
+// The guard with a real consequence: an unredacted provider error on a durable
+// job row is a token-leak surface. Removing the redaction call anywhere on this
+// field's write path turns this test RED.
+func TestRunRedactsDeliveryErrorOnTheJobRow(t *testing.T) {
+	store := daemonWorkerStore(t)
+	journal := runFailingDelivery(t, store, t.TempDir(), "job-delivery-secret", errors.New(deliveryErrorSecretFixture))
+
+	diag := deliveryErrorDiagnostics(t, store, "job-delivery-secret")
+	if diag == nil {
+		t.Fatal("FailureDiagnostics = nil, want the delivery error recorded on the row")
+	}
+	if !strings.Contains(journal, deliveryErrorSecret) {
+		t.Fatalf("journal line = %q, want the RAW token (otherwise this test proves nothing)", journal)
+	}
+	if strings.Contains(diag.DeliveryError, deliveryErrorSecret) {
+		t.Fatalf("delivery_error leaked the token: %q", diag.DeliveryError)
+	}
+	if !strings.Contains(diag.DeliveryError, "[REDACTED]") {
+		t.Fatalf("delivery_error = %q, want the redaction marker", diag.DeliveryError)
+	}
+	if !strings.Contains(diag.DeliveryError, "unexpected status 404 Not Found") {
+		t.Fatalf("delivery_error = %q, want the triage-bearing text kept", diag.DeliveryError)
+	}
+	// Byte-for-byte what StderrTail's own path produces for the same input: the
+	// new field must not acquire a second, weaker redaction path. If the write
+	// path ever skips redaction the stored text has no "[REDACTED]" for this
+	// already-redacted string to match against, so this fails too.
+	if want := workflow.WithDeliveryError(nil, journal).DeliveryError; !strings.Contains(diag.DeliveryError, want) {
+		t.Fatalf("delivery_error = %q, want it to carry the stderr-tail redaction result %q", diag.DeliveryError, want)
+	}
+}
+
+// The delegated (temp-worker) terminal path is a SECOND call site and needs its
+// own case: a delegated run's runtime error was journal-only too.
+func TestTempWorkerRunRecordsDeliveryErrorOnTheJobRow(t *testing.T) {
+	ctx := context.Background()
+	store := daemonWorkerStore(t)
+	checkout := t.TempDir()
+	runGit(t, checkout, "init")
+	runGit(t, checkout, "branch", "-m", "main")
+	runGit(t, checkout, "remote", "add", "origin", "https://github.com/owner/repo.git")
+	seedDaemonWorkerRepo(t, store, "owner/repo", checkout)
+	original := runtime.Agent{
+		Name: "codex-reviewer", Role: "worker", Runtime: runtime.CodexRuntime,
+		RuntimeRef: "550e8400-e29b-41d4-a716-446655440002", RepoScope: "owner/repo",
+		Capabilities: []string{"ask"}, AutonomyPolicy: runtime.AutonomyPolicyAuto,
+	}
+	seedDaemonWorkerAgent(t, store, original.Name, original.Runtime, original.RuntimeRef, original.Capabilities, original.RepoScope)
+	enqueueDaemonWorkerJob(t, store, workflow.JobRequest{
+		ID: "job-temp-delivery-error", Agent: original.Name, Action: "ask", Repo: "owner/repo",
+	})
+	admitted := mustWorkerJob(t, store, "job-temp-delivery-error")
+	payload, err := daemonJobPayload(admitted)
+	if err != nil {
+		t.Fatalf("daemonJobPayload returned error: %v", err)
+	}
+
+	stdout := &lockedBuffer{}
+	worker := defaultJobWorker(store, stdout, t.TempDir())
+	worker.StartAdapterFactory = func(execbackend.Backend, string, string) (runtime.Adapter, error) {
+		return &cliWorkerFakeAdapter{startRuntimeRef: "550e8400-e29b-41d4-a716-446655440003"}, nil
+	}
+	worker.AdapterFactory = func(runtime.Agent, string) (workflow.DeliveryAdapter, error) {
+		return &cliWorkerFakeAdapter{err: errors.New(deliveryErrorFixture)}, nil
+	}
+	policy := config.DefaultParallelSessionPolicy()
+	policy.MergeBack = config.ParallelSessionMergeBackOff
+	if err := worker.runWithTempWorker(ctx, admitted, payload, execbackend.Local, original, checkout, policy, "test contention", false); err != nil {
+		t.Fatalf("runWithTempWorker returned error: %v", err)
+	}
+
+	after := mustWorkerJob(t, store, admitted.ID)
+	if after.State != string(workflow.JobFailed) {
+		t.Fatalf("state = %q, want failed", after.State)
+	}
+	diag := deliveryErrorDiagnostics(t, store, admitted.ID)
+	if diag == nil {
+		t.Fatal("FailureDiagnostics = nil, want the delegated run's delivery error on the row")
+	}
+	if !strings.Contains(diag.DeliveryError, deliveryErrorFixture) {
+		t.Fatalf("delivery_error = %q, want the delegated runtime's own error", diag.DeliveryError)
+	}
+	if journal := journalFailureText(t, stdout.String(), admitted.ID); !strings.Contains(diag.DeliveryError, journal) {
+		t.Fatalf("delivery_error = %q, want it to carry the daemon's journal text %q", diag.DeliveryError, journal)
+	}
+}
+
+// A job that fails with an empty error must not grow an empty/garbage field, and
+// must not conjure a diagnostics block out of nothing.
+func TestRecordDeliveryFailureDiagnosticsIgnoresEmptyError(t *testing.T) {
+	ctx := context.Background()
+	store := daemonWorkerStore(t)
+	seedDaemonWorkerAgent(t, store, "audit", runtime.ShellRuntime, "", []string{"ask"}, "owner/repo")
+	enqueueDaemonWorkerJob(t, store, workflow.JobRequest{
+		ID: "job-empty-delivery-error", Agent: "audit", Action: "ask", Repo: "owner/repo", Branch: "main",
+	})
+	job := mustWorkerJob(t, store, "job-empty-delivery-error")
+	worker := defaultJobWorker(store, io.Discard, t.TempDir())
+
+	worker.recordDeliveryFailureDiagnostics(ctx, job.ID, job.LifecycleGeneration, errors.New(""))
+	worker.recordDeliveryFailureDiagnostics(ctx, job.ID, job.LifecycleGeneration, errors.New("   \n\t "))
+	worker.recordDeliveryFailureDiagnostics(ctx, job.ID, job.LifecycleGeneration, nil)
+
+	if diag := deliveryErrorDiagnostics(t, store, job.ID); diag != nil {
+		t.Fatalf("FailureDiagnostics = %+v, want none for an empty delivery error", diag)
+	}
+	stored := mustWorkerJob(t, store, job.ID)
+	if strings.Contains(stored.Payload, "delivery_error") {
+		t.Fatalf("payload = %q, want no delivery_error key", stored.Payload)
+	}
+}
+
+// A retry that claimed the row between the run error and this write owns a NEWER
+// generation and has already cleared diagnostics for its own run; stamping the
+// dead run's error onto it would be a live-row corruption, so the write drops.
+func TestRecordDeliveryFailureDiagnosticsSkipsSupersededGeneration(t *testing.T) {
+	ctx := context.Background()
+	store := daemonWorkerStore(t)
+	seedDaemonWorkerAgent(t, store, "audit", runtime.ShellRuntime, "", []string{"ask"}, "owner/repo")
+	enqueueDaemonWorkerJob(t, store, workflow.JobRequest{
+		ID: "job-superseded-delivery-error", Agent: "audit", Action: "ask", Repo: "owner/repo", Branch: "main",
+	})
+	job := mustWorkerJob(t, store, "job-superseded-delivery-error")
+	worker := defaultJobWorker(store, io.Discard, t.TempDir())
+
+	worker.recordDeliveryFailureDiagnostics(ctx, job.ID, job.LifecycleGeneration-1, errors.New(deliveryErrorFixture))
+
+	if diag := deliveryErrorDiagnostics(t, store, job.ID); diag != nil {
+		t.Fatalf("FailureDiagnostics = %+v, want none: a superseded run must not write", diag)
+	}
+}

--- a/internal/cli/job.go
+++ b/internal/cli/job.go
@@ -1385,7 +1385,11 @@ func printFailureDiagnostics(stdout io.Writer, diag *workflow.FailureDiagnostics
 		return
 	}
 	fmt.Fprintln(stdout, "failure_diagnostics:")
-	fmt.Fprintf(stdout, "  phase: %s\n", diag.Phase)
+	// A delivery that failed before the adapter reported any session evidence has
+	// no phase to claim (#1620); print nothing rather than a blank "phase:" line.
+	if diag.Phase != "" {
+		fmt.Fprintf(stdout, "  phase: %s\n", diag.Phase)
+	}
 	if diag.ExitCode != nil {
 		fmt.Fprintf(stdout, "  exit_code: %d\n", *diag.ExitCode)
 	}
@@ -1394,6 +1398,15 @@ func printFailureDiagnostics(stdout io.Writer, diag *workflow.FailureDiagnostics
 	}
 	if diag.SessionID != "" {
 		fmt.Fprintf(stdout, "  runtime_session: %s\n", diag.SessionID)
+	}
+	// The engine's own terminal error for the delivery, printed BEFORE the stderr
+	// tail because it is the line that actually distinguishes one exit_code: 1
+	// from another (#1620). Redacted and bounded at capture time, same as the tail.
+	if diag.DeliveryError != "" {
+		fmt.Fprintln(stdout, "  delivery_error:")
+		for _, line := range strings.Split(diag.DeliveryError, "\n") {
+			fmt.Fprintf(stdout, "    %s\n", line)
+		}
 	}
 	if diag.StderrTail != "" {
 		fmt.Fprintln(stdout, "  stderr_tail:")

--- a/internal/cli/job_test.go
+++ b/internal/cli/job_test.go
@@ -1019,10 +1019,11 @@ func TestPrintJobRendersFailureDiagnosticsBlock(t *testing.T) {
 	payload := workflow.JobPayload{
 		Repo: "owner/repo",
 		FailureDiagnostics: &workflow.FailureDiagnostics{
-			Phase:      workflow.FailurePhaseLaunched,
-			ExitCode:   &exitCode,
-			StderrTail: "first crash line\nsecond crash line",
-			SessionID:  "sess-1234",
+			Phase:         workflow.FailurePhaseLaunched,
+			ExitCode:      &exitCode,
+			StderrTail:    "first crash line\nsecond crash line",
+			DeliveryError: "400 invalid_request_error: model requires a newer CLI",
+			SessionID:     "sess-1234",
 		},
 	}
 
@@ -1034,6 +1035,8 @@ func TestPrintJobRendersFailureDiagnosticsBlock(t *testing.T) {
 		"  phase: launched",
 		"  exit_code: 7",
 		"  runtime_session: sess-1234",
+		"  delivery_error:",
+		"    400 invalid_request_error: model requires a newer CLI",
 		"  stderr_tail:",
 		"    first crash line",
 		"    second crash line",
@@ -1041,6 +1044,26 @@ func TestPrintJobRendersFailureDiagnosticsBlock(t *testing.T) {
 		if !strings.Contains(out, want) {
 			t.Fatalf("job show output missing %q:\n%s", want, out)
 		}
+	}
+}
+
+// A delivery that failed before the adapter reported session evidence has no
+// phase to claim (#1620); the block must not render a blank "phase:" line.
+func TestPrintJobFailureDiagnosticsOmitsBlankPhase(t *testing.T) {
+	var buf bytes.Buffer
+	payload := workflow.JobPayload{
+		Repo:               "owner/repo",
+		FailureDiagnostics: workflow.WithDeliveryError(nil, "unexpected status 404 Not Found"),
+	}
+
+	printJob(&buf, db.Job{ID: "job-z", State: "failed", Type: "review", Agent: "audit"}, payload, stuckReason{}, false, "", reviewStatusDisplay{})
+
+	out := buf.String()
+	if !strings.Contains(out, "  delivery_error:") || !strings.Contains(out, "    unexpected status 404 Not Found") {
+		t.Fatalf("job show output missing the delivery error:\n%s", out)
+	}
+	if strings.Contains(out, "  phase:") {
+		t.Fatalf("job show printed a phase line for a phase-less diagnostics:\n%s", out)
 	}
 }
 

--- a/internal/db/job_lifecycle_generation_test.go
+++ b/internal/db/job_lifecycle_generation_test.go
@@ -8,6 +8,14 @@ import (
 
 var _ func(*Store, context.Context, string, string, int64, string, string, JobEvent, ...JobEvent) (bool, error) = (*Store).TransitionJobStatePayloadWithEventAtGeneration
 
+// The two payload writers must keep DIFFERENT shapes: one anchored, one not. Pinning both
+// signatures makes "collapse them into one function" a COMPILE failure rather than a silent
+// behaviour change, which is the failure mode TestUpdateJobPayloadStaysUnconditional guards
+// at runtime.
+var _ func(*Store, context.Context, string, string) error = (*Store).UpdateJobPayload
+
+var _ func(*Store, context.Context, string, string, int64) (bool, error) = (*Store).UpdateJobPayloadAtGeneration
+
 func openLifecycleGenerationStore(t *testing.T) *Store {
 	t.Helper()
 	store, err := openCachedTestStore(t, filepath.Join(t.TempDir(), "gitmoot.db"))
@@ -225,5 +233,148 @@ func TestTransitionJobStatePayloadWithEventAtGenerationAnchorsPayload(t *testing
 	}
 	if afterLive.State != "blocked" || afterLive.Payload != livePayload {
 		t.Fatalf("live settlement = state %q payload %q, want blocked and replacement payload", afterLive.State, afterLive.Payload)
+	}
+}
+
+// armStaleLifecycleGeneration drives a freshly created queued job through one full retry so it
+// lands at state "failed" with lifecycle_generation 1. That is the ABA shape the anchor exists
+// for: a writer holding generation 0 reads back exactly the state string it expects, and the
+// counter is the only thing that says it is stale.
+func armStaleLifecycleGeneration(t *testing.T, store *Store, id string) {
+	t.Helper()
+	ctx := context.Background()
+	for _, step := range [][2]string{
+		{"queued", "running"}, {"running", "failed"}, {"failed", "queued"},
+		{"queued", "running"}, {"running", "failed"},
+	} {
+		if _, err := store.TransitionJobState(ctx, id, step[0], step[1]); err != nil {
+			t.Fatalf("TransitionJobState(%s->%s) returned error: %v", step[0], step[1], err)
+		}
+	}
+	job, err := store.GetJob(ctx, id)
+	if err != nil {
+		t.Fatalf("GetJob returned error: %v", err)
+	}
+	if job.State != "failed" || job.LifecycleGeneration != 1 {
+		t.Fatalf("fixture = state %q generation %d, want failed/1 -- the stale-generation setup did not arm", job.State, job.LifecycleGeneration)
+	}
+}
+
+// TestUpdateJobPayloadAtGenerationRefusesStaleGeneration pins the payload-only CAS (#1620) at
+// the layer that implements it.
+//
+// The discriminating case is a write whose anchor has gone stale while the row's STATE is
+// unchanged: state-based guards cannot see it, so it is the only case that separates this
+// function from UpdateJobPayload. Losing must be a SILENT NO-OP -- (false, nil), not an error --
+// because the payload describes a superseded run and writing nothing is the correct outcome;
+// returning an error would push callers into a retry that can only make the overwrite happen.
+// The live payload is compared byte-for-byte rather than by decision field, so a partial write
+// that lands the diagnostics but not the rest cannot pass.
+func TestUpdateJobPayloadAtGenerationRefusesStaleGeneration(t *testing.T) {
+	ctx := context.Background()
+	store := openLifecycleGenerationStore(t)
+
+	runTwoPayload := `{"result":{"decision":"implemented","summary":"run two"}}`
+	if err := store.CreateJob(ctx, Job{ID: "payload-gen", Agent: "lead", Type: "implement", State: "queued", Payload: runTwoPayload}); err != nil {
+		t.Fatalf("CreateJob returned error: %v", err)
+	}
+	armStaleLifecycleGeneration(t, store, "payload-gen")
+
+	// The stale writer observed generation 0 -- the run that has already been retried away.
+	runOnePayload := `{"result":{"decision":"blocked","summary":"run one delivery diagnostics"}}`
+	written, err := store.UpdateJobPayloadAtGeneration(ctx, "payload-gen", runOnePayload, 0)
+	if err != nil {
+		t.Fatalf("UpdateJobPayloadAtGeneration at a stale generation returned error %v; losing the CAS is a normal outcome and must not be reported as a failure", err)
+	}
+	if written {
+		t.Fatal("a payload write anchored to generation 0 won against generation 1: the generation is not being applied in the WHERE clause, so run one's payload overwrites run two's (the #1620 race)")
+	}
+
+	afterStale, err := store.GetJob(ctx, "payload-gen")
+	if err != nil {
+		t.Fatalf("GetJob after the refused write returned error: %v", err)
+	}
+	if afterStale.Payload != runTwoPayload {
+		t.Fatalf("payload after the refused write = %q, want %q byte-identical: a lost CAS must leave the row untouched", afterStale.Payload, runTwoPayload)
+	}
+	if afterStale.State != "failed" || afterStale.LifecycleGeneration != 1 {
+		t.Fatalf("row after the refused write = state %q generation %d, want failed/1 unchanged", afterStale.State, afterStale.LifecycleGeneration)
+	}
+
+	// Control: the SAME call at the CURRENT generation lands. Without it a mutant that returns
+	// (false, nil) unconditionally -- or one that never writes at all -- passes everything above.
+	runTwoDiagnostics := `{"result":{"decision":"implemented","summary":"run two delivery diagnostics"}}`
+	written, err = store.UpdateJobPayloadAtGeneration(ctx, "payload-gen", runTwoDiagnostics, 1)
+	if err != nil {
+		t.Fatalf("UpdateJobPayloadAtGeneration at the current generation returned error: %v", err)
+	}
+	if !written {
+		t.Fatal("a payload write anchored to the CURRENT generation lost the CAS; the anchor is rejecting live callers too")
+	}
+	afterLive, err := store.GetJob(ctx, "payload-gen")
+	if err != nil {
+		t.Fatalf("GetJob after the accepted write returned error: %v", err)
+	}
+	if afterLive.Payload != runTwoDiagnostics {
+		t.Fatalf("payload after the accepted write = %q, want %q", afterLive.Payload, runTwoDiagnostics)
+	}
+	// A payload write is not a lifecycle event. If it advanced the counter (or the state), every
+	// anchor held by a concurrent settler would be invalidated by a plain result write, which is
+	// a second way to lose the same data the CAS is here to protect.
+	if afterLive.State != "failed" || afterLive.LifecycleGeneration != 1 {
+		t.Fatalf("row after the accepted write = state %q generation %d, want failed/1: a payload write must advance neither", afterLive.State, afterLive.LifecycleGeneration)
+	}
+}
+
+// TestUpdateJobPayloadStaysUnconditional pins that the UNTOUCHED UpdateJobPayload still writes
+// at any generation.
+//
+// #1620 anchored one caller and deliberately left this function alone: its callers write
+// payloads that were never anchored to an observed run, so they hold no generation to pass. The
+// regression this guards is a later refactor collapsing the two -- routing the generation-less
+// callers through the CAS behind some default anchor. That failure is SILENT by construction:
+// the CAS reports a loss as (false, nil), so every such write would be dropped with no error
+// raised anywhere, and only a job that had been retried at least once would lose its payload.
+func TestUpdateJobPayloadStaysUnconditional(t *testing.T) {
+	ctx := context.Background()
+	store := openLifecycleGenerationStore(t)
+	if err := store.CreateJob(ctx, Job{ID: "payload-plain", Agent: "lead", Type: "implement", State: "queued", Payload: `{"result":{"decision":"implemented"}}`}); err != nil {
+		t.Fatalf("CreateJob returned error: %v", err)
+	}
+
+	// Generation 0 first: the value a mistakenly-anchored refactor would most plausibly default
+	// to, and therefore the one arm that would keep passing after such a change.
+	atZero := `{"result":{"decision":"implemented","summary":"written at generation 0"}}`
+	if err := store.UpdateJobPayload(ctx, "payload-plain", atZero); err != nil {
+		t.Fatalf("UpdateJobPayload at generation 0 returned error: %v", err)
+	}
+	beforeRetry, err := store.GetJob(ctx, "payload-plain")
+	if err != nil {
+		t.Fatalf("GetJob before the retry returned error: %v", err)
+	}
+	if beforeRetry.Payload != atZero {
+		t.Fatalf("payload at generation 0 = %q, want %q", beforeRetry.Payload, atZero)
+	}
+	if beforeRetry.LifecycleGeneration != 0 {
+		t.Fatalf("generation after an unconditional payload write = %d, want 0: a payload write is not a lifecycle event", beforeRetry.LifecycleGeneration)
+	}
+
+	armStaleLifecycleGeneration(t, store, "payload-plain")
+
+	// Generation 1: the arm that actually discriminates. An anchored variant defaulting to 0
+	// silently drops this write and reports nothing.
+	atOne := `{"result":{"decision":"blocked","summary":"written at generation 1"}}`
+	if err := store.UpdateJobPayload(ctx, "payload-plain", atOne); err != nil {
+		t.Fatalf("UpdateJobPayload at generation 1 returned error: %v", err)
+	}
+	afterRetry, err := store.GetJob(ctx, "payload-plain")
+	if err != nil {
+		t.Fatalf("GetJob after the retry returned error: %v", err)
+	}
+	if afterRetry.Payload != atOne {
+		t.Fatalf("payload after an unconditional write at generation 1 = %q, want %q: UpdateJobPayload has acquired a generation predicate its callers cannot satisfy", afterRetry.Payload, atOne)
+	}
+	if afterRetry.State != "failed" || afterRetry.LifecycleGeneration != 1 {
+		t.Fatalf("row after an unconditional write = state %q generation %d, want failed/1: a payload write must advance neither", afterRetry.State, afterRetry.LifecycleGeneration)
 	}
 }

--- a/internal/db/store_jobs.go
+++ b/internal/db/store_jobs.go
@@ -1017,6 +1017,53 @@ func (s *Store) UpdateJobPayload(ctx context.Context, id string, payload string)
 	return tx.Commit()
 }
 
+// UpdateJobPayloadAtGeneration is UpdateJobPayload with the job's LIFECYCLE
+// GENERATION folded into the same UPDATE (#1620).
+//
+// UpdateJobPayload predicates on (id, workflow_id) only. A caller that reads the
+// row, decides the generation it observed is still current, and only THEN writes
+// therefore has a window between the check and the write: a retry claiming the
+// row inside it bumps the generation, and the now-stale writer overwrites the NEW
+// run's payload with the old run's. Making the generation part of the WHERE turns
+// that read-decide-write into one compare-and-swap, so the check cannot go stale
+// before the write it guards.
+//
+// Losing the CAS returns false with the row untouched, and is NOT an error: it
+// means the payload being written describes a superseded run, and writing nothing
+// is the correct outcome. Callers must not retry it. As with
+// TransitionJobStatePayloadWithEventAtGeneration, false alone cannot say whether
+// the state, the generation, or the row's existence is what failed to match; a
+// caller that needs to know re-reads the row.
+//
+// UpdateJobPayload itself is deliberately left alone: its callers write payloads
+// that are not anchored to an observed run, and giving them a CAS they never
+// consented to would silently start dropping their writes.
+func (s *Store) UpdateJobPayloadAtGeneration(ctx context.Context, id string, payload string, atGeneration int64) (bool, error) {
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return false, err
+	}
+	defer tx.Rollback()
+	projection := jobProjectionFromPayload(payload)
+	result, err := tx.ExecContext(ctx, `UPDATE jobs SET payload = ?, result_hash = ?, repo = ?, pull_request = ?, blocker_retry_at = ?, blocker_suggested_action = ?, updated_at = CURRENT_TIMESTAMP WHERE id = ? AND workflow_id = ? AND lifecycle_generation = ?`,
+		payload, jobResultHashFromPayload(payload), projection.Repo, projection.PullRequest, projection.BlockerRetryAt,
+		projection.BlockerSuggestedAction, id, projection.WorkflowID, atGeneration)
+	if err != nil {
+		return false, err
+	}
+	affected, err := result.RowsAffected()
+	if err != nil {
+		return false, err
+	}
+	if affected == 0 {
+		if err := rejectWorkflowIDMismatch(ctx, tx, id, projection.WorkflowID); err != nil {
+			return false, err
+		}
+		return false, tx.Commit()
+	}
+	return true, tx.Commit()
+}
+
 func (s *Store) UpdateJobPayloadAndStateWithEvent(ctx context.Context, id string, payload string, state string, event JobEvent) error {
 	tx, err := s.db.BeginTx(ctx, nil)
 	if err != nil {

--- a/internal/workflow/failure_diagnostics.go
+++ b/internal/workflow/failure_diagnostics.go
@@ -47,9 +47,42 @@ type FailureDiagnostics struct {
 	// stderr, run through the same token-redaction rules as GitHub job comments
 	// and bug reports before storage.
 	StderrTail string `json:"stderr_tail,omitempty"`
+	// DeliveryError is the redacted text of the ENGINE's own terminal error for
+	// the delivery — the very string the daemon logs as "job <id> failed: <err>"
+	// (#1620). It is deliberately NOT folded into StderrTail: that field means
+	// "tail of the runtime CLI's stderr", which is a different source and often
+	// carries only an echo of the prompt. Before this field the daemon journal
+	// held the only copy, so a model/CLI mismatch and a compaction-endpoint 404
+	// both read as an identical `phase: streaming, exit_code: 1` on the job row
+	// and operators re-dispatched instead of triaging. Set only through
+	// WithDeliveryError, which is what keeps redaction from being bypassed.
+	DeliveryError string `json:"delivery_error,omitempty"`
 	// SessionID is the concrete runtime session id in play when one was
 	// created/known.
 	SessionID string `json:"session_id,omitempty"`
+}
+
+// WithDeliveryError records the engine's terminal delivery error on diag and
+// returns it. The detail runs through redactedStderrTail — the IDENTICAL
+// redaction-then-bound path StderrTail uses — because a provider error routinely
+// carries a URL, a request id, or a token, and a job row is a durable, widely
+// read surface.
+//
+// A blank detail (or one that redacts away to nothing) is a no-op that never
+// allocates: a job whose delivery failed with an empty error must not grow an
+// empty diagnostics block. A nil diag with a real detail allocates a PHASE-LESS
+// FailureDiagnostics rather than inventing a phase — the delivery failed without
+// the adapter reporting session evidence, so there is no phase to claim.
+func WithDeliveryError(diag *FailureDiagnostics, detail string) *FailureDiagnostics {
+	redacted := redactedStderrTail(detail)
+	if redacted == "" {
+		return diag
+	}
+	if diag == nil {
+		diag = &FailureDiagnostics{}
+	}
+	diag.DeliveryError = redacted
+	return diag
 }
 
 // failureDiagnosticsFromSession converts an adapter's raw session evidence into

--- a/internal/workflow/failure_diagnostics_test.go
+++ b/internal/workflow/failure_diagnostics_test.go
@@ -244,6 +244,86 @@ func TestRedactedStderrTailBoundsAndRedacts(t *testing.T) {
 	}
 }
 
+// The engine's own delivery error is a DIFFERENT source from the CLI's stderr,
+// but it is exactly as likely to carry a token, a URL, or a request id — so it
+// must go through the identical redaction+bound path (#1620). This is the guard
+// with a real consequence: an unredacted provider error on a durable job row is
+// a token-leak surface.
+func TestWithDeliveryErrorRedactsThroughTheStderrTailPath(t *testing.T) {
+	secret := "ghp_" + strings.Repeat("A", 36)
+	detail := "400 invalid_request_error: rejected (authorization: Bearer " + secret + ")"
+
+	diag := WithDeliveryError(nil, detail)
+
+	if diag == nil {
+		t.Fatal("WithDeliveryError(nil, <detail>) = nil, want an allocated diagnostics")
+	}
+	if strings.Contains(diag.DeliveryError, secret) {
+		t.Fatalf("delivery error leaked the token: %q", diag.DeliveryError)
+	}
+	if !strings.Contains(diag.DeliveryError, "[REDACTED]") {
+		t.Fatalf("delivery error = %q, want the redaction marker", diag.DeliveryError)
+	}
+	if !strings.Contains(diag.DeliveryError, "400 invalid_request_error") {
+		t.Fatalf("delivery error = %q, want the triage-bearing text kept", diag.DeliveryError)
+	}
+	// Identical to what StderrTail would do with the same input — the field must
+	// not acquire its own, weaker redaction path.
+	if want := redactedStderrTail(detail); diag.DeliveryError != want {
+		t.Fatalf("delivery error = %q, want the stderr-tail redaction result %q", diag.DeliveryError, want)
+	}
+}
+
+func TestWithDeliveryErrorBoundsLikeStderrTail(t *testing.T) {
+	detail := strings.Repeat("x", 4*MaxStderrTailBytes) + "\ntail-marker-end"
+
+	diag := WithDeliveryError(nil, detail)
+
+	if len(diag.DeliveryError) > MaxStderrTailBytes {
+		t.Fatalf("len = %d, want <= %d", len(diag.DeliveryError), MaxStderrTailBytes)
+	}
+	if !strings.HasSuffix(diag.DeliveryError, "tail-marker-end") {
+		t.Fatalf("delivery error (%d bytes) does not end at the tail marker", len(diag.DeliveryError))
+	}
+}
+
+// A delivery that failed with an empty error must not grow an empty/garbage
+// field, and must not conjure a diagnostics block out of nothing.
+func TestWithDeliveryErrorIgnoresBlankDetail(t *testing.T) {
+	if diag := WithDeliveryError(nil, ""); diag != nil {
+		t.Fatalf("WithDeliveryError(nil, \"\") = %+v, want nil", diag)
+	}
+	if diag := WithDeliveryError(nil, "   \n\t "); diag != nil {
+		t.Fatalf("WithDeliveryError(nil, whitespace) = %+v, want nil", diag)
+	}
+	existing := &FailureDiagnostics{Phase: FailurePhaseStreaming, StderrTail: "prompt echo"}
+	if diag := WithDeliveryError(existing, " "); diag.DeliveryError != "" {
+		t.Fatalf("delivery error = %q, want it left unset by a blank detail", diag.DeliveryError)
+	}
+}
+
+// Additive only: the crash evidence a job already carried survives untouched.
+func TestWithDeliveryErrorPreservesExistingDiagnostics(t *testing.T) {
+	exitCode := 1
+	existing := &FailureDiagnostics{
+		Phase: FailurePhaseStreaming, ExitCode: &exitCode, Signal: "SIGKILL",
+		StderrTail: "echo of the skill system prompt", SessionID: "sess-9",
+	}
+
+	diag := WithDeliveryError(existing, "unexpected status 404 Not Found")
+
+	if diag != existing {
+		t.Fatalf("WithDeliveryError returned a different diagnostics pointer")
+	}
+	if diag.Phase != FailurePhaseStreaming || diag.ExitCode == nil || *diag.ExitCode != 1 ||
+		diag.Signal != "SIGKILL" || diag.StderrTail != "echo of the skill system prompt" || diag.SessionID != "sess-9" {
+		t.Fatalf("existing diagnostics disturbed: %+v", diag)
+	}
+	if diag.DeliveryError != "unexpected status 404 Not Found" {
+		t.Fatalf("delivery error = %q", diag.DeliveryError)
+	}
+}
+
 func TestTailBytesKeepsValidUTF8(t *testing.T) {
 	// 3-byte runes force the byte cut to land mid-rune, exercising the
 	// boundary re-alignment.

--- a/skills/gitmoot/references/CLI.md
+++ b/skills/gitmoot/references/CLI.md
@@ -2483,12 +2483,27 @@ but no valid envelope was found, `recovery` = daemon recovery proved the durable
 runner was gone), the process `exit_code` **or** terminating
 `signal`, a **redacted** stderr tail (hard-capped at 4 KB; redaction runs over
 the full text with the same token-redaction rules as job comments *before* the
-tail is cut, so a secret can never leak partially), and the runtime session id
-when one is known. `gitmoot job show` prints a `failure_diagnostics:` block,
+tail is cut, so a secret can never leak partially), the **`delivery_error`** —
+the engine's own terminal error for the delivery, i.e. the exact line the daemon
+logs as `job <id> failed: <err>` (#1620) — and the runtime session id when one is
+known. `gitmoot job show` prints a `failure_diagnostics:` block,
 `job show --json` carries `payload.failure_diagnostics`, and `gitmoot report
 bug` includes a "Failure diagnostics" section. Successful jobs never store one,
 and a retried job clears the previous run's crash report. Terminal `failed`
 events embed the same bounded, redacted stderr tail for durable triage.
+
+`delivery_error` is what distinguishes faults the row otherwise collapses into
+one identical `phase: streaming, exit_code: 1` — a model/CLI mismatch (`400
+invalid_request_error: The '<model>' model requires a newer version of Codex.`)
+and a compaction-endpoint `404`, say, need different remedies but used to look
+the same on the job row because the runtime's real error existed only in
+`journalctl --user -u gitmoot-daemon`. It is a **different source** from
+`stderr_tail` (which is the runtime CLI's own stderr, often just an echo of the
+skill system prompt) and never replaces it; both go through the identical
+redaction and 4 KB bound, because a provider error routinely carries a URL, a
+request id, or a token. A delivery that failed before the adapter reported any
+session evidence records `delivery_error` with **no** `phase` line, and a
+delivery that failed with an empty error records no field at all.
 
 Jobs stuck in `running` are also backstopped, but transcript silence alone never
 kills work. The recurring same-boot sweep moves `running` to `failed` only when

--- a/website/docs/reference/cli.md
+++ b/website/docs/reference/cli.md
@@ -2184,12 +2184,27 @@ valid envelope was found, `recovery` = daemon recovery proved the durable runner
 was gone), the process `exit_code` **or** terminating `signal`,
 a **redacted** stderr tail (hard-capped at 4 KB; redaction runs over the full
 text with the same token-redaction rules as job comments *before* the tail is
-cut, so a secret can never leak partially), and the runtime session id when one
-is known. `gitmoot job show` prints a `failure_diagnostics:` block,
+cut, so a secret can never leak partially), the **`delivery_error`** — the
+engine's own terminal error for the delivery, i.e. the exact line the daemon logs
+as `job <id> failed: <err>` (#1620) — and the runtime session id when one is
+known. `gitmoot job show` prints a `failure_diagnostics:` block,
 `job show --json` carries `payload.failure_diagnostics`, and `gitmoot report
 bug` includes a "Failure diagnostics" section. Successful jobs never store one,
 and a retried job clears the previous run's crash report. Terminal `failed`
 events embed the same bounded, redacted stderr tail for durable triage.
+
+`delivery_error` is what distinguishes faults the row otherwise collapses into
+one identical `phase: streaming, exit_code: 1` — a model/CLI mismatch (`400
+invalid_request_error: The '<model>' model requires a newer version of Codex.`)
+and a compaction-endpoint `404`, say, need different remedies but used to look
+the same on the job row because the runtime's real error existed only in
+`journalctl --user -u gitmoot-daemon`. It is a **different source** from
+`stderr_tail` (which is the runtime CLI's own stderr, often just an echo of the
+skill system prompt) and never replaces it; both go through the identical
+redaction and 4 KB bound, because a provider error routinely carries a URL, a
+request id, or a token. A delivery that failed before the adapter reported any
+session evidence records `delivery_error` with **no** `phase` line, and a
+delivery that failed with an empty error records no field at all.
 
 Jobs stuck in `running` are backstopped too, but transcript silence alone never
 kills work. The recurring same-boot sweep moves `running` to `failed` only when

--- a/website/static/llms-full.txt
+++ b/website/static/llms-full.txt
@@ -12659,12 +12659,27 @@ but no valid envelope was found, `recovery` = daemon recovery proved the durable
 runner was gone), the process `exit_code` **or** terminating
 `signal`, a **redacted** stderr tail (hard-capped at 4 KB; redaction runs over
 the full text with the same token-redaction rules as job comments *before* the
-tail is cut, so a secret can never leak partially), and the runtime session id
-when one is known. `gitmoot job show` prints a `failure_diagnostics:` block,
+tail is cut, so a secret can never leak partially), the **`delivery_error`** —
+the engine's own terminal error for the delivery, i.e. the exact line the daemon
+logs as `job <id> failed: <err>` (#1620) — and the runtime session id when one is
+known. `gitmoot job show` prints a `failure_diagnostics:` block,
 `job show --json` carries `payload.failure_diagnostics`, and `gitmoot report
 bug` includes a "Failure diagnostics" section. Successful jobs never store one,
 and a retried job clears the previous run's crash report. Terminal `failed`
 events embed the same bounded, redacted stderr tail for durable triage.
+
+`delivery_error` is what distinguishes faults the row otherwise collapses into
+one identical `phase: streaming, exit_code: 1` — a model/CLI mismatch (`400
+invalid_request_error: The '<model>' model requires a newer version of Codex.`)
+and a compaction-endpoint `404`, say, need different remedies but used to look
+the same on the job row because the runtime's real error existed only in
+`journalctl --user -u gitmoot-daemon`. It is a **different source** from
+`stderr_tail` (which is the runtime CLI's own stderr, often just an echo of the
+skill system prompt) and never replaces it; both go through the identical
+redaction and 4 KB bound, because a provider error routinely carries a URL, a
+request id, or a token. A delivery that failed before the adapter reported any
+session evidence records `delivery_error` with **no** `phase` line, and a
+delivery that failed with an empty error records no field at all.
 
 Jobs stuck in `running` are also backstopped, but transcript silence alone never
 kills work. The recurring same-boot sweep moves `running` to `failed` only when


### PR DESCRIPTION
WHAT:
GITMOOT-COC IMPLEMENT — gitmoot#1620: the runtime's real error now lands on the job row instead of only in the daemon journal.

DESIGN
- internal/workflow/failure_diagnostics.go:59 — new FailureDiagnostics.DeliveryError (`json:"delivery_error,omitempty"`), documented as a DIFFERENT source from StderrTail (engine's own terminal error for the delivery vs. tail of the runtime CLI's stderr). StderrTail's meaning, 4 KB cap and redaction rules are untouched.
- internal/workflow/failure_diagnostics.go:76 — WithDeliveryError(diag, detail) is the ONLY way to set the field from outside the package, and it calls redactedStderrTail — literally the same function StderrTail uses — so the redaction cannot be bypassed by a caller. Blank/whitespace detail is a no-op that never allocates; a nil diag with a real detail allocates a PHASE-LESS diagnostics rather than inventing a phase.
- internal/cli/daemon_result.go:395 — recordDeliveryFailureDiagnostics: best-effort read-modify-write of the payload (workflow.ParseJobPayload for legacy preset_* tolerance, Store.UpdateJobPayload), anchored to the run's lifecycle generation. running->failed does NOT bump lifecycle_generation (internal/db/store_jobs.go:589 bumps only on a transition TO 'queued'), so the normal case writes; a retry that re-queued the row bumps it and the write correctly drops instead of stamping a live run with a dead run's error.
- Both call sites record the SAME `err` the journal logs (not commentErr, which can be swapped for the permission-blocked operator message).

ANCHOR CENSUS (file:line, quoted, post-change)
1. internal/cli/daemon_worker.go:866 `w.recordDeliveryFailureDiagnostics(ctx, job.ID, job.LifecycleGeneration, err)` inserted immediately above the unchanged :867 `writeLine(w.Stdout, "job %s failed: %v", job.ID, err)` (the brief's :861).
2. internal/cli/daemon_worker.go:2134 `w.recordDeliveryFailureDiagnostics(ctx, delegatedJob.ID, delegatedJob.LifecycleGeneration, err)` above the unchanged :2135 `writeLine(w.Stdout, "job %s failed: %v", delegatedJob.ID, err)` (the brief's :2125).
3. internal/cli/job.go:1405-1410 — printFailureDiagnostics renders `  delivery_error:` BEFORE `  stderr_tail:`; job.go:1390 guards the phase line so a phase-less diagnostics does not print a blank `phase:`.
4. internal/cli/daemon_result.go:301/306 — the timeout detail struct exposes `delivery_error` alongside `stderr_tail`.

BLOCKED VERIFICATION (the one thing I could not deliver)
This seat's Bash policy denies `go` (`go build ./internal/workflow/` -> 'This command requires approval'), `node` (the llms generator), and `gitmoot` (`gitmoot workflow note --help` -> denied). So: NOTHING WAS COMPILED, NO TEST WAS RUN, AND THE MUTATION EVIDENCE DID NOT RUN. I am not reporting a baseline match count or a PASS/FAIL for anything, because I have none — a claimed result here would be fabricated. The plan could not be posted as a workflow note for the same reason; it is in this summary instead. The coordinator must gate the worktree; exact commands and mutation recipes are in needs[].

DOCS
CLI.md / website cli.md / llms-full.txt all updated. llms-full.txt embeds skills/gitmoot/references/CLI.md VERBATIM (website/scripts/build-llms-full.mjs:48), and I mirrored the CLI.md edit byte-for-byte into it — I read both 30-line regions back and they are identical, so `npm run build:llms` is a no-op for this region and converges by construction. website/static/llms.txt is hand-curated and never mentioned failure diagnostics, so it needs no change.

DELIBERATE OMISSION
internal/report/report.go:252 (`gitmoot report bug`) renders the diagnostics but was NOT extended with the new field — the brief enumerated exactly two render surfaces (printFailureDiagnostics + daemon_result.go) and I kept the additive-only fence. The docs I wrote do not claim report bug shows it. Worth a follow-up.

No test was deleted or rewritten; the two existing job_test.go diagnostics tests keep their axes and one gained a delivery_error assertion.

WHY:
Gitmoot finalized this implementation from a task worktree.

CHANGES:
- Committed changes from /root/.gitmoot/worktrees/gitmoot--gitmoot/adhoc-c28910ff

RESULTS:
- No tests reported by the implementing agent.

RISK:
Review the generated diff before merging.

TASK:
adhoc-c28910ff

AGENTS:
- lead

RAW FINAL REVIEW OUTPUT:
````text
GITMOOT-COC IMPLEMENT — gitmoot#1620: the runtime's real error now lands on the job row instead of only in the daemon journal.

DESIGN
- internal/workflow/failure_diagnostics.go:59 — new FailureDiagnostics.DeliveryError (`json:"delivery_error,omitempty"`), documented as a DIFFERENT source from StderrTail (engine's own terminal error for the delivery vs. tail of the runtime CLI's stderr). StderrTail's meaning, 4 KB cap and redaction rules are untouched.
- internal/workflow/failure_diagnostics.go:76 — WithDeliveryError(diag, detail) is the ONLY way to set the field from outside the package, and it calls redactedStderrTail — literally the same function StderrTail uses — so the redaction cannot be bypassed by a caller. Blank/whitespace detail is a no-op that never allocates; a nil diag with a real detail allocates a PHASE-LESS diagnostics rather than inventing a phase.
- internal/cli/daemon_result.go:395 — recordDeliveryFailureDiagnostics: best-effort read-modify-write of the payload (workflow.ParseJobPayload for legacy preset_* tolerance, Store.UpdateJobPayload), anchored to the run's lifecycle generation. running->failed does NOT bump lifecycle_generation (internal/db/store_jobs.go:589 bumps only on a transition TO 'queued'), so the normal case writes; a retry that re-queued the row bumps it and the write correctly drops instead of stamping a live run with a dead run's error.
- Both call sites record the SAME `err` the journal logs (not commentErr, which can be swapped for the permission-blocked operator message).

ANCHOR CENSUS (file:line, quoted, post-change)
1. internal/cli/daemon_worker.go:866 `w.recordDeliveryFailureDiagnostics(ctx, job.ID, job.LifecycleGeneration, err)` inserted immediately above the unchanged :867 `writeLine(w.Stdout, "job %s failed: %v", job.ID, err)` (the brief's :861).
2. internal/cli/daemon_worker.go:2134 `w.recordDeliveryFailureDiagnostics(ctx, delegatedJob.ID, delegatedJob.LifecycleGeneration, err)` above the unchanged :2135 `writeLine(w.Stdout, "job %s failed: %v", delegatedJob.ID, err)` (the brief's :2125).
3. internal/cli/job.go:1405-1410 — printFailureDiagnostics renders `  delivery_error:` BEFORE `  stderr_tail:`; job.go:1390 guards the phase line so a phase-less diagnostics does not print a blank `phase:`.
4. internal/cli/daemon_result.go:301/306 — the timeout detail struct exposes `delivery_error` alongside `stderr_tail`.

BLOCKED VERIFICATION (the one thing I could not deliver)
This seat's Bash policy denies `go` (`go build ./internal/workflow/` -> 'This command requires approval'), `node` (the llms generator), and `gitmoot` (`gitmoot workflow note --help` -> denied). So: NOTHING WAS COMPILED, NO TEST WAS RUN, AND THE MUTATION EVIDENCE DID NOT RUN. I am not reporting a baseline match count or a PASS/FAIL for anything, because I have none — a claimed result here would be fabricated. The plan could not be posted as a workflow note for the same reason; it is in this summary instead. The coordinator must gate the worktree; exact commands and mutation recipes are in needs[].

DOCS
CLI.md / website cli.md / llms-full.txt all updated. llms-full.txt embeds skills/gitmoot/references/CLI.md VERBATIM (website/scripts/build-llms-full.mjs:48), and I mirrored the CLI.md edit byte-for-byte into it — I read both 30-line regions back and they are identical, so `npm run build:llms` is a no-op for this region and converges by construction. website/static/llms.txt is hand-curated and never mentioned failure diagnostics, so it needs no change.

DELIBERATE OMISSION
internal/report/report.go:252 (`gitmoot report bug`) renders the diagnostics but was NOT extended with the new field — the brief enumerated exactly two render surfaces (printFailureDiagnostics + daemon_result.go) and I kept the additive-only fence. The docs I wrote do not claim report bug shows it. Worth a follow-up.

No test was deleted or rewritten; the two existing job_test.go diagnostics tests keep their axes and one gained a delivery_error assertion.
````
