### PR TITLE
fix(cli): report the resolved path on permission-policy effect capture failures (#1617)

### DIFF
--- a/internal/cli/permission_policy_effects.go
+++ b/internal/cli/permission_policy_effects.go
@@ -63,7 +63,9 @@ func (w jobWorker) capturePermissionPolicyEffects(ctx context.Context, jobID, ch
 		} else {
 			runner, runnerErr := w.subprocessRunnerForJob(job)
 			if runnerErr != nil {
-				return fmt.Errorf("resolve permission-policy effect runner: %w", runnerErr)
+				err = fmt.Errorf("resolve permission-policy effect runner: %w", runnerErr)
+				logPermissionPolicyEffectCaptureFailure(w.Stdout, jobID, checkout, err)
+				return err
 			}
 			git = jobGitClient(checkout, runner)
 		}

--- a/internal/cli/permission_policy_effects.go
+++ b/internal/cli/permission_policy_effects.go
@@ -3,6 +3,9 @@ package cli
 import (
 	"context"
 	"fmt"
+	"io"
+	"os"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -41,12 +44,12 @@ func (w jobWorker) observePermissionPolicyEffects(adapter workflow.DeliveryAdapt
 func (w jobWorker) capturePermissionPolicyEffects(ctx context.Context, jobID, checkout string) error {
 	job, err := w.Store.GetJob(ctx, jobID)
 	if err != nil {
-		writeLine(w.Stdout, "job %s permission-policy effect capture failed: %v", jobID, err)
+		logPermissionPolicyEffectCaptureFailure(w.Stdout, jobID, checkout, err)
 		return err
 	}
 	payload, err := daemonJobPayload(job)
 	if err != nil {
-		writeLine(w.Stdout, "job %s permission-policy effect capture failed: %v", jobID, err)
+		logPermissionPolicyEffectCaptureFailure(w.Stdout, jobID, checkout, err)
 		return err
 	}
 	if strings.TrimSpace(checkout) == "" {
@@ -70,7 +73,33 @@ func (w jobWorker) capturePermissionPolicyEffects(ctx context.Context, jobID, ch
 	_, err = permissionpolicy.RecordEffects(captureCtx, w.Store, jobID, checkout, payload.Branch, payload.PullRequest, git)
 	if err != nil {
 		err = fmt.Errorf("capture repository effects: %w", err)
-		writeLine(w.Stdout, "job %s permission-policy effect capture failed: %v", jobID, err)
+		logPermissionPolicyEffectCaptureFailure(w.Stdout, jobID, checkout, err)
 	}
 	return err
+}
+
+func logPermissionPolicyEffectCaptureFailure(stdout io.Writer, jobID, checkout string, err error) {
+	writeLine(stdout, "job %s permission-policy effect capture failed (%s): %v", jobID, permissionPolicyEffectCaptureLocation(checkout), err)
+}
+
+func permissionPolicyEffectCaptureLocation(checkout string) string {
+	path := workflow.RedactCommentText(checkout)
+	exists, workTree := "unknown", "unknown"
+	if checkout != "" {
+		info, err := os.Stat(checkout)
+		switch {
+		case err == nil:
+			exists = "true"
+			if !info.IsDir() {
+				workTree = "false"
+			} else if _, gitErr := os.Stat(filepath.Join(checkout, ".git")); gitErr == nil {
+				workTree = "true"
+			} else if os.IsNotExist(gitErr) {
+				workTree = "false"
+			}
+		case os.IsNotExist(err):
+			exists = "false"
+		}
+	}
+	return fmt.Sprintf("path=%q exists=%s work_tree=%s", path, exists, workTree)
 }

--- a/internal/cli/permission_policy_effects_test.go
+++ b/internal/cli/permission_policy_effects_test.go
@@ -152,6 +152,80 @@ func TestPermissionPolicyEffectCaptureFailureLogsResolvedLocation(t *testing.T) 
 		}
 		assertPermissionPolicyCaptureLocation(t, output.String(), checkout, "true", "true")
 	})
+
+	t.Run("effect capture logs caller checkout when payload worktree differs", func(t *testing.T) {
+		ctx := context.Background()
+		store := daemonWorkerStore(t)
+		checkout := t.TempDir()
+		payloadCheckout := filepath.Join(t.TempDir(), "different-payload-checkout")
+		enqueueDaemonWorkerJob(t, store, workflow.JobRequest{
+			ID: "caller-checkout-policy-job", Agent: "policy-agent", Action: "ask",
+			Repo: "owner/repo", Branch: "main", WorktreePath: payloadCheckout,
+		})
+		job, err := store.GetJob(ctx, "caller-checkout-policy-job")
+		if err != nil {
+			t.Fatal(err)
+		}
+		agent := runtime.Agent{
+			Name: "policy-agent", Runtime: runtime.ShellRuntime, RuntimeRef: "printf done",
+			AutonomyPolicy: runtime.AutonomyPolicyAuto,
+		}
+		claimed, err := permissionpolicy.RecordWarning(ctx, store, job, agent, &permissionPolicyTestAdapter{property: runtime.PermissionPolicyNotApplied}, time.Now())
+		if err != nil || !claimed {
+			t.Fatalf("RecordWarning = claimed %t, err %v", claimed, err)
+		}
+
+		var output bytes.Buffer
+		worker := defaultJobWorker(store, &output)
+		worker.PermissionPolicyEffectGit = func(string) permissionpolicy.EffectGit {
+			return &permissionPolicyEffectGitFake{
+				behindErr: errors.New("local upstream unavailable"),
+				remoteErr: errors.New("remote unavailable"),
+			}
+		}
+		if err := worker.capturePermissionPolicyEffects(ctx, job.ID, checkout); err == nil {
+			t.Fatal("capture returned nil error for remote failure")
+		}
+		assertPermissionPolicyCaptureLocation(t, output.String(), checkout, "true", "false")
+	})
+
+	t.Run("runner resolution logs caller checkout", func(t *testing.T) {
+		ctx := context.Background()
+		store := daemonWorkerStore(t)
+		checkout := t.TempDir()
+		enqueueDaemonWorkerJob(t, store, workflow.JobRequest{
+			ID: "runner-resolution-policy-job", Agent: "policy-agent", Action: "ask",
+			Repo: "owner/repo", Branch: "main", WorktreePath: filepath.Join(t.TempDir(), "payload-checkout"),
+		})
+		job, err := store.GetJob(ctx, "runner-resolution-policy-job")
+		if err != nil {
+			t.Fatal(err)
+		}
+		var payload map[string]any
+		if err := json.Unmarshal([]byte(job.Payload), &payload); err != nil {
+			t.Fatal(err)
+		}
+		payload["exec_backend"] = "unimplemented-runner"
+		encoded, err := json.Marshal(payload)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := store.UpdateJobPayload(ctx, job.ID, string(encoded)); err != nil {
+			t.Fatal(err)
+		}
+		job, err = store.GetJob(ctx, job.ID)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		var output bytes.Buffer
+		worker := defaultJobWorker(store, &output)
+		err = worker.capturePermissionPolicyEffects(ctx, job.ID, checkout)
+		if err == nil || !strings.Contains(err.Error(), "resolve permission-policy effect runner") {
+			t.Fatalf("capture error = %v, want runner resolution failure", err)
+		}
+		assertPermissionPolicyCaptureLocation(t, output.String(), checkout, "true", "false")
+	})
 }
 
 func assertPermissionPolicyCaptureLocation(t *testing.T, output, checkout, exists, workTree string) {

--- a/internal/cli/permission_policy_effects_test.go
+++ b/internal/cli/permission_policy_effects_test.go
@@ -1,12 +1,16 @@
 package cli
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
+	"path/filepath"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/gitmoot/gitmoot/internal/db"
 	"github.com/gitmoot/gitmoot/internal/permissionpolicy"
@@ -79,6 +83,82 @@ func TestPermissionPolicyEffectCaptureFailureDoesNotFailCleanJob(t *testing.T) {
 	effects := permissionPolicyEffectWarning(t, store, job.ID).Effects
 	if effects == nil || effects.CheckoutDirty == nil || *effects.CheckoutDirty {
 		t.Fatalf("effects = %#v, want checkout_dirty=false", effects)
+	}
+}
+
+func TestPermissionPolicyEffectCaptureFailureLogsResolvedLocation(t *testing.T) {
+	t.Run("job lookup uses caller checkout and identifies non-repository", func(t *testing.T) {
+		checkout := t.TempDir()
+		var output bytes.Buffer
+		worker := defaultJobWorker(daemonWorkerStore(t), &output)
+		if err := worker.capturePermissionPolicyEffects(context.Background(), "missing-policy-job", checkout); err == nil {
+			t.Fatal("capture returned nil error for missing job")
+		}
+		assertPermissionPolicyCaptureLocation(t, output.String(), checkout, "true", "false")
+	})
+
+	t.Run("payload parse uses caller checkout and identifies absent path", func(t *testing.T) {
+		ctx := context.Background()
+		store := daemonWorkerStore(t)
+		enqueueDaemonWorkerJob(t, store, workflow.JobRequest{ID: "malformed-policy-job", Agent: "policy-agent", Action: "ask", Repo: "owner/repo"})
+		if err := store.UpdateJobPayload(ctx, "malformed-policy-job", "{"); err != nil {
+			t.Fatal(err)
+		}
+		checkout := filepath.Join(t.TempDir(), "missing")
+		var output bytes.Buffer
+		worker := defaultJobWorker(store, &output)
+		if err := worker.capturePermissionPolicyEffects(ctx, "malformed-policy-job", checkout); err == nil {
+			t.Fatal("capture returned nil error for malformed payload")
+		}
+		assertPermissionPolicyCaptureLocation(t, output.String(), checkout, "false", "unknown")
+	})
+
+	t.Run("effect capture uses payload fallback and identifies work tree", func(t *testing.T) {
+		ctx := context.Background()
+		store := daemonWorkerStore(t)
+		checkout := createDaemonWorkerGitCheckout(t, "main")
+		enqueueDaemonWorkerJob(t, store, workflow.JobRequest{
+			ID: "fallback-policy-job", Agent: "policy-agent", Action: "ask",
+			Repo: "owner/repo", Branch: "main", WorktreePath: checkout,
+		})
+		job, err := store.GetJob(ctx, "fallback-policy-job")
+		if err != nil {
+			t.Fatal(err)
+		}
+		agent := runtime.Agent{
+			Name: "policy-agent", Runtime: runtime.ShellRuntime, RuntimeRef: "printf done",
+			AutonomyPolicy: runtime.AutonomyPolicyAuto,
+		}
+		claimed, err := permissionpolicy.RecordWarning(ctx, store, job, agent, &permissionPolicyTestAdapter{property: runtime.PermissionPolicyNotApplied}, time.Now())
+		if err != nil || !claimed {
+			t.Fatalf("RecordWarning = claimed %t, err %v", claimed, err)
+		}
+
+		var output bytes.Buffer
+		usedCheckout := ""
+		worker := defaultJobWorker(store, &output)
+		worker.PermissionPolicyEffectGit = func(got string) permissionpolicy.EffectGit {
+			usedCheckout = got
+			return &permissionPolicyEffectGitFake{
+				behindErr: errors.New("local upstream unavailable"),
+				remoteErr: errors.New("remote unavailable"),
+			}
+		}
+		if err := worker.capturePermissionPolicyEffects(ctx, job.ID, ""); err == nil {
+			t.Fatal("capture returned nil error for remote failure")
+		}
+		if usedCheckout != checkout {
+			t.Fatalf("effect git checkout = %q, want payload fallback %q", usedCheckout, checkout)
+		}
+		assertPermissionPolicyCaptureLocation(t, output.String(), checkout, "true", "true")
+	})
+}
+
+func assertPermissionPolicyCaptureLocation(t *testing.T, output, checkout, exists, workTree string) {
+	t.Helper()
+	want := fmt.Sprintf("path=%q exists=%s work_tree=%s", workflow.RedactCommentText(checkout), exists, workTree)
+	if !strings.Contains(output, want) {
+		t.Fatalf("capture failure output = %q, want location %q", output, want)
 	}
 }
 


### PR DESCRIPTION
## What

Fixes #1617. `permission-policy effect capture` fails on read-only worktree jobs — **10 occurrences in
7 days, 10/10 identical signature**, spanning `ask` and `review`, three runtimes, several repos. The
failure message names the **remote** when the problem is the **working directory**:

```
git ls-remote --heads origin refs/heads/main: exit status 128
  (stderr: fatal: 'origin' does not appear to be a git repository
```

Reproduced in an empty directory: that is exactly what git emits when run **outside a repository** —
it cannot resolve `origin` as a *remote name*, so it falls back to treating it as a path.

**This PR is instrumentation, not a fix.** The underlying mechanism is still unestablished, and three
plausible explanations are already disproved: worktrees *do* inherit `origin`; the capture is
synchronous inside `Deliver` so it is not a teardown race; and every affected repo's checkout reaches
`origin` fine. Rather than guess, this adds the one measurement that would identify it.

## Changes

- All **four** failure arms in `internal/cli/permission_policy_effects.go` now report
  `path=%q exists=%s work_tree=%s` — the resolved path redacted through `workflow.RedactCommentText`,
  plus whether it exists and whether it looks like a work tree. That distinguishes *absent* from
  *present-but-not-a-repository*, which the current message cannot express.
- The fourth arm (runner resolution) previously returned without logging at all, and the observer
  discards its error — so that path produced no journal line. It now reports like the other three.

Capture behaviour is unchanged: still best-effort, still cannot fail, block or retry a job, same
errors returned.

## Verification

Two independent review families approved at this head with zero findings, each re-running its own
mutant rather than trusting the author's tests.

Mutation evidence, before and after:

```
M3 (log payload.WorktreePath instead of checkout at site 3)
  before : compiled, SURVIVED the full 17-match filter
  after  : compiled, killed by the new differing-path subtest
fourth-arm logger removal : compiled, killed by its own subtest
independence : each mutant leaves the OTHER guard passing (two separate runs)
```

The differing-path test deliberately uses **distinct** values for the caller `checkout` and
`payload.WorktreePath` — if they were equal the mutant would be unobservable, which is how it survived
in the first place.

Full suite at this exact head from a clone under `/root`: `build ok`, `go generate` + `git diff
--exit-code` clean, `vet ok`, **41 packages ok, exit 0**.

## Deploy notes

Operator-facing journal output only; no user-facing surface and no docs change. Behaviour unchanged.

-- GITMOOT-COC
