### PR TITLE
docs(cli): state the host-runner guard complement structurally instead of enumerating forms (#1606)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,8 +44,18 @@ Job-execution code in `internal/cli`, `internal/workflow`, and
 host `subprocess.ExecRunner`, constructing an `exec.Cmd`, or calling
 `exec.Command` or `exec.CommandContext` directly. Deliberate host-side exceptions
 require a reasoned `file:function` entry in
-`internal/cli/host_runner_guard_test.go`; that test also documents the syntactic
-guard's blind spots.
+`internal/cli/host_runner_guard_test.go`.
+
+The guard detects direct `exec.Command` and `exec.CommandContext` calls,
+explicitly typed `exec.Cmd{}` and `&exec.Cmd{}` literals, explicitly typed
+`subprocess.ExecRunner{}` literals, and `new(subprocess.ExecRunner)` allocations.
+The scanner does not type-check. It recognises exactly the listed syntactic
+forms. Any other syntax that yields these types is invisible to it—for example
+elided-element-type literals, zero-value declarations, `new()` allocations, and
+type conversions. Process-launch APIs other than the fixed forms above (for
+example, `os.StartProcess` or `syscall.ForkExec`) are also invisible to it.
+Generated files, test files, and files outside `internal/cli`,
+`internal/workflow`, and `internal/daemon` are excluded from the scan.
 
 For docs:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,9 +41,10 @@ git diff --check
 
 Job-execution code in `internal/cli`, `internal/workflow`, and
 `internal/daemon` must pass its resolved subprocess runner instead of creating a
-host `subprocess.ExecRunner{}` or calling `exec.Command` directly. Deliberate
-host-side exceptions require a reasoned `file:function` entry in
-`internal/cli/host_runner_guard_test.go`.
+host `subprocess.ExecRunner`, constructing an `exec.Cmd`, or calling
+`exec.Command` directly. Deliberate host-side exceptions require a reasoned
+`file:function` entry in `internal/cli/host_runner_guard_test.go`; that test also
+documents the syntactic guard's blind spots.
 
 For docs:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,9 +42,10 @@ git diff --check
 Job-execution code in `internal/cli`, `internal/workflow`, and
 `internal/daemon` must pass its resolved subprocess runner instead of creating a
 host `subprocess.ExecRunner`, constructing an `exec.Cmd`, or calling
-`exec.Command` directly. Deliberate host-side exceptions require a reasoned
-`file:function` entry in `internal/cli/host_runner_guard_test.go`; that test also
-documents the syntactic guard's blind spots.
+`exec.Command` or `exec.CommandContext` directly. Deliberate host-side exceptions
+require a reasoned `file:function` entry in
+`internal/cli/host_runner_guard_test.go`; that test also documents the syntactic
+guard's blind spots.
 
 For docs:
 

--- a/internal/cli/host_runner_guard_test.go
+++ b/internal/cli/host_runner_guard_test.go
@@ -256,10 +256,15 @@ func TestJobPathsDoNotHardcodeHostRunners(t *testing.T) {
 // exec.Command calls, exec.Cmd{} and &exec.Cmd{} composite literals,
 // subprocess.ExecRunner composite literals, and new(subprocess.ExecRunner)
 // allocations are detected.
-// It does not follow calls through local function values, runners returned by
-// helpers, fields assigned elsewhere, commands constructed in another package
-// and passed in, reflection, generated files, or os/exec and subprocess imports
-// reached through aliases or dot imports.
+// The scanner does not type-check, so it cannot follow function or type aliases,
+// helper-returned runners, values stored in fields or interfaces, or commands
+// constructed in another package and passed in. It also misses zero-value
+// declarations and other allocation forms (for example, var cmd exec.Cmd,
+// var runner subprocess.ExecRunner, and new(exec.Cmd)), process-launch APIs
+// other than the fixed forms above (for example, os.StartProcess or
+// syscall.ForkExec), reflection, generated files, test files, files outside the
+// three directories below, and os/exec or subprocess imports reached through
+// aliases or dot imports.
 // Production files in all three directories are scanned by default, so a new
 // internal/cli file is guarded unless each detected file:function site earns an
 // explicit allowance with a reason.

--- a/internal/cli/host_runner_guard_test.go
+++ b/internal/cli/host_runner_guard_test.go
@@ -256,15 +256,13 @@ func TestJobPathsDoNotHardcodeHostRunners(t *testing.T) {
 // exec.Command and exec.CommandContext calls, explicitly typed exec.Cmd{} and
 // &exec.Cmd{} literals, explicitly typed subprocess.ExecRunner{} literals, and
 // new(subprocess.ExecRunner) allocations are detected.
-// The scanner does not type-check, so it cannot follow function or type aliases,
-// helper-returned runners, values stored in fields or interfaces, or commands
-// constructed in another package and passed in. It also misses zero-value
-// declarations and other allocation forms (for example, elided element-type
-// composite literals, var cmd exec.Cmd, var runner subprocess.ExecRunner, and
-// new(exec.Cmd)), process-launch APIs other than the fixed forms above (for
-// example, os.StartProcess or syscall.ForkExec), reflection, generated files,
-// test files, files outside the three directories below, and os/exec or
-// subprocess imports reached through aliases or dot imports.
+// The scanner does not type-check. It recognises exactly the listed syntactic
+// forms. Any other syntax that yields these types is invisible to it—for example
+// elided-element-type literals, zero-value declarations, new() allocations, and
+// type conversions. Process-launch APIs other than the fixed forms above (for
+// example, os.StartProcess or syscall.ForkExec) are also invisible to it.
+// Generated files, test files, and files outside the three directories below are
+// excluded from the scan.
 // Production files in all three directories are scanned by default, so a new
 // internal/cli file is guarded unless each detected file:function site earns an
 // explicit allowance with a reason.

--- a/internal/cli/host_runner_guard_test.go
+++ b/internal/cli/host_runner_guard_test.go
@@ -253,18 +253,18 @@ func TestJobPathsDoNotHardcodeHostRunners(t *testing.T) {
 }
 
 // collectHardcodedHostRunnerSites is intentionally a syntactic guard. Direct
-// exec.Command and exec.CommandContext calls, exec.Cmd{} and &exec.Cmd{} literals,
-// subprocess.ExecRunner composite literals, and new(subprocess.ExecRunner)
-// allocations are detected.
+// exec.Command and exec.CommandContext calls, explicitly typed exec.Cmd{} and
+// &exec.Cmd{} literals, explicitly typed subprocess.ExecRunner{} literals, and
+// new(subprocess.ExecRunner) allocations are detected.
 // The scanner does not type-check, so it cannot follow function or type aliases,
 // helper-returned runners, values stored in fields or interfaces, or commands
 // constructed in another package and passed in. It also misses zero-value
-// declarations and other allocation forms (for example, var cmd exec.Cmd,
-// var runner subprocess.ExecRunner, and new(exec.Cmd)), process-launch APIs
-// other than the fixed forms above (for example, os.StartProcess or
-// syscall.ForkExec), reflection, generated files, test files, files outside the
-// three directories below, and os/exec or subprocess imports reached through
-// aliases or dot imports.
+// declarations and other allocation forms (for example, elided element-type
+// composite literals, var cmd exec.Cmd, var runner subprocess.ExecRunner, and
+// new(exec.Cmd)), process-launch APIs other than the fixed forms above (for
+// example, os.StartProcess or syscall.ForkExec), reflection, generated files,
+// test files, files outside the three directories below, and os/exec or
+// subprocess imports reached through aliases or dot imports.
 // Production files in all three directories are scanned by default, so a new
 // internal/cli file is guarded unless each detected file:function site earns an
 // explicit allowance with a reason.

--- a/internal/cli/host_runner_guard_test.go
+++ b/internal/cli/host_runner_guard_test.go
@@ -6,6 +6,7 @@ import (
 	"go/parser"
 	"go/token"
 	"io/fs"
+	"os"
 	"path/filepath"
 	"runtime"
 	"sort"
@@ -204,9 +205,10 @@ func TestJobPathsDoNotHardcodeHostRunners(t *testing.T) {
 	byKey := make(map[string][]hostRunnerSite)
 	for _, site := range sites {
 		byKey[site.key] = append(byKey[site.key], site)
-		if site.kind == "subprocess.ExecRunner{}" {
+		switch site.kind {
+		case "subprocess.ExecRunner{}", "new(subprocess.ExecRunner)":
 			execRunnerSites++
-		} else {
+		case "exec.Command", "exec.Cmd{}":
 			rawCommandSites++
 		}
 	}
@@ -232,9 +234,9 @@ func TestJobPathsDoNotHardcodeHostRunners(t *testing.T) {
 		var execRunners, rawCommands int
 		for _, site := range actual {
 			switch site.kind {
-			case "subprocess.ExecRunner{}":
+			case "subprocess.ExecRunner{}", "new(subprocess.ExecRunner)":
 				execRunners++
-			case "exec.Command":
+			case "exec.Command", "exec.Cmd{}":
 				rawCommands++
 			}
 		}
@@ -250,10 +252,14 @@ func TestJobPathsDoNotHardcodeHostRunners(t *testing.T) {
 		len(sites), execRunnerSites, rawCommandSites, len(hostRunnerAllowlist))
 }
 
-// collectHardcodedHostRunnerSites is intentionally a syntactic guard. It does
-// not follow runners returned by helpers, fields assigned elsewhere, commands
-// constructed in another package and passed in, reflection, generated files,
-// or os/exec and subprocess imports reached through aliases or dot imports.
+// collectHardcodedHostRunnerSites is intentionally a syntactic guard. Direct
+// exec.Command calls, exec.Cmd{} and &exec.Cmd{} composite literals,
+// subprocess.ExecRunner composite literals, and new(subprocess.ExecRunner)
+// allocations are detected.
+// It does not follow calls through local function values, runners returned by
+// helpers, fields assigned elsewhere, commands constructed in another package
+// and passed in, reflection, generated files, or os/exec and subprocess imports
+// reached through aliases or dot imports.
 // Production files in all three directories are scanned by default, so a new
 // internal/cli file is guarded unless each detected file:function site earns an
 // explicit allowance with a reason.
@@ -296,12 +302,18 @@ func collectHardcodedHostRunnerSites(t *testing.T, repoRoot string) []hostRunner
 				ast.Inspect(node, func(node ast.Node) bool {
 					switch node := node.(type) {
 					case *ast.CompositeLit:
-						if isSelector(node.Type, "subprocess", "ExecRunner") {
+						switch {
+						case isSelector(node.Type, "subprocess", "ExecRunner"):
 							sites = append(sites, hostRunnerSite{key: key, kind: "subprocess.ExecRunner{}", position: fset.Position(node.Pos())})
+						case isSelector(node.Type, "exec", "Cmd"):
+							sites = append(sites, hostRunnerSite{key: key, kind: "exec.Cmd{}", position: fset.Position(node.Pos())})
 						}
 					case *ast.CallExpr:
-						if isSelector(node.Fun, "exec", "Command") || isSelector(node.Fun, "exec", "CommandContext") {
+						switch {
+						case isSelector(node.Fun, "exec", "Command") || isSelector(node.Fun, "exec", "CommandContext"):
 							sites = append(sites, hostRunnerSite{key: key, kind: "exec.Command", position: fset.Position(node.Pos())})
+						case isNewOfSelector(node, "subprocess", "ExecRunner"):
+							sites = append(sites, hostRunnerSite{key: key, kind: "new(subprocess.ExecRunner)", position: fset.Position(node.Pos())})
 						}
 					}
 					return true
@@ -322,6 +334,72 @@ func collectHardcodedHostRunnerSites(t *testing.T, repoRoot string) []hostRunner
 	return sites
 }
 
+// GITMOOT-COC IMPLEMENT: these fixtures pin both newly covered constructions
+// and the deliberately unsupported local-function-value indirection.
+func TestHostRunnerGuardDetectsExecCmdCompositeLiterals(t *testing.T) {
+	sites := collectHostRunnerFixtureSites(t, `package cli
+
+import "os/exec"
+
+func fixture() {
+	_ = exec.Cmd{Path: "/bin/true"}
+	_ = &exec.Cmd{Path: "/bin/true"}
+}
+`)
+	assertHostRunnerFixtureKinds(t, sites, "exec.Cmd{}", "exec.Cmd{}")
+}
+
+func TestHostRunnerGuardDetectsNewExecRunner(t *testing.T) {
+	sites := collectHostRunnerFixtureSites(t, `package cli
+
+import "github.com/gitmoot/gitmoot/internal/subprocess"
+
+func fixture() subprocess.Runner {
+	return new(subprocess.ExecRunner)
+}
+`)
+	assertHostRunnerFixtureKinds(t, sites, "new(subprocess.ExecRunner)")
+}
+
+func TestHostRunnerGuardDocumentsLocalFunctionValueBlindSpot(t *testing.T) {
+	sites := collectHostRunnerFixtureSites(t, `package cli
+
+import "os/exec"
+
+func fixture() *exec.Cmd {
+	command := exec.Command
+	return command("/bin/true")
+}
+`)
+	assertHostRunnerFixtureKinds(t, sites)
+}
+
+func collectHostRunnerFixtureSites(t *testing.T, source string) []hostRunnerSite {
+	t.Helper()
+	repoRoot := t.TempDir()
+	for _, dir := range []string{"internal/cli", "internal/workflow", "internal/daemon"} {
+		if err := os.MkdirAll(filepath.Join(repoRoot, filepath.FromSlash(dir)), 0o755); err != nil {
+			t.Fatalf("create fixture directory %s: %v", dir, err)
+		}
+	}
+	fixture := filepath.Join(repoRoot, "internal", "cli", "fixture.go")
+	if err := os.WriteFile(fixture, []byte(source), 0o600); err != nil {
+		t.Fatalf("write host-runner fixture: %v", err)
+	}
+	return collectHardcodedHostRunnerSites(t, repoRoot)
+}
+
+func assertHostRunnerFixtureKinds(t *testing.T, sites []hostRunnerSite, want ...string) {
+	t.Helper()
+	got := make([]string, 0, len(sites))
+	for _, site := range sites {
+		got = append(got, site.kind)
+	}
+	if fmt.Sprint(got) != fmt.Sprint(want) {
+		t.Fatalf("hardcoded host-runner fixture sites = %v, want %v", got, want)
+	}
+}
+
 func isSelector(node ast.Expr, pkg, name string) bool {
 	selector, ok := node.(*ast.SelectorExpr)
 	if !ok || selector.Sel.Name != name {
@@ -329,6 +407,11 @@ func isSelector(node ast.Expr, pkg, name string) bool {
 	}
 	ident, ok := selector.X.(*ast.Ident)
 	return ok && ident.Name == pkg
+}
+
+func isNewOfSelector(call *ast.CallExpr, pkg, name string) bool {
+	ident, ok := call.Fun.(*ast.Ident)
+	return ok && ident.Name == "new" && len(call.Args) == 1 && isSelector(call.Args[0], pkg, name)
 }
 
 func reportUnallowlistedHostRunner(t *testing.T, site hostRunnerSite) {

--- a/internal/cli/host_runner_guard_test.go
+++ b/internal/cli/host_runner_guard_test.go
@@ -253,7 +253,7 @@ func TestJobPathsDoNotHardcodeHostRunners(t *testing.T) {
 }
 
 // collectHardcodedHostRunnerSites is intentionally a syntactic guard. Direct
-// exec.Command calls, exec.Cmd{} and &exec.Cmd{} composite literals,
+// exec.Command and exec.CommandContext calls, exec.Cmd{} and &exec.Cmd{} literals,
 // subprocess.ExecRunner composite literals, and new(subprocess.ExecRunner)
 // allocations are detected.
 // The scanner does not type-check, so it cannot follow function or type aliases,


### PR DESCRIPTION
## What

Fixes #1606. The host-runner guard's documented blind-spot list was incomplete — and **stayed**
incomplete across three rounds of adding to it.

## Why the approach changed, which is the real content here

Three panel rounds produced **six** undetected forms, each measured at 0 sites against the real
collector, each a different Go construction:

```
round 1 (issue)  &exec.Cmd{} literal · new(subprocess.ExecRunner) · calls through function values
round 2 (panel)  var runner subprocess.ExecRunner  ·  command := new(exec.Cmd)
round 3 (panel)  subprocess.ExecRunner(struct{}{})           <- a type conversion
```

Every fix was correct and every finding was real. **The method could not terminate**: the comment
stated its complement by *enumerating* construction forms, and Go has unbounded ways to produce a
value — typed and elided literals, `new()`, zero-value declarations, conversions, returns, reflection.

**The evidence was inside the artefact.** That same comment already stated the API axis structurally
(*"process-launch APIs other than the fixed forms above"*), and **that half needed zero amendments
across three rounds while the enumerated half needed three.** One comment, two halves, three rounds.

## The change

Give the construction axis the same treatment:

> The scanner does not type-check. **It recognises exactly the listed syntactic forms. Any other syntax
> that yields these types is invisible to it** — for example elided-element-type literals, zero-value
> declarations, `new()` allocations, and type conversions.

The six found forms become **examples, not the definition**. A seventh form is now already described, so
it needs no amendment. `CONTRIBUTING.md` mirrors the same contract.

Along the way the positive list was also corrected in both directions: `exec.CommandContext` added (it
is detected but was unlisted), and the composite-literal claim narrowed to **explicitly typed** forms
(the elided spelling is not detected).

Wording only — no detector change, no test logic, no fixtures, no allowlist movement.

## Verification

Both review families approve at this head. The final round was dispatched with **inverted finding
criteria**: a seventh undetected form counts as the statement *working*, not a defect.

One family **invented and compiled 16 forms** to attack the complement. 14 returned 0 sites and every
one is described by the wording — including five constructions no prior round tried: a local type
alias, a nested elided array, an anonymous-struct zero-value field, a generic instantiation, and
`reflect.New`. It reported them as passes, and disclosed that 2 of its 16 returned 1 site because they
embedded a positive-list literal. Positive list verified form-by-form: **0 named-as-detected forms that
are not detected**.

Full suite at this exact head from a clone under `/root`: build ok, `go generate` + `git diff
--exit-code` clean, vet ok, **41 packages ok, exit 0**.

## Known, filed separately

Two non-blocking wording inaccuracies remain, both raised by the panel and both filed rather than
folded in, since the approach question is settled: the `new()` complement example reads loosely against
the positive list's `new(subprocess.ExecRunner)`, and "test files are excluded" holds only for the
`_test.go` suffix — `.go` files under `testdata/` inside a scanned directory are scanned.

-- GITMOOT-COC
