### PR TITLE
Gitmoot: GITMOOT-COC — IMPLEMENT BRIEF: make the wake-outbox health

### DIFF
--- a/internal/cli/daemon_scheduler.go
+++ b/internal/cli/daemon_scheduler.go
@@ -1324,8 +1324,11 @@ func runEnabledRepoWorkerTicksTracked(ctx context.Context, store *db.Store, work
 	// #1200/#1201 durable addressed-note wakes belong to the shared store, not
 	// any repository. Drain before listing repos so zero enabled repos cannot
 	// suppress delivery or hide an unreadable outbox behind a healthy fleet tick.
-	if err := drainFleetReplyWakeOutbox(ctx, store, worker, now); err != nil {
+	health, err := drainFleetReplyWakeOutbox(ctx, store, worker, now)
+	if err != nil {
 		writeLine(stdout, "reply wake outbox drain unhealthy: %v", err)
+	} else if health.inert > 0 {
+		writeLine(stdout, "reply wake outbox drain health: %s", health)
 	}
 	if tracker.staleTaskLaneLockReclaimDue(now) {
 		if err := reclaimStaleTaskLaneLocks(ctx, store, "", stdout, now); err != nil {
@@ -1397,11 +1400,12 @@ func runEnabledRepoWorkerTicksTracked(ctx context.Context, store *db.Store, work
 	return nil
 }
 
-func drainFleetReplyWakeOutbox(ctx context.Context, store *db.Store, worker jobWorker, now time.Time) error {
-	if err := drainReplyWakeOutbox(ctx, store, now, worker.replyWakeDelivery); err != nil {
-		return fmt.Errorf("reply wake outbox drain failed: %w", err)
+func drainFleetReplyWakeOutbox(ctx context.Context, store *db.Store, worker jobWorker, now time.Time) (replyWakeOutboxHealth, error) {
+	health, err := drainReplyWakeOutboxWithHealth(ctx, store, now, worker.replyWakeDelivery)
+	if err != nil {
+		return health, fmt.Errorf("reply wake outbox drain failed: %w", err)
 	}
-	return nil
+	return health, nil
 }
 
 func jobStateCanRetryAdvancement(state string) bool {

--- a/internal/cli/daemon_supervision.go
+++ b/internal/cli/daemon_supervision.go
@@ -728,8 +728,11 @@ func startSingleRepoWorkerLoop(ctx context.Context, interval time.Duration, stor
 		// The durable reply outbox is store-global maintenance. Run it once at
 		// the supervisor boundary, outside the repository tick, matching the
 		// multi-repo fleet loop.
-		if err := drainFleetReplyWakeOutbox(ctx, store, worker, now); err != nil {
+		health, err := drainFleetReplyWakeOutbox(ctx, store, worker, now)
+		if err != nil {
 			writeLine(stdout, "reply wake outbox drain unhealthy: %v", err)
+		} else if health.inert > 0 {
+			writeLine(stdout, "reply wake outbox drain health: %s", health)
 		}
 		// The checkout lock now guards the TICK (maintenance + claim/dispatch),
 		// not whole job runs: dispatched jobs execute on their own goroutines

--- a/internal/cli/org_directive_test.go
+++ b/internal/cli/org_directive_test.go
@@ -246,7 +246,6 @@ func TestDirectiveWakeOutboxIsConfigInert(t *testing.T) {
 		store,
 		createdAt.Add(-time.Minute),
 		replyWakeTestDeliveryResolver(deliverySink),
-		nil,
 	)
 	if err != nil || health.pending != 0 || health.inert != 1 {
 		t.Fatalf("config-inert directive health: %s err=%v", health, err)

--- a/internal/cli/org_directive_test.go
+++ b/internal/cli/org_directive_test.go
@@ -246,6 +246,7 @@ func TestDirectiveWakeOutboxIsConfigInert(t *testing.T) {
 		store,
 		createdAt.Add(-time.Minute),
 		replyWakeTestDeliveryResolver(deliverySink),
+		nil,
 	)
 	if err != nil || health.pending != 0 || health.inert != 1 {
 		t.Fatalf("config-inert directive health: %s err=%v", health, err)

--- a/internal/cli/org_directive_test.go
+++ b/internal/cli/org_directive_test.go
@@ -241,8 +241,14 @@ func TestDirectiveWakeOutboxIsConfigInert(t *testing.T) {
 	if err := drainReplyWakeOutbox(context.Background(), store, createdAt.Add(replyWakeCoalescingWindow+time.Second), replyWakeTestDeliveryResolver(deliverySink)); err != nil {
 		t.Fatalf("config-inert drain for directive %d: %v", directive.ID, err)
 	}
-	if err := wakeOutboxObligationHealth(context.Background(), store, createdAt.Add(-time.Minute)); err != nil {
-		t.Fatalf("config-inert directive health: %v", err)
+	health, err := wakeOutboxObligationHealth(
+		context.Background(),
+		store,
+		createdAt.Add(-time.Minute),
+		replyWakeTestDeliveryResolver(deliverySink),
+	)
+	if err != nil || health.pending != 0 || health.inert != 1 {
+		t.Fatalf("config-inert directive health: %s err=%v", health, err)
 	}
 	stillPending, err := store.ListWakeOutbox(context.Background(), db.WakeOutboxStatePending)
 	if err != nil || len(stillPending) != 1 || wake.promptCalls != 0 {

--- a/internal/cli/reply_wake_outbox.go
+++ b/internal/cli/reply_wake_outbox.go
@@ -35,8 +35,8 @@ type replyWakeDeliveryResolver func(context.Context) (replyWakeDelivery, error)
 type replyWakeOutboxHealth struct {
 	pending int
 	inert   int
-	// routeRemoved means the row matched an earlier authoritative rule
-	// snapshot in this drain, but not the final snapshot.
+	// routeRemoved means a durable tombstone proves that a matching rule was
+	// deleted after the pending row existed.
 	routeRemoved  int
 	agedAttempted int
 }
@@ -188,7 +188,34 @@ func wakeOutboxObligationHealth(
 	if err != nil {
 		return replyWakeOutboxHealth{}, fmt.Errorf("classify wake outbox obligations: %w", err)
 	}
-	deletedRules, err := store.ListDeletedEventRules(ctx)
+	type unmatchedWakeObligation struct {
+		event     events.Event
+		createdAt time.Time
+	}
+	unmatched := make([]unmatchedWakeObligation, 0, len(obligations.Pending))
+	routes := make([]db.EventRuleRoute, 0, len(obligations.Pending))
+	seenRoutes := make(map[string]struct{})
+	for _, obligation := range obligations.Pending {
+		event, err := wakeOutboxEvent([]db.WakeOutboxObligation{obligation}, attemptedBefore)
+		if err != nil {
+			return replyWakeOutboxHealth{}, fmt.Errorf("classify wake outbox row %d: %w", obligation.ID, err)
+		}
+		if len(matchingWakeRules(delivery.rules, event)) > 0 {
+			health.pending++
+			continue
+		}
+		createdAt, err := time.Parse(time.RFC3339Nano, obligation.CreatedAt)
+		if err != nil {
+			return replyWakeOutboxHealth{}, fmt.Errorf("parse wake outbox created_at for row %d: %w", obligation.ID, err)
+		}
+		unmatched = append(unmatched, unmatchedWakeObligation{event: event, createdAt: createdAt})
+		key := wakeRuleRouteKey(event.WakeTargetRole, event.WakeKind)
+		if _, ok := seenRoutes[key]; !ok {
+			seenRoutes[key] = struct{}{}
+			routes = append(routes, db.EventRuleRoute{OnKind: event.WakeKind, WakeRole: event.WakeTargetRole})
+		}
+	}
+	deletedRules, err := store.ListDeletedEventRulesForRoutes(ctx, routes)
 	if err != nil {
 		return replyWakeOutboxHealth{}, fmt.Errorf("classify wake outbox obligations against deleted rules: %w", err)
 	}
@@ -196,24 +223,13 @@ func wakeOutboxObligationHealth(
 	if err != nil {
 		return replyWakeOutboxHealth{}, fmt.Errorf("classify wake outbox obligations against deleted rules: %w", err)
 	}
-	for _, obligation := range obligations.Pending {
-		event, err := wakeOutboxEvent([]db.WakeOutboxObligation{obligation}, attemptedBefore)
-		if err != nil {
-			return replyWakeOutboxHealth{}, fmt.Errorf("classify wake outbox row %d: %w", obligation.ID, err)
-		}
-		if len(matchingWakeRules(delivery.rules, event)) == 0 {
-			createdAt, err := time.Parse(time.RFC3339Nano, obligation.CreatedAt)
-			if err != nil {
-				return replyWakeOutboxHealth{}, fmt.Errorf("parse wake outbox created_at for row %d: %w", obligation.ID, err)
-			}
-			if matchesDeletedWakeRule(deletedRulesAt, event, createdAt) {
-				health.routeRemoved++
-				continue
-			}
-			health.inert++
+	for _, obligation := range unmatched {
+		deletions := deletedRulesAt[wakeRuleRouteKey(obligation.event.WakeTargetRole, obligation.event.WakeKind)]
+		if matchesDeletedWakeRule(deletions, obligation.event, obligation.createdAt) {
+			health.routeRemoved++
 			continue
 		}
-		health.pending++
+		health.inert++
 	}
 	if health.pending == 0 && health.routeRemoved == 0 && health.agedAttempted == 0 {
 		return health, nil
@@ -226,16 +242,21 @@ type deletedWakeRule struct {
 	deletedAt time.Time
 }
 
-func parseDeletedWakeRules(deletions []db.DeletedEventRule) ([]deletedWakeRule, error) {
-	parsed := make([]deletedWakeRule, 0, len(deletions))
+func parseDeletedWakeRules(deletions []db.DeletedEventRule) (map[string][]deletedWakeRule, error) {
+	parsed := make(map[string][]deletedWakeRule)
 	for _, deletion := range deletions {
 		deletedAt, err := time.Parse(time.RFC3339Nano, deletion.DeletedAt)
 		if err != nil {
 			return nil, fmt.Errorf("parse deletion time for event rule %q: %w", deletion.ID, err)
 		}
-		parsed = append(parsed, deletedWakeRule{rule: deletion.EventRule, deletedAt: deletedAt})
+		key := wakeRuleRouteKey(deletion.WakeRole, deletion.OnKind)
+		parsed[key] = append(parsed[key], deletedWakeRule{rule: deletion.EventRule, deletedAt: deletedAt})
 	}
 	return parsed, nil
+}
+
+func wakeRuleRouteKey(wakeRole, onKind string) string {
+	return strings.ToLower(strings.TrimSpace(wakeRole)) + "\x00" + strings.ToLower(strings.TrimSpace(onKind))
 }
 
 func matchesDeletedWakeRule(deletions []deletedWakeRule, event events.Event, rowCreatedAt time.Time) bool {

--- a/internal/cli/reply_wake_outbox.go
+++ b/internal/cli/reply_wake_outbox.go
@@ -33,16 +33,20 @@ type replyWakeDelivery struct {
 type replyWakeDeliveryResolver func(context.Context) (replyWakeDelivery, error)
 
 type replyWakeOutboxHealth struct {
-	pending       int
-	inert         int
+	pending int
+	inert   int
+	// routeRemoved means the row matched an earlier authoritative rule
+	// snapshot in this drain, but not the final snapshot.
+	routeRemoved  int
 	agedAttempted int
 }
 
 func (h replyWakeOutboxHealth) String() string {
 	return fmt.Sprintf(
-		"pending=%d inert=%d aged_attempted=%d",
+		"pending=%d inert=%d route_removed=%d aged_attempted=%d",
 		h.pending,
 		h.inert,
+		h.routeRemoved,
 		h.agedAttempted,
 	)
 }
@@ -93,6 +97,9 @@ func drainReplyWakeOutboxWithHealth(ctx context.Context, store *db.Store, now ti
 		keys = append(keys, key)
 	}
 	sort.Strings(keys)
+	// Event-rule deletion is a hard delete, so the store has no durable route
+	// history. Preserve only what this drain can prove from snapshots it read.
+	previouslyRoutable := make(map[int64]struct{})
 
 	for _, key := range keys {
 		items := groups[key]
@@ -132,6 +139,14 @@ func drainReplyWakeOutboxWithHealth(ctx context.Context, store *db.Store, now ti
 			if err != nil {
 				return replyWakeOutboxHealth{}, fmt.Errorf("resolve wake outbox delivery: %w", err)
 			}
+			if err := recordRoutableWakeOutboxObligations(
+				delivery.rules,
+				obligations.Pending,
+				now,
+				previouslyRoutable,
+			); err != nil {
+				return replyWakeOutboxHealth{}, err
+			}
 			if delivery.sink == nil {
 				break
 			}
@@ -158,10 +173,34 @@ func drainReplyWakeOutboxWithHealth(ctx context.Context, store *db.Store, now ti
 			start = end
 		}
 	}
-	return wakeOutboxObligationHealth(ctx, store, attemptedBefore, resolve)
+	return wakeOutboxObligationHealth(ctx, store, attemptedBefore, resolve, previouslyRoutable)
 }
 
-func wakeOutboxObligationHealth(ctx context.Context, store *db.Store, attemptedBefore time.Time, resolve replyWakeDeliveryResolver) (replyWakeOutboxHealth, error) {
+func recordRoutableWakeOutboxObligations(
+	rules []db.EventRule,
+	obligations []db.WakeOutboxObligation,
+	now time.Time,
+	previouslyRoutable map[int64]struct{},
+) error {
+	for _, obligation := range obligations {
+		event, err := wakeOutboxEvent([]db.WakeOutboxObligation{obligation}, now)
+		if err != nil {
+			return fmt.Errorf("classify wake outbox row %d against delivery rules: %w", obligation.ID, err)
+		}
+		if len(matchingWakeRules(rules, event)) > 0 {
+			previouslyRoutable[obligation.ID] = struct{}{}
+		}
+	}
+	return nil
+}
+
+func wakeOutboxObligationHealth(
+	ctx context.Context,
+	store *db.Store,
+	attemptedBefore time.Time,
+	resolve replyWakeDeliveryResolver,
+	previouslyRoutable map[int64]struct{},
+) (replyWakeOutboxHealth, error) {
 	obligations, err := store.ListWakeOutboxObligations(ctx, attemptedBefore)
 	if err != nil {
 		return replyWakeOutboxHealth{}, fmt.Errorf("read wake outbox obligations: %w", err)
@@ -186,12 +225,16 @@ func wakeOutboxObligationHealth(ctx context.Context, store *db.Store, attemptedB
 			return replyWakeOutboxHealth{}, fmt.Errorf("classify wake outbox row %d: %w", obligation.ID, err)
 		}
 		if len(matchingWakeRules(delivery.rules, event)) == 0 {
+			if _, wasRoutable := previouslyRoutable[obligation.ID]; wasRoutable {
+				health.routeRemoved++
+				continue
+			}
 			health.inert++
 			continue
 		}
 		health.pending++
 	}
-	if health.pending == 0 && health.agedAttempted == 0 {
+	if health.pending == 0 && health.routeRemoved == 0 && health.agedAttempted == 0 {
 		return health, nil
 	}
 	return health, fmt.Errorf("wake outbox has outstanding obligations: %s", health)

--- a/internal/cli/reply_wake_outbox.go
+++ b/internal/cli/reply_wake_outbox.go
@@ -32,27 +32,47 @@ type replyWakeDelivery struct {
 
 type replyWakeDeliveryResolver func(context.Context) (replyWakeDelivery, error)
 
+type replyWakeOutboxHealth struct {
+	pending       int
+	inert         int
+	agedAttempted int
+}
+
+func (h replyWakeOutboxHealth) String() string {
+	return fmt.Sprintf(
+		"pending=%d inert=%d aged_attempted=%d",
+		h.pending,
+		h.inert,
+		h.agedAttempted,
+	)
+}
+
 // drainReplyWakeOutbox is a store-global daemon operation. It deliberately
 // reads durable work before resolving delivery: unreadable outbox state and an
 // empty outbox therefore cannot collapse into the same result.
 func drainReplyWakeOutbox(ctx context.Context, store *db.Store, now time.Time, resolve replyWakeDeliveryResolver) error {
+	_, err := drainReplyWakeOutboxWithHealth(ctx, store, now, resolve)
+	return err
+}
+
+func drainReplyWakeOutboxWithHealth(ctx context.Context, store *db.Store, now time.Time, resolve replyWakeDeliveryResolver) (replyWakeOutboxHealth, error) {
 	if store == nil {
-		return errors.New("wake outbox store is required")
+		return replyWakeOutboxHealth{}, errors.New("wake outbox store is required")
 	}
 	attemptedBefore := now.UTC().Add(-replyWakeAttemptedUnknownAfter)
 	obligations, err := store.ListWakeOutboxObligations(ctx, attemptedBefore)
 	if err != nil || obligations.Len() == 0 {
-		return err
+		return replyWakeOutboxHealth{}, err
 	}
 
 	agedAttempted := len(obligations.AgedAttempted)
 	if agedAttempted > 0 {
 		expired, err := store.ExpireAgedWakeOutbox(ctx, attemptedBefore, now)
 		if err != nil {
-			return fmt.Errorf("expire aged attempted wake outbox: %w", err)
+			return replyWakeOutboxHealth{}, fmt.Errorf("expire aged attempted wake outbox: %w", err)
 		}
 		if len(expired) > 0 {
-			return fmt.Errorf(
+			return replyWakeOutboxHealth{}, fmt.Errorf(
 				"wake outbox delivery unknown: expired %d aged attempted rows without retry",
 				len(expired),
 			)
@@ -65,7 +85,7 @@ func drainReplyWakeOutbox(ctx context.Context, store *db.Store, now time.Time, r
 		groups[key] = append(groups[key], entry)
 	}
 	if resolve == nil {
-		return errors.New("wake outbox delivery resolver is required")
+		return replyWakeOutboxHealth{}, errors.New("wake outbox delivery resolver is required")
 	}
 
 	keys := make([]string, 0, len(groups))
@@ -79,14 +99,14 @@ func drainReplyWakeOutbox(ctx context.Context, store *db.Store, now time.Time, r
 		for start := 0; start < len(items); {
 			startedAt, err := time.Parse(time.RFC3339Nano, items[start].CreatedAt)
 			if err != nil {
-				return fmt.Errorf("parse wake outbox created_at for row %d: %w", items[start].ID, err)
+				return replyWakeOutboxHealth{}, fmt.Errorf("parse wake outbox created_at for row %d: %w", items[start].ID, err)
 			}
 			deadline := startedAt.Add(replyWakeCoalescingWindow)
 			end := start + 1
 			for end < len(items) {
 				createdAt, err := time.Parse(time.RFC3339Nano, items[end].CreatedAt)
 				if err != nil {
-					return fmt.Errorf("parse wake outbox created_at for row %d: %w", items[end].ID, err)
+					return replyWakeOutboxHealth{}, fmt.Errorf("parse wake outbox created_at for row %d: %w", items[end].ID, err)
 				}
 				if !createdAt.Before(deadline) {
 					break
@@ -102,7 +122,7 @@ func drainReplyWakeOutbox(ctx context.Context, store *db.Store, now time.Time, r
 			batch := items[start:end]
 			event, err := wakeOutboxEvent(batch, now)
 			if err != nil {
-				return err
+				return replyWakeOutboxHealth{}, err
 			}
 			// Authorization is deliberately batch-scoped and pre-claim. A rule
 			// removed while an earlier synchronous batch is delivering cannot
@@ -110,7 +130,7 @@ func drainReplyWakeOutbox(ctx context.Context, store *db.Store, now time.Time, r
 			// attempted rows on a routing-store failure.
 			delivery, err := resolve(ctx)
 			if err != nil {
-				return fmt.Errorf("resolve wake outbox delivery: %w", err)
+				return replyWakeOutboxHealth{}, fmt.Errorf("resolve wake outbox delivery: %w", err)
 			}
 			if delivery.sink == nil {
 				break
@@ -127,44 +147,54 @@ func drainReplyWakeOutbox(ctx context.Context, store *db.Store, now time.Time, r
 			}
 			claimed, err := store.ClaimWakeOutbox(ctx, ids, now)
 			if err != nil {
-				return err
+				return replyWakeOutboxHealth{}, err
 			}
 			if claimed {
 				event.WakeOutboxIDs = ids
 				if err := emitReplyWakeOutboxEvent(ctx, delivery.sink, event, matchingRules); err != nil {
-					return fmt.Errorf("emit claimed %s wake: %w", event.WakeKind, err)
+					return replyWakeOutboxHealth{}, fmt.Errorf("emit claimed %s wake: %w", event.WakeKind, err)
 				}
 			}
 			start = end
 		}
 	}
-	return wakeOutboxObligationHealth(ctx, store, attemptedBefore)
+	return wakeOutboxObligationHealth(ctx, store, attemptedBefore, resolve)
 }
 
-func wakeOutboxObligationHealth(ctx context.Context, store *db.Store, attemptedBefore time.Time) error {
+func wakeOutboxObligationHealth(ctx context.Context, store *db.Store, attemptedBefore time.Time, resolve replyWakeDeliveryResolver) (replyWakeOutboxHealth, error) {
 	obligations, err := store.ListWakeOutboxObligations(ctx, attemptedBefore)
 	if err != nil {
-		return fmt.Errorf("read wake outbox obligations: %w", err)
+		return replyWakeOutboxHealth{}, fmt.Errorf("read wake outbox obligations: %w", err)
 	}
-	pending := 0
+	health := replyWakeOutboxHealth{agedAttempted: len(obligations.AgedAttempted)}
+	if len(obligations.Pending) == 0 {
+		if health.agedAttempted == 0 {
+			return health, nil
+		}
+		return health, fmt.Errorf("wake outbox has outstanding obligations: %s", health)
+	}
+	if resolve == nil {
+		return replyWakeOutboxHealth{}, errors.New("classify wake outbox obligations: delivery resolver is required")
+	}
+	delivery, err := resolve(ctx)
+	if err != nil {
+		return replyWakeOutboxHealth{}, fmt.Errorf("classify wake outbox obligations: %w", err)
+	}
 	for _, obligation := range obligations.Pending {
-		// Directives are config-inert by contract: without a matching rule their
-		// durable row remains pending for later configuration, not as a permanent
-		// daemon health error stream.
-		if strings.HasPrefix(strings.ToLower(obligation.CoalesceKey), db.WakeOutboxDirectiveCoalescePrefix) {
+		event, err := wakeOutboxEvent([]db.WakeOutboxObligation{obligation}, attemptedBefore)
+		if err != nil {
+			return replyWakeOutboxHealth{}, fmt.Errorf("classify wake outbox row %d: %w", obligation.ID, err)
+		}
+		if len(matchingWakeRules(delivery.rules, event)) == 0 {
+			health.inert++
 			continue
 		}
-		pending++
+		health.pending++
 	}
-	agedAttempted := len(obligations.AgedAttempted)
-	if pending == 0 && agedAttempted == 0 {
-		return nil
+	if health.pending == 0 && health.agedAttempted == 0 {
+		return health, nil
 	}
-	return fmt.Errorf(
-		"wake outbox has outstanding obligations: pending=%d aged_attempted=%d",
-		pending,
-		agedAttempted,
-	)
+	return health, fmt.Errorf("wake outbox has outstanding obligations: %s", health)
 }
 
 type synchronousWakeOutboxSink interface {

--- a/internal/cli/reply_wake_outbox.go
+++ b/internal/cli/reply_wake_outbox.go
@@ -97,10 +97,6 @@ func drainReplyWakeOutboxWithHealth(ctx context.Context, store *db.Store, now ti
 		keys = append(keys, key)
 	}
 	sort.Strings(keys)
-	// Event-rule deletion is a hard delete, so the store has no durable route
-	// history. Preserve only what this drain can prove from snapshots it read.
-	previouslyRoutable := make(map[int64]struct{})
-
 	for _, key := range keys {
 		items := groups[key]
 		for start := 0; start < len(items); {
@@ -139,14 +135,6 @@ func drainReplyWakeOutboxWithHealth(ctx context.Context, store *db.Store, now ti
 			if err != nil {
 				return replyWakeOutboxHealth{}, fmt.Errorf("resolve wake outbox delivery: %w", err)
 			}
-			if err := recordRoutableWakeOutboxObligations(
-				delivery.rules,
-				obligations.Pending,
-				now,
-				previouslyRoutable,
-			); err != nil {
-				return replyWakeOutboxHealth{}, err
-			}
 			if delivery.sink == nil {
 				break
 			}
@@ -173,25 +161,7 @@ func drainReplyWakeOutboxWithHealth(ctx context.Context, store *db.Store, now ti
 			start = end
 		}
 	}
-	return wakeOutboxObligationHealth(ctx, store, attemptedBefore, resolve, previouslyRoutable)
-}
-
-func recordRoutableWakeOutboxObligations(
-	rules []db.EventRule,
-	obligations []db.WakeOutboxObligation,
-	now time.Time,
-	previouslyRoutable map[int64]struct{},
-) error {
-	for _, obligation := range obligations {
-		event, err := wakeOutboxEvent([]db.WakeOutboxObligation{obligation}, now)
-		if err != nil {
-			return fmt.Errorf("classify wake outbox row %d against delivery rules: %w", obligation.ID, err)
-		}
-		if len(matchingWakeRules(rules, event)) > 0 {
-			previouslyRoutable[obligation.ID] = struct{}{}
-		}
-	}
-	return nil
+	return wakeOutboxObligationHealth(ctx, store, attemptedBefore, resolve)
 }
 
 func wakeOutboxObligationHealth(
@@ -199,7 +169,6 @@ func wakeOutboxObligationHealth(
 	store *db.Store,
 	attemptedBefore time.Time,
 	resolve replyWakeDeliveryResolver,
-	previouslyRoutable map[int64]struct{},
 ) (replyWakeOutboxHealth, error) {
 	obligations, err := store.ListWakeOutboxObligations(ctx, attemptedBefore)
 	if err != nil {
@@ -219,13 +188,25 @@ func wakeOutboxObligationHealth(
 	if err != nil {
 		return replyWakeOutboxHealth{}, fmt.Errorf("classify wake outbox obligations: %w", err)
 	}
+	deletedRules, err := store.ListDeletedEventRules(ctx)
+	if err != nil {
+		return replyWakeOutboxHealth{}, fmt.Errorf("classify wake outbox obligations against deleted rules: %w", err)
+	}
+	deletedRulesAt, err := parseDeletedWakeRules(deletedRules)
+	if err != nil {
+		return replyWakeOutboxHealth{}, fmt.Errorf("classify wake outbox obligations against deleted rules: %w", err)
+	}
 	for _, obligation := range obligations.Pending {
 		event, err := wakeOutboxEvent([]db.WakeOutboxObligation{obligation}, attemptedBefore)
 		if err != nil {
 			return replyWakeOutboxHealth{}, fmt.Errorf("classify wake outbox row %d: %w", obligation.ID, err)
 		}
 		if len(matchingWakeRules(delivery.rules, event)) == 0 {
-			if _, wasRoutable := previouslyRoutable[obligation.ID]; wasRoutable {
+			createdAt, err := time.Parse(time.RFC3339Nano, obligation.CreatedAt)
+			if err != nil {
+				return replyWakeOutboxHealth{}, fmt.Errorf("parse wake outbox created_at for row %d: %w", obligation.ID, err)
+			}
+			if matchesDeletedWakeRule(deletedRulesAt, event, createdAt) {
 				health.routeRemoved++
 				continue
 			}
@@ -238,6 +219,35 @@ func wakeOutboxObligationHealth(
 		return health, nil
 	}
 	return health, fmt.Errorf("wake outbox has outstanding obligations: %s", health)
+}
+
+type deletedWakeRule struct {
+	rule      db.EventRule
+	deletedAt time.Time
+}
+
+func parseDeletedWakeRules(deletions []db.DeletedEventRule) ([]deletedWakeRule, error) {
+	parsed := make([]deletedWakeRule, 0, len(deletions))
+	for _, deletion := range deletions {
+		deletedAt, err := time.Parse(time.RFC3339Nano, deletion.DeletedAt)
+		if err != nil {
+			return nil, fmt.Errorf("parse deletion time for event rule %q: %w", deletion.ID, err)
+		}
+		parsed = append(parsed, deletedWakeRule{rule: deletion.EventRule, deletedAt: deletedAt})
+	}
+	return parsed, nil
+}
+
+func matchesDeletedWakeRule(deletions []deletedWakeRule, event events.Event, rowCreatedAt time.Time) bool {
+	for _, deletion := range deletions {
+		if deletion.deletedAt.Before(rowCreatedAt) {
+			continue
+		}
+		if len(matchingWakeRules([]db.EventRule{deletion.rule}, event)) > 0 {
+			return true
+		}
+	}
+	return false
 }
 
 type synchronousWakeOutboxSink interface {

--- a/internal/cli/reply_wake_outbox_test.go
+++ b/internal/cli/reply_wake_outbox_test.go
@@ -195,10 +195,47 @@ func TestWakeOutboxTickHealthIncludesBlockedAndEscalation(t *testing.T) {
 			rules, err := store.ListEventRules(ctx)
 			return replyWakeDelivery{rules: rules}, err
 		},
+		nil,
 	)
 	if err == nil || health.pending != 2 || health.inert != 0 ||
-		!strings.Contains(err.Error(), "pending=2 inert=0 aged_attempted=0") {
+		!strings.Contains(err.Error(), "pending=2 inert=0 route_removed=0 aged_attempted=0") {
 		t.Fatalf("tick health = %s err=%v, want two routable outstanding obligations", health, err)
+	}
+}
+
+func TestWakeOutboxHealthDistinguishesRemovedRouteFromNeverConfigured(t *testing.T) {
+	store := daemonWorkerStore(t)
+	ctx := context.Background()
+	for _, target := range []string{"owner", "worker"} {
+		if _, err := store.InsertWorkflowNote(ctx, db.WorkflowNote{
+			WorkflowID: "release/route-history", Author: "worker", Body: target,
+			AddressedTarget: target,
+		}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	pending, err := store.ListWakeOutbox(ctx, db.WakeOutboxStatePending)
+	if err != nil || len(pending) != 2 {
+		t.Fatalf("pending = %+v, err=%v", pending, err)
+	}
+	previouslyRoutable := make(map[int64]struct{})
+	for _, row := range pending {
+		if row.TargetRole == "owner" {
+			previouslyRoutable[row.ID] = struct{}{}
+		}
+	}
+	health, err := wakeOutboxObligationHealth(
+		ctx,
+		store,
+		time.Now().UTC().Add(-replyWakeAttemptedUnknownAfter),
+		func(context.Context) (replyWakeDelivery, error) {
+			return replyWakeDelivery{}, nil
+		},
+		previouslyRoutable,
+	)
+	if err == nil || health.pending != 0 || health.inert != 1 || health.routeRemoved != 1 ||
+		!strings.Contains(err.Error(), "pending=0 inert=1 route_removed=1 aged_attempted=0") {
+		t.Fatalf("route-history health = %s err=%v", health, err)
 	}
 }
 
@@ -294,7 +331,7 @@ func TestReplyWakeOutboxInertHealthDoesNotEscalateSingleRepoLoop(t *testing.T) {
 		t.Fatalf("inert reply wake health reached escalation ladder: %q", stdout.String())
 	}
 	if strings.Contains(stdout.String(), "reply wake outbox drain unhealthy:") ||
-		!strings.Contains(stdout.String(), "pending=0 inert=1 aged_attempted=0") {
+		!strings.Contains(stdout.String(), "pending=0 inert=1 route_removed=0 aged_attempted=0") {
 		t.Fatalf("inert reply wake health log = %q", stdout.String())
 	}
 }
@@ -611,7 +648,7 @@ func TestReplyWakeOutboxZeroRulesReportsInertWithoutUnhealthy(t *testing.T) {
 	if tickErr != nil {
 		t.Fatalf("fleet tick aborted on inert pending-obligation health: %v", tickErr)
 	}
-	if !strings.Contains(stdout.String(), "reply wake outbox drain health: pending=0 inert=1 aged_attempted=0") ||
+	if !strings.Contains(stdout.String(), "reply wake outbox drain health: pending=0 inert=1 route_removed=0 aged_attempted=0") ||
 		strings.Contains(stdout.String(), "reply wake outbox drain unhealthy:") {
 		t.Fatalf("fleet tick log = %q, want visible inert-only health", stdout.String())
 	}
@@ -664,7 +701,7 @@ func TestReplyWakeOutboxUnrelatedEnabledRuleReportsPendingObligationInert(t *tes
 	if tickErr != nil {
 		t.Fatalf("fleet tick aborted on inert pending-obligation health: %v", tickErr)
 	}
-	if !strings.Contains(stdout.String(), "reply wake outbox drain health: pending=0 inert=1 aged_attempted=0") ||
+	if !strings.Contains(stdout.String(), "reply wake outbox drain health: pending=0 inert=1 route_removed=0 aged_attempted=0") ||
 		strings.Contains(stdout.String(), "reply wake outbox drain unhealthy:") {
 		t.Fatalf("fleet tick log = %q, want visible inert-only health", stdout.String())
 	}
@@ -767,7 +804,8 @@ func TestReplyWakeOutboxRuleDeletedMidDrainRefusesLaterBatch(t *testing.T) {
 	if tickErr != nil {
 		t.Fatalf("fleet tick aborted on later batch refusal: %v", tickErr)
 	}
-	if !strings.Contains(stdout.String(), "outstanding obligations: pending=1") {
+	if !strings.Contains(stdout.String(), "reply wake outbox drain unhealthy:") ||
+		!strings.Contains(stdout.String(), "pending=0 inert=0 route_removed=1 aged_attempted=0") {
 		t.Fatalf("fleet tick log = %q, want later batch refusal", stdout.String())
 	}
 	if wake.promptCalls != 1 {

--- a/internal/cli/reply_wake_outbox_test.go
+++ b/internal/cli/reply_wake_outbox_test.go
@@ -195,7 +195,6 @@ func TestWakeOutboxTickHealthIncludesBlockedAndEscalation(t *testing.T) {
 			rules, err := store.ListEventRules(ctx)
 			return replyWakeDelivery{rules: rules}, err
 		},
-		nil,
 	)
 	if err == nil || health.pending != 2 || health.inert != 0 ||
 		!strings.Contains(err.Error(), "pending=2 inert=0 route_removed=0 aged_attempted=0") {
@@ -206,6 +205,11 @@ func TestWakeOutboxTickHealthIncludesBlockedAndEscalation(t *testing.T) {
 func TestWakeOutboxHealthDistinguishesRemovedRouteFromNeverConfigured(t *testing.T) {
 	store := daemonWorkerStore(t)
 	ctx := context.Background()
+	if err := store.AddEventRule(ctx, db.EventRule{
+		ID: "reply-owner", OnKind: "reply", WakeRole: "owner", Enabled: true,
+	}); err != nil {
+		t.Fatal(err)
+	}
 	for _, target := range []string{"owner", "worker"} {
 		if _, err := store.InsertWorkflowNote(ctx, db.WorkflowNote{
 			WorkflowID: "release/route-history", Author: "worker", Body: target,
@@ -214,15 +218,8 @@ func TestWakeOutboxHealthDistinguishesRemovedRouteFromNeverConfigured(t *testing
 			t.Fatal(err)
 		}
 	}
-	pending, err := store.ListWakeOutbox(ctx, db.WakeOutboxStatePending)
-	if err != nil || len(pending) != 2 {
-		t.Fatalf("pending = %+v, err=%v", pending, err)
-	}
-	previouslyRoutable := make(map[int64]struct{})
-	for _, row := range pending {
-		if row.TargetRole == "owner" {
-			previouslyRoutable[row.ID] = struct{}{}
-		}
+	if err := store.DeleteEventRule(ctx, "reply-owner"); err != nil {
+		t.Fatal(err)
 	}
 	health, err := wakeOutboxObligationHealth(
 		ctx,
@@ -231,11 +228,50 @@ func TestWakeOutboxHealthDistinguishesRemovedRouteFromNeverConfigured(t *testing
 		func(context.Context) (replyWakeDelivery, error) {
 			return replyWakeDelivery{}, nil
 		},
-		previouslyRoutable,
 	)
 	if err == nil || health.pending != 0 || health.inert != 1 || health.routeRemoved != 1 ||
 		!strings.Contains(err.Error(), "pending=0 inert=1 route_removed=1 aged_attempted=0") {
 		t.Fatalf("route-history health = %s err=%v", health, err)
+	}
+}
+
+func TestReplyWakeOutboxMalformedRowDoesNotBlockOtherRoleDelivery(t *testing.T) {
+	store, sink, wake, _ := replyWakeTestHarness(t, []replyWakeTestRole{
+		{"owner", "w1:p1"},
+		{"zulu", "w1:p2"},
+	})
+	ctx := context.Background()
+	for _, target := range []string{"owner", "zulu"} {
+		if _, err := store.InsertWorkflowNote(ctx, db.WorkflowNote{
+			WorkflowID: "release/malformed-isolation", Author: "worker", Body: target,
+			AddressedTarget: target,
+		}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	raw, err := sql.Open("sqlite", store.DatabasePath())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer raw.Close()
+	if _, err := raw.Exec(`UPDATE wake_outbox SET source_kind = 'bogus_kind' WHERE target_role = 'zulu'`); err != nil {
+		t.Fatal(err)
+	}
+
+	err = drainReplyWakeAfterAllRowsAreDueResult(t, store, sink)
+	if err == nil || !strings.Contains(err.Error(), `unsupported source kind "bogus_kind"`) {
+		t.Fatalf("drain error = %v, want malformed zulu row after owner delivery", err)
+	}
+	if wake.promptCalls != 1 || len(wake.panes) != 1 || wake.panes[0] != "w1:p1" {
+		t.Fatalf("wake calls=%d panes=%v prompts=%v, want only owner delivered", wake.promptCalls, wake.panes, wake.prompts)
+	}
+	delivered, err := store.ListWakeOutbox(ctx, db.WakeOutboxStateDelivered)
+	if err != nil || len(delivered) != 1 || delivered[0].TargetRole != "owner" {
+		t.Fatalf("delivered=%+v err=%v, want owner only", delivered, err)
+	}
+	pending, err := store.ListWakeOutbox(ctx, db.WakeOutboxStatePending)
+	if err != nil || len(pending) != 1 || pending[0].TargetRole != "zulu" {
+		t.Fatalf("pending=%+v err=%v, want malformed zulu retained", pending, err)
 	}
 }
 
@@ -818,6 +854,22 @@ func TestReplyWakeOutboxRuleDeletedMidDrainRefusesLaterBatch(t *testing.T) {
 	pending, err := store.ListWakeOutbox(ctx, db.WakeOutboxStatePending)
 	if err != nil || len(pending) != 1 || pending[0].SourceID != fmt.Sprint(second.ID) || pending[0].AttemptCount != 0 {
 		t.Fatalf("pending later batch = %+v, err=%v", pending, err)
+	}
+
+	stdout.Reset()
+	tickErr = runEnabledRepoWorkerTicksTracked(
+		ctx, store, worker, 0, "", &stdout,
+		base.Add(2*replyWakeCoalescingWindow+2*time.Second), nil, nil,
+	)
+	if tickErr != nil {
+		t.Fatalf("second fleet tick aborted on durable route removal: %v", tickErr)
+	}
+	if !strings.Contains(stdout.String(), "reply wake outbox drain unhealthy:") ||
+		!strings.Contains(stdout.String(), "pending=0 inert=0 route_removed=1 aged_attempted=0") {
+		t.Fatalf("second fleet tick log = %q, want durable later-batch refusal", stdout.String())
+	}
+	if wake.promptCalls != 1 {
+		t.Fatalf("second tick re-emitted refused batch: calls=%d prompts=%v", wake.promptCalls, wake.prompts)
 	}
 }
 

--- a/internal/cli/reply_wake_outbox_test.go
+++ b/internal/cli/reply_wake_outbox_test.go
@@ -235,6 +235,55 @@ func TestWakeOutboxHealthDistinguishesRemovedRouteFromNeverConfigured(t *testing
 	}
 }
 
+func TestWakeOutboxHealthBoundsDeletedRuleLookupToPendingRoutes(t *testing.T) {
+	store := daemonWorkerStore(t)
+	ctx := context.Background()
+	rules := []db.EventRule{{
+		ID: "reply-owner", OnKind: "reply", WakeRole: "owner", Enabled: true,
+	}}
+	for i := 0; i < 100; i++ {
+		rules = append(rules, db.EventRule{
+			ID: fmt.Sprintf("unrelated-%03d", i), OnKind: "reply", WakeRole: "unrelated", Enabled: true,
+		})
+	}
+	if err := store.AddEventRules(ctx, rules); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.InsertWorkflowNote(ctx, db.WorkflowNote{
+		WorkflowID: "release/bounded-route-history", Author: "worker", Body: "owner",
+		AddressedTarget: "owner",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.DeleteEventRule(ctx, "reply-owner"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.DeleteEventRulesForRole(ctx, "unrelated"); err != nil {
+		t.Fatal(err)
+	}
+	raw, err := sql.Open("sqlite", store.DatabasePath())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer raw.Close()
+	if _, err := raw.Exec(`UPDATE event_rule_deletions SET deleted_at = 'malformed' WHERE wake_role = 'unrelated'`); err != nil {
+		t.Fatal(err)
+	}
+
+	health, err := wakeOutboxObligationHealth(
+		ctx,
+		store,
+		time.Now().UTC().Add(-replyWakeAttemptedUnknownAfter),
+		func(context.Context) (replyWakeDelivery, error) {
+			return replyWakeDelivery{}, nil
+		},
+	)
+	if err == nil || health.routeRemoved != 1 || health.inert != 0 || health.pending != 0 ||
+		!strings.Contains(err.Error(), "pending=0 inert=0 route_removed=1 aged_attempted=0") {
+		t.Fatalf("bounded route-history health = %s err=%v, want one relevant tombstone from 101 total", health, err)
+	}
+}
+
 func TestReplyWakeOutboxMalformedRowDoesNotBlockOtherRoleDelivery(t *testing.T) {
 	store, sink, wake, _ := replyWakeTestHarness(t, []replyWakeTestRole{
 		{"owner", "w1:p1"},

--- a/internal/cli/reply_wake_outbox_test.go
+++ b/internal/cli/reply_wake_outbox_test.go
@@ -187,9 +187,18 @@ func TestWakeOutboxTickHealthIncludesBlockedAndEscalation(t *testing.T) {
 	if !kinds["blocked"] || !kinds["escalation"] {
 		t.Fatalf("pending source kinds = %v, want blocked and escalation", kinds)
 	}
-	if err := wakeOutboxObligationHealth(ctx, store, now.Add(-replyWakeAttemptedUnknownAfter)); err == nil ||
-		!strings.Contains(err.Error(), "pending=2") {
-		t.Fatalf("tick health = %v, want two outstanding obligations", err)
+	health, err := wakeOutboxObligationHealth(
+		ctx,
+		store,
+		now.Add(-replyWakeAttemptedUnknownAfter),
+		func(ctx context.Context) (replyWakeDelivery, error) {
+			rules, err := store.ListEventRules(ctx)
+			return replyWakeDelivery{rules: rules}, err
+		},
+	)
+	if err == nil || health.pending != 2 || health.inert != 0 ||
+		!strings.Contains(err.Error(), "pending=2 inert=0 aged_attempted=0") {
+		t.Fatalf("tick health = %s err=%v, want two routable outstanding obligations", health, err)
 	}
 }
 
@@ -202,8 +211,13 @@ func TestReplyWakeOutboxDrainFailureDoesNotAbortRepoWork(t *testing.T) {
 		Repo: "owner/repo", Branch: "main", PullRequest: 1,
 	})
 	if _, err := store.InsertWorkflowNote(context.Background(), db.WorkflowNote{
-		WorkflowID: "release/drain-isolation", Author: "worker", Body: "no matching route",
+		WorkflowID: "release/drain-isolation", Author: "worker", Body: "matching route without a delivery sink",
 		AddressedTarget: "owner",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.AddEventRule(context.Background(), db.EventRule{
+		ID: "reply-owner", OnKind: "reply", WakeRole: "owner", Enabled: true,
 	}); err != nil {
 		t.Fatal(err)
 	}
@@ -227,7 +241,7 @@ func TestReplyWakeOutboxDrainFailureDoesNotAbortRepoWork(t *testing.T) {
 	}
 }
 
-func TestReplyWakeOutboxDrainFailureDoesNotEscalateSingleRepoLoop(t *testing.T) {
+func TestReplyWakeOutboxInertHealthDoesNotEscalateSingleRepoLoop(t *testing.T) {
 	store := daemonWorkerStore(t)
 	seedDaemonWorkerRepo(t, store, "owner/repo", t.TempDir())
 	if _, err := store.InsertWorkflowNote(context.Background(), db.WorkflowNote{
@@ -250,20 +264,20 @@ func TestReplyWakeOutboxDrainFailureDoesNotEscalateSingleRepoLoop(t *testing.T) 
 	)
 
 	deadline := time.Now().Add(5 * time.Second)
-	for strings.Count(stdout.String(), "reply wake outbox drain unhealthy:") <= maxConsecutiveWorkerTickFailures {
+	for strings.Count(stdout.String(), "reply wake outbox drain health:") <= maxConsecutiveWorkerTickFailures {
 		select {
 		case err := <-errCh:
-			t.Fatalf("single-repo loop escalated persistent reply wake drain failure: %v", err)
+			t.Fatalf("single-repo loop escalated persistent inert wake health: %v", err)
 		default:
 		}
 		if time.Now().After(deadline) {
-			t.Fatalf("single-repo loop did not survive beyond %d drain failures; log=%q", maxConsecutiveWorkerTickFailures, stdout.String())
+			t.Fatalf("single-repo loop did not report inert health beyond %d ticks; log=%q", maxConsecutiveWorkerTickFailures, stdout.String())
 		}
 		time.Sleep(time.Millisecond)
 	}
 	select {
 	case err := <-errCh:
-		t.Fatalf("single-repo loop exited after drain failures: %v", err)
+		t.Fatalf("single-repo loop exited while reporting inert health: %v", err)
 	default:
 	}
 
@@ -277,7 +291,11 @@ func TestReplyWakeOutboxDrainFailureDoesNotEscalateSingleRepoLoop(t *testing.T) 
 		t.Fatal("single-repo loop did not stop after cancellation")
 	}
 	if strings.Contains(stdout.String(), "consecutive failures, escalating") {
-		t.Fatalf("reply wake drain failure reached escalation ladder: %q", stdout.String())
+		t.Fatalf("inert reply wake health reached escalation ladder: %q", stdout.String())
+	}
+	if strings.Contains(stdout.String(), "reply wake outbox drain unhealthy:") ||
+		!strings.Contains(stdout.String(), "pending=0 inert=1 aged_attempted=0") {
+		t.Fatalf("inert reply wake health log = %q", stdout.String())
 	}
 }
 
@@ -520,7 +538,7 @@ func TestReplyWakeOutboxReadFailureLogsUnhealthyWithoutAbortingFleetTick(t *test
 	}
 }
 
-func TestReplyWakeOutboxEventRulesReadFailureLogsUnhealthyWithoutAbortingFleetTick(t *testing.T) {
+func TestReplyWakeOutboxHealthFailsClosedWhenEventRulesAreUnreadable(t *testing.T) {
 	store, _, _, home := replyWakeTestHarness(t, []replyWakeTestRole{{"owner", "w1:p1"}})
 	if _, err := store.InsertWorkflowNote(context.Background(), db.WorkflowNote{
 		WorkflowID: "release/rules-read-failure", Author: "worker", Body: "must stay pending",
@@ -550,7 +568,7 @@ func TestReplyWakeOutboxEventRulesReadFailureLogsUnhealthyWithoutAbortingFleetTi
 	var stdout bytes.Buffer
 	tickErr := runEnabledRepoWorkerTicksTracked(
 		context.Background(), store, worker, 0, "", &stdout,
-		createdAt.Add(replyWakeCoalescingWindow+time.Second), nil, nil,
+		createdAt.Add(replyWakeCoalescingWindow-time.Millisecond), nil, nil,
 	)
 	pending, err := store.ListWakeOutbox(context.Background(), db.WakeOutboxStatePending)
 	if err != nil || len(pending) != 1 {
@@ -559,13 +577,14 @@ func TestReplyWakeOutboxEventRulesReadFailureLogsUnhealthyWithoutAbortingFleetTi
 	if tickErr != nil {
 		t.Fatalf("daemon tick aborted after sink resolution skipped a pending wake: %v", tickErr)
 	}
-	if !strings.Contains(stdout.String(), "resolve wake outbox delivery") ||
-		!strings.Contains(stdout.String(), "no such table: event_rules") {
+	if !strings.Contains(stdout.String(), "classify wake outbox obligations") ||
+		!strings.Contains(stdout.String(), "no such table: event_rules") ||
+		strings.Contains(stdout.String(), "inert=") {
 		t.Fatalf("daemon tick log = %q, want explicit event_rules read cause", stdout.String())
 	}
 }
 
-func TestReplyWakeOutboxZeroRulesLogsUnhealthyWithoutAbortingFleetTick(t *testing.T) {
+func TestReplyWakeOutboxZeroRulesReportsInertWithoutUnhealthy(t *testing.T) {
 	home := t.TempDir()
 	paths := config.PathsForHome(home)
 	if err := os.MkdirAll(filepath.Dir(paths.ConfigFile), 0o700); err != nil {
@@ -590,10 +609,11 @@ func TestReplyWakeOutboxZeroRulesLogsUnhealthyWithoutAbortingFleetTick(t *testin
 		time.Now().UTC(), nil, nil,
 	)
 	if tickErr != nil {
-		t.Fatalf("fleet tick aborted on pending-obligation health failure: %v", tickErr)
+		t.Fatalf("fleet tick aborted on inert pending-obligation health: %v", tickErr)
 	}
-	if !strings.Contains(stdout.String(), "outstanding obligations: pending=1") {
-		t.Fatalf("fleet tick log = %q, want pending-obligation health failure", stdout.String())
+	if !strings.Contains(stdout.String(), "reply wake outbox drain health: pending=0 inert=1 aged_attempted=0") ||
+		strings.Contains(stdout.String(), "reply wake outbox drain unhealthy:") {
+		t.Fatalf("fleet tick log = %q, want visible inert-only health", stdout.String())
 	}
 	pending, err := store.ListWakeOutbox(context.Background(), db.WakeOutboxStatePending)
 	if err != nil || len(pending) != 1 {
@@ -601,7 +621,7 @@ func TestReplyWakeOutboxZeroRulesLogsUnhealthyWithoutAbortingFleetTick(t *testin
 	}
 }
 
-func TestReplyWakeOutboxUnrelatedEnabledRuleLeavesPendingObligationUnhealthy(t *testing.T) {
+func TestReplyWakeOutboxUnrelatedEnabledRuleReportsPendingObligationInert(t *testing.T) {
 	home := t.TempDir()
 	paths := config.PathsForHome(home)
 	if err := os.MkdirAll(filepath.Dir(paths.ConfigFile), 0o700); err != nil {
@@ -642,10 +662,11 @@ func TestReplyWakeOutboxUnrelatedEnabledRuleLeavesPendingObligationUnhealthy(t *
 		createdAt.Add(replyWakeCoalescingWindow+time.Second), nil, nil,
 	)
 	if tickErr != nil {
-		t.Fatalf("fleet tick aborted on pending-obligation health failure: %v", tickErr)
+		t.Fatalf("fleet tick aborted on inert pending-obligation health: %v", tickErr)
 	}
-	if !strings.Contains(stdout.String(), "outstanding obligations: pending=1") {
-		t.Fatalf("fleet tick log = %q, want pending-obligation health failure", stdout.String())
+	if !strings.Contains(stdout.String(), "reply wake outbox drain health: pending=0 inert=1 aged_attempted=0") ||
+		strings.Contains(stdout.String(), "reply wake outbox drain unhealthy:") {
+		t.Fatalf("fleet tick log = %q, want visible inert-only health", stdout.String())
 	}
 	pending, err = store.ListWakeOutbox(context.Background(), db.WakeOutboxStatePending)
 	if err != nil || len(pending) != 1 || pending[0].AttemptCount != 0 {

--- a/internal/cli/reply_wake_outbox_test.go
+++ b/internal/cli/reply_wake_outbox_test.go
@@ -379,38 +379,25 @@ func TestReplyWakeOutboxInertHealthDoesNotEscalateSingleRepoLoop(t *testing.T) {
 	live := newDaemonReloadableConfig(30*time.Second, 1, false)
 	tracker := newInflightJobTracker(ctx)
 	var checkoutLock sync.Mutex
-	var stdout syncBuffer
+	stdout := &cancelAfterWakeHealthWriter{
+		cancel:    cancel,
+		threshold: maxConsecutiveWorkerTickFailures + 1,
+	}
 	errCh := startSingleRepoWorkerLoop(
 		ctx, 100*time.Microsecond, store, worker, live, &checkoutLock, tracker,
-		"owner/repo", "", &stdout,
+		"owner/repo", "", stdout,
 	)
 
-	deadline := time.Now().Add(5 * time.Second)
-	for strings.Count(stdout.String(), "reply wake outbox drain health:") <= maxConsecutiveWorkerTickFailures {
-		select {
-		case err := <-errCh:
-			t.Fatalf("single-repo loop escalated persistent inert wake health: %v", err)
-		default:
-		}
-		if time.Now().After(deadline) {
-			t.Fatalf("single-repo loop did not report inert health beyond %d ticks; log=%q", maxConsecutiveWorkerTickFailures, stdout.String())
-		}
-		time.Sleep(time.Millisecond)
-	}
-	select {
-	case err := <-errCh:
-		t.Fatalf("single-repo loop exited while reporting inert health: %v", err)
-	default:
-	}
-
-	cancel()
 	select {
 	case err, ok := <-errCh:
 		if ok && err != nil {
-			t.Fatalf("single-repo loop shutdown surfaced error: %v", err)
+			t.Fatalf("single-repo loop escalated persistent inert wake health: %v", err)
 		}
 	case <-time.After(5 * time.Second):
-		t.Fatal("single-repo loop did not stop after cancellation")
+		t.Fatalf("single-repo loop did not report inert health beyond %d ticks; log=%q", maxConsecutiveWorkerTickFailures, stdout.String())
+	}
+	if got := strings.Count(stdout.String(), "reply wake outbox drain health:"); got <= maxConsecutiveWorkerTickFailures {
+		t.Fatalf("inert health lines = %d, want more than escalation threshold %d; log=%q", got, maxConsecutiveWorkerTickFailures, stdout.String())
 	}
 	if strings.Contains(stdout.String(), "consecutive failures, escalating") {
 		t.Fatalf("inert reply wake health reached escalation ladder: %q", stdout.String())
@@ -419,6 +406,28 @@ func TestReplyWakeOutboxInertHealthDoesNotEscalateSingleRepoLoop(t *testing.T) {
 		!strings.Contains(stdout.String(), "pending=0 inert=1 route_removed=0 aged_attempted=0") {
 		t.Fatalf("inert reply wake health log = %q", stdout.String())
 	}
+}
+
+// cancelAfterWakeHealthWriter makes shutdown deterministic: cancellation is
+// triggered only after the threshold-crossing health line has been committed,
+// so it cannot land inside the drain that produced the observed line.
+type cancelAfterWakeHealthWriter struct {
+	output    syncBuffer
+	cancel    context.CancelFunc
+	threshold int
+	once      sync.Once
+}
+
+func (w *cancelAfterWakeHealthWriter) Write(p []byte) (int, error) {
+	n, err := w.output.Write(p)
+	if err == nil && strings.Count(w.output.String(), "reply wake outbox drain health:") >= w.threshold {
+		w.once.Do(w.cancel)
+	}
+	return n, err
+}
+
+func (w *cancelAfterWakeHealthWriter) String() string {
+	return w.output.String()
 }
 
 func TestReplyWakeOutboxBurstCoalescesToExactlyOneWake(t *testing.T) {

--- a/internal/db/event_rules.go
+++ b/internal/db/event_rules.go
@@ -36,6 +36,13 @@ type DeletedEventRule struct {
 	DeletedAt string
 }
 
+// EventRuleRoute identifies the event kind and addressed role that can make a
+// wake-outbox row routable.
+type EventRuleRoute struct {
+	OnKind   string
+	WakeRole string
+}
+
 // AddEventRule persists a new opt-in event rule.
 func (s *Store) AddEventRule(ctx context.Context, rule EventRule) error {
 	rule, err := normalizeEventRule(rule)
@@ -160,10 +167,34 @@ func (s *Store) ListEventRules(ctx context.Context) ([]EventRule, error) {
 	return rules, rows.Err()
 }
 
-// ListDeletedEventRules returns durable rule tombstones in deletion order.
-func (s *Store) ListDeletedEventRules(ctx context.Context) ([]DeletedEventRule, error) {
-	rows, err := s.db.QueryContext(ctx, `SELECT id, on_kind, COALESCE(match_filter, ''), wake_role, scope, enabled, created_at, deleted_at
-		FROM event_rule_deletions ORDER BY deletion_id`)
+// ListDeletedEventRulesForRoutes returns enabled tombstones for the exact
+// kind/role pairs that could route current wake-outbox rows.
+func (s *Store) ListDeletedEventRulesForRoutes(ctx context.Context, routes []EventRuleRoute) ([]DeletedEventRule, error) {
+	conditions := make([]string, 0, len(routes))
+	args := make([]any, 0, 2*len(routes))
+	seen := make(map[string]struct{}, len(routes))
+	for _, route := range routes {
+		onKind := strings.TrimSpace(route.OnKind)
+		wakeRole := strings.TrimSpace(route.WakeRole)
+		if onKind == "" || wakeRole == "" {
+			continue
+		}
+		key := strings.ToLower(wakeRole) + "\x00" + strings.ToLower(onKind)
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		conditions = append(conditions, `(wake_role = ? COLLATE NOCASE AND on_kind = ? COLLATE NOCASE)`)
+		args = append(args, wakeRole, onKind)
+	}
+	if len(conditions) == 0 {
+		return []DeletedEventRule{}, nil
+	}
+	query := `SELECT id, on_kind, COALESCE(match_filter, ''), wake_role, scope, enabled, created_at, deleted_at
+		FROM event_rule_deletions
+		WHERE enabled = 1 AND (` + strings.Join(conditions, " OR ") + `)
+		ORDER BY deletion_id`
+	rows, err := s.db.QueryContext(ctx, query, args...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/db/event_rules.go
+++ b/internal/db/event_rules.go
@@ -28,6 +28,14 @@ type EventRule struct {
 	CreatedAt   string
 }
 
+// DeletedEventRule preserves the routing semantics and deletion time of a rule.
+// Wake-outbox health uses it to distinguish removed routes from rows that never
+// had a matching route.
+type DeletedEventRule struct {
+	EventRule
+	DeletedAt string
+}
+
 // AddEventRule persists a new opt-in event rule.
 func (s *Store) AddEventRule(ctx context.Context, rule EventRule) error {
 	rule, err := normalizeEventRule(rule)
@@ -152,11 +160,57 @@ func (s *Store) ListEventRules(ctx context.Context) ([]EventRule, error) {
 	return rules, rows.Err()
 }
 
+// ListDeletedEventRules returns durable rule tombstones in deletion order.
+func (s *Store) ListDeletedEventRules(ctx context.Context) ([]DeletedEventRule, error) {
+	rows, err := s.db.QueryContext(ctx, `SELECT id, on_kind, COALESCE(match_filter, ''), wake_role, scope, enabled, created_at, deleted_at
+		FROM event_rule_deletions ORDER BY deletion_id`)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	deletions := []DeletedEventRule{}
+	for rows.Next() {
+		var deletion DeletedEventRule
+		var enabled int
+		if err := rows.Scan(
+			&deletion.ID,
+			&deletion.OnKind,
+			&deletion.MatchFilter,
+			&deletion.WakeRole,
+			&deletion.Scope,
+			&enabled,
+			&deletion.CreatedAt,
+			&deletion.DeletedAt,
+		); err != nil {
+			return nil, err
+		}
+		deletion.Enabled = enabled != 0
+		deletions = append(deletions, deletion)
+	}
+	return deletions, rows.Err()
+}
+
 // DeleteEventRule removes a rule by id. Removing an already-absent id is an
 // idempotent no-op, which keeps best-effort operator cleanup simple.
 func (s *Store) DeleteEventRule(ctx context.Context, id string) error {
-	_, err := s.db.ExecContext(ctx, `DELETE FROM event_rules WHERE id = ?`, strings.TrimSpace(id))
-	return err
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback()
+	id = strings.TrimSpace(id)
+	deletedAt := time.Now().UTC().Format(time.RFC3339Nano)
+	if _, err := tx.ExecContext(ctx, `INSERT INTO event_rule_deletions(
+		id, on_kind, match_filter, wake_role, scope, enabled, created_at, deleted_at
+	)
+	SELECT id, on_kind, match_filter, wake_role, scope, enabled, created_at, ?
+	FROM event_rules WHERE id = ?`, deletedAt, id); err != nil {
+		return err
+	}
+	if _, err := tx.ExecContext(ctx, `DELETE FROM event_rules WHERE id = ?`, id); err != nil {
+		return err
+	}
+	return tx.Commit()
 }
 
 // DeleteEventRulesForRole removes all routes targeting role in one transaction
@@ -194,6 +248,14 @@ func (s *Store) DeleteEventRulesForRole(ctx context.Context, role string) ([]Eve
 		return nil, err
 	}
 	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	deletedAt := time.Now().UTC().Format(time.RFC3339Nano)
+	if _, err := tx.ExecContext(ctx, `INSERT INTO event_rule_deletions(
+		id, on_kind, match_filter, wake_role, scope, enabled, created_at, deleted_at
+	)
+	SELECT id, on_kind, match_filter, wake_role, scope, enabled, created_at, ?
+	FROM event_rules WHERE LOWER(TRIM(wake_role)) = ?`, deletedAt, role); err != nil {
 		return nil, err
 	}
 	if _, err := tx.ExecContext(ctx, `DELETE FROM event_rules WHERE LOWER(TRIM(wake_role)) = ?`, role); err != nil {

--- a/internal/db/event_rules_test.go
+++ b/internal/db/event_rules_test.go
@@ -42,6 +42,52 @@ func TestEventRuleRoundTrip(t *testing.T) {
 	if len(rules) != 0 {
 		t.Fatalf("rules after delete = %#v", rules)
 	}
+	deletions, err := store.ListDeletedEventRules(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(deletions) != 1 || deletions[0].EventRule != want || strings.TrimSpace(deletions[0].DeletedAt) == "" {
+		t.Fatalf("deleted rules = %#v, want one complete tombstone for %#v", deletions, want)
+	}
+}
+
+func TestDeleteEventRulesForRoleRecordsDeletionHistory(t *testing.T) {
+	store, err := openCachedTestStore(t, filepath.Join(t.TempDir(), "gitmoot.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+	ctx := context.Background()
+	rules := []EventRule{
+		{ID: "owner-reply", OnKind: "reply", WakeRole: "owner", Enabled: true},
+		{ID: "owner-blocked", OnKind: "blocked", WakeRole: "owner", Enabled: true},
+		{ID: "worker-reply", OnKind: "reply", WakeRole: "worker", Enabled: true},
+	}
+	if err := store.AddEventRules(ctx, rules); err != nil {
+		t.Fatal(err)
+	}
+
+	removed, err := store.DeleteEventRulesForRole(ctx, "owner")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(removed) != 2 {
+		t.Fatalf("removed rules = %#v, want two owner rules", removed)
+	}
+	active, err := store.ListEventRules(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(active) != 1 || active[0].ID != "worker-reply" {
+		t.Fatalf("active rules = %#v, want worker rule only", active)
+	}
+	deletions, err := store.ListDeletedEventRules(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(deletions) != 2 || deletions[0].WakeRole != "owner" || deletions[1].WakeRole != "owner" {
+		t.Fatalf("deleted rules = %#v, want two owner tombstones", deletions)
+	}
 }
 
 func TestEventRuleScopeObserverRoundTripAndValidation(t *testing.T) {

--- a/internal/db/event_rules_test.go
+++ b/internal/db/event_rules_test.go
@@ -42,7 +42,9 @@ func TestEventRuleRoundTrip(t *testing.T) {
 	if len(rules) != 0 {
 		t.Fatalf("rules after delete = %#v", rules)
 	}
-	deletions, err := store.ListDeletedEventRules(ctx)
+	deletions, err := store.ListDeletedEventRulesForRoutes(ctx, []EventRuleRoute{{
+		OnKind: want.OnKind, WakeRole: want.WakeRole,
+	}})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -81,12 +83,49 @@ func TestDeleteEventRulesForRoleRecordsDeletionHistory(t *testing.T) {
 	if len(active) != 1 || active[0].ID != "worker-reply" {
 		t.Fatalf("active rules = %#v, want worker rule only", active)
 	}
-	deletions, err := store.ListDeletedEventRules(ctx)
+	deletions, err := store.ListDeletedEventRulesForRoutes(ctx, []EventRuleRoute{
+		{OnKind: "reply", WakeRole: "owner"},
+		{OnKind: "blocked", WakeRole: "owner"},
+	})
 	if err != nil {
 		t.Fatal(err)
 	}
 	if len(deletions) != 2 || deletions[0].WakeRole != "owner" || deletions[1].WakeRole != "owner" {
 		t.Fatalf("deleted rules = %#v, want two owner tombstones", deletions)
+	}
+}
+
+func TestDeletedEventRuleRouteLookupUsesBoundedIndex(t *testing.T) {
+	store, err := openCachedTestStore(t, filepath.Join(t.TempDir(), "gitmoot.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+	rows, err := store.db.QueryContext(context.Background(), `EXPLAIN QUERY PLAN
+		SELECT id, on_kind, match_filter, wake_role, scope, enabled, created_at, deleted_at
+		FROM event_rule_deletions
+		WHERE enabled = 1 AND (wake_role = ? COLLATE NOCASE AND on_kind = ? COLLATE NOCASE)
+		ORDER BY deletion_id`, "owner", "reply")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer rows.Close()
+	usedBoundedIndex := false
+	for rows.Next() {
+		var id, parent, unused int
+		var detail string
+		if err := rows.Scan(&id, &parent, &unused, &detail); err != nil {
+			t.Fatal(err)
+		}
+		if strings.Contains(detail, "idx_event_rule_deletions_route") {
+			usedBoundedIndex = true
+		}
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatal(err)
+	}
+	if !usedBoundedIndex {
+		t.Fatal("deleted event-rule route lookup did not use idx_event_rule_deletions_route")
 	}
 }
 

--- a/internal/db/store_migrations.go
+++ b/internal/db/store_migrations.go
@@ -2074,4 +2074,23 @@ CREATE INDEX idx_cleanup_obligations_due
 	ON cleanup_obligations(state, next_attempt_at, owner_job_id)
 	WHERE state IN ('pending', 'retryable');
 	`,
+	// #1496 durable event-rule deletion history. Wake-outbox rows deliberately
+	// remain pending when no route matches; preserving the deleted rule semantics
+	// lets health distinguish a route removed after a row existed from a route
+	// that was never configured. Append-only tail; migrations are positional.
+	`
+CREATE TABLE event_rule_deletions (
+	deletion_id INTEGER PRIMARY KEY AUTOINCREMENT,
+	id TEXT NOT NULL,
+	on_kind TEXT NOT NULL,
+	match_filter TEXT,
+	wake_role TEXT NOT NULL,
+	scope TEXT NOT NULL,
+	enabled INTEGER NOT NULL,
+	created_at TEXT NOT NULL,
+	deleted_at TEXT NOT NULL
+);
+CREATE INDEX idx_event_rule_deletions_deleted_at
+	ON event_rule_deletions(deleted_at, deletion_id);
+	`,
 }

--- a/internal/db/store_migrations.go
+++ b/internal/db/store_migrations.go
@@ -2090,7 +2090,13 @@ CREATE TABLE event_rule_deletions (
 	created_at TEXT NOT NULL,
 	deleted_at TEXT NOT NULL
 );
-CREATE INDEX idx_event_rule_deletions_deleted_at
-	ON event_rule_deletions(deleted_at, deletion_id);
+CREATE INDEX idx_event_rule_deletions_route
+	ON event_rule_deletions(
+		wake_role COLLATE NOCASE,
+		on_kind COLLATE NOCASE,
+		deleted_at,
+		deletion_id
+	)
+	WHERE enabled = 1;
 	`,
 }


### PR DESCRIPTION
WHAT:
Wake-outbox health now distinguishes routable from inert pending rows, reports both counts, and fails closed when rules are unreadable. GITMOOT-COC-IMPL

WHY:
Gitmoot finalized this implementation from a task worktree.

CHANGES:
- Committed changes from /root/.gitmoot/worktrees/gitmoot--gitmoot/adhoc-cea7f0c7

RESULTS:
- Focused filter baseline matched 6 tests; all 6 passed before mutation and after revert.
- Mutant changed health.inert++ to health.pending++; go test -c compiled successfully. TestReplyWakeOutboxZeroRulesReportsInertWithoutUnhealthy failed with an unhealthy pending=1 inert=0 line; the matching-rule and unreadable-rule guards still passed. Mutant reverted.
- Secondary focused filter matched 1 test, TestReplyWakeOutboxDrainFailureDoesNotAbortRepoWork; passed.
- go build -buildvcs=false ./... exited 0.
- go vet ./... exited 0.
- gofmt and git diff --check passed. Full suite was not run.

RISK:
Review the generated diff before merging.

TASK:
adhoc-cea7f0c7

AGENTS:
- wave-impl

RAW FINAL REVIEW OUTPUT:
````text
Wake-outbox health now distinguishes routable from inert pending rows, reports both counts, and fails closed when rules are unreadable. GITMOOT-COC-IMPL
````
