### PR TITLE
feat(org): route every roster consumer through one choke-point seam (#1635)

### DIFF
--- a/internal/cli/blocked_since.go
+++ b/internal/cli/blocked_since.go
@@ -41,6 +41,7 @@ type blockedRoleWakeDependencies struct {
 	availability blockedRoleAvailability
 	provider     func([]config.OrgRole) org.Provider
 	eventSink    func(context.Context, *db.Store, string) (events.Sink, error)
+	roster       func(context.Context, *db.Store, config.OrgConfig) orgRoster
 	directives   directiveTTLDependencies
 	awaitedFacts awaitedFactTTLDependencies
 }
@@ -80,6 +81,13 @@ func defaultBlockedRoleWakeDependencies() blockedRoleWakeDependencies {
 		provider:     cockpit.NewHerdrOrgProvider,
 		eventSink:    enabledBlockedSinceEventSink,
 	}
+}
+
+func (d blockedRoleWakeDependencies) loadRoster(ctx context.Context, store *db.Store, cfg config.OrgConfig) orgRoster {
+	if d.roster != nil {
+		return d.roster(ctx, store, cfg)
+	}
+	return loadOrgRoster(ctx, store, cfg)
 }
 
 func (d directiveTTLDependencies) listOpen(ctx context.Context, store *db.Store, limit int) ([]db.OrgDirectiveObligation, error) {
@@ -312,7 +320,8 @@ func runBlockedRoleWakeOnce(ctx context.Context, store *db.Store, home string, s
 		writeLine(stdout, "blocked_since role org config load failed: %v", err)
 		return
 	}
-	roles := loadOrgRoster(ctx, store, orgConfig).Members()
+	roster := deps.loadRoster(ctx, store, orgConfig)
+	roles := roster.Members()
 	if len(roles) == 0 {
 		// No org roles configured: there is nothing to snapshot or persist, so
 		// skip silently (matches the pre-#1118 behavior for an unconfigured
@@ -378,12 +387,30 @@ func runBlockedRoleWakeOnce(ctx context.Context, store *db.Store, home string, s
 	if wakeAfter <= 0 || sink == nil {
 		return
 	}
-	if err := evaluateBlockedRoleEpisodes(ctx, store, sink, snapshot, wakeAfter, stdout, now.UTC()); err != nil {
+	// Presence records every live member; automated alarms evaluate only seats
+	// whose standing permits nudges.
+	nudgeSnapshot := snapshotForOrgRoles(snapshot, roster.Nudgeable())
+	if err := evaluateBlockedRoleEpisodes(ctx, store, sink, nudgeSnapshot, wakeAfter, stdout, now.UTC()); err != nil {
 		writeLine(stdout, "blocked_since role evaluation failed: %v", err)
 	}
-	if err := evaluateInputPendingRoleEpisodes(ctx, store, sink, snapshot, wakeAfter, stdout, now.UTC()); err != nil {
+	if err := evaluateInputPendingRoleEpisodes(ctx, store, sink, nudgeSnapshot, wakeAfter, stdout, now.UTC()); err != nil {
 		writeLine(stdout, "input_pending role evaluation failed: %v", err)
 	}
+}
+
+func snapshotForOrgRoles(snapshot org.Snapshot, roles []config.OrgRole) org.Snapshot {
+	allowed := make(map[string]struct{}, len(roles))
+	for _, role := range roles {
+		allowed[strings.ToLower(strings.TrimSpace(role.Name))] = struct{}{}
+	}
+	states := make(map[string]org.RoleLiveState, len(allowed))
+	for role, state := range snapshot.States {
+		if _, ok := allowed[strings.ToLower(strings.TrimSpace(role))]; ok {
+			states[role] = state
+		}
+	}
+	snapshot.States = states
+	return snapshot
 }
 
 func evaluateAwaitedFactTTLs(ctx context.Context, store *db.Store, orgConfig config.OrgConfig, stdout io.Writer, now time.Time, deps awaitedFactTTLDependencies) error {

--- a/internal/cli/blocked_since.go
+++ b/internal/cli/blocked_since.go
@@ -312,7 +312,7 @@ func runBlockedRoleWakeOnce(ctx context.Context, store *db.Store, home string, s
 		writeLine(stdout, "blocked_since role org config load failed: %v", err)
 		return
 	}
-	roles := orgConfig.Roles()
+	roles := loadOrgRoster(ctx, store, orgConfig).Members()
 	if len(roles) == 0 {
 		// No org roles configured: there is nothing to snapshot or persist, so
 		// skip silently (matches the pre-#1118 behavior for an unconfigured

--- a/internal/cli/blocked_since_test.go
+++ b/internal/cli/blocked_since_test.go
@@ -376,19 +376,15 @@ func TestRunBlockedRoleWakeOnceDoesNotWakePausedSeat(t *testing.T) {
 		},
 		eventSink: func(context.Context, *db.Store, string) (events.Sink, error) { return sink, nil },
 		roster: func(_ context.Context, _ *db.Store, cfg config.OrgConfig) orgRoster {
-			owner, ownerOK := cfg.Role("owner")
-			review, reviewOK := cfg.Role("review")
-			if !ownerOK || !reviewOK {
-				t.Fatal("test org roles missing")
+			if _, ok := cfg.Role("owner"); !ok {
+				t.Fatal("test org role owner missing")
 			}
-			return orgRoster{
-				members:   []config.OrgRole{owner, review},
-				nudgeable: []config.OrgRole{review},
-				standing: map[string]orgSeatStanding{
-					"owner":  orgSeatPaused,
-					"review": orgSeatActive,
-				},
+			if _, ok := cfg.Role("review"); !ok {
+				t.Fatal("test org role review missing")
 			}
+			// Rosters are constructed only through the resolver (round 3:
+			// the fields are unexported outside internal/config).
+			return resolveOrgRoster(cfg, nil, map[string]string{"owner": "test pause"})
 		},
 	}
 

--- a/internal/cli/blocked_since_test.go
+++ b/internal/cli/blocked_since_test.go
@@ -247,7 +247,8 @@ func (f *fakeBlockedRoleAvailability) Available(context.Context) bool {
 	return f.available
 }
 
-func TestRunBlockedRoleWakeOnceUsesInjectedProviderAndDedups(t *testing.T) {
+func blockedRoleWakeTestStore(t *testing.T) (string, *db.Store) {
+	t.Helper()
 	home := t.TempDir()
 	paths := config.PathsForHome(home)
 	if err := config.Initialize(paths); err != nil {
@@ -282,7 +283,12 @@ blocked_role_wake_after = "1h"
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer store.Close()
+	t.Cleanup(func() { _ = store.Close() })
+	return home, store
+}
+
+func TestRunBlockedRoleWakeOnceUsesInjectedProviderAndDedups(t *testing.T) {
+	home, store := blockedRoleWakeTestStore(t)
 
 	now := time.Date(2026, 7, 22, 12, 0, 0, 0, time.UTC)
 	snapshot := org.Snapshot{
@@ -347,6 +353,58 @@ blocked_role_wake_after = "1h"
 	}
 	if len(livePresence) != 1 || livePresence[0].Role != "owner" || livePresence[0].State != string(org.StateWorking) {
 		t.Fatalf("persisted live presence after reap = %+v", livePresence)
+	}
+}
+
+func TestRunBlockedRoleWakeOnceDoesNotWakePausedSeat(t *testing.T) {
+	home, store := blockedRoleWakeTestStore(t)
+	now := time.Date(2026, 7, 22, 12, 0, 0, 0, time.UTC)
+	snapshot := org.Snapshot{
+		States: map[string]org.RoleLiveState{
+			"owner":  {State: org.StateBlocked},
+			"review": {State: org.StateIdle},
+		},
+		ObservedAt: now.Add(-2 * time.Hour), ProviderVersion: "test-v1",
+	}
+	sink := &recordingSink{}
+	var providerRoles []config.OrgRole
+	deps := blockedRoleWakeDependencies{
+		availability: &fakeBlockedRoleAvailability{available: true},
+		provider: func(roles []config.OrgRole) org.Provider {
+			providerRoles = append([]config.OrgRole(nil), roles...)
+			return orgFixtureProvider{snapshot: snapshot}
+		},
+		eventSink: func(context.Context, *db.Store, string) (events.Sink, error) { return sink, nil },
+		roster: func(_ context.Context, _ *db.Store, cfg config.OrgConfig) orgRoster {
+			owner, ownerOK := cfg.Role("owner")
+			review, reviewOK := cfg.Role("review")
+			if !ownerOK || !reviewOK {
+				t.Fatal("test org roles missing")
+			}
+			return orgRoster{
+				members:   []config.OrgRole{owner, review},
+				nudgeable: []config.OrgRole{review},
+				standing: map[string]orgSeatStanding{
+					"owner":  orgSeatPaused,
+					"review": orgSeatActive,
+				},
+			}
+		},
+	}
+
+	runBlockedRoleWakeOnce(context.Background(), store, home, io.Discard, now, deps)
+	if got := len(sink.byType(events.EventJobBlocked)); got != 0 {
+		t.Fatalf("paused owner job.blocked events = %d, want 0", got)
+	}
+	if len(providerRoles) != 2 || providerRoles[0].Name != "owner" || providerRoles[1].Name != "review" {
+		t.Fatalf("provider roles = %v, want Members() including paused owner", providerRoles)
+	}
+	presence, err := store.ListRoleLivePresence(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(presence) != 2 || presence[0].Role != "owner" || presence[0].State != string(org.StateBlocked) {
+		t.Fatalf("persisted live presence = %+v, want paused owner retained", presence)
 	}
 }
 

--- a/internal/cli/daemon_workflow.go
+++ b/internal/cli/daemon_workflow.go
@@ -899,7 +899,7 @@ func mergeGateEscalationFrom(cfg config.OrgConfig, repo string) string {
 
 func repoOrgOwner(cfg config.OrgConfig, repo string) (string, bool) {
 	best, bestDepth := "", -1
-	for _, role := range cfg.Roles() {
+	for _, role := range loadOrgRoster(context.Background(), nil, cfg).Members() {
 		if config.ScopeMatches(role.Scope, repo) {
 			if depth := len(cfg.Path(role.Name)); depth > bestDepth {
 				best, bestDepth = role.Name, depth

--- a/internal/cli/dashboard_web_org_activity.go
+++ b/internal/cli/dashboard_web_org_activity.go
@@ -157,7 +157,7 @@ func (d *webDataSource) fleetActivitySnapshot(ctx context.Context) (dashboardFle
 	if !cfg.Enabled() {
 		live.ObservedAt = time.Now().UTC()
 	} else {
-		provider := newOrgProvider(cfg.Roles())
+		provider := newOrgProvider(loadOrgRoster(ctx, nil, cfg).Members())
 		if provider == nil {
 			sourceErr = errors.New("Herdr organization provider is not configured")
 		} else {
@@ -235,7 +235,7 @@ func buildDashboardFleetActivity(
 	}
 	out.Summary.EscalationsOpen = len(dashboardOrgEscalations(escalations, "", resolved))
 
-	for _, role := range cfg.Roles() {
+	for _, role := range loadOrgRoster(ctx, store, cfg).Members() {
 		name := strings.ToLower(strings.TrimSpace(role.Name))
 		item := dashboardFleetActivityRole{
 			Name: role.Name, DisplayName: dashboardOrgDisplayName(cfg, role.Name),

--- a/internal/cli/doctor_org_activity.go
+++ b/internal/cli/doctor_org_activity.go
@@ -43,7 +43,7 @@ func orgRoleActivityDoctorCheck(paths config.Paths) (doctor.Check, bool) {
 
 func monitoredOrgActivityRoles(cfg config.OrgConfig) []config.OrgRole {
 	roles := make([]config.OrgRole, 0)
-	for _, role := range loadOrgRoster(context.Background(), nil, cfg).Members() {
+	for _, role := range loadOrgRoster(context.Background(), nil, cfg).Nudgeable() {
 		if cfg.RecycleAfterFor(role.Name) > 0 {
 			roles = append(roles, role)
 		}

--- a/internal/cli/doctor_org_activity.go
+++ b/internal/cli/doctor_org_activity.go
@@ -43,7 +43,7 @@ func orgRoleActivityDoctorCheck(paths config.Paths) (doctor.Check, bool) {
 
 func monitoredOrgActivityRoles(cfg config.OrgConfig) []config.OrgRole {
 	roles := make([]config.OrgRole, 0)
-	for _, role := range cfg.Roles() {
+	for _, role := range loadOrgRoster(context.Background(), nil, cfg).Members() {
 		if cfg.RecycleAfterFor(role.Name) > 0 {
 			roles = append(roles, role)
 		}

--- a/internal/cli/org.go
+++ b/internal/cli/org.go
@@ -645,7 +645,7 @@ func runOrgValidateOrShow(args []string, stdout, stderr io.Writer) int {
 	if args[0] == "validate" {
 		return runOrgValidateReality(context.Background(), paths, cfg, stdout, stderr)
 	}
-	for _, role := range cfg.Roles() {
+	for _, role := range loadOrgRoster(context.Background(), nil, cfg).Members() {
 		fmt.Fprintf(stdout, "%s\tparent=%s\tscope=%s\tmerge_rule=%s\n", role.Name, role.Parent, strings.Join(role.Scope, ","), firstNonEmpty(role.MergeRule, "owner"))
 	}
 	return 0
@@ -697,11 +697,12 @@ func runOrgValidateReality(ctx context.Context, paths config.Paths, cfg config.O
 		missedByRole[strings.ToLower(strings.TrimSpace(missed.Role))] = missed.Consecutive
 	}
 	claimedPanes := make(map[string]string)
+	roster := loadOrgRoster(ctx, store, cfg)
 	summary := orgValidationSummary{
-		roles: len(cfg.Roles()), livePanes: len(snapshot.Panes), enabledRoutes: enabledRoutes,
+		roles: len(roster.Members()), livePanes: len(snapshot.Panes), enabledRoutes: enabledRoutes,
 	}
 	var issues []string
-	for _, role := range cfg.Roles() {
+	for _, role := range roster.Members() {
 		name := strings.ToLower(strings.TrimSpace(role.Name))
 		binding := snapshot.PaneBindings[name]
 		if strings.TrimSpace(binding.PaneID) == "" {
@@ -1198,7 +1199,7 @@ func loadOrgCommandState(ctx context.Context, home string) (config.OrgConfig, ma
 }
 
 func orgProviderSnapshot(ctx context.Context, cfg config.OrgConfig) (org.Snapshot, error) {
-	provider := newOrgProvider(cfg.Roles())
+	provider := newOrgProvider(loadOrgRoster(ctx, nil, cfg).Members())
 	if provider == nil {
 		return org.Snapshot{}, errors.New("organization live-state provider is not configured")
 	}

--- a/internal/cli/org_overview.go
+++ b/internal/cli/org_overview.go
@@ -140,8 +140,9 @@ func storeOrgLiveSource(shared *orgSharedState) orgLiveSource {
 		}
 		now := time.Now().UTC()
 		var latest time.Time
-		states := make(map[string]org.RoleLiveState, len(cfg.Roles()))
-		for _, role := range cfg.Roles() {
+		members := loadOrgRoster(ctx, shared.Store, cfg).Members()
+		states := make(map[string]org.RoleLiveState, len(members))
+		for _, role := range members {
 			state := org.StateUnknown
 			if blocked[role.Name] {
 				state = org.StateBlocked
@@ -213,7 +214,7 @@ func buildOrgStatusRows(ctx context.Context, shared *orgSharedState, src orgLive
 	if err != nil {
 		return nil, &orgLiveSourceError{err: err}
 	}
-	roles := shared.Config.Roles()
+	roles := loadOrgRoster(ctx, shared.Store, shared.Config).Members()
 	rows := make([]orgStatusOutput, 0, len(roles))
 	observedNow := time.Now().UTC()
 	for _, role := range roles {

--- a/internal/cli/org_roster.go
+++ b/internal/cli/org_roster.go
@@ -1,0 +1,126 @@
+package cli
+
+import (
+	"context"
+	"strings"
+	"time"
+
+	"github.com/gitmoot/gitmoot/internal/config"
+	"github.com/gitmoot/gitmoot/internal/db"
+)
+
+// This file is THE roster choke-point (#1635, herdrup#173). Every production
+// decision over "which org seats exist right now" draws from resolveOrgRoster /
+// loadOrgRoster instead of iterating config.OrgConfig.Roles() directly, so that
+// seat-lifecycle exclusions (archived, paused) are applied in exactly one place.
+// TestOrgRosterSeamIsTheOnlyRolesCallSite pins that invariant: a new direct
+// cfg.Roles() call site fails CI until it is routed through the roster.
+//
+// Lifecycle contract (herdrup#173): herdr owns archive state; gitmoot only
+// READS it (an `archived` block on `herdr agent list --json`). A seat absent
+// from the archived observations is ACTIVE — so nil observations reproduce the
+// pre-#1635 roster exactly, and either side can deploy first.
+
+// orgSeatStanding classifies a configured role's roster membership.
+type orgSeatStanding string
+
+const (
+	// orgSeatActive: full roster member — appears everywhere, receives
+	// sweeps, nudges, and automated wakes.
+	orgSeatActive orgSeatStanding = "active"
+	// orgSeatPaused: soft exclusion — still a live roster member (chart,
+	// health, presence, provider, dispatch, escalation routing) but excluded
+	// from nudge ladders, idle/blocked alarms, and automated wakes.
+	orgSeatPaused orgSeatStanding = "paused"
+	// orgSeatArchived: full exclusion — out of rotation entirely; the seat has
+	// no pane and its open work is parked (rendered by `org seats archived`).
+	orgSeatArchived orgSeatStanding = "archived"
+)
+
+// orgArchivedObservation is one observed herdr archive record: the `archived`
+// block herdr serializes per agent, plus when gitmoot observed it. Presence of
+// the block means archived; absence means active.
+type orgArchivedObservation struct {
+	At         time.Time
+	By         string
+	Reason     string
+	ObservedAt time.Time
+}
+
+// orgArchivedSeat pairs a configured role with its archive observation for the
+// `org seats archived` view.
+type orgArchivedSeat struct {
+	Role config.OrgRole
+	orgArchivedObservation
+}
+
+type orgRoster struct {
+	members   []config.OrgRole
+	nudgeable []config.OrgRole
+	archived  []orgArchivedSeat
+	standing  map[string]orgSeatStanding
+}
+
+// resolveOrgRoster classifies every configured role. Observation maps are keyed
+// by role name; lookups are case-insensitive on the role side and expect
+// lower-case keys on the supplier side. paused maps role name -> reason.
+func resolveOrgRoster(cfg config.OrgConfig, archived map[string]orgArchivedObservation, paused map[string]string) orgRoster {
+	roster := orgRoster{standing: map[string]orgSeatStanding{}}
+	for _, role := range cfg.Roles() {
+		key := strings.ToLower(strings.TrimSpace(role.Name))
+		if observation, ok := archived[key]; ok {
+			roster.standing[key] = orgSeatArchived
+			roster.archived = append(roster.archived, orgArchivedSeat{Role: role, orgArchivedObservation: observation})
+			continue
+		}
+		roster.members = append(roster.members, role)
+		if _, ok := paused[key]; ok {
+			roster.standing[key] = orgSeatPaused
+			continue
+		}
+		roster.standing[key] = orgSeatActive
+		roster.nudgeable = append(roster.nudgeable, role)
+	}
+	return roster
+}
+
+// Members returns the live roster: active + paused seats. Chart, health,
+// presence, provider construction, dispatch, and escalation routing use this
+// view.
+func (r orgRoster) Members() []config.OrgRole { return r.members }
+
+// Nudgeable returns active seats only. Sweeps, nudge ladders, idle/blocked
+// alarms, and automated wakes use this view.
+func (r orgRoster) Nudgeable() []config.OrgRole { return r.nudgeable }
+
+// Archived returns the observed archived seats for the `org seats archived`
+// view.
+func (r orgRoster) Archived() []orgArchivedSeat { return r.archived }
+
+// Standing reports a role's classification. Unknown (unconfigured) roles read
+// active: absence of lifecycle evidence must never exclude a seat.
+func (r orgRoster) Standing(role string) orgSeatStanding {
+	if s, ok := r.standing[strings.ToLower(strings.TrimSpace(role))]; ok {
+		return s
+	}
+	return orgSeatActive
+}
+
+// loadOrgRosterObservations is the ONE supplier seam for lifecycle
+// observations. It returns nothing today; the #1635 ingest (the herdr
+// `agent list --json` reader and its durable mirror) lands inside this
+// function without touching any roster consumer. A nil store must stay
+// valid: several call sites resolve the roster without an open store, and
+// missing observations mean an unfiltered (all-active) roster by contract.
+func loadOrgRosterObservations(ctx context.Context, store *db.Store) (archived map[string]orgArchivedObservation, paused map[string]string) {
+	_ = ctx
+	_ = store
+	return nil, nil
+}
+
+// loadOrgRoster resolves the roster with observations from the supplier seam.
+// store may be nil (observation-less roster).
+func loadOrgRoster(ctx context.Context, store *db.Store, cfg config.OrgConfig) orgRoster {
+	archived, paused := loadOrgRosterObservations(ctx, store)
+	return resolveOrgRoster(cfg, archived, paused)
+}

--- a/internal/cli/org_roster.go
+++ b/internal/cli/org_roster.go
@@ -2,117 +2,60 @@ package cli
 
 import (
 	"context"
-	"strings"
-	"time"
 
 	"github.com/gitmoot/gitmoot/internal/config"
 	"github.com/gitmoot/gitmoot/internal/db"
 )
 
 // This file is THE roster choke-point (#1635, herdrup#173). Every production
-// decision over "which org seats exist right now" draws from resolveOrgRoster /
-// loadOrgRoster instead of iterating config.OrgConfig.Roles() directly, so that
-// seat-lifecycle exclusions (archived, paused) are applied in exactly one place.
-// TestOrgRosterSeamIsTheOnlyRolesCallSite pins that invariant: a new direct
-// cfg.Roles() call site fails CI until it is routed through the roster.
+// decision over "which org seats exist right now" draws from loadOrgRoster.
+// Roster resolution itself lives in internal/config (config.ResolveOrgRoster),
+// where the raw role registry has NO exported bulk accessor: a consumer that
+// tries to enumerate roles without lifecycle classification does not compile.
+// This file holds the one production ResolveOrgRoster call site and the
+// observation supplier; TestOrgRosterSeamIsTheOnlyResolveCallSite censuses
+// every reference to ResolveOrgRoster and allows exactly this file.
 //
 // Lifecycle contract (herdrup#173): herdr owns archive state; gitmoot only
-// READS it (an `archived` block on `herdr agent list --json`). A seat absent
-// from the archived observations is ACTIVE — so nil observations reproduce the
-// pre-#1635 roster exactly, and either side can deploy first.
+// READS it (an `archived` block on `herdr agent list`, JSON by default). A
+// seat absent from the archived observations is ACTIVE — so nil observations
+// reproduce the pre-#1635 roster exactly, and either side can deploy first.
+//
+// STATED LIMITS of the boundary (kept in sync with config/org_roster.go, the
+// #1626 disposition): ResolveOrgRoster stays exported and nil-fed calls yield
+// the unfiltered roster (census-guarded); a deliberate Roots()+Children()
+// structural walk can rebuild the role set (review-visible, accepted);
+// config-internal code can call sortedRoles() directly.
 
-// orgSeatStanding classifies a configured role's roster membership.
-type orgSeatStanding string
+type orgSeatStanding = config.OrgSeatStanding
 
 const (
-	// orgSeatActive: full roster member — appears everywhere, receives
-	// sweeps, nudges, and automated wakes.
-	orgSeatActive orgSeatStanding = "active"
-	// orgSeatPaused: soft exclusion — still a live roster member (chart,
-	// health, presence, provider, dispatch, escalation routing) but excluded
-	// from nudge ladders, idle/blocked alarms, and automated wakes.
-	orgSeatPaused orgSeatStanding = "paused"
-	// orgSeatArchived: full exclusion — out of rotation entirely; the seat has
-	// no pane and its open work is parked (rendered by `org seats archived`).
-	orgSeatArchived orgSeatStanding = "archived"
+	orgSeatActive   = config.OrgSeatActive
+	orgSeatPaused   = config.OrgSeatPaused
+	orgSeatArchived = config.OrgSeatArchived
 )
 
-// orgArchivedObservation is one observed herdr archive record: the `archived`
-// block herdr serializes per agent, plus when gitmoot observed it. Presence of
-// the block means archived; absence means active.
-type orgArchivedObservation struct {
-	At         time.Time
-	By         string
-	Reason     string
-	ObservedAt time.Time
-}
+type orgArchivedObservation = config.OrgArchivedObservation
 
-// orgArchivedSeat pairs a configured role with its archive observation for the
-// `org seats archived` view.
-type orgArchivedSeat struct {
-	Role config.OrgRole
-	orgArchivedObservation
-}
+type orgArchivedSeat = config.OrgArchivedSeat
 
-type orgRoster struct {
-	members   []config.OrgRole
-	nudgeable []config.OrgRole
-	archived  []orgArchivedSeat
-	standing  map[string]orgSeatStanding
-}
+type orgRoster = config.OrgRoster
 
-// resolveOrgRoster classifies every configured role. Observation maps are keyed
-// by role name; lookups are case-insensitive on the role side and expect
-// lower-case keys on the supplier side. paused maps role name -> reason.
+// resolveOrgRoster is the seam's pure half, kept as a local name so tests and
+// the stacked parking work keep one spelling. It is the single production
+// reference to config.ResolveOrgRoster.
 func resolveOrgRoster(cfg config.OrgConfig, archived map[string]orgArchivedObservation, paused map[string]string) orgRoster {
-	roster := orgRoster{standing: map[string]orgSeatStanding{}}
-	for _, role := range cfg.Roles() {
-		key := strings.ToLower(strings.TrimSpace(role.Name))
-		if observation, ok := archived[key]; ok {
-			roster.standing[key] = orgSeatArchived
-			roster.archived = append(roster.archived, orgArchivedSeat{Role: role, orgArchivedObservation: observation})
-			continue
-		}
-		roster.members = append(roster.members, role)
-		if _, ok := paused[key]; ok {
-			roster.standing[key] = orgSeatPaused
-			continue
-		}
-		roster.standing[key] = orgSeatActive
-		roster.nudgeable = append(roster.nudgeable, role)
-	}
-	return roster
-}
-
-// Members returns the live roster: active + paused seats. Chart, health,
-// presence, provider construction, dispatch, and escalation routing use this
-// view.
-func (r orgRoster) Members() []config.OrgRole { return r.members }
-
-// Nudgeable returns active seats only. Sweeps, nudge ladders, idle/blocked
-// alarms, and automated wakes use this view.
-func (r orgRoster) Nudgeable() []config.OrgRole { return r.nudgeable }
-
-// Archived returns the observed archived seats for the `org seats archived`
-// view.
-func (r orgRoster) Archived() []orgArchivedSeat { return r.archived }
-
-// Standing reports a role's classification. Unknown (unconfigured) roles read
-// active: absence of lifecycle evidence must never exclude a seat.
-func (r orgRoster) Standing(role string) orgSeatStanding {
-	if s, ok := r.standing[strings.ToLower(strings.TrimSpace(role))]; ok {
-		return s
-	}
-	return orgSeatActive
+	return config.ResolveOrgRoster(cfg, archived, paused)
 }
 
 // loadOrgRosterObservations is the ONE supplier seam for lifecycle
 // observations. It returns nothing today; the #1635 ingest (the herdr
-// `agent list --json` reader and its durable mirror) lands inside this
-// function without touching any roster consumer. A nil store must stay
-// valid: several call sites resolve the roster without an open store, and
-// missing observations mean an unfiltered (all-active) roster by contract.
-func loadOrgRosterObservations(ctx context.Context, store *db.Store) (archived map[string]orgArchivedObservation, paused map[string]string) {
+// `agent list` reader and its durable mirror) lands inside this function
+// without touching any roster consumer. A nil store must stay valid: several
+// call sites resolve the roster without an open store, and missing
+// observations mean an unfiltered (all-active) roster by contract. A package
+// var so tests can classify seats without an ingest.
+var loadOrgRosterObservations = func(ctx context.Context, store *db.Store) (archived map[string]orgArchivedObservation, paused map[string]string) {
 	_ = ctx
 	_ = store
 	return nil, nil

--- a/internal/cli/org_roster_doctor_pin_test.go
+++ b/internal/cli/org_roster_doctor_pin_test.go
@@ -1,0 +1,39 @@
+package cli
+
+import (
+	"context"
+	"testing"
+
+	"github.com/gitmoot/gitmoot/internal/db"
+)
+
+// Pins the doctor's VIEW CHOICE (#1637 round 3, ordered by GITMOOT-COC): the
+// idle-activity check monitors Nudgeable() — a paused seat is deliberately
+// idle, so warning that it is idle is noise. Reverting
+// monitoredOrgActivityRoles to Members() must fail here; before this pin that
+// revert broke no test.
+func TestMonitoredOrgActivityRolesExcludePausedSeats(t *testing.T) {
+	cfg := loadOrgActivityTestConfig(t)
+	original := loadOrgRosterObservations
+	loadOrgRosterObservations = func(context.Context, *db.Store) (map[string]orgArchivedObservation, map[string]string) {
+		return nil, map[string]string{"owner": "deliberately idle"}
+	}
+	t.Cleanup(func() { loadOrgRosterObservations = original })
+
+	roles := monitoredOrgActivityRoles(cfg)
+	names := make([]string, 0, len(roles))
+	for _, role := range roles {
+		names = append(names, role.Name)
+	}
+	if len(names) != 1 || names[0] != "review" {
+		t.Fatalf("monitored roles = %v, want only the active review seat — a paused seat must not be idle-warned", names)
+	}
+	// And the supplier restored: with no observations both monitored roles
+	// return, proving the exclusion above came from the paused classification
+	// rather than from the recycle_after filter.
+	loadOrgRosterObservations = original
+	roles = monitoredOrgActivityRoles(cfg)
+	if len(roles) != 2 {
+		t.Fatalf("baseline monitored roles = %d, want 2 — the fixture no longer exercises the paused exclusion", len(roles))
+	}
+}

--- a/internal/cli/org_roster_guard_test.go
+++ b/internal/cli/org_roster_guard_test.go
@@ -1,9 +1,11 @@
 package cli
 
 import (
+	"go/ast"
+	"go/parser"
+	"go/token"
 	"os"
 	"path/filepath"
-	"regexp"
 	"runtime"
 	"strings"
 	"testing"
@@ -25,12 +27,10 @@ var orgRosterAllowedRolesCallSites = map[string]bool{
 	"internal/cli/org_roster.go": true,
 }
 
-// TestOrgRosterSeamIsTheOnlyRolesCallSite scans every non-test Go file under
-// internal/ and cmd/ for `.Roles()` calls and requires each hit to be in the
-// allow-list above. The match is textual by design: a false positive from some
-// future unrelated Roles() method fails LOUDLY here and gets resolved by a
-// deliberate allow-list edit, which is exactly the review conversation the
-// seam wants to force.
+// TestOrgRosterSeamIsTheOnlyRolesCallSite parses every non-test Go file in the
+// repository for executable `.Roles()` calls and requires each hit to be in the
+// allow-list above. This is intentionally syntax-based: comments documenting
+// the seam must not make an implementation with no real Roles call pass.
 func TestOrgRosterSeamIsTheOnlyRolesCallSite(t *testing.T) {
 	_, thisFile, _, ok := runtime.Caller(0)
 	if !ok {
@@ -40,47 +40,69 @@ func TestOrgRosterSeamIsTheOnlyRolesCallSite(t *testing.T) {
 	if _, err := os.Stat(filepath.Join(repoRoot, "go.mod")); err != nil {
 		t.Fatalf("repo root %s has no go.mod: %v", repoRoot, err)
 	}
-	pattern := regexp.MustCompile(`\.Roles\(\)`)
+	fset := token.NewFileSet()
 	scanned := 0
+	scannedOutsideLegacyRoots := 0
+	seamCalls := 0
 	var violations []string
-	for _, top := range []string{"internal", "cmd"} {
-		err := filepath.WalkDir(filepath.Join(repoRoot, top), func(path string, entry os.DirEntry, err error) error {
-			if err != nil {
-				return err
-			}
-			if entry.IsDir() || !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
-				return nil
-			}
-			rel, err := filepath.Rel(repoRoot, path)
-			if err != nil {
-				return err
-			}
-			rel = filepath.ToSlash(rel)
-			content, err := os.ReadFile(path)
-			if err != nil {
-				return err
-			}
-			scanned++
-			if !pattern.Match(content) {
-				return nil
-			}
-			if !orgRosterAllowedRolesCallSites[rel] {
-				violations = append(violations, rel)
+	err := filepath.WalkDir(repoRoot, func(path string, entry os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if entry.IsDir() {
+			if entry.Name() == ".git" {
+				return filepath.SkipDir
 			}
 			return nil
-		})
-		if err != nil {
-			t.Fatal(err)
 		}
+		if !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
+			return nil
+		}
+		rel, err := filepath.Rel(repoRoot, path)
+		if err != nil {
+			return err
+		}
+		rel = filepath.ToSlash(rel)
+		file, err := parser.ParseFile(fset, path, nil, 0)
+		if err != nil {
+			return err
+		}
+		scanned++
+		if !strings.HasPrefix(rel, "internal/") && !strings.HasPrefix(rel, "cmd/") {
+			scannedOutsideLegacyRoots++
+		}
+		ast.Inspect(file, func(node ast.Node) bool {
+			call, ok := node.(*ast.CallExpr)
+			if !ok {
+				return true
+			}
+			selector, ok := call.Fun.(*ast.SelectorExpr)
+			if !ok || selector.Sel.Name != "Roles" {
+				return true
+			}
+			position := fset.Position(selector.Sel.Pos())
+			if orgRosterAllowedRolesCallSites[rel] {
+				seamCalls++
+			} else {
+				violations = append(violations, position.String())
+			}
+			return true
+		})
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
 	}
 	// A broken walk that scans nothing would pass vacuously; require the scan
 	// to have actually covered the tree, including the one allowed file.
 	if scanned < 100 {
 		t.Fatalf("scanned only %d non-test Go files; the walk is broken, not the tree clean", scanned)
 	}
-	seam := filepath.Join(repoRoot, "internal", "cli", "org_roster.go")
-	if content, err := os.ReadFile(seam); err != nil || !pattern.Match(content) {
-		t.Fatalf("seam file %s missing or no longer calls .Roles() (err=%v); the guard's subject moved", seam, err)
+	if scannedOutsideLegacyRoots == 0 {
+		t.Fatal("scanned no non-test Go files outside internal/ and cmd/; repository-wide guard scope regressed")
+	}
+	if seamCalls == 0 {
+		t.Fatal("internal/cli/org_roster.go no longer contains an executable .Roles() call; the guard's subject moved")
 	}
 	if len(violations) != 0 {
 		t.Fatalf("direct config.OrgConfig.Roles() call sites outside the roster seam: %v — route them through resolveOrgRoster/loadOrgRoster (internal/cli/org_roster.go, #1635)", violations)

--- a/internal/cli/org_roster_guard_test.go
+++ b/internal/cli/org_roster_guard_test.go
@@ -1,0 +1,88 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// orgRosterAllowedRolesCallSites is the exhaustive allow-list of non-test
+// production files that may call config.OrgConfig.Roles() directly. The roster
+// seam (#1635) exists so that seat-lifecycle exclusions (archived, paused) are
+// applied in exactly ONE place; a new direct call site is a roster consumer
+// that would silently bypass those exclusions — the N-filters drift this repo
+// has already paid for (#1283's five-copies-of-the-rule freeze).
+//
+// If this test failed on your change: route the new consumer through
+// resolveOrgRoster / loadOrgRoster (internal/cli/org_roster.go) and pick the
+// view it needs — Members() (chart/health/presence/dispatch/routing) or
+// Nudgeable() (sweeps/nudges/alarms/automated wakes). Only extend this list
+// for the seam itself.
+var orgRosterAllowedRolesCallSites = map[string]bool{
+	"internal/cli/org_roster.go": true,
+}
+
+// TestOrgRosterSeamIsTheOnlyRolesCallSite scans every non-test Go file under
+// internal/ and cmd/ for `.Roles()` calls and requires each hit to be in the
+// allow-list above. The match is textual by design: a false positive from some
+// future unrelated Roles() method fails LOUDLY here and gets resolved by a
+// deliberate allow-list edit, which is exactly the review conversation the
+// seam wants to force.
+func TestOrgRosterSeamIsTheOnlyRolesCallSite(t *testing.T) {
+	_, thisFile, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("runtime.Caller failed")
+	}
+	repoRoot := filepath.Clean(filepath.Join(filepath.Dir(thisFile), "..", ".."))
+	if _, err := os.Stat(filepath.Join(repoRoot, "go.mod")); err != nil {
+		t.Fatalf("repo root %s has no go.mod: %v", repoRoot, err)
+	}
+	pattern := regexp.MustCompile(`\.Roles\(\)`)
+	scanned := 0
+	var violations []string
+	for _, top := range []string{"internal", "cmd"} {
+		err := filepath.WalkDir(filepath.Join(repoRoot, top), func(path string, entry os.DirEntry, err error) error {
+			if err != nil {
+				return err
+			}
+			if entry.IsDir() || !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
+				return nil
+			}
+			rel, err := filepath.Rel(repoRoot, path)
+			if err != nil {
+				return err
+			}
+			rel = filepath.ToSlash(rel)
+			content, err := os.ReadFile(path)
+			if err != nil {
+				return err
+			}
+			scanned++
+			if !pattern.Match(content) {
+				return nil
+			}
+			if !orgRosterAllowedRolesCallSites[rel] {
+				violations = append(violations, rel)
+			}
+			return nil
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+	// A broken walk that scans nothing would pass vacuously; require the scan
+	// to have actually covered the tree, including the one allowed file.
+	if scanned < 100 {
+		t.Fatalf("scanned only %d non-test Go files; the walk is broken, not the tree clean", scanned)
+	}
+	seam := filepath.Join(repoRoot, "internal", "cli", "org_roster.go")
+	if content, err := os.ReadFile(seam); err != nil || !pattern.Match(content) {
+		t.Fatalf("seam file %s missing or no longer calls .Roles() (err=%v); the guard's subject moved", seam, err)
+	}
+	if len(violations) != 0 {
+		t.Fatalf("direct config.OrgConfig.Roles() call sites outside the roster seam: %v — route them through resolveOrgRoster/loadOrgRoster (internal/cli/org_roster.go, #1635)", violations)
+	}
+}

--- a/internal/cli/org_roster_guard_test.go
+++ b/internal/cli/org_roster_guard_test.go
@@ -6,32 +6,52 @@ import (
 	"go/token"
 	"os"
 	"path/filepath"
+	"reflect"
 	"runtime"
+	"sort"
 	"strings"
 	"testing"
+
+	"github.com/gitmoot/gitmoot/internal/config"
 )
 
-// orgRosterAllowedRolesCallSites is the exhaustive allow-list of non-test
-// production files that may call config.OrgConfig.Roles() directly. The roster
-// seam (#1635) exists so that seat-lifecycle exclusions (archived, paused) are
-// applied in exactly ONE place; a new direct call site is a roster consumer
-// that would silently bypass those exclusions — the N-filters drift this repo
-// has already paid for (#1283's five-copies-of-the-rule freeze).
+// Round-3 enforcement of the single-choke-point claim (#1635, PR #1637).
 //
-// If this test failed on your change: route the new consumer through
-// resolveOrgRoster / loadOrgRoster (internal/cli/org_roster.go) and pick the
-// view it needs — Members() (chart/health/presence/dispatch/routing) or
-// Nudgeable() (sweeps/nudges/alarms/automated wakes). Only extend this list
-// for the seam itself.
-var orgRosterAllowedRolesCallSites = map[string]bool{
-	"internal/cli/org_roster.go": true,
+// Rounds 1-2 tried to DETECT direct config.OrgConfig.Roles() access and lost
+// the syntactic-form enumeration game twice (a comment satisfied the round-1
+// regex; a method value bypassed the round-2 CallExpr walk). Round 3 PREVENTS
+// instead: the accessor is unexported (sortedRoles), so a plain call, method
+// value, method expression, or reflection invocation from outside
+// internal/config no longer compiles or is refused by reflect. The compiler
+// covers the whole module — the scope the earlier walks approximated.
+//
+// What remains guardable by test is the ONE exported surface the seam needs:
+// config.ResolveOrgRoster, whose nil-observation result is the unfiltered
+// roster. TestOrgRosterSeamIsTheOnlyResolveCallSite censuses every reference
+// to that IDENTIFIER: a function cannot be referenced without its name
+// appearing as an identifier (import aliasing renames the package qualifier,
+// not the function; dot-imports keep it; assigning it to a variable still
+// writes it once), so this is object-level detection rather than call-form
+// enumeration.
+//
+// STATED LIMITS (the #1626 disposition — hitting one of these later is the
+// statement working, not a finding):
+//   - reflection can look up ResolveOrgRoster by string and call it;
+//   - a deliberate Roots()+Children() structural walk can rebuild the role
+//     set (those accessors serve chart/escalation-path structure and stay);
+//   - code inside internal/config can call sortedRoles() directly.
+// All three are deliberate, review-visible acts. The accidental class this
+// guard family exists for — a new consumer innocently enumerating roles and
+// silently bypassing lifecycle exclusions — is a compile error.
+
+// orgRosterResolveAllowedFiles are the only non-test production files that may
+// reference ResolveOrgRoster: its definition and the cli seam.
+var orgRosterResolveAllowedFiles = map[string]bool{
+	"internal/config/org_roster.go": true,
+	"internal/cli/org_roster.go":    true,
 }
 
-// TestOrgRosterSeamIsTheOnlyRolesCallSite parses every non-test Go file in the
-// repository for executable `.Roles()` calls and requires each hit to be in the
-// allow-list above. This is intentionally syntax-based: comments documenting
-// the seam must not make an implementation with no real Roles call pass.
-func TestOrgRosterSeamIsTheOnlyRolesCallSite(t *testing.T) {
+func TestOrgRosterSeamIsTheOnlyResolveCallSite(t *testing.T) {
 	_, thisFile, _, ok := runtime.Caller(0)
 	if !ok {
 		t.Fatal("runtime.Caller failed")
@@ -40,17 +60,18 @@ func TestOrgRosterSeamIsTheOnlyRolesCallSite(t *testing.T) {
 	if _, err := os.Stat(filepath.Join(repoRoot, "go.mod")); err != nil {
 		t.Fatalf("repo root %s has no go.mod: %v", repoRoot, err)
 	}
-	fset := token.NewFileSet()
 	scanned := 0
-	scannedOutsideLegacyRoots := 0
-	seamCalls := 0
+	seamReferences := 0
 	var violations []string
 	err := filepath.WalkDir(repoRoot, func(path string, entry os.DirEntry, err error) error {
 		if err != nil {
 			return err
 		}
 		if entry.IsDir() {
-			if entry.Name() == ".git" {
+			name := entry.Name()
+			// The module's Go source lives outside these; website/ and node
+			// trees hold no production Go and slow the walk down.
+			if name == ".git" || name == "node_modules" || name == "website" || name == "testdata" {
 				return filepath.SkipDir
 			}
 			return nil
@@ -63,48 +84,84 @@ func TestOrgRosterSeamIsTheOnlyRolesCallSite(t *testing.T) {
 			return err
 		}
 		rel = filepath.ToSlash(rel)
-		file, err := parser.ParseFile(fset, path, nil, 0)
+		fset := token.NewFileSet()
+		parsed, err := parser.ParseFile(fset, path, nil, 0)
 		if err != nil {
 			return err
 		}
 		scanned++
-		if !strings.HasPrefix(rel, "internal/") && !strings.HasPrefix(rel, "cmd/") {
-			scannedOutsideLegacyRoots++
-		}
-		ast.Inspect(file, func(node ast.Node) bool {
-			call, ok := node.(*ast.CallExpr)
-			if !ok {
-				return true
-			}
-			selector, ok := call.Fun.(*ast.SelectorExpr)
-			if !ok || selector.Sel.Name != "Roles" {
-				return true
-			}
-			position := fset.Position(selector.Sel.Pos())
-			if orgRosterAllowedRolesCallSites[rel] {
-				seamCalls++
-			} else {
-				violations = append(violations, position.String())
+		references := 0
+		ast.Inspect(parsed, func(n ast.Node) bool {
+			if ident, ok := n.(*ast.Ident); ok && ident.Name == "ResolveOrgRoster" {
+				references++
 			}
 			return true
 		})
+		if references == 0 {
+			return nil
+		}
+		if rel == "internal/cli/org_roster.go" {
+			seamReferences = references
+		}
+		if !orgRosterResolveAllowedFiles[rel] {
+			violations = append(violations, rel)
+		}
 		return nil
 	})
 	if err != nil {
 		t.Fatal(err)
 	}
-	// A broken walk that scans nothing would pass vacuously; require the scan
-	// to have actually covered the tree, including the one allowed file.
+	// Fail-closed floor: a walk that scans almost nothing is a broken census,
+	// not a clean tree (round-1 lesson, kept).
 	if scanned < 100 {
-		t.Fatalf("scanned only %d non-test Go files; the walk is broken, not the tree clean", scanned)
+		t.Fatalf("scanned only %d non-test Go files; the census walk is broken, not the tree clean", scanned)
 	}
-	if scannedOutsideLegacyRoots == 0 {
-		t.Fatal("scanned no non-test Go files outside internal/ and cmd/; repository-wide guard scope regressed")
-	}
-	if seamCalls == 0 {
-		t.Fatal("internal/cli/org_roster.go no longer contains an executable .Roles() call; the guard's subject moved")
+	// Positive control: the seam's own reference must be seen. Its absence
+	// means the census is broken or the subject moved — never a clean tree.
+	if seamReferences == 0 {
+		t.Fatal("census found no ResolveOrgRoster reference in internal/cli/org_roster.go; the guard's subject moved or the census is broken")
 	}
 	if len(violations) != 0 {
-		t.Fatalf("direct config.OrgConfig.Roles() call sites outside the roster seam: %v — route them through resolveOrgRoster/loadOrgRoster (internal/cli/org_roster.go, #1635)", violations)
+		t.Fatalf("ResolveOrgRoster referenced outside the roster seam: %v — consumers draw from loadOrgRoster (internal/cli/org_roster.go, #1635); a direct nil-observation resolve is the unfiltered-roster bypass", violations)
+	}
+}
+
+// TestOrgConfigMethodSetIsPinned snapshots OrgConfig's exported method set.
+// It is a change-forcing guard, not a bypass detector: re-exporting a bulk
+// roles accessor, or adding a new one, must arrive together with an edit here
+// that names why the single-choke-point policy (#1635) permits it.
+func TestOrgConfigMethodSetIsPinned(t *testing.T) {
+	want := []string{
+		"Ancestors",
+		"Children",
+		"DirectiveAckTTL",
+		"DirectiveDoneTTL",
+		"DirectiveMaxNudges",
+		"Enabled",
+		"Enforce",
+		"Path",
+		"RecycleAfterFor",
+		"RecycleEnforce",
+		"Role",
+		"Roots",
+	}
+	typ := reflect.TypeOf(config.OrgConfig{})
+	got := make([]string, 0, typ.NumMethod())
+	for i := 0; i < typ.NumMethod(); i++ {
+		got = append(got, typ.Method(i).Name)
+	}
+	sort.Strings(got)
+	// Fail-closed: an empty method set means the reflection read is broken or
+	// the type moved, never that the policy is satisfied.
+	if len(got) == 0 {
+		t.Fatal("OrgConfig exports no methods; the pin is reading the wrong type")
+	}
+	if len(got) != len(want) {
+		t.Fatalf("OrgConfig exported methods = %v, pinned %v — a new or re-exported accessor must update this pin alongside a stated reason it honors the #1635 single-choke-point policy", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("OrgConfig exported methods = %v, pinned %v — a new or re-exported accessor must update this pin alongside a stated reason it honors the #1635 single-choke-point policy", got, want)
+		}
 	}
 }

--- a/internal/cli/org_roster_test.go
+++ b/internal/cli/org_roster_test.go
@@ -1,0 +1,146 @@
+package cli
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/gitmoot/gitmoot/internal/config"
+)
+
+func orgRosterTestConfig(t *testing.T) config.OrgConfig {
+	t.Helper()
+	home := t.TempDir()
+	paths := config.PathsForHome(home)
+	if err := os.MkdirAll(filepath.Dir(paths.ConfigFile), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(paths.ConfigFile, []byte(`
+[org.roles."owner"]
+scope = ["*"]
+pane = "Gitmoot"
+[org.roles."keeper"]
+parent = "owner"
+scope = ["gitmoot/*"]
+[org.roles."scout"]
+parent = "owner"
+scope = ["gitmoot/*"]
+`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := config.LoadOrg(paths)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return cfg
+}
+
+func rosterNames(roles []config.OrgRole) []string {
+	names := make([]string, 0, len(roles))
+	for _, role := range roles {
+		names = append(names, role.Name)
+	}
+	return names
+}
+
+func assertRosterNames(t *testing.T, label string, got []config.OrgRole, want ...string) {
+	t.Helper()
+	names := rosterNames(got)
+	if len(names) != len(want) {
+		t.Fatalf("%s = %v, want %v", label, names, want)
+	}
+	for i := range want {
+		if names[i] != want[i] {
+			t.Fatalf("%s = %v, want %v", label, names, want)
+		}
+	}
+}
+
+// Nil observations must reproduce the pre-#1635 roster exactly: every
+// configured role is a full member, nudgeable, standing active. This is the
+// deploy-in-either-order contract (missing lifecycle field means ACTIVE).
+func TestResolveOrgRosterNilObservationsIsIdentity(t *testing.T) {
+	cfg := orgRosterTestConfig(t)
+	roster := resolveOrgRoster(cfg, nil, nil)
+	assertRosterNames(t, "Members()", roster.Members(), "keeper", "owner", "scout")
+	assertRosterNames(t, "Nudgeable()", roster.Nudgeable(), "keeper", "owner", "scout")
+	if len(roster.Archived()) != 0 {
+		t.Fatalf("Archived() = %v, want empty", roster.Archived())
+	}
+	for _, name := range []string{"owner", "keeper", "scout"} {
+		if s := roster.Standing(name); s != orgSeatActive {
+			t.Fatalf("Standing(%q) = %q, want active", name, s)
+		}
+	}
+}
+
+// An archived observation removes the seat from BOTH views (full exclusion) and
+// surfaces it, with its observation fields intact, in Archived().
+func TestResolveOrgRosterArchivedIsFullExclusion(t *testing.T) {
+	cfg := orgRosterTestConfig(t)
+	at := time.Date(2026, 8, 26, 10, 0, 0, 0, time.UTC)
+	observed := at.Add(30 * time.Minute)
+	roster := resolveOrgRoster(cfg, map[string]orgArchivedObservation{
+		"scout": {At: at, By: "jarvis", Reason: "project paused", ObservedAt: observed},
+	}, nil)
+	assertRosterNames(t, "Members()", roster.Members(), "keeper", "owner")
+	assertRosterNames(t, "Nudgeable()", roster.Nudgeable(), "keeper", "owner")
+	if got := roster.Archived(); len(got) != 1 ||
+		got[0].Role.Name != "scout" || !got[0].At.Equal(at) ||
+		got[0].By != "jarvis" || got[0].Reason != "project paused" || !got[0].ObservedAt.Equal(observed) {
+		t.Fatalf("Archived() = %+v, want one scout entry with observation fields", got)
+	}
+	if s := roster.Standing("scout"); s != orgSeatArchived {
+		t.Fatalf("Standing(scout) = %q, want archived", s)
+	}
+}
+
+// A paused seat is a SOFT exclusion: still a member (chart/health/presence/
+// dispatch) but not nudgeable (no nudge ladders, alarms, automated wakes).
+// Distinct from archived by ruling on #1635 — collapsing the two over-hides a
+// live paused seat or under-hides an archived one.
+func TestResolveOrgRosterPausedIsSoftExclusion(t *testing.T) {
+	cfg := orgRosterTestConfig(t)
+	roster := resolveOrgRoster(cfg, nil, map[string]string{"scout": "deliberately idle"})
+	assertRosterNames(t, "Members()", roster.Members(), "keeper", "owner", "scout")
+	assertRosterNames(t, "Nudgeable()", roster.Nudgeable(), "keeper", "owner")
+	if s := roster.Standing("scout"); s != orgSeatPaused {
+		t.Fatalf("Standing(scout) = %q, want paused", s)
+	}
+	if len(roster.Archived()) != 0 {
+		t.Fatalf("Archived() = %v, want empty", roster.Archived())
+	}
+}
+
+// Standing lookups are case-insensitive on the caller side (config guarantees
+// lower-case role names; callers may not).
+func TestResolveOrgRosterLookupIsCaseInsensitive(t *testing.T) {
+	cfg := orgRosterTestConfig(t)
+	roster := resolveOrgRoster(cfg, map[string]orgArchivedObservation{"keeper": {ObservedAt: time.Now().UTC()}}, nil)
+	assertRosterNames(t, "Members()", roster.Members(), "owner", "scout")
+	if s := roster.Standing("KEEPER"); s != orgSeatArchived {
+		t.Fatalf("Standing(KEEPER) = %q, want archived", s)
+	}
+}
+
+// An unconfigured role reads ACTIVE: absence of lifecycle evidence must never
+// exclude a seat.
+func TestOrgRosterStandingUnknownRoleReadsActive(t *testing.T) {
+	cfg := orgRosterTestConfig(t)
+	roster := resolveOrgRoster(cfg, nil, nil)
+	if s := roster.Standing("nobody"); s != orgSeatActive {
+		t.Fatalf("Standing(nobody) = %q, want active", s)
+	}
+}
+
+// The supplier seam returns no observations today (the #1635 ingest lands
+// there), so loadOrgRoster with any store — including nil — is the identity
+// roster.
+func TestLoadOrgRosterNilStoreIsIdentity(t *testing.T) {
+	cfg := orgRosterTestConfig(t)
+	roster := loadOrgRoster(context.Background(), nil, cfg)
+	assertRosterNames(t, "Members()", roster.Members(), "keeper", "owner", "scout")
+	assertRosterNames(t, "Nudgeable()", roster.Nudgeable(), "keeper", "owner", "scout")
+}

--- a/internal/config/org.go
+++ b/internal/config/org.go
@@ -109,7 +109,11 @@ func (c OrgConfig) Roots() []string {
 	return roots
 }
 
-func (c OrgConfig) Roles() []OrgRole {
+// sortedRoles is deliberately unexported (#1635 / PR #1637 round 3): the only
+// cross-package enumeration path is ResolveOrgRoster, so a consumer that
+// bypasses lifecycle classification does not compile. See org_roster.go for
+// the stated limits of this boundary.
+func (c OrgConfig) sortedRoles() []OrgRole {
 	names := make([]string, 0, len(c.roles))
 	for name := range c.roles {
 		names = append(names, name)

--- a/internal/config/org_roster.go
+++ b/internal/config/org_roster.go
@@ -1,0 +1,119 @@
+package config
+
+import (
+	"strings"
+	"time"
+)
+
+// Roster resolution lives HERE, next to the role registry, so that the raw
+// role map has no exported bulk accessor at all (#1635, PR #1637 round 3).
+// OrgConfig.roles is reachable outside this package only through
+// ResolveOrgRoster, which applies seat-lifecycle classification. The former
+// OrgConfig.Roles() accessor is unexported (sortedRoles()): a direct call, method
+// value, method expression, or reflection invocation from another package is
+// a compile error or a reflect refusal — not a test finding.
+//
+// STATED LIMITS, deliberately documented rather than left latent
+// (the #1626 disposition — a reviewer producing one of these later is the
+// statement working, not a finding):
+//   - ResolveOrgRoster is exported (the cli seam must call it) and
+//     ResolveOrgRoster(cfg, nil, nil).Members() is the unfiltered roster.
+//     TestOrgRosterSeamIsTheOnlyResolveCallSite censuses every reference to
+//     it and allows exactly the seam.
+//   - A deliberate Roots()+Children() structural walk can rebuild the role
+//     set. Those accessors serve chart/escalation-path structure and stay; a
+//     reconstruction through them is a review-visible act, not an accident.
+//   - Code inside this package can call sortedRoles() directly.
+
+// OrgSeatStanding classifies a configured role's roster membership.
+type OrgSeatStanding string
+
+const (
+	// OrgSeatActive: full roster member — appears everywhere, receives
+	// sweeps, nudges, and automated wakes.
+	OrgSeatActive OrgSeatStanding = "active"
+	// OrgSeatPaused: soft exclusion — still a live roster member (chart,
+	// health, presence, provider, dispatch, escalation routing) but excluded
+	// from nudge ladders, idle/blocked alarms, and automated wakes.
+	OrgSeatPaused OrgSeatStanding = "paused"
+	// OrgSeatArchived: full exclusion — out of rotation entirely; the seat has
+	// no pane and its open work is parked (rendered by `org seats archived`).
+	OrgSeatArchived OrgSeatStanding = "archived"
+)
+
+// OrgArchivedObservation is one observed herdr archive record: the `archived`
+// block herdr serializes per agent, plus when gitmoot observed it. Presence of
+// the block means archived; absence means active.
+type OrgArchivedObservation struct {
+	At         time.Time
+	By         string
+	Reason     string
+	ObservedAt time.Time
+}
+
+// OrgArchivedSeat pairs a configured role with its archive observation for the
+// `org seats archived` view.
+type OrgArchivedSeat struct {
+	Role OrgRole
+	OrgArchivedObservation
+}
+
+// OrgRoster is the lifecycle-classified view of the configured roles.
+type OrgRoster struct {
+	members   []OrgRole
+	nudgeable []OrgRole
+	archived  []OrgArchivedSeat
+	standing  map[string]OrgSeatStanding
+}
+
+// ResolveOrgRoster classifies every configured role. It is the ONLY way to
+// enumerate roles from outside this package, and its one production caller is
+// the cli roster seam (loadOrgRoster) — enforced by the reference census in
+// internal/cli/org_roster_guard_test.go. Observation maps are keyed by role
+// name; lookups are case-insensitive on the role side and expect lower-case
+// keys on the supplier side. paused maps role name -> reason. Nil observation
+// maps reproduce the unclassified roster exactly (missing evidence means
+// ACTIVE, the herdrup#173 deploy-in-either-order contract).
+func ResolveOrgRoster(cfg OrgConfig, archived map[string]OrgArchivedObservation, paused map[string]string) OrgRoster {
+	roster := OrgRoster{standing: map[string]OrgSeatStanding{}}
+	for _, role := range cfg.sortedRoles() {
+		key := strings.ToLower(strings.TrimSpace(role.Name))
+		if observation, ok := archived[key]; ok {
+			roster.standing[key] = OrgSeatArchived
+			roster.archived = append(roster.archived, OrgArchivedSeat{Role: role, OrgArchivedObservation: observation})
+			continue
+		}
+		roster.members = append(roster.members, role)
+		if _, ok := paused[key]; ok {
+			roster.standing[key] = OrgSeatPaused
+			continue
+		}
+		roster.standing[key] = OrgSeatActive
+		roster.nudgeable = append(roster.nudgeable, role)
+	}
+	return roster
+}
+
+// Members returns the live roster: active + paused seats. Chart, health,
+// presence, provider construction, dispatch, and escalation routing use this
+// view.
+func (r OrgRoster) Members() []OrgRole { return r.members }
+
+// Nudgeable returns active seats only. Sweeps, nudge ladders, idle/blocked
+// alarms, and automated wakes use this view.
+func (r OrgRoster) Nudgeable() []OrgRole { return r.nudgeable }
+
+// Archived returns the observed archived seats. Zero production callers today
+// by design: the `org seats archived` view arrives with the #1635 ingest PR.
+func (r OrgRoster) Archived() []OrgArchivedSeat { return r.archived }
+
+// Standing reports a role's classification. Unknown (unconfigured) roles read
+// active: absence of lifecycle evidence must never exclude a seat. Zero
+// production callers today by design: dispatch/recycle refusals arrive with
+// the #1635 ingest PR.
+func (r OrgRoster) Standing(role string) OrgSeatStanding {
+	if s, ok := r.standing[strings.ToLower(strings.TrimSpace(role))]; ok {
+		return s
+	}
+	return OrgSeatActive
+}


### PR DESCRIPTION
GM-ARCHIVE — PR1 of #1635, the gitmoot side of jerryfane/herdrup#173 (archive agents). Authorized by GITMOOT-COC (directive 85458; plans 85481/85639/85675; round-3 approval on-pane 2026-08-26).

## The safety argument, first

**This PR changes no behavior.** Identity with the pre-PR roster holds because of what the code IS, not because a test says so (correction per JARVIS's merge review, directive 85732): `Roles()` was RENAMED to `sortedRoles()` with its body unchanged, and `ResolveOrgRoster` iterates `cfg.sortedRoles()` with two map lookups that both MISS on a nil map — so with nil observations every role lands in members and nudgeable, standing `active`, in the same order, because the enumeration is the same function. That is checkable by reading the diff. `TestResolveOrgRosterNilObservationsIsIdentity` pins the fixture behavior but asserts hardcoded names and never calls the old accessor — a reimplemented expectation, not a witness to the original — so it is corroboration, not the argument. This identity is the justification for converting twelve call sites in one PR.

**What this PR does NOT do:** no ingest, no herdr read, no archived seats anywhere yet. The observation supplier returns nothing. `Archived()` and `Standing()` therefore have **zero production callers by design** — the `org seats archived` view and dispatch/recycle refusals land with the ingest PR; the methods existing is not the feature existing.

## What it does

Creates THE roster choke-point and routes every roster consumer through it, so seat-lifecycle exclusions (archived = full, paused = soft — distinct by ruling on #1635) are applied in exactly one place. Views: `Members()` (active+paused: chart, health, presence, provider, dispatch, routing) and `Nudgeable()` (active only: sweeps, nudge ladders, idle/blocked alarms, wakes). The supplier (`loadOrgRosterObservations`) **returns nil today and that is the design, not dead code** — the #1635 ingest lands inside it, touching zero consumers.

Twelve call sites converted (the plan estimated ten; enumeration found twelve): `org.go:648,701,704,1201` · `daemon_workflow.go:902` · `org_overview.go:143-145,216` · `blocked_since.go:315` · `dashboard_web_org_activity.go:160,238` · `doctor_org_activity.go:46`. Sites resolving with a nil store (ingest-PR checklist): `org.go:648`, `org.go:1201`, `daemon_workflow.go:902`, `doctor_org_activity.go:46`, `dashboard_web_org_activity.go:160`.

## How the single-choke-point claim is enforced (round 3)

Rounds 1–2 tried to **detect** direct `Roles()` access and lost the syntactic enumeration game twice (a doc comment satisfied the round-1 regex; a method value bypassed the round-2 `CallExpr` walk). Round 3 **prevents**:

- **Roster resolution moved into `internal/config`** (`ResolveOrgRoster`; verified zero new imports — no cycle risk) and the raw accessor **unexported** (`sortedRoles`). Every access form to the roles map — plain call, method value, method expression, **and reflection, which cannot invoke an unexported method** — is now a compile error across the whole module. Demonstrated: `cfg.sortedRoles()` from `internal/cli` → `cannot refer to unexported method sortedRoles`.
- **The one residual exported surface is censused by IDENTIFIER.** `ResolveOrgRoster` must stay exported for the seam to call it, and `ResolveOrgRoster(cfg, nil, nil).Members()` is the unfiltered roster — so unexporting alone would move the bypass one name over, not remove it. A function cannot be referenced without its name appearing as an AST identifier (import aliasing renames the qualifier, not the function; dot-imports keep it), so `TestOrgRosterSeamIsTheOnlyResolveCallSite` is **object-level detection, not form enumeration** — codex's round-3 mechanism, applied at its narrowest point, stdlib-only. Fail-closed both ways: a near-empty walk fails, and the seam's own reference is the positive control.
- **A method-set snapshot pin on `OrgConfig`** (`TestOrgConfigMethodSetIsPinned`): re-exporting `Roles` or adding a bulk accessor trips a named-policy test. Change-forcing, not bypass-enumerating — it cannot go inert the way rounds 1–2 did.
- **Stated limits, #1626-style, in both files** (do not simplify these away): reflection can reach the exported `ResolveOrgRoster` by string; a deliberate `Roots()`+`Children()` walk can rebuild the role set (review-visible act, accepted); config-internal code can call `sortedRoles()`. A later reviewer producing one of these is the statement working, not a finding.

A process note that belongs in the record: the original round-3 plan measured that `.Roles()` had zero callers outside the seam and recommended prevention on that basis. **The measurement was correct and answered the COST question, not the BOUNDARY question** — codex's objection named the exported-replacement hole, and this design (a′) is the synthesis: compile-time death for the map accessor, identifier census for the one surface that must stay exported. Credit both reviews; both blocks and the objection were exact.

## Also in this round

- **The doctor's `Nudgeable()` choice is pinned** (`TestMonitoredOrgActivityRolesExcludePausedSeats`): reverting `monitoredOrgActivityRoles` to `Members()` previously broke no test; now it fails with a message naming why a paused seat must not be idle-warned.
- Round-2's blocked/input-pending alarm exclusions and injectable roster dependency are retained unchanged.

## Verification (targeted; the full gate runs coordinator-side)

9 seam/guard/pin tests pass; 18 existing tests over the converted sites pass; full `internal/config` package passes. Mutants, each compiled via `go test -c -o /dev/null`, each killed by exactly one distinct test: **G1** re-exported bulk accessor → only the method-set pin fails; **G2** `ResolveOrgRoster` referenced outside the seam → only the census fails; **G3** doctor reverted to `Members()` → only the doctor pin fails. Plus the compiler demonstration above for the boundary itself.

## Deploy notes

No behavior change, no migration, no config change; safe to deploy in any order relative to herdr. Docs deliberately absent: this PR is user-invisible; CLI.md/site/llms updates ride the PRs that add visible behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

