### PR TITLE
feat(org): park directive obligations for archived seats (#1635)

### DIFF
--- a/internal/cli/org_directive_park.go
+++ b/internal/cli/org_directive_park.go
@@ -1,0 +1,48 @@
+package cli
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/gitmoot/gitmoot/internal/db"
+)
+
+// parkOutstandingDirectivesForArchivedSeats parks every open directive
+// obligation addressed to a seat in the archived set (#1635). Nothing calls it
+// yet: the #1635 ingest invokes it once archived observations exist, the same
+// late-supplier shape as loadOrgRosterObservations.
+//
+// PARK-ONLY BY DESIGN. Parking is safe under partial observation — the worst
+// case is a directive that pauses nagging. Unparking is the dangerous
+// direction: driven off an absent or degraded read it would resume nag ladders
+// for every archived seat, the exact herdr-down failure the #1635 mirror
+// answers forbid. Unpark therefore stays an explicit per-role act
+// (UnparkOrgDirectivesForRole) keyed to an OBSERVED archived->active
+// transition, which only the ingest can attest.
+func parkOutstandingDirectivesForArchivedSeats(ctx context.Context, store *db.Store, archived map[string]orgArchivedObservation, now time.Time) (int64, error) {
+	if store == nil || len(archived) == 0 {
+		return 0, nil
+	}
+	roles := make([]string, 0, len(archived))
+	for role := range archived {
+		roles = append(roles, role)
+	}
+	sort.Strings(roles)
+	var parked int64
+	for _, role := range roles {
+		observation := archived[role]
+		reason := fmt.Sprintf("seat archived %s by %s", observation.At.UTC().Format(time.RFC3339), strings.TrimSpace(observation.By))
+		if detail := strings.TrimSpace(observation.Reason); detail != "" {
+			reason += ": " + detail
+		}
+		n, err := store.ParkOpenOrgDirectivesForRole(ctx, role, now, reason)
+		if err != nil {
+			return parked, fmt.Errorf("park directives for archived seat %q: %w", role, err)
+		}
+		parked += n
+	}
+	return parked, nil
+}

--- a/internal/cli/org_directive_park_test.go
+++ b/internal/cli/org_directive_park_test.go
@@ -1,0 +1,100 @@
+package cli
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/gitmoot/gitmoot/internal/config"
+	"github.com/gitmoot/gitmoot/internal/db"
+	dbtest "github.com/gitmoot/gitmoot/internal/db/dbtest"
+)
+
+// The helper parks exactly the archived seats' open directives — other roles'
+// obligations keep sweeping — and a nil/empty archived set parks NOTHING: the
+// helper is park-only, so absent observation can never suspend or resume
+// anything on its own.
+func TestParkOutstandingDirectivesForArchivedSeats(t *testing.T) {
+	home := t.TempDir()
+	store, err := dbtest.Open(t, config.PathsForHome(home).Database)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+	ctx := context.Background()
+	insert := func(body string) db.WorkflowNote {
+		t.Helper()
+		note, err := store.InsertWorkflowNote(ctx, db.WorkflowNote{WorkflowID: "wave/park", Author: "owner", Body: body})
+		if err != nil {
+			t.Fatal(err)
+		}
+		return note
+	}
+	archivedSeat := insert("[org:directive to=scout from=owner wf=wave/park] parked with the seat")
+	liveSeat := insert("[org:directive to=keeper from=owner wf=wave/park] keeps sweeping")
+
+	if n, err := parkOutstandingDirectivesForArchivedSeats(ctx, store, nil, time.Now()); err != nil || n != 0 {
+		t.Fatalf("nil archived set parked %d err=%v, want 0", n, err)
+	}
+
+	at := time.Date(2026, 8, 20, 9, 0, 0, 0, time.UTC)
+	archived := map[string]orgArchivedObservation{
+		"scout": {At: at, By: "jarvis", Reason: "project paused", ObservedAt: at.Add(time.Minute)},
+	}
+	n, err := parkOutstandingDirectivesForArchivedSeats(ctx, store, archived, at.Add(time.Minute))
+	if err != nil || n != 1 {
+		t.Fatalf("parked %d err=%v, want 1", n, err)
+	}
+	open, err := store.ListOpenOrgDirectiveObligations(ctx, 50)
+	if err != nil || len(open) != 1 || open[0].ID != liveSeat.ID {
+		t.Fatalf("open = %+v err=%v, want only keeper's %d", open, err, liveSeat.ID)
+	}
+	rows, err := store.ListParkedOrgDirectives(ctx, "scout")
+	if err != nil || len(rows) != 1 || rows[0].ID != archivedSeat.ID {
+		t.Fatalf("parked = %+v err=%v, want scout's %d", rows, err, archivedSeat.ID)
+	}
+	if want := "seat archived 2026-08-20T09:00:00Z by jarvis: project paused"; rows[0].ParkedReason != want {
+		t.Fatalf("parked reason = %q, want %q", rows[0].ParkedReason, want)
+	}
+}
+
+// After unpark, the evaluator must NOT find the directive due until a full TTL
+// has elapsed from unpark time — a directive returning from parking with an
+// already-blown TTL must not nag immediately (#1635 ruling). The unpark write
+// sets directive_last_nudged_at to unpark time; this pins that the due-check
+// honors that anchor.
+func TestDirectiveTTLNotDueImmediatelyAfterUnpark(t *testing.T) {
+	home := t.TempDir()
+	paths := config.PathsForHome(home)
+	if err := os.MkdirAll(filepath.Dir(paths.ConfigFile), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(paths.ConfigFile, []byte(`
+[org]
+directive_ack_ttl = "1h"
+[org.roles."owner"]
+scope = ["*"]
+[org.roles."scout"]
+parent = "owner"
+scope = ["*"]
+`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := config.LoadOrg(paths)
+	if err != nil {
+		t.Fatal(err)
+	}
+	unparkAt := time.Date(2026, 8, 26, 15, 0, 0, 0, time.UTC)
+	item := db.OrgDirectiveObligation{
+		WorkflowNote: db.WorkflowNote{ID: 7, CreatedAt: "2026-01-01 00:00:00"}, // TTL long blown while parked
+		LastNudgedAt: unparkAt.Format(time.RFC3339Nano),                        // what UnparkOrgDirectivesForRole writes
+	}
+	if _, _, _, _, due := directiveTTLDue(item, cfg, unparkAt.Add(time.Minute)); due {
+		t.Fatal("directive due one minute after unpark; the reset anchor is not honored")
+	}
+	if _, _, _, _, due := directiveTTLDue(item, cfg, unparkAt.Add(time.Hour+time.Minute)); !due {
+		t.Fatal("directive not due one full TTL after unpark; the ladder never resumes")
+	}
+}

--- a/internal/db/org_directive_park.go
+++ b/internal/db/org_directive_park.go
@@ -1,0 +1,110 @@
+package db
+
+import (
+	"context"
+	"strings"
+	"time"
+)
+
+// Directive parking (#1635, herdrup#173). Parking SUSPENDS a directive's nudge
+// ladder while its target seat is out of rotation. It is deliberately neither
+// `done` (which asserts a deliverable exists) nor `cancel` (which discards the
+// obligation): a parked directive stays open and queryable, its ladder frozen,
+// and returns to the live sweep on unpark. That preserves #1418's exhaustion
+// discrimination — an archived seat's directives must not exhaust into the
+// background rate.
+//
+// The park stamp lives in ladder columns (like directive_exhausted_at), not in
+// a done/cancel-style marker note, because it records LADDER state rather than
+// obligation completion.
+
+// ParkOpenOrgDirectivesForRole parks every OPEN directive obligation addressed
+// to targetRole that is not already parked. Done and cancelled directives are
+// untouched (they carry no ladder to suspend). Returns how many rows parked.
+func (s *Store) ParkOpenOrgDirectivesForRole(ctx context.Context, targetRole string, at time.Time, reason string) (int64, error) {
+	targetRole = strings.ToLower(strings.TrimSpace(targetRole))
+	if targetRole == "" {
+		return 0, nil
+	}
+	stamp := at.UTC().Format(time.RFC3339Nano)
+	result, err := s.db.ExecContext(ctx, `
+UPDATE workflow_notes
+SET directive_parked_at = ?, directive_parked_reason = ?
+WHERE substr(body, 1, length('[org:directive to=' || ? || ' ')) = '[org:directive to=' || ? || ' '
+	AND TRIM(directive_parked_at) = ''
+	AND NOT EXISTS (
+		SELECT 1 FROM workflow_notes r
+		WHERE r.workflow_id = workflow_notes.workflow_id AND (
+			substr(r.body, 1, length('[org:directive-cancel id=' || workflow_notes.id || ' ')) = '[org:directive-cancel id=' || workflow_notes.id || ' '
+			OR substr(r.body, 1, length('[org:directive-done id=' || workflow_notes.id || ' ')) = '[org:directive-done id=' || workflow_notes.id || ' '
+		)
+	)`,
+		stamp, strings.TrimSpace(reason), targetRole, targetRole)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected()
+}
+
+// UnparkOrgDirectivesForRole returns targetRole's parked directives to the live
+// sweep. The nudge anchor (directive_last_nudged_at) is reset to the unpark
+// time: a directive whose TTL elapsed while its seat was archived must get a
+// full fresh TTL from unpark, not nag immediately (#1635 ruling).
+func (s *Store) UnparkOrgDirectivesForRole(ctx context.Context, targetRole string, at time.Time) (int64, error) {
+	targetRole = strings.ToLower(strings.TrimSpace(targetRole))
+	if targetRole == "" {
+		return 0, nil
+	}
+	stamp := at.UTC().Format(time.RFC3339Nano)
+	result, err := s.db.ExecContext(ctx, `
+UPDATE workflow_notes
+SET directive_parked_at = '', directive_parked_reason = '', directive_last_nudged_at = ?
+WHERE substr(body, 1, length('[org:directive to=' || ? || ' ')) = '[org:directive to=' || ? || ' '
+	AND TRIM(directive_parked_at) <> ''`,
+		stamp, targetRole, targetRole)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected()
+}
+
+// ListParkedOrgDirectives returns parked directive obligations oldest-first,
+// for the archived-seat backlog view. An empty targetRole lists every parked
+// directive.
+func (s *Store) ListParkedOrgDirectives(ctx context.Context, targetRole string) ([]OrgDirectiveObligation, error) {
+	targetRole = strings.ToLower(strings.TrimSpace(targetRole))
+	rows, err := s.db.QueryContext(ctx, `
+SELECT d.id, d.workflow_id, d.author, d.body, d.repo, d.memory_observation_id, d.created_at,
+	d.directive_nudge_count, d.directive_last_nudged_at, d.directive_done_ttl_seconds,
+	d.directive_done_nudge_count, d.directive_exhausted_at,
+	d.directive_parked_at, d.directive_parked_reason,
+	COALESCE((
+		SELECT MIN(a.created_at) FROM workflow_notes a
+		WHERE a.workflow_id = d.workflow_id
+			AND substr(a.body, 1, length('[org:directive-ack id=' || d.id || ' ')) = '[org:directive-ack id=' || d.id || ' '
+	), '')
+FROM workflow_notes d
+WHERE substr(d.body, 1, length('[org:directive ')) = '[org:directive '
+	AND TRIM(d.directive_parked_at) <> ''
+	AND (? = '' OR substr(d.body, 1, length('[org:directive to=' || ? || ' ')) = '[org:directive to=' || ? || ' ')
+ORDER BY d.created_at ASC, d.id ASC`, targetRole, targetRole, targetRole)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	obligations := make([]OrgDirectiveObligation, 0)
+	for rows.Next() {
+		var item OrgDirectiveObligation
+		if err := rows.Scan(
+			&item.ID, &item.WorkflowID, &item.Author, &item.Body, &item.Repo,
+			&item.MemoryObservationID, &item.CreatedAt, &item.NudgeCount,
+			&item.LastNudgedAt, &item.DoneTTLOverrideSeconds,
+			&item.DoneNudgeCount, &item.ExhaustedAt,
+			&item.ParkedAt, &item.ParkedReason, &item.AckedAt,
+		); err != nil {
+			return nil, err
+		}
+		obligations = append(obligations, item)
+	}
+	return obligations, rows.Err()
+}

--- a/internal/db/org_directive_park_test.go
+++ b/internal/db/org_directive_park_test.go
@@ -1,0 +1,133 @@
+package db
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+)
+
+func insertParkTestDirective(t *testing.T, store *Store, workflowID, body string) WorkflowNote {
+	t.Helper()
+	note, err := store.InsertWorkflowNote(context.Background(), WorkflowNote{
+		WorkflowID: workflowID, Author: "owner", Body: body,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return note
+}
+
+// Parking a role suspends its OPEN obligations: they leave the live sweep
+// (list AND count, which must share one open-predicate) and appear in the
+// parked listing with their stamp and reason. Done directives carry no ladder
+// and are untouched; other roles' obligations are untouched.
+func TestParkOrgDirectivesSuspendsOpenSweep(t *testing.T) {
+	store := openWorkflowTestStore(t)
+	ctx := context.Background()
+	first := insertParkTestDirective(t, store, "wave/park", "[org:directive to=worker from=owner wf=wave/park] first")
+	second := insertParkTestDirective(t, store, "wave/park", "[org:directive to=worker from=owner wf=wave/park] second")
+	other := insertParkTestDirective(t, store, "wave/park", "[org:directive to=peer from=owner wf=wave/park] keep sweeping")
+	done := insertParkTestDirective(t, store, "wave/park", "[org:directive to=worker from=owner wf=wave/park] already done")
+	if _, err := store.InsertWorkflowNote(ctx, WorkflowNote{
+		WorkflowID: "wave/park", Author: "worker",
+		Body: fmt.Sprintf("[org:directive-done id=%d by=worker]", done.ID),
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	parkedAt := time.Date(2026, 8, 26, 12, 0, 0, 0, time.UTC)
+	parked, err := store.ParkOpenOrgDirectivesForRole(ctx, "worker", parkedAt, "seat archived")
+	if err != nil || parked != 2 {
+		t.Fatalf("park = %d, %v; want 2 rows (open only, done untouched)", parked, err)
+	}
+
+	open, err := store.ListOpenOrgDirectiveObligations(ctx, 50)
+	if err != nil || len(open) != 1 || open[0].ID != other.ID {
+		t.Fatalf("open after park = %+v err=%v, want only peer's %d", open, err, other.ID)
+	}
+	count, err := store.CountOpenOrgDirectiveObligations(ctx)
+	if err != nil || count != len(open) {
+		t.Fatalf("count=%d err=%v, want %d — count and list must share the open-predicate", count, err, len(open))
+	}
+
+	stamp := parkedAt.Format(time.RFC3339Nano)
+	rows, err := store.ListParkedOrgDirectives(ctx, "worker")
+	if err != nil || len(rows) != 2 || rows[0].ID != first.ID || rows[1].ID != second.ID {
+		t.Fatalf("parked listing = %+v err=%v, want [%d %d]", rows, err, first.ID, second.ID)
+	}
+	for _, row := range rows {
+		if row.ParkedAt != stamp || row.ParkedReason != "seat archived" {
+			t.Fatalf("parked row = %+v, want stamp %q reason %q", row, stamp, "seat archived")
+		}
+	}
+	all, err := store.ListParkedOrgDirectives(ctx, "")
+	if err != nil || len(all) != 2 {
+		t.Fatalf("all-roles parked listing = %+v err=%v, want 2", all, err)
+	}
+
+	// Idempotent: already-parked rows are not re-stamped.
+	again, err := store.ParkOpenOrgDirectivesForRole(ctx, "worker", parkedAt.Add(time.Hour), "later")
+	if err != nil || again != 0 {
+		t.Fatalf("re-park = %d, %v; want 0", again, err)
+	}
+}
+
+// A parked row refuses nudge marks at the write site, so a sweep that listed
+// an obligation just before it was parked cannot nudge it afterwards.
+func TestParkedDirectiveRefusesNudgeMarks(t *testing.T) {
+	store := openWorkflowTestStore(t)
+	ctx := context.Background()
+	unacked := insertParkTestDirective(t, store, "wave/park", "[org:directive to=worker from=owner wf=wave/park] unacked")
+	acked := insertParkTestDirective(t, store, "wave/park", "[org:directive to=worker from=owner wf=wave/park] acked")
+	if _, err := store.InsertWorkflowNote(ctx, WorkflowNote{
+		WorkflowID: "wave/park", Author: "worker",
+		Body: fmt.Sprintf("[org:directive-ack id=%d by=worker]", acked.ID),
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if parked, err := store.ParkOpenOrgDirectivesForRole(ctx, "worker", time.Now(), "seat archived"); err != nil || parked != 2 {
+		t.Fatalf("park = %d, %v", parked, err)
+	}
+	now := time.Now().UTC()
+	if _, claimed, err := store.MarkOrgDirectiveNudged(ctx, unacked.ID, 0, "", now); err != nil || claimed {
+		t.Fatalf("ack-phase nudge on parked row claimed=%v err=%v, want refused", claimed, err)
+	}
+	if _, claimed, err := store.MarkOrgDirectiveDoneNudged(ctx, acked.ID, 0, "", now); err != nil || claimed {
+		t.Fatalf("done-phase nudge on parked row claimed=%v err=%v, want refused", claimed, err)
+	}
+}
+
+// Unpark returns the obligation to the live sweep — park is SUSPENSION, not
+// done/cancel, which never come back — and resets the nudge anchor to unpark
+// time so a TTL that elapsed while archived does not nag immediately.
+func TestUnparkRestoresObligationAndResetsNudgeAnchor(t *testing.T) {
+	store := openWorkflowTestStore(t)
+	ctx := context.Background()
+	old := insertParkTestDirective(t, store, "wave/park", "[org:directive to=worker from=owner wf=wave/park] stale ttl")
+	if _, err := store.db.ExecContext(ctx, `UPDATE workflow_notes SET created_at = ? WHERE id = ?`, "2026-01-01 00:00:00", old.ID); err != nil {
+		t.Fatal(err)
+	}
+	if parked, err := store.ParkOpenOrgDirectivesForRole(ctx, "worker", time.Date(2026, 8, 1, 0, 0, 0, 0, time.UTC), "seat archived"); err != nil || parked != 1 {
+		t.Fatalf("park = %d, %v", parked, err)
+	}
+	unparkAt := time.Date(2026, 8, 26, 15, 0, 0, 0, time.UTC)
+	unparked, err := store.UnparkOrgDirectivesForRole(ctx, "worker", unparkAt)
+	if err != nil || unparked != 1 {
+		t.Fatalf("unpark = %d, %v; want 1", unparked, err)
+	}
+	open, err := store.ListOpenOrgDirectiveObligations(ctx, 50)
+	if err != nil || len(open) != 1 || open[0].ID != old.ID {
+		t.Fatalf("open after unpark = %+v err=%v, want the unparked row", open, err)
+	}
+	if got, want := open[0].LastNudgedAt, unparkAt.Format(time.RFC3339Nano); got != want {
+		t.Fatalf("nudge anchor after unpark = %q, want unpark stamp %q — a returning seat must get a fresh TTL", got, want)
+	}
+	if rows, err := store.ListParkedOrgDirectives(ctx, "worker"); err != nil || len(rows) != 0 {
+		t.Fatalf("parked listing after unpark = %+v err=%v, want empty", rows, err)
+	}
+	// Nothing left to unpark.
+	if n, err := store.UnparkOrgDirectivesForRole(ctx, "worker", unparkAt); err != nil || n != 0 {
+		t.Fatalf("re-unpark = %d, %v; want 0", n, err)
+	}
+}

--- a/internal/db/store_migrations.go
+++ b/internal/db/store_migrations.go
@@ -2099,4 +2099,18 @@ CREATE INDEX idx_event_rule_deletions_route
 	)
 	WHERE enabled = 1;
 	`,
+	// #1635 archive-agents: parked directive obligations. Parking SUSPENDS the
+	// nudge ladder for a seat taken out of rotation — it is neither done (done
+	// asserts a deliverable exists) nor cancel (cancel discards the obligation).
+	// Suspension preserves #1418's exhaustion discrimination: an archived
+	// seat's directives must not exhaust into the background rate, or
+	// exhaustion stops distinguishing a real stall. Unpark clears the stamp
+	// and resets the nudge anchor (directive_last_nudged_at) to unpark time so
+	// a returning seat is not nagged immediately for time it spent archived.
+	// Rebase note: this entry moved BEHIND #1496's event_rule_deletions when
+	// main gained that tail first — append-only, a new tail, never reordered.
+	`
+ALTER TABLE workflow_notes ADD COLUMN directive_parked_at TEXT NOT NULL DEFAULT '';
+ALTER TABLE workflow_notes ADD COLUMN directive_parked_reason TEXT NOT NULL DEFAULT '';
+	`,
 }

--- a/internal/db/workflow_store.go
+++ b/internal/db/workflow_store.go
@@ -98,10 +98,16 @@ type OrgDirectiveObligation struct {
 	DoneTTLOverrideSeconds int64
 	// #1352: the completion phase counts separately, because NudgeCount is
 	// cumulative across both phases and never resets at ack. ExhaustedAt is the
-	// terminal stamp — non-empty means the ladder ended and the obligation is
-	// parked but still VISIBLE in this list.
+	// terminal stamp — non-empty means the ladder ended and the obligation
+	// stays open and VISIBLE in this list.
 	DoneNudgeCount int
 	ExhaustedAt    string
+	// #1635: a non-empty ParkedAt suspends the nudge ladder while the target
+	// seat is out of rotation — distinct from ExhaustedAt (terminal) and from
+	// done/cancel (obligation ended). Parked rows leave the open sweep entirely
+	// and are listed by ListParkedOrgDirectives instead.
+	ParkedAt     string
+	ParkedReason string
 }
 
 // WorkflowMeta is the latest external-coordinator handoff identity recorded for
@@ -865,6 +871,7 @@ func (s *Store) CountOpenOrgDirectiveObligations(ctx context.Context) (int, erro
 SELECT COUNT(*)
 FROM workflow_notes d
 WHERE substr(d.body, 1, length('[org:directive ')) = '[org:directive '
+	AND TRIM(d.directive_parked_at) = ''
 	AND NOT EXISTS (
 		SELECT 1 FROM workflow_notes r
 		WHERE r.workflow_id = d.workflow_id AND (
@@ -902,6 +909,7 @@ SELECT d.id, d.workflow_id, d.author, d.body, d.repo, d.memory_observation_id, d
 	), '')
 FROM workflow_notes d INDEXED BY idx_workflow_notes_directive_oldest
 WHERE substr(d.body, 1, length('[org:directive ')) = '[org:directive '
+	AND TRIM(d.directive_parked_at) = ''
 	AND NOT EXISTS (
 		SELECT 1 FROM workflow_notes r
 		WHERE r.workflow_id = d.workflow_id AND (
@@ -946,6 +954,7 @@ WHERE id = ?
 	AND directive_done_nudge_count = ?
 	AND directive_last_nudged_at = ?
 	AND TRIM(directive_exhausted_at) = ''
+	AND TRIM(directive_parked_at) = ''
 	AND substr(body, 1, length('[org:directive ')) = '[org:directive '
 	AND NOT EXISTS (
 		SELECT 1 FROM workflow_notes r
@@ -1012,6 +1021,7 @@ SET directive_nudge_count = directive_nudge_count + 1,
 WHERE id = ?
 	AND directive_nudge_count = ?
 	AND directive_last_nudged_at = ?
+	AND TRIM(directive_parked_at) = ''
 	AND substr(body, 1, length('[org:directive ')) = '[org:directive '
 	AND NOT EXISTS (
 		SELECT 1 FROM workflow_notes r


### PR DESCRIPTION
GM-ARCHIVE — PR2 of #1635 (archive-agents, gitmoot half of jerryfane/herdrup#173). Authorized and sequenced by JARVIS directive 85850: parking lands alone against a still base; the ingest (the daemon-lane write site) follows as its own PR after this merges.

## What this is

The directive-parking mechanism: when a seat is archived, its outstanding directive obligations must stop nagging without being falsified. Parking SUSPENDS the nudge ladder — deliberately **neither `done`** (done asserts a deliverable exists) **nor `cancel`** (cancel discards the obligation). Suspension preserves #1418's exhaustion discrimination: an archived seat's directives must not exhaust into the background rate, or exhaustion stops distinguishing a real stall.

**Nothing calls the archived-set entry point yet.** `parkOutstandingDirectivesForArchivedSeats` takes the archived-set as a parameter and is wired to nothing — the #1635 ingest PR is its only intended caller. Park-only by design: parking is safe under partial observation; unparking driven off absent data would resume every archived seat's ladders on a degraded read, so `UnparkOrgDirectivesForRole` stays an explicit per-role act that only an observed archived→active transition (which only the ingest can attest) should drive.

## Mechanics

- **Migration, new append-only tail**: `directive_parked_at` + `directive_parked_reason` on `workflow_notes`. The entry moved BEHIND #1630's `event_rule_deletions` when main gained that tail first — append-only, never reordered; the migration comment records the move. Fixture safety pre-verified: migration fixtures locate by CONTENT (`migrationsBefore`), so a new tail breaks nothing.
- **Park** (`ParkOpenOrgDirectivesForRole`): stamps OPEN obligations for a role; done/cancelled rows untouched (no ladder to suspend); idempotent (already-parked rows are not re-stamped).
- **Suspension is enforced at both the read AND write sites**: `TRIM(directive_parked_at) = ''` added to the open-predicate in `ListOpenOrgDirectiveObligations` AND `CountOpenOrgDirectiveObligations` (they must agree — the coupling is asserted in-test), and to both nudge-mark UPDATEs — a sweep that listed a row just before it was parked cannot nudge it afterwards; the CAS alone cannot catch a park, which never touches `last_nudged_at`.
- **Unpark** resets the nudge anchor (`directive_last_nudged_at`) to unpark time: a directive whose TTL elapsed while its seat was archived gets a full fresh TTL from unpark, not an immediate nag. Pinned from both sides: the write stamps it, and a `directiveTTLDue` test proves the evaluator honors it (not due at unpark+1m on a long-blown TTL; due after a full TTL).
- **`ListParkedOrgDirectives`** feeds the future `org seats archived` backlog view.

## Verification (targeted; the full gate runs coordinator-side)

Baseline: 3 db + 2 cli parking tests, plus `-run Directive` regression = 4 db + 33 cli existing tests, all PASS; migration-position/canary fixture tests PASS on the rebased tree. Mutants, each compiled via `go test -c -o /dev/null`, each killed by exactly one distinct test: **M1** parked-exclusion dropped from the open lister → only the suspension test fails (the count/list coupling assertion fires as designed); **M2** unpark forgets the anchor reset → only the anchor test fails; **M3** write-site parked guard dropped from the ack-phase mark → only the refusal test fails.

## Deploy notes

Migration-only schema change; no behavior change until the ingest lands (no production caller parks anything yet). Docs deliberately absent here: user-visible behavior arrives with the ingest PR, which carries the archived-seats documentation for all three surfaces.

## Local-gate disclosure (required by the substitution grant)

**This PR is gated LOCALLY, not by GitHub Actions**, under the owner-granted local-gate substitution — JARVIS directive **86373** (to the gating coordinator) / **86374** (to the author), granted in the owner's words for the duration of the gitmoot/gitmoot Actions outage, lapsing the instant Actions executes a run on this repo. At gate-report time the lapse check was re-run: check-runs at this head = 0, runs created after the stuck one = 0 — the grant was in force.

- **SHA gated:** `b078c1945c687ae32696e9fda30c424813ac43c1` (this PR's head, re-read from GitHub at report time; 0 commits behind main)
- **Gate result** (GITMOOT-COC, detached, fresh clone at /root/gate-1640, env scrub proven, workflow note 86532): `build_exit=0 vet_exit=0 generate_clean_exit=0`; **SUITE: SUITE_EXIT=0, 40 packages ok, 0 fail lines**; **RACE: RACE_EXIT=0, 5 packages ok, 0 DATA RACE warnings** (workflow 203.6s, cli 1879.0s, db 361.1s, daemon 20.3s, pipeline 10.9s). One disclosed deviation: the race leg was restarted per-package at 60m timeouts after the single-timeout first attempt could not have completed within its own budget; the suite leg is the original run.
- **Separation:** gm-archive authored, GITMOOT-COC gated, jarvis reviews and merges. Three parties.
- The vacuous `mergeStateStatus: CLEAN` on this PR (zero check-runs) means nothing and was not relied on; this merge rests on the named local gate result at the named SHA plus jarvis's review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

