### PR TITLE
Gitmoot: JARVIS DISPATCH — gitmoot#1633 SLICE A. Sign GITMOOT-IMPL

### DIFF
--- a/docs/remote-exec.md
+++ b/docs/remote-exec.md
@@ -17,8 +17,10 @@ local_gid = 1000
 local_root = "/var/tmp/gitmoot-local"
 ```
 
-`local` is the default and the only implemented backend. For an engine-driven
-daemon job, Gitmoot provisions one job-scoped instance, syncs the selected host
+`local` is the default and the only currently provisioned backend. `remote` is
+parseable, but its provider is not configured in this slice; unsupported routes
+refuse explicitly rather than falling back to host execution. For an
+engine-driven daemon job, Gitmoot provisions one job-scoped instance, syncs the selected host
 checkout into a distinct detached Git worktree, streams runtime commands there,
 collects changes, and destroys the instance after the job. The same instance
 survives Mailbox repair deliveries. An implement job's changes return through
@@ -65,16 +67,16 @@ directory that Git never registered remains the known orphaned-but-present
 cleanup limitation tracked in #1572.
 
 Gitmoot reads `[remote_exec]` when it dispatches a job; it is not cached and
-needs no SIGHUP wiring. Foreground dispatch retains the host runner path because
-the lifecycle is acquired at the daemon job-worker boundary.
+needs no SIGHUP wiring. Foreground dispatch refuses `remote` because it has no
+daemon-owned lifecycle, ledger, or reaper.
 
 A job payload's `exec_backend` field overrides the config value for that one
 job. When either selector is explicitly present its value must be non-blank;
 an absent selector defaults to `local`, while `backend = ""` or an explicit
 `"exec_backend":""` fails loudly.
 
-Any value outside the allowed set — currently only `local` — **fails the job
+Any value outside the allowed set (`local`, `remote`) **fails the job
 loudly at dispatch**: the failure names the offending value and the allowed
-set (for example `unknown execution backend "e2b" (allowed: local)`). There
-is no silent fallback. Remote backends (see the parallel-isolated-execution
-epic, #1529) will extend the allowed set in later phases.
+set (for example `unknown execution backend "e2b" (allowed: local, remote)`).
+There is no silent fallback. Provider construction for `remote` lands in later
+phases of the parallel-isolated-execution epic (#1529).

--- a/internal/cli/agent_dispatch.go
+++ b/internal/cli/agent_dispatch.go
@@ -39,6 +39,9 @@ var localAgentDispatchExecBackendFor = func(home string) (execbackend.Backend, e
 func foregroundRuntimeAdapterFactoryFor(backend execbackend.Backend) (foregroundRuntimeAdapterFactory, error) {
 	return execbackend.Consume(backend, func() (foregroundRuntimeAdapterFactory, error) {
 		return localAgentDispatchRuntimeAdapterFor, nil
+	}, func() (foregroundRuntimeAdapterFactory, error) {
+		// Foreground dispatch has no daemon lifecycle owner, ledger, or reaper.
+		return nil, errors.New("foreground dispatch does not support the remote execution backend")
 	})
 }
 
@@ -318,16 +321,18 @@ func dispatchLocalAgentJob(ctx context.Context, store *db.Store, request localAg
 	}
 	var foregroundContract *runtime.RuntimeContractResult
 	if !request.Background {
-		result, err := runtimeContractPreflightForBackend(execBackend, func() runtime.RuntimeContractResult {
+		result, checked, err := runtimeContractPreflightForBackend(execBackend, func() runtime.RuntimeContractResult {
 			return localRuntimeContractPreflight(ctx, effectiveAgent)
 		})
 		if err != nil {
 			return localAgentJobOutput{}, err
 		}
-		if err := runtime.RuntimeContractDispatchError(effectiveAgent, result); err != nil {
-			return localAgentJobOutput{}, err
+		if checked {
+			if err := runtime.RuntimeContractDispatchError(effectiveAgent, result); err != nil {
+				return localAgentJobOutput{}, err
+			}
+			foregroundContract = &result
 		}
-		foregroundContract = &result
 	}
 	switch request.Action {
 	case "review":

--- a/internal/cli/daemon_worker.go
+++ b/internal/cli/daemon_worker.go
@@ -599,7 +599,7 @@ func (w jobWorker) run(ctx context.Context, job db.Job) error {
 	// delivery and is destroyed synchronously on every return path. Host checkout,
 	// git, observation, and finalization remain on checkout/jobRunner; only runtime
 	// delivery executes in the distinct backend workspace.
-	lifecycle, instance, lifecycleErr := w.provisionExecutionBackend(ctx, execBackend, agent.Runtime, job, checkout)
+	lifecycle, instance, lifecycleErr := w.provisionExecutionBackend(ctx, execBackend, agent.Runtime, job, jobTimeout+runtimeLeaseTeardownGrace, checkout)
 	if instance != nil {
 		defer w.destroyExecutionBackend(job.ID, lifecycle, instance)
 	}
@@ -974,20 +974,29 @@ func payloadWithImplementationPreflightRetry(raw string, payload workflow.JobPay
 	return string(encoded), nil
 }
 
-func runtimeContractPreflightForBackend(backend execbackend.Backend, local func() runtime.RuntimeContractResult) (runtime.RuntimeContractResult, error) {
-	return execbackend.Consume(backend, func() (runtime.RuntimeContractResult, error) {
-		return local(), nil
+func runtimeContractPreflightForBackend(backend execbackend.Backend, local func() runtime.RuntimeContractResult) (runtime.RuntimeContractResult, bool, error) {
+	type result struct {
+		contract runtime.RuntimeContractResult
+		checked  bool
+	}
+	consumed, err := execbackend.Consume(backend, func() (result, error) {
+		return result{contract: local(), checked: true}, nil
+	}, func() (result, error) {
+		// This preflight runs before provisioning, so a host probe would answer
+		// about the wrong machine. The attached instance is checked at delivery.
+		return result{}, nil
 	})
+	return consumed.contract, consumed.checked, err
 }
 
 func (w jobWorker) runtimeContractPreflight(ctx context.Context, backend execbackend.Backend, agent runtime.Agent, request runtime.RuntimeContractRequest) (runtime.RuntimeContractResult, bool, error) {
 	if w.RuntimePreflight == nil {
 		return runtime.RuntimeContractResult{}, false, nil
 	}
-	result, err := runtimeContractPreflightForBackend(backend, func() runtime.RuntimeContractResult {
+	result, checked, err := runtimeContractPreflightForBackend(backend, func() runtime.RuntimeContractResult {
 		return w.RuntimePreflight(ctx, agent, request)
 	})
-	return result, true, err
+	return result, checked, err
 }
 
 func (w jobWorker) lookupAgent(ctx context.Context, name string) (db.Agent, error) {
@@ -2959,13 +2968,31 @@ func (w jobWorker) buildSeatAwareAdapterForBackend(backend execbackend.Backend, 
 	consumed, err := execbackend.Consume(backend, func() (result, error) {
 		adapter, token, err := w.buildLocalSeatAwareAdapter(agent, checkout, payload, output...)
 		return result{adapter: adapter, token: token}, err
+	}, func() (result, error) {
+		if payload.MootSeat {
+			// The chat relay is a host Unix socket and cannot be injected into a
+			// provider-backed instance.
+			return result{}, errors.New("moot-seat relay is not supported on the remote execution backend")
+		}
+		return result{adapter: unprovisionedRemoteDeliveryAdapter{}}, nil
 	})
 	return consumed.adapter, consumed.token, err
+}
+
+// unprovisionedRemoteDeliveryAdapter prevents a configured remote job from
+// falling back to a host adapter before its lifecycle instance is attached.
+type unprovisionedRemoteDeliveryAdapter struct{}
+
+func (unprovisionedRemoteDeliveryAdapter) Deliver(context.Context, runtime.Agent, runtime.Job) (runtime.Result, error) {
+	return runtime.Result{}, errors.New("remote execution backend is not provisioned")
 }
 
 func (w jobWorker) deliveryAdapterForBackend(backend execbackend.Backend, agent runtime.Agent, checkout string) (workflow.DeliveryAdapter, error) {
 	return execbackend.Consume(backend, func() (workflow.DeliveryAdapter, error) {
 		return w.AdapterFactory(agent, checkout)
+	}, func() (workflow.DeliveryAdapter, error) {
+		// The temporary-worker loop never provisions an execution instance.
+		return nil, errors.New("temporary workers do not support the remote execution backend")
 	})
 }
 
@@ -3026,7 +3053,45 @@ func buildRuntimeAdapter(home string, agent runtime.Agent, checkout string, runn
 	// call site supplies that backend's builder.
 	return execbackend.Consume(backend, func() (workflow.DeliveryAdapter, error) {
 		return buildLocalRuntimeAdapter(home, agent, checkout, runner)
+	}, func() (workflow.DeliveryAdapter, error) {
+		return buildRemoteRuntimeAdapter(agent, checkout, runner)
 	})
+}
+
+func buildRemoteRuntimeAdapter(agent runtime.Agent, checkout string, runner subprocess.Runner) (workflow.DeliveryAdapter, error) {
+	if !runnerReachesExecutionInstance(runner) {
+		return nil, errors.New("remote execution backend runtime runner is not attached to an instance")
+	}
+	if agent.Runtime != runtime.ShellRuntime {
+		return nil, fmt.Errorf("runtime %q is not supported on the remote execution backend", agent.Runtime)
+	}
+	if len(agent.WritablePaths) > 0 || len(agent.ReadablePaths) > 0 || len(agent.ReadableFiles) > 0 {
+		return nil, errors.New("runtime path grants are not supported on the remote execution backend")
+	}
+	return runtime.ShellAdapter{Dir: checkout, Runner: runner}, nil
+}
+
+func runnerReachesExecutionInstance(runner subprocess.Runner) bool {
+	switch runner := runner.(type) {
+	case execbackend.InstanceRunner:
+		return runner.Backend != nil && runner.Instance != nil
+	case *execbackend.InstanceRunner:
+		return runner != nil && runner.Backend != nil && runner.Instance != nil
+	case subprocess.TeeRunner:
+		return runnerReachesExecutionInstance(runner.Inner)
+	case *subprocess.TeeRunner:
+		return runner != nil && runnerReachesExecutionInstance(runner.Inner)
+	case subprocess.EnvInjectingRunner:
+		return runnerReachesExecutionInstance(runner.Inner)
+	case *subprocess.EnvInjectingRunner:
+		return runner != nil && runnerReachesExecutionInstance(runner.Inner)
+	case subprocess.WrappingRunner:
+		return runnerReachesExecutionInstance(runner.Inner)
+	case *subprocess.WrappingRunner:
+		return runner != nil && runnerReachesExecutionInstance(runner.Inner)
+	default:
+		return false
+	}
 }
 
 // buildLocalRuntimeAdapter is the pre-#1536 runner-composition pipeline. Keep
@@ -3069,6 +3134,9 @@ func buildLocalRuntimeAdapter(home string, agent runtime.Agent, checkout string,
 func startRuntimeAdapterForBackend(backend execbackend.Backend, home string, runtimeName string, checkout string) (runtime.Adapter, error) {
 	return execbackend.Consume(backend, func() (runtime.Adapter, error) {
 		return runtimeAdapterFor(home, runtimeName, checkout)
+	}, func() (runtime.Adapter, error) {
+		// Agent-start sessions are host-owned and have no lifecycle instance.
+		return nil, errors.New("agent start sessions do not support the remote execution backend")
 	})
 }
 

--- a/internal/cli/execbackend_e2e_test.go
+++ b/internal/cli/execbackend_e2e_test.go
@@ -232,7 +232,7 @@ func TestExecBackendUnknownFailsLoudDaemonE2E(t *testing.T) {
 			if !strings.Contains(failedMessage, `"`+tc.value+`"`) {
 				t.Fatalf("dispatch error = %q, want it to name %q", failedMessage, tc.value)
 			}
-			if !strings.Contains(failedMessage, "allowed: local") {
+			if !strings.Contains(failedMessage, "allowed: local, remote") {
 				t.Fatalf("dispatch error = %q, want the allowed set named", failedMessage)
 			}
 			if !strings.Contains(failedMessage, "[remote_exec].backend") {
@@ -263,7 +263,7 @@ func TestExecBackendUnknownFailsLoudForegroundE2E(t *testing.T) {
 	if _, err := os.Stat(marker); !os.IsNotExist(err) {
 		t.Fatalf("foreground adapter ran with an unknown backend (marker err=%v)", err)
 	}
-	if got := errBuf.String(); !strings.Contains(got, `"e2b"`) || !strings.Contains(got, "allowed: local") || !strings.Contains(got, "[remote_exec].backend") {
+	if got := errBuf.String(); !strings.Contains(got, `"e2b"`) || !strings.Contains(got, "allowed: local, remote") || !strings.Contains(got, "[remote_exec].backend") {
 		t.Fatalf("foreground error = %q, want config source + value + allowed set", got)
 	}
 	jobs, err := store.ListJobs(context.Background())
@@ -798,7 +798,7 @@ func TestP2GapEveryJobAdapterConstructionRouteRefusesLocalFallback(t *testing.T)
 	})
 	t.Run("runtime contract preflight", func(t *testing.T) {
 		calls := 0
-		if _, err := runtimeContractPreflightForBackend(backend, func() runtime.RuntimeContractResult {
+		if _, _, err := runtimeContractPreflightForBackend(backend, func() runtime.RuntimeContractResult {
 			calls++
 			return runtime.RuntimeContractResult{}
 		}); err == nil {
@@ -822,6 +822,120 @@ func TestP2GapEveryJobAdapterConstructionRouteRefusesLocalFallback(t *testing.T)
 	})
 	if localDeliveryCalls != 0 {
 		t.Fatalf("local delivery factory calls = %d, want 0", localDeliveryCalls)
+	}
+}
+
+func TestRemoteBackendRefusesEveryHostOnlyRoute(t *testing.T) {
+	localDeliveryCalls := 0
+	worker := jobWorker{
+		AdapterFactory: func(runtime.Agent, string) (workflow.DeliveryAdapter, error) {
+			localDeliveryCalls++
+			return &cliWorkerFakeAdapter{}, nil
+		},
+	}
+	agent := runtime.Agent{Runtime: runtime.ShellRuntime, ExecBackend: string(execbackend.Remote)}
+
+	t.Run("lifecycle provider is not configured", func(t *testing.T) {
+		if _, err := worker.defaultExecutionBackend(execbackend.Remote); err == nil || !strings.Contains(err.Error(), "not configured") {
+			t.Fatalf("remote lifecycle error = %v, want temporary not-configured refusal", err)
+		}
+	})
+	t.Run("daemon primary delivery is an unprovisioned placeholder", func(t *testing.T) {
+		adapter, token, err := worker.buildSeatAwareAdapterForBackend(execbackend.Remote, &agent, t.TempDir(), workflow.JobPayload{})
+		if err != nil {
+			t.Fatalf("build remote placeholder: %v", err)
+		}
+		if token != "" {
+			t.Fatalf("remote placeholder relay token = %q, want empty", token)
+		}
+		if _, err := adapter.Deliver(context.Background(), agent, runtime.Job{}); err == nil || !strings.Contains(err.Error(), "not provisioned") {
+			t.Fatalf("remote placeholder Deliver error = %v, want unprovisioned refusal", err)
+		}
+	})
+	t.Run("moot seat relay", func(t *testing.T) {
+		if _, _, err := worker.buildSeatAwareAdapterForBackend(execbackend.Remote, &agent, t.TempDir(), workflow.JobPayload{MootSeat: true}); err == nil {
+			t.Fatal("remote moot seat accepted a host relay")
+		}
+	})
+	t.Run("temporary worker delivery", func(t *testing.T) {
+		if _, err := worker.deliveryAdapterForBackend(execbackend.Remote, agent, t.TempDir()); err == nil {
+			t.Fatal("temporary worker accepted remote delivery")
+		}
+	})
+	t.Run("runtime composition requires an instance", func(t *testing.T) {
+		if _, err := buildRuntimeAdapter("", agent, t.TempDir(), subprocess.GroupRunner{}); err == nil || !strings.Contains(err.Error(), "not attached to an instance") {
+			t.Fatalf("remote non-instance runner error = %v, want attached-instance refusal", err)
+		}
+	})
+	t.Run("runtime composition is shell-only without path grants", func(t *testing.T) {
+		backend, err := execbackend.NewLocalBackend(filepath.Join(t.TempDir(), "instances"), nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		runner := execbackend.InstanceRunner{Backend: backend, Instance: &execbackend.Instance{ID: "remote-fixture"}}
+		adapter, err := buildRuntimeAdapter("", agent, t.TempDir(), runner)
+		if err != nil {
+			t.Fatalf("build remote shell adapter: %v", err)
+		}
+		if _, ok := adapter.(runtime.ShellAdapter); !ok {
+			t.Fatalf("remote shell adapter = %T, want runtime.ShellAdapter", adapter)
+		}
+		unsupportedRuntime := agent
+		unsupportedRuntime.Runtime = runtime.CodexRuntime
+		if _, err := buildRuntimeAdapter("", unsupportedRuntime, t.TempDir(), runner); err == nil {
+			t.Fatal("remote runtime composition accepted a non-shell runtime")
+		}
+		for _, granted := range []runtime.Agent{
+			{Runtime: runtime.ShellRuntime, ExecBackend: string(execbackend.Remote), WritablePaths: []string{"/write"}},
+			{Runtime: runtime.ShellRuntime, ExecBackend: string(execbackend.Remote), ReadablePaths: []string{"/read"}},
+			{Runtime: runtime.ShellRuntime, ExecBackend: string(execbackend.Remote), ReadableFiles: []string{"/file"}},
+		} {
+			if _, err := buildRuntimeAdapter("", granted, t.TempDir(), runner); err == nil {
+				t.Fatalf("remote runtime composition accepted path grants: %+v", granted)
+			}
+		}
+	})
+	t.Run("runtime session start", func(t *testing.T) {
+		if _, err := startRuntimeAdapterForBackend(execbackend.Remote, "", runtime.ShellRuntime, t.TempDir()); err == nil {
+			t.Fatal("agent start accepted the remote backend")
+		}
+	})
+	t.Run("foreground dispatch", func(t *testing.T) {
+		if _, err := foregroundRuntimeAdapterFactoryFor(execbackend.Remote); err == nil {
+			t.Fatal("foreground dispatch accepted the remote backend")
+		}
+	})
+	t.Run("pre-provision runtime contract is skipped", func(t *testing.T) {
+		calls := 0
+		_, checked, err := runtimeContractPreflightForBackend(execbackend.Remote, func() runtime.RuntimeContractResult {
+			calls++
+			return runtime.RuntimeContractResult{}
+		})
+		if err != nil || checked || calls != 0 {
+			t.Fatalf("remote preflight = checked %t, error %v, host calls %d; want skipped", checked, err, calls)
+		}
+	})
+	t.Run("pre-provision auth is unknown", func(t *testing.T) {
+		calls := 0
+		verdict, err := authProbeForBackend(execbackend.Remote, func() authProbeVerdict {
+			calls++
+			return authProbeValid
+		})
+		if err != nil || verdict != authProbeUnknown || calls != 0 {
+			t.Fatalf("remote auth probe = verdict %d, error %v, host calls %d; want unknown without host probe", verdict, err, calls)
+		}
+	})
+	t.Run("job subprocesses remain host-only", func(t *testing.T) {
+		runner, err := jobSubprocessRunnerForBackend(execbackend.Remote)
+		if err != nil {
+			t.Fatalf("remote host subprocess runner: %v", err)
+		}
+		if _, ok := runner.(hostJobSubprocessRunner); !ok {
+			t.Fatalf("remote job subprocess runner = %T, want hostJobSubprocessRunner", runner)
+		}
+	})
+	if localDeliveryCalls != 0 {
+		t.Fatalf("remote routes invoked local delivery factory %d times, want 0", localDeliveryCalls)
 	}
 }
 
@@ -912,7 +1026,7 @@ func TestExecBackendOverrideResolutionDaemonE2E(t *testing.T) {
 		for _, event := range execBackendEvents(t, store, jobID) {
 			failedMessage = event
 		}
-		if !strings.Contains(failedMessage, "exec_backend") || !strings.Contains(failedMessage, `"e2b"`) || !strings.Contains(failedMessage, "allowed: local") {
+		if !strings.Contains(failedMessage, "exec_backend") || !strings.Contains(failedMessage, `"e2b"`) || !strings.Contains(failedMessage, "allowed: local, remote") {
 			t.Fatalf("failed event = %q, want override source + value + allowed set", failedMessage)
 		}
 	})
@@ -1080,7 +1194,7 @@ func TestExecBackendCompositionPreservedForLocal(t *testing.T) {
 	if err == nil {
 		t.Fatal("buildRuntimeAdapter with exec_backend=e2b succeeded, want a loud error")
 	}
-	if !strings.Contains(err.Error(), `"e2b"`) || !strings.Contains(err.Error(), "allowed: local") {
+	if !strings.Contains(err.Error(), `"e2b"`) || !strings.Contains(err.Error(), "allowed: local, remote") {
 		t.Fatalf("composition-site error = %q, want the value AND the allowed set", err)
 	}
 

--- a/internal/cli/execbackend_lifecycle.go
+++ b/internal/cli/execbackend_lifecycle.go
@@ -55,18 +55,21 @@ func (w jobWorker) defaultExecutionBackend(backend execbackend.Backend) (execbac
 		// Reap once per resolved root in this process. A restarted daemon has a
 		// fresh map and therefore reconciles the prior process's instances before
 		// provisioning its first new job.
-		rootKey := root
+		rootKey := string(backend) + "|" + root
 		if _, loaded := reapedExecutionBackendRoots.LoadOrStore(rootKey, struct{}{}); !loaded {
-			if _, err := local.Reap(context.Background()); err != nil {
+			var reaper execbackend.Reaper = local
+			if _, err := reaper.Reap(context.Background()); err != nil {
 				reapedExecutionBackendRoots.Delete(rootKey)
 				return nil, fmt.Errorf("reap local execution backends: %w", err)
 			}
 		}
 		return local, nil
+	}, func() (execbackend.ExecutionBackend, error) {
+		return nil, errors.New("remote execution backend is not configured")
 	})
 }
 
-func (w jobWorker) provisionExecutionBackend(ctx context.Context, backend execbackend.Backend, runtimeName string, job db.Job, checkout string) (execbackend.ExecutionBackend, *execbackend.Instance, error) {
+func (w jobWorker) provisionExecutionBackend(ctx context.Context, backend execbackend.Backend, runtimeName string, job db.Job, ttl time.Duration, checkout string) (execbackend.ExecutionBackend, *execbackend.Instance, error) {
 	if w.ExecutionBackendFactory == nil {
 		return nil, nil, nil
 	}
@@ -74,7 +77,7 @@ func (w jobWorker) provisionExecutionBackend(ctx context.Context, backend execba
 	if err != nil {
 		return nil, nil, fmt.Errorf("construct %s execution backend: %w", backend, err)
 	}
-	instance, err := lifecycle.Provision(ctx, execbackend.JobScope{JobID: job.ID, LifecycleGeneration: job.LifecycleGeneration})
+	instance, err := lifecycle.Provision(ctx, execbackend.JobScope{JobID: job.ID, LifecycleGeneration: job.LifecycleGeneration, TTL: ttl})
 	if err != nil {
 		return nil, nil, fmt.Errorf("provision %s execution backend for job %s: %w", backend, job.ID, err)
 	}

--- a/internal/cli/execbackend_lifecycle_e2e_test.go
+++ b/internal/cli/execbackend_lifecycle_e2e_test.go
@@ -11,6 +11,7 @@ import (
 	"strconv"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/gitmoot/gitmoot/internal/config"
 	"github.com/gitmoot/gitmoot/internal/db"
@@ -73,7 +74,8 @@ func TestProvisionExecutionBackendLocalBehaviorUnchanged(t *testing.T) {
 	}}
 	job := db.Job{ID: "local-credential-gate", LifecycleGeneration: 4}
 
-	lifecycle, instance, err := worker.provisionExecutionBackend(context.Background(), execbackend.Local, runtime.ShellRuntime, job, "/checkout")
+	const ttl = 9 * time.Minute
+	lifecycle, instance, err := worker.provisionExecutionBackend(context.Background(), execbackend.Local, runtime.ShellRuntime, job, ttl, "/checkout")
 	if err != nil {
 		t.Fatalf("provisionExecutionBackend(local): %v", err)
 	}
@@ -83,8 +85,8 @@ func TestProvisionExecutionBackendLocalBehaviorUnchanged(t *testing.T) {
 	if backend.provisionCalls != 1 || backend.syncInCalls != 1 {
 		t.Fatalf("local Provision calls = %d, SyncIn calls = %d; want 1, 1", backend.provisionCalls, backend.syncInCalls)
 	}
-	if backend.scope.JobID != job.ID || backend.scope.LifecycleGeneration != job.LifecycleGeneration {
-		t.Fatalf("local provision scope = %+v, want job id %q generation %d", backend.scope, job.ID, job.LifecycleGeneration)
+	if backend.scope.JobID != job.ID || backend.scope.LifecycleGeneration != job.LifecycleGeneration || backend.scope.TTL != ttl {
+		t.Fatalf("local provision scope = %+v, want job id %q generation %d ttl %s", backend.scope, job.ID, job.LifecycleGeneration, ttl)
 	}
 	if backend.materials.SourceWorktree != "/checkout" {
 		t.Fatalf("local SyncIn source = %q, want /checkout", backend.materials.SourceWorktree)

--- a/internal/cli/execbackend_subprocess.go
+++ b/internal/cli/execbackend_subprocess.go
@@ -8,11 +8,11 @@ import (
 	"github.com/gitmoot/gitmoot/internal/subprocess"
 )
 
-type localJobSubprocessRunner struct {
+type hostJobSubprocessRunner struct {
 	subprocess.ExecRunner
 }
 
-func (localJobSubprocessRunner) grouped() subprocess.Runner {
+func (hostJobSubprocessRunner) grouped() subprocess.Runner {
 	return subprocess.GroupRunner{}
 }
 
@@ -34,12 +34,13 @@ func (w jobWorker) subprocessRunnerForJob(job db.Job) (subprocess.Runner, error)
 }
 
 // jobSubprocessRunnerForBackend is the single consumption seam for
-// job-associated git, checkout, and verifier subprocesses. Local preserves the
-// pre-#1560 host runner; a future backend must add its positional builder to
-// execbackend.Consume before any job subprocess can use it.
+// job-associated git, checkout, and verifier subprocesses. These operations are
+// host-only for both backends; runtime delivery is the only instance-bound path.
 func jobSubprocessRunnerForBackend(backend execbackend.Backend) (subprocess.Runner, error) {
 	return execbackend.Consume(backend, func() (subprocess.Runner, error) {
-		return localJobSubprocessRunner{}, nil
+		return hostJobSubprocessRunner{}, nil
+	}, func() (subprocess.Runner, error) {
+		return hostJobSubprocessRunner{}, nil
 	})
 }
 
@@ -50,7 +51,7 @@ func jobGroupedSubprocessRunner(runner subprocess.Runner) subprocess.Runner {
 	return runner
 }
 
-var _ subprocess.Runner = localJobSubprocessRunner{}
+var _ subprocess.Runner = hostJobSubprocessRunner{}
 
 func jobGitClient(dir string, runner subprocess.Runner) gitutil.Client {
 	return gitutil.NewClient(dir, runner)

--- a/internal/cli/job_blocker_auth_probe.go
+++ b/internal/cli/job_blocker_auth_probe.go
@@ -181,6 +181,10 @@ func (w jobWorker) defaultAuthProbe(ctx context.Context, job db.Job, payload wor
 func authProbeForBackend(backend execbackend.Backend, local func() authProbeVerdict) (authProbeVerdict, error) {
 	return execbackend.Consume(backend, func() (authProbeVerdict, error) {
 		return local(), nil
+	}, func() (authProbeVerdict, error) {
+		// A valid host credential says nothing about an unprovisioned remote
+		// instance. Unknown leaves the scheduling decision to the normal cadence.
+		return authProbeUnknown, nil
 	})
 }
 

--- a/internal/cli/trace_harvest_daemon.go
+++ b/internal/cli/trace_harvest_daemon.go
@@ -144,7 +144,7 @@ func daemonDeterministicCheckerDispatcher(store *db.Store, gh github.Client, che
 // cannot escape into the live checkout (reusing gitmoot's single-binary git tooling, no
 // external sandbox dep).
 func daemonHardVerifierDispatcher(store *db.Store, checkout string, home string) workflow.HardVerifierDispatcher {
-	return daemonHardVerifierDispatcherForRunner(store, checkout, home, localJobSubprocessRunner{})
+	return daemonHardVerifierDispatcherForRunner(store, checkout, home, hostJobSubprocessRunner{})
 }
 
 func daemonHardVerifierDispatcherForRunner(store *db.Store, checkout string, home string, runner subprocess.Runner) workflow.HardVerifierDispatcher {

--- a/internal/config/init.go
+++ b/internal/config/init.go
@@ -123,12 +123,13 @@ artifact_blobs = %q
 # keychain_path = "" # default: <base-home>/.config/gitmoot/keychain.env
 
 # [remote_exec] selects the execution backend — WHERE a job's runtime
-# subprocess executes (#1535 contract, #1536). "local" is the default and the
-# only implemented backend: a byte-for-byte passthrough to the existing runner
-# composition (subprocess GroupRunner innermost; credential-gateway and
-# Landlock produce wrappers unchanged). With no [remote_exec] section behavior
-# is byte-identical. Any other value FAILS THE JOB LOUDLY at dispatch naming
-# the value and the allowed set — there is no silent fallback. A job payload's
+# subprocess executes (#1535 contract, #1536). "local" is the default and a
+# byte-for-byte passthrough to the existing runner composition (subprocess
+# GroupRunner innermost; credential-gateway and Landlock produce wrappers
+# unchanged). "remote" is parseable but its provider is not configured yet, so
+# unsupported routes fail loudly instead of falling back to the host. With no
+# [remote_exec] section behavior is byte-identical. Any other value FAILS THE
+# JOB LOUDLY at dispatch naming the value and the allowed set. A job payload's
 # exec_backend field overrides this per job. This is NOT the Landlock local
 # confinement surface (internal/sandbox, the "sandbox" CLI, agent path
 # grants), which is unrelated.

--- a/internal/config/remote_exec.go
+++ b/internal/config/remote_exec.go
@@ -20,8 +20,8 @@ import (
 // loads the DefaultRemoteExecConfig ("local"), which is a byte-for-byte
 // passthrough to the pre-#1536 runner composition.
 type RemoteExecConfig struct {
-	// Backend is the [remote_exec].backend selection. "local" is the default
-	// and the only implemented value; anything else fails validation loud.
+	// Backend is the [remote_exec].backend selection. "local" is the default;
+	// "remote" is parseable while its provider factory remains a loud refusal.
 	Backend string
 	// LocalUID and LocalGID opt local-backend commands into an OS-level
 	// privilege drop. They are a pair: omitting both preserves the daemon

--- a/internal/config/remote_exec_test.go
+++ b/internal/config/remote_exec_test.go
@@ -39,14 +39,18 @@ func TestLoadRemoteExecConfigDefaultsToLocal(t *testing.T) {
 	}
 }
 
-func TestLoadRemoteExecConfigExplicitLocal(t *testing.T) {
-	paths := remoteExecTestPaths(t, "[remote_exec]\nbackend = \"local\"\n")
-	cfg, err := LoadRemoteExecConfig(paths)
-	if err != nil {
-		t.Fatalf("LoadRemoteExecConfig: %v", err)
-	}
-	if cfg.Backend != "local" {
-		t.Fatalf("Backend = %q, want local", cfg.Backend)
+func TestLoadRemoteExecConfigExplicitImplementedBackend(t *testing.T) {
+	for _, backend := range []string{"local", "remote"} {
+		t.Run(backend, func(t *testing.T) {
+			paths := remoteExecTestPaths(t, "[remote_exec]\nbackend = \""+backend+"\"\n")
+			cfg, err := LoadRemoteExecConfig(paths)
+			if err != nil {
+				t.Fatalf("LoadRemoteExecConfig: %v", err)
+			}
+			if cfg.Backend != backend {
+				t.Fatalf("Backend = %q, want %q", cfg.Backend, backend)
+			}
+		})
 	}
 }
 
@@ -98,7 +102,7 @@ func TestLoadRemoteExecConfigUnknownFailsLoud(t *testing.T) {
 		if !strings.Contains(err.Error(), "[remote_exec].backend") {
 			t.Fatalf("backend %q error = %q, want the config key named", value, err)
 		}
-		if !strings.Contains(err.Error(), `"`+value+`"`) || !strings.Contains(err.Error(), "allowed: local") {
+		if !strings.Contains(err.Error(), `"`+value+`"`) || !strings.Contains(err.Error(), "allowed: local, remote") {
 			t.Fatalf("backend %q error = %q, want the value AND the allowed set", value, err)
 		}
 	}
@@ -111,7 +115,7 @@ func TestLoadRemoteExecConfigExplicitBlankFailsLoud(t *testing.T) {
 		if err == nil {
 			t.Fatalf("explicit blank backend %q loaded, want a loud error", value)
 		}
-		if !strings.Contains(err.Error(), "[remote_exec].backend") || !strings.Contains(err.Error(), `unknown execution backend ""`) || !strings.Contains(err.Error(), "allowed: local") {
+		if !strings.Contains(err.Error(), "[remote_exec].backend") || !strings.Contains(err.Error(), `unknown execution backend ""`) || !strings.Contains(err.Error(), "allowed: local, remote") {
 			t.Fatalf("explicit blank backend %q error = %q, want key + blank value + allowed set", value, err)
 		}
 	}

--- a/internal/execbackend/execbackend.go
+++ b/internal/execbackend/execbackend.go
@@ -9,11 +9,11 @@
 // retain their existing runner while runtime delivery uses InstanceRunner and
 // returns changes through BuildChangeSet/ImportChangeSet.
 // Where P1 carries a resolved selection into adapter construction, that route
-// consumes it through Consume, whose only positive implementation is Local; any
-// other parsed backend is refused at runtime. Adding a backend to
-// ParseImplemented alone still compiles and then fails closed at consumption. If
-// P2 extends Consume with a required positional builder, that signature change
-// will make its existing callers fail to compile until they supply it. Adapter
+// consumes it through Consume. Local and Remote are explicit positional arms;
+// any other parsed backend is refused at runtime. Adding a backend to
+// ParseImplemented alone still compiles and then fails closed at consumption.
+// Extending Consume with another required positional builder makes its existing
+// callers fail to compile until they supply it. Adapter
 // builds without a selector retain the Local default. Job-associated git,
 // GitHub CLI, verifier, and read-only-diff subprocesses consume the resolved
 // runner through Consume and fail closed when the backend has no execution
@@ -33,22 +33,21 @@ import (
 type Backend string
 
 const (
-	// Local is the default and — until a remote backend lands — the only
-	// implemented execution backend. It resolves to today's behaviour exactly:
+	// Local is the default execution backend. It resolves to today's behaviour exactly:
 	// the existing runner composition with subprocess.GroupRunner{} innermost.
 	Local Backend = "local"
-	// Remote reserves the name for a future execution backend. It is
-	// intentionally absent from AllowedNames until an implementation exists, so
-	// Parse continues to reject it.
+	// Remote selects provider-backed execution. Slice A makes the selector and
+	// every consumption arm explicit while provider construction remains a loud
+	// temporary refusal.
 	Remote Backend = "remote"
 )
 
 // AllowedNames is the canonical allowed set of backend names, in the order
 // error messages render them. Parse accepts names exclusively from this list,
 // so a backend cannot be accepted without also being advertised.
-var AllowedNames = []string{string(Local)}
+var AllowedNames = []string{string(Local), string(Remote)}
 
-// Allowed renders the allowed set for error messages (e.g. "local").
+// Allowed renders the allowed set for error messages (e.g. "local, remote").
 func Allowed() string {
 	return strings.Join(AllowedNames, ", ")
 }
@@ -83,7 +82,7 @@ func ParseImplemented(value string) (Backend, error) {
 		return "", err
 	}
 	switch backend {
-	case Local:
+	case Local, Remote:
 		return backend, nil
 	default:
 		return "", fmt.Errorf("execution backend %q is advertised but not implemented", backend)
@@ -91,15 +90,17 @@ func ParseImplemented(value string) (Backend, error) {
 }
 
 // Consume dispatches an already-resolved backend to its execution
-// implementation. The positive Local arm is deliberately separate from
+// implementation. The positive arms are deliberately separate from
 // ParseImplemented: making a future backend parseable cannot make it inherit
-// Local's runner pipeline. When P2 adds an implementation, it must add a
-// positional builder here; changing this signature then makes every
-// construction route fail to compile until it supplies that backend's builder.
-func Consume[T any](backend Backend, local func() (T, error)) (T, error) {
+// an existing runner pipeline. New implementations must add a positional
+// builder here; changing this signature then makes every construction route
+// fail to compile until it supplies that backend's builder.
+func Consume[T any](backend Backend, local, remote func() (T, error)) (T, error) {
 	switch backend {
 	case Local:
 		return local()
+	case Remote:
+		return remote()
 	default:
 		var zero T
 		return zero, fmt.Errorf("execution backend %q has no execution implementation", backend)

--- a/internal/execbackend/execbackend_test.go
+++ b/internal/execbackend/execbackend_test.go
@@ -5,20 +5,20 @@ import (
 	"testing"
 )
 
-func TestParseResolvesAdvertisedLocal(t *testing.T) {
-	for _, value := range []string{"local", " local "} {
+func TestParseResolvesAdvertisedBackends(t *testing.T) {
+	for _, value := range []string{"local", " local ", "remote", " remote "} {
 		backend, err := Parse(value)
 		if err != nil {
-			t.Fatalf("Parse(%q) error = %v, want local", value, err)
+			t.Fatalf("Parse(%q) error = %v", value, err)
 		}
-		if backend != Local {
-			t.Fatalf("Parse(%q) = %q, want %q", value, backend, Local)
+		if backend != Backend(strings.TrimSpace(value)) {
+			t.Fatalf("Parse(%q) = %q", value, backend)
 		}
 	}
 }
 
 func TestParseUnknownAndBlankFailLoudNamingValueAndAllowedSet(t *testing.T) {
-	for _, value := range []string{"", "   ", "e2b", "loca", "LOCAL", "remote"} {
+	for _, value := range []string{"", "   ", "e2b", "loca", "LOCAL"} {
 		backend, err := Parse(value)
 		if err == nil {
 			t.Fatalf("Parse(%q) = %q, want a loud error", value, backend)
@@ -26,7 +26,7 @@ func TestParseUnknownAndBlankFailLoudNamingValueAndAllowedSet(t *testing.T) {
 		if !strings.Contains(err.Error(), `"`+strings.TrimSpace(value)+`"`) {
 			t.Fatalf("Parse(%q) error = %q, want it to name the offending value", value, err)
 		}
-		if !strings.Contains(err.Error(), "allowed: local") {
+		if !strings.Contains(err.Error(), "allowed: local, remote") {
 			t.Fatalf("Parse(%q) error = %q, want it to name the allowed set", value, err)
 		}
 	}
@@ -45,7 +45,7 @@ func TestResolveOverrideWinsOverConfig(t *testing.T) {
 	if err == nil {
 		t.Fatal("Resolve(local, e2b) succeeded, want a loud override error")
 	}
-	if !strings.Contains(err.Error(), "exec_backend") || !strings.Contains(err.Error(), `"e2b"`) || !strings.Contains(err.Error(), "allowed: local") {
+	if !strings.Contains(err.Error(), "exec_backend") || !strings.Contains(err.Error(), `"e2b"`) || !strings.Contains(err.Error(), "allowed: local, remote") {
 		t.Fatalf("Resolve(local, e2b) error = %q, want override source + value + allowed set", err)
 	}
 	// An absent override falls through to the config value; an unknown config
@@ -74,6 +74,9 @@ func TestAllowedNamesMatchesParse(t *testing.T) {
 		if _, err := Parse(name); err != nil {
 			t.Fatalf("AllowedNames entry %q does not parse: %v", name, err)
 		}
+		if _, err := ParseImplemented(name); err != nil {
+			t.Fatalf("AllowedNames entry %q is not implemented: %v", name, err)
+		}
 	}
 	_, err := Parse("definitely-not-a-backend")
 	if err == nil || !strings.Contains(err.Error(), "allowed: "+Allowed()) {
@@ -98,23 +101,33 @@ func TestAdvertisedBackendWithoutImplementationFailsLoud(t *testing.T) {
 }
 
 func TestConsumeRequiresPositiveImplementation(t *testing.T) {
-	called := 0
-	got, err := Consume(Local, func() (string, error) {
-		called++
+	localCalls := 0
+	remoteCalls := 0
+	local := func() (string, error) {
+		localCalls++
 		return "local-result", nil
-	})
-	if err != nil || got != "local-result" || called != 1 {
-		t.Fatalf("Consume(local) = %q, %v, calls=%d; want local-result, nil, 1", got, err, called)
+	}
+	remote := func() (string, error) {
+		remoteCalls++
+		return "remote-result", nil
+	}
+	got, err := Consume(Local, func() (string, error) {
+		return local()
+	}, remote)
+	if err != nil || got != "local-result" || localCalls != 1 || remoteCalls != 0 {
+		t.Fatalf("Consume(local) = %q, %v, local calls=%d remote calls=%d", got, err, localCalls, remoteCalls)
 	}
 
-	got, err = Consume(Backend("p2-probe"), func() (string, error) {
-		called++
-		return "silently-local", nil
-	})
+	got, err = Consume(Remote, local, remote)
+	if err != nil || got != "remote-result" || localCalls != 1 || remoteCalls != 1 {
+		t.Fatalf("Consume(remote) = %q, %v, local calls=%d remote calls=%d", got, err, localCalls, remoteCalls)
+	}
+
+	got, err = Consume(Backend("p2-probe"), local, remote)
 	if err == nil || !strings.Contains(err.Error(), `"p2-probe"`) {
 		t.Fatalf("Consume(p2-probe) = %q, %v; want a loud missing-implementation error", got, err)
 	}
-	if called != 1 {
-		t.Fatalf("local builder calls = %d, want 1; future backend reached local implementation", called)
+	if localCalls != 1 || remoteCalls != 1 {
+		t.Fatalf("p2-probe invoked a builder: local calls=%d remote calls=%d", localCalls, remoteCalls)
 	}
 }

--- a/internal/execbackend/lifecycle.go
+++ b/internal/execbackend/lifecycle.go
@@ -15,6 +15,7 @@ import (
 	"strings"
 	"sync"
 	"syscall"
+	"time"
 
 	"github.com/gitmoot/gitmoot/internal/subprocess"
 )
@@ -27,6 +28,8 @@ import (
 type ExecutionBackend interface {
 	Name() Backend
 	Provision(context.Context, JobScope) (*Instance, error)
+	// Attach deliberately has zero non-test callers; #1539 owns the durable
+	// instance ledger and the first production wiring.
 	Attach(context.Context, string) (*Instance, error)
 	SyncIn(context.Context, *Instance, Materials) error
 	Exec(context.Context, *Instance, Command) (Stream, error)
@@ -44,6 +47,7 @@ type Reaper interface {
 type JobScope struct {
 	JobID               string
 	LifecycleGeneration int64
+	TTL                 time.Duration
 }
 
 // Materials are non-secret inputs staged into one execution instance. The

--- a/internal/workflow/mailbox.go
+++ b/internal/workflow/mailbox.go
@@ -1582,8 +1582,13 @@ func runProduceCheck(ctx context.Context, payload JobPayload, fallbackDir string
 	}
 	checkCtx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
-	result, err := execbackend.Consume(backend, func() (subprocess.Result, error) {
+	local := func() (subprocess.Result, error) {
 		return (subprocess.GroupRunner{MaxOutputBytes: 2 * maxProduceCheckOutputBytes}).Run(checkCtx, dir, "sh", "-c", payload.Check)
+	}
+	result, err := execbackend.Consume(backend, local, func() (subprocess.Result, error) {
+		// Produce output stays in the instance because only implement imports a
+		// changeset. A host check here would validate stale pre-delivery bytes.
+		return subprocess.Result{}, errors.New("produce deterministic checks are not supported on the remote execution backend")
 	})
 	return sanitizeProduceCheckOutput(result.Stdout + result.Stderr), err
 }

--- a/internal/workflow/mailbox_test.go
+++ b/internal/workflow/mailbox_test.go
@@ -359,6 +359,21 @@ func TestProduceCheckNonLocalBackendCannotRunLocally(t *testing.T) {
 	}
 }
 
+func TestRemoteProduceCheckRefusesHostFallback(t *testing.T) {
+	dir := t.TempDir()
+	marker := filepath.Join(dir, "remote-check-must-not-run")
+	_, err := runProduceCheck(context.Background(), JobPayload{
+		WorktreePath: dir,
+		Check:        "touch remote-check-must-not-run",
+	}, "", time.Second, execbackend.Remote)
+	if _, statErr := os.Stat(marker); !os.IsNotExist(statErr) {
+		t.Fatalf("remote produce check executed on the host (marker err=%v)", statErr)
+	}
+	if err == nil || !strings.Contains(err.Error(), "not supported on the remote execution backend") {
+		t.Fatalf("runProduceCheck(remote) error = %v, want remote refusal", err)
+	}
+}
+
 func TestMailboxRejectsProduceOutsidePipelineSender(t *testing.T) {
 	mailbox := Mailbox{store: openTestStore(t), resolveDeliveryWorktree: ExcludedDeliveryWorktreeResolver("test_explicit_no_worktree")}
 	_, err := mailbox.Enqueue(context.Background(), JobRequest{ID: "bad-produce", Agent: "p", Action: "produce", Repo: "owner/repo", Sender: "user"})

--- a/internal/workflow/result_observation.go
+++ b/internal/workflow/result_observation.go
@@ -165,6 +165,8 @@ func observeResultChanges(ctx context.Context, worktree string, result AgentResu
 	}
 	files, err := execbackend.Consume(backend, func() ([]string, error) {
 		return changedWorktreeFiles(ctx, worktree)
+	}, func() ([]string, error) {
+		return changedWorktreeFiles(ctx, worktree)
 	})
 	if err != nil {
 		return &ResultObservation{

--- a/internal/workflow/result_observation_test.go
+++ b/internal/workflow/result_observation_test.go
@@ -465,6 +465,21 @@ func TestObserveResultChangesReadsTrackedAndUntrackedWorktreeDiff(t *testing.T) 
 	}
 }
 
+func TestObserveResultChangesRemoteReadsImportedHostWorktree(t *testing.T) {
+	repo := observationTestRepo(t)
+	writeObservationFile(t, repo, "remote.go", "package changed\n")
+
+	observation := observeResultChanges(context.Background(), repo, AgentResult{
+		ChangesMade: []string{"remote.go:1 — imported"},
+	}, execbackend.Remote)
+	if observation == nil || observation.Error != "" || observation.Divergent {
+		t.Fatalf("remote observation = %+v, want successful host worktree diff", observation)
+	}
+	if got, want := fmt.Sprint(observation.TouchedFiles), "[remote.go]"; got != want {
+		t.Fatalf("TouchedFiles = %s, want %s", got, want)
+	}
+}
+
 func TestObserveResultChangesNonLocalBackendCannotRunLocalGit(t *testing.T) {
 	observation := observeResultChanges(context.Background(), t.TempDir(), AgentResult{
 		ChangesMade: []string{"tracked.go:1 — updated"},


### PR DESCRIPTION
WHAT:
GITMOOT-IMPL: implemented #1633 Slice A on checked-out base ab854269230e814131f00fe0b1ccbc21b46bfd67. Remote is parseable and every Consume route now has explicit final semantics, with unsupported execution paths refusing host fallback.

WHY:
Gitmoot finalized this implementation from a task worktree.

CHANGES:
- Committed changes from /root/.gitmoot/worktrees/gitmoot--gitmoot/adhoc-856ef63e

RESULTS:
- Pinned-env compile checks: go test -buildvcs=false -c -o /dev/null for ./internal/execbackend, ./internal/config, ./internal/workflow, and ./internal/cli all exited 0. The initial unpinned execbackend compile attempted unavailable automatic toolchain resolution; it was rerun successfully with the mandated Go 1.26.4 environment.
- Workflow final targeted run matched 2 top-level tests / 2 RUN events: TestRemoteProduceCheckRefusesHostFallback and TestObserveResultChangesRemoteReadsImportedHostWorktree; PASS.
- CLI final targeted run matched 5 top-level tests / 25 RUN events: p2-probe refusal, remote route matrix, local composition identity, TTL lifecycle behavior, and local shell implement round trip; PASS.
- Execbackend targeted run matched 3 tests / 3 RUN events covering advertised parsing, registry consistency, and positional Consume; PASS.
- Config targeted run matched 3 top-level tests / 5 RUN events covering explicit local/remote and unknown/blank refusal; PASS.
- Strength mutant: baseline filter matched 1 test. Changing only the remote runProduceCheck arm to `return local()` compiled with go test -c, then TestRemoteProduceCheckRefusesHostFallback failed because the host marker was created. The mutation was reverted and the test passed.
- Distinctness run under the produce-only mutant matched 3 top-level CLI tests / 14 RUN events; the remote adapter matrix and both local-preservation guards still passed independently.
- git diff --check passed; no .test binaries remain. Full suite, build, and vet were not run per dispatch.

RISK:
Review the generated diff before merging.

TASK:
adhoc-856ef63e

AGENTS:
- wave-impl

RAW FINAL REVIEW OUTPUT:
````text
GITMOOT-IMPL: implemented #1633 Slice A on checked-out base ab854269230e814131f00fe0b1ccbc21b46bfd67. Remote is parseable and every Consume route now has explicit final semantics, with unsupported execution paths refusing host fallback.
````
