### PR TITLE
Gitmoot: JARVIS DISPATCH — gitmoot#1633 SLICE B. Sign GITMOOT-IMPL

### DIFF
--- a/internal/execbackend/e2b/client.go
+++ b/internal/execbackend/e2b/client.go
@@ -1,8 +1,7 @@
-// Package e2b implements the E2B control-plane REST client.
+// Package e2b implements E2B control-plane and envd data-plane clients.
 //
-// It deliberately does not implement execbackend.Backend: command execution
-// and file transfer use the sandbox envd protocol and remain outside this
-// package.
+// It deliberately does not implement execbackend.Backend or wire either client
+// into the daemon; provider lifecycle integration remains a separate slice.
 package e2b
 
 import (
@@ -25,6 +24,7 @@ import (
 
 const (
 	DefaultBaseURL               = "https://api.e2b.app"
+	DefaultSandboxDomain         = "e2b.app"
 	DefaultRequestTimeout        = 15 * time.Second
 	maxProviderResponseBodyBytes = 1 << 20
 	minAPIKeyLength              = 8
@@ -129,7 +129,17 @@ type Sandbox struct {
 	DiskSizeMB  int32             `json:"diskSizeMB,omitempty"`
 	Metadata    map[string]string `json:"metadata,omitempty"`
 	State       string            `json:"state,omitempty"`
+	Domain      string            `json:"domain,omitempty"`
 }
+
+// EnvdCredential is a sandbox-scoped envd access credential. Its token is
+// deliberately inaccessible and every standard rendering is redacted.
+type EnvdCredential struct {
+	token string
+}
+
+func (EnvdCredential) String() string   { return "[REDACTED]" }
+func (EnvdCredential) GoString() string { return "[REDACTED]" }
 
 type listedSandbox struct {
 	ID          *string           `json:"sandboxID"`
@@ -298,35 +308,53 @@ type createPayload struct {
 	TemplateID string `json:"templateID"`
 	Timeout    int32  `json:"timeout"`
 	// Get cannot prove all-state absence, so TTL expiry must kill rather than pause.
-	AutoPause bool              `json:"autoPause"`
-	Metadata  map[string]string `json:"metadata,omitempty"`
-	Env       map[string]string `json:"envVars,omitempty"`
+	AutoPause bool `json:"autoPause"`
+	// Secure makes envd reject unauthenticated traffic. Create verifies the
+	// response token so a provider that ignores this request cannot look healthy.
+	Secure   bool              `json:"secure"`
+	Metadata map[string]string `json:"metadata,omitempty"`
+	Env      map[string]string `json:"envVars,omitempty"`
+}
+
+type createResponse struct {
+	Sandbox
+	EnvdAccessToken string  `json:"envdAccessToken"`
+	Domain          *string `json:"domain"`
 }
 
 // Create starts a sandbox with a required provider-side TTL.
-func (c *Client) Create(ctx context.Context, templateID string, ttl time.Duration, options CreateOptions) (Sandbox, error) {
+func (c *Client) Create(ctx context.Context, templateID string, ttl time.Duration, options CreateOptions) (Sandbox, EnvdCredential, error) {
 	if strings.TrimSpace(templateID) == "" {
-		return Sandbox{}, errors.New("E2B template ID is required")
+		return Sandbox{}, EnvdCredential{}, errors.New("E2B template ID is required")
 	}
 	ttlSeconds, err := durationSeconds(ttl)
 	if err != nil {
-		return Sandbox{}, fmt.Errorf("E2B create TTL: %w", err)
+		return Sandbox{}, EnvdCredential{}, fmt.Errorf("E2B create TTL: %w", err)
 	}
-	var sandbox Sandbox
+	var response createResponse
 	_, err = c.doJSON(ctx, http.MethodPost, "/sandboxes", createPayload{
 		TemplateID: templateID,
 		Timeout:    ttlSeconds,
 		AutoPause:  false,
+		Secure:     true,
 		Metadata:   options.Metadata,
 		Env:        options.Env,
-	}, http.StatusCreated, &sandbox)
+	}, http.StatusCreated, &response)
 	if err != nil {
-		return Sandbox{}, err
+		return Sandbox{}, EnvdCredential{}, err
 	}
-	if strings.TrimSpace(sandbox.ID) == "" {
-		return Sandbox{}, c.errorf(nil, "create sandbox: malformed response: missing sandboxID")
+	if strings.TrimSpace(response.ID) == "" {
+		return Sandbox{}, EnvdCredential{}, c.errorf(nil, "create sandbox: malformed response: missing sandboxID")
 	}
-	return sandbox, nil
+	if strings.TrimSpace(response.EnvdAccessToken) == "" {
+		return Sandbox{}, EnvdCredential{}, c.errorf(nil, "create sandbox: secure response is missing envdAccessToken")
+	}
+	domain := DefaultSandboxDomain
+	if response.Domain != nil && strings.TrimSpace(*response.Domain) != "" {
+		domain = strings.TrimSpace(*response.Domain)
+	}
+	response.Sandbox.Domain = domain
+	return response.Sandbox, EnvdCredential{token: response.EnvdAccessToken}, nil
 }
 
 // List returns all sandboxes in the provider response.

--- a/internal/execbackend/e2b/client_test.go
+++ b/internal/execbackend/e2b/client_test.go
@@ -37,11 +37,11 @@ func TestClientControlPlaneOperations(t *testing.T) {
 		}
 		switch r.Method + " " + r.URL.EscapedPath() {
 		case "POST /sandboxes":
-			if got := readBody(t, r); got != `{"templateID":"template-a","timeout":600,"autoPause":false,"metadata":{"job":"42"},"envVars":{"MODE":"test"}}` {
+			if got := readBody(t, r); got != `{"templateID":"template-a","timeout":600,"autoPause":false,"secure":true,"metadata":{"job":"42"},"envVars":{"MODE":"test"}}` {
 				t.Errorf("create body = %s", got)
 			}
 			w.WriteHeader(http.StatusCreated)
-			_, _ = w.Write([]byte(`{"sandboxID":"sbx-1","templateID":"template-a","clientID":"client","envdVersion":"1.0"}`))
+			_, _ = w.Write([]byte(`{"sandboxID":"sbx-1","templateID":"template-a","clientID":"client","envdVersion":"1.0","envdAccessToken":"sandbox-envd-secret","domain":null}`))
 		case "GET /v2/sandboxes":
 			if got := r.URL.Query().Get("limit"); got != "100" {
 				t.Errorf("list limit = %q, want 100", got)
@@ -68,12 +68,15 @@ func TestClientControlPlaneOperations(t *testing.T) {
 	client := newTestClient(t, server.URL, time.Second, server.Client())
 	ctx := context.Background()
 
-	created, err := client.Create(ctx, "template-a", 10*time.Minute, CreateOptions{
+	created, credential, err := client.Create(ctx, "template-a", 10*time.Minute, CreateOptions{
 		Metadata: map[string]string{"job": "42"},
 		Env:      map[string]string{"MODE": "test"},
 	})
-	if err != nil || created.ID != "sbx-1" {
+	if err != nil || created.ID != "sbx-1" || created.Domain != DefaultSandboxDomain || credential.token != "sandbox-envd-secret" {
 		t.Fatalf("Create = %+v, %v", created, err)
+	}
+	if got := fmt.Sprintf("%s/%#v", credential, credential); got != "[REDACTED]/[REDACTED]" {
+		t.Fatalf("credential rendering = %q", got)
 	}
 	listed, err := client.List(ctx)
 	if err != nil || len(listed) != 1 || listed[0].State != "running" {
@@ -204,13 +207,33 @@ func TestClientRequiresCreationTTL(t *testing.T) {
 	client := newTestClient(t, server.URL, time.Second, server.Client())
 
 	for _, ttl := range []time.Duration{0, -time.Second, 1500 * time.Millisecond} {
-		_, err := client.Create(context.Background(), "template-a", ttl, CreateOptions{})
+		_, _, err := client.Create(context.Background(), "template-a", ttl, CreateOptions{})
 		if err == nil {
 			t.Errorf("Create TTL %s succeeded", ttl)
 		}
 	}
 	if got := calls.Load(); got != 0 {
 		t.Fatalf("provider calls = %d, want 0", got)
+	}
+}
+
+func TestClientCreateRequiresEnvdCredential(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if body := readBody(t, r); !strings.Contains(body, `"secure":true`) {
+			t.Errorf("create body = %s, want secure=true", body)
+		}
+		w.WriteHeader(http.StatusCreated)
+		_, _ = w.Write([]byte(`{"sandboxID":"sbx-unsecured","templateID":"base","domain":null}`))
+	}))
+	defer server.Close()
+	client := newTestClient(t, server.URL, time.Second, server.Client())
+
+	sandbox, credential, err := client.Create(context.Background(), "base", time.Minute, CreateOptions{})
+	if err == nil || !strings.Contains(err.Error(), "missing envdAccessToken") {
+		t.Fatalf("Create = %+v, %v, %v; want missing-token error", sandbox, credential, err)
 	}
 }
 

--- a/internal/execbackend/e2b/envd.go
+++ b/internal/execbackend/e2b/envd.go
@@ -11,6 +11,7 @@ import (
 	"mime"
 	"net/http"
 	"net/url"
+	"sort"
 	"strings"
 	"time"
 
@@ -33,15 +34,20 @@ type EnvdOptions struct {
 	HTTPClient       *http.Client
 	RequestTimeout   time.Duration
 	EndpointResolver func(sandboxID string, port int) string
+
+	// OnUnknownEndEventFields, when set, is called once per terminal event that
+	// carries keys this client does not model. It never affects the result.
+	OnUnknownEndEventFields func(fields []string)
 }
 
 // Envd calls one sandbox's authenticated envd endpoint.
 type Envd struct {
-	sandboxID       string
-	credential      EnvdCredential
-	httpClient      *http.Client
-	requestTimeout  time.Duration
-	resolveEndpoint func(string, int) string
+	sandboxID               string
+	credential              EnvdCredential
+	httpClient              *http.Client
+	requestTimeout          time.Duration
+	onUnknownEndEventFields func(fields []string)
+	resolveEndpoint         func(string, int) string
 }
 
 // NewEnvd constructs an authenticated envd client. A missing credential is a
@@ -88,6 +94,8 @@ func NewEnvd(sandbox Sandbox, credential EnvdCredential, options EnvdOptions) (*
 		httpClient:      &httpClientCopy,
 		requestTimeout:  timeout,
 		resolveEndpoint: resolver,
+
+		onUnknownEndEventFields: options.OnUnknownEndEventFields,
 	}
 	if _, err := envd.endpoint(""); err != nil {
 		return nil, err
@@ -356,6 +364,9 @@ func (e *Envd) readStartStream(reader io.Reader, request StartRequest) (execback
 			}
 			ended = true
 			processEnd = *response.Event.End
+			if len(processEnd.UnknownFields) > 0 && e.onUnknownEndEventFields != nil {
+				e.onUnknownEndEventFields(processEnd.UnknownFields)
+			}
 		case response.Event.Keepalive != nil:
 			continue
 		default:
@@ -419,19 +430,56 @@ type endEvent struct {
 	Exited   bool   `json:"exited"`
 	Status   string `json:"status"`
 	Error    string `json:"error"`
+
+	// Not a wire field: the provider keys this client does not model, recorded
+	// so a wire change is observable. Deliberately never consulted when
+	// deciding success — see UnmarshalJSON for why rejecting them is worse.
+	UnknownFields []string `json:"-" envd:"ignored: recorded for observability and surfaced via EnvdOptions.OnUnknownEndEventFields; never used to decide success"`
 }
 
-// UnmarshalJSON fails closed when envd adds a terminal field that this client
-// does not yet understand. TestEndEventFieldsHaveExplicitHandling separately
-// prevents a field added here from bypassing endEventError.
+// UnmarshalJSON ACCEPTS terminal fields this client does not model rather than
+// rejecting them. Additive fields are how wire protocols normally evolve, so
+// failing on one would turn every SUCCESSFUL exec into an outage on the
+// provider's release schedule — and no test of ours could ever go red first,
+// because our fixtures only ever carry fields we already know about. Unknown
+// keys are recorded and surfaced through EnvdOptions.OnUnknownEndEventFields so
+// a provider change is observable instead of silent.
+//
+// TestEndEventFieldsHaveExplicitHandling separately prevents a field added to
+// this struct from bypassing endEventError; that guard's subject is OUR struct
+// and it fires in CI, which is the difference that makes it worth having.
 func (e *endEvent) UnmarshalJSON(data []byte) error {
 	type wireEndEvent endEvent
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	if err := decoder.Decode((*wireEndEvent)(e)); err != nil {
 		return err
 	}
-	return requireJSONEOF(decoder)
+	if err := requireJSONEOF(decoder); err != nil {
+		return err
+	}
+	e.UnknownFields = unknownEndEventKeys(data)
+	return nil
+}
+
+// unknownEndEventKeys reports the object keys the endEvent struct does not
+// model, in a stable order. It never fails the decode.
+func unknownEndEventKeys(data []byte) []string {
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return nil
+	}
+	known := map[string]struct{}{"exitCode": {}, "exited": {}, "status": {}, "error": {}}
+	unknown := make([]string, 0, len(raw))
+	for key := range raw {
+		if _, ok := known[key]; !ok {
+			unknown = append(unknown, key)
+		}
+	}
+	sort.Strings(unknown)
+	if len(unknown) == 0 {
+		return nil
+	}
+	return unknown
 }
 
 type outputTail struct {

--- a/internal/execbackend/e2b/envd.go
+++ b/internal/execbackend/e2b/envd.go
@@ -109,15 +109,25 @@ type StartRequest struct {
 
 // ExitError reports a provider-confirmed non-zero process exit.
 type ExitError struct {
-	Code   int
-	Status string
+	Code          int
+	Status        string
+	ProviderError string
 }
 
 func (e *ExitError) Error() string {
-	if strings.TrimSpace(e.Status) == "" {
+	detail := strings.TrimSpace(e.Status)
+	providerError := strings.TrimSpace(e.ProviderError)
+	if providerError != "" && providerError != detail {
+		if detail == "" {
+			detail = providerError
+		} else {
+			detail += ": " + providerError
+		}
+	}
+	if detail == "" {
 		return fmt.Sprintf("remote command exited with code %d", e.Code)
 	}
-	return fmt.Sprintf("remote command exited with code %d: %s", e.Code, e.Status)
+	return fmt.Sprintf("remote command exited with code %d: %s", e.Code, detail)
 }
 
 type streamResult struct {
@@ -285,8 +295,7 @@ func (e *Envd) readStartStream(reader io.Reader, request StartRequest) (execback
 	started := false
 	ended := false
 	terminal := false
-	var exitCode int
-	var exitStatus string
+	var processEnd endEvent
 
 	for {
 		flag, data, err := readConnectFrame(reader)
@@ -346,8 +355,7 @@ func (e *Envd) readStartStream(reader io.Reader, request StartRequest) (execback
 				return result, e.errorf(nil, "envd Start returned an invalid end event")
 			}
 			ended = true
-			exitCode = response.Event.End.ExitCode
-			exitStatus = response.Event.End.Status
+			processEnd = *response.Event.End
 		case response.Event.Keepalive != nil:
 			continue
 		default:
@@ -363,10 +371,27 @@ func (e *Envd) readStartStream(reader io.Reader, request StartRequest) (execback
 	if !ended {
 		return result, e.errorf(nil, "envd Start stream ended without a process result")
 	}
-	if exitCode != 0 {
-		return result, &ExitError{Code: exitCode, Status: exitStatus}
+	if err := e.endEventError(processEnd); err != nil {
+		return result, err
 	}
 	return result, nil
+}
+
+func (e *Envd) endEventError(event endEvent) error {
+	if !event.Exited {
+		return e.errorf(nil, "envd Start end event did not confirm process termination")
+	}
+	providerError := strings.TrimSpace(event.Error)
+	if providerError != "" {
+		if event.ExitCode == 0 {
+			return e.errorf(nil, "envd process failed: %s", providerError)
+		}
+		return &ExitError{Code: event.ExitCode, Status: event.Status, ProviderError: providerError}
+	}
+	if event.ExitCode != 0 {
+		return &ExitError{Code: event.ExitCode, Status: event.Status}
+	}
+	return nil
 }
 
 type startResponse struct {
@@ -387,11 +412,26 @@ type dataEvent struct {
 	Stderr []byte `json:"stderr"`
 }
 
+// Every field must be read by endEventError or carry an envd:"ignored: reason"
+// tag; TestEndEventFieldsHaveExplicitHandling derives that check from this type.
 type endEvent struct {
 	ExitCode int    `json:"exitCode"`
 	Exited   bool   `json:"exited"`
 	Status   string `json:"status"`
 	Error    string `json:"error"`
+}
+
+// UnmarshalJSON fails closed when envd adds a terminal field that this client
+// does not yet understand. TestEndEventFieldsHaveExplicitHandling separately
+// prevents a field added here from bypassing endEventError.
+func (e *endEvent) UnmarshalJSON(data []byte) error {
+	type wireEndEvent endEvent
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode((*wireEndEvent)(e)); err != nil {
+		return err
+	}
+	return requireJSONEOF(decoder)
 }
 
 type outputTail struct {

--- a/internal/execbackend/e2b/envd.go
+++ b/internal/execbackend/e2b/envd.go
@@ -11,6 +11,7 @@ import (
 	"mime"
 	"net/http"
 	"net/url"
+	"reflect"
 	"sort"
 	"strings"
 	"time"
@@ -35,8 +36,13 @@ type EnvdOptions struct {
 	RequestTimeout   time.Duration
 	EndpointResolver func(sandboxID string, port int) string
 
-	// OnUnknownEndEventFields, when set, is called once per terminal event that
-	// carries keys this client does not model. It never affects the result.
+	// OnUnknownEndEventFields, when set, is called once when a decoded process
+	// end event carries keys this client does not model. It runs before the
+	// Connect terminal frame is validated and never affects the result.
+	//
+	// The callback receives names, not values. It makes additive wire changes
+	// observable, but the client still applies its existing interpretation if an
+	// unknown field changes the meaning of a modeled field.
 	OnUnknownEndEventFields func(fields []string)
 }
 
@@ -468,10 +474,12 @@ func unknownEndEventKeys(data []byte) []string {
 	if err := json.Unmarshal(data, &raw); err != nil {
 		return nil
 	}
-	known := map[string]struct{}{"exitCode": {}, "exited": {}, "status": {}, "error": {}}
+	known := jsonWireFieldNames(reflect.TypeOf(endEvent{}))
 	unknown := make([]string, 0, len(raw))
 	for key := range raw {
-		if _, ok := known[key]; !ok {
+		// encoding/json matches field names case-insensitively. A key that can
+		// drive the verdict is modeled and must not also be reported as unknown.
+		if _, ok := known[strings.ToLower(key)]; !ok {
 			unknown = append(unknown, key)
 		}
 	}
@@ -480,6 +488,25 @@ func unknownEndEventKeys(data []byte) []string {
 		return nil
 	}
 	return unknown
+}
+
+func jsonWireFieldNames(structType reflect.Type) map[string]struct{} {
+	known := make(map[string]struct{}, structType.NumField())
+	for i := 0; i < structType.NumField(); i++ {
+		field := structType.Field(i)
+		if !field.IsExported() {
+			continue
+		}
+		name, _, _ := strings.Cut(field.Tag.Get("json"), ",")
+		if name == "-" {
+			continue
+		}
+		if name == "" {
+			name = field.Name
+		}
+		known[strings.ToLower(name)] = struct{}{}
+	}
+	return known
 }
 
 type outputTail struct {

--- a/internal/execbackend/e2b/envd.go
+++ b/internal/execbackend/e2b/envd.go
@@ -1,0 +1,511 @@
+package e2b
+
+import (
+	"bytes"
+	"context"
+	"encoding/binary"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"mime"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/gitmoot/gitmoot/internal/execbackend"
+	"github.com/gitmoot/gitmoot/internal/workflow"
+)
+
+const (
+	envdPort                 = 49983
+	envdDefaultUser          = "user"
+	maxConnectFrameBytes     = 16 << 20
+	connectEndStreamFlag     = byte(2)
+	connectCompressedFlag    = byte(1)
+	connectProtocolMediaType = "application/connect+json"
+)
+
+// EnvdOptions configures sandbox envd calls. Zero RequestTimeout selects the
+// bounded control-plane default. EndpointResolver is an offline-test seam.
+type EnvdOptions struct {
+	HTTPClient       *http.Client
+	RequestTimeout   time.Duration
+	EndpointResolver func(sandboxID string, port int) string
+}
+
+// Envd calls one sandbox's authenticated envd endpoint.
+type Envd struct {
+	sandboxID       string
+	credential      EnvdCredential
+	httpClient      *http.Client
+	requestTimeout  time.Duration
+	resolveEndpoint func(string, int) string
+}
+
+// NewEnvd constructs an authenticated envd client. A missing credential is a
+// construction error, so no request can accidentally fall back to public envd.
+func NewEnvd(sandbox Sandbox, credential EnvdCredential, options EnvdOptions) (*Envd, error) {
+	sandboxID := strings.TrimSpace(sandbox.ID)
+	if sandboxID == "" {
+		return nil, errors.New("E2B sandbox ID is required for envd")
+	}
+	if strings.TrimSpace(credential.token) == "" {
+		return nil, errors.New("E2B envd credential is required")
+	}
+	timeout := options.RequestTimeout
+	if timeout == 0 {
+		timeout = DefaultRequestTimeout
+	}
+	if timeout < 0 {
+		return nil, errors.New("E2B envd request timeout must be positive")
+	}
+
+	resolver := options.EndpointResolver
+	if resolver == nil {
+		domain := strings.TrimSpace(sandbox.Domain)
+		if domain == "" {
+			domain = DefaultSandboxDomain
+		}
+		resolver = func(id string, port int) string {
+			return fmt.Sprintf("https://%d-%s.%s", port, id, domain)
+		}
+	}
+	httpClient := options.HTTPClient
+	if httpClient == nil {
+		httpClient = &http.Client{}
+	}
+	httpClientCopy := *httpClient
+	// A redirect must never receive the sandbox-scoped access token.
+	httpClientCopy.CheckRedirect = func(_ *http.Request, _ []*http.Request) error {
+		return http.ErrUseLastResponse
+	}
+
+	envd := &Envd{
+		sandboxID:       sandboxID,
+		credential:      credential,
+		httpClient:      &httpClientCopy,
+		requestTimeout:  timeout,
+		resolveEndpoint: resolver,
+	}
+	if _, err := envd.endpoint(""); err != nil {
+		return nil, err
+	}
+	return envd, nil
+}
+
+// StartRequest describes one envd process and its streaming capture. Output
+// receives stdout and stderr in event order while Wait retains separate tails.
+type StartRequest struct {
+	Name           string
+	Args           []string
+	Dir            string
+	Env            []string
+	Output         io.Writer
+	MaxOutputBytes int
+	OnStart        func(pid int)
+}
+
+// ExitError reports a provider-confirmed non-zero process exit.
+type ExitError struct {
+	Code   int
+	Status string
+}
+
+func (e *ExitError) Error() string {
+	if strings.TrimSpace(e.Status) == "" {
+		return fmt.Sprintf("remote command exited with code %d", e.Code)
+	}
+	return fmt.Sprintf("remote command exited with code %d: %s", e.Code, e.Status)
+}
+
+type streamResult struct {
+	result execbackend.ExecResult
+	err    error
+}
+
+// Stream is an in-flight envd process stream.
+type Stream struct {
+	result chan streamResult
+}
+
+// Wait consumes the terminal process result.
+func (s *Stream) Wait() (execbackend.ExecResult, error) {
+	if s == nil || s.result == nil {
+		return execbackend.ExecResult{}, errors.New("E2B envd stream is nil")
+	}
+	result := <-s.result
+	return result.result, result.err
+}
+
+type startPayload struct {
+	Process processPayload `json:"process"`
+	Stdin   bool           `json:"stdin"`
+}
+
+type processPayload struct {
+	Command string            `json:"cmd"`
+	Args    []string          `json:"args,omitempty"`
+	Env     map[string]string `json:"envs,omitempty"`
+	Dir     string            `json:"cwd,omitempty"`
+}
+
+// Start launches a process through Connect's server-streaming JSON protocol.
+func (e *Envd) Start(ctx context.Context, request StartRequest) (*Stream, error) {
+	if e == nil {
+		return nil, errors.New("E2B envd client is nil")
+	}
+	if strings.TrimSpace(request.Name) == "" {
+		return nil, errors.New("E2B envd command is required")
+	}
+	if request.MaxOutputBytes < 0 {
+		return nil, errors.New("E2B envd max output bytes must not be negative")
+	}
+	env, err := envMap(request.Env)
+	if err != nil {
+		return nil, err
+	}
+	payload, err := json.Marshal(startPayload{
+		Process: processPayload{
+			Command: request.Name,
+			Args:    append([]string(nil), request.Args...),
+			Env:     env,
+			Dir:     request.Dir,
+		},
+		Stdin: false,
+	})
+	if err != nil {
+		return nil, e.errorf(err, "encode envd Start request")
+	}
+	body := connectFrame(0, payload)
+	endpoint, err := e.endpoint("/process.Process/Start")
+	if err != nil {
+		return nil, err
+	}
+
+	requestCtx, cancel := context.WithCancel(ctx)
+	req, err := http.NewRequestWithContext(requestCtx, http.MethodPost, endpoint, bytes.NewReader(body))
+	if err != nil {
+		cancel()
+		return nil, e.errorf(err, "build envd Start request")
+	}
+	e.authenticate(req)
+	req.Header.Set("Content-Type", connectProtocolMediaType)
+	req.Header.Set("Accept", connectProtocolMediaType)
+	req.Header.Set("connect-protocol-version", "1")
+
+	// Bound only the response-header handshake. Once envd starts streaming, the
+	// caller's context owns the process lifetime rather than a per-request timer.
+	handshake := time.AfterFunc(e.requestTimeout, cancel)
+	resp, err := e.httpClient.Do(req)
+	handshake.Stop()
+	if err != nil {
+		cancel()
+		return nil, e.errorf(err, "envd Start request failed")
+	}
+	if resp.StatusCode != http.StatusOK {
+		defer resp.Body.Close()
+		defer cancel()
+		data, oversized, readErr := readProviderResponseBody(resp.Body)
+		if readErr != nil {
+			return nil, e.errorf(readErr, "envd Start returned HTTP %d and its response could not be read", resp.StatusCode)
+		}
+		if oversized {
+			return nil, e.errorf(nil, "envd Start returned HTTP %d with an oversized response", resp.StatusCode)
+		}
+		if resp.StatusCode == http.StatusUnsupportedMediaType {
+			return nil, e.errorf(nil, "envd Start reached the route but HTTP 415 rejected the Connect codec: %s", data)
+		}
+		return nil, e.errorf(nil, "envd Start returned HTTP %d: %s", resp.StatusCode, data)
+	}
+	if err := requireConnectMediaType(resp.Header); err != nil {
+		resp.Body.Close()
+		cancel()
+		return nil, e.errorf(err, "envd Start response has the wrong codec")
+	}
+
+	stream := &Stream{result: make(chan streamResult, 1)}
+	go func() {
+		defer resp.Body.Close()
+		defer cancel()
+		result, readErr := e.readStartStream(resp.Body, request)
+		stream.result <- streamResult{result: result, err: readErr}
+	}()
+	return stream, nil
+}
+
+// Upload streams one file into the same user account envd uses for Start.
+func (e *Envd) Upload(ctx context.Context, path string, reader io.Reader) error {
+	if e == nil {
+		return errors.New("E2B envd client is nil")
+	}
+	if strings.TrimSpace(path) == "" {
+		return errors.New("E2B envd upload path is required")
+	}
+	if reader == nil {
+		return errors.New("E2B envd upload reader is required")
+	}
+	query := url.Values{"path": []string{path}, "username": []string{envdDefaultUser}}
+	endpoint, err := e.endpoint("/files?" + query.Encode())
+	if err != nil {
+		return err
+	}
+	requestCtx, cancel := context.WithTimeout(ctx, e.requestTimeout)
+	defer cancel()
+	req, err := http.NewRequestWithContext(requestCtx, http.MethodPost, endpoint, reader)
+	if err != nil {
+		return e.errorf(err, "build envd upload request")
+	}
+	e.authenticate(req)
+	req.Header.Set("Content-Type", "application/octet-stream")
+	req.Header.Set("Accept", "application/json")
+	resp, err := e.httpClient.Do(req)
+	if err != nil {
+		return e.errorf(err, "envd upload request failed")
+	}
+	defer resp.Body.Close()
+	data, oversized, readErr := readProviderResponseBody(resp.Body)
+	if readErr != nil {
+		return e.errorf(readErr, "envd upload returned HTTP %d and its response could not be read", resp.StatusCode)
+	}
+	if oversized {
+		return e.errorf(nil, "envd upload returned HTTP %d with an oversized response", resp.StatusCode)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return e.errorf(nil, "envd upload returned HTTP %d: %s", resp.StatusCode, data)
+	}
+	return nil
+}
+
+func (e *Envd) readStartStream(reader io.Reader, request StartRequest) (execbackend.ExecResult, error) {
+	result := execbackend.ExecResult{Command: request.Name, Args: append([]string(nil), request.Args...)}
+	stdout := outputTail{max: request.MaxOutputBytes}
+	stderr := outputTail{max: request.MaxOutputBytes}
+	started := false
+	ended := false
+	terminal := false
+	var exitCode int
+	var exitStatus string
+
+	for {
+		flag, data, err := readConnectFrame(reader)
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		if err != nil {
+			return result, e.errorf(err, "read envd Start stream")
+		}
+		if flag&connectCompressedFlag != 0 {
+			return result, e.errorf(nil, "envd Start returned an unsupported compressed Connect frame")
+		}
+		if flag&connectEndStreamFlag != 0 {
+			terminal = true
+			if detail := strings.TrimSpace(string(data)); detail != "" && detail != "{}" {
+				return result, e.errorf(nil, "envd Start terminal error: %s", detail)
+			}
+			break
+		}
+		if flag != 0 {
+			return result, e.errorf(nil, "envd Start returned unsupported Connect frame flags %d", flag)
+		}
+
+		var response startResponse
+		decoder := json.NewDecoder(bytes.NewReader(data))
+		if err := decoder.Decode(&response); err != nil {
+			return result, e.errorf(err, "decode envd Start event")
+		}
+		if err := requireJSONEOF(decoder); err != nil {
+			return result, e.errorf(err, "decode envd Start event")
+		}
+		switch {
+		case response.Event.Start != nil:
+			if started || response.Event.Start.PID <= 0 {
+				return result, e.errorf(nil, "envd Start returned an invalid start event")
+			}
+			started = true
+			if request.OnStart != nil {
+				request.OnStart(response.Event.Start.PID)
+			}
+		case response.Event.Data != nil:
+			if !started || ended {
+				return result, e.errorf(nil, "envd Start returned process data outside its lifetime")
+			}
+			if len(response.Event.Data.Stdout) > 0 {
+				if err := writeProcessOutput(&stdout, request.Output, response.Event.Data.Stdout); err != nil {
+					return result, e.errorf(err, "stream envd stdout")
+				}
+			}
+			if len(response.Event.Data.Stderr) > 0 {
+				if err := writeProcessOutput(&stderr, request.Output, response.Event.Data.Stderr); err != nil {
+					return result, e.errorf(err, "stream envd stderr")
+				}
+			}
+		case response.Event.End != nil:
+			if !started || ended {
+				return result, e.errorf(nil, "envd Start returned an invalid end event")
+			}
+			ended = true
+			exitCode = response.Event.End.ExitCode
+			exitStatus = response.Event.End.Status
+		case response.Event.Keepalive != nil:
+			continue
+		default:
+			return result, e.errorf(nil, "envd Start returned an unknown process event")
+		}
+	}
+
+	result.Stdout = stdout.String()
+	result.Stderr = stderr.String()
+	if !terminal {
+		return result, e.errorf(nil, "envd Start stream ended without a terminal frame")
+	}
+	if !ended {
+		return result, e.errorf(nil, "envd Start stream ended without a process result")
+	}
+	if exitCode != 0 {
+		return result, &ExitError{Code: exitCode, Status: exitStatus}
+	}
+	return result, nil
+}
+
+type startResponse struct {
+	Event struct {
+		Start     *startEvent `json:"start"`
+		Data      *dataEvent  `json:"data"`
+		End       *endEvent   `json:"end"`
+		Keepalive *struct{}   `json:"keepalive"`
+	} `json:"event"`
+}
+
+type startEvent struct {
+	PID int `json:"pid"`
+}
+
+type dataEvent struct {
+	Stdout []byte `json:"stdout"`
+	Stderr []byte `json:"stderr"`
+}
+
+type endEvent struct {
+	ExitCode int    `json:"exitCode"`
+	Exited   bool   `json:"exited"`
+	Status   string `json:"status"`
+	Error    string `json:"error"`
+}
+
+type outputTail struct {
+	max  int
+	data []byte
+}
+
+func (b *outputTail) Write(data []byte) (int, error) {
+	count := len(data)
+	b.data = append(b.data, data...)
+	if b.max > 0 && len(b.data) > b.max {
+		b.data = append(b.data[:0], b.data[len(b.data)-b.max:]...)
+	}
+	return count, nil
+}
+
+func (b *outputTail) String() string { return string(b.data) }
+
+func writeProcessOutput(tail *outputTail, output io.Writer, data []byte) error {
+	if _, err := tail.Write(data); err != nil {
+		return err
+	}
+	if output == nil {
+		return nil
+	}
+	written, err := output.Write(data)
+	if err != nil {
+		return err
+	}
+	if written != len(data) {
+		return io.ErrShortWrite
+	}
+	return nil
+}
+
+func envMap(entries []string) (map[string]string, error) {
+	if len(entries) == 0 {
+		return nil, nil
+	}
+	result := make(map[string]string, len(entries))
+	for _, entry := range entries {
+		name, value, ok := strings.Cut(entry, "=")
+		if !ok || strings.TrimSpace(name) == "" {
+			return nil, fmt.Errorf("invalid E2B envd environment entry %q", entry)
+		}
+		result[name] = value
+	}
+	return result, nil
+}
+
+func connectFrame(flag byte, payload []byte) []byte {
+	framed := make([]byte, 5+len(payload))
+	framed[0] = flag
+	binary.BigEndian.PutUint32(framed[1:5], uint32(len(payload)))
+	copy(framed[5:], payload)
+	return framed
+}
+
+func readConnectFrame(reader io.Reader) (byte, []byte, error) {
+	var header [5]byte
+	if _, err := io.ReadFull(reader, header[:]); err != nil {
+		return 0, nil, err
+	}
+	length := binary.BigEndian.Uint32(header[1:])
+	if length > maxConnectFrameBytes {
+		return 0, nil, fmt.Errorf("Connect frame length %d exceeds %d bytes", length, maxConnectFrameBytes)
+	}
+	payload := make([]byte, int(length))
+	if _, err := io.ReadFull(reader, payload); err != nil {
+		return 0, nil, err
+	}
+	return header[0], payload, nil
+}
+
+func requireConnectMediaType(headers http.Header) error {
+	raw := strings.TrimSpace(headers.Get("Content-Type"))
+	if raw == "" {
+		return errors.New("missing Content-Type")
+	}
+	mediaType, _, err := mime.ParseMediaType(raw)
+	if err != nil {
+		return fmt.Errorf("invalid Content-Type %q", raw)
+	}
+	if !strings.EqualFold(mediaType, connectProtocolMediaType) {
+		return fmt.Errorf("Content-Type %q is not %s", mediaType, connectProtocolMediaType)
+	}
+	return nil
+}
+
+func (e *Envd) endpoint(suffix string) (string, error) {
+	base := strings.TrimSpace(e.resolveEndpoint(e.sandboxID, envdPort))
+	parsed, err := url.Parse(base)
+	if err != nil {
+		return "", e.errorf(err, "parse E2B envd endpoint")
+	}
+	if parsed.Scheme != "http" && parsed.Scheme != "https" || parsed.Host == "" || parsed.RawQuery != "" || parsed.Fragment != "" {
+		return "", e.errorf(nil, "E2B envd endpoint must be an absolute HTTP(S) URL without query or fragment")
+	}
+	return strings.TrimRight(parsed.String(), "/") + suffix, nil
+}
+
+func (e *Envd) authenticate(request *http.Request) {
+	request.Header.Set("X-Access-Token", e.credential.token)
+}
+
+func (e *Envd) errorf(cause error, format string, args ...any) error {
+	message := fmt.Sprintf(format, args...)
+	if cause != nil {
+		message += ": " + cause.Error()
+	}
+	return &clientError{
+		message: workflow.RedactedStderrTail(message, e.credential.token),
+		match:   contextErrorIdentity(cause),
+	}
+}
+
+var _ execbackend.Stream = (*Stream)(nil)

--- a/internal/execbackend/e2b/envd_test.go
+++ b/internal/execbackend/e2b/envd_test.go
@@ -1,0 +1,270 @@
+package e2b
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+const testEnvdToken = "envd-GITMOOT-IMPL-sandbox-secret"
+
+func TestEnvdStartStreamsAndBoundsOutput(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assertEnvdRequest(t, r, "/process.Process/Start", connectProtocolMediaType)
+		if got := r.Header.Get("connect-protocol-version"); got != "1" {
+			t.Errorf("connect-protocol-version = %q, want 1", got)
+		}
+		flag, body, err := readConnectFrame(r.Body)
+		if err != nil || flag != 0 {
+			t.Errorf("request frame = flag %d, %v", flag, err)
+			return
+		}
+		var request startPayload
+		if err := json.Unmarshal(body, &request); err != nil {
+			t.Errorf("decode request: %v", err)
+			return
+		}
+		if request.Process.Command != "sh" || strings.Join(request.Process.Args, " ") != "-c echo test" || request.Process.Dir != "/workspace" || request.Process.Env["MODE"] != "test" {
+			t.Errorf("start request = %+v", request)
+		}
+
+		w.Header().Set("Content-Type", connectProtocolMediaType)
+		writeConnectTestFrame(t, w, 0, `{"event":{"start":{"pid":42}}}`)
+		writeConnectTestFrame(t, w, 0, `{"event":{"data":{"stdout":"cHJlZml4LQ=="}}}`)
+		writeConnectTestFrame(t, w, 0, `{"event":{"data":{"stdout":"dGFpbA=="}}}`)
+		writeConnectTestFrame(t, w, 0, `{"event":{"data":{"stderr":"d2FybmluZw=="}}}`)
+		writeConnectTestFrame(t, w, 0, `{"event":{"end":{"exitCode":0,"exited":true,"status":"exit status 0","error":""}}}`)
+		writeConnectTestFrame(t, w, connectEndStreamFlag, `{}`)
+	}))
+	defer server.Close()
+	envd := newTestEnvd(t, server, EnvdCredential{token: testEnvdToken})
+
+	var output bytes.Buffer
+	var pid atomic.Int32
+	stream, err := envd.Start(context.Background(), StartRequest{
+		Name:           "sh",
+		Args:           []string{"-c", "echo test"},
+		Dir:            "/workspace",
+		Env:            []string{"MODE=test"},
+		Output:         &output,
+		MaxOutputBytes: 4,
+		OnStart:        func(value int) { pid.Store(int32(value)) },
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	result, err := stream.Wait()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if pid.Load() != 42 {
+		t.Fatalf("start pid = %d, want 42", pid.Load())
+	}
+	if got := output.String(); got != "prefix-tailwarning" {
+		t.Fatalf("streamed output = %q", got)
+	}
+	if result.Command != "sh" || strings.Join(result.Args, " ") != "-c echo test" || result.Stdout != "tail" || result.Stderr != "ning" {
+		t.Fatalf("result = %+v", result)
+	}
+}
+
+func TestEnvdStartNonzeroExitUsesMeasuredEndEvent(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", connectProtocolMediaType)
+		writeConnectTestFrame(t, w, 0, `{"event":{"start":{"pid":2000}}}`)
+		writeConnectTestFrame(t, w, 0, `{"event":{"end":{"exitCode":3, "exited":true, "status":"exit status 3", "error":"exit status 3"}}}`)
+		writeConnectTestFrame(t, w, connectEndStreamFlag, `{}`)
+	}))
+	defer server.Close()
+	envd := newTestEnvd(t, server, EnvdCredential{token: testEnvdToken})
+
+	stream, err := envd.Start(context.Background(), StartRequest{Name: "sh", Args: []string{"-c", "exit 3"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	result, err := stream.Wait()
+	var exitErr *ExitError
+	if !errors.As(err, &exitErr) || exitErr.Code != 3 || exitErr.Status != "exit status 3" {
+		t.Fatalf("Wait = %+v, %v; want exit code 3", result, err)
+	}
+}
+
+func TestEnvdUploadUsesProcessUserAndCredential(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assertEnvdRequest(t, r, "/files", "application/octet-stream")
+		if got := r.URL.Query().Get("path"); got != "/home/user/input.txt" {
+			t.Errorf("upload path = %q", got)
+		}
+		if got := r.URL.Query().Get("username"); got != envdDefaultUser {
+			t.Errorf("upload username = %q, want %q", got, envdDefaultUser)
+		}
+		data, err := io.ReadAll(r.Body)
+		if err != nil || string(data) != "payload" {
+			t.Errorf("upload body = %q, %v", data, err)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`[{"name":"input.txt","path":"/home/user/input.txt","type":"file"}]`))
+	}))
+	defer server.Close()
+	envd := newTestEnvd(t, server, EnvdCredential{token: testEnvdToken})
+
+	if err := envd.Upload(context.Background(), "/home/user/input.txt", strings.NewReader("payload")); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestEnvdRejectsMissingCredentialBeforeRequest(t *testing.T) {
+	t.Parallel()
+
+	var calls atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		calls.Add(1)
+	}))
+	defer server.Close()
+
+	envd, err := NewEnvd(Sandbox{ID: "sbx-1"}, EnvdCredential{}, EnvdOptions{
+		HTTPClient:       server.Client(),
+		EndpointResolver: func(string, int) string { return server.URL },
+	})
+	if err == nil || envd != nil || !strings.Contains(err.Error(), "credential is required") {
+		t.Fatalf("NewEnvd = %+v, %v; want credential error", envd, err)
+	}
+	if got := calls.Load(); got != 0 {
+		t.Fatalf("provider calls = %d, want 0", got)
+	}
+}
+
+func TestEnvdEndpointUsesSandboxIDAndDomainWithoutClientID(t *testing.T) {
+	t.Parallel()
+
+	var host string
+	client := &http.Client{Transport: roundTripFunc(func(request *http.Request) (*http.Response, error) {
+		host = request.URL.Host
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     http.Header{"Content-Type": []string{"application/json"}},
+			Body:       io.NopCloser(strings.NewReader(`[]`)),
+			Request:    request,
+		}, nil
+	})}
+	envd, err := NewEnvd(Sandbox{ID: "sbx-1", ClientID: "deprecated-client", Domain: "sandbox.example"}, EnvdCredential{token: testEnvdToken}, EnvdOptions{HTTPClient: client})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := envd.Upload(context.Background(), "/home/user/input", strings.NewReader("x")); err != nil {
+		t.Fatal(err)
+	}
+	if host != "49983-sbx-1.sandbox.example" {
+		t.Fatalf("envd host = %q", host)
+	}
+}
+
+func TestEnvdStartTreats415AsCodecFailureAndRedacts(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusUnsupportedMediaType)
+		_, _ = w.Write([]byte("wrong codec " + testEnvdToken))
+	}))
+	defer server.Close()
+	envd := newTestEnvd(t, server, EnvdCredential{token: testEnvdToken})
+
+	_, err := envd.Start(context.Background(), StartRequest{Name: "true"})
+	if err == nil || !strings.Contains(err.Error(), "reached the route") || !strings.Contains(err.Error(), "rejected the Connect codec") {
+		t.Fatalf("Start error = %v", err)
+	}
+	if strings.Contains(err.Error(), testEnvdToken) || !strings.Contains(err.Error(), "[REDACTED]") {
+		t.Fatalf("Start error leaked credential: %q", err)
+	}
+}
+
+func TestEnvdCallsAreTimeoutBounded(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		select {
+		case <-r.Context().Done():
+		case <-time.After(200 * time.Millisecond):
+		}
+	}))
+	defer server.Close()
+	envd, err := NewEnvd(Sandbox{ID: "sbx-timeout"}, EnvdCredential{token: testEnvdToken}, EnvdOptions{
+		HTTPClient:       server.Client(),
+		RequestTimeout:   20 * time.Millisecond,
+		EndpointResolver: func(string, int) string { return server.URL },
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tests := []struct {
+		name string
+		call func() error
+	}{
+		{name: "start handshake", call: func() error {
+			_, err := envd.Start(context.Background(), StartRequest{Name: "true"})
+			return err
+		}},
+		{name: "upload", call: func() error {
+			return envd.Upload(context.Background(), "/home/user/input", strings.NewReader("x"))
+		}},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			started := time.Now()
+			if err := test.call(); err == nil {
+				t.Fatal("call succeeded")
+			}
+			if elapsed := time.Since(started); elapsed > time.Second {
+				t.Fatalf("call took %s", elapsed)
+			}
+		})
+	}
+}
+
+func newTestEnvd(t *testing.T, server *httptest.Server, credential EnvdCredential) *Envd {
+	t.Helper()
+	envd, err := NewEnvd(Sandbox{ID: "sbx-test"}, credential, EnvdOptions{
+		HTTPClient:       server.Client(),
+		RequestTimeout:   time.Second,
+		EndpointResolver: func(string, int) string { return server.URL },
+	})
+	if err != nil {
+		t.Fatalf("NewEnvd: %v", err)
+	}
+	return envd
+}
+
+func assertEnvdRequest(t *testing.T, request *http.Request, path, contentType string) {
+	t.Helper()
+	if request.Method != http.MethodPost || request.URL.EscapedPath() != path {
+		t.Errorf("request = %s %s", request.Method, request.URL.EscapedPath())
+	}
+	if got := request.Header.Get("X-Access-Token"); got != testEnvdToken {
+		t.Errorf("X-Access-Token = %q", got)
+	}
+	if got := request.Header.Get("Content-Type"); got != contentType {
+		t.Errorf("Content-Type = %q, want %q", got, contentType)
+	}
+}
+
+func writeConnectTestFrame(t *testing.T, writer io.Writer, flag byte, body string) {
+	t.Helper()
+	if _, err := writer.Write(connectFrame(flag, []byte(body))); err != nil {
+		t.Errorf("write Connect frame: %v", err)
+	}
+}

--- a/internal/execbackend/e2b/envd_test.go
+++ b/internal/execbackend/e2b/envd_test.go
@@ -5,13 +5,22 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"go/ast"
+	"go/parser"
+	"go/token"
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"path/filepath"
+	"reflect"
+	"runtime"
+	"strconv"
 	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
+
+	"github.com/gitmoot/gitmoot/internal/execbackend"
 )
 
 const testEnvdToken = "envd-GITMOOT-IMPL-sandbox-secret"
@@ -96,8 +105,169 @@ func TestEnvdStartNonzeroExitUsesMeasuredEndEvent(t *testing.T) {
 	}
 	result, err := stream.Wait()
 	var exitErr *ExitError
-	if !errors.As(err, &exitErr) || exitErr.Code != 3 || exitErr.Status != "exit status 3" {
+	if !errors.As(err, &exitErr) || exitErr.Code != 3 || exitErr.Status != "exit status 3" || exitErr.ProviderError != "exit status 3" {
 		t.Fatalf("Wait = %+v, %v; want exit code 3", result, err)
+	}
+	if got := strings.Count(err.Error(), "exit status 3"); got != 1 {
+		t.Fatalf("Wait error = %q; provider status repeated %d times", err, got)
+	}
+}
+
+func TestEnvdEndEventSemantics(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name              string
+		end               string
+		wantError         string
+		wantExitCode      int
+		wantStatus        string
+		wantProviderError string
+	}{
+		{
+			name: "omitted exitCode uses semantic zero",
+			end:  `{"exited":true,"status":"exit status 0"}`,
+		},
+		{
+			name:      "exited false invalidates result",
+			end:       `{"exited":false,"status":"still running"}`,
+			wantError: "did not confirm process termination",
+		},
+		{
+			name:      "provider error fails zero exit",
+			end:       `{"exited":true,"status":"exit status 0","error":"provider process failure"}`,
+			wantError: "provider process failure",
+		},
+		{
+			name:         "status describes nonzero exit",
+			end:          `{"exitCode":7,"exited":true,"status":"exit status 7"}`,
+			wantExitCode: 7,
+			wantStatus:   "exit status 7",
+		},
+		{
+			name:              "provider error augments distinct status",
+			end:               `{"exitCode":7,"exited":true,"status":"exit status 7","error":"provider process failure"}`,
+			wantExitCode:      7,
+			wantStatus:        "exit status 7",
+			wantProviderError: "provider process failure",
+		},
+		{
+			name:      "unknown provider field fails closed",
+			end:       `{"exited":true,"status":"exit status 0","futureField":true}`,
+			wantError: "unknown field",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			result, err := readTestEndEvent(t, test.end)
+			if test.wantExitCode != 0 {
+				var exitErr *ExitError
+				if !errors.As(err, &exitErr) || exitErr.Code != test.wantExitCode || exitErr.Status != test.wantStatus || exitErr.ProviderError != test.wantProviderError {
+					t.Fatalf("end event result = %+v, %v; want ExitError code=%d status=%q provider_error=%q", result, err, test.wantExitCode, test.wantStatus, test.wantProviderError)
+				}
+				return
+			}
+			if test.wantError != "" {
+				if err == nil || !strings.Contains(err.Error(), test.wantError) {
+					t.Fatalf("end event result = %+v, %v; want error containing %q", result, err, test.wantError)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("end event result = %+v, %v; want success", result, err)
+			}
+		})
+	}
+}
+
+func TestEndEventFieldsHaveExplicitHandling(t *testing.T) {
+	t.Parallel()
+
+	_, testFile, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("locate envd test source")
+	}
+	path := filepath.Join(filepath.Dir(testFile), "envd.go")
+	fileSet := token.NewFileSet()
+	file, err := parser.ParseFile(fileSet, path, nil, parser.SkipObjectResolution)
+	if err != nil {
+		t.Fatalf("parse envd.go: %v", err)
+	}
+
+	type contractField struct {
+		name   string
+		policy string
+	}
+	var fields []contractField
+	var handler *ast.FuncDecl
+	ast.Inspect(file, func(node ast.Node) bool {
+		switch node := node.(type) {
+		case *ast.TypeSpec:
+			if node.Name.Name != "endEvent" {
+				return true
+			}
+			structure, ok := node.Type.(*ast.StructType)
+			if !ok {
+				t.Fatal("endEvent is not a struct")
+			}
+			for _, field := range structure.Fields.List {
+				policy := ""
+				if field.Tag != nil {
+					rawTag, err := strconv.Unquote(field.Tag.Value)
+					if err != nil {
+						t.Fatalf("parse endEvent field tag: %v", err)
+					}
+					policy = reflect.StructTag(rawTag).Get("envd")
+				}
+				for _, name := range field.Names {
+					fields = append(fields, contractField{name: name.Name, policy: policy})
+				}
+			}
+		case *ast.FuncDecl:
+			if node.Name.Name == "endEventError" {
+				handler = node
+			}
+		}
+		return true
+	})
+	if len(fields) == 0 || handler == nil {
+		t.Fatalf("endEvent contract discovery found %d fields and handler=%v", len(fields), handler != nil)
+	}
+
+	parameter := ""
+	for _, field := range handler.Type.Params.List {
+		typeName, ok := field.Type.(*ast.Ident)
+		if ok && typeName.Name == "endEvent" && len(field.Names) == 1 {
+			parameter = field.Names[0].Name
+			break
+		}
+	}
+	if parameter == "" {
+		t.Fatal("endEventError has no endEvent parameter")
+	}
+	handled := make(map[string]bool, len(fields))
+	ast.Inspect(handler.Body, func(node ast.Node) bool {
+		selector, ok := node.(*ast.SelectorExpr)
+		if !ok {
+			return true
+		}
+		base, ok := selector.X.(*ast.Ident)
+		if ok && base.Name == parameter {
+			handled[selector.Sel.Name] = true
+		}
+		return true
+	})
+	for _, field := range fields {
+		if handled[field.name] {
+			continue
+		}
+		const ignoredPrefix = "ignored:"
+		if strings.HasPrefix(field.policy, ignoredPrefix) && strings.TrimSpace(strings.TrimPrefix(field.policy, ignoredPrefix)) != "" {
+			continue
+		}
+		t.Errorf("endEvent.%s is neither read by endEventError nor tagged envd:\"ignored: reason\"", field.name)
 	}
 }
 
@@ -317,6 +487,17 @@ func newTestEnvd(t *testing.T, server *httptest.Server, credential EnvdCredentia
 		t.Fatalf("NewEnvd: %v", err)
 	}
 	return envd
+}
+
+func readTestEndEvent(t *testing.T, event string) (execbackend.ExecResult, error) {
+	t.Helper()
+
+	var stream bytes.Buffer
+	writeConnectTestFrame(t, &stream, 0, `{"event":{"start":{"pid":42}}}`)
+	writeConnectTestFrame(t, &stream, 0, `{"event":{"end":`+event+`}}`)
+	writeConnectTestFrame(t, &stream, connectEndStreamFlag, `{}`)
+	envd := &Envd{credential: EnvdCredential{token: testEnvdToken}}
+	return envd.readStartStream(&stream, StartRequest{Name: "sh"})
 }
 
 func assertEnvdRequest(t *testing.T, request *http.Request, path, contentType string) {

--- a/internal/execbackend/e2b/envd_test.go
+++ b/internal/execbackend/e2b/envd_test.go
@@ -151,10 +151,21 @@ func TestEnvdEndEventSemantics(t *testing.T) {
 			wantStatus:        "exit status 7",
 			wantProviderError: "provider process failure",
 		},
+		// AXIS CHANGE, deliberate (jarvis ruling, 2026-08-28). The removed case
+		// pinned "an end event carrying a field this client does not model is
+		// REJECTED". That axis is gone on purpose: its subject was the PROVIDER,
+		// it could only fire at runtime, and no fixture of ours could ever turn it
+		// red — so it was a permanently-green check that would first speak by
+		// taking every successful exec down on someone else's release. The
+		// replacement axis is "such a field is ACCEPTED, RECORDED and SURFACED,
+		// and never changes the result", pinned here and in
+		// TestEnvdSurfacesUnknownEndEventFields. The "our struct gained an
+		// unhandled field" axis is unaffected and still covered by
+		// TestEndEventFieldsHaveExplicitHandling, whose subject is our own code
+		// and which fires in CI.
 		{
-			name:      "unknown provider field fails closed",
-			end:       `{"exited":true,"status":"exit status 0","futureField":true}`,
-			wantError: "unknown field",
+			name: "unknown provider field is accepted and does not affect success",
+			end:  `{"exited":true,"status":"exit status 0","futureField":true}`,
 		},
 	}
 	for _, test := range tests {
@@ -517,5 +528,47 @@ func writeConnectTestFrame(t *testing.T, writer io.Writer, flag byte, body strin
 	t.Helper()
 	if _, err := writer.Write(connectFrame(flag, []byte(body))); err != nil {
 		t.Errorf("write Connect frame: %v", err)
+	}
+}
+
+// Frames captured VERBATIM from a live E2B sandbox on 2026-08-28. These are real
+// provider bytes, not fixtures we authored, and they are the only evidence in the
+// tree of what envd actually sends.
+func TestEnvdRealCapturedEndFrames(t *testing.T) {
+	t.Parallel()
+
+	t.Run("zero exit", func(t *testing.T) {
+		t.Parallel()
+
+		if _, err := readTestEndEvent(t, `{"exited": true, "status": "exit status 0"}`); err != nil {
+			t.Fatalf("live zero-exit frame = %v; want success", err)
+		}
+	})
+	t.Run("nonzero exit dedupes identical status and error", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := readTestEndEvent(t, `{"error": "exit status 7", "exitCode": 7, "exited": true, "status": "exit status 7"}`)
+		var exitErr *ExitError
+		if !errors.As(err, &exitErr) {
+			t.Fatalf("live exit-7 frame = %v; want ExitError", err)
+		}
+		if got, want := exitErr.Error(), "remote command exited with code 7: exit status 7"; got != want {
+			t.Fatalf("ExitError.Error() = %q, want %q (the provider sends status and error identical; they must not be doubled)", got, want)
+		}
+	})
+}
+
+func TestEnvdSurfacesUnknownEndEventFields(t *testing.T) {
+	t.Parallel()
+
+	var event endEvent
+	if err := json.Unmarshal([]byte(`{"exited":true,"status":"exit status 0","futureField":true,"another":1}`), &event); err != nil {
+		t.Fatalf("unknown fields must not fail the decode: %v", err)
+	}
+	if got, want := strings.Join(event.UnknownFields, ","), "another,futureField"; got != want {
+		t.Fatalf("UnknownFields = %q, want %q", got, want)
+	}
+	if err := (&Envd{}).endEventError(event); err != nil {
+		t.Fatalf("unknown fields must not change the result: %v", err)
 	}
 }

--- a/internal/execbackend/e2b/envd_test.go
+++ b/internal/execbackend/e2b/envd_test.go
@@ -562,7 +562,7 @@ func TestEnvdSurfacesUnknownEndEventFields(t *testing.T) {
 	t.Parallel()
 
 	var event endEvent
-	if err := json.Unmarshal([]byte(`{"exited":true,"status":"exit status 0","futureField":true,"another":1}`), &event); err != nil {
+	if err := json.Unmarshal([]byte(`{"exitCode":0,"exited":true,"status":"exit status 0","error":"","futureField":true,"another":1}`), &event); err != nil {
 		t.Fatalf("unknown fields must not fail the decode: %v", err)
 	}
 	if got, want := strings.Join(event.UnknownFields, ","), "another,futureField"; got != want {
@@ -570,5 +570,112 @@ func TestEnvdSurfacesUnknownEndEventFields(t *testing.T) {
 	}
 	if err := (&Envd{}).endEventError(event); err != nil {
 		t.Fatalf("unknown fields must not change the result: %v", err)
+	}
+
+	var caseVariant endEvent
+	if err := json.Unmarshal([]byte(`{"ExitCode":7,"Exited":true,"Status":"exit status 7","Error":"provider failure"}`), &caseVariant); err != nil {
+		t.Fatalf("case-variant modeled fields must decode: %v", err)
+	}
+	if caseVariant.ExitCode != 7 || !caseVariant.Exited || caseVariant.Status != "exit status 7" || caseVariant.Error != "provider failure" {
+		t.Fatalf("case-variant modeled fields = %+v; want all fields consumed", caseVariant)
+	}
+	if len(caseVariant.UnknownFields) != 0 {
+		t.Fatalf("case-variant modeled fields reported as unknown: %v", caseVariant.UnknownFields)
+	}
+}
+
+func TestJSONWireFieldNamesMatchEncodingJSON(t *testing.T) {
+	t.Parallel()
+
+	type contractFixture struct {
+		Signal  string `json:"signal,omitempty"`
+		Ignored string `json:"-"`
+		Legacy  string
+		hidden  string
+	}
+	known := jsonWireFieldNames(reflect.TypeOf(contractFixture{}))
+	for _, name := range []string{"signal", "legacy"} {
+		if _, ok := known[name]; !ok {
+			t.Errorf("derived JSON wire names = %v; missing %q", known, name)
+		}
+	}
+	for _, name := range []string{"signal,omitempty", "-", "ignored", "hidden", ""} {
+		if _, ok := known[name]; ok {
+			t.Errorf("derived JSON wire names = %v; unexpectedly contains %q", known, name)
+		}
+	}
+}
+
+func TestEnvdUnknownEndEventCallbackContract(t *testing.T) {
+	tests := []struct {
+		name          string
+		endEvents     []string
+		wantError     string
+		wantCallbacks [][]string
+	}{
+		{
+			name:          "unknown names are surfaced once in stable order",
+			endEvents:     []string{`{"exitCode":0,"exited":true,"status":"exit status 0","error":"","futureField":true,"another":1}`},
+			wantCallbacks: [][]string{{"another", "futureField"}},
+		},
+		{
+			name:      "modeled fields do not fire callback",
+			endEvents: []string{`{"exitCode":0,"exited":true,"status":"exit status 0","error":""}`},
+		},
+		{
+			name: "second end is rejected before a second callback",
+			endEvents: []string{
+				`{"exited":true,"status":"exit status 0","firstUnknown":true}`,
+				`{"exited":true,"status":"exit status 0","secondUnknown":true}`,
+			},
+			wantError:     "invalid end event",
+			wantCallbacks: [][]string{{"firstUnknown"}},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			var callbacks [][]string
+			envd, err := NewEnvd(Sandbox{ID: "sbx-test"}, EnvdCredential{token: testEnvdToken}, EnvdOptions{
+				EndpointResolver: func(string, int) string { return "https://envd.example" },
+				OnUnknownEndEventFields: func(fields []string) {
+					callbacks = append(callbacks, append([]string(nil), fields...))
+				},
+			})
+			if err != nil {
+				t.Fatalf("NewEnvd: %v", err)
+			}
+			var stream bytes.Buffer
+			writeConnectTestFrame(t, &stream, 0, `{"event":{"start":{"pid":42}}}`)
+			for _, event := range test.endEvents {
+				writeConnectTestFrame(t, &stream, 0, `{"event":{"end":`+event+`}}`)
+			}
+			writeConnectTestFrame(t, &stream, connectEndStreamFlag, `{}`)
+
+			_, err = envd.readStartStream(&stream, StartRequest{Name: "sh"})
+			if test.wantError == "" {
+				if err != nil {
+					t.Fatalf("readStartStream: %v", err)
+				}
+			} else if err == nil || !strings.Contains(err.Error(), test.wantError) {
+				t.Fatalf("readStartStream = %v; want error containing %q", err, test.wantError)
+			}
+			if !reflect.DeepEqual(callbacks, test.wantCallbacks) {
+				t.Fatalf("callbacks = %v, want %v", callbacks, test.wantCallbacks)
+			}
+		})
+	}
+}
+
+func TestEnvdRequiresConnectTerminalFrameAfterProcessEnd(t *testing.T) {
+	t.Parallel()
+
+	var stream bytes.Buffer
+	writeConnectTestFrame(t, &stream, 0, `{"event":{"start":{"pid":42}}}`)
+	writeConnectTestFrame(t, &stream, 0, `{"event":{"end":{"exitCode":0,"exited":true,"status":"exit status 0","error":""}}}`)
+
+	envd := &Envd{credential: EnvdCredential{token: testEnvdToken}}
+	_, err := envd.readStartStream(&stream, StartRequest{Name: "sh"})
+	if err == nil || !strings.Contains(err.Error(), "without a terminal frame") {
+		t.Fatalf("readStartStream = %v; want missing terminal-frame error", err)
 	}
 }

--- a/internal/execbackend/e2b/envd_test.go
+++ b/internal/execbackend/e2b/envd_test.go
@@ -148,6 +148,32 @@ func TestEnvdRejectsMissingCredentialBeforeRequest(t *testing.T) {
 	}
 }
 
+func TestEnvdRefusesRedirectWithoutForwardingAccessToken(t *testing.T) {
+	t.Parallel()
+
+	var destinationCalls atomic.Int32
+	destination := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		destinationCalls.Add(1)
+		if got := r.Header.Get("X-Access-Token"); got != "" {
+			t.Errorf("redirect forwarded envd access token %q", got)
+		}
+	}))
+	defer destination.Close()
+	source := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Redirect(w, &http.Request{}, destination.URL, http.StatusTemporaryRedirect)
+	}))
+	defer source.Close()
+	envd := newTestEnvd(t, source, EnvdCredential{token: testEnvdToken})
+
+	err := envd.Upload(context.Background(), "/home/user/input", strings.NewReader("payload"))
+	if err == nil {
+		t.Fatal("Upload succeeded; redirect must fail")
+	}
+	if got := destinationCalls.Load(); got != 0 {
+		t.Fatalf("redirect destination calls = %d, want 0", got)
+	}
+}
+
 func TestEnvdEndpointUsesSandboxIDAndDomainWithoutClientID(t *testing.T) {
 	t.Parallel()
 

--- a/internal/execbackend/e2b/envd_test.go
+++ b/internal/execbackend/e2b/envd_test.go
@@ -174,6 +174,50 @@ func TestEnvdRefusesRedirectWithoutForwardingAccessToken(t *testing.T) {
 	}
 }
 
+func TestEnvdRejectsInvalidResolvedEndpoint(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		endpoint string
+	}{
+		{name: "unsupported scheme", endpoint: "ftp://envd.example"},
+		{name: "missing host", endpoint: "https:///envd"},
+		{name: "query", endpoint: "https://envd.example?credential=wrong"},
+		{name: "fragment", endpoint: "https://envd.example#fragment"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			envd, err := NewEnvd(Sandbox{ID: "sbx-1"}, EnvdCredential{token: testEnvdToken}, EnvdOptions{
+				EndpointResolver: func(string, int) string { return test.endpoint },
+			})
+			if err == nil || envd != nil || !strings.Contains(err.Error(), "absolute HTTP(S) URL without query or fragment") {
+				t.Fatalf("NewEnvd = %+v, %v; want invalid endpoint error", envd, err)
+			}
+		})
+	}
+}
+
+// The default resolver interpolates Sandbox.Domain, which Create takes straight
+// from the provider response with only TrimSpace applied, so a hostile domain is
+// reachable input rather than a hypothetical.
+func TestEnvdRejectsHostileSandboxDomainThroughDefaultResolver(t *testing.T) {
+	t.Parallel()
+
+	for _, domain := range []string{"e2b.app/path?leak=1", "e2b.app#frag", "e2b.app/?a=b"} {
+		t.Run(domain, func(t *testing.T) {
+			t.Parallel()
+
+			envd, err := NewEnvd(Sandbox{ID: "sbx-1", Domain: domain}, EnvdCredential{token: testEnvdToken}, EnvdOptions{})
+			if err == nil || envd != nil {
+				t.Fatalf("NewEnvd(domain=%q) = %+v, %v; want rejection", domain, envd, err)
+			}
+		})
+	}
+}
+
 func TestEnvdEndpointUsesSandboxIDAndDomainWithoutClientID(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
WHAT:
GITMOOT-IMPL: implemented Slice B at checked-out base 3c6fd969c6a2c585f588ae65330e90ce76a6acbf. Secure creation now proves envd authentication, and the isolated envd data plane supports authenticated process streaming and uploads. Slice B converts zero Slice A refusals and adds zero production importers.

WHY:
Gitmoot finalized this implementation from a task worktree.

CHANGES:
- Committed changes from /root/.gitmoot/worktrees/gitmoot--gitmoot/adhoc-58c4dfeb

RESULTS:
- Live smoke used one sandbox at a time with forced TTLs of 120s and 180s. Both runs started with List count 0, DELETE returned HTTP 204, and ended with List count 0.
- Measured nonzero event literal: {"event":{"end":{"exitCode":3, "exited":true, "status":"exit status 3", "error":"exit status 3"}}}; terminal frame was flag 2 with JSON {}.
- Measured identity literals: {"event":{"data":{"stdout":"UFJPQ0VTU19VU0VSPQ=="}}}, {"event":{"data":{"stdout":"dXNlcgo="}}}, {"event":{"data":{"stdout":"REVGQVVMVF9PV05FUj0="}}}, {"event":{"data":{"stdout":"dXNlcgo="}}}, {"event":{"data":{"stdout":"VVNFUl9PV05FUj0="}}}, {"event":{"data":{"stdout":"dXNlcgo="}}}. Decoded: process user=user, default upload owner=user, explicit username=user upload owner=user.
- go test -c -o /dev/null ./internal/execbackend/e2b: exit 0; no .test artifacts remained.
- Target filter matched 9 top-level tests; all passed with -count=1 in 0.231s.
- Missing-token mutant: removed the envdAccessToken check; compilation exited 0. Distinctness filter matched 2 unrelated guards and both passed. Strength filter matched 1 test and TestClientCreateRequiresEnvdCredential failed. The check was restored and the final control passed.
- git diff --check: exit 0.
- git diff --name-only 3c6fd969c6a2c585f588ae65330e90ce76a6acbf...HEAD
output: ""
- grep -rl 'internal/execbackend/e2b' --include='*.go' . | grep -v '/e2b/'
output: ""; no-importer count 0.
- Supplemental working-tree output:
 M internal/execbackend/e2b/client.go
 M internal/execbackend/e2b/client_test.go
?? internal/execbackend/e2b/envd.go
?? internal/execbackend/e2b/envd_test.go
- The full suite, build, and vet were not run, per the coordinator-owned gate instruction.

RISK:
Review the generated diff before merging.

TASK:
adhoc-58c4dfeb

AGENTS:
- wave-impl

RAW FINAL REVIEW OUTPUT:
````text
GITMOOT-IMPL: implemented Slice B at checked-out base 3c6fd969c6a2c585f588ae65330e90ce76a6acbf. Secure creation now proves envd authentication, and the isolated envd data plane supports authenticated process streaming and uploads. Slice B converts zero Slice A refusals and adds zero production importers.
````
