### PR TITLE
Gitmoot: JARVIS DISPATCH — gitmoot#1633 SLICE C. Sign GITMOOT-IMPL.

### DIFF
--- a/internal/execbackend/changeset.go
+++ b/internal/execbackend/changeset.go
@@ -902,6 +902,23 @@ func materializationOrder(entries []ChangeManifestEntry) []ChangeManifestEntry {
 	return ordered
 }
 
+// StageAt materialises baseHEAD in a throwaway worktree beside hostWorktree,
+// calls fn with its path, and removes it.
+func StageAt(ctx context.Context, hostWorktree, baseHEAD string, fn func(stage string) error) (retErr error) {
+	if fn == nil {
+		return errors.New("changeset staging callback is required")
+	}
+	stage, err := createStagingWorktree(ctx, hostWorktree, baseHEAD)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		cleanupErr := removeStagingWorktree(context.WithoutCancel(ctx), hostWorktree, stage)
+		retErr = errors.Join(retErr, cleanupErr)
+	}()
+	return fn(stage)
+}
+
 func createStagingWorktree(ctx context.Context, worktree, base string) (string, error) {
 	parent := filepath.Dir(filepath.Clean(worktree))
 	placeholder, err := os.MkdirTemp(parent, ".gitmoot-changeset-stage-")

--- a/internal/execbackend/changeset_test.go
+++ b/internal/execbackend/changeset_test.go
@@ -46,6 +46,28 @@ func TestChangeSetJSONTransportPreservesFilenameBytes(t *testing.T) {
 	}
 }
 
+func TestStageAtRemovesWorktreeAfterCallbackFailure(t *testing.T) {
+	host, _, base := changeSetRepoPair(t)
+	sentinel := errors.New("stop staging")
+	var stage string
+	err := StageAt(context.Background(), host, base, func(path string) error {
+		stage = path
+		if got := strings.TrimSpace(changeSetGit(t, path, "rev-parse", "HEAD")); got != base {
+			t.Fatalf("staging HEAD = %s, want %s", got, base)
+		}
+		return sentinel
+	})
+	if !errors.Is(err, sentinel) {
+		t.Fatalf("StageAt error = %v, want callback error", err)
+	}
+	if _, err := os.Stat(stage); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("staging worktree remains at %q: %v", stage, err)
+	}
+	if got := changeSetGit(t, host, "worktree", "list", "--porcelain"); strings.Contains(got, stage) {
+		t.Fatalf("staging worktree remains registered:\n%s", got)
+	}
+}
+
 func TestChangeSetRoundTripsTrackedManifestAndIsIdempotent(t *testing.T) {
 	host, sandbox, base := changeSetRepoPair(t)
 	writeChangeSetFile(t, sandbox, "tracked.txt", "changed\n", 0o644)

--- a/internal/execbackend/remote/backend.go
+++ b/internal/execbackend/remote/backend.go
@@ -1,0 +1,567 @@
+// Package remote implements the provider-backed execution lifecycle.
+// Construction is deliberately not wired into the daemon until Slice D.
+package remote
+
+import (
+	"archive/tar"
+	"compress/gzip"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync"
+	"syscall"
+
+	"github.com/gitmoot/gitmoot/internal/execbackend"
+	"github.com/gitmoot/gitmoot/internal/execbackend/e2b"
+)
+
+const (
+	workspacePath   = "/home/user/workspace"
+	syncArchivePath = "/home/user/.gitmoot-sync.tar.gz"
+
+	metadataJobID               = "job_id"
+	metadataLifecycleGeneration = "lifecycle_generation"
+	metadataBootID              = "boot_id"
+	metadataOwnerPID            = "owner_pid"
+	metadataOwnerStartTime      = "owner_start_time"
+)
+
+const syncWorkspaceScript = `set -eu
+rm -rf /home/user/workspace /home/user/.gitmoot-sync
+mkdir -p /home/user/.gitmoot-sync
+tar -xzf /home/user/.gitmoot-sync.tar.gz -C /home/user/.gitmoot-sync
+mv /home/user/.gitmoot-sync/workspace /home/user/workspace
+cd /home/user/workspace
+git init -q
+git config user.name gitmoot
+git config user.email gitmoot@localhost
+git add -A
+git commit -q --allow-empty -m 'gitmoot sync base'
+if [ -s /home/user/.gitmoot-sync/changes.patch ]; then
+  git apply --binary --whitespace=nowarn /home/user/.gitmoot-sync/changes.patch
+fi
+rm -rf /home/user/.gitmoot-sync /home/user/.gitmoot-sync.tar.gz
+git rev-parse HEAD`
+
+const collectPatchScript = `set -eu
+git add -A
+git diff --binary --full-index --no-ext-diff --no-renames --cached HEAD --`
+
+// Options configures a remote Backend. TemplateID is required. Envd is copied
+// into each sandbox-scoped data-plane client.
+type Options struct {
+	TemplateID string
+	Envd       e2b.EnvdOptions
+}
+
+// Backend owns E2B sandboxes for one daemon process.
+type Backend struct {
+	client     *e2b.Client
+	templateID string
+	envd       e2b.EnvdOptions
+
+	bootID     string
+	ownerPID   int
+	ownerStart string
+	ownerAlive func(pid int, bootID, startTime string) bool
+
+	mu        sync.Mutex
+	sandboxes map[string]*sandboxState
+}
+
+type sandboxState struct {
+	mu sync.Mutex
+
+	sandbox      e2b.Sandbox
+	envd         *e2b.Envd
+	jobID        string
+	generation   int64
+	hostWorktree string
+	hostBase     string
+	remoteBase   string
+}
+
+var _ execbackend.ExecutionBackend = (*Backend)(nil)
+var _ execbackend.Reaper = (*Backend)(nil)
+
+// NewBackend constructs an unwired E2B lifecycle provider.
+func NewBackend(client *e2b.Client, options Options) (*Backend, error) {
+	if client == nil {
+		return nil, errors.New("remote execution backend E2B client is required")
+	}
+	templateID := strings.TrimSpace(options.TemplateID)
+	if templateID == "" {
+		return nil, errors.New("remote execution backend template ID is required")
+	}
+	pid := os.Getpid()
+	return &Backend{
+		client:     client,
+		templateID: templateID,
+		envd:       options.Envd,
+		bootID:     hostBootID(),
+		ownerPID:   pid,
+		ownerStart: processStartTime(pid),
+		ownerAlive: processOwnerAlive,
+		sandboxes:  make(map[string]*sandboxState),
+	}, nil
+}
+
+func (b *Backend) Name() execbackend.Backend { return execbackend.Remote }
+
+func (b *Backend) Provision(ctx context.Context, scope execbackend.JobScope) (*execbackend.Instance, error) {
+	if b == nil {
+		return nil, errors.New("remote execution backend is nil")
+	}
+	jobID := strings.TrimSpace(scope.JobID)
+	if jobID == "" {
+		return nil, errors.New("remote execution backend job id is required")
+	}
+	if scope.TTL <= 0 {
+		return nil, errors.New("remote execution backend TTL must be positive")
+	}
+	metadata := map[string]string{
+		metadataJobID:               jobID,
+		metadataLifecycleGeneration: strconv.FormatInt(scope.LifecycleGeneration, 10),
+		metadataBootID:              b.bootID,
+		metadataOwnerPID:            strconv.Itoa(b.ownerPID),
+		metadataOwnerStartTime:      b.ownerStart,
+	}
+	sandbox, credential, err := b.client.Create(ctx, b.templateID, scope.TTL, e2b.CreateOptions{Metadata: metadata})
+	if err != nil {
+		return nil, fmt.Errorf("provision remote execution sandbox: %w", err)
+	}
+	envd, envdErr := e2b.NewEnvd(sandbox, credential, b.envd)
+	if envdErr != nil {
+		_, deleteErr := b.client.Delete(context.WithoutCancel(ctx), sandbox.ID)
+		return nil, errors.Join(fmt.Errorf("construct remote sandbox data plane: %w", envdErr), deleteErr)
+	}
+	state := &sandboxState{
+		sandbox:    sandbox,
+		envd:       envd,
+		jobID:      jobID,
+		generation: scope.LifecycleGeneration,
+	}
+	b.mu.Lock()
+	b.sandboxes[sandbox.ID] = state
+	b.mu.Unlock()
+	return state.instance(), nil
+}
+
+// Attach reuses only credentials retained by this process. Durable reattach is
+// owned by #1539 and cannot be reconstructed from an ID alone.
+func (b *Backend) Attach(_ context.Context, id string) (*execbackend.Instance, error) {
+	state, err := b.stateByID(id)
+	if err != nil {
+		return nil, err
+	}
+	state.mu.Lock()
+	defer state.mu.Unlock()
+	return state.instance(), nil
+}
+
+func (b *Backend) SyncIn(ctx context.Context, instance *execbackend.Instance, materials execbackend.Materials) error {
+	state, err := b.stateFor(instance)
+	if err != nil {
+		return err
+	}
+	hostWorktree := strings.TrimSpace(materials.SourceWorktree)
+	if hostWorktree == "" {
+		return errors.New("remote execution backend source worktree is required")
+	}
+	hostWorktree, err = filepath.Abs(hostWorktree)
+	if err != nil {
+		return fmt.Errorf("resolve remote source worktree: %w", err)
+	}
+	hostWorktree = filepath.Clean(hostWorktree)
+	hostBase, err := hostGitOutput(ctx, hostWorktree, "rev-parse", "HEAD")
+	if err != nil {
+		return fmt.Errorf("read remote execution host base HEAD: %w", err)
+	}
+	hostBase = strings.TrimSpace(hostBase)
+	inputChanges, err := execbackend.BuildChangeSet(ctx, hostWorktree, hostBase)
+	if err != nil {
+		return fmt.Errorf("capture remote execution sync input: %w", err)
+	}
+
+	state.mu.Lock()
+	defer state.mu.Unlock()
+	if err := execbackend.StageAt(ctx, hostWorktree, hostBase, func(stage string) error {
+		var inputPatch []byte
+		if len(inputChanges.Patch) > 0 || len(inputChanges.Manifest) > 0 {
+			if err := execbackend.ImportChangeSet(ctx, stage, inputChanges); err != nil {
+				return fmt.Errorf("materialize remote sync staging tree: %w", err)
+			}
+			if _, err := hostGitOutput(ctx, stage, "add", "-A"); err != nil {
+				return fmt.Errorf("index remote sync input: %w", err)
+			}
+			inputPatch, err = hostGitBytes(ctx, stage, "diff", "--binary", "--full-index", "--no-ext-diff", "--no-renames", "--cached", "HEAD", "--")
+			if err != nil {
+				return fmt.Errorf("capture remote sync patch: %w", err)
+			}
+			if _, err := hostGitOutput(ctx, stage, "reset", "--hard", "HEAD"); err != nil {
+				return fmt.Errorf("restore remote sync base: %w", err)
+			}
+			if _, err := hostGitOutput(ctx, stage, "clean", "-fdx"); err != nil {
+				return fmt.Errorf("clean remote sync base: %w", err)
+			}
+		}
+		return uploadWorkspaceArchive(ctx, state.envd, stage, inputPatch)
+	}); err != nil {
+		return fmt.Errorf("stage remote execution workspace: %w", err)
+	}
+	result, err := runEnvd(ctx, state.envd, e2b.StartRequest{
+		Name: "sh",
+		Args: []string{"-c", syncWorkspaceScript},
+		Dir:  "/home/user",
+	})
+	if err != nil {
+		return fmt.Errorf("initialize remote execution workspace: %w", err)
+	}
+	remoteBase := strings.TrimSpace(result.Stdout)
+	if remoteBase == "" || strings.ContainsAny(remoteBase, "\r\n\t ") {
+		return fmt.Errorf("initialize remote execution workspace: invalid base HEAD %q", remoteBase)
+	}
+	state.hostWorktree = hostWorktree
+	state.hostBase = hostBase
+	state.remoteBase = remoteBase
+	instance.BaseHEAD = hostBase
+	return nil
+}
+
+func (b *Backend) Exec(ctx context.Context, instance *execbackend.Instance, command execbackend.Command) (execbackend.Stream, error) {
+	state, err := b.stateFor(instance)
+	if err != nil {
+		return nil, err
+	}
+	if strings.TrimSpace(command.Name) == "" {
+		return nil, errors.New("remote execution backend command is required")
+	}
+	dir := strings.TrimSpace(command.Dir)
+	if !path.IsAbs(dir) {
+		return nil, fmt.Errorf("remote execution command directory must be absolute: %q", command.Dir)
+	}
+	dir = path.Clean(dir)
+	if dir != workspacePath && !strings.HasPrefix(dir, workspacePath+"/") {
+		return nil, fmt.Errorf("remote execution command directory %q escapes workspace %q", command.Dir, workspacePath)
+	}
+	state.mu.Lock()
+	envd := state.envd
+	ready := state.remoteBase != ""
+	state.mu.Unlock()
+	if !ready {
+		return nil, errors.New("remote execution instance has not been synced")
+	}
+	// OnStart is intentionally not forwarded. A sandbox PID checked against host
+	// /proc can alias an unrelated host process and authorize a wrong kill.
+	stream, err := envd.Start(ctx, e2b.StartRequest{
+		Name:           command.Name,
+		Args:           append([]string(nil), command.Args...),
+		Dir:            dir,
+		Env:            append([]string(nil), command.Env...),
+		Output:         command.Output,
+		MaxOutputBytes: command.MaxOutputBytes,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("start remote execution command: %w", err)
+	}
+	return stream, nil
+}
+
+func (b *Backend) Collect(ctx context.Context, instance *execbackend.Instance) (execbackend.ChangeSet, error) {
+	state, err := b.stateFor(instance)
+	if err != nil {
+		return execbackend.ChangeSet{}, err
+	}
+	state.mu.Lock()
+	defer state.mu.Unlock()
+	if state.remoteBase == "" || state.hostBase == "" || state.hostWorktree == "" {
+		return execbackend.ChangeSet{}, errors.New("remote execution instance has no synced base HEAD")
+	}
+	head, err := runEnvd(ctx, state.envd, e2b.StartRequest{
+		Name:           "git",
+		Args:           []string{"rev-parse", "HEAD"},
+		Dir:            workspacePath,
+		MaxOutputBytes: 256,
+	})
+	if err != nil {
+		return execbackend.ChangeSet{}, fmt.Errorf("read remote execution HEAD: %w", err)
+	}
+	if got := strings.TrimSpace(head.Stdout); got != state.remoteBase {
+		return execbackend.ChangeSet{}, fmt.Errorf("sandbox-created commits are forbidden: sandbox HEAD %s, expected base %s", got, state.remoteBase)
+	}
+	patchResult, err := runEnvd(ctx, state.envd, e2b.StartRequest{
+		Name:           "sh",
+		Args:           []string{"-c", collectPatchScript},
+		Dir:            workspacePath,
+		MaxOutputBytes: execbackend.MaxChangeSetPatchBytes + 1,
+	})
+	if err != nil {
+		return execbackend.ChangeSet{}, fmt.Errorf("capture remote execution patch: %w", err)
+	}
+	patch := []byte(patchResult.Stdout)
+	if len(patch) > execbackend.MaxChangeSetPatchBytes {
+		return execbackend.ChangeSet{}, fmt.Errorf("remote execution patch is larger than limit %d", execbackend.MaxChangeSetPatchBytes)
+	}
+
+	var changes execbackend.ChangeSet
+	err = execbackend.StageAt(ctx, state.hostWorktree, state.hostBase, func(stage string) error {
+		if len(patch) > 0 {
+			cmd := exec.CommandContext(ctx, "git", "-C", stage, "apply", "--binary", "--whitespace=nowarn", "-")
+			cmd.Stdin = strings.NewReader(string(patch))
+			if output, applyErr := cmd.CombinedOutput(); applyErr != nil {
+				return fmt.Errorf("apply remote execution patch: %w: %s", applyErr, strings.TrimSpace(string(output)))
+			}
+		}
+		var buildErr error
+		changes, buildErr = execbackend.BuildChangeSet(ctx, stage, state.hostBase)
+		return buildErr
+	})
+	if err != nil {
+		return execbackend.ChangeSet{}, fmt.Errorf("collect remote execution changes: %w", err)
+	}
+	return changes, nil
+}
+
+func (b *Backend) Cancel(ctx context.Context, instance *execbackend.Instance) error {
+	return b.Destroy(ctx, instance)
+}
+
+func (b *Backend) Destroy(ctx context.Context, instance *execbackend.Instance) error {
+	if instance == nil || strings.TrimSpace(instance.ID) == "" {
+		return nil
+	}
+	b.mu.Lock()
+	_, tracked := b.sandboxes[instance.ID]
+	b.mu.Unlock()
+	if !tracked {
+		return nil
+	}
+	state, err := b.client.Delete(ctx, instance.ID)
+	if err != nil {
+		return fmt.Errorf("destroy remote execution sandbox %q: %w", instance.ID, err)
+	}
+	if state != e2b.Gone {
+		return fmt.Errorf("destroy remote execution sandbox %q was inconclusive: %s", instance.ID, state)
+	}
+	b.mu.Lock()
+	delete(b.sandboxes, instance.ID)
+	b.mu.Unlock()
+	return nil
+}
+
+// Reap is account-global, unlike LocalBackend.Reap's filesystem-root scope. It
+// must require this host's boot_id before checking owner liveness; otherwise one
+// daemon can delete another host's live sandboxes from the shared E2B account.
+func (b *Backend) Reap(ctx context.Context) ([]string, error) {
+	if b == nil {
+		return nil, errors.New("remote execution backend is nil")
+	}
+	sandboxes, err := b.client.List(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("list remote execution sandboxes for reap: %w", err)
+	}
+	var reaped []string
+	var reapErrs []error
+	for _, sandbox := range sandboxes {
+		metadata := sandbox.Metadata
+		if strings.TrimSpace(metadata[metadataBootID]) == "" || strings.TrimSpace(metadata[metadataBootID]) != b.bootID {
+			continue
+		}
+		pid, parseErr := strconv.Atoi(strings.TrimSpace(metadata[metadataOwnerPID]))
+		if parseErr != nil || b.ownerAlive(pid, metadata[metadataBootID], metadata[metadataOwnerStartTime]) {
+			continue
+		}
+		state, deleteErr := b.client.Delete(ctx, sandbox.ID)
+		if deleteErr != nil || state != e2b.Gone {
+			reapErrs = append(reapErrs, errors.Join(fmt.Errorf("reap remote execution sandbox %q", sandbox.ID), deleteErr))
+			continue
+		}
+		b.mu.Lock()
+		delete(b.sandboxes, sandbox.ID)
+		b.mu.Unlock()
+		reaped = append(reaped, sandbox.ID)
+	}
+	return reaped, errors.Join(reapErrs...)
+}
+
+func (b *Backend) stateFor(instance *execbackend.Instance) (*sandboxState, error) {
+	if instance == nil {
+		return nil, errors.New("remote execution instance is required")
+	}
+	state, err := b.stateByID(instance.ID)
+	if err != nil {
+		return nil, err
+	}
+	if instance.Workspace != workspacePath || instance.JobID != state.jobID || instance.LifecycleGeneration != state.generation {
+		return nil, fmt.Errorf("remote execution instance %q does not match provider state", instance.ID)
+	}
+	return state, nil
+}
+
+func (b *Backend) stateByID(id string) (*sandboxState, error) {
+	if b == nil {
+		return nil, errors.New("remote execution backend is nil")
+	}
+	id = strings.TrimSpace(id)
+	if id == "" {
+		return nil, errors.New("remote execution instance id is required")
+	}
+	b.mu.Lock()
+	state := b.sandboxes[id]
+	b.mu.Unlock()
+	if state == nil {
+		return nil, fmt.Errorf("remote execution instance %q is not attached", id)
+	}
+	return state, nil
+}
+
+func (s *sandboxState) instance() *execbackend.Instance {
+	return &execbackend.Instance{
+		ID:                  s.sandbox.ID,
+		JobID:               s.jobID,
+		LifecycleGeneration: s.generation,
+		Workspace:           workspacePath,
+		BaseHEAD:            s.hostBase,
+	}
+}
+
+func runEnvd(ctx context.Context, envd *e2b.Envd, request e2b.StartRequest) (execbackend.ExecResult, error) {
+	stream, err := envd.Start(ctx, request)
+	if err != nil {
+		return execbackend.ExecResult{}, err
+	}
+	return stream.Wait()
+}
+
+func uploadWorkspaceArchive(ctx context.Context, envd *e2b.Envd, stage string, inputPatch []byte) error {
+	reader, writer := io.Pipe()
+	done := make(chan error, 1)
+	go func() {
+		archiveErr := writeWorkspaceArchive(writer, stage, inputPatch)
+		_ = writer.CloseWithError(archiveErr)
+		done <- archiveErr
+	}()
+	uploadErr := envd.Upload(ctx, syncArchivePath, reader)
+	_ = reader.CloseWithError(uploadErr)
+	archiveErr := <-done
+	return errors.Join(uploadErr, archiveErr)
+}
+
+func writeWorkspaceArchive(destination io.Writer, root string, inputPatch []byte) error {
+	gzipWriter := gzip.NewWriter(destination)
+	tarWriter := tar.NewWriter(gzipWriter)
+	if err := tarWriter.WriteHeader(&tar.Header{Name: "workspace/", Typeflag: tar.TypeDir, Mode: 0o755}); err != nil {
+		return errors.Join(err, tarWriter.Close(), gzipWriter.Close())
+	}
+	walkErr := filepath.Walk(root, func(filePath string, info os.FileInfo, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		relative, err := filepath.Rel(root, filePath)
+		if err != nil {
+			return err
+		}
+		if relative == "." {
+			return nil
+		}
+		if relative == ".git" {
+			if info.IsDir() {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		link := ""
+		if info.Mode()&os.ModeSymlink != 0 {
+			link, err = os.Readlink(filePath)
+			if err != nil {
+				return err
+			}
+		}
+		header, err := tar.FileInfoHeader(info, link)
+		if err != nil {
+			return err
+		}
+		header.Name = path.Join("workspace", filepath.ToSlash(relative))
+		header.Uid, header.Gid = 0, 0
+		header.Uname, header.Gname = "", ""
+		if err := tarWriter.WriteHeader(header); err != nil {
+			return err
+		}
+		if !info.Mode().IsRegular() {
+			return nil
+		}
+		file, err := os.Open(filePath)
+		if err != nil {
+			return err
+		}
+		_, copyErr := io.Copy(tarWriter, file)
+		closeErr := file.Close()
+		return errors.Join(copyErr, closeErr)
+	})
+	if walkErr == nil {
+		walkErr = tarWriter.WriteHeader(&tar.Header{Name: "changes.patch", Mode: 0o600, Size: int64(len(inputPatch))})
+		if walkErr == nil && len(inputPatch) > 0 {
+			_, walkErr = tarWriter.Write(inputPatch)
+		}
+	}
+	return errors.Join(walkErr, tarWriter.Close(), gzipWriter.Close())
+}
+
+func hostGitOutput(ctx context.Context, dir string, args ...string) (string, error) {
+	output, err := hostGitBytes(ctx, dir, args...)
+	return string(output), err
+}
+
+func hostGitBytes(ctx context.Context, dir string, args ...string) ([]byte, error) {
+	cmd := exec.CommandContext(ctx, "git", append([]string{"-C", dir}, args...)...)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return nil, fmt.Errorf("git %s: %w: %s", strings.Join(args, " "), err, strings.TrimSpace(string(output)))
+	}
+	return output, nil
+}
+
+func hostBootID() string {
+	data, err := os.ReadFile("/proc/sys/kernel/random/boot_id")
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(data))
+}
+
+func processStartTime(pid int) string {
+	data, err := os.ReadFile(filepath.Join("/proc", strconv.Itoa(pid), "stat"))
+	if err != nil {
+		return ""
+	}
+	closeParen := strings.LastIndexByte(string(data), ')')
+	if closeParen < 0 || closeParen+2 >= len(data) {
+		return ""
+	}
+	fields := strings.Fields(string(data[closeParen+2:]))
+	if len(fields) <= 19 {
+		return ""
+	}
+	return fields[19]
+}
+
+func processOwnerAlive(pid int, bootID, startTime string) bool {
+	if pid <= 0 {
+		return false
+	}
+	currentBoot := hostBootID()
+	if strings.TrimSpace(bootID) != "" && currentBoot != "" && strings.TrimSpace(bootID) != currentBoot {
+		return false
+	}
+	if strings.TrimSpace(startTime) != "" {
+		return processStartTime(pid) == strings.TrimSpace(startTime)
+	}
+	return syscall.Kill(pid, 0) == nil
+}

--- a/internal/execbackend/remote/backend.go
+++ b/internal/execbackend/remote/backend.go
@@ -30,6 +30,7 @@ const (
 	metadataLifecycleGeneration = "lifecycle_generation"
 	metadataBootID              = "boot_id"
 	metadataOwnerPID            = "owner_pid"
+	metadataOwnerPIDNamespace   = "owner_pid_namespace"
 	metadataOwnerStartTime      = "owner_start_time"
 )
 
@@ -67,10 +68,11 @@ type Backend struct {
 	templateID string
 	envd       e2b.EnvdOptions
 
-	bootID     string
-	ownerPID   int
-	ownerStart string
-	ownerAlive func(pid int, bootID, startTime string) bool
+	bootID       string
+	pidNamespace string
+	ownerPID     int
+	ownerStart   string
+	ownerAlive   func(pid int, bootID, startTime string) bool
 
 	mu        sync.Mutex
 	sandboxes map[string]*sandboxState
@@ -102,14 +104,15 @@ func NewBackend(client *e2b.Client, options Options) (*Backend, error) {
 	}
 	pid := os.Getpid()
 	return &Backend{
-		client:     client,
-		templateID: templateID,
-		envd:       options.Envd,
-		bootID:     hostBootID(),
-		ownerPID:   pid,
-		ownerStart: processStartTime(pid),
-		ownerAlive: processOwnerAlive,
-		sandboxes:  make(map[string]*sandboxState),
+		client:       client,
+		templateID:   templateID,
+		envd:         options.Envd,
+		bootID:       hostBootID(),
+		pidNamespace: processPIDNamespace(),
+		ownerPID:     pid,
+		ownerStart:   processStartTime(pid),
+		ownerAlive:   processOwnerAlive,
+		sandboxes:    make(map[string]*sandboxState),
 	}, nil
 }
 
@@ -131,6 +134,7 @@ func (b *Backend) Provision(ctx context.Context, scope execbackend.JobScope) (*e
 		metadataLifecycleGeneration: strconv.FormatInt(scope.LifecycleGeneration, 10),
 		metadataBootID:              b.bootID,
 		metadataOwnerPID:            strconv.Itoa(b.ownerPID),
+		metadataOwnerPIDNamespace:   b.pidNamespace,
 		metadataOwnerStartTime:      b.ownerStart,
 	}
 	sandbox, credential, err := b.client.Create(ctx, b.templateID, scope.TTL, e2b.CreateOptions{Metadata: metadata})
@@ -356,9 +360,10 @@ func (b *Backend) Destroy(ctx context.Context, instance *execbackend.Instance) e
 	return nil
 }
 
-// Reap is account-global, unlike LocalBackend.Reap's filesystem-root scope. It
-// must require this host's boot_id before checking owner liveness; otherwise one
-// daemon can delete another host's live sandboxes from the shared E2B account.
+// Reap is account-global, unlike LocalBackend.Reap's filesystem-root scope.
+// boot_id separates machines, but is shared by every PID namespace on one
+// kernel. Require both identities before interpreting PID/start-time liveness,
+// so one container cannot reap another container's live sandbox.
 func (b *Backend) Reap(ctx context.Context) ([]string, error) {
 	if b == nil {
 		return nil, errors.New("remote execution backend is nil")
@@ -372,6 +377,10 @@ func (b *Backend) Reap(ctx context.Context) ([]string, error) {
 	for _, sandbox := range sandboxes {
 		metadata := sandbox.Metadata
 		if strings.TrimSpace(metadata[metadataBootID]) == "" || strings.TrimSpace(metadata[metadataBootID]) != b.bootID {
+			continue
+		}
+		ownerPIDNamespace := strings.TrimSpace(metadata[metadataOwnerPIDNamespace])
+		if ownerPIDNamespace == "" || b.pidNamespace == "" || ownerPIDNamespace != b.pidNamespace {
 			continue
 		}
 		pid, parseErr := strconv.Atoi(strings.TrimSpace(metadata[metadataOwnerPID]))
@@ -534,6 +543,14 @@ func hostBootID() string {
 		return ""
 	}
 	return strings.TrimSpace(string(data))
+}
+
+func processPIDNamespace() string {
+	identity, err := os.Readlink("/proc/self/ns/pid")
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(identity)
 }
 
 func processStartTime(pid int) string {

--- a/internal/execbackend/remote/backend_test.go
+++ b/internal/execbackend/remote/backend_test.go
@@ -1,0 +1,594 @@
+package remote
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"context"
+	"encoding/binary"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"reflect"
+	"sort"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/gitmoot/gitmoot/internal/execbackend"
+	"github.com/gitmoot/gitmoot/internal/execbackend/e2b"
+)
+
+const testAccessToken = "remote-envd-access-token-GITMOOT-IMPL"
+
+func TestRemoteProvisionRequiresTTLAndRecordsOwnership(t *testing.T) {
+	harness := newProviderHarness(t)
+	backend := harness.backend(t)
+	backend.bootID = "boot-test"
+	backend.ownerPID = 1234
+	backend.ownerStart = "5678"
+
+	if instance, err := backend.Provision(context.Background(), execbackend.JobScope{JobID: "job-zero"}); err == nil || instance != nil || !strings.Contains(err.Error(), "remote execution backend TTL must be positive") {
+		t.Fatalf("Provision without TTL = %+v, %v; want refusal", instance, err)
+	}
+	if got := harness.createCount(); got != 0 {
+		t.Fatalf("create calls after zero TTL = %d, want 0", got)
+	}
+
+	instance, err := backend.Provision(context.Background(), execbackend.JobScope{
+		JobID:               "job-1",
+		LifecycleGeneration: 9,
+		TTL:                 90 * time.Second,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if instance.ID != "sandbox-1" || instance.Workspace != workspacePath || instance.JobID != "job-1" || instance.LifecycleGeneration != 9 {
+		t.Fatalf("instance = %+v", instance)
+	}
+	request := harness.lastCreate()
+	if request.Timeout != 90 || request.Metadata[metadataJobID] != "job-1" || request.Metadata[metadataLifecycleGeneration] != "9" || request.Metadata[metadataBootID] != "boot-test" || request.Metadata[metadataOwnerPID] != "1234" || request.Metadata[metadataOwnerStartTime] != "5678" {
+		t.Fatalf("create request = %+v", request)
+	}
+}
+
+func TestRemoteExecRefusesRelativeDirAndDoesNotForwardOnStart(t *testing.T) {
+	harness := newProviderHarness(t)
+	backend := harness.backend(t)
+	instance := provisionAndSync(t, backend, testSourceRepo(t))
+
+	if stream, err := backend.Exec(context.Background(), instance, execbackend.Command{Name: "true", Dir: "relative"}); err == nil || stream != nil {
+		t.Fatalf("relative Exec = %+v, %v; want refusal", stream, err)
+	}
+	started := false
+	stream, err := backend.Exec(context.Background(), instance, execbackend.Command{
+		Name:    "sh",
+		Args:    []string{"-c", "printf remote-ok"},
+		Dir:     workspacePath,
+		OnStart: func(int) { started = true },
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	result, err := stream.Wait()
+	if err != nil || result.Stdout != "remote-ok" {
+		t.Fatalf("Wait = %+v, %v", result, err)
+	}
+	if started {
+		t.Fatal("remote Exec forwarded sandbox PID to the host OnStart callback")
+	}
+}
+
+func TestRemoteDestroyIsIdempotent(t *testing.T) {
+	harness := newProviderHarness(t)
+	backend := harness.backend(t)
+	instance, err := backend.Provision(context.Background(), execbackend.JobScope{JobID: "job-1", TTL: time.Minute})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := backend.Destroy(context.Background(), instance); err != nil {
+		t.Fatal(err)
+	}
+	if err := backend.Destroy(context.Background(), instance); err != nil {
+		t.Fatalf("second Destroy: %v", err)
+	}
+	if got := harness.deletedIDs(); !reflect.DeepEqual(got, []string{"sandbox-1"}) {
+		t.Fatalf("deleted sandboxes = %v", got)
+	}
+}
+
+func TestRemoteReapLeavesForeignBootSandboxAlone(t *testing.T) {
+	harness := newProviderHarness(t)
+	harness.setInventory([]e2b.Sandbox{
+		{ID: "foreign", TemplateID: "template-test", State: "running", Metadata: map[string]string{
+			metadataBootID: "boot-foreign", metadataOwnerPID: "999999", metadataOwnerStartTime: "1",
+		}},
+		{ID: "stale-local", TemplateID: "template-test", State: "paused", Metadata: map[string]string{
+			metadataBootID: "boot-local", metadataOwnerPID: "999998", metadataOwnerStartTime: "2",
+		}},
+	})
+	backend := harness.backend(t)
+	backend.bootID = "boot-local"
+	backend.ownerAlive = func(int, string, string) bool { return false }
+
+	reaped, err := backend.Reap(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(reaped, []string{"stale-local"}) {
+		t.Fatalf("reaped = %v", reaped)
+	}
+	if got := harness.deletedIDs(); !reflect.DeepEqual(got, []string{"stale-local"}) {
+		t.Fatalf("deleted sandboxes = %v; foreign boot must remain", got)
+	}
+}
+
+func TestRemoteCollectMatchesLocalCollect(t *testing.T) {
+	ctx := context.Background()
+	source := testSourceRepo(t)
+	harness := newProviderHarness(t)
+	remoteBackend := harness.backend(t)
+	remoteInstance := provisionAndSync(t, remoteBackend, source)
+
+	localBackend, err := execbackend.NewLocalBackend(filepath.Join(t.TempDir(), "local-instances"), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	localInstance, err := localBackend.Provision(ctx, execbackend.JobScope{JobID: "local"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := localBackend.SyncIn(ctx, localInstance, execbackend.Materials{SourceWorktree: source}); err != nil {
+		t.Fatal(err)
+	}
+
+	applyCollectionCorpus(t, localInstance.Workspace)
+	applyCollectionCorpus(t, harness.workspace)
+	localChanges, err := localBackend.Collect(ctx, localInstance)
+	if err != nil {
+		t.Fatalf("local Collect: %v", err)
+	}
+	remoteChanges, err := remoteBackend.Collect(ctx, remoteInstance)
+	if err != nil {
+		t.Fatalf("remote Collect: %v", err)
+	}
+	if !reflect.DeepEqual(remoteChanges, localChanges) {
+		localJSON, _ := json.MarshalIndent(localChanges, "", "  ")
+		remoteJSON, _ := json.MarshalIndent(remoteChanges, "", "  ")
+		t.Fatalf("ChangeSet mismatch\nlocal:\n%s\nremote:\n%s", localJSON, remoteJSON)
+	}
+}
+
+func provisionAndSync(t *testing.T, backend *Backend, source string) *execbackend.Instance {
+	t.Helper()
+	instance, err := backend.Provision(context.Background(), execbackend.JobScope{JobID: "job-1", LifecycleGeneration: 2, TTL: time.Minute})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := backend.SyncIn(context.Background(), instance, execbackend.Materials{SourceWorktree: source}); err != nil {
+		t.Fatal(err)
+	}
+	return instance
+}
+
+func testSourceRepo(t *testing.T) string {
+	t.Helper()
+	root := filepath.Join(t.TempDir(), "source")
+	if err := os.MkdirAll(root, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	testGit(t, root, "init", "-q")
+	testGit(t, root, "config", "user.email", "tests@gitmoot.local")
+	testGit(t, root, "config", "user.name", "Gitmoot Tests")
+	testWriteFile(t, root, "tracked.txt", []byte("original\n"), 0o644)
+	testWriteFile(t, root, "deleted.txt", []byte("delete me\n"), 0o644)
+	testWriteFile(t, root, "script.sh", []byte("#!/bin/sh\n"), 0o644)
+	testWriteFile(t, root, "input.txt", []byte("base input\n"), 0o644)
+	if err := os.Symlink("deleted.txt", filepath.Join(root, "tracked-link")); err != nil {
+		t.Fatal(err)
+	}
+	testGit(t, root, "add", "-A")
+	testGit(t, root, "commit", "-q", "-m", "base")
+	testWriteFile(t, root, "input.txt", []byte("host input change\n"), 0o644)
+	testWriteFile(t, root, "input-untracked.txt", []byte("host untracked input\n"), 0o644)
+	return root
+}
+
+func applyCollectionCorpus(t *testing.T, root string) {
+	t.Helper()
+	testWriteFile(t, root, "tracked.txt", []byte("changed\n"), 0o644)
+	if err := os.Remove(filepath.Join(root, "deleted.txt")); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(filepath.Join(root, "script.sh"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Remove(filepath.Join(root, "tracked-link")); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink("tracked.txt", filepath.Join(root, "tracked-link")); err != nil {
+		t.Fatal(err)
+	}
+	testWriteFile(t, root, "nested/untracked.bin", []byte{'n', 'e', 'w', 0, 0xff, '\n'}, 0o644)
+	if err := os.Symlink("untracked.bin", filepath.Join(root, "nested", "untracked-link")); err != nil {
+		t.Fatal(err)
+	}
+	invalidName := "invalid-\xff-name.txt"
+	testWriteFile(t, root, invalidName, []byte("byte-exact\n"), 0o644)
+}
+
+func testWriteFile(t *testing.T, root, name string, data []byte, mode os.FileMode) {
+	t.Helper()
+	filePath := filepath.Join(root, filepath.FromSlash(name))
+	if err := os.MkdirAll(filepath.Dir(filePath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filePath, data, mode); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func testGit(t *testing.T, dir string, args ...string) string {
+	t.Helper()
+	cmd := exec.Command("git", append([]string{"-C", dir}, args...)...)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %s: %v: %s", strings.Join(args, " "), err, output)
+	}
+	return string(output)
+}
+
+type createRequest struct {
+	TemplateID string            `json:"templateID"`
+	Timeout    int               `json:"timeout"`
+	Metadata   map[string]string `json:"metadata"`
+}
+
+type providerHarness struct {
+	t *testing.T
+
+	mu        sync.Mutex
+	creates   []createRequest
+	deleted   []string
+	inventory []e2b.Sandbox
+	upload    []byte
+
+	workspace string
+	control   *httptest.Server
+	envd      *httptest.Server
+}
+
+func newProviderHarness(t *testing.T) *providerHarness {
+	t.Helper()
+	harness := &providerHarness{t: t, workspace: filepath.Join(t.TempDir(), "sandbox-workspace")}
+	harness.control = httptest.NewServer(http.HandlerFunc(harness.serveControl))
+	harness.envd = httptest.NewServer(http.HandlerFunc(harness.serveEnvd))
+	t.Cleanup(harness.control.Close)
+	t.Cleanup(harness.envd.Close)
+	return harness
+}
+
+func (h *providerHarness) backend(t *testing.T) *Backend {
+	t.Helper()
+	client, err := e2b.NewClient("api-key-GITMOOT-IMPL", e2b.Options{BaseURL: h.control.URL, HTTPClient: h.control.Client()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	backend, err := NewBackend(client, Options{
+		TemplateID: "template-test",
+		Envd: e2b.EnvdOptions{
+			HTTPClient:       h.envd.Client(),
+			EndpointResolver: func(string, int) string { return h.envd.URL },
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return backend
+}
+
+func (h *providerHarness) serveControl(w http.ResponseWriter, r *http.Request) {
+	switch {
+	case r.Method == http.MethodPost && r.URL.Path == "/sandboxes":
+		var request createRequest
+		if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
+			h.t.Errorf("decode create request: %v", err)
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		h.mu.Lock()
+		h.creates = append(h.creates, request)
+		id := fmt.Sprintf("sandbox-%d", len(h.creates))
+		h.mu.Unlock()
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"sandboxID": id, "templateID": request.TemplateID, "envdAccessToken": testAccessToken, "domain": nil,
+		})
+	case r.Method == http.MethodDelete && strings.HasPrefix(r.URL.Path, "/sandboxes/"):
+		id := strings.TrimPrefix(r.URL.Path, "/sandboxes/")
+		h.mu.Lock()
+		h.deleted = append(h.deleted, id)
+		h.mu.Unlock()
+		w.WriteHeader(http.StatusNoContent)
+	case r.Method == http.MethodGet && r.URL.Path == "/v2/sandboxes":
+		h.mu.Lock()
+		inventory := append([]e2b.Sandbox(nil), h.inventory...)
+		h.mu.Unlock()
+		items := make([]map[string]any, 0, len(inventory))
+		for _, sandbox := range inventory {
+			items = append(items, listedSandboxJSON(sandbox))
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(items)
+	default:
+		h.t.Errorf("unexpected control request: %s %s", r.Method, r.URL.String())
+		http.NotFound(w, r)
+	}
+}
+
+func (h *providerHarness) serveEnvd(w http.ResponseWriter, r *http.Request) {
+	if got := r.Header.Get("X-Access-Token"); got != testAccessToken {
+		h.t.Errorf("X-Access-Token = %q", got)
+		http.Error(w, "unauthorized", http.StatusUnauthorized)
+		return
+	}
+	switch {
+	case r.Method == http.MethodPost && r.URL.Path == "/files":
+		if got := r.URL.Query().Get("username"); got != "user" {
+			h.t.Errorf("upload username = %q", got)
+		}
+		data, err := io.ReadAll(r.Body)
+		if err != nil {
+			h.t.Errorf("read upload: %v", err)
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		h.mu.Lock()
+		h.upload = data
+		h.mu.Unlock()
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`[]`))
+	case r.Method == http.MethodPost && r.URL.Path == "/process.Process/Start":
+		h.serveStart(w, r)
+	default:
+		h.t.Errorf("unexpected envd request: %s %s", r.Method, r.URL.String())
+		http.NotFound(w, r)
+	}
+}
+
+func (h *providerHarness) serveStart(w http.ResponseWriter, r *http.Request) {
+	_, body, err := readTestConnectFrame(r.Body)
+	if err != nil {
+		h.t.Errorf("read Start frame: %v", err)
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	var request struct {
+		Process struct {
+			Command string            `json:"cmd"`
+			Args    []string          `json:"args"`
+			Env     map[string]string `json:"envs"`
+			Dir     string            `json:"cwd"`
+		} `json:"process"`
+	}
+	if err := json.Unmarshal(body, &request); err != nil {
+		h.t.Errorf("decode Start request: %v", err)
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	stdout, stderr, exitCode, providerError := h.runProcess(r.Context(), request.Process.Command, request.Process.Args, request.Process.Dir, request.Process.Env)
+	w.Header().Set("Content-Type", "application/connect+json")
+	writeTestConnectJSON(h.t, w, 0, map[string]any{"event": map[string]any{"start": map[string]any{"pid": 42}}})
+	if len(stdout) > 0 {
+		writeTestConnectJSON(h.t, w, 0, map[string]any{"event": map[string]any{"data": map[string]any{"stdout": stdout}}})
+	}
+	if len(stderr) > 0 {
+		writeTestConnectJSON(h.t, w, 0, map[string]any{"event": map[string]any{"data": map[string]any{"stderr": stderr}}})
+	}
+	status := fmt.Sprintf("exit status %d", exitCode)
+	writeTestConnectJSON(h.t, w, 0, map[string]any{"event": map[string]any{"end": map[string]any{
+		"exitCode": exitCode, "exited": true, "status": status, "error": providerError,
+	}}})
+	writeTestConnectJSON(h.t, w, 2, map[string]any{})
+}
+
+func (h *providerHarness) runProcess(ctx context.Context, command string, args []string, remoteDir string, env map[string]string) ([]byte, []byte, int, string) {
+	if command == "sh" && reflect.DeepEqual(args, []string{"-c", syncWorkspaceScript}) {
+		h.mu.Lock()
+		archive := append([]byte(nil), h.upload...)
+		h.mu.Unlock()
+		staging := filepath.Join(filepath.Dir(h.workspace), "sync-staging")
+		if err := os.RemoveAll(h.workspace); err != nil {
+			return nil, nil, 1, err.Error()
+		}
+		if err := os.RemoveAll(staging); err != nil {
+			return nil, nil, 1, err.Error()
+		}
+		if err := extractTestArchive(archive, staging); err != nil {
+			return nil, nil, 1, err.Error()
+		}
+		if err := os.Rename(filepath.Join(staging, "workspace"), h.workspace); err != nil {
+			return nil, nil, 1, err.Error()
+		}
+		for _, gitArgs := range [][]string{{"init", "-q"}, {"config", "user.name", "gitmoot"}, {"config", "user.email", "gitmoot@localhost"}, {"add", "-A"}, {"commit", "-q", "--allow-empty", "-m", "gitmoot sync base"}} {
+			cmd := exec.CommandContext(ctx, "git", append([]string{"-C", h.workspace}, gitArgs...)...)
+			if output, err := cmd.CombinedOutput(); err != nil {
+				return nil, output, 1, err.Error()
+			}
+		}
+		inputPatch, err := os.ReadFile(filepath.Join(staging, "changes.patch"))
+		if err != nil {
+			return nil, nil, 1, err.Error()
+		}
+		if len(inputPatch) > 0 {
+			cmd := exec.CommandContext(ctx, "git", "-C", h.workspace, "apply", "--binary", "--whitespace=nowarn", "-")
+			cmd.Stdin = bytes.NewReader(inputPatch)
+			if output, err := cmd.CombinedOutput(); err != nil {
+				return nil, output, 1, err.Error()
+			}
+		}
+		if err := os.RemoveAll(staging); err != nil {
+			return nil, nil, 1, err.Error()
+		}
+		cmd := exec.CommandContext(ctx, "git", "-C", h.workspace, "rev-parse", "HEAD")
+		output, err := cmd.CombinedOutput()
+		if err != nil {
+			return nil, output, 1, err.Error()
+		}
+		return output, nil, 0, ""
+	}
+
+	cmd := exec.CommandContext(ctx, command, args...)
+	cmd.Dir = h.localDir(remoteDir)
+	cmd.Env = os.Environ()
+	keys := make([]string, 0, len(env))
+	for key := range env {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	for _, key := range keys {
+		cmd.Env = append(cmd.Env, key+"="+env[key])
+	}
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout, cmd.Stderr = &stdout, &stderr
+	err := cmd.Run()
+	if err == nil {
+		return stdout.Bytes(), stderr.Bytes(), 0, ""
+	}
+	var exitErr *exec.ExitError
+	if errors.As(err, &exitErr) {
+		return stdout.Bytes(), stderr.Bytes(), exitErr.ExitCode(), strings.TrimSpace(stderr.String())
+	}
+	return stdout.Bytes(), stderr.Bytes(), 1, err.Error()
+}
+
+func (h *providerHarness) localDir(remoteDir string) string {
+	if remoteDir == workspacePath {
+		return h.workspace
+	}
+	if strings.HasPrefix(remoteDir, workspacePath+"/") {
+		return filepath.Join(h.workspace, filepath.FromSlash(strings.TrimPrefix(remoteDir, workspacePath+"/")))
+	}
+	return filepath.Dir(h.workspace)
+}
+
+func (h *providerHarness) setInventory(inventory []e2b.Sandbox) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.inventory = append([]e2b.Sandbox(nil), inventory...)
+}
+
+func (h *providerHarness) createCount() int {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	return len(h.creates)
+}
+
+func (h *providerHarness) lastCreate() createRequest {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	return h.creates[len(h.creates)-1]
+}
+
+func (h *providerHarness) deletedIDs() []string {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	return append([]string(nil), h.deleted...)
+}
+
+func listedSandboxJSON(sandbox e2b.Sandbox) map[string]any {
+	return map[string]any{
+		"sandboxID": sandbox.ID, "templateID": sandbox.TemplateID,
+		"startedAt": time.Unix(1, 0).UTC().Format(time.RFC3339),
+		"endAt":     time.Unix(3601, 0).UTC().Format(time.RFC3339),
+		"cpuCount":  1, "memoryMB": 128, "diskSizeMB": 512,
+		"envdVersion": "test", "state": sandbox.State, "metadata": sandbox.Metadata,
+	}
+}
+
+func readTestConnectFrame(reader io.Reader) (byte, []byte, error) {
+	var header [5]byte
+	if _, err := io.ReadFull(reader, header[:]); err != nil {
+		return 0, nil, err
+	}
+	length := binary.BigEndian.Uint32(header[1:])
+	body := make([]byte, int(length))
+	if _, err := io.ReadFull(reader, body); err != nil {
+		return 0, nil, err
+	}
+	return header[0], body, nil
+}
+
+func writeTestConnectJSON(t *testing.T, writer io.Writer, flag byte, value any) {
+	t.Helper()
+	body, err := json.Marshal(value)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var header [5]byte
+	header[0] = flag
+	binary.BigEndian.PutUint32(header[1:], uint32(len(body)))
+	if _, err := writer.Write(append(header[:], body...)); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func extractTestArchive(data []byte, destination string) error {
+	if err := os.MkdirAll(destination, 0o755); err != nil {
+		return err
+	}
+	gzipReader, err := gzip.NewReader(bytes.NewReader(data))
+	if err != nil {
+		return err
+	}
+	defer gzipReader.Close()
+	tarReader := tar.NewReader(gzipReader)
+	for {
+		header, err := tarReader.Next()
+		if errors.Is(err, io.EOF) {
+			return nil
+		}
+		if err != nil {
+			return err
+		}
+		clean := filepath.Clean(filepath.FromSlash(header.Name))
+		if clean == "." || filepath.IsAbs(clean) || clean == ".." || strings.HasPrefix(clean, ".."+string(filepath.Separator)) {
+			return fmt.Errorf("unsafe archive path %q", header.Name)
+		}
+		filePath := filepath.Join(destination, clean)
+		switch header.Typeflag {
+		case tar.TypeDir:
+			if err := os.MkdirAll(filePath, os.FileMode(header.Mode)); err != nil {
+				return err
+			}
+		case tar.TypeSymlink:
+			if err := os.MkdirAll(filepath.Dir(filePath), 0o755); err != nil {
+				return err
+			}
+			if err := os.Symlink(header.Linkname, filePath); err != nil {
+				return err
+			}
+		case tar.TypeReg, tar.TypeRegA:
+			if err := os.MkdirAll(filepath.Dir(filePath), 0o755); err != nil {
+				return err
+			}
+			file, err := os.OpenFile(filePath, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, os.FileMode(header.Mode))
+			if err != nil {
+				return err
+			}
+			_, copyErr := io.Copy(file, tarReader)
+			closeErr := file.Close()
+			if err := errors.Join(copyErr, closeErr); err != nil {
+				return err
+			}
+		}
+	}
+}

--- a/internal/execbackend/remote/backend_test.go
+++ b/internal/execbackend/remote/backend_test.go
@@ -32,6 +32,7 @@ func TestRemoteProvisionRequiresTTLAndRecordsOwnership(t *testing.T) {
 	harness := newProviderHarness(t)
 	backend := harness.backend(t)
 	backend.bootID = "boot-test"
+	backend.pidNamespace = "pid:[test]"
 	backend.ownerPID = 1234
 	backend.ownerStart = "5678"
 
@@ -54,18 +55,27 @@ func TestRemoteProvisionRequiresTTLAndRecordsOwnership(t *testing.T) {
 		t.Fatalf("instance = %+v", instance)
 	}
 	request := harness.lastCreate()
-	if request.Timeout != 90 || request.Metadata[metadataJobID] != "job-1" || request.Metadata[metadataLifecycleGeneration] != "9" || request.Metadata[metadataBootID] != "boot-test" || request.Metadata[metadataOwnerPID] != "1234" || request.Metadata[metadataOwnerStartTime] != "5678" {
+	if request.Timeout != 90 || request.Metadata[metadataJobID] != "job-1" || request.Metadata[metadataLifecycleGeneration] != "9" || request.Metadata[metadataBootID] != "boot-test" || request.Metadata[metadataOwnerPID] != "1234" || request.Metadata[metadataOwnerPIDNamespace] != "pid:[test]" || request.Metadata[metadataOwnerStartTime] != "5678" {
 		t.Fatalf("create request = %+v", request)
 	}
 }
 
-func TestRemoteExecRefusesRelativeDirAndDoesNotForwardOnStart(t *testing.T) {
+func TestRemoteExecRefusesEscapingDirAndDoesNotForwardOnStart(t *testing.T) {
 	harness := newProviderHarness(t)
 	backend := harness.backend(t)
 	instance := provisionAndSync(t, backend, testSourceRepo(t))
 
-	if stream, err := backend.Exec(context.Background(), instance, execbackend.Command{Name: "true", Dir: "relative"}); err == nil || stream != nil {
-		t.Fatalf("relative Exec = %+v, %v; want refusal", stream, err)
+	for name, dir := range map[string]string{
+		"empty":     "",
+		"relative":  "relative",
+		"sibling":   workspacePath + "-sibling",
+		"traversal": workspacePath + "/../outside",
+	} {
+		t.Run(name, func(t *testing.T) {
+			if stream, err := backend.Exec(context.Background(), instance, execbackend.Command{Name: "true", Dir: dir}); err == nil || stream != nil {
+				t.Fatalf("Exec Dir %q = %+v, %v; want refusal", dir, stream, err)
+			}
+		})
 	}
 	started := false
 	stream, err := backend.Exec(context.Background(), instance, execbackend.Command{
@@ -104,21 +114,50 @@ func TestRemoteDestroyIsIdempotent(t *testing.T) {
 	}
 }
 
-func TestRemoteReapLeavesForeignBootSandboxAlone(t *testing.T) {
+func TestRemoteReapScopesOwnerLivenessToPIDNamespace(t *testing.T) {
 	harness := newProviderHarness(t)
+	reaper := harness.backend(t)
+	if reaper.bootID == "" || reaper.pidNamespace == "" || reaper.ownerStart == "" {
+		t.Fatalf("owner identity is incomplete: boot=%q namespace=%q start=%q", reaper.bootID, reaper.pidNamespace, reaper.ownerStart)
+	}
+
+	const foreignPID = 2147483646
+	foreignOwner := harness.backend(t)
+	foreignOwner.bootID = reaper.bootID
+	foreignOwner.pidNamespace = "pid:[foreign-container]"
+	foreignOwner.ownerPID = foreignPID
+	foreignOwner.ownerStart = "foreign-start"
+	if _, err := foreignOwner.Provision(context.Background(), execbackend.JobScope{JobID: "foreign-live", TTL: time.Minute}); err != nil {
+		t.Fatal(err)
+	}
+	foreignMetadata := harness.lastCreate().Metadata
+
+	realOwnerAlive := reaper.ownerAlive
+	reaper.ownerAlive = func(pid int, bootID, startTime string) bool {
+		if pid == foreignPID {
+			// This models a live PID that is invisible from the reaper's namespace.
+			return false
+		}
+		return realOwnerAlive(pid, bootID, startTime)
+	}
+	ownerPID := fmt.Sprintf("%d", reaper.ownerPID)
 	harness.setInventory([]e2b.Sandbox{
-		{ID: "foreign", TemplateID: "template-test", State: "running", Metadata: map[string]string{
-			metadataBootID: "boot-foreign", metadataOwnerPID: "999999", metadataOwnerStartTime: "1",
+		{ID: "foreign-boot", TemplateID: "template-test", State: "running", Metadata: map[string]string{
+			metadataBootID: "boot-foreign", metadataOwnerPIDNamespace: reaper.pidNamespace, metadataOwnerPID: "2147483647", metadataOwnerStartTime: "1",
+		}},
+		{ID: "foreign-namespace-live", TemplateID: "template-test", State: "running", Metadata: foreignMetadata},
+		{ID: "missing-namespace", TemplateID: "template-test", State: "paused", Metadata: map[string]string{
+			metadataBootID: reaper.bootID, metadataOwnerPID: "2147483647", metadataOwnerStartTime: "1",
+		}},
+		{ID: "live-local", TemplateID: "template-test", State: "running", Metadata: map[string]string{
+			metadataBootID: reaper.bootID, metadataOwnerPIDNamespace: reaper.pidNamespace, metadataOwnerPID: ownerPID, metadataOwnerStartTime: reaper.ownerStart,
 		}},
 		{ID: "stale-local", TemplateID: "template-test", State: "paused", Metadata: map[string]string{
-			metadataBootID: "boot-local", metadataOwnerPID: "999998", metadataOwnerStartTime: "2",
+			metadataBootID: reaper.bootID, metadataOwnerPIDNamespace: reaper.pidNamespace, metadataOwnerPID: "2147483647", metadataOwnerStartTime: "2",
 		}},
 	})
-	backend := harness.backend(t)
-	backend.bootID = "boot-local"
-	backend.ownerAlive = func(int, string, string) bool { return false }
 
-	reaped, err := backend.Reap(context.Background())
+	reaped, err := reaper.Reap(context.Background())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -126,11 +165,11 @@ func TestRemoteReapLeavesForeignBootSandboxAlone(t *testing.T) {
 		t.Fatalf("reaped = %v", reaped)
 	}
 	if got := harness.deletedIDs(); !reflect.DeepEqual(got, []string{"stale-local"}) {
-		t.Fatalf("deleted sandboxes = %v; foreign boot must remain", got)
+		t.Fatalf("deleted sandboxes = %v; foreign scope and live owner must remain", got)
 	}
 }
 
-func TestRemoteCollectMatchesLocalCollect(t *testing.T) {
+func TestRemoteCollectMaterializesSameTreeAsLocalCollect(t *testing.T) {
 	ctx := context.Background()
 	source := testSourceRepo(t)
 	harness := newProviderHarness(t)
@@ -159,10 +198,10 @@ func TestRemoteCollectMatchesLocalCollect(t *testing.T) {
 	if err != nil {
 		t.Fatalf("remote Collect: %v", err)
 	}
-	if !reflect.DeepEqual(remoteChanges, localChanges) {
-		localJSON, _ := json.MarshalIndent(localChanges, "", "  ")
-		remoteJSON, _ := json.MarshalIndent(remoteChanges, "", "  ")
-		t.Fatalf("ChangeSet mismatch\nlocal:\n%s\nremote:\n%s", localJSON, remoteJSON)
+	localTree := materializedTree(t, source, localChanges)
+	remoteTree := materializedTree(t, source, remoteChanges)
+	if !reflect.DeepEqual(remoteTree, localTree) {
+		t.Fatalf("materialized tree mismatch\nlocal: %#v\nremote: %#v", localTree, remoteTree)
 	}
 }
 
@@ -217,11 +256,64 @@ func applyCollectionCorpus(t *testing.T, root string) {
 		t.Fatal(err)
 	}
 	testWriteFile(t, root, "nested/untracked.bin", []byte{'n', 'e', 'w', 0, 0xff, '\n'}, 0o644)
+	testWriteFile(t, root, "staged-new.txt", []byte("staged by agent\n"), 0o644)
+	testGit(t, root, "add", "staged-new.txt")
 	if err := os.Symlink("untracked.bin", filepath.Join(root, "nested", "untracked-link")); err != nil {
 		t.Fatal(err)
 	}
 	invalidName := "invalid-\xff-name.txt"
 	testWriteFile(t, root, invalidName, []byte("byte-exact\n"), 0o644)
+}
+
+type testTreeEntry struct {
+	Mode    os.FileMode
+	Content []byte
+	Target  string
+}
+
+func materializedTree(t *testing.T, source string, changes execbackend.ChangeSet) map[string]testTreeEntry {
+	t.Helper()
+	target := filepath.Join(t.TempDir(), "materialized")
+	testGit(t, filepath.Dir(target), "clone", "-q", "--no-hardlinks", source, target)
+	if err := execbackend.ImportChangeSet(context.Background(), target, changes); err != nil {
+		t.Fatalf("materialize ChangeSet: %v", err)
+	}
+
+	tree := make(map[string]testTreeEntry)
+	err := filepath.WalkDir(target, func(filePath string, entry os.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		relative, err := filepath.Rel(target, filePath)
+		if err != nil {
+			return err
+		}
+		if entry.IsDir() {
+			if relative == ".git" {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		info, err := entry.Info()
+		if err != nil {
+			return err
+		}
+		item := testTreeEntry{Mode: info.Mode() & (os.ModeType | os.ModePerm)}
+		if info.Mode()&os.ModeSymlink != 0 {
+			item.Target, err = os.Readlink(filePath)
+		} else {
+			item.Content, err = os.ReadFile(filePath)
+		}
+		if err != nil {
+			return err
+		}
+		tree[filepath.ToSlash(relative)] = item
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("snapshot materialized tree: %v", err)
+	}
+	return tree
 }
 
 func testWriteFile(t *testing.T, root, name string, data []byte, mode os.FileMode) {


### PR DESCRIPTION
WHAT:
GITMOOT-IMPL: Implemented Slice C at base e95a38c7fa30e631b037ce21d15b217183493b7a. Added the unwired remote E2B provider without changing e2b signatures or daemon wiring.

WHY:
Gitmoot finalized this implementation from a task worktree.

CHANGES:
- Committed changes from /root/.gitmoot/worktrees/gitmoot--gitmoot/adhoc-b7c77ec4

RESULTS:
- Final compile checks: go test -c -o /dev/null ./internal/execbackend/ and ./internal/execbackend/remote/ passed.
- Final StageAt target: MATCH_COUNT=1, passed.
- Final remote target: MATCH_COUNT=5, passed. No full suite was run.
- TTL mutant: applied=true, compile exit 0. Initial test falsely survived via downstream e2b validation; assertion was strengthened. Reapplied mutant then failed its MATCH_COUNT=1 strength run; distinct MATCH_COUNT=4 passed.
- Relative-directory fallback mutant: applied=true, compile exit 0, MATCH_COUNT=1 failed; distinct MATCH_COUNT=4 passed.
- Destroy idempotency mutant: applied=true, compile exit 0, MATCH_COUNT=1 failed with two deletes; distinct MATCH_COUNT=4 passed.
- Foreign boot predicate removal: applied=true, compile exit 0, MATCH_COUNT=1 failed by reaping both foreign and local sandboxes; distinct MATCH_COUNT=4 passed.
- Sandbox-authored ChangeSet mutant: applied=true, compile exit 0, final MATCH_COUNT=1 failed against local equivalence; distinct MATCH_COUNT=4 passed.
- StageAt cleanup removal: applied=true, compile exit 0, MATCH_COUNT=1 failed with a registered staging worktree remaining; distinct remote MATCH_COUNT=5 passed.
- OnStart forwarding mutant: applied=true, compile exit 0, MATCH_COUNT=1 failed by observing the sandbox PID callback; distinct MATCH_COUNT=4 passed.
- All mutants restored. git diff --check passed; zero .test binaries remain; zero changed files are outside internal/execbackend; remote has zero importers; only remote/backend.go and its test import e2b.

RISK:
Review the generated diff before merging.

TASK:
adhoc-b7c77ec4

AGENTS:
- wave-impl

RAW FINAL REVIEW OUTPUT:
````text
GITMOOT-IMPL: Implemented Slice C at base e95a38c7fa30e631b037ce21d15b217183493b7a. Added the unwired remote E2B provider without changing e2b signatures or daemon wiring.
````
