### PR TITLE
Gitmoot: JARVIS DISPATCH — gitmoot#1633 FINDINGS BATCH, seven filed

### DIFF
--- a/internal/execbackend/e2b/envd.go
+++ b/internal/execbackend/e2b/envd.go
@@ -443,6 +443,10 @@ type endEvent struct {
 	UnknownFields []string `json:"-" envd:"ignored: recorded for observability and surfaced via EnvdOptions.OnUnknownEndEventFields; never used to decide success"`
 }
 
+// GITMOOT-IMPL: wireEndEvent avoids recursively invoking endEvent.UnmarshalJSON when
+// encoding/json is used to derive the fields it can address.
+type wireEndEvent endEvent
+
 // UnmarshalJSON ACCEPTS terminal fields this client does not model rather than
 // rejecting them. Additive fields are how wire protocols normally evolve, so
 // failing on one would turn every SUCCESSFUL exec into an outage on the
@@ -455,7 +459,6 @@ type endEvent struct {
 // this struct from bypassing endEventError; that guard's subject is OUR struct
 // and it fires in CI, which is the difference that makes it worth having.
 func (e *endEvent) UnmarshalJSON(data []byte) error {
-	type wireEndEvent endEvent
 	decoder := json.NewDecoder(bytes.NewReader(data))
 	if err := decoder.Decode((*wireEndEvent)(e)); err != nil {
 		return err
@@ -474,12 +477,12 @@ func unknownEndEventKeys(data []byte) []string {
 	if err := json.Unmarshal(data, &raw); err != nil {
 		return nil
 	}
-	known := jsonWireFieldNames(reflect.TypeOf(endEvent{}))
+	known := jsonWireFieldNames(reflect.TypeOf(wireEndEvent{}))
 	unknown := make([]string, 0, len(raw))
 	for key := range raw {
-		// encoding/json matches field names case-insensitively. A key that can
-		// drive the verdict is modeled and must not also be reported as unknown.
-		if _, ok := known[strings.ToLower(key)]; !ok {
+		// A key that can drive the verdict is modeled and must not also be
+		// reported as unknown.
+		if !jsonWireFieldNameKnown(known, key) {
 			unknown = append(unknown, key)
 		}
 	}
@@ -491,22 +494,82 @@ func unknownEndEventKeys(data []byte) []string {
 }
 
 func jsonWireFieldNames(structType reflect.Type) map[string]struct{} {
-	known := make(map[string]struct{}, structType.NumField())
-	for i := 0; i < structType.NumField(); i++ {
-		field := structType.Field(i)
-		if !field.IsExported() {
-			continue
+	for structType.Kind() == reflect.Pointer {
+		structType = structType.Elem()
+	}
+	if structType.Kind() != reflect.Struct {
+		return nil
+	}
+	candidates := make(map[string]struct{}, structType.NumField())
+	collectJSONWireFieldCandidates(structType, make(map[reflect.Type]bool), candidates)
+	known := make(map[string]struct{}, len(candidates))
+	for name := range candidates {
+		if encodingJSONAcceptsWireField(structType, name) {
+			known[name] = struct{}{}
 		}
-		name, _, _ := strings.Cut(field.Tag.Get("json"), ",")
-		if name == "-" {
-			continue
-		}
-		if name == "" {
-			name = field.Name
-		}
-		known[strings.ToLower(name)] = struct{}{}
 	}
 	return known
+}
+
+func collectJSONWireFieldCandidates(structType reflect.Type, visited map[reflect.Type]bool, candidates map[string]struct{}) {
+	for structType.Kind() == reflect.Pointer {
+		structType = structType.Elem()
+	}
+	if structType.Kind() != reflect.Struct || visited[structType] {
+		return
+	}
+	visited[structType] = true
+	for i := 0; i < structType.NumField(); i++ {
+		field := structType.Field(i)
+		fieldType := field.Type
+		for fieldType.Kind() == reflect.Pointer {
+			fieldType = fieldType.Elem()
+		}
+		if field.Anonymous {
+			if !field.IsExported() && fieldType.Kind() != reflect.Struct {
+				continue
+			}
+		} else if !field.IsExported() {
+			continue
+		}
+		tag := field.Tag.Get("json")
+		if tag == "-" {
+			continue
+		}
+		name, _, _ := strings.Cut(tag, ",")
+		candidates[field.Name] = struct{}{}
+		if name != "" {
+			candidates[name] = struct{}{}
+		}
+		if field.Anonymous && fieldType.Kind() == reflect.Struct {
+			collectJSONWireFieldCandidates(fieldType, visited, candidates)
+		}
+	}
+}
+
+// GITMOOT-IMPL: encoding/json exposes no field-selection metadata. Probe decoding delegates
+// embedded-field promotion, tags, and shadowing to the codec itself instead of
+// maintaining a second approximation of its dominance rules.
+func encodingJSONAcceptsWireField(structType reflect.Type, name string) bool {
+	data, err := json.Marshal(map[string]any{name: nil})
+	if err != nil {
+		return false
+	}
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	decoder.DisallowUnknownFields()
+	err = decoder.Decode(reflect.New(structType).Interface())
+	return err == nil || !strings.HasPrefix(err.Error(), "json: unknown field ")
+}
+
+func jsonWireFieldNameKnown(known map[string]struct{}, name string) bool {
+	for candidate := range known {
+		// GITMOOT-IMPL: strings.EqualFold uses Unicode simple case folding, the same matching
+		// relation encoding/json documents for folded field names.
+		if strings.EqualFold(candidate, name) {
+			return true
+		}
+	}
+	return false
 }
 
 type outputTail struct {

--- a/internal/execbackend/e2b/envd_test.go
+++ b/internal/execbackend/e2b/envd_test.go
@@ -587,21 +587,52 @@ func TestEnvdSurfacesUnknownEndEventFields(t *testing.T) {
 func TestJSONWireFieldNamesMatchEncodingJSON(t *testing.T) {
 	t.Parallel()
 
+	type promotedFields struct {
+		Promoted  string `json:"promoted"`
+		Ambiguous string
+	}
+	type competingFields struct {
+		Ambiguous string
+	}
 	type contractFixture struct {
+		promotedFields
+		competingFields
 		Signal  string `json:"signal,omitempty"`
+		Status  string `json:"status"`
 		Ignored string `json:"-"`
 		Legacy  string
 		hidden  string
 	}
-	known := jsonWireFieldNames(reflect.TypeOf(contractFixture{}))
-	for _, name := range []string{"signal", "legacy"} {
-		if _, ok := known[name]; !ok {
-			t.Errorf("derived JSON wire names = %v; missing %q", known, name)
-		}
+	fixtureType := reflect.TypeOf(contractFixture{})
+	known := jsonWireFieldNames(fixtureType)
+	candidates := map[string]struct{}{
+		"signal":           {},
+		"Signal":           {},
+		"signal,omitempty": {},
+		"legacy":           {},
+		"promoted":         {},
+		"ambiguous":        {},
+		"status":           {},
+		"\u017ftatus":      {},
+		"-":                {},
+		"ignored":          {},
+		"hidden":           {},
+		"spurious":         {},
 	}
-	for _, name := range []string{"signal,omitempty", "-", "ignored", "hidden", ""} {
-		if _, ok := known[name]; ok {
-			t.Errorf("derived JSON wire names = %v; unexpectedly contains %q", known, name)
+	for name := range known {
+		candidates[name] = struct{}{}
+	}
+	for name := range candidates {
+		data, err := json.Marshal(map[string]any{name: "probe"})
+		if err != nil {
+			t.Fatal(err)
+		}
+		decoder := json.NewDecoder(bytes.NewReader(data))
+		decoder.DisallowUnknownFields()
+		actual := decoder.Decode(reflect.New(fixtureType).Interface()) == nil
+		derived := jsonWireFieldNameKnown(known, name)
+		if derived != actual {
+			t.Errorf("derived JSON wire names = %v; key %q derived=%t encoding/json=%t", known, name, derived, actual)
 		}
 	}
 }

--- a/internal/execbackend/remote/backend.go
+++ b/internal/execbackend/remote/backend.go
@@ -379,8 +379,7 @@ func (b *Backend) Reap(ctx context.Context) ([]string, error) {
 		if strings.TrimSpace(metadata[metadataBootID]) == "" || strings.TrimSpace(metadata[metadataBootID]) != b.bootID {
 			continue
 		}
-		ownerPIDNamespace := strings.TrimSpace(metadata[metadataOwnerPIDNamespace])
-		if ownerPIDNamespace == "" || b.pidNamespace == "" || ownerPIDNamespace != b.pidNamespace {
+		if !matchingNonEmptyIdentity(metadata[metadataOwnerPIDNamespace], b.pidNamespace) {
 			continue
 		}
 		pid, parseErr := strconv.Atoi(strings.TrimSpace(metadata[metadataOwnerPID]))
@@ -398,6 +397,12 @@ func (b *Backend) Reap(ctx context.Context) ([]string, error) {
 		reaped = append(reaped, sandbox.ID)
 	}
 	return reaped, errors.Join(reapErrs...)
+}
+
+func matchingNonEmptyIdentity(left, right string) bool {
+	left = strings.TrimSpace(left)
+	right = strings.TrimSpace(right)
+	return left != "" && right != "" && left == right
 }
 
 func (b *Backend) stateFor(instance *execbackend.Instance) (*sandboxState, error) {

--- a/internal/execbackend/remote/backend_test.go
+++ b/internal/execbackend/remote/backend_test.go
@@ -167,6 +167,74 @@ func TestRemoteReapScopesOwnerLivenessToPIDNamespace(t *testing.T) {
 	if got := harness.deletedIDs(); !reflect.DeepEqual(got, []string{"stale-local"}) {
 		t.Fatalf("deleted sandboxes = %v; foreign scope and live owner must remain", got)
 	}
+
+	// GITMOOT-IMPL: kills R34, which makes two absent namespace identities
+	// compare equal and reopens cross-container reaping.
+	blindHarness := newProviderHarness(t)
+	blindHarness.setInventory([]e2b.Sandbox{{
+		ID: "legacy-no-ns", TemplateID: "template-test", State: "running", Metadata: map[string]string{
+			metadataBootID: "boot-blind", metadataOwnerPID: "2147483647", metadataOwnerStartTime: "1",
+		},
+	}})
+	blindReaper := blindHarness.backend(t)
+	blindReaper.bootID = "boot-blind"
+	blindReaper.pidNamespace = ""
+	blindReaper.ownerAlive = func(int, string, string) bool { return false }
+	reaped, err = blindReaper.Reap(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(reaped) != 0 || len(blindHarness.deletedIDs()) != 0 {
+		t.Fatalf("blind reaper deleted namespace-less sandbox: reaped=%v deleted=%v", reaped, blindHarness.deletedIDs())
+	}
+}
+
+// GITMOOT-IMPL: kills MA, removal of git apply from syncWorkspaceScript.
+func TestRemoteSyncInAppliesHostChanges(t *testing.T) {
+	source := testSourceRepo(t)
+	harness := newProviderHarness(t)
+	provisionAndSync(t, harness.backend(t), source)
+
+	for name, want := range map[string]string{
+		"input.txt":           "host input change\n",
+		"input-untracked.txt": "host untracked input\n",
+	} {
+		data, err := os.ReadFile(filepath.Join(harness.workspace, name))
+		if err != nil {
+			t.Fatalf("read synced %s: %v", name, err)
+		}
+		if string(data) != want {
+			t.Fatalf("synced %s = %q, want %q", name, data, want)
+		}
+	}
+}
+
+// GITMOOT-IMPL: kills MG, removal of the sandbox-created commit guard.
+func TestRemoteCollectRefusesSandboxCreatedCommit(t *testing.T) {
+	harness := newProviderHarness(t)
+	backend := harness.backend(t)
+	instance := provisionAndSync(t, backend, testSourceRepo(t))
+	testWriteFile(t, harness.workspace, "committed-by-agent.txt", []byte("committed\n"), 0o644)
+	testGit(t, harness.workspace, "add", "committed-by-agent.txt")
+	testGit(t, harness.workspace, "commit", "-q", "-m", "agent commit")
+
+	changes, err := backend.Collect(context.Background(), instance)
+	if err == nil || !strings.Contains(err.Error(), "sandbox-created commits are forbidden") {
+		t.Fatalf("Collect after sandbox commit = %+v, %v; want refusal", changes, err)
+	}
+}
+
+// GITMOOT-IMPL: kills MH, removal of the remote patch-size check.
+func TestRemoteCollectRejectsOversizedPatch(t *testing.T) {
+	harness := newProviderHarness(t)
+	backend := harness.backend(t)
+	instance := provisionAndSync(t, backend, testSourceRepo(t))
+	testWriteFile(t, harness.workspace, "oversized.txt", bytes.Repeat([]byte("x"), execbackend.MaxChangeSetPatchBytes+1024), 0o644)
+
+	changes, err := backend.Collect(context.Background(), instance)
+	if err == nil || !strings.Contains(err.Error(), "remote execution patch is larger than limit") {
+		t.Fatalf("Collect oversized patch = %+v, %v; want size refusal", changes, err)
+	}
 }
 
 func TestRemoteCollectMaterializesSameTreeAsLocalCollect(t *testing.T) {
@@ -479,11 +547,16 @@ func (h *providerHarness) serveStart(w http.ResponseWriter, r *http.Request) {
 	stdout, stderr, exitCode, providerError := h.runProcess(r.Context(), request.Process.Command, request.Process.Args, request.Process.Dir, request.Process.Env)
 	w.Header().Set("Content-Type", "application/connect+json")
 	writeTestConnectJSON(h.t, w, 0, map[string]any{"event": map[string]any{"start": map[string]any{"pid": 42}}})
-	if len(stdout) > 0 {
-		writeTestConnectJSON(h.t, w, 0, map[string]any{"event": map[string]any{"data": map[string]any{"stdout": stdout}}})
+	const testDataFrameBytes = 1 << 20
+	for len(stdout) > 0 {
+		count := min(len(stdout), testDataFrameBytes)
+		writeTestConnectJSON(h.t, w, 0, map[string]any{"event": map[string]any{"data": map[string]any{"stdout": stdout[:count]}}})
+		stdout = stdout[count:]
 	}
-	if len(stderr) > 0 {
-		writeTestConnectJSON(h.t, w, 0, map[string]any{"event": map[string]any{"data": map[string]any{"stderr": stderr}}})
+	for len(stderr) > 0 {
+		count := min(len(stderr), testDataFrameBytes)
+		writeTestConnectJSON(h.t, w, 0, map[string]any{"event": map[string]any{"data": map[string]any{"stderr": stderr[:count]}}})
+		stderr = stderr[count:]
 	}
 	status := fmt.Sprintf("exit status %d", exitCode)
 	writeTestConnectJSON(h.t, w, 0, map[string]any{"event": map[string]any{"end": map[string]any{
@@ -520,7 +593,7 @@ func (h *providerHarness) runProcess(ctx context.Context, command string, args [
 		if err != nil {
 			return nil, nil, 1, err.Error()
 		}
-		if len(inputPatch) > 0 {
+		if len(inputPatch) > 0 && strings.Contains(syncWorkspaceScript, "git apply --binary --whitespace=nowarn /home/user/.gitmoot-sync/changes.patch") {
 			cmd := exec.CommandContext(ctx, "git", "-C", h.workspace, "apply", "--binary", "--whitespace=nowarn", "-")
 			cmd.Stdin = bytes.NewReader(inputPatch)
 			if output, err := cmd.CombinedOutput(); err != nil {


### PR DESCRIPTION
WHAT:
GITMOOT-IMPL: Implemented all seven pre-Slice-D guard fixes at checked-out base 48bb5ad8dfc0eb978c88ea89e90206d9777a5d5a. No shipping wiring was added. For 1655-C, chose strings.EqualFold because it matches encoding/json's Unicode folding and prevents modeled keys being falsely reported as unknown.

WHY:
Gitmoot finalized this implementation from a task worktree.

CHANGES:
- Committed changes from /root/.gitmoot/worktrees/gitmoot--gitmoot/adhoc-6734a7b9

RESULTS:
- GITMOOT-IMPL: e2b compile check exit 0; package -run '.' matched 36 top-level tests and passed.
- GITMOOT-IMPL: remote compile check exit 0; package -run '.' matched 8 top-level tests and passed.
- GITMOOT-IMPL: 1655-A spurious-alias mutant applied:true, compile exit 0, MATCH_COUNT=36, killed by TestJSONWireFieldNamesMatchEncodingJSON; restored.
- GITMOOT-IMPL: 1655-B disabled embedded recursion mutant applied:true, compile exit 0, MATCH_COUNT=36, killed by TestJSONWireFieldNamesMatchEncodingJSON; restored.
- GITMOOT-IMPL: 1655-C restored ToLower matcher mutant applied:true, compile exit 0, MATCH_COUNT=36, killed by TestJSONWireFieldNamesMatchEncodingJSON; restored.
- GITMOOT-IMPL: R34 empty-identity equality mutant applied:true, compile exit 0, MATCH_COUNT=8, killed by TestRemoteReapScopesOwnerLivenessToPIDNamespace; restored.
- GITMOOT-IMPL: MA removed git-apply command mutant applied:true, compile exit 0, MATCH_COUNT=8, killed by TestRemoteSyncInAppliesHostChanges; restored.
- GITMOOT-IMPL: MG removed sandbox-created commit guard mutant applied:true, compile exit 0, MATCH_COUNT=8, killed by TestRemoteCollectRefusesSandboxCreatedCommit; restored.
- GITMOOT-IMPL: MH removed patch-size guard mutant applied:true, compile exit 0, MATCH_COUNT=8, killed by TestRemoteCollectRejectsOversizedPatch; restored.
- GITMOOT-IMPL: Targeted TestJSONWireFieldNamesMatchEncodingJSON run MATCH_COUNT=1 and passed.
- GITMOOT-IMPL: go vet for e2b and remote exit 0; git diff --check exit 0; no .test binaries remain.
- GITMOOT-IMPL: go list -deps ./cmd/gitmoot: E2B_IMPORT_COUNT=0, REMOTE_IMPORT_COUNT=0, EXECBACKEND_CONTROL_COUNT=1.
- GITMOOT-IMPL: Full suite intentionally not run; coordinator owns the detached gate.

RISK:
Review the generated diff before merging.

TASK:
adhoc-6734a7b9

AGENTS:
- wave-impl

RAW FINAL REVIEW OUTPUT:
````text
GITMOOT-IMPL: Implemented all seven pre-Slice-D guard fixes at checked-out base 48bb5ad8dfc0eb978c88ea89e90206d9777a5d5a. No shipping wiring was added. For 1655-C, chose strings.EqualFold because it matches encoding/json's Unicode folding and prevents modeled keys being falsely reported as unknown.
````
