### PR TITLE
Gitmoot: JARVIS DISPATCH — gitmoot#1634: wire the execbackend_attempts ledger.

### DIFF
--- a/internal/cli/execbackend_ledger.go
+++ b/internal/cli/execbackend_ledger.go
@@ -1,0 +1,293 @@
+package cli
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/gitmoot/gitmoot/internal/db"
+	"github.com/gitmoot/gitmoot/internal/execbackend"
+)
+
+const e2bAttemptProvider = "e2b"
+
+type ledgeredExecutionBackend struct {
+	inner           execbackend.ExecutionBackend
+	inventoryReaper execbackend.InventoryReaper
+	store           *db.Store
+	provider        string
+	fencingToken    string
+	bootID          string
+	stdout          io.Writer
+	now             func() time.Time
+
+	mu      sync.Mutex
+	attempt map[string]db.ExecBackendAttemptKey
+}
+
+func newLedgeredExecutionBackend(store *db.Store, inner execbackend.ExecutionBackend, provider, fencingToken, bootID string, stdout io.Writer) (*ledgeredExecutionBackend, error) {
+	if store == nil {
+		return nil, errors.New("execution backend attempt ledger store is required")
+	}
+	if inner == nil {
+		return nil, errors.New("execution backend attempt ledger provider is required")
+	}
+	inventoryReaper, ok := inner.(execbackend.InventoryReaper)
+	if !ok {
+		return nil, fmt.Errorf("execution backend %q does not expose provider inventory", inner.Name())
+	}
+	provider = strings.TrimSpace(provider)
+	if provider == "" {
+		return nil, errors.New("execution backend attempt ledger provider name is required")
+	}
+	fencingToken = strings.TrimSpace(fencingToken)
+	if fencingToken == "" {
+		return nil, errors.New("execution backend attempt ledger fencing token is required")
+	}
+	bootID = strings.TrimSpace(bootID)
+	if bootID == "" {
+		return nil, errors.New("execution backend attempt ledger boot id is required")
+	}
+	return &ledgeredExecutionBackend{
+		inner:           inner,
+		inventoryReaper: inventoryReaper,
+		store:           store,
+		provider:        provider,
+		fencingToken:    fencingToken,
+		bootID:          bootID,
+		stdout:          stdout,
+		now:             time.Now,
+		attempt:         make(map[string]db.ExecBackendAttemptKey),
+	}, nil
+}
+
+func (b *ledgeredExecutionBackend) Name() execbackend.Backend { return b.inner.Name() }
+
+func (b *ledgeredExecutionBackend) Provision(ctx context.Context, scope execbackend.JobScope) (*execbackend.Instance, error) {
+	attempt := scope.Attempt
+	if attempt == 0 {
+		attempt = 1
+	}
+	key := db.ExecBackendAttemptKey{
+		JobID:               strings.TrimSpace(scope.JobID),
+		Attempt:             attempt,
+		LifecycleGeneration: scope.LifecycleGeneration,
+	}
+	scope.Attempt = attempt
+	scope.DaemonFencingToken = b.fencingToken
+	if err := b.store.ReserveExecBackendAttempt(ctx, db.ExecBackendAttemptReservation{
+		ExecBackendAttemptKey: key,
+		Provider:              b.provider,
+		DaemonFencingToken:    b.fencingToken,
+		BootID:                b.bootID,
+		TTLExpiresAt:          b.now().UTC().Add(scope.TTL),
+		CostReservedUSD:       0,
+	}); err != nil {
+		return nil, fmt.Errorf("reserve execution backend attempt: %w", err)
+	}
+	changed, err := b.store.MarkExecBackendAttemptProvisioning(ctx, key)
+	if err != nil || !changed {
+		return nil, errors.Join(errors.New("mark execution backend attempt provisioning"), err)
+	}
+
+	instance, err := b.inner.Provision(ctx, scope)
+	if err != nil {
+		// A transport failure is not proof that the provider did not allocate.
+		// Keep the metadata-keyed row recoverable until a complete inventory can
+		// either attach its sandbox ID or mark it orphaned.
+		return instance, err
+	}
+	if instance == nil || strings.TrimSpace(instance.ID) == "" {
+		return nil, errors.New("execution backend provision returned an empty instance")
+	}
+	b.mu.Lock()
+	b.attempt[instance.ID] = key
+	b.mu.Unlock()
+	changed, err = b.store.MarkExecBackendAttemptRunning(context.WithoutCancel(ctx), key, instance.ID)
+	if err != nil || !changed {
+		return instance, errors.Join(errors.New("mark execution backend attempt running"), err)
+	}
+	return instance, nil
+}
+
+func (b *ledgeredExecutionBackend) Attach(ctx context.Context, id string) (*execbackend.Instance, error) {
+	return b.inner.Attach(ctx, id)
+}
+
+func (b *ledgeredExecutionBackend) SyncIn(ctx context.Context, instance *execbackend.Instance, materials execbackend.Materials) error {
+	return b.inner.SyncIn(ctx, instance, materials)
+}
+
+func (b *ledgeredExecutionBackend) Exec(ctx context.Context, instance *execbackend.Instance, command execbackend.Command) (execbackend.Stream, error) {
+	return b.inner.Exec(ctx, instance, command)
+}
+
+func (b *ledgeredExecutionBackend) Collect(ctx context.Context, instance *execbackend.Instance) (execbackend.ChangeSet, error) {
+	if key, ok := b.keyFor(instance); ok {
+		changed, err := b.store.MarkExecBackendAttemptCollecting(context.WithoutCancel(ctx), key)
+		if err != nil || !changed {
+			return execbackend.ChangeSet{}, errors.Join(errors.New("mark execution backend attempt collecting"), err)
+		}
+	}
+	return b.inner.Collect(ctx, instance)
+}
+
+func (b *ledgeredExecutionBackend) Cancel(ctx context.Context, instance *execbackend.Instance) error {
+	return b.teardown(ctx, instance, b.inner.Cancel)
+}
+
+func (b *ledgeredExecutionBackend) Destroy(ctx context.Context, instance *execbackend.Instance) error {
+	return b.teardown(ctx, instance, b.inner.Destroy)
+}
+
+func (b *ledgeredExecutionBackend) teardown(ctx context.Context, instance *execbackend.Instance, destroy func(context.Context, *execbackend.Instance) error) error {
+	key, tracked := b.keyFor(instance)
+	var ledgerErrs []error
+	if tracked {
+		if _, err := b.store.MarkExecBackendAttemptCollecting(context.WithoutCancel(ctx), key); err != nil {
+			ledgerErrs = append(ledgerErrs, fmt.Errorf("mark execution backend attempt collecting for teardown: %w", err))
+		}
+		changed, err := b.store.MarkExecBackendAttemptDestroying(context.WithoutCancel(ctx), key)
+		if err != nil {
+			ledgerErrs = append(ledgerErrs, fmt.Errorf("mark execution backend attempt destroying: %w", err))
+		} else if !changed {
+			ledgerErrs = append(ledgerErrs, errors.New("mark execution backend attempt destroying changed no row"))
+		}
+	}
+
+	providerErr := destroy(ctx, instance)
+	if providerErr == nil && tracked {
+		changed, err := b.store.MarkExecBackendAttemptDestroyed(context.WithoutCancel(ctx), key, 0)
+		if err != nil {
+			ledgerErrs = append(ledgerErrs, fmt.Errorf("mark execution backend attempt destroyed: %w", err))
+		} else if !changed {
+			ledgerErrs = append(ledgerErrs, errors.New("mark execution backend attempt destroyed changed no row"))
+		} else {
+			b.mu.Lock()
+			delete(b.attempt, instance.ID)
+			b.mu.Unlock()
+		}
+	}
+	return errors.Join(append([]error{providerErr}, ledgerErrs...)...)
+}
+
+func (b *ledgeredExecutionBackend) Reap(ctx context.Context) ([]string, error) {
+	report, err := b.ReapInventory(ctx)
+	return report.Destroyed, err
+}
+
+func (b *ledgeredExecutionBackend) ReapInventory(ctx context.Context) (execbackend.ReapReport, error) {
+	report, reapErr := b.inventoryReaper.ReapInventory(ctx)
+	// An inconclusive List is not evidence that every active ledger row is
+	// orphaned. Preserve all rows and retry recovery when inventory is observed.
+	if !report.InventoryObserved {
+		if reapErr == nil {
+			reapErr = errors.New("execution backend provider inventory was not observed")
+		}
+		return report, reapErr
+	}
+	reconcileErr := b.reconcileInventory(context.WithoutCancel(ctx), report)
+	return report, errors.Join(reapErr, reconcileErr)
+}
+
+func (b *ledgeredExecutionBackend) reconcileInventory(ctx context.Context, report execbackend.ReapReport) error {
+	attempts, err := b.store.ListRecoverableExecBackendAttempts(ctx, b.provider)
+	if err != nil {
+		return fmt.Errorf("list execution backend attempts for recovery: %w", err)
+	}
+	byKey := make(map[db.ExecBackendAttemptKey]*db.ExecBackendAttempt, len(attempts))
+	bySandbox := make(map[string]*db.ExecBackendAttempt, len(attempts))
+	for i := range attempts {
+		attempt := &attempts[i]
+		byKey[attempt.ExecBackendAttemptKey] = attempt
+		if attempt.SandboxID != nil {
+			bySandbox[*attempt.SandboxID] = attempt
+		}
+	}
+
+	observed := make(map[string]struct{}, len(report.Inventory))
+	matched := make(map[db.ExecBackendAttemptKey]struct{}, len(report.Inventory))
+	var reconcileErrs []error
+	for _, instance := range report.Inventory {
+		id := strings.TrimSpace(instance.ID)
+		if id == "" {
+			continue
+		}
+		observed[id] = struct{}{}
+		if attempt := bySandbox[id]; attempt != nil {
+			matched[attempt.ExecBackendAttemptKey] = struct{}{}
+			continue
+		}
+		key := db.ExecBackendAttemptKey{JobID: instance.JobID, Attempt: instance.Attempt, LifecycleGeneration: instance.LifecycleGeneration}
+		attempt := byKey[key]
+		if attempt != nil && attempt.SandboxID == nil && attempt.DaemonFencingToken == instance.DaemonFencingToken && attempt.BootID == instance.BootID {
+			if attempt.State == db.ExecBackendAttemptStateReserved {
+				if changed, markErr := b.store.MarkExecBackendAttemptProvisioning(ctx, key); markErr != nil || !changed {
+					reconcileErrs = append(reconcileErrs, errors.Join(fmt.Errorf("recover execution backend attempt %+v to provisioning", key), markErr))
+					continue
+				}
+			}
+			if changed, markErr := b.store.MarkExecBackendAttemptRunning(ctx, key, id); markErr != nil || !changed {
+				reconcileErrs = append(reconcileErrs, errors.Join(fmt.Errorf("recover execution backend attempt %+v sandbox %q", key, id), markErr))
+				continue
+			}
+			attempt.SandboxID = &id
+			attempt.State = db.ExecBackendAttemptStateRunning
+			bySandbox[id] = attempt
+			matched[key] = struct{}{}
+			continue
+		}
+		writeLine(b.stdout, "execution backend recovery: provider sandbox %s has no matching ledger row", id)
+	}
+
+	destroyed := make(map[string]struct{}, len(report.Destroyed))
+	for _, id := range report.Destroyed {
+		destroyed[strings.TrimSpace(id)] = struct{}{}
+	}
+	for i := range attempts {
+		attempt := &attempts[i]
+		key := attempt.ExecBackendAttemptKey
+		if attempt.SandboxID == nil {
+			if _, ok := matched[key]; ok {
+				continue
+			}
+			writeLine(b.stdout, "execution backend recovery: ledger attempt %s/%d/%d was not observed in provider inventory", key.JobID, key.LifecycleGeneration, key.Attempt)
+			if report.InventoryComplete {
+				if changed, markErr := b.store.MarkExecBackendAttemptOrphaned(ctx, key); markErr != nil || !changed {
+					reconcileErrs = append(reconcileErrs, errors.Join(fmt.Errorf("mark execution backend attempt %+v orphaned", key), markErr))
+				}
+			}
+			continue
+		}
+		id := *attempt.SandboxID
+		if _, ok := destroyed[id]; ok {
+			if changed, markErr := b.store.MarkExecBackendAttemptOrphaned(ctx, key); markErr != nil || !changed {
+				reconcileErrs = append(reconcileErrs, errors.Join(fmt.Errorf("mark reaped execution backend attempt %+v orphaned", key), markErr))
+			}
+			continue
+		}
+		if _, ok := observed[id]; !ok {
+			writeLine(b.stdout, "execution backend recovery: ledger sandbox %s was not observed in provider inventory", id)
+			if report.InventoryComplete {
+				if changed, markErr := b.store.MarkExecBackendAttemptOrphaned(ctx, key); markErr != nil || !changed {
+					reconcileErrs = append(reconcileErrs, errors.Join(fmt.Errorf("mark execution backend attempt %+v orphaned", key), markErr))
+				}
+			}
+		}
+	}
+	return errors.Join(reconcileErrs...)
+}
+
+func (b *ledgeredExecutionBackend) keyFor(instance *execbackend.Instance) (db.ExecBackendAttemptKey, bool) {
+	if instance == nil {
+		return db.ExecBackendAttemptKey{}, false
+	}
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	key, ok := b.attempt[instance.ID]
+	return key, ok
+}

--- a/internal/cli/execbackend_ledger_test.go
+++ b/internal/cli/execbackend_ledger_test.go
@@ -1,0 +1,321 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gitmoot/gitmoot/internal/db"
+	"github.com/gitmoot/gitmoot/internal/db/dbtest"
+	"github.com/gitmoot/gitmoot/internal/execbackend"
+)
+
+type ledgerTestBackend struct {
+	provision  func(execbackend.JobScope) (*execbackend.Instance, error)
+	report     execbackend.ReapReport
+	reapErr    error
+	destroyErr error
+	cancelErr  error
+	destroys   int
+	cancels    int
+}
+
+func TestProvisionExecutionBackendPreservesInstanceOnProvisionError(t *testing.T) {
+	instance := &execbackend.Instance{ID: "sandbox-needs-teardown", JobID: "job-needs-teardown"}
+	inner := &ledgerTestBackend{provision: func(execbackend.JobScope) (*execbackend.Instance, error) {
+		return instance, errors.New("persist running row")
+	}}
+	worker := jobWorker{ExecutionBackendFactory: func(execbackend.Backend) (execbackend.ExecutionBackend, error) {
+		return inner, nil
+	}}
+	lifecycle, got, err := worker.provisionExecutionBackend(context.Background(), execbackend.Remote, "shell", db.Job{ID: instance.JobID}, time.Minute, "/checkout")
+	if err == nil || !strings.Contains(err.Error(), "persist running row") {
+		t.Fatalf("provision error = %v", err)
+	}
+	if lifecycle != inner || got != instance {
+		t.Fatalf("provision failure returned lifecycle=%T instance=%+v; teardown handle was discarded", lifecycle, got)
+	}
+}
+
+func (*ledgerTestBackend) Name() execbackend.Backend { return execbackend.Remote }
+
+func (b *ledgerTestBackend) Provision(_ context.Context, scope execbackend.JobScope) (*execbackend.Instance, error) {
+	if b.provision != nil {
+		return b.provision(scope)
+	}
+	return &execbackend.Instance{ID: "sandbox-ledger", JobID: scope.JobID, LifecycleGeneration: scope.LifecycleGeneration}, nil
+}
+
+func (*ledgerTestBackend) Attach(context.Context, string) (*execbackend.Instance, error) {
+	return nil, errors.New("not attached")
+}
+
+func (*ledgerTestBackend) SyncIn(context.Context, *execbackend.Instance, execbackend.Materials) error {
+	return nil
+}
+
+func (*ledgerTestBackend) Exec(context.Context, *execbackend.Instance, execbackend.Command) (execbackend.Stream, error) {
+	return nil, errors.New("not executed")
+}
+
+func (*ledgerTestBackend) Collect(context.Context, *execbackend.Instance) (execbackend.ChangeSet, error) {
+	return execbackend.ChangeSet{}, nil
+}
+
+func (b *ledgerTestBackend) Cancel(context.Context, *execbackend.Instance) error {
+	b.cancels++
+	return b.cancelErr
+}
+
+func (b *ledgerTestBackend) Destroy(context.Context, *execbackend.Instance) error {
+	b.destroys++
+	return b.destroyErr
+}
+
+func (b *ledgerTestBackend) Reap(context.Context) ([]string, error) {
+	return append([]string(nil), b.report.Destroyed...), b.reapErr
+}
+
+func (b *ledgerTestBackend) ReapInventory(context.Context) (execbackend.ReapReport, error) {
+	return b.report, b.reapErr
+}
+
+func TestExecBackendLedgerReservesBeforeProviderProvision(t *testing.T) {
+	store := openExecBackendLedgerTestStore(t)
+	key := db.ExecBackendAttemptKey{JobID: "job-order", Attempt: 1, LifecycleGeneration: 4}
+	providerObservedReservation := false
+	inner := &ledgerTestBackend{}
+	inner.provision = func(scope execbackend.JobScope) (*execbackend.Instance, error) {
+		attempt, err := store.GetExecBackendAttempt(context.Background(), key)
+		if err != nil {
+			t.Fatalf("provider entered before reservation: %v", err)
+		}
+		if attempt.State != db.ExecBackendAttemptStateProvisioning || attempt.SandboxID != nil {
+			t.Fatalf("row at provider entry = %+v, want provisioning without sandbox id", attempt)
+		}
+		if scope.Attempt != 1 || scope.DaemonFencingToken != "fence-order" {
+			t.Fatalf("provider scope = %+v", scope)
+		}
+		providerObservedReservation = true
+		return &execbackend.Instance{ID: "sandbox-order", JobID: scope.JobID, LifecycleGeneration: scope.LifecycleGeneration}, nil
+	}
+	backend := newExecBackendLedgerForTest(t, store, inner, nil, "fence-order", "boot-order")
+	backend.now = func() time.Time { return time.Date(2026, 8, 29, 12, 0, 0, 0, time.UTC) }
+	instance, err := backend.Provision(context.Background(), execbackend.JobScope{JobID: key.JobID, LifecycleGeneration: key.LifecycleGeneration, TTL: 5 * time.Minute})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !providerObservedReservation || instance.ID != "sandbox-order" {
+		t.Fatalf("providerObservedReservation=%v instance=%+v", providerObservedReservation, instance)
+	}
+	attempt, err := store.GetExecBackendAttempt(context.Background(), key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if attempt.State != db.ExecBackendAttemptStateRunning || attempt.SandboxID == nil || *attempt.SandboxID != instance.ID {
+		t.Fatalf("running attempt = %+v", attempt)
+	}
+	if attempt.TTLExpiresAt != "2026-08-29T12:05:00Z" {
+		t.Fatalf("ttl_expires_at = %q", attempt.TTLExpiresAt)
+	}
+
+	errorStore := openExecBackendLedgerTestStore(t)
+	errorKey := db.ExecBackendAttemptKey{JobID: "job-ambiguous", Attempt: 1, LifecycleGeneration: 5}
+	errorInner := &ledgerTestBackend{provision: func(execbackend.JobScope) (*execbackend.Instance, error) {
+		attempt, err := errorStore.GetExecBackendAttempt(context.Background(), errorKey)
+		if err != nil || attempt.State != db.ExecBackendAttemptStateProvisioning {
+			t.Fatalf("ambiguous provider call did not have a provisioning row: attempt=%+v err=%v", attempt, err)
+		}
+		return nil, errors.New("ambiguous provider response")
+	}}
+	errorBackend := newExecBackendLedgerForTest(t, errorStore, errorInner, nil, "fence-ambiguous", "boot-ambiguous")
+	if _, err := errorBackend.Provision(context.Background(), execbackend.JobScope{JobID: errorKey.JobID, LifecycleGeneration: errorKey.LifecycleGeneration, TTL: time.Minute}); err == nil || !strings.Contains(err.Error(), "ambiguous provider response") {
+		t.Fatalf("ambiguous provision error = %v", err)
+	}
+	if got := execBackendAttemptForTest(t, errorStore, errorKey).State; got != db.ExecBackendAttemptStateProvisioning {
+		t.Fatalf("ambiguous provision attempt state = %q, want recoverable provisioning", got)
+	}
+}
+
+func TestExecBackendLedgerTeardownUpdatesEveryPath(t *testing.T) {
+	tests := []struct {
+		name        string
+		act         func(*ledgeredExecutionBackend, *execbackend.Instance) error
+		destroyErr  error
+		cancelErr   error
+		wantState   string
+		wantError   bool
+		wantDestroy int
+		wantCancel  int
+	}{
+		{name: "success", act: func(b *ledgeredExecutionBackend, i *execbackend.Instance) error {
+			return b.Destroy(context.Background(), i)
+		}, wantState: db.ExecBackendAttemptStateDestroyed, wantDestroy: 1},
+		{name: "failure", act: func(b *ledgeredExecutionBackend, i *execbackend.Instance) error {
+			return b.Destroy(context.Background(), i)
+		}, destroyErr: errors.New("delete failed"), wantState: db.ExecBackendAttemptStateDestroying, wantError: true, wantDestroy: 1},
+		{name: "cancel", act: func(b *ledgeredExecutionBackend, i *execbackend.Instance) error {
+			return b.Cancel(context.Background(), i)
+		}, wantState: db.ExecBackendAttemptStateDestroyed, wantCancel: 1},
+		{name: "panic", act: func(b *ledgeredExecutionBackend, i *execbackend.Instance) (err error) {
+			func() {
+				defer func() { _ = recover() }()
+				defer func() { err = b.Destroy(context.Background(), i) }()
+				panic("ledger panic path")
+			}()
+			return err
+		}, wantState: db.ExecBackendAttemptStateDestroyed, wantDestroy: 1},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			store := openExecBackendLedgerTestStore(t)
+			inner := &ledgerTestBackend{destroyErr: test.destroyErr, cancelErr: test.cancelErr}
+			backend := newExecBackendLedgerForTest(t, store, inner, nil, "fence-"+test.name, "boot-"+test.name)
+			instance, err := backend.Provision(context.Background(), execbackend.JobScope{JobID: "job-" + test.name, LifecycleGeneration: 2, TTL: time.Minute})
+			if err != nil {
+				t.Fatal(err)
+			}
+			err = test.act(backend, instance)
+			if (err != nil) != test.wantError {
+				t.Fatalf("teardown error = %v, wantError=%v", err, test.wantError)
+			}
+			key := db.ExecBackendAttemptKey{JobID: "job-" + test.name, Attempt: 1, LifecycleGeneration: 2}
+			if got := execBackendAttemptForTest(t, store, key).State; got != test.wantState {
+				t.Fatalf("state = %q, want %q", got, test.wantState)
+			}
+			if inner.destroys != test.wantDestroy || inner.cancels != test.wantCancel {
+				t.Fatalf("destroy calls=%d cancel calls=%d, want %d/%d", inner.destroys, inner.cancels, test.wantDestroy, test.wantCancel)
+			}
+		})
+	}
+
+	t.Run("startup reap", func(t *testing.T) {
+		store := openExecBackendLedgerTestStore(t)
+		key := seedRunningExecBackendAttempt(t, store, "job-reap", "sandbox-reap", "fence-reap", "boot-reap")
+		inner := &ledgerTestBackend{report: execbackend.ReapReport{
+			InventoryObserved: true,
+			Inventory:         []execbackend.ProviderInstance{{ID: "sandbox-reap", JobID: key.JobID, Attempt: key.Attempt, LifecycleGeneration: key.LifecycleGeneration, DaemonFencingToken: "fence-reap", BootID: "boot-reap"}},
+			Destroyed:         []string{"sandbox-reap"},
+		}}
+		backend := newExecBackendLedgerForTest(t, store, inner, nil, "fence-current", "boot-current")
+		if reaped, err := backend.Reap(context.Background()); err != nil {
+			t.Fatal(err)
+		} else if !reflect.DeepEqual(reaped, []string{"sandbox-reap"}) {
+			t.Fatalf("reaped = %v", reaped)
+		}
+		if got := execBackendAttemptForTest(t, store, key).State; got != db.ExecBackendAttemptStateOrphaned {
+			t.Fatalf("startup-reaped state = %q, want orphaned", got)
+		}
+	})
+}
+
+func TestExecBackendLedgerReconcilesBothInventoryDirections(t *testing.T) {
+	store := openExecBackendLedgerTestStore(t)
+	ledgerOnly := seedRunningExecBackendAttempt(t, store, "job-ledger-only", "sandbox-ledger-only", "fence-ledger", "boot-ledger")
+	crashKey := db.ExecBackendAttemptKey{JobID: "job-crash", Attempt: 1, LifecycleGeneration: 8}
+	if err := store.ReserveExecBackendAttempt(context.Background(), db.ExecBackendAttemptReservation{
+		ExecBackendAttemptKey: crashKey, Provider: e2bAttemptProvider, DaemonFencingToken: "fence-crash", BootID: "boot-crash", TTLExpiresAt: time.Now().Add(time.Minute),
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if changed, err := store.MarkExecBackendAttemptProvisioning(context.Background(), crashKey); err != nil || !changed {
+		t.Fatalf("mark crash row provisioning: changed=%v err=%v", changed, err)
+	}
+	inner := &ledgerTestBackend{report: execbackend.ReapReport{InventoryObserved: true, Inventory: []execbackend.ProviderInstance{
+		{ID: "sandbox-provider-only", JobID: "job-provider-only", Attempt: 1, LifecycleGeneration: 1, DaemonFencingToken: "foreign-fence", BootID: "foreign-boot"},
+		{ID: "sandbox-crash", JobID: crashKey.JobID, Attempt: crashKey.Attempt, LifecycleGeneration: crashKey.LifecycleGeneration, DaemonFencingToken: "fence-crash", BootID: "boot-crash"},
+	}}}
+	var output bytes.Buffer
+	backend := newExecBackendLedgerForTest(t, store, inner, &output, "fence-current", "boot-current")
+	if _, err := backend.ReapInventory(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if got := output.String(); !strings.Contains(got, "provider sandbox sandbox-provider-only has no matching ledger row") || !strings.Contains(got, "ledger sandbox sandbox-ledger-only was not observed in provider inventory") {
+		t.Fatalf("recovery output did not name both mismatch directions:\n%s", got)
+	}
+	crash := execBackendAttemptForTest(t, store, crashKey)
+	if crash.State != db.ExecBackendAttemptStateRunning || crash.SandboxID == nil || *crash.SandboxID != "sandbox-crash" {
+		t.Fatalf("crash-window attempt = %+v, want recovered running sandbox", crash)
+	}
+	if got := execBackendAttemptForTest(t, store, ledgerOnly).State; got != db.ExecBackendAttemptStateRunning {
+		t.Fatalf("ledger-only attempt state = %q, want running without authoritative absence", got)
+	}
+}
+
+func TestExecBackendLedgerRefusesIncompleteInventory(t *testing.T) {
+	for _, test := range []struct {
+		name    string
+		reapErr error
+		wantErr string
+	}{
+		{name: "provider error", reapErr: errors.New("provider list failed"), wantErr: "provider list failed"},
+		{name: "silent unavailable report", wantErr: "provider inventory was not observed"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			store := openExecBackendLedgerTestStore(t)
+			key := seedRunningExecBackendAttempt(t, store, "job-incomplete", "sandbox-incomplete", "fence-incomplete", "boot-incomplete")
+			inner := &ledgerTestBackend{reapErr: test.reapErr}
+			var output bytes.Buffer
+			backend := newExecBackendLedgerForTest(t, store, inner, &output, "fence-current", "boot-current")
+			if _, err := backend.ReapInventory(context.Background()); err == nil || !strings.Contains(err.Error(), test.wantErr) {
+				t.Fatalf("incomplete inventory error = %v, want %q", err, test.wantErr)
+			}
+			if got := execBackendAttemptForTest(t, store, key).State; got != db.ExecBackendAttemptStateRunning {
+				t.Fatalf("incomplete inventory changed ledger state to %q, want running", got)
+			}
+			if output.Len() != 0 {
+				t.Fatalf("incomplete inventory produced mismatch conclusions: %q", output.String())
+			}
+		})
+	}
+}
+
+func openExecBackendLedgerTestStore(t *testing.T) *db.Store {
+	t.Helper()
+	store, err := dbtest.Open(t, filepath.Join(t.TempDir(), "ledger.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+	return store
+}
+
+func newExecBackendLedgerForTest(t *testing.T, store *db.Store, inner *ledgerTestBackend, output *bytes.Buffer, fencingToken, bootID string) *ledgeredExecutionBackend {
+	t.Helper()
+	backend, err := newLedgeredExecutionBackend(store, inner, e2bAttemptProvider, fencingToken, bootID, output)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return backend
+}
+
+func seedRunningExecBackendAttempt(t *testing.T, store *db.Store, jobID, sandboxID, fencingToken, bootID string) db.ExecBackendAttemptKey {
+	t.Helper()
+	key := db.ExecBackendAttemptKey{JobID: jobID, Attempt: 1, LifecycleGeneration: 3}
+	if err := store.ReserveExecBackendAttempt(context.Background(), db.ExecBackendAttemptReservation{
+		ExecBackendAttemptKey: key, Provider: e2bAttemptProvider, DaemonFencingToken: fencingToken, BootID: bootID, TTLExpiresAt: time.Now().Add(time.Minute),
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if changed, err := store.MarkExecBackendAttemptProvisioning(context.Background(), key); err != nil || !changed {
+		t.Fatalf("mark provisioning: changed=%v err=%v", changed, err)
+	}
+	if changed, err := store.MarkExecBackendAttemptRunning(context.Background(), key, sandboxID); err != nil || !changed {
+		t.Fatalf("mark running: changed=%v err=%v", changed, err)
+	}
+	return key
+}
+
+func execBackendAttemptForTest(t *testing.T, store *db.Store, key db.ExecBackendAttemptKey) db.ExecBackendAttempt {
+	t.Helper()
+	attempt, err := store.GetExecBackendAttempt(context.Background(), key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return attempt
+}

--- a/internal/cli/execbackend_lifecycle.go
+++ b/internal/cli/execbackend_lifecycle.go
@@ -28,6 +28,8 @@ const executionBackendReapTimeout = 30 * time.Second
 
 var reapedExecutionBackendRoots sync.Map
 
+var executionBackendFencingToken = sync.OnceValues(newRuntimeLockOwnerToken)
+
 func (w jobWorker) defaultExecutionBackend(backend execbackend.Backend) (execbackend.ExecutionBackend, error) {
 	return execbackend.Consume(backend, func() (execbackend.ExecutionBackend, error) {
 		home := strings.TrimSpace(w.workflowHome())
@@ -90,6 +92,14 @@ func (w jobWorker) defaultExecutionBackend(backend execbackend.Backend) (execbac
 		if err != nil {
 			return nil, err
 		}
+		fencingToken, err := executionBackendFencingToken()
+		if err != nil {
+			return nil, fmt.Errorf("create execution backend daemon fencing token: %w", err)
+		}
+		ledgeredBackend, err := newLedgeredExecutionBackend(w.Store, remoteBackend, e2bAttemptProvider, fencingToken, db.BootID(), w.Stdout)
+		if err != nil {
+			return nil, err
+		}
 		baseURL := strings.TrimSpace(cfg.E2BBaseURL)
 		if baseURL == "" {
 			baseURL = e2b.DefaultBaseURL
@@ -99,13 +109,13 @@ func (w jobWorker) defaultExecutionBackend(backend execbackend.Backend) (execbac
 		if _, loaded := reapedExecutionBackendRoots.LoadOrStore(reapKey, struct{}{}); !loaded {
 			reapCtx, cancel := context.WithTimeout(context.Background(), executionBackendReapTimeout)
 			defer cancel()
-			var reaper execbackend.Reaper = remoteBackend
+			var reaper execbackend.Reaper = ledgeredBackend
 			if _, err := reaper.Reap(reapCtx); err != nil {
 				reapedExecutionBackendRoots.Delete(reapKey)
 				return nil, fmt.Errorf("reap remote execution backends: %w", err)
 			}
 		}
-		return remoteBackend, nil
+		return ledgeredBackend, nil
 	})
 }
 
@@ -139,7 +149,10 @@ func (w jobWorker) provisionExecutionBackend(ctx context.Context, backend execba
 	}
 	instance, err := lifecycle.Provision(ctx, execbackend.JobScope{JobID: job.ID, LifecycleGeneration: job.LifecycleGeneration, TTL: ttl})
 	if err != nil {
-		return nil, nil, fmt.Errorf("provision %s execution backend for job %s: %w", backend, job.ID, err)
+		// A provider can create an instance and then fail to persist its handle in
+		// the ledger. Preserve both values so the caller installs its teardown defer
+		// before handling the error; discarding them here strands a billed sandbox.
+		return lifecycle, instance, fmt.Errorf("provision %s execution backend for job %s: %w", backend, job.ID, err)
 	}
 	if err := lifecycle.SyncIn(ctx, instance, execbackend.Materials{SourceWorktree: checkout}); err != nil {
 		return lifecycle, instance, fmt.Errorf("sync job %s into %s execution backend: %w", job.ID, backend, err)

--- a/internal/cli/execbackend_lifecycle_e2e_test.go
+++ b/internal/cli/execbackend_lifecycle_e2e_test.go
@@ -864,6 +864,15 @@ printf '%s' '{"gitmoot_result":{"decision":"implemented","summary":"remote backe
 	if fmt.Sprint(deleted) != "[sandbox-1]" {
 		t.Fatalf("provider deletes = %v, want exactly [sandbox-1]", deleted)
 	}
+	attempt, err := store.GetExecBackendAttempt(ctx, db.ExecBackendAttemptKey{
+		JobID: job.ID, Attempt: 1, LifecycleGeneration: job.LifecycleGeneration,
+	})
+	if err != nil {
+		t.Fatalf("get remote execution ledger attempt: %v", err)
+	}
+	if attempt.State != db.ExecBackendAttemptStateDestroyed || attempt.SandboxID == nil || *attempt.SandboxID != "sandbox-1" {
+		t.Fatalf("remote execution ledger attempt = %+v, want destroyed sandbox-1", attempt)
+	}
 	if _, err := os.Stat(harness.workspace); !os.IsNotExist(err) {
 		t.Fatalf("sandbox workspace still exists after provider deletion: %v", err)
 	}

--- a/internal/db/store_execbackend_attempts.go
+++ b/internal/db/store_execbackend_attempts.go
@@ -239,6 +239,37 @@ func (s *Store) ListExecBackendAttemptsWithoutSandboxID(ctx context.Context) ([]
 	return attempts, rows.Err()
 }
 
+// ListRecoverableExecBackendAttempts returns every active row for one provider.
+// Terminal rows make no claim that a sandbox remains live; if a provider later
+// reports one with only a terminal-row identity, recovery surfaces it as a
+// provider-only allocation rather than silently reviving terminal evidence.
+func (s *Store) ListRecoverableExecBackendAttempts(ctx context.Context, provider string) ([]ExecBackendAttempt, error) {
+	provider = strings.TrimSpace(provider)
+	if provider == "" {
+		return nil, errors.New("execution backend provider is required")
+	}
+	rows, err := s.db.QueryContext(ctx, `SELECT `+execBackendAttemptColumns+`
+		FROM execbackend_attempts
+		WHERE provider = ? AND state NOT IN (?, ?, ?)
+		ORDER BY job_id, lifecycle_generation, attempt`,
+		provider, ExecBackendAttemptStateDestroyed, ExecBackendAttemptStateOrphaned,
+		ExecBackendAttemptStateFailed)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var attempts []ExecBackendAttempt
+	for rows.Next() {
+		attempt, err := scanExecBackendAttempt(rows)
+		if err != nil {
+			return nil, err
+		}
+		attempts = append(attempts, attempt)
+	}
+	return attempts, rows.Err()
+}
+
 func scanExecBackendAttempt(row interface{ Scan(...any) error }) (ExecBackendAttempt, error) {
 	var (
 		attempt      ExecBackendAttempt

--- a/internal/db/store_execbackend_attempts_test.go
+++ b/internal/db/store_execbackend_attempts_test.go
@@ -35,7 +35,7 @@ func TestMigrateAddsExecBackendAttempts(t *testing.T) {
 		t.Fatalf("sql.Open: %v", err)
 	}
 	preMigration := &Store{db: raw}
-	for version, migration := range migrationsBefore(t, "CREATE TABLE execbackend_attempts") {
+	for version, migration := range migrationsBefore(t, "lifecycle_generation INTEGER,\n\tprovider TEXT NOT NULL") {
 		if err := preMigration.applyMigration(ctx, version+1, migration); err != nil {
 			t.Fatalf("applyMigration(%d): %v", version+1, err)
 		}
@@ -55,6 +55,63 @@ func TestMigrateAddsExecBackendAttempts(t *testing.T) {
 	}
 	t.Cleanup(func() { _ = upgraded.Close() })
 	assertExecBackendAttemptsTable(t, ctx, upgraded, "upgraded database")
+}
+
+func TestMigrateExecBackendAttemptsLifecycleGenerationNotNullPreservesRows(t *testing.T) {
+	ctx := context.Background()
+	path := filepath.Join(t.TempDir(), "upgrade-not-null.db")
+	raw, err := sql.Open("sqlite", path)
+	if err != nil {
+		t.Fatalf("sql.Open: %v", err)
+	}
+	preMigration := &Store{db: raw}
+	for version, migration := range migrationsBefore(t, "ALTER TABLE execbackend_attempts RENAME TO execbackend_attempts_nullable_generation") {
+		if err := preMigration.applyMigration(ctx, version+1, migration); err != nil {
+			t.Fatalf("applyMigration(%d): %v", version+1, err)
+		}
+	}
+	if _, err := raw.ExecContext(ctx, `INSERT INTO execbackend_attempts(
+		job_id, attempt, lifecycle_generation, provider, daemon_fencing_token,
+		boot_id, ttl_expires_at, state
+	) VALUES ('preserved', 1, 7, 'e2b', 'fence', 'boot', '2026-08-29T12:00:00Z', 'reserved')`); err != nil {
+		t.Fatalf("seed pre-fix row: %v", err)
+	}
+	if err := raw.Close(); err != nil {
+		t.Fatalf("close pre-migration database: %v", err)
+	}
+
+	upgraded, err := openRealTestStore(t, path)
+	if err != nil {
+		t.Fatalf("open upgraded store: %v", err)
+	}
+	t.Cleanup(func() { _ = upgraded.Close() })
+	assertExecBackendAttemptsTable(t, ctx, upgraded, "NOT NULL upgraded database")
+	if attempt, err := upgraded.GetExecBackendAttempt(ctx, ExecBackendAttemptKey{JobID: "preserved", Attempt: 1, LifecycleGeneration: 7}); err != nil {
+		t.Fatalf("read preserved row: %v", err)
+	} else if attempt.State != ExecBackendAttemptStateReserved {
+		t.Fatalf("preserved row state = %q, want reserved", attempt.State)
+	}
+}
+
+func TestExecBackendAttemptLifecycleGenerationEnforcedBySchema(t *testing.T) {
+	store, err := openCachedTestStore(t, filepath.Join(t.TempDir(), "schema.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+	ctx := context.Background()
+	for i := 0; i < 2; i++ {
+		if _, err := store.db.ExecContext(ctx, `INSERT INTO execbackend_attempts(
+			job_id, attempt, lifecycle_generation, provider, daemon_fencing_token,
+			boot_id, ttl_expires_at, state
+		) VALUES ('null-generation', 1, NULL, 'e2b', 'fence', 'boot', '2026-08-29T12:00:00Z', 'reserved')`); err == nil {
+			t.Fatalf("raw NULL lifecycle generation insert %d succeeded", i+1)
+		}
+	}
+	reservation := testExecBackendReservation(ExecBackendAttemptKey{JobID: "negative-generation", Attempt: 1, LifecycleGeneration: -1})
+	if err := store.ReserveExecBackendAttempt(ctx, reservation); err == nil {
+		t.Fatal("negative lifecycle generation succeeded")
+	}
 }
 
 func TestReserveExecBackendAttempt(t *testing.T) {
@@ -185,7 +242,7 @@ func assertExecBackendAttemptsTable(t *testing.T, ctx context.Context, store *St
 	want := []columnContract{
 		{name: "job_id", typeName: "TEXT", notNull: true, pk: 1},
 		{name: "attempt", typeName: "INTEGER", notNull: true, pk: 2},
-		{name: "lifecycle_generation", typeName: "INTEGER", pk: 3},
+		{name: "lifecycle_generation", typeName: "INTEGER", notNull: true, pk: 3},
 		{name: "provider", typeName: "TEXT", notNull: true},
 		{name: "sandbox_id", typeName: "TEXT"},
 		{name: "daemon_fencing_token", typeName: "TEXT", notNull: true},

--- a/internal/db/store_migrations.go
+++ b/internal/db/store_migrations.go
@@ -2153,4 +2153,44 @@ CREATE TABLE org_archive_pending (
 	observed_at TEXT NOT NULL
 );
 	`,
+	// #1634 closes the NULL-primary-key gap in the execution-backend ledger.
+	// SQLite permits multiple NULL values in a composite non-rowid PRIMARY KEY,
+	// so lifecycle_generation must be constrained by the schema rather than only
+	// by Go callers. Rebuild at the append-only tail because SQLite cannot add a
+	// NOT NULL constraint to an existing column in place. The INSERT deliberately
+	// fails closed if an unexpected historical NULL exists; silently dropping or
+	// coalescing such a row would erase evidence of an allocation attempt.
+	`
+ALTER TABLE execbackend_attempts RENAME TO execbackend_attempts_nullable_generation;
+CREATE TABLE execbackend_attempts (
+	job_id TEXT NOT NULL,
+	attempt INTEGER NOT NULL,
+	lifecycle_generation INTEGER NOT NULL CHECK(lifecycle_generation >= 0),
+	provider TEXT NOT NULL,
+	sandbox_id TEXT,
+	daemon_fencing_token TEXT NOT NULL,
+	boot_id TEXT NOT NULL,
+	ttl_expires_at TIMESTAMP NOT NULL,
+	state TEXT NOT NULL CHECK(state IN (
+		'reserved', 'provisioning', 'running', 'collecting', 'destroying',
+		'destroyed', 'orphaned', 'failed'
+	)),
+	cost_reserved_usd REAL,
+	cost_actual_usd REAL,
+	created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+	updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+	PRIMARY KEY (job_id, attempt, lifecycle_generation)
+);
+INSERT INTO execbackend_attempts(
+	job_id, attempt, lifecycle_generation, provider, sandbox_id,
+	daemon_fencing_token, boot_id, ttl_expires_at, state,
+	cost_reserved_usd, cost_actual_usd, created_at, updated_at
+)
+SELECT
+	job_id, attempt, lifecycle_generation, provider, sandbox_id,
+	daemon_fencing_token, boot_id, ttl_expires_at, state,
+	cost_reserved_usd, cost_actual_usd, created_at, updated_at
+FROM execbackend_attempts_nullable_generation;
+DROP TABLE execbackend_attempts_nullable_generation;
+	`,
 }

--- a/internal/db/test_store_cache_test.go
+++ b/internal/db/test_store_cache_test.go
@@ -85,6 +85,7 @@ func TestStoreOpenPolicy(t *testing.T) {
 		"TestTaskEventsMigrationAppliesToExistingDatabase":        true,
 		"TestWorkflowMetaTextMigrations":                          true,
 	}
+	realPathTests["TestMigrateExecBackendAttemptsLifecycleGenerationNotNullPreservesRows"] = true
 	directOpenFunctions := map[string]bool{
 		"ensureCachedMigratedTestTemplateOnce": true,
 		"openRealTestStore":                    true,

--- a/internal/execbackend/lifecycle.go
+++ b/internal/execbackend/lifecycle.go
@@ -44,9 +44,43 @@ type Reaper interface {
 	Reap(context.Context) ([]string, error)
 }
 
-type JobScope struct {
+// ProviderInstance is the durable identity exposed by a provider inventory.
+// It intentionally omits credentials and data-plane details: recovery only
+// needs enough information to match one live allocation to its ledger row.
+type ProviderInstance struct {
+	ID                  string
 	JobID               string
+	Attempt             int
 	LifecycleGeneration int64
+	DaemonFencingToken  string
+	BootID              string
+}
+
+// ReapReport keeps the inventory that a reaper inspected beside the subset it
+// destroyed. InventoryObserved means the provider returned a valid inventory;
+// InventoryComplete additionally means its contract proves that inventory is
+// exhaustive. Recovery may always use positive observations, but may infer
+// absence only from a complete inventory.
+type ReapReport struct {
+	InventoryObserved bool
+	InventoryComplete bool
+	Inventory         []ProviderInstance
+	Destroyed         []string
+}
+
+// InventoryReaper is implemented by providers whose account observations can
+// be reconciled against the durable execution-attempt ledger.
+type InventoryReaper interface {
+	ReapInventory(context.Context) (ReapReport, error)
+}
+
+type JobScope struct {
+	JobID string
+	// Attempt is one provider allocation within a lifecycle generation. Zero is
+	// accepted as the legacy/default spelling of the first attempt.
+	Attempt             int
+	LifecycleGeneration int64
+	DaemonFencingToken  string
 	TTL                 time.Duration
 }
 

--- a/internal/execbackend/remote/backend.go
+++ b/internal/execbackend/remote/backend.go
@@ -27,7 +27,9 @@ const (
 	syncArchivePath = "/home/user/.gitmoot-sync.tar.gz"
 
 	metadataJobID               = "job_id"
+	metadataAttempt             = "attempt"
 	metadataLifecycleGeneration = "lifecycle_generation"
+	metadataDaemonFencingToken  = "daemon_fencing_token"
 	metadataBootID              = "boot_id"
 	metadataOwnerPID            = "owner_pid"
 	metadataOwnerPIDNamespace   = "owner_pid_namespace"
@@ -92,6 +94,7 @@ type sandboxState struct {
 
 var _ execbackend.ExecutionBackend = (*Backend)(nil)
 var _ execbackend.Reaper = (*Backend)(nil)
+var _ execbackend.InventoryReaper = (*Backend)(nil)
 
 // NewBackend constructs an unwired E2B lifecycle provider.
 func NewBackend(client *e2b.Client, options Options) (*Backend, error) {
@@ -129,13 +132,24 @@ func (b *Backend) Provision(ctx context.Context, scope execbackend.JobScope) (*e
 	if scope.TTL <= 0 {
 		return nil, errors.New("remote execution backend TTL must be positive")
 	}
+	attempt := scope.Attempt
+	if attempt == 0 {
+		attempt = 1
+	}
+	if attempt < 1 {
+		return nil, errors.New("remote execution backend attempt must be positive")
+	}
 	metadata := map[string]string{
 		metadataJobID:               jobID,
+		metadataAttempt:             strconv.Itoa(attempt),
 		metadataLifecycleGeneration: strconv.FormatInt(scope.LifecycleGeneration, 10),
 		metadataBootID:              b.bootID,
 		metadataOwnerPID:            strconv.Itoa(b.ownerPID),
 		metadataOwnerPIDNamespace:   b.pidNamespace,
 		metadataOwnerStartTime:      b.ownerStart,
+	}
+	if token := strings.TrimSpace(scope.DaemonFencingToken); token != "" {
+		metadata[metadataDaemonFencingToken] = token
 	}
 	sandbox, credential, err := b.client.Create(ctx, b.templateID, scope.TTL, e2b.CreateOptions{Metadata: metadata})
 	if err != nil {
@@ -365,17 +379,45 @@ func (b *Backend) Destroy(ctx context.Context, instance *execbackend.Instance) e
 // kernel. Require both identities before interpreting PID/start-time liveness,
 // so one container cannot reap another container's live sandbox.
 func (b *Backend) Reap(ctx context.Context) ([]string, error) {
+	report, err := b.ReapInventory(ctx)
+	return report.Destroyed, err
+}
+
+// ReapInventory returns the provider observations used for the reap decision
+// and the directly deleted subset. E2B cannot prove all-state completeness, so
+// consumers may reconcile positive observations but not infer absence.
+func (b *Backend) ReapInventory(ctx context.Context) (execbackend.ReapReport, error) {
 	if b == nil {
-		return nil, errors.New("remote execution backend is nil")
+		return execbackend.ReapReport{}, errors.New("remote execution backend is nil")
 	}
 	sandboxes, err := b.client.List(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("list remote execution sandboxes for reap: %w", err)
+		return execbackend.ReapReport{}, fmt.Errorf("list remote execution sandboxes for reap: %w", err)
+	}
+	report := execbackend.ReapReport{
+		// E2B has no all-state total. A successful List proves every returned
+		// sandbox exists, but a dropped continuation header can still hide a
+		// later page, so absence from this inventory is not authoritative.
+		InventoryObserved: true,
+		Inventory:         make([]execbackend.ProviderInstance, 0, len(sandboxes)),
 	}
 	var reaped []string
 	var reapErrs []error
 	for _, sandbox := range sandboxes {
 		metadata := sandbox.Metadata
+		attempt, _ := strconv.Atoi(strings.TrimSpace(metadata[metadataAttempt]))
+		generation := int64(-1)
+		if parsed, parseErr := strconv.ParseInt(strings.TrimSpace(metadata[metadataLifecycleGeneration]), 10, 64); parseErr == nil && parsed >= 0 {
+			generation = parsed
+		}
+		report.Inventory = append(report.Inventory, execbackend.ProviderInstance{
+			ID:                  sandbox.ID,
+			JobID:               strings.TrimSpace(metadata[metadataJobID]),
+			Attempt:             attempt,
+			LifecycleGeneration: generation,
+			DaemonFencingToken:  strings.TrimSpace(metadata[metadataDaemonFencingToken]),
+			BootID:              strings.TrimSpace(metadata[metadataBootID]),
+		})
 		if strings.TrimSpace(metadata[metadataBootID]) == "" || strings.TrimSpace(metadata[metadataBootID]) != b.bootID {
 			continue
 		}
@@ -396,7 +438,8 @@ func (b *Backend) Reap(ctx context.Context) ([]string, error) {
 		b.mu.Unlock()
 		reaped = append(reaped, sandbox.ID)
 	}
-	return reaped, errors.Join(reapErrs...)
+	report.Destroyed = reaped
+	return report, errors.Join(reapErrs...)
 }
 
 func matchingNonEmptyIdentity(left, right string) bool {

--- a/internal/execbackend/remote/backend_test.go
+++ b/internal/execbackend/remote/backend_test.go
@@ -45,7 +45,9 @@ func TestRemoteProvisionRequiresTTLAndRecordsOwnership(t *testing.T) {
 
 	instance, err := backend.Provision(context.Background(), execbackend.JobScope{
 		JobID:               "job-1",
+		Attempt:             3,
 		LifecycleGeneration: 9,
+		DaemonFencingToken:  "daemon-fence-test",
 		TTL:                 90 * time.Second,
 	})
 	if err != nil {
@@ -55,7 +57,7 @@ func TestRemoteProvisionRequiresTTLAndRecordsOwnership(t *testing.T) {
 		t.Fatalf("instance = %+v", instance)
 	}
 	request := harness.lastCreate()
-	if request.Timeout != 90 || request.Metadata[metadataJobID] != "job-1" || request.Metadata[metadataLifecycleGeneration] != "9" || request.Metadata[metadataBootID] != "boot-test" || request.Metadata[metadataOwnerPID] != "1234" || request.Metadata[metadataOwnerPIDNamespace] != "pid:[test]" || request.Metadata[metadataOwnerStartTime] != "5678" {
+	if request.Timeout != 90 || request.Metadata[metadataJobID] != "job-1" || request.Metadata[metadataAttempt] != "3" || request.Metadata[metadataLifecycleGeneration] != "9" || request.Metadata[metadataDaemonFencingToken] != "daemon-fence-test" || request.Metadata[metadataBootID] != "boot-test" || request.Metadata[metadataOwnerPID] != "1234" || request.Metadata[metadataOwnerPIDNamespace] != "pid:[test]" || request.Metadata[metadataOwnerStartTime] != "5678" {
 		t.Fatalf("create request = %+v", request)
 	}
 }
@@ -155,14 +157,40 @@ func TestRemoteReapScopesOwnerLivenessToPIDNamespace(t *testing.T) {
 		{ID: "stale-local", TemplateID: "template-test", State: "paused", Metadata: map[string]string{
 			metadataBootID: reaper.bootID, metadataOwnerPIDNamespace: reaper.pidNamespace, metadataOwnerPID: "2147483647", metadataOwnerStartTime: "2",
 		}},
+		{ID: "malformed-generation", TemplateID: "template-test", State: "running", Metadata: map[string]string{
+			metadataJobID: "malformed", metadataAttempt: "1", metadataLifecycleGeneration: "not-an-integer",
+			metadataDaemonFencingToken: "fence-malformed", metadataBootID: reaper.bootID,
+		}},
 	})
 
-	reaped, err := reaper.Reap(context.Background())
+	report, err := reaper.ReapInventory(context.Background())
 	if err != nil {
 		t.Fatal(err)
 	}
+	if !report.InventoryObserved || report.InventoryComplete {
+		t.Fatalf("E2B inventory authority = observed:%v complete:%v, want true/false", report.InventoryObserved, report.InventoryComplete)
+	}
+	reaped := report.Destroyed
 	if !reflect.DeepEqual(reaped, []string{"stale-local"}) {
 		t.Fatalf("reaped = %v", reaped)
+	}
+	var foundForeignOwner, foundMalformedGeneration bool
+	for _, instance := range report.Inventory {
+		switch instance.ID {
+		case "foreign-namespace-live":
+			foundForeignOwner = true
+			if instance.JobID != "foreign-live" || instance.Attempt != 1 || instance.LifecycleGeneration != 0 || instance.BootID != reaper.bootID {
+				t.Fatalf("inventory identity = %+v", instance)
+			}
+		case "malformed-generation":
+			foundMalformedGeneration = true
+			if instance.LifecycleGeneration != -1 {
+				t.Fatalf("malformed generation identity = %+v, want unmatchable generation -1", instance)
+			}
+		}
+	}
+	if !foundForeignOwner || !foundMalformedGeneration {
+		t.Fatalf("inventory omitted provisioned sandbox: %+v", report.Inventory)
 	}
 	if got := harness.deletedIDs(); !reflect.DeepEqual(got, []string{"stale-local"}) {
 		t.Fatalf("deleted sandboxes = %v; foreign scope and live owner must remain", got)


### PR DESCRIPTION
WHAT:
GITMOOT-IMPL wired the execbackend_attempts ledger from base HEAD 18ba30ae1d753a5540a35af33eeabbfc6778fde5. Remote provisioning now reserves before provider allocation, all teardown paths persist outcomes, and recovery reconciles positive provider observations without treating an incomplete E2B inventory as proof of absence.

WHY:
Gitmoot finalized this implementation from a task worktree.

CHANGES:
- Committed changes from /root/.gitmoot/worktrees/gitmoot--gitmoot/adhoc-4a70b140

RESULTS:
- Baseline targeted ledger matrix: MATCH_COUNT=5, PASS.
- Offline lifecycle E2E/startup-reap matrix: MATCH_COUNT=3, PASS; httptest only, no live E2B calls or sandboxes. Live sandbox count attributable to this work: 0.
- Remote metadata/reaper matrix: MATCH_COUNT=2, PASS. Database migration/schema matrix: MATCH_COUNT=5, PASS.
- Compile checks: go test -c -o /dev/null for ./internal/db, ./internal/execbackend/remote, and ./internal/cli all exit 0; zero .test binaries remain. git diff --check exits 0. Full suite was not run.
- Axis 1 mutants: discarding lifecycle/instance applied:true, compile:0, strength MATCH=1 FAIL, distinct MATCH=3 PASS; terminalizing ambiguous provision failure applied:true, compile:0, strength MATCH=1 FAIL, distinct MATCH=4 PASS.
- Axis 2 mutant removing the destroyed transition applied:true, compile:0, strength MATCH=1 FAIL, distinct MATCH=3 PASS.
- Axis 3 required mutant deleting the Go lifecycle-generation check applied-but-unobservable, compile:0: schema guard MATCH=1 PASS because SQLite still rejected NULL/negative values; distinct MATCH=4 PASS. Weakening the schema constraint applied:true, compile:0, strength MATCH=1 FAIL, distinct MATCH=4 PASS.
- Axis 4 mutants: suppress provider-only diagnostics applied:true, compile:0, strength MATCH=1 FAIL, distinct MATCH=4 PASS; corrupt inventory attempt metadata applied:true, compile:0, strength MATCH=1 FAIL, distinct MATCH=1 PASS.
- Authority and wiring mutants: bypass InventoryObserved applied:true, compile:0, strength MATCH=1 FAIL, distinct MATCH=4 PASS; return raw remote backend applied:true, compile:0, E2E MATCH=1 FAIL with missing ledger row, distinct MATCH=5 PASS.
- Environment disclosure: GITMOOT_STALE_RUNNING_AFTER was initially set to 4h; GITMOOT_ORG_ROLE, GOCACHE, and XDG_CACHE_HOME were initially unset. Every test/compile command scrubbed both Gitmoot variables and used GOCACHE=/tmp/gc-shared and XDG_CACHE_HOME=/tmp/xdg-cache-shared.

RISK:
Review the generated diff before merging.

TASK:
adhoc-4a70b140

AGENTS:
- wave-impl

RAW FINAL REVIEW OUTPUT:
````text
GITMOOT-IMPL wired the execbackend_attempts ledger from base HEAD 18ba30ae1d753a5540a35af33eeabbfc6778fde5. Remote provisioning now reserves before provider allocation, all teardown paths persist outcomes, and recovery reconciles positive provider observations without treating an incomplete E2B inventory as proof of absence.
````


---

## ⚠️ MERGE EVIDENCE: ONE REVIEW FAMILY, NOT TWO — READ THIS BEFORE CITING THIS PR AS PRECEDENT

This PR was merged on **one** model family's approval. The normal bar for this repo is two
independent families at one exact head. It was **not met**, and that is recorded here rather than
absorbed silently.

**Why the second family was unreachable — not skipped:**

| family | status |
|---|---|
| claude (`gm-review-opus`) | **APPROVED** at `74d60ba569eb22edfedd9142a6534811412263fa` |
| kimi (`gm-review-kimi`) | `403 You've reached your weekly (7-day) usage limit` — 3/3 attempts, **no reset date given** by the provider |
| codex | **excluded**: codex (`wave-impl`) implemented this PR, and #1145 correctly rejects a verdict authored by the implementing family |

A second same-family reader was attempted and is **mechanically unavailable** at this head: the
engine's review-loop guard and its `ready_to_merge` fix-pass guard both refuse, correctly.

**What the one review actually established** (it was thorough, and that is why this was acceptable):
- Mutant S-A — remove `NOT NULL` from the rebuilt table: **KILLED 4 of 4 guards**, including the
  decisive `raw NULL lifecycle generation insert 1 succeeded`. The load-bearing constraint is pinned.
- Mutant G — delete the Go check: **applied-but-unobservable**, which is the success condition once
  the constraint lives in the schema. The reviewer did **not** weaken the schema to manufacture a
  kill, and proved restoration by sha256-matching all touched files against their git blobs.
- Migration is **append-only** (zero deleted lines; the new entry is the slice tail).
- Live store read **read-only** (`immutable=1`): `execbackend_attempts` is at the old nullable schema
  with **row count 0**, so the rebuild copies nothing.
- CI at the merged head: **26 fetched, 26 completed, 26 success, 0 skipped, 0 bad.**

**Known open finding, deliberately not blocking:** the non-negative `CHECK (lifecycle_generation >= 0)`
has **no independent guard** — mutant S-B removes it while keeping `NOT NULL` and **survives**,
because the only negative-value assertion goes through `ReserveExecBackendAttempt` where the Go check
rejects `-1` before SQLite sees it. Consequence: *a future migration rebuild that drops the CHECK
ships with CI green.* It is redundant defence-in-depth (the value comes from a counter incremented
from 0 and cannot go negative through any production path), so it was accepted as a follow-up rather
than held. Tracked separately.

**Decision owner:** the repository owner, asked explicitly and answered in a completed turn, after
being shown that the wait alternative was unbounded (rolling 7-day window, no stated reset).
Merged by JARVIS, bound to the exact reviewed SHA with `--match-head-commit`.
