### PR TITLE
fix: bound native review dispatch

### DIFF
--- a/docs/pipelines.md
+++ b/docs/pipelines.md
@@ -522,8 +522,9 @@ stages:
   may merge after review and CI (see [Gate stages](#gate-stages)).
 - **Declared review suppresses native fan-out.** When an implement stage has a
   downstream `action: review` stage with `source` pointing to it, its job carries
-  `SkipNativeReviewFanout`. Gitmoot does not also enqueue the ordinary native
-  reviewers; without that declaration, native review behavior is unchanged.
+  `SkipNativeReviewFanout`. Gitmoot does not also enqueue native reviewers;
+  without that declaration, scheduling follows `[review].native_fanout_enabled`
+  (off by default, with repository overrides).
 - Still a **leaf** — it may mutate but never fan out.
 
 ### Source-bound review stages

--- a/internal/cli/agent_dispatch_test.go
+++ b/internal/cli/agent_dispatch_test.go
@@ -338,6 +338,64 @@ func TestCLIReviewLoopRefusesBothHeadResolutionBranches(t *testing.T) {
 	}
 }
 
+// The agent-identity loop guard never admits an unresolved requester. Production
+// dispatch resolves and authorizes the reviewer before DetectReviewLoop, so an
+// unregistered reviewer must fail closed without creating loop evidence or work.
+func TestCLIReviewLoopUnresolvableReviewerFailsClosedBeforeIdentityGuard(t *testing.T) {
+	ctx := context.Background()
+	fixture := newCLIReviewLoopFixture(t)
+	seedCLIReviewLoopVerdict(t, fixture.store, "prior-review", "same-head", "approved")
+
+	family, resolved, err := workflow.ResolveRuntimeFamily(ctx, fixture.store, "ghost-reviewer", "")
+	if err != nil {
+		t.Fatalf("ResolveRuntimeFamily: %v", err)
+	}
+	if resolved || family != "" {
+		t.Fatalf("fixture weakened: ghost-reviewer family = %q, resolved=%v; want unresolved", family, resolved)
+	}
+
+	adapterCalls := 0
+	previousFactory := localAgentDispatchRuntimeAdapterFor
+	localAgentDispatchRuntimeAdapterFor = func(string, runtime.Agent, string) (runtime.Adapter, error) {
+		adapterCalls++
+		return nil, errors.New("adapter must not be selected for an unresolved reviewer")
+	}
+	t.Cleanup(func() { localAgentDispatchRuntimeAdapterFor = previousFactory })
+
+	_, err = dispatchLocalAgentJob(ctx, fixture.store, localAgentDispatchRequest{
+		RepoFlag: "owner/repo", Agent: "ghost-reviewer", Action: "review", PullRequest: 227,
+		Branch: "main", HeadSHA: "same-head", Instructions: "Review unchanged head.", Home: fixture.home,
+	})
+	if err == nil || !strings.Contains(err.Error(), `agent "ghost-reviewer" not found`) {
+		t.Fatalf("dispatch error = %v, want fail-closed unregistered reviewer refusal", err)
+	}
+
+	jobs, listErr := fixture.store.ListJobs(ctx)
+	if listErr != nil {
+		t.Fatalf("ListJobs: %v", listErr)
+	}
+	if len(jobs) != 1 || jobs[0].ID != "prior-review" {
+		t.Fatalf("jobs = %+v, want only the prior succeeded review", jobs)
+	}
+	if got := countCLIJobEvents(t, fixture.store, "prior-review", workflow.ReviewLoopDetectedEventKind); got != 0 {
+		t.Fatalf("review_loop_detected events = %d, want zero before identity guard", got)
+	}
+	tasks, listErr := fixture.store.ListTasks(ctx)
+	if listErr != nil {
+		t.Fatalf("ListTasks: %v", listErr)
+	}
+	if len(tasks) != 0 {
+		t.Fatalf("tasks = %+v, want none before reviewer admission", tasks)
+	}
+	worktreeRoot := filepath.Join(config.PathsForHome(fixture.home).Home, "worktrees")
+	if _, statErr := os.Stat(worktreeRoot); !errors.Is(statErr, os.ErrNotExist) {
+		t.Fatalf("worktree root %q was created before refusal: %v", worktreeRoot, statErr)
+	}
+	if adapterCalls != 0 {
+		t.Fatalf("runtime adapter selected %d times, want zero", adapterCalls)
+	}
+}
+
 // TestCLIReviewLoopAllowsNewHeadAndMixedDecisions kills repo/PR-only and
 // decision-blind suppression mutants at the CLI preparation seam.
 func TestCLIReviewLoopAllowsNewHeadAndMixedDecisions(t *testing.T) {

--- a/internal/cli/agent_dispatch_test.go
+++ b/internal/cli/agent_dispatch_test.go
@@ -363,7 +363,7 @@ func TestCLIReviewLoopUnresolvableReviewerFailsClosedBeforeIdentityGuard(t *test
 	t.Cleanup(func() { localAgentDispatchRuntimeAdapterFor = previousFactory })
 
 	_, err = dispatchLocalAgentJob(ctx, fixture.store, localAgentDispatchRequest{
-		RepoFlag: "owner/repo", Agent: "ghost-reviewer", Action: "review", PullRequest: 227,
+		RepoFlag: "owner/repo", Agent: "ghost-reviewer", LeadAgent: "reviewer", Action: "review", PullRequest: 227,
 		Branch: "main", HeadSHA: "same-head", Instructions: "Review unchanged head.", Home: fixture.home,
 	})
 	if err == nil || !strings.Contains(err.Error(), `agent "ghost-reviewer" not found`) {

--- a/internal/cli/agent_dispatch_test.go
+++ b/internal/cli/agent_dispatch_test.go
@@ -249,6 +249,11 @@ func newCLIReviewLoopFixture(t *testing.T) cliReviewLoopFixture {
 
 func seedCLIReviewLoopVerdict(t *testing.T, store *db.Store, id, head, decision string) {
 	t.Helper()
+	seedCLIReviewLoopVerdictForAgent(t, store, "reviewer", id, head, decision)
+}
+
+func seedCLIReviewLoopVerdictForAgent(t *testing.T, store *db.Store, agent, id, head, decision string) {
+	t.Helper()
 	payload, err := json.Marshal(workflow.JobPayload{
 		Repo: "owner/repo", Branch: "main", PullRequest: 227, HeadSHA: head,
 		TaskID: "review-pr-227", ReviewRound: "review-1",
@@ -258,7 +263,7 @@ func seedCLIReviewLoopVerdict(t *testing.T, store *db.Store, id, head, decision 
 		t.Fatalf("Marshal verdict: %v", err)
 	}
 	if err := store.CreateJobWithEvent(context.Background(), db.Job{
-		ID: id, Agent: "reviewer", Type: "review", State: string(workflow.JobSucceeded), Payload: string(payload),
+		ID: id, Agent: agent, Type: "review", State: string(workflow.JobSucceeded), Payload: string(payload),
 	}, db.JobEvent{Kind: string(workflow.JobSucceeded), Message: decision}); err != nil {
 		t.Fatalf("CreateJobWithEvent(%s): %v", id, err)
 	}
@@ -344,7 +349,7 @@ func TestCLIReviewLoopRefusesBothHeadResolutionBranches(t *testing.T) {
 func TestCLIReviewLoopUnresolvableReviewerFailsClosedBeforeIdentityGuard(t *testing.T) {
 	ctx := context.Background()
 	fixture := newCLIReviewLoopFixture(t)
-	seedCLIReviewLoopVerdict(t, fixture.store, "prior-review", "same-head", "approved")
+	seedCLIReviewLoopVerdictForAgent(t, fixture.store, "ghost-reviewer", "prior-review", "same-head", "approved")
 
 	family, resolved, err := workflow.ResolveRuntimeFamily(ctx, fixture.store, "ghost-reviewer", "")
 	if err != nil {

--- a/internal/cli/daemon_scheduler_test.go
+++ b/internal/cli/daemon_scheduler_test.go
@@ -915,7 +915,9 @@ func TestRunQueuedJobsRefreshesImplementedHeadBeforeReviewDispatch(t *testing.T)
 		return adapter, nil
 	}
 	worker.WorkflowFactory = func(checkout string) workflow.Engine {
-		return daemonWorkflowEngine(store, github.NoopClient{}, checkout, "")
+		engine := daemonWorkflowEngine(store, github.NoopClient{}, checkout, "")
+		engine.NativeReviewFanoutEnabled = func(string) bool { return true }
+		return engine
 	}
 
 	if err := runQueuedJobsForRepo(ctx, worker, 1, "", ""); err != nil {
@@ -3395,7 +3397,9 @@ func TestRetryPendingJobAdvancementsRefreshesImplementedHeadBeforePreflight(t *t
 	}
 	worker := defaultJobWorker(store, io.Discard)
 	worker.WorkflowFactory = func(checkout string) workflow.Engine {
-		return daemonWorkflowEngine(store, github.NoopClient{}, checkout, "")
+		engine := daemonWorkflowEngine(store, github.NoopClient{}, checkout, "")
+		engine.NativeReviewFanoutEnabled = func(string) bool { return true }
+		return engine
 	}
 
 	if err := retryPendingJobAdvancements(ctx, worker, "", "", nil, newTickCandidates(worker.Store)); err != nil {

--- a/internal/cli/review_risk.go
+++ b/internal/cli/review_risk.go
@@ -10,28 +10,29 @@ import (
 	"github.com/gitmoot/gitmoot/internal/workflow"
 )
 
-// loadReviewPolicy reads the [review] section for a `home` that may be either an
-// already-resolved <home>/.gitmoot root or a raw --home (resolveConfigFile
-// handles both). It fails safe to the default (risk tiers OFF) so a missing or
-// malformed config never turns the opt-in path on or breaks the daemon.
-func loadReviewPolicy(home string) config.ReviewPolicy {
+// loadReviewConfig reads the global and repository-scoped [review] settings for
+// a `home` that may be either an already-resolved <home>/.gitmoot root or a raw
+// --home. It fails safe to the default: native fanout and risk tiers both off.
+func loadReviewConfig(home string) config.ReviewConfig {
 	cfg := resolveConfigFile(home)
 	if cfg == "" {
-		return config.DefaultReviewPolicy()
+		return config.ReviewConfig{Global: config.DefaultReviewPolicy()}
 	}
-	policy, err := config.LoadReviewPolicy(config.Paths{ConfigFile: cfg})
+	policy, err := config.LoadReviewConfig(config.Paths{ConfigFile: cfg})
 	if err != nil {
-		return config.DefaultReviewPolicy()
+		return config.ReviewConfig{Global: config.DefaultReviewPolicy()}
 	}
 	return policy
 }
 
-// applyReviewPolicy copies the opt-in [review] risk-tiered review policy (#650)
-// onto the engine. With risk tiers off (the default) it sets RiskTiersEnabled
-// false and the engine's review fan-out is byte-identical, so calling it
-// unconditionally at engine construction is safe.
+// applyReviewPolicy copies the global risk-tier policy and installs the
+// repository-aware native-fanout resolver onto the engine.
 func applyReviewPolicy(engine *workflow.Engine, home string) {
-	policy := loadReviewPolicy(home)
+	cfg := loadReviewConfig(home)
+	policy := cfg.For("")
+	engine.NativeReviewFanoutEnabled = func(repo string) bool {
+		return cfg.For(repo).NativeFanoutEnabled
+	}
 	engine.RiskTiersEnabled = policy.RiskTiersEnabled
 	engine.HighRiskPaths = policy.HighRiskPaths
 	engine.RiskLabelHigh = policy.RiskLabelHigh

--- a/internal/cli/review_risk_test.go
+++ b/internal/cli/review_risk_test.go
@@ -24,6 +24,9 @@ func TestApplyReviewPolicyOffByDefault(t *testing.T) {
 	if engine.RiskTiersEnabled {
 		t.Fatal("applyReviewPolicy must leave risk tiers OFF when [review] is absent")
 	}
+	if engine.NativeReviewFanoutEnabled == nil || engine.NativeReviewFanoutEnabled("owner/repo") {
+		t.Fatal("applyReviewPolicy must install native fanout OFF when [review] is absent")
+	}
 }
 
 func TestApplyReviewPolicyEnabledFromConfig(t *testing.T) {
@@ -32,7 +35,7 @@ func TestApplyReviewPolicyEnabledFromConfig(t *testing.T) {
 	if err := os.MkdirAll(root, 0o755); err != nil {
 		t.Fatal(err)
 	}
-	body := "[review]\nrisk_tiers_enabled = true\nhigh_risk_paths = [\"cmd/**\"]\nrisk_label_high = \"sev:1\"\n"
+	body := "[review]\nnative_fanout_enabled = true\nrisk_tiers_enabled = true\nhigh_risk_paths = [\"cmd/**\"]\nrisk_label_high = \"sev:1\"\n[repos.\"owner/off\".review]\nnative_fanout_enabled = false\n"
 	if err := os.WriteFile(filepath.Join(root, config.ConfigName), []byte(body), 0o644); err != nil {
 		t.Fatal(err)
 	}
@@ -47,6 +50,12 @@ func TestApplyReviewPolicyEnabledFromConfig(t *testing.T) {
 	if engine.RiskLabelHigh != "sev:1" {
 		t.Fatalf("RiskLabelHigh = %q", engine.RiskLabelHigh)
 	}
+	if engine.NativeReviewFanoutEnabled == nil || !engine.NativeReviewFanoutEnabled("owner/on") {
+		t.Fatal("global native_fanout_enabled = true was not applied")
+	}
+	if engine.NativeReviewFanoutEnabled("owner/off") {
+		t.Fatal("repository native_fanout_enabled = false override was not applied")
+	}
 }
 
 func TestApplyReviewPolicyEmptyHomeIsOff(t *testing.T) {
@@ -54,5 +63,8 @@ func TestApplyReviewPolicyEmptyHomeIsOff(t *testing.T) {
 	applyReviewPolicy(&engine, "")
 	if engine.RiskTiersEnabled {
 		t.Fatal("empty home must resolve to risk tiers OFF")
+	}
+	if engine.NativeReviewFanoutEnabled == nil || engine.NativeReviewFanoutEnabled("owner/repo") {
+		t.Fatal("empty home must resolve native fanout OFF")
 	}
 }

--- a/internal/config/init.go
+++ b/internal/config/init.go
@@ -613,6 +613,23 @@ path = ""
 # [agents.builder]
 # chat_autorespond = true
 
+# [review] controls native PR review scheduling. Native fanout is disabled by
+# default; request deliberate reviews with 'gitmoot agent review <agent>'.
+# Set native_fanout_enabled = true to opt in globally. A repository override at
+# [repos."owner/repo".review] wins. Enabled fanout selects the runtime family of
+# the first configured reviewer whose family resolves, then dispatches only
+# reviewers in that family. Request another family explicitly when needed.
+# Risk tiers remain independently opt-in and global.
+# [review]
+# native_fanout_enabled = false
+# risk_tiers_enabled = false
+# high_risk_paths = ["**/auth/**", "cmd/**"]
+# risk_label_high = "risk:high"
+# risk_label_routine = "risk:routine"
+#
+# [repos."owner/repo".review]
+# native_fanout_enabled = true
+
 # [merge_gate] controls native task merges. Native auto-merge is enabled by
 # default, but only when an approved review verdict matches the exact current
 # head SHA and all SHA-scoped commit statuses and check-runs are green. A missing

--- a/internal/config/orchestrate.go
+++ b/internal/config/orchestrate.go
@@ -488,12 +488,14 @@ func validateEventsPolicy(policy EventsPolicy) error {
 	return nil
 }
 
-// ReviewPolicy is the host-level review policy read from the [review] section of
-// the gitmoot config (#650). It gates the OPT-IN risk-tiered adaptive review:
-// when RiskTiersEnabled is false (the default) the workflow engine never
-// classifies a PR and the single-review fan-out is byte-identical. HighRiskPaths,
-// RiskLabelHigh, and RiskLabelRoutine are only consulted when risk tiers are on.
+// ReviewPolicy is the resolved review policy for one repository. Native review
+// fanout is disabled by default: agents and coordinators request reviews
+// explicitly, while operators may opt a repository back into native scheduling.
+// Risk-tiered adaptive review remains independently opt-in.
 type ReviewPolicy struct {
+	// NativeFanoutEnabled permits HandlePullRequestOpened to schedule the
+	// configured native reviewer roster. Default false = OFF.
+	NativeFanoutEnabled bool
 	// RiskTiersEnabled opts the engine into risk-tiered review. Default false = OFF.
 	RiskTiersEnabled bool
 	// HighRiskPaths is the changed-path glob list that resolves the `high` tier.
@@ -507,22 +509,46 @@ type ReviewPolicy struct {
 }
 
 func DefaultReviewPolicy() ReviewPolicy {
-	return ReviewPolicy{RiskTiersEnabled: false}
+	return ReviewPolicy{NativeFanoutEnabled: false, RiskTiersEnabled: false}
 }
 
-// LoadReviewPolicy parses the [review] section. A missing config file or section
-// yields the default (risk tiers OFF), so the caller never has to distinguish
-// "no config" from "explicitly off".
-func LoadReviewPolicy(paths Paths) (ReviewPolicy, error) {
+// ReviewConfig is the parsed global [review] policy plus the
+// [repos."owner/repo".review].native_fanout_enabled override.
+type ReviewConfig struct {
+	Global ReviewPolicy
+	repos  map[string]reviewPolicyOverride
+}
+
+type reviewPolicyOverride struct {
+	nativeFanoutEnabled *bool
+}
+
+// For resolves the effective policy for repo. Risk-tier settings remain global;
+// only native fanout has a repository override.
+func (c ReviewConfig) For(repo string) ReviewPolicy {
+	policy := c.Global
+	policy.HighRiskPaths = append([]string(nil), policy.HighRiskPaths...)
+	override, ok := c.repos[strings.TrimSpace(repo)]
+	if ok && override.nativeFanoutEnabled != nil {
+		policy.NativeFanoutEnabled = *override.nativeFanoutEnabled
+	}
+	return policy
+}
+
+// LoadReviewConfig parses [review] and [repos."owner/repo".review]. A missing
+// config file or section yields the default with native fanout and risk tiers
+// both disabled.
+func LoadReviewConfig(paths Paths) (ReviewConfig, error) {
 	content, err := os.ReadFile(paths.ConfigFile)
 	if err != nil {
 		if os.IsNotExist(err) {
-			return DefaultReviewPolicy(), nil
+			return ReviewConfig{Global: DefaultReviewPolicy(), repos: map[string]reviewPolicyOverride{}}, nil
 		}
-		return ReviewPolicy{}, err
+		return ReviewConfig{}, err
 	}
-	policy := DefaultReviewPolicy()
-	current := false
+	cfg := ReviewConfig{Global: DefaultReviewPolicy(), repos: map[string]reviewPolicyOverride{}}
+	var repo string
+	inSection := false
 	for _, raw := range strings.Split(string(content), "\n") {
 		line := strings.TrimSpace(stripConfigComment(raw))
 		if line == "" {
@@ -530,25 +556,69 @@ func LoadReviewPolicy(paths Paths) (ReviewPolicy, error) {
 		}
 		if strings.HasPrefix(line, "[") && strings.HasSuffix(line, "]") {
 			section := strings.TrimSuffix(strings.TrimPrefix(line, "["), "]")
-			current = strings.TrimSpace(section) == "review"
+			repo, inSection = parseReviewSection(section)
+			if inSection && repo != "" {
+				if _, ok := cfg.repos[repo]; !ok {
+					cfg.repos[repo] = reviewPolicyOverride{}
+				}
+			}
 			continue
 		}
-		if !current {
+		if !inSection {
 			continue
 		}
 		key, value, ok := strings.Cut(line, "=")
 		if !ok {
 			continue
 		}
-		if err := applyReviewPolicyField(&policy, strings.TrimSpace(key), strings.TrimSpace(value)); err != nil {
-			return ReviewPolicy{}, fmt.Errorf("parse [review].%s: %w", strings.TrimSpace(key), err)
+		key = strings.TrimSpace(key)
+		value = strings.TrimSpace(value)
+		if repo == "" {
+			if err := applyReviewPolicyField(&cfg.Global, key, value); err != nil {
+				return ReviewConfig{}, fmt.Errorf("parse [review].%s: %w", key, err)
+			}
+			continue
 		}
+		override := cfg.repos[repo]
+		if err := applyReviewPolicyOverrideField(&override, key, value); err != nil {
+			return ReviewConfig{}, fmt.Errorf("parse [repos.%q.review].%s: %w", repo, key, err)
+		}
+		cfg.repos[repo] = override
 	}
-	return policy, nil
+	return cfg, nil
+}
+
+func parseReviewSection(section string) (string, bool) {
+	section = strings.TrimSpace(section)
+	if section == "review" {
+		return "", true
+	}
+	if !strings.HasPrefix(section, "repos.") || !strings.HasSuffix(section, ".review") {
+		return "", false
+	}
+	rest := strings.TrimSpace(strings.TrimSuffix(strings.TrimPrefix(section, "repos."), ".review"))
+	if rest == "" {
+		return "", false
+	}
+	if strings.HasPrefix(rest, "\"") {
+		unquoted, err := strconv.Unquote(rest)
+		if err != nil || strings.TrimSpace(unquoted) == "" {
+			return "", false
+		}
+		return strings.TrimSpace(unquoted), true
+	}
+	return rest, true
 }
 
 func applyReviewPolicyField(policy *ReviewPolicy, key string, value string) error {
 	switch key {
+	case "native_fanout_enabled":
+		parsed, err := parseConfigBool(value)
+		if err != nil {
+			return err
+		}
+		policy.NativeFanoutEnabled = parsed
+		return nil
 	case "risk_tiers_enabled":
 		parsed, err := parseConfigBool(value)
 		if err != nil {
@@ -580,6 +650,18 @@ func applyReviewPolicyField(policy *ReviewPolicy, key string, value string) erro
 	default:
 		return nil
 	}
+}
+
+func applyReviewPolicyOverrideField(override *reviewPolicyOverride, key string, value string) error {
+	if key != "native_fanout_enabled" {
+		return nil
+	}
+	parsed, err := parseConfigBool(value)
+	if err != nil {
+		return err
+	}
+	override.nativeFanoutEnabled = &parsed
+	return nil
 }
 
 // SkillOptPolicy is the host-level template-learning policy read from the

--- a/internal/config/review_test.go
+++ b/internal/config/review_test.go
@@ -16,40 +16,43 @@ func writeReviewConfig(t *testing.T, body string) Paths {
 	return Paths{ConfigFile: cfg}
 }
 
-func TestLoadReviewPolicyDefaultsOff(t *testing.T) {
-	// No file at all -> default (off), no error.
-	policy, err := LoadReviewPolicy(Paths{ConfigFile: filepath.Join(t.TempDir(), "missing.toml")})
+func TestLoadReviewConfigDefaultsNativeFanoutOff(t *testing.T) {
+	cfg, err := LoadReviewConfig(Paths{ConfigFile: filepath.Join(t.TempDir(), "missing.toml")})
 	if err != nil {
-		t.Fatalf("LoadReviewPolicy(missing) error: %v", err)
+		t.Fatalf("LoadReviewConfig(missing) error: %v", err)
 	}
-	if policy.RiskTiersEnabled {
+	if cfg.For("owner/repo").NativeFanoutEnabled {
+		t.Fatal("missing config must default native fanout OFF")
+	}
+	if cfg.For("owner/repo").RiskTiersEnabled {
 		t.Fatal("missing config must default risk tiers OFF")
 	}
 
-	// A config with no [review] section -> default off.
-	policy, err = LoadReviewPolicy(writeReviewConfig(t, "[orchestrate]\ncockpit_mode = \"off\"\n"))
+	cfg, err = LoadReviewConfig(writeReviewConfig(t, "[orchestrate]\ncockpit_mode = \"off\"\n"))
 	if err != nil {
-		t.Fatalf("LoadReviewPolicy(no section) error: %v", err)
+		t.Fatalf("LoadReviewConfig(no section) error: %v", err)
 	}
-	if policy.RiskTiersEnabled {
-		t.Fatal("absent [review] section must default OFF")
+	if cfg.For("owner/repo").NativeFanoutEnabled {
+		t.Fatal("absent [review] section must default native fanout OFF")
 	}
 }
 
-func TestLoadReviewPolicyParsesFields(t *testing.T) {
+func TestLoadReviewConfigParsesGlobalFields(t *testing.T) {
 	body := `
 [review]
+native_fanout_enabled = true
 risk_tiers_enabled = true
 high_risk_paths = ["**/auth/**", "cmd/**", "go.mod"]
 risk_label_high = "sev:1"
 risk_label_routine = "sev:routine"
 `
-	policy, err := LoadReviewPolicy(writeReviewConfig(t, body))
+	cfg, err := LoadReviewConfig(writeReviewConfig(t, body))
 	if err != nil {
-		t.Fatalf("LoadReviewPolicy error: %v", err)
+		t.Fatalf("LoadReviewConfig error: %v", err)
 	}
-	if !policy.RiskTiersEnabled {
-		t.Fatal("risk_tiers_enabled = true not parsed")
+	policy := cfg.For("owner/repo")
+	if !policy.NativeFanoutEnabled || !policy.RiskTiersEnabled {
+		t.Fatalf("parsed switches = %+v", policy)
 	}
 	if len(policy.HighRiskPaths) != 3 || policy.HighRiskPaths[1] != "cmd/**" {
 		t.Fatalf("high_risk_paths = %v", policy.HighRiskPaths)
@@ -59,9 +62,28 @@ risk_label_routine = "sev:routine"
 	}
 }
 
-func TestLoadReviewPolicyRejectsBadBool(t *testing.T) {
-	_, err := LoadReviewPolicy(writeReviewConfig(t, "[review]\nrisk_tiers_enabled = yes\n"))
+func TestLoadReviewConfigRepoOverrideWins(t *testing.T) {
+	body := `
+[review]
+native_fanout_enabled = false
+[repos."owner/enabled".review]
+native_fanout_enabled = true
+`
+	cfg, err := LoadReviewConfig(writeReviewConfig(t, body))
+	if err != nil {
+		t.Fatalf("LoadReviewConfig error: %v", err)
+	}
+	if cfg.For("owner/disabled").NativeFanoutEnabled {
+		t.Fatal("repo without override must inherit global OFF")
+	}
+	if !cfg.For("owner/enabled").NativeFanoutEnabled {
+		t.Fatal("repository override must enable native fanout")
+	}
+}
+
+func TestLoadReviewConfigRejectsBadBool(t *testing.T) {
+	_, err := LoadReviewConfig(writeReviewConfig(t, "[review]\nnative_fanout_enabled = yes\n"))
 	if err == nil {
-		t.Fatal("expected error for non-bool risk_tiers_enabled")
+		t.Fatal("expected error for non-bool native_fanout_enabled")
 	}
 }

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -1010,7 +1010,7 @@ func (d Daemon) supersedeStaleReviewJobs(ctx context.Context, pull github.PullRe
 		if err != nil {
 			return err
 		}
-		if !workflowReviewJobMatchesPull(d.Repo.FullName(), pull, payload) {
+		if !reviewJobTargetsPull(d.Repo.FullName(), pull, payload) {
 			continue
 		}
 		if strings.TrimSpace(payload.HeadSHA) == pull.HeadSHA {
@@ -1022,6 +1022,16 @@ func (d Daemon) supersedeStaleReviewJobs(ctx context.Context, pull github.PullRe
 		}
 	}
 	return nil
+}
+
+// reviewJobTargetsPull is deliberately broader than
+// workflowReviewJobMatchesPull: supersession applies to every queued/running
+// review pinned to an obsolete head, including deliberate review roots that do
+// not carry native fanout metadata.
+func reviewJobTargetsPull(repoFullName string, pull github.PullRequest, payload workflow.JobPayload) bool {
+	return payload.Repo == repoFullName &&
+		payload.PullRequest == int(pull.Number) &&
+		payload.Branch == pull.HeadRef
 }
 
 func workflowReviewJobMatchesPull(repoFullName string, pull github.PullRequest, payload workflow.JobPayload) bool {

--- a/internal/daemon/poll_path_projection_test.go
+++ b/internal/daemon/poll_path_projection_test.go
@@ -180,6 +180,43 @@ func TestSupersedeStaleReviewJobsSkipsLargeNonReviewPayload(t *testing.T) {
 	}
 }
 
+func TestSupersedeStaleReviewJobsIncludesDeliberateReviewRoots(t *testing.T) {
+	ctx := context.Background()
+	store := testStore(t)
+	repo := github.Repository{Owner: "gitmoot", Name: "gitmoot"}
+	payload, err := json.Marshal(workflow.JobPayload{
+		Repo:        repo.FullName(),
+		Branch:      "task-7",
+		PullRequest: 7,
+		HeadSHA:     "old-head",
+		TaskID:      "task-007",
+	})
+	if err != nil {
+		t.Fatalf("Marshal review payload returned error: %v", err)
+	}
+	if err := store.CreateJobWithEvent(ctx, db.Job{
+		ID:      "deliberate-review-stale",
+		Agent:   "audit",
+		Type:    "review",
+		State:   string(workflow.JobQueued),
+		Payload: string(payload),
+	}, db.JobEvent{JobID: "deliberate-review-stale", Kind: string(workflow.JobQueued)}); err != nil {
+		t.Fatalf("CreateJobWithEvent returned error: %v", err)
+	}
+
+	d := Daemon{Repo: repo, Store: store, Workflow: &workflow.Engine{Store: store}}
+	if err := d.supersedeStaleReviewJobs(ctx, reviewPull("new-head"), nil); err != nil {
+		t.Fatalf("supersedeStaleReviewJobs returned error: %v", err)
+	}
+	job, err := store.GetJob(ctx, "deliberate-review-stale")
+	if err != nil {
+		t.Fatalf("GetJob returned error: %v", err)
+	}
+	if job.State != string(workflow.JobCancelled) {
+		t.Fatalf("stale deliberate review state = %q, want cancelled", job.State)
+	}
+}
+
 // TestPullRequestWorkflowRoutingStaleAmongLargeNonReviewPayload proves routing's
 // stale detection is unchanged by the projection swap.
 func TestPullRequestWorkflowRoutingStaleAmongLargeNonReviewPayload(t *testing.T) {

--- a/internal/db/awaited_facts.go
+++ b/internal/db/awaited_facts.go
@@ -217,11 +217,12 @@ type SucceededReviewVerdict struct {
 	EffectiveRuntime string
 }
 
-// SucceededReviewVerdicts returns valid succeeded review verdicts for repo/PR,
-// newest first. Head SHA and decision live only in the JSON payload, so they are
-// decoded and filtered in Go rather than pretending jobs has indexed columns for
-// them. This is a pure read: unlike SubscribeAwaitedFact it creates no durable
-// interest or other state.
+// SucceededReviewVerdicts returns stable approved or changes-requested review
+// verdicts for repo/PR, newest first. Head SHA and decision live only in the JSON
+// payload, so they are decoded and filtered in Go rather than pretending jobs
+// has indexed columns for them. This is a pure read: unlike SubscribeAwaitedFact
+// it creates no durable interest or other state. Skipped reviews are abstentions,
+// not verdicts, and must remain retryable at the same head.
 func (s *Store) SucceededReviewVerdicts(ctx context.Context, repo string, pullRequest int) ([]SucceededReviewVerdict, error) {
 	repo = strings.ToLower(strings.TrimSpace(repo))
 	if repo == "" {
@@ -251,7 +252,7 @@ ORDER BY updated_at DESC, id DESC`, repo, pullRequest)
 			continue
 		}
 		decision := strings.ToLower(strings.TrimSpace(decoded.Result.Decision))
-		if decision == "" {
+		if decision != "approved" && decision != "changes_requested" {
 			continue
 		}
 		verdicts = append(verdicts, SucceededReviewVerdict{

--- a/internal/db/awaited_facts_test.go
+++ b/internal/db/awaited_facts_test.go
@@ -208,6 +208,8 @@ func TestSucceededReviewVerdictsFiltersCanonicalRows(t *testing.T) {
 		awaitedReviewPayload(t, "Acme/Widget", 52, "HEAD-A", " APPROVED ", "valid-a"))
 	seed("valid-z", "audit-z", "review", "succeeded", "acme/widget", 52,
 		awaitedReviewPayload(t, "acme/widget", 52, "head-a", "changes_requested", "valid-z"))
+	seed("skipped-abstention", "audit-skipped", "review", "succeeded", "acme/widget", 52,
+		awaitedReviewPayload(t, "acme/widget", 52, "head-a", "skipped", "skipped-abstention"))
 	seed("wrong-pr", "audit", "review", "succeeded", "acme/widget", 53,
 		awaitedReviewPayload(t, "acme/widget", 53, "head-a", "approved", "wrong-pr"))
 	seed("wrong-repo", "audit", "review", "succeeded", "acme/other", 52,

--- a/internal/workflow/engine.go
+++ b/internal/workflow/engine.go
@@ -357,6 +357,11 @@ type Engine struct {
 	// forward row; "block" additionally fails the job via the contract-violation
 	// path.
 	ResultCheckMode ResultCheckMode
+	// NativeReviewFanoutEnabled resolves whether native PR events may schedule
+	// reviews for a repository. The daemon always wires it from [review] config,
+	// whose default is false. Nil preserves the legacy enabled behavior for direct
+	// Engine constructions that do not participate in host configuration.
+	NativeReviewFanoutEnabled func(repo string) bool
 	// RiskTiersEnabled gates the opt-in risk-tiered adaptive review (#650). When
 	// false (the default), HandlePullRequestOpened NEVER classifies a PR and runs
 	// the single-review fan-out byte-identically. When true, a PR opened event is

--- a/internal/workflow/engine_fanout_roster_1236_test.go
+++ b/internal/workflow/engine_fanout_roster_1236_test.go
@@ -162,3 +162,78 @@ func TestFanoutUnconfiguredRosterStillRunsTheMergeGate(t *testing.T) {
 		t.Fatalf("merge gate requests = %+v, want exactly one for an unconfigured roster", gate.requests)
 	}
 }
+
+func TestFanoutSelectsOneRuntimeFamilyInConfiguredOrder(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	seedAgent(t, store, "impl", []string{"implement"}, "owner/repo")
+	seedReviewLoopAgent(t, store, "codex-a", "codex", "gpt-5.6-sol")
+	seedReviewLoopAgent(t, store, "codex-b", "codex", "gpt-5.6-sol")
+	seedReviewLoopAgent(t, store, "claude-a", "claude", "opus-5")
+	engine := testEngine(store)
+
+	err := engine.HandlePullRequestOpened(ctx, PullRequestEvent{
+		Repo:              "owner/repo",
+		Branch:            "task-7",
+		PullRequest:       7,
+		HeadSHA:           "head123",
+		TaskID:            "task-7",
+		LeadAgent:         "impl",
+		Sender:            "impl",
+		RequiredReviewers: []string{"codex-a", "claude-a", "codex-b"},
+	})
+	if err != nil {
+		t.Fatalf("HandlePullRequestOpened returned error: %v", err)
+	}
+	jobs, err := store.ListJobs(ctx)
+	if err != nil {
+		t.Fatalf("ListJobs returned error: %v", err)
+	}
+	var reviewers []string
+	for _, job := range jobs {
+		if job.Type == "review" {
+			reviewers = append(reviewers, job.Agent)
+		}
+	}
+	if len(reviewers) != 2 || reviewers[0] != "codex-a" || reviewers[1] != "codex-b" {
+		t.Fatalf("review jobs = %v, want [codex-a codex-b]", reviewers)
+	}
+}
+
+func TestConfiguredNativeFanoutOffSkipsReviewsAndMergeGate(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	seedAgent(t, store, "impl", []string{"implement"}, "owner/repo")
+	seedAgent(t, store, "reviewer", []string{"review"}, "owner/repo")
+	engine := testEngine(store)
+	engine.NativeReviewFanoutEnabled = func(string) bool { return false }
+	gate := &fakeMergeGate{decision: MergeDecision{Merged: true}}
+	engine.MergeGate = gate
+
+	err := engine.HandlePullRequestOpened(ctx, PullRequestEvent{
+		Repo:              "owner/repo",
+		Branch:            "task-8",
+		PullRequest:       8,
+		HeadSHA:           "head-off",
+		TaskID:            "task-8",
+		LeadAgent:         "impl",
+		Sender:            "impl",
+		RequiredReviewers: []string{"reviewer"},
+	})
+	if err != nil {
+		t.Fatalf("HandlePullRequestOpened returned error: %v", err)
+	}
+	jobs, err := store.ListJobs(ctx)
+	if err != nil {
+		t.Fatalf("ListJobs returned error: %v", err)
+	}
+	var reviewJobs int
+	for _, job := range jobs {
+		if job.Type == "review" {
+			reviewJobs++
+		}
+	}
+	if reviewJobs != 0 || len(gate.requests) != 0 {
+		t.Fatalf("fanout off produced %d review jobs and %d merge-gate requests", reviewJobs, len(gate.requests))
+	}
+}

--- a/internal/workflow/engine_pr_lifecycle.go
+++ b/internal/workflow/engine_pr_lifecycle.go
@@ -72,6 +72,16 @@ func (e Engine) HandlePullRequestOpened(ctx context.Context, event PullRequestEv
 			return e.recordPullRequestBaseline(ctx, event)
 		}
 		reviewers = eligible
+		for _, reviewer := range reviewers {
+			if err := e.ensureAgentAllowed(ctx, JobRequest{
+				Agent:  reviewer,
+				Action: "review",
+				Repo:   event.Repo,
+				Branch: event.Branch,
+			}, ref); err != nil {
+				return err
+			}
+		}
 		selected, familyDropped, family, err := e.selectNativeReviewFamily(ctx, reviewers)
 		if err != nil {
 			return err
@@ -210,11 +220,7 @@ func (e Engine) HandlePullRequestOpened(ctx context.Context, event PullRequestEv
 		}
 		requests = append(requests, request)
 	}
-	for _, request := range requests {
-		if err := e.ensureAgentAllowed(ctx, request, ref); err != nil {
-			return err
-		}
-	}
+
 	for _, request := range requests {
 		if err := e.enqueue(ctx, request); err != nil {
 			return err

--- a/internal/workflow/engine_pr_lifecycle.go
+++ b/internal/workflow/engine_pr_lifecycle.go
@@ -34,7 +34,8 @@ func (e Engine) HandlePullRequestOpened(ctx context.Context, event PullRequestEv
 	if len(reviewers) == 0 {
 		reviewers = compactStrings(append([]string{}, e.RequiredReviewers...))
 	}
-	if event.SkipReviewFanout {
+	nativeFanoutDisabled := e.NativeReviewFanoutEnabled != nil && !e.NativeReviewFanoutEnabled(event.Repo)
+	if event.SkipReviewFanout || nativeFanoutDisabled {
 		return e.recordPullRequestBaseline(ctx, event)
 	}
 	// #1236: filter the roster down to agents that may actually review THIS head.
@@ -71,6 +72,28 @@ func (e Engine) HandlePullRequestOpened(ctx context.Context, event PullRequestEv
 			return e.recordPullRequestBaseline(ctx, event)
 		}
 		reviewers = eligible
+		selected, familyDropped, family, err := e.selectNativeReviewFamily(ctx, reviewers)
+		if err != nil {
+			return err
+		}
+		if len(familyDropped) > 0 {
+			_ = e.Store.AddTaskEvent(ctx, db.TaskEvent{
+				TaskID: event.TaskID,
+				Kind:   "review_fanout_family_selected",
+				Reason: fmt.Sprintf("pull request #%d at %s: selected runtime family %q with [%s]; dropped %s",
+					event.PullRequest, event.HeadSHA, family, strings.Join(selected, " "), strings.Join(familyDropped, "; ")),
+			})
+		}
+		if len(selected) == 0 {
+			_ = e.Store.AddTaskEvent(ctx, db.TaskEvent{
+				TaskID: event.TaskID,
+				Kind:   "review_fanout_no_resolved_family",
+				Reason: fmt.Sprintf("pull request #%d at %s: no configured reviewer had a resolvable runtime family; no review dispatched and the native merge gate was NOT run",
+					event.PullRequest, event.HeadSHA),
+			})
+			return e.recordPullRequestBaseline(ctx, event)
+		}
+		reviewers = selected
 	}
 	if len(reviewers) == 0 {
 		decision, err := e.runMergeGate(ctx, "", JobPayload{
@@ -93,14 +116,35 @@ func (e Engine) HandlePullRequestOpened(ctx context.Context, event PullRequestEv
 		}
 		return e.recordPullRequestBaseline(ctx, event)
 	}
-	reviewRound, err := e.nextReviewRound(ctx, event)
+	repeated, err := FindRepeatedReviewers(ctx, e.Store, event.Repo, event.PullRequest, event.HeadSHA, reviewers)
 	if err != nil {
 		return err
 	}
-	if match, detected, err := DetectReviewLoop(ctx, e.Store, event.Repo, event.PullRequest, event.HeadSHA, reviewers); err != nil {
+	if len(repeated) > 0 {
+		repeatedAgents := make(map[string]struct{}, len(repeated))
+		for _, match := range repeated {
+			repeatedAgents[strings.ToLower(strings.TrimSpace(match.Agent))] = struct{}{}
+		}
+		filtered := reviewers[:0]
+		for _, reviewer := range reviewers {
+			if _, exists := repeatedAgents[strings.ToLower(strings.TrimSpace(reviewer))]; !exists {
+				filtered = append(filtered, reviewer)
+			}
+		}
+		_ = e.Store.AddTaskEvent(ctx, db.TaskEvent{
+			TaskID: event.TaskID,
+			Kind:   ReviewLoopDetectedEventKind,
+			Reason: fmt.Sprintf("pull request #%d at %s: skipped agents with existing exact-head verdicts [%s]",
+				event.PullRequest, event.HeadSHA, strings.Join(matchAgents(repeated), " ")),
+		})
+		if len(filtered) == 0 {
+			return e.block(ctx, ref, repeated[0].Reason())
+		}
+		reviewers = filtered
+	}
+	reviewRound, err := e.nextReviewRound(ctx, event)
+	if err != nil {
 		return err
-	} else if detected {
-		return e.block(ctx, ref, match.Reason())
 	}
 	// Opt-in risk-tiered adaptive review (#650). When RiskTiersEnabled, classify
 	// the PR (label > path > default). A `high` tier replaces the single native
@@ -632,6 +676,43 @@ func (e Engine) eligibleReviewers(ctx context.Context, repo string, implementer 
 		eligible = append(eligible, name)
 	}
 	return eligible, dropped
+}
+
+// selectNativeReviewFamily keeps the configured order and selects the runtime
+// family of the first reviewer whose family can be resolved. Later reviewers in
+// that family remain in the fanout; every other family is reserved for an
+// explicit `agent review` request.
+func (e Engine) selectNativeReviewFamily(ctx context.Context, reviewers []string) ([]string, []string, string, error) {
+	selected := make([]string, 0, len(reviewers))
+	dropped := make([]string, 0, len(reviewers))
+	selectedFamily := ""
+	for _, reviewer := range reviewers {
+		family, ok, err := ResolveRuntimeFamily(ctx, e.Store, reviewer, "")
+		if err != nil {
+			return nil, nil, "", err
+		}
+		if !ok {
+			dropped = append(dropped, fmt.Sprintf("%s (runtime family unresolved)", reviewer))
+			continue
+		}
+		if selectedFamily == "" {
+			selectedFamily = family
+		}
+		if family != selectedFamily {
+			dropped = append(dropped, fmt.Sprintf("%s (runtime family %s)", reviewer, family))
+			continue
+		}
+		selected = append(selected, reviewer)
+	}
+	return selected, dropped, selectedFamily, nil
+}
+
+func matchAgents(matches []ReviewLoopMatch) []string {
+	agents := make([]string, 0, len(matches))
+	for _, match := range matches {
+		agents = append(agents, match.Agent)
+	}
+	return agents
 }
 
 func (e Engine) recordPullRequestBaseline(ctx context.Context, event PullRequestEvent) error {

--- a/internal/workflow/review_loop.go
+++ b/internal/workflow/review_loop.go
@@ -23,10 +23,6 @@ type ReviewLoopMatch struct {
 	HeadSHA     string
 	Decision    string
 	EmptyHead   bool
-	// Family is the runtime family, already represented at this head, that the
-	// requesting reviewer belongs to (#1528). Empty when the refusal is the
-	// fail-closed kind: a family involved at this head could not be determined.
-	Family string
 }
 
 // Reason is the actionable refusal shown by both dispatch paths.
@@ -35,139 +31,107 @@ func (m ReviewLoopMatch) Reason() string {
 		return fmt.Sprintf("review loop detected for %s pull request #%d: requested head SHA is empty after succeeded review job %s (%s); supply the current head SHA before retrying",
 			m.Repo, m.PullRequest, m.JobID, m.Decision)
 	}
-	if m.Family != "" {
-		return fmt.Sprintf("review loop detected for %s pull request #%d at head %s: runtime family %q already holds the stable %s decision at this head (succeeded review job %s by %s); dispatch the review from an unrepresented runtime family or escalate to an operator before retrying",
-			m.Repo, m.PullRequest, m.HeadSHA, m.Family, m.Decision, m.JobID, m.Agent)
-	}
-	return fmt.Sprintf("review loop detected for %s pull request #%d at head %s: every succeeded verdict at this head recorded the stable %s decision (succeeded review job %s) and a runtime family involved at this head could not be determined; refusing fail-closed — dispatch a reviewer with a registered or recorded runtime, or escalate to an operator before retrying",
-		m.Repo, m.PullRequest, m.HeadSHA, m.Decision, m.JobID)
+	return fmt.Sprintf("review loop detected for %s pull request #%d at head %s: agent %s already holds the stable %s decision at this head (succeeded review job %s); dispatch a different agent or push a new head before retrying",
+		m.Repo, m.PullRequest, m.HeadSHA, m.Agent, m.Decision, m.JobID)
 }
 
-// DetectReviewLoop checks the safe, evidence-only half of review-loop
-// prevention. A non-empty head is refused only when every succeeded verdict at
-// that exact head agrees AND no requesting agent can PROVE it would bring a
-// new runtime family to the head (#1528): a review from a family with no
-// verdict at this head is new information by construction, and the guard
-// exists to stop repetition, not information. Mixed decisions proceed because
-// the earlier claim is unstable. An empty requested head proceeds only before
-// any succeeded history exists; afterward it fails closed because it cannot
-// prove a new commit — the family narrowing never applies to it.
-//
-// Unknown families FAIL CLOSED: if a requesting agent's family or a matched
-// verdict's family cannot be determined (agent absent from the registry with
-// no recorded runtime), the refusal stands. Unknown must never read as "not
-// yet represented", or this guard becomes a way to add unlimited reviews.
+// DetectReviewLoop refuses a dispatch when any requested agent already produced
+// a succeeded verdict at the exact requested head. Agent identity is the
+// boundary: a different agent from the same runtime family is independent for
+// merge-gate purposes and remains eligible. An empty requested head proceeds
+// only before any succeeded history exists; afterward it fails closed because it
+// cannot prove a new commit.
 //
 // On a match, the event is claimed against the matched succeeded job. No new
 // review job is created, and no prior result is returned to the caller.
 func DetectReviewLoop(ctx context.Context, store *db.Store, repo string, pullRequest int, headSHA string, requestingAgents []string) (ReviewLoopMatch, bool, error) {
+	matches, err := FindRepeatedReviewers(ctx, store, repo, pullRequest, headSHA, requestingAgents)
+	if err != nil {
+		return ReviewLoopMatch{}, false, err
+	}
+	if len(matches) == 0 {
+		return ReviewLoopMatch{}, false, nil
+	}
+	return matches[0], true, nil
+}
+
+// FindRepeatedReviewers returns exact-head verdict evidence for each requesting
+// agent that has already reviewed the head. The result preserves requester
+// order and performs one verdict query for the whole native roster.
+func FindRepeatedReviewers(ctx context.Context, store *db.Store, repo string, pullRequest int, headSHA string, requestingAgents []string) ([]ReviewLoopMatch, error) {
 	repo = strings.ToLower(strings.TrimSpace(repo))
 	headSHA = strings.ToLower(strings.TrimSpace(headSHA))
 	verdicts, err := store.SucceededReviewVerdicts(ctx, repo, pullRequest)
 	if err != nil {
-		return ReviewLoopMatch{}, false, err
+		return nil, err
 	}
-	if len(verdicts) == 0 {
-		return ReviewLoopMatch{}, false, nil
+	if len(verdicts) == 0 || len(requestingAgents) == 0 {
+		return nil, nil
 	}
 
-	var matched []db.SucceededReviewVerdict
-	emptyHead := headSHA == ""
-	family := ""
-	if emptyHead {
-		matched = verdicts[:1]
-	} else {
+	requesters := compactStrings(requestingAgents)
+	evidenceByAgent := make(map[string]db.SucceededReviewVerdict, len(verdicts))
+	if headSHA != "" {
 		for _, verdict := range verdicts {
-			if verdict.HeadSHA == headSHA {
-				matched = append(matched, verdict)
+			if verdict.HeadSHA != headSHA {
+				continue
+			}
+			agent := strings.ToLower(strings.TrimSpace(verdict.Agent))
+			if agent == "" {
+				continue
+			}
+			if _, exists := evidenceByAgent[agent]; !exists {
+				evidenceByAgent[agent] = verdict
 			}
 		}
-		if len(matched) == 0 {
-			return ReviewLoopMatch{}, false, nil
+		if len(evidenceByAgent) == 0 {
+			return nil, nil
 		}
-		decision := matched[0].Decision
-		for _, verdict := range matched[1:] {
-			if verdict.Decision != decision {
-				return ReviewLoopMatch{}, false, nil
+	}
+
+	matches := make([]ReviewLoopMatch, 0, len(requesters))
+	seenRequesters := make(map[string]struct{}, len(requesters))
+	for _, requester := range requesters {
+		key := strings.ToLower(strings.TrimSpace(requester))
+		if key == "" {
+			continue
+		}
+		if _, seen := seenRequesters[key]; seen {
+			continue
+		}
+		seenRequesters[key] = struct{}{}
+
+		evidence := verdicts[0]
+		if headSHA != "" {
+			var ok bool
+			evidence, ok = evidenceByAgent[key]
+			if !ok {
+				continue
 			}
 		}
-		represented, representedFamily, err := requestingFamilyRepresented(ctx, store, matched, requestingAgents)
-		if err != nil {
-			return ReviewLoopMatch{}, false, err
+		match := ReviewLoopMatch{
+			JobID:       evidence.JobID,
+			Agent:       evidence.Agent,
+			Repo:        repo,
+			PullRequest: pullRequest,
+			HeadSHA:     headSHA,
+			Decision:    evidence.Decision,
+			EmptyHead:   headSHA == "",
 		}
-		if !represented {
-			return ReviewLoopMatch{}, false, nil
+		eventHead := headSHA
+		if eventHead == "" {
+			eventHead = "<empty>"
 		}
-		family = representedFamily
+		message := fmt.Sprintf("repo=%s pull_request=%d head_sha=%s decision=%s matched_job=%s: %s",
+			repo, pullRequest, eventHead, evidence.Decision, evidence.JobID, match.Reason())
+		if _, err := store.ClaimJobEvent(ctx, db.JobEvent{
+			JobID:   evidence.JobID,
+			Kind:    ReviewLoopDetectedEventKind,
+			Message: message,
+		}); err != nil {
+			return nil, err
+		}
+		matches = append(matches, match)
 	}
-
-	evidence := matched[0]
-	match := ReviewLoopMatch{
-		JobID:       evidence.JobID,
-		Agent:       evidence.Agent,
-		Repo:        repo,
-		PullRequest: pullRequest,
-		HeadSHA:     headSHA,
-		Decision:    evidence.Decision,
-		EmptyHead:   emptyHead,
-		Family:      family,
-	}
-	eventHead := headSHA
-	if eventHead == "" {
-		eventHead = "<empty>"
-	}
-	message := fmt.Sprintf("repo=%s pull_request=%d head_sha=%s decision=%s matched_job=%s: %s",
-		repo, pullRequest, eventHead, evidence.Decision, evidence.JobID, match.Reason())
-	if _, err := store.ClaimJobEvent(ctx, db.JobEvent{
-		JobID:   evidence.JobID,
-		Kind:    ReviewLoopDetectedEventKind,
-		Message: message,
-	}); err != nil {
-		return ReviewLoopMatch{}, false, err
-	}
-	return match, true, nil
-}
-
-// requestingFamilyRepresented reports whether the unanimous matched verdicts
-// already cover every requesting agent's runtime family. A requester PROVABLY
-// bringing a new family — its own family resolved, every matched verdict's
-// family resolved, and no overlap — returns represented=false (allow). Every
-// unknown family keeps represented=true (fail closed). The returned family
-// names a represented requesting family for the refusal message when one could
-// be resolved; it stays empty for the fail-closed unknown case.
-func requestingFamilyRepresented(ctx context.Context, store *db.Store, matched []db.SucceededReviewVerdict, requestingAgents []string) (bool, string, error) {
-	representedFamilies := make(map[string]struct{}, len(matched))
-	for _, verdict := range matched {
-		family, ok, err := ResolveRuntimeFamily(ctx, store, verdict.Agent, verdict.EffectiveRuntime)
-		if err != nil {
-			return true, "", err
-		}
-		if !ok {
-			return true, "", nil
-		}
-		representedFamilies[family] = struct{}{}
-	}
-
-	requestingFamilies := make([]string, 0, len(requestingAgents))
-	for _, requester := range requestingAgents {
-		requesterFamily, ok, err := ResolveRuntimeFamily(ctx, store, requester, "")
-		if err != nil {
-			return true, "", err
-		}
-		if !ok {
-			return true, "", nil
-		}
-		requestingFamilies = append(requestingFamilies, requesterFamily)
-	}
-
-	representedFamily := ""
-	for _, requesterFamily := range requestingFamilies {
-		if _, represented := representedFamilies[requesterFamily]; !represented {
-			return false, "", nil
-		}
-		if representedFamily == "" {
-			representedFamily = requesterFamily
-		}
-	}
-	return true, representedFamily, nil
+	return matches, nil
 }

--- a/internal/workflow/review_loop_test.go
+++ b/internal/workflow/review_loop_test.go
@@ -10,14 +10,10 @@ import (
 
 var _ func(context.Context, *db.Store, string, int, string, []string) (ReviewLoopMatch, bool, error) = DetectReviewLoop
 
-// Review-loop family-count tests (#1528). The guard must count DISTINCT
-// REVIEWER FAMILIES at the head, not agreement among whoever happened to run.
-// Every test pins the fixture property it is named for — asserted or derived
-// from the store, never assumed — so a silently weakened fixture goes red
-// instead of passing for the wrong reason.
+// Review-loop tests pin the agent-identity boundary. Runtime family is
+// deliberately not part of the refusal: a different agent of the same family
+// remains an independent reviewer for the merge gate.
 
-// seedReviewLoopAgent registers an agent with an EXPLICIT runtime (and model),
-// because family — not agent name — is what the guard must count.
 func seedReviewLoopAgent(t *testing.T, store *db.Store, name, runtimeName, model string) {
 	t.Helper()
 	if err := store.UpsertAgent(context.Background(), db.Agent{
@@ -35,10 +31,6 @@ func seedReviewLoopAgent(t *testing.T, store *db.Store, name, runtimeName, model
 	}
 }
 
-// seedReviewLoopVerdict stores a succeeded review job and READS IT BACK,
-// asserting the fixture's distinguishing properties (head, decision, recorded
-// runtime) actually landed — a fixture that can be silently weakened is not a
-// test.
 func seedReviewLoopVerdict(t *testing.T, store *db.Store, jobID, agent, headSHA, decision, effectiveRuntime string) {
 	t.Helper()
 	ctx := context.Background()
@@ -73,302 +65,113 @@ func seedReviewLoopVerdict(t *testing.T, store *db.Store, jobID, agent, headSHA,
 	}
 }
 
-// Acceptance 1 — same family, same head, unanimous approval: STILL REFUSED.
-// The anti-loop property itself; must fail if the guard is removed.
-func TestDetectReviewLoopSameFamilySameHeadRefused(t *testing.T) {
+func TestDetectReviewLoopSameAgentSameHeadRefused(t *testing.T) {
 	ctx := context.Background()
 	store := openEngineStore(t)
 	seedReviewLoopAgent(t, store, "g7-review", "codex", "gpt-5.6-sol")
-	seedReviewLoopVerdict(t, store, "prior-review", "g7-review", "head-a", "approved", "codex")
+	seedReviewLoopVerdict(t, store, "review-g7", "g7-review", "head-a", "approved", "codex")
 
 	match, detected, err := DetectReviewLoop(ctx, store, "owner/repo", 227, "head-a", []string{"g7-review"})
 	if err != nil {
 		t.Fatalf("DetectReviewLoop: %v", err)
 	}
 	if !detected {
-		t.Fatal("same family re-reviewing a unanimously approved head must be refused")
+		t.Fatal("same agent at the same head must be refused")
 	}
-	// Pin the fixture: the requester IS the verdict's agent.
-	if match.Agent != "g7-review" {
-		t.Fatalf("matched agent = %q, want g7-review (fixture weakened)", match.Agent)
+	if match.Agent != "g7-review" || match.JobID != "review-g7" || match.Decision != "approved" {
+		t.Fatalf("match = %+v", match)
 	}
-	if match.Family != "codex" {
-		t.Fatalf("match.Family = %q, want codex named in the refusal", match.Family)
+	if !strings.Contains(match.Reason(), "agent g7-review already holds") {
+		t.Fatalf("reason = %q", match.Reason())
 	}
-	reason := match.Reason()
-	if !strings.Contains(reason, `runtime family "codex"`) || !strings.Contains(reason, "prior-review") {
-		t.Fatalf("refusal must name the represented family and the evidence job: %q", reason)
-	}
-	if strings.Contains(reason, "push a new commit") {
-		t.Fatalf("refusal must not prescribe manufacturing a commit: %q", reason)
-	}
-	if got := countJobEvents(t, store, "prior-review", ReviewLoopDetectedEventKind); got != 1 {
-		t.Fatalf("review_loop_detected events = %d, want one claimed event", got)
-	}
-}
 
-// Acceptance 2 — unrepresented family, same head, unanimous approval: NOW
-// ALLOWED. This is the case the old guard blocked on PR #1527 (gm-review-kimi
-// refused after a claude approval) and the test that fails on the old code.
-func TestDetectReviewLoopUnrepresentedFamilyAllowed(t *testing.T) {
-	ctx := context.Background()
-	store := openEngineStore(t)
-	seedReviewLoopAgent(t, store, "gm-review-opus", "claude", "claude-opus-4-8")
-	seedReviewLoopAgent(t, store, "gm-review-kimi", "kimi", "kimi-for-coding")
-	seedReviewLoopVerdict(t, store, "prior-review", "gm-review-opus", "head-a", "approved", "claude")
-
-	// Pin the fixture: the two agents are DIFFERENT families, and the head's
-	// history is a unanimous approval (the shape the old guard refused).
-	holder, err := store.GetAgent(ctx, "gm-review-opus")
+	events, err := store.ListJobEvents(ctx, "review-g7")
 	if err != nil {
-		t.Fatalf("GetAgent(gm-review-opus): %v", err)
+		t.Fatalf("ListJobEvents: %v", err)
 	}
-	requester, err := store.GetAgent(ctx, "gm-review-kimi")
-	if err != nil {
-		t.Fatalf("GetAgent(gm-review-kimi): %v", err)
-	}
-	if holder.Runtime == requester.Runtime {
-		t.Fatalf("fixture weakened: %s and %s must be different runtime families", holder.Name, requester.Name)
-	}
-
-	if _, detected, err := DetectReviewLoop(ctx, store, "owner/repo", 227, "head-a", []string{"gm-review-kimi"}); err != nil {
-		t.Fatalf("DetectReviewLoop: %v", err)
-	} else if detected {
-		t.Fatal("a review from an unrepresented family is new information; the guard must allow it")
-	}
-}
-
-// Acceptance 3 — THE DISCRIMINATOR: different NAME, SAME family -> REFUSED.
-// g7-review holds the approval; af-review-sol requests one; both are
-// codex/gpt-5.6-sol. A name-keyed implementation passes tests 1 and 2 and
-// fails ONLY here.
-func TestDetectReviewLoopDifferentNameSameFamilyRefused(t *testing.T) {
-	ctx := context.Background()
-	store := openEngineStore(t)
-	seedReviewLoopAgent(t, store, "g7-review", "codex", "gpt-5.6-sol")
-	seedReviewLoopAgent(t, store, "af-review-sol", "codex", "gpt-5.6-sol")
-	seedReviewLoopVerdict(t, store, "prior-review", "g7-review", "head-a", "approved", "codex")
-
-	// Pin the fixture INDEPENDENTLY of the resolver under test: different
-	// names, same runtime AND same model, read straight from the registry.
-	holder, err := store.GetAgent(ctx, "g7-review")
-	if err != nil {
-		t.Fatalf("GetAgent(g7-review): %v", err)
-	}
-	requester, err := store.GetAgent(ctx, "af-review-sol")
-	if err != nil {
-		t.Fatalf("GetAgent(af-review-sol): %v", err)
-	}
-	if holder.Name == requester.Name {
-		t.Fatal("fixture weakened: the discriminator needs DIFFERENT agent names")
-	}
-	if holder.Runtime != requester.Runtime || holder.Model != requester.Model {
-		t.Fatalf("fixture weakened: both agents must be the same family (runtime+model), got %s/%s vs %s/%s",
-			holder.Runtime, holder.Model, requester.Runtime, requester.Model)
-	}
-
-	match, detected, err := DetectReviewLoop(ctx, store, "owner/repo", 227, "head-a", []string{"af-review-sol"})
-	if err != nil {
-		t.Fatalf("DetectReviewLoop: %v", err)
-	}
-	if !detected {
-		t.Fatal("af-review-sol is a different NAME but the SAME codex family as g7-review; the guard must refuse")
-	}
-	if match.Family != "codex" {
-		t.Fatalf("match.Family = %q, want codex", match.Family)
-	}
-}
-
-// Acceptance 4 — mixed decisions at the head: still allowed (unchanged),
-// even when the requester's family IS represented. Guards against the
-// narrowing accidentally widening the mixed-decision path.
-func TestDetectReviewLoopMixedDecisionsAllowed(t *testing.T) {
-	ctx := context.Background()
-	store := openEngineStore(t)
-	seedReviewLoopAgent(t, store, "gm-review-opus", "claude", "claude-opus-4-8")
-	seedReviewLoopAgent(t, store, "g7-review", "codex", "gpt-5.6-sol")
-	seedReviewLoopVerdict(t, store, "prior-approved", "gm-review-opus", "head-a", "approved", "claude")
-	seedReviewLoopVerdict(t, store, "prior-changes", "g7-review", "head-a", "changes_requested", "codex")
-
-	// Pin the fixture: BOTH verdicts sit at the SAME head and DISAGREE.
-	verdicts, err := store.SucceededReviewVerdicts(ctx, "owner/repo", 227)
-	if err != nil {
-		t.Fatalf("SucceededReviewVerdicts: %v", err)
-	}
-	atHead := map[string]string{}
-	for _, verdict := range verdicts {
-		if verdict.HeadSHA == "head-a" {
-			atHead[verdict.JobID] = verdict.Decision
+	var claims int
+	for _, event := range events {
+		if event.Kind == ReviewLoopDetectedEventKind {
+			claims++
 		}
 	}
-	if len(atHead) != 2 || atHead["prior-approved"] == atHead["prior-changes"] {
-		t.Fatalf("fixture weakened: want two disagreeing verdicts at head-a, got %v", atHead)
-	}
-
-	// The requester's family (claude) IS represented at the head; only the
-	// mixed decisions may allow this.
-	if _, detected, err := DetectReviewLoop(ctx, store, "owner/repo", 227, "head-a", []string{"gm-review-opus"}); err != nil {
-		t.Fatalf("DetectReviewLoop: %v", err)
-	} else if detected {
-		t.Fatal("mixed decisions at the head must still proceed; the earlier claim is unstable")
+	if claims != 1 {
+		t.Fatalf("review-loop claim count = %d, want 1", claims)
 	}
 }
 
-// Acceptance 5 — empty requested head: allowed before any succeeded history,
-// refused after, regardless of families (unchanged rule).
+func TestDetectReviewLoopDifferentAgentSameFamilyAllowed(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	seedReviewLoopAgent(t, store, "g7-review", "codex", "gpt-5.6-sol")
+	seedReviewLoopAgent(t, store, "g6-review-sol", "codex", "gpt-5.6-sol")
+	seedReviewLoopVerdict(t, store, "review-g7", "g7-review", "head-a", "approved", "codex")
+
+	if _, detected, err := DetectReviewLoop(ctx, store, "owner/repo", 227, "head-a", []string{"g7-review"}); err != nil || !detected {
+		t.Fatalf("control same-agent detection = %v, err=%v; want true", detected, err)
+	}
+	if _, detected, err := DetectReviewLoop(ctx, store, "owner/repo", 227, "head-a", []string{"g6-review-sol"}); err != nil {
+		t.Fatalf("DetectReviewLoop different agent: %v", err)
+	} else if detected {
+		t.Fatal("different agent in the same runtime family must remain eligible")
+	}
+}
+
+func TestFindRepeatedReviewersFiltersOnlyAgentsWithVerdicts(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	seedReviewLoopAgent(t, store, "g7-review", "codex", "gpt-5.6-sol")
+	seedReviewLoopAgent(t, store, "g6-review-sol", "codex", "gpt-5.6-sol")
+	seedReviewLoopVerdict(t, store, "review-g7", "g7-review", "head-a", "changes_requested", "codex")
+
+	matches, err := FindRepeatedReviewers(ctx, store, "owner/repo", 227, "head-a", []string{"g7-review", "g6-review-sol"})
+	if err != nil {
+		t.Fatalf("FindRepeatedReviewers: %v", err)
+	}
+	if len(matches) != 1 || matches[0].Agent != "g7-review" {
+		t.Fatalf("matches = %+v, want only g7-review", matches)
+	}
+}
+
+func TestDetectReviewLoopSameAgentNewHeadAllowed(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	seedReviewLoopAgent(t, store, "g7-review", "codex", "gpt-5.6-sol")
+	seedReviewLoopVerdict(t, store, "review-g7", "g7-review", "head-a", "approved", "codex")
+
+	if _, detected, err := DetectReviewLoop(ctx, store, "owner/repo", 227, "head-a", []string{"g7-review"}); err != nil || !detected {
+		t.Fatalf("control same-head detection = %v, err=%v; want true", detected, err)
+	}
+	if _, detected, err := DetectReviewLoop(ctx, store, "owner/repo", 227, "head-b", []string{"g7-review"}); err != nil {
+		t.Fatalf("DetectReviewLoop new head: %v", err)
+	} else if detected {
+		t.Fatal("a new head must permit the same reviewer")
+	}
+}
+
 func TestDetectReviewLoopEmptyHeadRule(t *testing.T) {
 	ctx := context.Background()
 	store := openEngineStore(t)
-	seedReviewLoopAgent(t, store, "gm-review-kimi", "kimi", "kimi-for-coding")
+	seedReviewLoopAgent(t, store, "g7-review", "codex", "gpt-5.6-sol")
 
-	if _, detected, err := DetectReviewLoop(ctx, store, "owner/repo", 227, "", []string{"gm-review-kimi"}); err != nil {
-		t.Fatalf("DetectReviewLoop(empty, no history): %v", err)
+	if _, detected, err := DetectReviewLoop(ctx, store, "owner/repo", 227, "", []string{"g7-review"}); err != nil {
+		t.Fatalf("DetectReviewLoop before history: %v", err)
 	} else if detected {
-		t.Fatal("empty head with no succeeded history must proceed")
+		t.Fatal("empty head before any succeeded history must be allowed")
 	}
-
-	// Even a verdict from a DIFFERENT family must not let an empty head
-	// through once history exists: the empty head cannot prove a new commit.
-	seedReviewLoopAgent(t, store, "gm-review-opus", "claude", "claude-opus-4-8")
-	seedReviewLoopVerdict(t, store, "prior-review", "gm-review-opus", "head-a", "approved", "claude")
-	match, detected, err := DetectReviewLoop(ctx, store, "owner/repo", 227, "", []string{"gm-review-kimi"})
+	seedReviewLoopVerdict(t, store, "review-g7", "g7-review", "head-a", "approved", "codex")
+	match, detected, err := DetectReviewLoop(ctx, store, "owner/repo", 227, "", []string{"g7-review"})
 	if err != nil {
-		t.Fatalf("DetectReviewLoop(empty, with history): %v", err)
+		t.Fatalf("DetectReviewLoop after history: %v", err)
 	}
 	if !detected || !match.EmptyHead {
-		t.Fatalf("empty head after succeeded history must fail closed: detected=%v match=%+v", detected, match)
-	}
-	if !strings.Contains(match.Reason(), "requested head SHA is empty") {
-		t.Fatalf("empty-head refusal must keep its own message branch: %q", match.Reason())
+		t.Fatalf("empty-head match = %+v, detected=%v", match, detected)
 	}
 }
 
-// Acceptance 8 — unknown family FAILS CLOSED. An unknown that counted as "not
-// yet represented" would turn the guard into a way to add unlimited reviews.
-func TestDetectReviewLoopUnknownFamilyFailsClosed(t *testing.T) {
-	ctx := context.Background()
-	store := openEngineStore(t)
-	seedReviewLoopAgent(t, store, "gm-review-kimi", "kimi", "kimi-for-coding")
-
-	t.Run("verdict family unknown", func(t *testing.T) {
-		// The verdict's agent is absent from the registry and recorded no
-		// runtime: its family cannot be determined.
-		seedReviewLoopVerdict(t, store, "ghost-review", "ghost", "head-a", "approved", "")
-		if _, err := store.GetAgent(ctx, "ghost"); err == nil {
-			t.Fatal("fixture weakened: ghost must be ABSENT from the registry")
-		}
-		match, detected, err := DetectReviewLoop(ctx, store, "owner/repo", 227, "head-a", []string{"gm-review-kimi"})
-		if err != nil {
-			t.Fatalf("DetectReviewLoop: %v", err)
-		}
-		if !detected {
-			t.Fatal("a verdict whose family cannot be determined must fail closed, not read as unrepresented")
-		}
-		if match.Family != "" {
-			t.Fatalf("fail-closed refusal names no family, got %q", match.Family)
-		}
-		if !strings.Contains(match.Reason(), "fail-closed") {
-			t.Fatalf("fail-closed refusal must say so: %q", match.Reason())
-		}
-	})
-
-	t.Run("requester family unknown", func(t *testing.T) {
-		seedReviewLoopAgent(t, store, "g7-review", "codex", "gpt-5.6-sol")
-		seedReviewLoopVerdict(t, store, "prior-review", "g7-review", "head-b", "approved", "codex")
-		if _, err := store.GetAgent(ctx, "ghost-requester"); err == nil {
-			t.Fatal("fixture weakened: ghost-requester must be ABSENT from the registry")
-		}
-		if _, detected, err := DetectReviewLoop(ctx, store, "owner/repo", 227, "head-b", []string{"ghost-requester"}); err != nil {
-			t.Fatalf("DetectReviewLoop: %v", err)
-		} else if !detected {
-			t.Fatal("a requester whose family cannot be determined cannot prove new information; must fail closed")
-		}
-	})
-
-	t.Run("mixed requester batch with unknown family", func(t *testing.T) {
-		seedReviewLoopAgent(t, store, "g7-review-batch", "codex", "gpt-5.6-sol")
-		seedReviewLoopVerdict(t, store, "prior-review-batch", "g7-review-batch", "head-c", "approved", "codex")
-		if _, err := store.GetAgent(ctx, "ghost-requester-batch"); err == nil {
-			t.Fatal("fixture weakened: ghost-requester-batch must be ABSENT from the registry")
-		}
-		// Pin the anchor the ordering cases below lean on: without the ghost,
-		// the batch PROVABLY brings a new family and is allowed — the unknown
-		// requester is the ONLY thing refusing.
-		if _, detected, err := DetectReviewLoop(ctx, store, "owner/repo", 227, "head-c", []string{"gm-review-kimi"}); err != nil {
-			t.Fatalf("DetectReviewLoop(known-only baseline): %v", err)
-		} else if detected {
-			t.Fatal("fixture weakened: the known-new requester alone must be ALLOWED, or this case cannot isolate the unknown's refusal")
-		}
-		match, detected, err := DetectReviewLoop(ctx, store, "owner/repo", 227, "head-c", []string{"ghost-requester-batch", "gm-review-kimi"})
-		if err != nil {
-			t.Fatalf("DetectReviewLoop: %v", err)
-		}
-		if !detected {
-			t.Fatal("one known-new requester must not hide an unresolved requester in the same batch")
-		}
-		if match.Family != "" {
-			t.Fatalf("mixed unknown batch must use the fail-closed refusal, got family %q", match.Family)
-		}
-	})
-
-	// Ordering cases (#1528 review): the original defect was order-dependent,
-	// so the fail-closed boundary must be order-INDEPENDENT. Each case pins the
-	// same anchor — the known requesters alone would be ALLOWED — so an
-	// "allow immediately on the first known-new family" implementation goes
-	// red here instead of surviving.
-	t.Run("mixed requester batch unknown LAST", func(t *testing.T) {
-		seedReviewLoopAgent(t, store, "g7-review-last", "codex", "gpt-5.6-sol")
-		seedReviewLoopVerdict(t, store, "prior-review-last", "g7-review-last", "head-d", "approved", "codex")
-		if _, err := store.GetAgent(ctx, "ghost-requester-last"); err == nil {
-			t.Fatal("fixture weakened: ghost-requester-last must be ABSENT from the registry")
-		}
-		if _, detected, err := DetectReviewLoop(ctx, store, "owner/repo", 227, "head-d", []string{"gm-review-kimi"}); err != nil {
-			t.Fatalf("DetectReviewLoop(known-only baseline): %v", err)
-		} else if detected {
-			t.Fatal("fixture weakened: the known-new requester alone must be ALLOWED, or this case cannot isolate the unknown's refusal")
-		}
-		match, detected, err := DetectReviewLoop(ctx, store, "owner/repo", 227, "head-d", []string{"gm-review-kimi", "ghost-requester-last"})
-		if err != nil {
-			t.Fatalf("DetectReviewLoop: %v", err)
-		}
-		if !detected {
-			t.Fatal("an unresolved requester in LAST position must still fail closed; an allow-on-first-known-new implementation passes for the wrong reason")
-		}
-		if match.Family != "" {
-			t.Fatalf("unknown-last batch must use the fail-closed refusal, got family %q", match.Family)
-		}
-	})
-
-	t.Run("mixed requester batch unknown BETWEEN two resolvable requesters", func(t *testing.T) {
-		seedReviewLoopAgent(t, store, "g7-review-between", "codex", "gpt-5.6-sol")
-		seedReviewLoopAgent(t, store, "gm-review-opus-between", "claude", "claude-opus-4-8")
-		seedReviewLoopVerdict(t, store, "prior-review-between", "g7-review-between", "head-e", "approved", "codex")
-		if _, err := store.GetAgent(ctx, "ghost-requester-between"); err == nil {
-			t.Fatal("fixture weakened: ghost-requester-between must be ABSENT from the registry")
-		}
-		// Baseline: BOTH flanking requesters are resolvable, and kimi is a
-		// provably NEW family — without the ghost the batch is allowed.
-		if _, detected, err := DetectReviewLoop(ctx, store, "owner/repo", 227, "head-e", []string{"gm-review-kimi", "gm-review-opus-between"}); err != nil {
-			t.Fatalf("DetectReviewLoop(known-only baseline): %v", err)
-		} else if detected {
-			t.Fatal("fixture weakened: the two resolvable requesters alone must be ALLOWED, or this case cannot isolate the unknown's refusal")
-		}
-		match, detected, err := DetectReviewLoop(ctx, store, "owner/repo", 227, "head-e", []string{"gm-review-kimi", "ghost-requester-between", "gm-review-opus-between"})
-		if err != nil {
-			t.Fatalf("DetectReviewLoop: %v", err)
-		}
-		if !detected {
-			t.Fatal("an unresolved requester BETWEEN two resolvable ones must still fail closed; an allow-on-first-known-new implementation passes for the wrong reason")
-		}
-		if match.Family != "" {
-			t.Fatalf("unknown-between batch must use the fail-closed refusal, got family %q", match.Family)
-		}
-	})
-}
-
-// Acceptance 7 — resolver precedence: a recorded effective runtime beats the
-// registry default when they disagree (the override-run case), the registry
-// covers unrecorded jobs, and the unknown case reports ok=false.
+// Runtime-family resolution still backs native one-family selection: a recorded
+// effective runtime wins, the registry covers unrecorded jobs, and unknown
+// agents report ok=false.
 func TestResolveRuntimeFamilyPrecedence(t *testing.T) {
 	ctx := context.Background()
 	store := openEngineStore(t)

--- a/internal/workflow/review_loop_test.go
+++ b/internal/workflow/review_loop_test.go
@@ -100,6 +100,19 @@ func TestDetectReviewLoopSameAgentSameHeadRefused(t *testing.T) {
 	}
 }
 
+func TestDetectReviewLoopSkippedSameAgentSameHeadAllowed(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	seedReviewLoopAgent(t, store, "g7-review", "codex", "gpt-5.6-sol")
+	seedReviewLoopVerdict(t, store, "review-g7-skipped", "g7-review", "head-a", "skipped", "codex")
+
+	if _, detected, err := DetectReviewLoop(ctx, store, "owner/repo", 227, "head-a", []string{"g7-review"}); err != nil {
+		t.Fatalf("DetectReviewLoop skipped abstention: %v", err)
+	} else if detected {
+		t.Fatal("skipped is an abstention and must not suppress same-agent retry")
+	}
+}
+
 func TestDetectReviewLoopDifferentAgentSameFamilyAllowed(t *testing.T) {
 	ctx := context.Background()
 	store := openEngineStore(t)

--- a/internal/workflow/risk_review_test.go
+++ b/internal/workflow/risk_review_test.go
@@ -99,6 +99,10 @@ func TestHighRiskReviewLoopBlocksBeforeCoordinator(t *testing.T) {
 		Repo: "gitmoot/gitmoot", Branch: "task-7", PullRequest: 7, HeadSHA: "high-head",
 		TaskID: "task-7", ReviewRound: "review-1", Result: &AgentResult{Decision: "changes_requested"},
 	})
+	insertCompletedJob(t, store, db.Job{ID: "prior-high-risk-security-review", Agent: "sec", Type: "review"}, JobPayload{
+		Repo: "gitmoot/gitmoot", Branch: "task-7", PullRequest: 7, HeadSHA: "high-head",
+		TaskID: "task-7", ReviewRound: "review-1", Result: &AgentResult{Decision: "approved"},
+	})
 	engine := testEngine(store)
 	engine.RiskTiersEnabled = true
 	event := highRiskEvent()


### PR DESCRIPTION
## Summary

- add `[review].native_fanout_enabled`, disabled by default, with a per-repository override
- when native fanout is enabled, select one deterministic runtime family and reserve other families for explicit `gitmoot agent review <agent>` requests
- suppress repeat reviews only when the same agent already has a succeeded verdict at the exact head
- broaden stale-head cancellation to deliberate review roots that lack native fanout metadata

## Decisions

The default is off because the owner explicitly directed agents and coordinators to request reviews deliberately. The first configured reviewer whose runtime family resolves selects the native family; later reviewers in that family remain eligible.

This default is also a security boundary, not only cost control. On gitmoot#1671, which contained a demonstrated credential exposure, native fanout started an auto-fix roughly twenty minutes after its coordinator recorded that it would not auto-fix that review round. Jarvis cancelled the leg. Native scheduling therefore overrode an explicit refusal to patch a security-sensitive boundary.

A different agent from the same runtime family remains eligible. The merge gate requires agent identity independence, not runtime-family independence.

## Review-loop cutover

- `TestDetectReviewLoopSameFamilySameHeadRefused` becomes `TestDetectReviewLoopSameAgentSameHeadRefused`: the stable-verdict key is now agent identity, matching the merge gate.
- `TestDetectReviewLoopDifferentNameSameFamilyRefused` and `TestDetectReviewLoopUnrepresentedFamilyAllowed` become `TestDetectReviewLoopDifferentAgentSameFamilyAllowed`: a different agent remains independent even when its runtime family is already represented.
- `TestDetectReviewLoopUnknownFamilyFailsClosed` becomes `TestCLIReviewLoopUnresolvableReviewerFailsClosedBeforeIdentityGuard`: production dispatch validates the lead, then resolves and authorizes the reviewer before `DetectReviewLoop`. The fixture uses a valid lead, an unregistered requester with no resolvable family, and a prior exact-head verdict under that same requester identity. It asserts refusal with no new job, task, worktree, runtime call, or loop event. Moving loop detection before reviewer admission makes this test fail.
- `TestDetectReviewLoopMixedDecisionsAllowed` is covered by `TestFindRepeatedReviewersFiltersOnlyAgentsWithVerdicts` and `TestDetectReviewLoopSkippedSameAgentSameHeadAllowed`: stable approved and changes-requested verdicts suppress only their producing agent, while skipped abstentions remain retryable.

The normalized pre-dispatch availability store currently records organization-role incidents and only classifies Claude quota failures. It cannot reliably prove Kimi 403 state before dispatch, so this change does not invent an availability signal. Default-off behavior and one-family selection remove the measured standing multi-family quota tax.

The comment-retrigger hypothesis was rejected from the code path: unaddressed acknowledgement comments return before dispatch, and addressed comments are deduplicated by comment ID. The same-agent exact-head guard remains valuable independently of the initiating mechanism.

## Verification

- 21 focused review scheduling tests matched and passed across `internal/config`, `internal/cli`, `internal/workflow`, and `internal/daemon`
- 6 focused fail-closed and agent-identity controls matched and passed in normal and race-enabled runs
- all four changed packages compiled successfully with no tests selected
- full suite not run locally; final GitHub Actions run `33331294038` passed all 26 checks, including every race shard

Refs #1678
Refs #1681
