### PR TITLE
Fix wake ownership for terminal and review events

### DIFF
--- a/docs/events.md
+++ b/docs/events.md
@@ -204,9 +204,10 @@ manually with `set-scope` when observer delivery is intended.
 Kinds are `escalation`, `attention`, `guard`, `job-terminal`,
 `review-verdict`, `blocked`, `recycle-overdue`, `pane_input_pending`, `reply`,
 `directive`, and `fact`.
-An owner/repo `--match` or `--repo` filter is case-insensitive and exact.
-Filters without a slash retain case-insensitive substring matching against the
-event repo and job id; empty matches all. Pass only one of `--match` and
+Repository comparison for a slash-bearing owner/repo filter is
+case-insensitive and exact. Job IDs always use case-insensitive substring
+matching, including slash-bearing delegation IDs. Without a slash, repositories
+also use substring matching; empty matches all. Pass only one of `--match` and
 `--repo`. A successful review terminal whose decision is `approved` or
 `changes_requested` matches both `job-terminal` and `review-verdict` and
 addresses the pull request owner's role. If no role can be resolved, addressed

--- a/docs/events.md
+++ b/docs/events.md
@@ -173,6 +173,7 @@ pane = "w1:p2"
 
 ```sh
 gitmoot org events rule add --on guard --match owner/repo --wake maintainer
+gitmoot org events rule add --on review-verdict --match owner/repo --wake maintainer
 gitmoot org events rule add --on blocked --repo tendwire --wake maintainer
 gitmoot org events rule add --on pane_input_pending --wake maintainer
 gitmoot org events rule add --on reply --wake maintainer
@@ -185,7 +186,7 @@ gitmoot org events rule rm <rule-id>
 Rules default to `--scope addressed`: when an event carries a target role, only
 the matching addressed rule receives it. During rule evaluation,
 `--scope observer` exempts a rule from that addressee gate.
-Events without a target role keep matching both scopes exactly as before.
+Events without a target role match observer rules only.
 Durable-outbox claim authorization is scope-blind: among enabled,
 filter-matching rules for the event's own kind, wake-role equality with the
 addressed target is the only routing condition. An observer-scoped rule is
@@ -200,13 +201,19 @@ rule set is empty.
 Filtered non-reply rules remain `addressed` after upgrade and must be promoted
 manually with `set-scope` when observer delivery is intended.
 
-Kinds are `escalation`, `attention`, `guard`, `job-terminal`, `blocked`,
-`recycle-overdue`, `pane_input_pending`, and `reply`.
-The v1 `--match` filter is a case-insensitive substring tested against the event
-repo and job id; empty matches all. `--repo` is an alias for that same filter;
-pass only one of the two flags. A plain `job.blocked` event matches both
-`job-terminal` and `blocked`, while guard-caused blocks match `guard` first. A
-synthesized `blocked_since` event matches only `blocked`. Task episodes due in
+Kinds are `escalation`, `attention`, `guard`, `job-terminal`,
+`review-verdict`, `blocked`, `recycle-overdue`, `pane_input_pending`, `reply`,
+`directive`, and `fact`.
+An owner/repo `--match` or `--repo` filter is case-insensitive and exact.
+Filters without a slash retain case-insensitive substring matching against the
+event repo and job id; empty matches all. Pass only one of `--match` and
+`--repo`. A successful review terminal whose decision is `approved` or
+`changes_requested` matches both `job-terminal` and `review-verdict` and
+addresses the pull request owner's role. If no role can be resolved, addressed
+rules fail closed while observer rules can still receive the verdict. A plain
+`job.blocked` event matches both `job-terminal` and `blocked`, while
+guard-caused blocks match `guard` first. A synthesized `blocked_since` event
+matches only `blocked`. Task episodes due in
 one evaluator pass are emitted as one oldest-first digest; blocked roles retain
 one event per role. Set
 `[orchestrate].blocked_role_wake_after` to a positive Go duration to emit such an

--- a/internal/cli/daemon_advance_blocked_test.go
+++ b/internal/cli/daemon_advance_blocked_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/gitmoot/gitmoot/internal/config"
 	"github.com/gitmoot/gitmoot/internal/db"
+	"github.com/gitmoot/gitmoot/internal/events"
 	"github.com/gitmoot/gitmoot/internal/execbackend"
 	"github.com/gitmoot/gitmoot/internal/github"
 	"github.com/gitmoot/gitmoot/internal/runtime"
@@ -19,17 +20,33 @@ import (
 )
 
 func TestBlockedAdvanceSettlesQueriedJobState(t *testing.T) {
-	job, _, events := runNonFastForwardBlockedAdvance(t)
+	job, _, dbEvents, _ := runNonFastForwardBlockedAdvance(t)
 	if job.State != string(workflow.JobBlocked) {
 		t.Fatalf("queried job state = %q, want blocked", job.State)
 	}
-	if !daemonWorkerHasEvent(events, "advance_blocked") {
-		t.Fatalf("events = %+v, want advance_blocked", events)
+	if !daemonWorkerHasEvent(dbEvents, "advance_blocked") {
+		t.Fatalf("events = %+v, want advance_blocked", dbEvents)
+	}
+}
+
+func TestBlockedAdvanceEmitsRoutableTerminalEvent(t *testing.T) {
+	_, _, _, sink := runNonFastForwardBlockedAdvance(t)
+	blocked := sink.byType(events.EventJobBlocked)
+	if len(blocked) != 1 {
+		t.Fatalf("job.blocked emissions = %d, want exactly 1; all=%+v", len(blocked), sink.events)
+	}
+	ev := blocked[0]
+	if ev.Cause != "advance_blocked" || ev.WakeTargetRole != "author" {
+		t.Fatalf("advance-blocked routing metadata = %+v", ev)
+	}
+	kinds := classifyEventRuleKinds(ev)
+	if len(kinds) != 2 || kinds[0] != "job-terminal" || kinds[1] != "blocked" {
+		t.Fatalf("advance-blocked classified kinds = %v, want [job-terminal blocked]", kinds)
 	}
 }
 
 func TestBlockedAdvancePostsBlockedDecision(t *testing.T) {
-	_, body, _ := runNonFastForwardBlockedAdvance(t)
+	_, body, _, _ := runNonFastForwardBlockedAdvance(t)
 	if !strings.Contains(body, "**Decision:** `blocked`") {
 		t.Fatalf("blocked advancement comment did not report blocked:\n%s", body)
 	}
@@ -42,7 +59,7 @@ func TestBlockedAdvancePostsBlockedDecision(t *testing.T) {
 }
 
 func TestBlockedAdvancePersistsBlockedDecision(t *testing.T) {
-	job, _, _ := runNonFastForwardBlockedAdvance(t)
+	job, _, _, _ := runNonFastForwardBlockedAdvance(t)
 	payload, err := daemonJobPayload(job)
 	if err != nil {
 		t.Fatalf("daemonJobPayload returned error: %v", err)
@@ -724,7 +741,7 @@ func (f selectiveBlockedFinalizer) FinalizeImplementation(_ context.Context, job
 	return payload, nil
 }
 
-func runNonFastForwardBlockedAdvance(t *testing.T) (db.Job, string, []db.JobEvent) {
+func runNonFastForwardBlockedAdvance(t *testing.T) (db.Job, string, []db.JobEvent, *recordingSink) {
 	t.Helper()
 	ctx := context.Background()
 	home := t.TempDir()
@@ -764,9 +781,11 @@ func runNonFastForwardBlockedAdvance(t *testing.T) (db.Job, string, []db.JobEven
 	if err := store.UpsertTask(ctx, db.Task{ID: "task-1", RepoFullName: "owner/repo", Title: "Task 1", State: string(workflow.TaskImplementing), Branch: "task-1", WorktreePath: checkout}); err != nil {
 		t.Fatalf("UpsertTask returned error: %v", err)
 	}
-	enqueueDaemonWorkerJob(t, store, workflow.JobRequest{ID: "job-non-fast-forward", Agent: "lead", Action: "implement", Repo: "owner/repo", Branch: "task-1", PullRequest: 7, TaskID: "task-1", TaskTitle: "Task 1"})
+	enqueueDaemonWorkerJob(t, store, workflow.JobRequest{ID: "job-non-fast-forward", Agent: "lead", Action: "implement", Repo: "owner/repo", Branch: "task-1", PullRequest: 7, TaskID: "task-1", TaskTitle: "Task 1", ActingOrgRole: "author"})
 	comments := &cliPollFakeGitHub{}
+	sink := &recordingSink{}
 	worker := defaultJobWorker(store, io.Discard)
+	worker.EventSinkOverride = sink
 	worker.CheckoutValidator = func(context.Context, db.Job, workflow.JobPayload, runtime.Agent) (string, error) {
 		return checkout, nil
 	}
@@ -792,7 +811,7 @@ func runNonFastForwardBlockedAdvance(t *testing.T) (db.Job, string, []db.JobEven
 	if !strings.HasPrefix(remoteAfter, remoteHead) {
 		t.Fatalf("remote task branch changed after rejected push: got %q, want head %s", remoteAfter, remoteHead)
 	}
-	return job, comments.posted[0].body, events
+	return job, comments.posted[0].body, events, sink
 }
 
 func configureTestGit(t *testing.T, dir string) {

--- a/internal/cli/daemon_result.go
+++ b/internal/cli/daemon_result.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/gitmoot/gitmoot/internal/daemon"
 	"github.com/gitmoot/gitmoot/internal/db"
-	"github.com/gitmoot/gitmoot/internal/events"
 	"github.com/gitmoot/gitmoot/internal/runtime"
 	"github.com/gitmoot/gitmoot/internal/workflow"
 )
@@ -58,8 +57,8 @@ func (w jobWorker) afterQueuedJobTransition(ctx context.Context, jobID string, s
 		// nil-safe when [events] is OFF. The subsequent finalizePreflightDelegationChild
 		// only attaches a synthetic result via savePayload (no further transition),
 		// so it does not double-emit.
-		if eventType, ok := daemonTerminalEventType(state); ok {
-			emitDaemonTerminalEvent(ctx, w.eventSink(), w.Store, jobID, eventType, string(state), cause.Error())
+		if eventKind, ok := daemonTerminalEventKind(state); ok {
+			emitDaemonTerminalEvent(ctx, w.eventSink(), w.Store, jobID, eventKind, string(state), cause.Error())
 		}
 	}
 	// A delegation child that fails in ANY pre-flight step (checkout/branch-lock
@@ -173,7 +172,7 @@ func (w jobWorker) handleRunJobError(ctx context.Context, jobID string, observed
 				// Mailbox.finishWithPayload chokepoint), so emit job.blocked exactly
 				// once here. The following finalizePreflightDelegationChild only attaches
 				// a synthetic result (savePayload, no transition), so it never re-emits.
-				emitDaemonTerminalEvent(ctx, w.eventSink(), w.Store, jobID, events.EventJobBlocked, string(workflow.JobBlocked), agentPermissionBlockedMessage, "permission_guard")
+				emitDaemonTerminalEvent(ctx, w.eventSink(), w.Store, jobID, daemonTerminalPermissionGuard, string(workflow.JobBlocked), agentPermissionBlockedMessage)
 				// A WRITABLE implement DELEGATION child whose runtime fails MID-RUN
 				// with a permission error (read-only FS / sandbox denies write) is
 				// transitioned JobRunning->JobBlocked here and returns early — it never
@@ -530,7 +529,7 @@ func (w jobWorker) settleBlockedAdvancement(ctx context.Context, jobID string, o
 		return err
 	}
 	if transitioned {
-		emitDaemonTerminalEvent(ctx, w.eventSink(), w.Store, jobID, events.EventJobBlocked, string(workflow.JobBlocked), message, "advance_blocked")
+		emitDaemonTerminalEvent(ctx, w.eventSink(), w.Store, jobID, daemonTerminalAdvanceBlocked, string(workflow.JobBlocked), message)
 		return nil
 	}
 	latest, err = w.Store.GetJob(ctx, jobID)

--- a/internal/cli/daemon_worker.go
+++ b/internal/cli/daemon_worker.go
@@ -395,7 +395,7 @@ func (w jobWorker) run(ctx context.Context, job db.Job) error {
 		// genuine transition above, nil-safe when [events] is OFF. The following
 		// finalizePreflightDelegationChild only attaches a synthetic result
 		// (savePayload, no transition), so it never re-emits.
-		emitDaemonTerminalEvent(ctx, w.eventSink(), w.Store, job.ID, events.EventJobBlocked, string(workflow.JobBlocked), agentPermissionBlockedMessage, "permission_guard")
+		emitDaemonTerminalEvent(ctx, w.eventSink(), w.Store, job.ID, daemonTerminalPermissionGuard, string(workflow.JobBlocked), agentPermissionBlockedMessage)
 		_ = w.postJobResultComment(ctx, job.ID, agent, "", errors.New(agentPermissionBlockedMessage))
 		writeLine(w.Stdout, "job %s blocked: %s", job.ID, agentPermissionBlockedMessage)
 		// A read-only implement DELEGATION child short-circuits to blocked here,
@@ -950,7 +950,7 @@ func (w jobWorker) retryImplementationPreflight(ctx context.Context, job db.Job,
 		if err != nil || !transitioned {
 			return err
 		}
-		emitDaemonTerminalEvent(ctx, w.eventSink(), w.Store, job.ID, events.EventJobDeferred, string(workflow.JobQueued), message)
+		emitDaemonTerminalEvent(ctx, w.eventSink(), w.Store, job.ID, daemonTerminalDeferred, string(workflow.JobQueued), message)
 		return nil
 	}
 	exhausted := fmt.Errorf("automatic implementation preflight retries exhausted after %d attempts for task %s in worktree %q: %w; inspect and repair the worktree, then run `gitmoot job retry %s`; if the dispatch metadata is stale, dispatch a fresh fix job against pull request #%d's current head", implementationPreflightAttemptLimit, payload.TaskID, payload.WorktreePath, cause, job.ID, payload.PullRequest)

--- a/internal/cli/doctor_event_observers.go
+++ b/internal/cli/doctor_event_observers.go
@@ -76,10 +76,6 @@ func blockedWakeDirectedKinds() []string {
 	return []string{db.WakeOutboxKindBlocked}
 }
 
-func daemonTerminalWakeDirectedKinds() []string {
-	return []string{"job-terminal", db.WakeOutboxKindBlocked}
-}
-
 func engineTerminalWakeDirectedKinds() []string {
 	return []string{"job-terminal", eventRuleKindReviewVerdict, db.WakeOutboxKindBlocked}
 }

--- a/internal/cli/doctor_event_observers.go
+++ b/internal/cli/doctor_event_observers.go
@@ -40,7 +40,7 @@ var wakeTargetRoleProducers = []wakeTargetRoleProducer{
 	{
 		File:     "internal/cli/event_sink.go",
 		Function: "emitDaemonTerminalEvent",
-		Kinds:    blockedWakeDirectedKinds,
+		Kinds:    daemonTerminalWakeDirectedKinds,
 	},
 	{
 		File:     "internal/cli/blocked_since.go",
@@ -57,6 +57,11 @@ var wakeTargetRoleProducers = []wakeTargetRoleProducer{
 		Function: "strandTask",
 		Kinds:    taskDisposalDirectedKinds,
 	},
+	{
+		File:     "internal/workflow/engine_types.go",
+		Function: "mailbox",
+		Kinds:    engineTerminalWakeDirectedKinds,
+	},
 }
 
 func directiveNudgeDirectedKinds() []string {
@@ -69,6 +74,14 @@ func directiveEscalationDirectedKinds() []string {
 
 func blockedWakeDirectedKinds() []string {
 	return []string{db.WakeOutboxKindBlocked}
+}
+
+func daemonTerminalWakeDirectedKinds() []string {
+	return []string{"job-terminal", db.WakeOutboxKindBlocked}
+}
+
+func engineTerminalWakeDirectedKinds() []string {
+	return []string{"job-terminal", eventRuleKindReviewVerdict, db.WakeOutboxKindBlocked}
 }
 
 func inputPendingDirectedKinds() []string {

--- a/internal/cli/event_rule_sink.go
+++ b/internal/cli/event_rule_sink.go
@@ -427,9 +427,10 @@ func classifyEventRuleKinds(event events.Event) []string {
 			return []string{"guard"}
 		case "blocked_since":
 			return []string{"blocked"}
-		case "":
-			// A plain blocked transition is both a terminal outcome and the
-			// narrower blocked rule kind.
+		case "", "advance_blocked":
+			// A blocked terminal transition is both a terminal outcome and the
+			// narrower blocked rule kind. advance_blocked names the daemon path,
+			// not a distinct routing policy.
 			return []string{"job-terminal", "blocked"}
 		}
 	case events.EventJobNeedsAttention:

--- a/internal/cli/event_rule_sink.go
+++ b/internal/cli/event_rule_sink.go
@@ -477,11 +477,12 @@ func eventRuleMatches(filter string, event events.Event) bool {
 	if filter == "" {
 		return true
 	}
+	repo := strings.ToLower(strings.TrimSpace(event.Repo))
+	jobID := strings.ToLower(event.JobID)
 	if strings.Contains(filter, "/") {
-		return strings.EqualFold(strings.TrimSpace(event.Repo), filter)
+		return repo == filter || strings.Contains(jobID, filter)
 	}
-	return strings.Contains(strings.ToLower(event.Repo), filter) ||
-		strings.Contains(strings.ToLower(event.JobID), filter)
+	return strings.Contains(repo, filter) || strings.Contains(jobID, filter)
 }
 
 func eventRuleWakePrompt(kind string, event events.Event) string {

--- a/internal/cli/event_rule_sink.go
+++ b/internal/cli/event_rule_sink.go
@@ -28,6 +28,7 @@ const (
 	eventRuleProbeTimeout           = 5 * time.Second
 	directiveCompletionOverdueCause = "directive_completion_overdue"
 	directiveTerminalCause          = "directive_terminal"
+	eventRuleKindReviewVerdict      = "review-verdict"
 )
 
 type eventWakeClient interface {
@@ -413,7 +414,12 @@ func (s *eventRuleSink) resolveRolePane(ctx context.Context, cfg config.OrgConfi
 
 func classifyEventRuleKinds(event events.Event) []string {
 	switch event.Type {
-	case events.EventJobFinished, events.EventJobFailed:
+	case events.EventJobFinished:
+		if event.Cause == events.EventCauseReviewVerdict {
+			return []string{"job-terminal", eventRuleKindReviewVerdict}
+		}
+		return []string{"job-terminal"}
+	case events.EventJobFailed:
 		return []string{"job-terminal"}
 	case events.EventJobBlocked:
 		switch event.Cause {
@@ -471,11 +477,25 @@ func eventRuleMatches(filter string, event events.Event) bool {
 	if filter == "" {
 		return true
 	}
+	if strings.Contains(filter, "/") {
+		return strings.EqualFold(strings.TrimSpace(event.Repo), filter)
+	}
 	return strings.Contains(strings.ToLower(event.Repo), filter) ||
 		strings.Contains(strings.ToLower(event.JobID), filter)
 }
 
 func eventRuleWakePrompt(kind string, event events.Event) string {
+	if strings.EqualFold(strings.TrimSpace(kind), eventRuleKindReviewVerdict) {
+		detail := truncateForWake(strings.TrimSpace(event.Detail), 320)
+		prompt := fmt.Sprintf(
+			"gitmoot review verdict %s for %s#%d from job %s",
+			event.ReviewDecision, event.Repo, event.PullRequest, event.JobID,
+		)
+		if detail != "" {
+			prompt += ": " + detail
+		}
+		return prompt
+	}
 	if strings.EqualFold(strings.TrimSpace(kind), db.WakeOutboxKindDirective) {
 		directiveID := strings.TrimPrefix(event.RootID, db.WakeOutboxSourceWorkflowNote+":")
 		switch event.Cause {

--- a/internal/cli/event_rule_sink_test.go
+++ b/internal/cli/event_rule_sink_test.go
@@ -161,6 +161,7 @@ func TestClassifyEventRuleKinds(t *testing.T) {
 		{name: "failed terminal", event: events.Event{Type: events.EventJobFailed, Cause: "unrelated"}, want: []string{"job-terminal"}},
 		{name: "review verdict", event: events.Event{Type: events.EventJobFinished, Cause: events.EventCauseReviewVerdict}, want: []string{"job-terminal", eventRuleKindReviewVerdict}},
 		{name: "plain blocked terminal and blocked", event: events.Event{Type: events.EventJobBlocked}, want: []string{"job-terminal", "blocked"}},
+		{name: "advance blocked terminal and blocked", event: events.Event{Type: events.EventJobBlocked, Cause: "advance_blocked"}, want: []string{"job-terminal", "blocked"}},
 		{name: "unknown blocked cause", event: events.Event{Type: events.EventJobBlocked, Cause: "other"}},
 		{name: "unknown attention cause", event: events.Event{Type: events.EventJobNeedsAttention, Cause: "other"}},
 	}

--- a/internal/cli/event_rule_sink_test.go
+++ b/internal/cli/event_rule_sink_test.go
@@ -518,7 +518,7 @@ pane="w1:p4"
 				}); err != nil {
 					t.Fatal(err)
 				}
-				emitDaemonTerminalEvent(ctx, sink, store, "blocked-job", events.EventJobBlocked, string(workflow.JobBlocked), "blocked")
+				emitDaemonTerminalEvent(ctx, sink, store, "blocked-job", daemonTerminalBlocked, string(workflow.JobBlocked), "blocked")
 			} else {
 				sink.Emit(ctx, events.Event{Type: events.EventJobBlocked, Cause: "blocked_since", JobID: "blocked-task", Repo: test.repo})
 			}
@@ -601,6 +601,12 @@ func TestEventRuleMatchUsesExactRepositoryAndSubstringJobID(t *testing.T) {
 	for _, filter := range []string{"acme/w", "acme/widget-plus", "missing"} {
 		if eventRuleMatches(filter, event) {
 			t.Fatalf("filter %q unexpectedly matched", filter)
+		}
+	}
+	delegated := events.Event{Repo: "owner/repo", JobID: "root/delegation/check"}
+	for _, filter := range []string{"root/delegation/check", "delegation/check"} {
+		if !eventRuleMatches(filter, delegated) {
+			t.Fatalf("slash-bearing job-id filter %q did not match %q", filter, delegated.JobID)
 		}
 	}
 	prefixCollision := events.Event{Repo: "acme/widget-plus", JobID: "other"}

--- a/internal/cli/event_rule_sink_test.go
+++ b/internal/cli/event_rule_sink_test.go
@@ -125,6 +125,21 @@ func TestEventRuleDirectiveWakePromptMatchesCurrentPhase(t *testing.T) {
 		})
 	}
 }
+func TestEventRuleReviewVerdictWakePrompt(t *testing.T) {
+	event := events.Event{
+		JobID:          "review-42",
+		Repo:           "gitmoot/gitmoot",
+		Detail:         "one blocking issue",
+		PullRequest:    42,
+		ReviewDecision: "changes_requested",
+	}
+	prompt := eventRuleWakePrompt(eventRuleKindReviewVerdict, event)
+	for _, want := range []string{"changes_requested", "gitmoot/gitmoot#42", "review-42", "one blocking issue"} {
+		if !strings.Contains(prompt, want) {
+			t.Fatalf("prompt %q does not contain %q", prompt, want)
+		}
+	}
+}
 
 func TestClassifyEventRuleKinds(t *testing.T) {
 	tests := []struct {
@@ -144,6 +159,7 @@ func TestClassifyEventRuleKinds(t *testing.T) {
 		{name: "addressed awaited fact", event: events.Event{Type: events.EventOrgFact, Cause: "awaited_fact_satisfied"}, want: []string{"fact"}},
 		{name: "finished terminal", event: events.Event{Type: events.EventJobFinished}, want: []string{"job-terminal"}},
 		{name: "failed terminal", event: events.Event{Type: events.EventJobFailed, Cause: "unrelated"}, want: []string{"job-terminal"}},
+		{name: "review verdict", event: events.Event{Type: events.EventJobFinished, Cause: events.EventCauseReviewVerdict}, want: []string{"job-terminal", eventRuleKindReviewVerdict}},
 		{name: "plain blocked terminal and blocked", event: events.Event{Type: events.EventJobBlocked}, want: []string{"job-terminal", "blocked"}},
 		{name: "unknown blocked cause", event: events.Event{Type: events.EventJobBlocked, Cause: "other"}},
 		{name: "unknown attention cause", event: events.Event{Type: events.EventJobNeedsAttention, Cause: "other"}},
@@ -159,7 +175,7 @@ func TestClassifyEventRuleKinds(t *testing.T) {
 
 func TestWakeTargetRoleProductionWritesMatchObserverRegistry(t *testing.T) {
 	writes := productionWakeTargetRoleWrites(t)
-	if got, want := fmt.Sprint(writes), "[internal/cli/blocked_since.go:buildDirectiveEscalationEvent internal/cli/blocked_since.go:buildDirectiveNudgeEvent internal/cli/blocked_since.go:emitInputPendingEpisode internal/cli/event_rule_sink.go:addressBlockedEvent internal/cli/event_sink.go:emitDaemonTerminalEvent internal/cli/reply_wake_outbox.go:wakeOutboxEvent internal/daemon/task_disposal.go:strandTask]"; got != want {
+	if got, want := fmt.Sprint(writes), "[internal/cli/blocked_since.go:buildDirectiveEscalationEvent internal/cli/blocked_since.go:buildDirectiveNudgeEvent internal/cli/blocked_since.go:emitInputPendingEpisode internal/cli/event_rule_sink.go:addressBlockedEvent internal/cli/event_sink.go:emitDaemonTerminalEvent internal/cli/reply_wake_outbox.go:wakeOutboxEvent internal/daemon/task_disposal.go:strandTask internal/workflow/engine_types.go:mailbox]"; got != want {
 		t.Fatalf("production WakeTargetRole writes = %s, want %s", got, want)
 	}
 	registryWrites := make([]wakeTargetRoleWrite, 0, len(wakeTargetRoleProducers))
@@ -350,6 +366,24 @@ func productionSelectorCallSites(t *testing.T, selectorName string) []wakeTarget
 		return calls[i].function < calls[j].function
 	})
 	return calls
+}
+
+func TestJobTerminalAddressedScopeMatchesDispatcherOnly(t *testing.T) {
+	author := db.EventRule{WakeRole: "author", Scope: db.EventRuleScopeAddressed}
+	other := db.EventRule{WakeRole: "other", Scope: db.EventRuleScopeAddressed}
+	observer := db.EventRule{WakeRole: "auditor", Scope: db.EventRuleScopeObserver}
+	addressed := events.Event{Type: events.EventJobFinished, Cause: events.EventCauseReviewVerdict, WakeTargetRole: "author"}
+	if !eventRuleMatchesAddressee(author, addressed) ||
+		eventRuleMatchesAddressee(other, addressed) ||
+		!eventRuleMatchesAddressee(observer, addressed) {
+		t.Fatal("addressed terminal event did not match author and observer only")
+	}
+	roleless := events.Event{Type: events.EventJobFinished}
+	if eventRuleMatchesAddressee(author, roleless) ||
+		eventRuleMatchesAddressee(other, roleless) ||
+		!eventRuleMatchesAddressee(observer, roleless) {
+		t.Fatal("roleless terminal event did not match observer only")
+	}
 }
 
 func TestEventRuleAddresseeGateIsKindAgnosticAndObserverExempt(t *testing.T) {
@@ -557,15 +591,21 @@ pane="w1:p2"
 	}
 }
 
-func TestEventRuleMatchV1(t *testing.T) {
+func TestEventRuleMatchUsesExactRepositoryAndSubstringJobID(t *testing.T) {
 	event := events.Event{Repo: "Acme/Widget", JobID: "Job-AbC"}
-	for _, filter := range []string{"", "acme/w", "WIDGET", "job-a", "ABC"} {
+	for _, filter := range []string{"", "acme/widget", "WIDGET", "job-a", "ABC"} {
 		if !eventRuleMatches(filter, event) {
 			t.Fatalf("filter %q did not match", filter)
 		}
 	}
-	if eventRuleMatches("missing", event) {
-		t.Fatal("unexpected match")
+	for _, filter := range []string{"acme/w", "acme/widget-plus", "missing"} {
+		if eventRuleMatches(filter, event) {
+			t.Fatalf("filter %q unexpectedly matched", filter)
+		}
+	}
+	prefixCollision := events.Event{Repo: "acme/widget-plus", JobID: "other"}
+	if eventRuleMatches("acme/widget", prefixCollision) {
+		t.Fatal("exact repo filter matched a prefix-colliding repository")
 	}
 }
 
@@ -812,6 +852,63 @@ func TestEventRuleWakeFiresEachMatchingRule(t *testing.T) {
 	sink.evaluate(context.Background(), events.Event{Type: events.EventJobBlocked, JobID: "job-1", WakeTargetRole: "owner"})
 	if wake.promptCalls != 2 {
 		t.Fatalf("want a wake for each of the 2 matching rules, got %d", wake.promptCalls)
+	}
+}
+func TestReviewVerdictWakeTargetsOwnerAndObservers(t *testing.T) {
+	home := t.TempDir()
+	paths := config.PathsForHome(home)
+	if err := os.MkdirAll(filepath.Dir(paths.ConfigFile), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	configBody := `
+[org.roles."owner"]
+scope=["*"]
+pane="w1:p0"
+[org.roles."author"]
+parent="owner"
+scope=["*"]
+pane="w1:p1"
+[org.roles."other"]
+parent="owner"
+scope=["*"]
+pane="w1:p2"
+[org.roles."auditor"]
+parent="owner"
+scope=["*"]
+pane="w1:p3"
+`
+	if err := os.WriteFile(paths.ConfigFile, []byte(configBody), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	store, err := dbtest.Open(t, paths.Database)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+	for _, rule := range []db.EventRule{
+		{ID: "author", OnKind: eventRuleKindReviewVerdict, WakeRole: "author", Scope: db.EventRuleScopeAddressed, Enabled: true},
+		{ID: "other", OnKind: eventRuleKindReviewVerdict, WakeRole: "other", Scope: db.EventRuleScopeAddressed, Enabled: true},
+		{ID: "auditor", OnKind: eventRuleKindReviewVerdict, WakeRole: "auditor", Scope: db.EventRuleScopeObserver, Enabled: true},
+	} {
+		if err := store.AddEventRule(context.Background(), rule); err != nil {
+			t.Fatal(err)
+		}
+	}
+	wake := &fakeEventWake{}
+	sink := &eventRuleSink{store: store, home: home, wake: wake}
+	sink.evaluate(context.Background(), events.Event{
+		Type:           events.EventJobFinished,
+		Cause:          events.EventCauseReviewVerdict,
+		JobID:          "review-42",
+		Repo:           "owner/repo",
+		WakeTargetRole: "author",
+		PullRequest:    42,
+		ReviewDecision: "approved",
+	})
+
+	sort.Strings(wake.panes)
+	if got, want := fmt.Sprint(wake.panes), "[w1:p1 w1:p3]"; got != want {
+		t.Fatalf("woken panes = %s, want %s", got, want)
 	}
 }
 

--- a/internal/cli/event_sink.go
+++ b/internal/cli/event_sink.go
@@ -172,18 +172,73 @@ func resolveConfigFile(home string) string {
 	return cfg
 }
 
-// daemonTerminalEventType maps a daemon-owned terminal JobState to the outbound
-// event_type (#446). Only failed/blocked map (the succeeded path is engine-owned
-// via the Mailbox chokepoint); any other state returns ok=false.
-func daemonTerminalEventType(state workflow.JobState) (events.EventType, bool) {
+type daemonTerminalEmissionKind uint8
+
+const (
+	daemonTerminalFailed daemonTerminalEmissionKind = iota
+	daemonTerminalBlocked
+	daemonTerminalPermissionGuard
+	daemonTerminalAdvanceBlocked
+	daemonTerminalDeferred
+	daemonTerminalEmissionKindCount
+)
+
+type daemonTerminalEventSpec struct {
+	eventType events.EventType
+	cause     string
+}
+
+func (kind daemonTerminalEmissionKind) spec() (daemonTerminalEventSpec, bool) {
+	switch kind {
+	case daemonTerminalFailed:
+		return daemonTerminalEventSpec{eventType: events.EventJobFailed}, true
+	case daemonTerminalBlocked:
+		return daemonTerminalEventSpec{eventType: events.EventJobBlocked}, true
+	case daemonTerminalPermissionGuard:
+		return daemonTerminalEventSpec{eventType: events.EventJobBlocked, cause: "permission_guard"}, true
+	case daemonTerminalAdvanceBlocked:
+		return daemonTerminalEventSpec{eventType: events.EventJobBlocked, cause: "advance_blocked"}, true
+	case daemonTerminalDeferred:
+		return daemonTerminalEventSpec{eventType: events.EventJobDeferred}, true
+	default:
+		return daemonTerminalEventSpec{}, false
+	}
+}
+
+// daemonTerminalEventKind maps daemon-owned terminal job states onto the
+// emission kinds accepted by emitDaemonTerminalEvent. Succeeded jobs remain
+// engine-owned.
+func daemonTerminalEventKind(state workflow.JobState) (daemonTerminalEmissionKind, bool) {
 	switch state {
 	case workflow.JobFailed:
-		return events.EventJobFailed, true
+		return daemonTerminalFailed, true
 	case workflow.JobBlocked:
-		return events.EventJobBlocked, true
+		return daemonTerminalBlocked, true
 	default:
-		return "", false
+		return 0, false
 	}
+}
+
+// daemonTerminalWakeDirectedKinds derives doctor coverage from every emission
+// kind the producer accepts. The count sentinel makes additions enter this loop,
+// while spec and per-kind doctor tests reject unmapped or uncovered kinds.
+func daemonTerminalWakeDirectedKinds() []string {
+	seen := make(map[string]struct{})
+	var kinds []string
+	for emission := daemonTerminalEmissionKind(0); emission < daemonTerminalEmissionKindCount; emission++ {
+		spec, ok := emission.spec()
+		if !ok {
+			continue
+		}
+		for _, kind := range classifyEventRuleKinds(events.Event{Type: spec.eventType, Cause: spec.cause}) {
+			if _, exists := seen[kind]; exists {
+				continue
+			}
+			seen[kind] = struct{}{}
+			kinds = append(kinds, kind)
+		}
+	}
+	return kinds
 }
 
 // emitDaemonTerminalEvent emits a best-effort terminal event for a job the
@@ -194,8 +249,9 @@ func daemonTerminalEventType(state workflow.JobState) (events.EventType, bool) {
 // resolves root_id from the payload (falling back to the job id). It must only be
 // called on a GENUINE transition so the engine and daemon never double-emit for
 // the same terminal state.
-func emitDaemonTerminalEvent(ctx context.Context, sink events.Sink, store *db.Store, jobID string, eventType events.EventType, status, detail string, cause ...string) {
-	if sink == nil {
+func emitDaemonTerminalEvent(ctx context.Context, sink events.Sink, store *db.Store, jobID string, emission daemonTerminalEmissionKind, status, detail string) {
+	spec, ok := emission.spec()
+	if sink == nil || !ok {
 		return
 	}
 	repo := ""
@@ -213,7 +269,7 @@ func emitDaemonTerminalEvent(ctx context.Context, sink events.Sink, store *db.St
 		}
 	}
 	event := events.NewEvent(
-		eventType,
+		spec.eventType,
 		jobID,
 		rootID,
 		repo,
@@ -222,8 +278,8 @@ func emitDaemonTerminalEvent(ctx context.Context, sink events.Sink, store *db.St
 		time.Time{},
 		workflow.RedactCommentText,
 	)
-	if len(cause) > 0 {
-		event.Cause = strings.TrimSpace(cause[0])
+	if spec.cause != "" {
+		event.Cause = spec.cause
 	}
 	if wakeTargetRole != "" {
 		event.WakeTargetRole = wakeTargetRole

--- a/internal/cli/event_sink.go
+++ b/internal/cli/event_sink.go
@@ -225,7 +225,7 @@ func emitDaemonTerminalEvent(ctx context.Context, sink events.Sink, store *db.St
 	if len(cause) > 0 {
 		event.Cause = strings.TrimSpace(cause[0])
 	}
-	if eventType == events.EventJobBlocked && wakeTargetRole != "" {
+	if wakeTargetRole != "" {
 		event.WakeTargetRole = wakeTargetRole
 	}
 	events.EmitEvent(ctx, sink, event)

--- a/internal/cli/event_sink_daemon_test.go
+++ b/internal/cli/event_sink_daemon_test.go
@@ -141,7 +141,7 @@ func TestDaemonTerminalEmissionKindsDriveObserverCoverage(t *testing.T) {
 		{name: "failed", emission: daemonTerminalFailed, want: []string{"job-terminal"}},
 		{name: "blocked", emission: daemonTerminalBlocked, want: []string{"job-terminal", "blocked"}},
 		{name: "permission guard", emission: daemonTerminalPermissionGuard, want: []string{"guard"}},
-		{name: "advance blocked", emission: daemonTerminalAdvanceBlocked},
+		{name: "advance blocked", emission: daemonTerminalAdvanceBlocked, want: []string{"job-terminal", "blocked"}},
 		{name: "deferred", emission: daemonTerminalDeferred},
 	}
 	if len(tests) != int(daemonTerminalEmissionKindCount) {

--- a/internal/cli/event_sink_daemon_test.go
+++ b/internal/cli/event_sink_daemon_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"io"
+	"reflect"
 	"sync"
 	"testing"
 
@@ -128,6 +129,38 @@ func TestFinishQueuedJobEmitsJobBlocked(t *testing.T) {
 		t.Fatalf("job.blocked emissions = %d, want 1", len(got))
 	} else if got[0].WakeTargetRole != "gmc-gate" {
 		t.Fatalf("job.blocked wake target = %q, want recorded role gmc-gate", got[0].WakeTargetRole)
+	}
+}
+
+func TestDaemonTerminalEmissionKindsDriveObserverCoverage(t *testing.T) {
+	tests := []struct {
+		name     string
+		emission daemonTerminalEmissionKind
+		want     []string
+	}{
+		{name: "failed", emission: daemonTerminalFailed, want: []string{"job-terminal"}},
+		{name: "blocked", emission: daemonTerminalBlocked, want: []string{"job-terminal", "blocked"}},
+		{name: "permission guard", emission: daemonTerminalPermissionGuard, want: []string{"guard"}},
+		{name: "advance blocked", emission: daemonTerminalAdvanceBlocked},
+		{name: "deferred", emission: daemonTerminalDeferred},
+	}
+	if len(tests) != int(daemonTerminalEmissionKindCount) {
+		t.Fatalf("emission cases = %d, want %d", len(tests), daemonTerminalEmissionKindCount)
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			spec, ok := test.emission.spec()
+			if !ok {
+				t.Fatalf("emission %d has no event specification", test.emission)
+			}
+			got := classifyEventRuleKinds(events.Event{Type: spec.eventType, Cause: spec.cause})
+			if !reflect.DeepEqual(got, test.want) {
+				t.Fatalf("classified kinds = %v, want %v", got, test.want)
+			}
+		})
+	}
+	if got, want := daemonTerminalWakeDirectedKinds(), []string{"job-terminal", "blocked", "guard"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("derived directed kinds = %v, want %v", got, want)
 	}
 }
 

--- a/internal/cli/event_sink_daemon_test.go
+++ b/internal/cli/event_sink_daemon_test.go
@@ -68,7 +68,7 @@ func TestFinishQueuedJobEmitsJobFailed(t *testing.T) {
 	if err := store.CreateJob(ctx, db.Job{ID: "queued-job", Agent: "coord", Type: "ask", State: string(workflow.JobQueued)}); err != nil {
 		t.Fatalf("CreateJob returned error: %v", err)
 	}
-	payload := workflow.JobPayload{Repo: "owner/repo", RootJobID: "root-1"}
+	payload := workflow.JobPayload{Repo: "owner/repo", RootJobID: "root-1", ActingOrgRole: "author"}
 	encoded, err := json.Marshal(payload)
 	if err != nil {
 		t.Fatalf("marshal payload: %v", err)
@@ -92,6 +92,9 @@ func TestFinishQueuedJobEmitsJobFailed(t *testing.T) {
 	ev := failed[0]
 	if ev.JobID != "queued-job" || ev.RootID != "root-1" || ev.Repo != "owner/repo" || ev.Status != "failed" {
 		t.Fatalf("job.failed event = %+v", ev)
+	}
+	if ev.WakeTargetRole != "author" {
+		t.Fatalf("wake target role = %q, want author", ev.WakeTargetRole)
 	}
 	if ev.SchemaVersion != 1 {
 		t.Fatalf("schema_version = %d, want 1", ev.SchemaVersion)

--- a/internal/cli/job_blocker.go
+++ b/internal/cli/job_blocker.go
@@ -14,7 +14,6 @@ import (
 	"unicode/utf8"
 
 	"github.com/gitmoot/gitmoot/internal/db"
-	"github.com/gitmoot/gitmoot/internal/events"
 	"github.com/gitmoot/gitmoot/internal/github"
 	"github.com/gitmoot/gitmoot/internal/runtime"
 	"github.com/gitmoot/gitmoot/internal/workflow"
@@ -526,7 +525,7 @@ func (w jobWorker) deferOperationalBlockerPreTerminal(ctx context.Context, jobID
 		// terminal-set transition for this run — the [events] stream sees the deferral
 		// directly, with no preceding failed→deferred flap. Best-effort and nil-safe
 		// when [events] is OFF, mirroring the daemon's other emits.
-		emitDaemonTerminalEvent(ctx, w.eventSink(), w.Store, jobID, events.EventJobDeferred, string(workflow.JobQueued), message)
+		emitDaemonTerminalEvent(ctx, w.eventSink(), w.Store, jobID, daemonTerminalDeferred, string(workflow.JobQueued), message)
 	}
 	return transitioned, nil
 }

--- a/internal/cli/job_blocker_checkout.go
+++ b/internal/cli/job_blocker_checkout.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	"github.com/gitmoot/gitmoot/internal/db"
-	"github.com/gitmoot/gitmoot/internal/events"
 	"github.com/gitmoot/gitmoot/internal/workflow"
 )
 
@@ -171,6 +170,6 @@ func (w jobWorker) deferCheckoutContention(ctx context.Context, job db.Job, payl
 	}
 	// Additive job.deferred, best-effort and nil-safe when [events] is OFF. No
 	// job.failed precedes it: finishQueuedJob was never called (pre-terminal).
-	emitDaemonTerminalEvent(ctx, w.eventSink(), w.Store, job.ID, events.EventJobDeferred, string(workflow.JobQueued), message)
+	emitDaemonTerminalEvent(ctx, w.eventSink(), w.Store, job.ID, daemonTerminalDeferred, string(workflow.JobQueued), message)
 	return true, nil
 }

--- a/internal/cli/org.go
+++ b/internal/cli/org.go
@@ -1819,11 +1819,11 @@ func runOrgEventRuleAdd(args []string, stdout, stderr io.Writer) int {
 	fs.SetOutput(stderr)
 	home := fs.String("home", "", "home directory to use instead of the current user's home")
 	onKind := fs.String("on", "", "event kind: escalation, attention, guard, job-terminal, review-verdict, blocked, recycle-overdue, pane_input_pending, reply, directive, or fact")
-	// A slash identifies an owner/repo filter and is matched exactly. Filters
-	// without a slash retain case-insensitive substring matching against repo and
-	// job id; an empty filter matches every event of the selected kind.
-	match := fs.String("match", "", "exact owner/repo when the filter contains '/', otherwise a case-insensitive repo or job-id substring; empty matches all")
-	repo := fs.String("repo", "", "repository filter; owner/name is exact, other values are case-insensitive substrings")
+	// A slash makes the repository comparison exact while job IDs always retain
+	// case-insensitive substring matching. Without a slash, repositories also use
+	// substring matching. An empty filter matches every event of the selected kind.
+	match := fs.String("match", "", "slash filters match owner/repo exactly and job IDs by substring; other filters use repo or job-ID substrings; empty matches all")
+	repo := fs.String("repo", "", "repository alias; owner/name is exact against repo while job-ID substring matching remains active")
 	wake := fs.String("wake", "", "organization role to wake")
 	scopeFlag := fs.String("scope", string(db.EventRuleScopeAddressed), "rule scope: addressed or observer")
 	if err := fs.Parse(args); err != nil {

--- a/internal/cli/org.go
+++ b/internal/cli/org.go
@@ -1769,6 +1769,7 @@ var eventRuleKinds = map[string]struct{}{
 	"attention":          {},
 	"guard":              {},
 	"job-terminal":       {},
+	"review-verdict":     {},
 	"blocked":            {},
 	"recycle-overdue":    {},
 	"pane_input_pending": {},
@@ -1807,7 +1808,7 @@ func runOrgEvents(args []string, stdout, stderr io.Writer) int {
 
 func printOrgEventRuleUsage(w io.Writer) {
 	fmt.Fprintln(w, "Usage:")
-	fmt.Fprintln(w, "  gitmoot org events rule add --on <kind> [--match <filter> | --repo <substring>] --wake <role> [--scope addressed|observer] [--home path]")
+	fmt.Fprintln(w, "  gitmoot org events rule add --on <kind> [--match <filter> | --repo <filter>] --wake <role> [--scope addressed|observer] [--home path]")
 	fmt.Fprintln(w, "  gitmoot org events rule list [--home path]")
 	fmt.Fprintln(w, "  gitmoot org events rule set-scope [--home path] <id> observer|addressed")
 	fmt.Fprintln(w, "  gitmoot org events rule rm [--home path] <id>")
@@ -1817,12 +1818,12 @@ func runOrgEventRuleAdd(args []string, stdout, stderr io.Writer) int {
 	fs := flag.NewFlagSet("org events rule add", flag.ContinueOnError)
 	fs.SetOutput(stderr)
 	home := fs.String("home", "", "home directory to use instead of the current user's home")
-	onKind := fs.String("on", "", "event kind: escalation, attention, guard, job-terminal, blocked, recycle-overdue, pane_input_pending, reply, directive, or fact")
-	// V1 intentionally keeps matching simple and inspectable: one
-	// case-insensitive substring tested independently against repo and job id;
-	// an empty filter matches every event of the selected kind.
-	match := fs.String("match", "", "case-insensitive substring matched against event repo or job id; empty matches all")
-	repo := fs.String("repo", "", "case-insensitive repo substring (alias for --match)")
+	onKind := fs.String("on", "", "event kind: escalation, attention, guard, job-terminal, review-verdict, blocked, recycle-overdue, pane_input_pending, reply, directive, or fact")
+	// A slash identifies an owner/repo filter and is matched exactly. Filters
+	// without a slash retain case-insensitive substring matching against repo and
+	// job id; an empty filter matches every event of the selected kind.
+	match := fs.String("match", "", "exact owner/repo when the filter contains '/', otherwise a case-insensitive repo or job-id substring; empty matches all")
+	repo := fs.String("repo", "", "repository filter; owner/name is exact, other values are case-insensitive substrings")
 	wake := fs.String("wake", "", "organization role to wake")
 	scopeFlag := fs.String("scope", string(db.EventRuleScopeAddressed), "rule scope: addressed or observer")
 	if err := fs.Parse(args); err != nil {
@@ -1851,7 +1852,7 @@ func runOrgEventRuleAdd(args []string, stdout, stderr io.Writer) int {
 	}
 	kind := strings.ToLower(strings.TrimSpace(*onKind))
 	if _, ok := eventRuleKinds[kind]; !ok {
-		fmt.Fprintf(stderr, "unknown event rule kind %q; want escalation, attention, guard, job-terminal, blocked, recycle-overdue, pane_input_pending, reply, directive, or fact\n", kind)
+		fmt.Fprintf(stderr, "unknown event rule kind %q; want escalation, attention, guard, job-terminal, review-verdict, blocked, recycle-overdue, pane_input_pending, reply, directive, or fact\n", kind)
 		return 2
 	}
 	roleName := strings.ToLower(strings.TrimSpace(*wake))

--- a/internal/cli/org_test.go
+++ b/internal/cli/org_test.go
@@ -2007,8 +2007,8 @@ func TestOrgEventRuleAddListRemoveAndValidation(t *testing.T) {
 	}
 	out.Reset()
 	errOut.Reset()
-	if code := runOrg([]string{"events", "rule", "add", "--home", home, "--on", "reply", "--wake", "owner", "--scope", "observer"}, &out, &errOut); code != 0 {
-		t.Fatalf("add reply code=%d out=%q err=%q", code, out.String(), errOut.String())
+	if code := runOrg([]string{"events", "rule", "add", "--home", home, "--on", "review-verdict", "--wake", "owner", "--scope", "observer"}, &out, &errOut); code != 0 {
+		t.Fatalf("add review-verdict code=%d out=%q err=%q", code, out.String(), errOut.String())
 	}
 
 	out.Reset()

--- a/internal/cli/preflight_delegation_finalize_test.go
+++ b/internal/cli/preflight_delegation_finalize_test.go
@@ -634,6 +634,7 @@ func TestPreflightReadOnlyImplementEmitsJobBlocked(t *testing.T) {
 	seedDaemonWorkerAgentWithPolicy(t, store, "lead", runtime.CodexRuntime, "unused", []string{"implement"}, "gitmoot/gitmoot", runtime.AutonomyPolicyReadOnly)
 	job := db.Job{ID: "impl-job", Agent: "lead", Type: "implement", State: string(workflow.JobQueued), Payload: mustJobPayload(t, workflow.JobPayload{
 		Repo: "gitmoot/gitmoot", Branch: "feature", TaskID: "task-impl", TaskTitle: "Solo implement", Sender: "lead", RootJobID: "root-impl",
+		ActingOrgRole: "author",
 	})}
 	if err := store.CreateJobWithEvent(ctx, job, db.JobEvent{Kind: string(workflow.JobQueued), Message: "seed"}); err != nil {
 		t.Fatalf("CreateJobWithEvent returned error: %v", err)
@@ -662,6 +663,12 @@ func TestPreflightReadOnlyImplementEmitsJobBlocked(t *testing.T) {
 	if ev.Detail != agentPermissionBlockedMessage {
 		t.Fatalf("detail = %q, want the permission-blocked message", ev.Detail)
 	}
+	if ev.Cause != "permission_guard" || ev.WakeTargetRole != "author" {
+		t.Fatalf("permission guard routing metadata = %+v", ev)
+	}
+	if kinds := classifyEventRuleKinds(ev); len(kinds) != 1 || kinds[0] != "guard" {
+		t.Fatalf("permission guard classified kinds = %v, want [guard]", kinds)
+	}
 }
 
 // TestPreflightAutoImplementIsPermissionBlocked closes the #452 gap: an implement
@@ -675,6 +682,7 @@ func TestPreflightAutoImplementIsPermissionBlocked(t *testing.T) {
 	seedDaemonWorkerAgentWithPolicy(t, store, "lead", runtime.CodexRuntime, "unused", []string{"implement"}, "gitmoot/gitmoot", runtime.AutonomyPolicyAuto)
 	job := db.Job{ID: "impl-auto-job", Agent: "lead", Type: "implement", State: string(workflow.JobQueued), Payload: mustJobPayload(t, workflow.JobPayload{
 		Repo: "gitmoot/gitmoot", Branch: "feature", TaskID: "task-impl", TaskTitle: "Solo implement", Sender: "lead", RootJobID: "root-impl",
+		ActingOrgRole: "author",
 	})}
 	if err := store.CreateJobWithEvent(ctx, job, db.JobEvent{Kind: string(workflow.JobQueued), Message: "seed"}); err != nil {
 		t.Fatalf("CreateJobWithEvent returned error: %v", err)
@@ -695,16 +703,23 @@ func TestPreflightAutoImplementIsPermissionBlocked(t *testing.T) {
 	if len(blocked) != 1 {
 		t.Fatalf("job.blocked emissions = %d, want exactly 1; all=%+v", len(blocked), sink.events)
 	}
-	if blocked[0].Detail != agentPermissionBlockedMessage {
-		t.Fatalf("detail = %q, want the permission-blocked message", blocked[0].Detail)
+	ev := blocked[0]
+	if ev.Detail != agentPermissionBlockedMessage {
+		t.Fatalf("detail = %q, want the permission-blocked message", ev.Detail)
+	}
+	if ev.Cause != "permission_guard" || ev.WakeTargetRole != "author" {
+		t.Fatalf("permission guard routing metadata = %+v", ev)
+	}
+	if kinds := classifyEventRuleKinds(ev); len(kinds) != 1 || kinds[0] != "guard" {
+		t.Fatalf("permission guard classified kinds = %v, want [guard]", kinds)
 	}
 }
 
 // TestPreflightEphemeralDelegationChildAdvancesParent is the load-bearing test for
 // finding 3: an EPHEMERAL delegation child whose pre-flight fails goes through the
-// ephemeral wrapper at run() (~2083-2093) — an `ephemeral_worker_failed` event +
-// finishQueuedJob(JobFailed) + postJobResultComment + a cleanupTempWorker defer —
-// which is NOT byte-identical routing to the other finishQueuedJob sites. Assert
+// ephemeral wrapper at run() (~2083-2093): an `ephemeral_worker_failed` event,
+// finishQueuedJob(JobFailed), postJobResultComment, and a cleanupTempWorker defer.
+// This is not byte-identical routing to the other finishQueuedJob sites. Assert
 // that this wrapper still finalizes the delegation child (synthetic result + DAG
 // advance + failure_policy).
 func TestPreflightEphemeralDelegationChildAdvancesParent(t *testing.T) {

--- a/internal/db/store_jobs.go
+++ b/internal/db/store_jobs.go
@@ -200,8 +200,9 @@ func (s *Store) GetJob(ctx context.Context, id string) (Job, error) {
 }
 
 // ResolvePullRequestOwner returns the strongest stored org owner for one pull
-// request task. Acting-role attribution wins, followed by the branch lock, then
-// the earliest implementing agent. An unresolved owner is ("", nil).
+// request task. Implement-job acting-role attribution wins, followed by the
+// branch lock, then the earliest implementing agent. An unresolved owner is
+// ("", nil).
 func (s *Store) ResolvePullRequestOwner(
 	ctx context.Context,
 	repo string,
@@ -221,6 +222,7 @@ func (s *Store) ResolvePullRequestOwner(
 SELECT trim(json_extract(payload, '$.acting_org_role'))
 FROM jobs
 WHERE repo = ? AND pull_request = ?
+	AND type = 'implement'
 	AND json_valid(payload)
 	AND json_type(payload, '$.acting_org_role') = 'text'
 	AND trim(json_extract(payload, '$.acting_org_role')) != ''

--- a/internal/db/store_jobs.go
+++ b/internal/db/store_jobs.go
@@ -199,6 +199,70 @@ func (s *Store) GetJob(ctx context.Context, id string) (Job, error) {
 	return job, nil
 }
 
+// ResolvePullRequestOwner returns the strongest stored org owner for one pull
+// request task. Acting-role attribution wins, followed by the branch lock, then
+// the earliest implementing agent. An unresolved owner is ("", nil).
+func (s *Store) ResolvePullRequestOwner(
+	ctx context.Context,
+	repo string,
+	branch string,
+	pullRequest int,
+	taskID string,
+) (string, error) {
+	repo = strings.TrimSpace(repo)
+	branch = strings.TrimSpace(branch)
+	taskID = strings.TrimSpace(taskID)
+	if repo == "" || pullRequest <= 0 {
+		return "", nil
+	}
+
+	var owner string
+	err := s.db.QueryRowContext(ctx, `
+SELECT trim(json_extract(payload, '$.acting_org_role'))
+FROM jobs
+WHERE repo = ? AND pull_request = ?
+	AND json_valid(payload)
+	AND json_type(payload, '$.acting_org_role') = 'text'
+	AND trim(json_extract(payload, '$.acting_org_role')) != ''
+	AND (? = '' OR COALESCE(json_extract(payload, '$.task_id'), '') = ?)
+ORDER BY created_at, id
+LIMIT 1`, repo, pullRequest, taskID, taskID).Scan(&owner)
+	if err == nil {
+		return strings.TrimSpace(owner), nil
+	}
+	if !errors.Is(err, sql.ErrNoRows) {
+		return "", err
+	}
+
+	if branch != "" {
+		lock, err := s.GetBranchLock(ctx, repo, branch)
+		switch {
+		case err == nil && strings.TrimSpace(lock.ActingOrgRole) != "":
+			return strings.TrimSpace(lock.ActingOrgRole), nil
+		case err != nil && !errors.Is(err, sql.ErrNoRows):
+			return "", err
+		}
+	}
+
+	err = s.db.QueryRowContext(ctx, `
+SELECT agent
+FROM jobs
+WHERE repo = ? AND pull_request = ? AND type = 'implement'
+	AND (? = '' OR (
+		json_valid(payload)
+		AND COALESCE(json_extract(payload, '$.task_id'), '') = ?
+	))
+ORDER BY created_at, id
+LIMIT 1`, repo, pullRequest, taskID, taskID).Scan(&owner)
+	if errors.Is(err, sql.ErrNoRows) {
+		return "", nil
+	}
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(owner), nil
+}
+
 // JobWorktreePath returns the worktree path recorded in one job payload without
 // scanning the rest of the job row. The daemon's best-effort reclaim pass uses
 // this narrow lookup to distinguish a candidate-local GetJob scan failure from a

--- a/internal/db/store_test.go
+++ b/internal/db/store_test.go
@@ -5529,7 +5529,7 @@ func TestResolvePullRequestOwnerPrecedenceAndFailClosed(t *testing.T) {
 		}
 	}
 
-	addJob("role-owner", "reviewer", "review", "owner/repo", 10, "task-role", "seat-owner")
+	addJob("role-owner", "implementer", "implement", "owner/repo", 10, "task-role", "seat-owner")
 	addJob("role-implement", "implementer", "implement", "owner/repo", 10, "task-role", "")
 	if created, err := store.CreateLock(ctx, BranchLock{
 		RepoFullName: "owner/repo", Branch: "branch-role", Owner: "lock-owner",
@@ -5538,6 +5538,7 @@ func TestResolvePullRequestOwnerPrecedenceAndFailClosed(t *testing.T) {
 		t.Fatalf("create role branch lock = %v, err=%v", created, err)
 	}
 	addJob("other-task-role", "reviewer", "review", "owner/repo", 11, "other-task", "wrong-owner")
+	addJob("same-task-review", "reviewer", "review", "owner/repo", 11, "wanted-task", "auditor")
 	addJob("task-implement", "task-implementer", "implement", "owner/repo", 11, "wanted-task", "")
 	if created, err := store.CreateLock(ctx, BranchLock{
 		RepoFullName: "owner/repo", Branch: "branch-lock", Owner: "lock-owner",
@@ -5556,7 +5557,7 @@ func TestResolvePullRequestOwnerPrecedenceAndFailClosed(t *testing.T) {
 		want        string
 	}{
 		{name: "acting role wins", branch: "branch-role", pullRequest: 10, taskID: "task-role", want: "seat-owner"},
-		{name: "branch lock beats other task role", branch: "branch-lock", pullRequest: 11, taskID: "wanted-task", want: "branch-owner"},
+		{name: "branch lock beats review role", branch: "branch-lock", pullRequest: 11, taskID: "wanted-task", want: "branch-owner"},
 		{name: "earliest implementing agent", pullRequest: 12, taskID: "task-implement", want: "first-implementer"},
 		{name: "unresolved", pullRequest: 13, taskID: "missing"},
 	}

--- a/internal/db/store_test.go
+++ b/internal/db/store_test.go
@@ -5508,3 +5508,66 @@ func TestRecordJobGatesReopensRepeatedNeedOnReblock(t *testing.T) {
 		t.Fatalf("CountJobGates after reblock = (%d,%d,%v), want (1,1,nil)", total, open, err)
 	}
 }
+
+func TestResolvePullRequestOwnerPrecedenceAndFailClosed(t *testing.T) {
+	ctx := context.Background()
+	store := openWorkflowTestStore(t)
+	addJob := func(id, agent, action, repo string, pullRequest int, taskID, actingRole string) {
+		payload, err := json.Marshal(map[string]any{
+			"repo":            repo,
+			"pull_request":    pullRequest,
+			"task_id":         taskID,
+			"acting_org_role": actingRole,
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := store.CreateJob(ctx, Job{
+			ID: id, Agent: agent, Type: action, State: "succeeded", Payload: string(payload),
+		}); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	addJob("role-owner", "reviewer", "review", "owner/repo", 10, "task-role", "seat-owner")
+	addJob("role-implement", "implementer", "implement", "owner/repo", 10, "task-role", "")
+	if created, err := store.CreateLock(ctx, BranchLock{
+		RepoFullName: "owner/repo", Branch: "branch-role", Owner: "lock-owner",
+		ActingOrgRole: "branch-owner",
+	}); err != nil || !created {
+		t.Fatalf("create role branch lock = %v, err=%v", created, err)
+	}
+	addJob("other-task-role", "reviewer", "review", "owner/repo", 11, "other-task", "wrong-owner")
+	addJob("task-implement", "task-implementer", "implement", "owner/repo", 11, "wanted-task", "")
+	if created, err := store.CreateLock(ctx, BranchLock{
+		RepoFullName: "owner/repo", Branch: "branch-lock", Owner: "lock-owner",
+		ActingOrgRole: "branch-owner",
+	}); err != nil || !created {
+		t.Fatalf("create fallback branch lock = %v, err=%v", created, err)
+	}
+	addJob("implement-a", "first-implementer", "implement", "owner/repo", 12, "task-implement", "")
+	addJob("implement-b", "later-implementer", "implement", "owner/repo", 12, "task-implement", "")
+
+	tests := []struct {
+		name        string
+		branch      string
+		pullRequest int
+		taskID      string
+		want        string
+	}{
+		{name: "acting role wins", branch: "branch-role", pullRequest: 10, taskID: "task-role", want: "seat-owner"},
+		{name: "branch lock beats other task role", branch: "branch-lock", pullRequest: 11, taskID: "wanted-task", want: "branch-owner"},
+		{name: "earliest implementing agent", pullRequest: 12, taskID: "task-implement", want: "first-implementer"},
+		{name: "unresolved", pullRequest: 13, taskID: "missing"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got, err := store.ResolvePullRequestOwner(
+				ctx, "owner/repo", test.branch, test.pullRequest, test.taskID,
+			)
+			if err != nil || got != test.want {
+				t.Fatalf("ResolvePullRequestOwner = %q, err=%v, want %q", got, err, test.want)
+			}
+		})
+	}
+}

--- a/internal/events/sink.go
+++ b/internal/events/sink.go
@@ -114,6 +114,10 @@ const (
 	EventOrchestrationFinished EventType = "orchestration.finished"
 )
 
+// EventCauseReviewVerdict marks a terminal review whose decision is ready for
+// the pull request owner.
+const EventCauseReviewVerdict = "review_verdict"
+
 // Event is the stable, versioned, redacted JSON object emitted outbound. Every
 // free-text field is redacted at construction (see NewEvent); ids are opaque,
 // Cause is a trusted enum, ts is RFC3339, and status is the terminal/lifecycle
@@ -145,11 +149,14 @@ type Event struct {
 	// EventType. It is assigned by trusted emit sites and deliberately bypasses
 	// free-text redaction and path scrubbing.
 	Cause string `json:"cause,omitempty"`
-	// WakeKind, WakeTargetRole, and WakeOutboxIDs are internal delivery metadata
-	// for the durable wake drain. They never alter the public event JSON contract.
+	// WakeKind, WakeTargetRole, WakeOutboxIDs, PullRequest, and ReviewDecision
+	// are internal delivery metadata. They never alter the public event JSON
+	// contract.
 	WakeKind       string  `json:"-"`
 	WakeTargetRole string  `json:"-"`
 	WakeOutboxIDs  []int64 `json:"-"`
+	PullRequest    int     `json:"-"`
+	ReviewDecision string  `json:"-"`
 }
 
 // Sink is the injected outbound seam the engine and daemon call from the

--- a/internal/events/sink_test.go
+++ b/internal/events/sink_test.go
@@ -11,6 +11,8 @@ import (
 func TestNewEventContractShape(t *testing.T) {
 	ts := time.Date(2026, 6, 16, 12, 0, 0, 0, time.UTC)
 	ev := NewEvent(EventJobFinished, "job-1", "root-1", "gitmoot/gitmoot", "succeeded", "all good", ts, nil)
+	ev.PullRequest = 42
+	ev.ReviewDecision = "approved"
 
 	if ev.SchemaVersion != 1 {
 		t.Fatalf("SchemaVersion = %d, want 1", ev.SchemaVersion)
@@ -47,6 +49,11 @@ func TestNewEventContractShape(t *testing.T) {
 	}
 	if decoded["event_type"].(string) != "job.finished" {
 		t.Fatalf("event_type = %v, want job.finished", decoded["event_type"])
+	}
+	for _, key := range []string{"pull_request", "review_decision"} {
+		if _, ok := decoded[key]; ok {
+			t.Fatalf("internal event metadata %q must not be serialized; got %s", key, raw)
+		}
 	}
 	if _, ok := decoded["cause"]; ok {
 		t.Fatalf("empty optional cause must be omitted; got %s", raw)

--- a/internal/workflow/engine_types.go
+++ b/internal/workflow/engine_types.go
@@ -170,17 +170,18 @@ func (e Engine) mailbox() Mailbox {
 			RedactCommentText,
 		)
 		wakeTargetRole := NormalizeActingOrgRole(payload.ActingOrgRole)
-		if state == JobSucceeded && payload.PullRequest > 0 && payload.Result != nil {
+		if state == JobSucceeded && payload.PullRequest > 0 && payload.Result != nil && e.Store != nil {
 			decision := strings.ToLower(strings.TrimSpace(payload.Result.Decision))
-			if decision == "approved" || decision == "changes_requested" {
-				owner := wakeTargetRole
-				if owner == "" && e.Store != nil {
-					resolved, err := e.Store.ResolvePullRequestOwner(
-						ctx, payload.Repo, payload.Branch, payload.PullRequest, payload.TaskID,
-					)
-					if err == nil {
-						owner = NormalizeActingOrgRole(resolved)
-					}
+			job, jobErr := e.Store.GetJob(ctx, jobID)
+			if jobErr == nil &&
+				strings.EqualFold(strings.TrimSpace(job.Type), "review") &&
+				(decision == "approved" || decision == "changes_requested") {
+				owner := ""
+				resolved, resolveErr := e.Store.ResolvePullRequestOwner(
+					ctx, payload.Repo, payload.Branch, payload.PullRequest, payload.TaskID,
+				)
+				if resolveErr == nil {
+					owner = NormalizeActingOrgRole(resolved)
 				}
 				event.Cause = events.EventCauseReviewVerdict
 				wakeTargetRole = owner

--- a/internal/workflow/engine_types.go
+++ b/internal/workflow/engine_types.go
@@ -159,7 +159,7 @@ func (e Engine) mailbox() Mailbox {
 		if payload.Result != nil {
 			detail = payload.Result.Summary
 		}
-		events.EmitEvent(ctx, e.EventSink, events.NewEvent(
+		event := events.NewEvent(
 			eventType,
 			jobID,
 			rootID,
@@ -168,7 +168,28 @@ func (e Engine) mailbox() Mailbox {
 			detail,
 			e.now(),
 			RedactCommentText,
-		))
+		)
+		wakeTargetRole := NormalizeActingOrgRole(payload.ActingOrgRole)
+		if state == JobSucceeded && payload.PullRequest > 0 && payload.Result != nil {
+			decision := strings.ToLower(strings.TrimSpace(payload.Result.Decision))
+			if decision == "approved" || decision == "changes_requested" {
+				owner := wakeTargetRole
+				if owner == "" && e.Store != nil {
+					resolved, err := e.Store.ResolvePullRequestOwner(
+						ctx, payload.Repo, payload.Branch, payload.PullRequest, payload.TaskID,
+					)
+					if err == nil {
+						owner = NormalizeActingOrgRole(resolved)
+					}
+				}
+				event.Cause = events.EventCauseReviewVerdict
+				wakeTargetRole = owner
+				event.PullRequest = payload.PullRequest
+				event.ReviewDecision = decision
+			}
+		}
+		event.WakeTargetRole = wakeTargetRole
+		events.EmitEvent(ctx, e.EventSink, event)
 	}
 	return mb
 }

--- a/internal/workflow/event_sink_test.go
+++ b/internal/workflow/event_sink_test.go
@@ -7,6 +7,7 @@ import (
 	"sync"
 	"testing"
 
+	"github.com/gitmoot/gitmoot/internal/db"
 	"github.com/gitmoot/gitmoot/internal/events"
 	"github.com/gitmoot/gitmoot/internal/runtime"
 )
@@ -63,13 +64,15 @@ func TestEngineEmitsJobFinishedOnSucceededTerminal(t *testing.T) {
 		`{"gitmoot_result":{"decision":"approved","summary":"looks good","findings":[],"changes_made":[],"tests_run":[],"needs":[],"delegations":[]}}`,
 	}}
 	if _, err := (Mailbox{store: store, resolveDeliveryWorktree: ExcludedDeliveryWorktreeResolver("test_explicit_no_worktree")}).Enqueue(ctx, JobRequest{
-		ID:        "review-job",
-		Agent:     "audit",
-		Action:    "review",
-		Repo:      "gitmoot/gitmoot",
-		Branch:    "task-9",
-		TaskID:    "task-9",
-		TaskTitle: "Review",
+		ID:            "review-job",
+		Agent:         "audit",
+		Action:        "review",
+		Repo:          "gitmoot/gitmoot",
+		Branch:        "task-9",
+		PullRequest:   42,
+		TaskID:        "task-9",
+		TaskTitle:     "Review",
+		ActingOrgRole: "author",
 	}); err != nil {
 		t.Fatalf("Enqueue returned error: %v", err)
 	}
@@ -86,11 +89,56 @@ func TestEngineEmitsJobFinishedOnSucceededTerminal(t *testing.T) {
 	if ev.JobID != "review-job" || ev.RootID != "review-job" || ev.Repo != "gitmoot/gitmoot" || ev.Status != "succeeded" {
 		t.Fatalf("job.finished event = %+v", ev)
 	}
+	if ev.WakeTargetRole != "author" {
+		t.Fatalf("wake target role = %q, want author", ev.WakeTargetRole)
+	}
+	if ev.Cause != events.EventCauseReviewVerdict || ev.PullRequest != 42 || ev.ReviewDecision != "approved" {
+		t.Fatalf("review verdict metadata = %+v", ev)
+	}
 	if ev.SchemaVersion != 1 {
 		t.Fatalf("schema_version = %d, want 1", ev.SchemaVersion)
 	}
 	if ev.Detail != "looks good" {
 		t.Fatalf("detail = %q, want the result summary", ev.Detail)
+	}
+}
+
+func TestEngineEmitsChangesRequestedReviewVerdict(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	if acquired, err := store.AcquireLock(ctx, db.BranchLock{
+		RepoFullName:  "gitmoot/gitmoot",
+		Branch:        "task-43",
+		Owner:         "audit",
+		ActingOrgRole: "author",
+	}); err != nil || !acquired {
+		t.Fatalf("AcquireLock returned acquired=%v err=%v", acquired, err)
+	}
+	sink := &recordingSink{}
+	engine := testEngine(store)
+	engine.EventSink = sink
+	mailbox := engine.mailbox()
+
+	mailbox.emitTerminal(ctx, "review-43", JobSucceeded, JobPayload{
+		Repo:        "gitmoot/gitmoot",
+		Branch:      "task-43",
+		PullRequest: 43,
+		Result: &AgentResult{
+			Decision: "changes_requested",
+			Summary:  "one blocking issue",
+		},
+	})
+
+	finished := sink.byType(events.EventJobFinished)
+	if len(finished) != 1 {
+		t.Fatalf("job.finished emissions = %d, want 1; all=%+v", len(finished), sink.snapshot())
+	}
+	event := finished[0]
+	if event.Cause != events.EventCauseReviewVerdict ||
+		event.ReviewDecision != "changes_requested" ||
+		event.PullRequest != 43 ||
+		event.WakeTargetRole != "author" {
+		t.Fatalf("changes-requested verdict event = %+v", event)
 	}
 }
 

--- a/internal/workflow/event_sink_test.go
+++ b/internal/workflow/event_sink_test.go
@@ -56,6 +56,14 @@ func TestEngineEmitsJobFinishedOnSucceededTerminal(t *testing.T) {
 	ctx := context.Background()
 	store := openEngineStore(t)
 	seedAgent(t, store, "audit", []string{"review"}, "gitmoot/gitmoot")
+	if acquired, err := store.AcquireLock(ctx, db.BranchLock{
+		RepoFullName:  "gitmoot/gitmoot",
+		Branch:        "task-9",
+		Owner:         "audit",
+		ActingOrgRole: "author",
+	}); err != nil || !acquired {
+		t.Fatalf("AcquireLock returned acquired=%v err=%v", acquired, err)
+	}
 	sink := &recordingSink{}
 	engine := testEngine(store)
 	engine.EventSink = sink
@@ -72,7 +80,7 @@ func TestEngineEmitsJobFinishedOnSucceededTerminal(t *testing.T) {
 		PullRequest:   42,
 		TaskID:        "task-9",
 		TaskTitle:     "Review",
-		ActingOrgRole: "author",
+		ActingOrgRole: "reviewer",
 	}); err != nil {
 		t.Fatalf("Enqueue returned error: %v", err)
 	}
@@ -114,15 +122,21 @@ func TestEngineEmitsChangesRequestedReviewVerdict(t *testing.T) {
 	}); err != nil || !acquired {
 		t.Fatalf("AcquireLock returned acquired=%v err=%v", acquired, err)
 	}
+	if err := store.CreateJob(ctx, db.Job{
+		ID: "review-43", Agent: "audit", Type: "review", State: string(JobSucceeded), Payload: "{}",
+	}); err != nil {
+		t.Fatalf("CreateJob returned error: %v", err)
+	}
 	sink := &recordingSink{}
 	engine := testEngine(store)
 	engine.EventSink = sink
 	mailbox := engine.mailbox()
 
 	mailbox.emitTerminal(ctx, "review-43", JobSucceeded, JobPayload{
-		Repo:        "gitmoot/gitmoot",
-		Branch:      "task-43",
-		PullRequest: 43,
+		Repo:          "gitmoot/gitmoot",
+		Branch:        "task-43",
+		PullRequest:   43,
+		ActingOrgRole: "auditor",
 		Result: &AgentResult{
 			Decision: "changes_requested",
 			Summary:  "one blocking issue",
@@ -139,6 +153,36 @@ func TestEngineEmitsChangesRequestedReviewVerdict(t *testing.T) {
 		event.PullRequest != 43 ||
 		event.WakeTargetRole != "author" {
 		t.Fatalf("changes-requested verdict event = %+v", event)
+	}
+}
+func TestEngineDoesNotClassifyNonReviewApprovedResult(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	if err := store.CreateJob(ctx, db.Job{
+		ID: "ask-44", Agent: "helper", Type: "ask", State: string(JobSucceeded), Payload: "{}",
+	}); err != nil {
+		t.Fatalf("CreateJob returned error: %v", err)
+	}
+	sink := &recordingSink{}
+	engine := testEngine(store)
+	engine.EventSink = sink
+	engine.mailbox().emitTerminal(ctx, "ask-44", JobSucceeded, JobPayload{
+		Repo:          "gitmoot/gitmoot",
+		PullRequest:   44,
+		ActingOrgRole: "requester",
+		Result:        &AgentResult{Decision: "approved", Summary: "answer accepted"},
+	})
+
+	finished := sink.byType(events.EventJobFinished)
+	if len(finished) != 1 {
+		t.Fatalf("job.finished emissions = %d, want 1; all=%+v", len(finished), sink.snapshot())
+	}
+	event := finished[0]
+	if event.Cause != "" || event.PullRequest != 0 || event.ReviewDecision != "" {
+		t.Fatalf("non-review terminal was classified as a review verdict: %+v", event)
+	}
+	if event.WakeTargetRole != "requester" {
+		t.Fatalf("ordinary terminal target = %q, want requester", event.WakeTargetRole)
 	}
 }
 

--- a/skills/gitmoot/references/CLI.md
+++ b/skills/gitmoot/references/CLI.md
@@ -1767,6 +1767,7 @@ Event-rule wakes are separately opt-in:
 
 ```sh
 gitmoot org events rule add --on attention --match owner/repo --wake maintainer
+gitmoot org events rule add --on review-verdict --match owner/repo --wake maintainer
 gitmoot org events rule add --on blocked --repo tendwire --wake maintainer
 gitmoot org events rule add --on pane_input_pending --wake maintainer
 gitmoot org events rule add --on reply --wake maintainer
@@ -1778,8 +1779,13 @@ gitmoot org events rule set-scope --home /alternate/home <rule-id> observer
 gitmoot org events rule rm --home /alternate/home <rule-id>
 ```
 
-`--on` accepts `escalation`, `attention`, `guard`, `job-terminal`, `blocked`,
-`recycle-overdue`, `pane_input_pending`, `reply`, `directive`, or `fact`. `pane_input_pending` matches the
+`--on` accepts `escalation`, `attention`, `guard`, `job-terminal`,
+`review-verdict`, `blocked`, `recycle-overdue`, `pane_input_pending`, `reply`,
+`directive`, or `fact`. A successful review terminal whose decision is
+`approved` or `changes_requested` matches both `job-terminal` and
+`review-verdict` and addresses the resolved pull request owner. If no owner can
+be resolved, addressed rules fail closed while observer rules remain eligible.
+`pane_input_pending` matches the
 `org.input_pending` event emitted when Herdr continuously reports
 `input_pending: true` for a role's pane longer than
 `[orchestrate].blocked_role_wake_after`; it re-nudges at most once per that
@@ -1816,10 +1822,10 @@ manually with `set-scope` when observer delivery is intended.
 Every outbox row retains a queryable `pending`, `attempted`, `delivered`,
 `stalled`, `failed`, or `delivery_unknown` state, so never-attempted is not
 confused with success and outstanding rows contribute to daemon tick health.
-`--match` is a case-insensitive substring matched independently against the
-event repo and job id; omit it to match every event of that kind. `--repo` is a
-discoverable alias for the same substring filter, useful for repo-to-role
-routing. Pass only one of `--match` or `--repo`. `--wake` must name a declared
+An owner/repo `--match` or `--repo` filter is case-insensitive and exact.
+Filters without a slash retain case-insensitive substring matching against the
+event repo and job id; omit either flag to match every event of that kind. Pass
+only one of `--match` and `--repo`. `--wake` must name a declared
 role whose config sets `pane = "<pane-id-or-label>"`. Gitmoot
 first resolves the value as an exact pane label and otherwise uses it as a
 literal pane id. The daemon calls `herdr agent prompt <pane> <text> --wait --timeout
@@ -1827,7 +1833,7 @@ literal pane id. The daemon calls `herdr agent prompt <pane> <text> --wait --tim
 `error.code = "timeout"`) apart from stalled (`error.code =
 "agent_prompt_stalled"`). Stalls increment the role's consecutive missed-wake
 counter and delivery resets it; transport failures leave it unchanged.
-`attention`, `guard`, `job-terminal`, `recycle-overdue`, and
+`attention`, `guard`, `job-terminal`, `review-verdict`, `recycle-overdue`, and
 `pane_input_pending` wakes remain best-effort. With no rule rows this path is
 off. Task episodes due in one evaluator pass produce one oldest-first digest
 event; blocked roles retain one event per role.

--- a/skills/gitmoot/references/CLI.md
+++ b/skills/gitmoot/references/CLI.md
@@ -1822,10 +1822,11 @@ manually with `set-scope` when observer delivery is intended.
 Every outbox row retains a queryable `pending`, `attempted`, `delivered`,
 `stalled`, `failed`, or `delivery_unknown` state, so never-attempted is not
 confused with success and outstanding rows contribute to daemon tick health.
-An owner/repo `--match` or `--repo` filter is case-insensitive and exact.
-Filters without a slash retain case-insensitive substring matching against the
-event repo and job id; omit either flag to match every event of that kind. Pass
-only one of `--match` and `--repo`. `--wake` must name a declared
+Repository comparison for a slash-bearing owner/repo filter is
+case-insensitive and exact. Job IDs always use case-insensitive substring
+matching, including slash-bearing delegation IDs. Without a slash, repositories
+also use substring matching; omit either flag to match every event of that kind.
+Pass only one of `--match` and `--repo`. `--wake` must name a declared
 role whose config sets `pane = "<pane-id-or-label>"`. Gitmoot
 first resolves the value as an exact pane label and otherwise uses it as a
 literal pane id. The daemon calls `herdr agent prompt <pane> <text> --wait --timeout

--- a/website/docs/reference/cli.md
+++ b/website/docs/reference/cli.md
@@ -1585,6 +1585,7 @@ Event-rule wakes are separately opt-in:
 
 ```sh
 gitmoot org events rule add --on attention --match owner/repo --wake maintainer
+gitmoot org events rule add --on review-verdict --match owner/repo --wake maintainer
 gitmoot org events rule add --on blocked --repo tendwire --wake maintainer
 gitmoot org events rule add --on pane_input_pending --wake maintainer
 gitmoot org events rule add --on reply --wake maintainer
@@ -1596,8 +1597,13 @@ gitmoot org events rule set-scope --home /alternate/home <rule-id> observer
 gitmoot org events rule rm --home /alternate/home <rule-id>
 ```
 
-`--on` accepts `escalation`, `attention`, `guard`, `job-terminal`, `blocked`,
-`recycle-overdue`, `pane_input_pending`, `reply`, `directive`, or `fact`. `pane_input_pending` matches the
+`--on` accepts `escalation`, `attention`, `guard`, `job-terminal`,
+`review-verdict`, `blocked`, `recycle-overdue`, `pane_input_pending`, `reply`,
+`directive`, or `fact`. A successful review terminal whose decision is
+`approved` or `changes_requested` matches both `job-terminal` and
+`review-verdict` and addresses the resolved pull request owner. If no owner can
+be resolved, addressed rules fail closed while observer rules remain eligible.
+`pane_input_pending` matches the
 `org.input_pending` event emitted when Herdr continuously reports
 `input_pending: true` for a role's pane longer than
 `[orchestrate].blocked_role_wake_after`; it re-nudges at most once per that
@@ -1634,15 +1640,16 @@ manually with `set-scope` when observer delivery is intended.
 Every outbox row retains a queryable `pending`, `attempted`, `delivered`,
 `stalled`, `failed`, or `delivery_unknown` state, so never-attempted is not
 confused with success and outstanding rows contribute to daemon tick health.
-`--match` is a case-insensitive substring matched against the event repo or job
-id; empty matches all. `--repo` is a discoverable alias for the same substring
-filter; pass only one of `--match` or `--repo`. The wake role must exist and set
+An owner/repo `--match` or `--repo` filter is case-insensitive and exact.
+Filters without a slash retain case-insensitive substring matching against the
+event repo and job id; omit either flag to match every event of that kind. Pass
+only one of `--match` and `--repo`. The wake role must exist and set
 `pane = "<herdr-pane>"`; Gitmoot resolves that value as an exact pane label first
 and otherwise treats it as a literal pane id.
 Delivery is verified with Herdr's `agent_prompted` versus
 `agent_prompt_stalled` result. `attention`, `guard`, `job-terminal`,
-`recycle-overdue`, and `pane_input_pending` wakes remain best-effort; zero rules
-leaves the feature off.
+`review-verdict`, `recycle-overdue`, and `pane_input_pending` wakes remain
+best-effort; zero rules leaves the feature off.
 
 ```sh
 gitmoot orchestrate planner "Coordinate the dashboard wave." --repo owner/repo --workflow fable/dashboard-redesign

--- a/website/docs/reference/cli.md
+++ b/website/docs/reference/cli.md
@@ -1640,10 +1640,11 @@ manually with `set-scope` when observer delivery is intended.
 Every outbox row retains a queryable `pending`, `attempted`, `delivered`,
 `stalled`, `failed`, or `delivery_unknown` state, so never-attempted is not
 confused with success and outstanding rows contribute to daemon tick health.
-An owner/repo `--match` or `--repo` filter is case-insensitive and exact.
-Filters without a slash retain case-insensitive substring matching against the
-event repo and job id; omit either flag to match every event of that kind. Pass
-only one of `--match` and `--repo`. The wake role must exist and set
+Repository comparison for a slash-bearing owner/repo filter is
+case-insensitive and exact. Job IDs always use case-insensitive substring
+matching, including slash-bearing delegation IDs. Without a slash, repositories
+also use substring matching; omit either flag to match every event of that kind.
+Pass only one of `--match` and `--repo`. The wake role must exist and set
 `pane = "<herdr-pane>"`; Gitmoot resolves that value as an exact pane label first
 and otherwise treats it as a literal pane id.
 Delivery is verified with Herdr's `agent_prompted` versus

--- a/website/docs/reference/event-stream.md
+++ b/website/docs/reference/event-stream.md
@@ -171,6 +171,7 @@ pane = "w1:p2"
 
 ```sh
 gitmoot org events rule add --on guard --match owner/repo --wake maintainer
+gitmoot org events rule add --on review-verdict --match owner/repo --wake maintainer
 gitmoot org events rule add --on blocked --repo tendwire --wake maintainer
 gitmoot org events rule add --on pane_input_pending --wake maintainer
 gitmoot org events rule add --on reply --wake maintainer
@@ -184,7 +185,7 @@ gitmoot org events rule rm <rule-id>
 Rules default to `--scope addressed`: when an event carries a target role, only
 the matching addressed rule receives it. During rule evaluation,
 `--scope observer` exempts a rule from that addressee gate.
-Events without a target role keep matching both scopes exactly as before.
+Events without a target role match observer rules only.
 Durable-outbox claim authorization is scope-blind: among enabled,
 filter-matching rules for the event's own kind, wake-role equality with the
 addressed target is the only routing condition. An observer-scoped rule is
@@ -205,13 +206,19 @@ rule set is empty.
 Filtered non-reply rules remain `addressed` after upgrade and must be promoted
 manually with `set-scope` when observer delivery is intended.
 
-Kinds are `escalation`, `attention`, `guard`, `job-terminal`, `blocked`,
-`recycle-overdue`, `pane_input_pending`, and `reply`.
-The v1 `--match` filter is a case-insensitive substring tested against the event
-repo and job id; empty matches all. `--repo` is an alias for that same filter;
-pass only one of the two flags. A plain `job.blocked` event matches both
-`job-terminal` and `blocked`, while guard-caused blocks match `guard` first. A
-synthesized `blocked_since` event matches only `blocked`. Task episodes due in
+Kinds are `escalation`, `attention`, `guard`, `job-terminal`,
+`review-verdict`, `blocked`, `recycle-overdue`, `pane_input_pending`, `reply`,
+`directive`, and `fact`.
+An owner/repo `--match` or `--repo` filter is case-insensitive and exact.
+Filters without a slash retain case-insensitive substring matching against the
+event repo and job id; empty matches all. Pass only one of `--match` and
+`--repo`. A successful review terminal whose decision is `approved` or
+`changes_requested` matches both `job-terminal` and `review-verdict` and
+addresses the pull request owner's role. If no role can be resolved, addressed
+rules fail closed while observer rules can still receive the verdict. A plain
+`job.blocked` event matches both `job-terminal` and `blocked`, while
+guard-caused blocks match `guard` first. A synthesized `blocked_since` event
+matches only `blocked`. Task episodes due in
 one evaluator pass are emitted as one oldest-first digest; blocked roles retain
 one event per role. Set
 `[orchestrate].blocked_role_wake_after` to a positive Go duration to emit such an

--- a/website/docs/reference/event-stream.md
+++ b/website/docs/reference/event-stream.md
@@ -209,9 +209,10 @@ manually with `set-scope` when observer delivery is intended.
 Kinds are `escalation`, `attention`, `guard`, `job-terminal`,
 `review-verdict`, `blocked`, `recycle-overdue`, `pane_input_pending`, `reply`,
 `directive`, and `fact`.
-An owner/repo `--match` or `--repo` filter is case-insensitive and exact.
-Filters without a slash retain case-insensitive substring matching against the
-event repo and job id; empty matches all. Pass only one of `--match` and
+Repository comparison for a slash-bearing owner/repo filter is
+case-insensitive and exact. Job IDs always use case-insensitive substring
+matching, including slash-bearing delegation IDs. Without a slash, repositories
+also use substring matching; empty matches all. Pass only one of `--match` and
 `--repo`. A successful review terminal whose decision is `approved` or
 `changes_requested` matches both `job-terminal` and `review-verdict` and
 addresses the pull request owner's role. If no role can be resolved, addressed

--- a/website/static/llms-full.txt
+++ b/website/static/llms-full.txt
@@ -2952,6 +2952,7 @@ pane = "w1:p2"
 
 ```sh
 gitmoot org events rule add --on guard --match owner/repo --wake maintainer
+gitmoot org events rule add --on review-verdict --match owner/repo --wake maintainer
 gitmoot org events rule add --on blocked --repo tendwire --wake maintainer
 gitmoot org events rule add --on pane_input_pending --wake maintainer
 gitmoot org events rule add --on reply --wake maintainer
@@ -2964,7 +2965,7 @@ gitmoot org events rule rm <rule-id>
 Rules default to `--scope addressed`: when an event carries a target role, only
 the matching addressed rule receives it. During rule evaluation,
 `--scope observer` exempts a rule from that addressee gate.
-Events without a target role keep matching both scopes exactly as before.
+Events without a target role match observer rules only.
 Durable-outbox claim authorization is scope-blind: among enabled,
 filter-matching rules for the event's own kind, wake-role equality with the
 addressed target is the only routing condition. An observer-scoped rule is
@@ -2979,13 +2980,19 @@ rule set is empty.
 Filtered non-reply rules remain `addressed` after upgrade and must be promoted
 manually with `set-scope` when observer delivery is intended.
 
-Kinds are `escalation`, `attention`, `guard`, `job-terminal`, `blocked`,
-`recycle-overdue`, `pane_input_pending`, and `reply`.
-The v1 `--match` filter is a case-insensitive substring tested against the event
-repo and job id; empty matches all. `--repo` is an alias for that same filter;
-pass only one of the two flags. A plain `job.blocked` event matches both
-`job-terminal` and `blocked`, while guard-caused blocks match `guard` first. A
-synthesized `blocked_since` event matches only `blocked`. Task episodes due in
+Kinds are `escalation`, `attention`, `guard`, `job-terminal`,
+`review-verdict`, `blocked`, `recycle-overdue`, `pane_input_pending`, `reply`,
+`directive`, and `fact`.
+An owner/repo `--match` or `--repo` filter is case-insensitive and exact.
+Filters without a slash retain case-insensitive substring matching against the
+event repo and job id; empty matches all. Pass only one of `--match` and
+`--repo`. A successful review terminal whose decision is `approved` or
+`changes_requested` matches both `job-terminal` and `review-verdict` and
+addresses the pull request owner's role. If no role can be resolved, addressed
+rules fail closed while observer rules can still receive the verdict. A plain
+`job.blocked` event matches both `job-terminal` and `blocked`, while
+guard-caused blocks match `guard` first. A synthesized `blocked_since` event
+matches only `blocked`. Task episodes due in
 one evaluator pass are emitted as one oldest-first digest; blocked roles retain
 one event per role. Set
 `[orchestrate].blocked_role_wake_after` to a positive Go duration to emit such an
@@ -11943,6 +11950,7 @@ Event-rule wakes are separately opt-in:
 
 ```sh
 gitmoot org events rule add --on attention --match owner/repo --wake maintainer
+gitmoot org events rule add --on review-verdict --match owner/repo --wake maintainer
 gitmoot org events rule add --on blocked --repo tendwire --wake maintainer
 gitmoot org events rule add --on pane_input_pending --wake maintainer
 gitmoot org events rule add --on reply --wake maintainer
@@ -11954,8 +11962,13 @@ gitmoot org events rule set-scope --home /alternate/home <rule-id> observer
 gitmoot org events rule rm --home /alternate/home <rule-id>
 ```
 
-`--on` accepts `escalation`, `attention`, `guard`, `job-terminal`, `blocked`,
-`recycle-overdue`, `pane_input_pending`, `reply`, `directive`, or `fact`. `pane_input_pending` matches the
+`--on` accepts `escalation`, `attention`, `guard`, `job-terminal`,
+`review-verdict`, `blocked`, `recycle-overdue`, `pane_input_pending`, `reply`,
+`directive`, or `fact`. A successful review terminal whose decision is
+`approved` or `changes_requested` matches both `job-terminal` and
+`review-verdict` and addresses the resolved pull request owner. If no owner can
+be resolved, addressed rules fail closed while observer rules remain eligible.
+`pane_input_pending` matches the
 `org.input_pending` event emitted when Herdr continuously reports
 `input_pending: true` for a role's pane longer than
 `[orchestrate].blocked_role_wake_after`; it re-nudges at most once per that
@@ -11992,10 +12005,10 @@ manually with `set-scope` when observer delivery is intended.
 Every outbox row retains a queryable `pending`, `attempted`, `delivered`,
 `stalled`, `failed`, or `delivery_unknown` state, so never-attempted is not
 confused with success and outstanding rows contribute to daemon tick health.
-`--match` is a case-insensitive substring matched independently against the
-event repo and job id; omit it to match every event of that kind. `--repo` is a
-discoverable alias for the same substring filter, useful for repo-to-role
-routing. Pass only one of `--match` or `--repo`. `--wake` must name a declared
+An owner/repo `--match` or `--repo` filter is case-insensitive and exact.
+Filters without a slash retain case-insensitive substring matching against the
+event repo and job id; omit either flag to match every event of that kind. Pass
+only one of `--match` and `--repo`. `--wake` must name a declared
 role whose config sets `pane = "<pane-id-or-label>"`. Gitmoot
 first resolves the value as an exact pane label and otherwise uses it as a
 literal pane id. The daemon calls `herdr agent prompt <pane> <text> --wait --timeout
@@ -12003,7 +12016,7 @@ literal pane id. The daemon calls `herdr agent prompt <pane> <text> --wait --tim
 `error.code = "timeout"`) apart from stalled (`error.code =
 "agent_prompt_stalled"`). Stalls increment the role's consecutive missed-wake
 counter and delivery resets it; transport failures leave it unchanged.
-`attention`, `guard`, `job-terminal`, `recycle-overdue`, and
+`attention`, `guard`, `job-terminal`, `review-verdict`, `recycle-overdue`, and
 `pane_input_pending` wakes remain best-effort. With no rule rows this path is
 off. Task episodes due in one evaluator pass produce one oldest-first digest
 event; blocked roles retain one event per role.

--- a/website/static/llms-full.txt
+++ b/website/static/llms-full.txt
@@ -2983,9 +2983,10 @@ manually with `set-scope` when observer delivery is intended.
 Kinds are `escalation`, `attention`, `guard`, `job-terminal`,
 `review-verdict`, `blocked`, `recycle-overdue`, `pane_input_pending`, `reply`,
 `directive`, and `fact`.
-An owner/repo `--match` or `--repo` filter is case-insensitive and exact.
-Filters without a slash retain case-insensitive substring matching against the
-event repo and job id; empty matches all. Pass only one of `--match` and
+Repository comparison for a slash-bearing owner/repo filter is
+case-insensitive and exact. Job IDs always use case-insensitive substring
+matching, including slash-bearing delegation IDs. Without a slash, repositories
+also use substring matching; empty matches all. Pass only one of `--match` and
 `--repo`. A successful review terminal whose decision is `approved` or
 `changes_requested` matches both `job-terminal` and `review-verdict` and
 addresses the pull request owner's role. If no role can be resolved, addressed
@@ -12005,10 +12006,11 @@ manually with `set-scope` when observer delivery is intended.
 Every outbox row retains a queryable `pending`, `attempted`, `delivered`,
 `stalled`, `failed`, or `delivery_unknown` state, so never-attempted is not
 confused with success and outstanding rows contribute to daemon tick health.
-An owner/repo `--match` or `--repo` filter is case-insensitive and exact.
-Filters without a slash retain case-insensitive substring matching against the
-event repo and job id; omit either flag to match every event of that kind. Pass
-only one of `--match` and `--repo`. `--wake` must name a declared
+Repository comparison for a slash-bearing owner/repo filter is
+case-insensitive and exact. Job IDs always use case-insensitive substring
+matching, including slash-bearing delegation IDs. Without a slash, repositories
+also use substring matching; omit either flag to match every event of that kind.
+Pass only one of `--match` and `--repo`. `--wake` must name a declared
 role whose config sets `pane = "<pane-id-or-label>"`. Gitmoot
 first resolves the value as an exact pane label and otherwise uses it as a
 literal pane id. The daemon calls `herdr agent prompt <pane> <text> --wait --timeout


### PR DESCRIPTION
## Problem

Addressed job-terminal rules did not receive a target role, owner/repo filters used substring matching, and pull request review verdicts did not wake the pull request owner.

## Change

- Address engine and daemon terminal events to the dispatching acting_org_role.
- Match slash-bearing owner/repo filters exactly while preserving legacy substring matching for other filters.
- Add the review-verdict rule kind for approved and changes_requested review terminals.
- Resolve pull request ownership from acting role, branch lock, then the earliest same-task implementer, failing closed when unresolved.
- Keep observer rules eligible for directed verdicts and document the routing contract.

## Verification

- Focused db, events, workflow, and cli changed-contract tests pass.
- Actual `gitmoot org events rule add --help` smoke lists review-verdict and exact owner/repo semantics.
- Full internal/db, internal/events, and internal/workflow package tests pass.
- Full internal/cli did not pass: widespread daemon E2E jobs stayed queued and the package hit its 10 minute timeout. All targeted changed-contract cli tests pass.
- No em or en dashes in changed lines.

Authorization for branch push and PR creation: durable directive row 97663.

Fixes #1680
Fixes #1689