### PR TITLE
fix(workflow): bind auto-fixes to PR ownership

### DIFF
--- a/internal/cli/agent_dispatch_test.go
+++ b/internal/cli/agent_dispatch_test.go
@@ -650,9 +650,9 @@ func TestDispatchReviewManagedTypeRequiresExplicitLeadBeforeProvisioning(t *test
 	}
 }
 
-// PRE-FIX RED at the production CLI parser. This kills parsed-but-unthreaded
-// --lead, reversed firstNonEmpty precedence, and fix routing back to the reviewer.
-func TestReviewDispatchLeadRoutesChangesRequestedFixToImplementer(t *testing.T) {
+// A review's --lead routes the review workflow, but it is not PR ownership.
+// Auto-fix must use the implementing agent recorded on the shared task.
+func TestReviewDispatchRoutesChangesRequestedFixToTaskImplementer(t *testing.T) {
 	for _, surface := range []string{"review", "run"} {
 		t.Run(surface, func(t *testing.T) {
 			home := t.TempDir()
@@ -663,6 +663,25 @@ func TestReviewDispatchLeadRoutesChangesRequestedFixToImplementer(t *testing.T) 
 			seedDaemonWorkerRepo(t, store, "owner/repo", checkout)
 			seedDaemonWorkerAgentWithPolicy(t, store, "reviewer", runtime.ShellRuntime, "true", []string{"review"}, "owner/repo", runtime.AutonomyPolicyReadOnly)
 			seedDaemonWorkerAgentWithPolicy(t, store, "implementer", runtime.ShellRuntime, "true", []string{"implement"}, "owner/repo", runtime.AutonomyPolicyWorkspaceWrite)
+			seedDaemonWorkerAgentWithPolicy(t, store, "payload-default", runtime.ShellRuntime, "true", []string{"implement"}, "owner/repo", runtime.AutonomyPolicyWorkspaceWrite)
+			if err := store.UpsertTask(context.Background(), db.Task{
+				ID: "owned-task", RepoFullName: "owner/repo", Branch: "feature/review", State: string(workflow.TaskReviewing),
+			}); err != nil {
+				t.Fatalf("UpsertTask returned error: %v", err)
+			}
+			originalPayload, err := json.Marshal(workflow.JobPayload{
+				Repo: "owner/repo", Branch: "feature/review", PullRequest: 7, TaskID: "owned-task",
+				Result: &workflow.AgentResult{Decision: "implemented"},
+			})
+			if err != nil {
+				t.Fatalf("marshal original implement payload: %v", err)
+			}
+			if err := store.CreateJob(context.Background(), db.Job{
+				ID: "original-implement", Agent: "implementer", Type: "implement",
+				State: string(workflow.JobSucceeded), Payload: string(originalPayload),
+			}); err != nil {
+				t.Fatalf("CreateJob(original-implement): %v", err)
+			}
 			head, err := (gitutil.NewHostClient(checkout)).HeadSHA(context.Background())
 			if err != nil {
 				t.Fatalf("HeadSHA returned error: %v", err)
@@ -674,7 +693,7 @@ func TestReviewDispatchLeadRoutesChangesRequestedFixToImplementer(t *testing.T) 
 
 			args := []string{
 				"reviewer", "Review this PR.", "--repo", "owner/repo", "--pr", "7",
-				"--head-sha", head, "--branch", "feature/review", "--lead", "implementer", "--home", home,
+				"--head-sha", head, "--branch", "feature/review", "--lead", "payload-default", "--home", home,
 			}
 			var stdout, stderr bytes.Buffer
 			var exit int
@@ -694,8 +713,8 @@ func TestReviewDispatchLeadRoutesChangesRequestedFixToImplementer(t *testing.T) 
 			if err != nil {
 				t.Fatalf("ListJobs returned error: %v", err)
 			}
-			if len(jobs) != 2 {
-				t.Fatalf("jobs = %+v, want review plus fix job", jobs)
+			if len(jobs) != 3 {
+				t.Fatalf("jobs = %+v, want original implement, review, and fix jobs", jobs)
 			}
 			var reviewJob, fixJob *db.Job
 			for index := range jobs {
@@ -703,7 +722,9 @@ func TestReviewDispatchLeadRoutesChangesRequestedFixToImplementer(t *testing.T) 
 				case "review":
 					reviewJob = &jobs[index]
 				case "implement":
-					fixJob = &jobs[index]
+					if jobs[index].ID != "original-implement" {
+						fixJob = &jobs[index]
+					}
 				}
 			}
 			if reviewJob == nil || reviewJob.Agent != "reviewer" {

--- a/internal/cli/implementation_advance_preflight_test.go
+++ b/internal/cli/implementation_advance_preflight_test.go
@@ -952,6 +952,13 @@ func enqueueAdvanceCreatedHeadlessFixJob(t *testing.T, store *db.Store, jobID, b
 	ctx := context.Background()
 	seedDaemonWorkerAgent(t, store, "audit", runtime.ShellRuntime, "unused", []string{"review"}, "owner/repo")
 	enqueueDaemonWorkerJob(t, store, workflow.JobRequest{
+		ID: "original-headless-implement", Agent: "lead", Action: "implement", Repo: "owner/repo",
+		Branch: branch, PullRequest: 1514, TaskID: "task-1514",
+	})
+	if err := store.UpdateJobState(ctx, "original-headless-implement", string(workflow.JobSucceeded)); err != nil {
+		t.Fatalf("UpdateJobState(original-headless-implement): %v", err)
+	}
+	enqueueDaemonWorkerJob(t, store, workflow.JobRequest{
 		ID: "headless-review", Agent: "audit", Action: "review", Repo: "owner/repo",
 		Branch: branch, PullRequest: 1514, TaskID: "task-1514", LeadAgent: "lead",
 	})

--- a/internal/cli/repo.go
+++ b/internal/cli/repo.go
@@ -33,6 +33,8 @@ func runRepo(args []string, stdout, stderr io.Writer) int {
 		return runRepoList(args[1:], stdout, stderr)
 	case "set-interval":
 		return runRepoSetInterval(args[1:], stdout, stderr)
+	case "auto-fix":
+		return runRepoAutoFix(args[1:], stdout, stderr)
 	case "remove":
 		return runRepoRemove(args[1:], stdout, stderr)
 	case "doctor":
@@ -74,6 +76,7 @@ func printRepoUsage(w io.Writer) {
 	fmt.Fprintln(w, "  gitmoot repo add owner/repo --path <path> [--poll <duration>] [--force] [--agents-md]")
 	fmt.Fprintln(w, "  gitmoot repo list")
 	fmt.Fprintln(w, "  gitmoot repo set-interval owner/repo (<duration>|default)")
+	fmt.Fprintln(w, "  gitmoot repo auto-fix owner/repo --pr <number> (--disable|--enable) --by <role-or-agent> --reason <text>")
 	fmt.Fprintln(w, "  gitmoot repo set-interval --all (<duration>|default)")
 	fmt.Fprintln(w, "  gitmoot repo remove owner/repo")
 	fmt.Fprintln(w, "  gitmoot repo doctor owner/repo")
@@ -338,6 +341,75 @@ func runRepoSetInterval(args []string, stdout, stderr io.Writer) int {
 	} else {
 		writeLine(stdout, "set poll interval for %s to %s", repoArg, display)
 	}
+	return 0
+}
+
+func runRepoAutoFix(args []string, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("repo auto-fix", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	home := fs.String("home", "", "home directory to use instead of the current user's home")
+	pullRequest := fs.Int("pr", 0, "pull request number")
+	disable := fs.Bool("disable", false, "disable automatic changes-requested fix dispatch")
+	enable := fs.Bool("enable", false, "re-enable automatic changes-requested fix dispatch")
+	actor := fs.String("by", "", "role or agent recording the decision")
+	reason := fs.String("reason", "", "durable reason for the decision")
+	repoArg, code := parseRepoPositional(
+		fs,
+		"repo auto-fix",
+		args,
+		map[string]struct{}{"home": {}, "pr": {}, "by": {}, "reason": {}},
+		map[string]struct{}{"disable": {}, "enable": {}},
+		stderr,
+	)
+	if code >= 0 {
+		return code
+	}
+	if *disable == *enable {
+		fmt.Fprintln(stderr, "repo auto-fix requires exactly one of --disable or --enable")
+		return 2
+	}
+	if *pullRequest <= 0 {
+		fmt.Fprintln(stderr, "repo auto-fix requires a positive --pr number")
+		return 2
+	}
+	if strings.TrimSpace(*actor) == "" {
+		fmt.Fprintln(stderr, "repo auto-fix requires --by")
+		return 2
+	}
+	if strings.TrimSpace(*reason) == "" {
+		fmt.Fprintln(stderr, "repo auto-fix requires --reason")
+		return 2
+	}
+	repo, err := daemon.ParseRepository(repoArg)
+	if err != nil {
+		fmt.Fprintf(stderr, "invalid repo: %v\n", err)
+		return 2
+	}
+	repoArg = repo.FullName()
+	if err := withStore(*home, func(store *db.Store) error {
+		if _, err := store.GetRepo(context.Background(), repoArg); err != nil {
+			if errors.Is(err, sql.ErrNoRows) {
+				return fmt.Errorf("repo %s is not registered", repoArg)
+			}
+			return err
+		}
+		return store.SetPullRequestAutoFixPolicy(
+			context.Background(),
+			repoArg,
+			*pullRequest,
+			*disable,
+			*actor,
+			*reason,
+		)
+	}); err != nil {
+		fmt.Fprintf(stderr, "repo auto-fix: %v\n", err)
+		return 1
+	}
+	state := "enabled"
+	if *disable {
+		state = "disabled"
+	}
+	writeLine(stdout, "auto-fix %s for %s pull request #%d by %s: %s", state, repoArg, *pullRequest, strings.TrimSpace(*actor), strings.TrimSpace(*reason))
 	return 0
 }
 

--- a/internal/cli/repo_test.go
+++ b/internal/cli/repo_test.go
@@ -198,6 +198,65 @@ func TestRunRepoSetIntervalSingleDefaultAndAll(t *testing.T) {
 	}
 }
 
+func TestRunRepoAutoFixPersistsPerPullRequestDecision(t *testing.T) {
+	home := t.TempDir()
+	store := openCLIJobStore(t, home)
+	ctx := context.Background()
+	if err := store.UpsertRepo(ctx, db.Repo{Owner: "owner", Name: "repo"}); err != nil {
+		t.Fatal(err)
+	}
+	store.Close()
+
+	var stdout, stderr bytes.Buffer
+	if code := Run([]string{
+		"repo", "auto-fix", "owner/repo",
+		"--pr", "1686",
+		"--disable",
+		"--by", "owner-role",
+		"--reason", "do not patch this review round",
+		"--home", home,
+	}, &stdout, &stderr); code != 0 {
+		t.Fatalf("disable code=%d stderr=%s", code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "auto-fix disabled for owner/repo pull request #1686") {
+		t.Fatalf("disable output = %q", stdout.String())
+	}
+	store = openCLIJobStore(t, home)
+	policy, configured, err := store.PullRequestAutoFixPolicyFor(ctx, "owner/repo", 1686)
+	store.Close()
+	if err != nil || !configured || !policy.Disabled || policy.Actor != "owner-role" {
+		t.Fatalf("disabled policy=%+v configured=%v err=%v", policy, configured, err)
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	if code := Run([]string{
+		"repo", "auto-fix",
+		"--enable",
+		"--reason", "resume after owner review",
+		"--by", "owner-role",
+		"--pr", "1686",
+		"--home", home,
+		"owner/repo",
+	}, &stdout, &stderr); code != 0 {
+		t.Fatalf("enable code=%d stderr=%s", code, stderr.String())
+	}
+	store = openCLIJobStore(t, home)
+	policy, configured, err = store.PullRequestAutoFixPolicyFor(ctx, "owner/repo", 1686)
+	store.Close()
+	if err != nil || !configured || policy.Disabled || policy.Reason != "resume after owner review" {
+		t.Fatalf("enabled policy=%+v configured=%v err=%v", policy, configured, err)
+	}
+}
+
+func TestRunRepoAutoFixRequiresExplicitAuditedDecision(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{"repo", "auto-fix", "owner/repo", "--pr", "7", "--disable"}, &stdout, &stderr)
+	if code != 2 || !strings.Contains(stderr.String(), "requires --by") {
+		t.Fatalf("code=%d stderr=%q", code, stderr.String())
+	}
+}
+
 func TestRunRepoAddRejectsWrongOrigin(t *testing.T) {
 	home := t.TempDir()
 	repoDir := t.TempDir()

--- a/internal/db/auto_fix_policy.go
+++ b/internal/db/auto_fix_policy.go
@@ -1,0 +1,97 @@
+package db
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"strings"
+)
+
+// PullRequestAutoFixPolicy is the durable operator decision the review
+// scheduler reads before dispatching a changes-requested fix.
+type PullRequestAutoFixPolicy struct {
+	RepoFullName string
+	PullRequest  int
+	Disabled     bool
+	Actor        string
+	Reason       string
+	CreatedAt    string
+	UpdatedAt    string
+}
+
+func normalizeAutoFixPolicySubject(repo string, pullRequest int) (string, error) {
+	repo = strings.ToLower(strings.TrimSpace(repo))
+	parts := strings.Split(repo, "/")
+	if len(parts) != 2 || parts[0] == "" || parts[1] == "" || strings.ContainsAny(repo, "#@ \t\r\n") {
+		return "", errors.New("auto-fix policy repo must be owner/repo")
+	}
+	if pullRequest <= 0 {
+		return "", errors.New("auto-fix policy pull request must be positive")
+	}
+	return repo, nil
+}
+
+// SetPullRequestAutoFixPolicy records an explicit disable or re-enable decision.
+// Rows are retained for both states so the latest operator decision remains
+// auditable instead of disappearing when auto-fix is re-enabled.
+func (s *Store) SetPullRequestAutoFixPolicy(ctx context.Context, repo string, pullRequest int, disabled bool, actor string, reason string) error {
+	repo, err := normalizeAutoFixPolicySubject(repo, pullRequest)
+	if err != nil {
+		return err
+	}
+	actor = strings.TrimSpace(actor)
+	reason = strings.TrimSpace(reason)
+	if actor == "" {
+		return errors.New("auto-fix policy actor is required")
+	}
+	if reason == "" {
+		return errors.New("auto-fix policy reason is required")
+	}
+	disabledValue := 0
+	if disabled {
+		disabledValue = 1
+	}
+	_, err = s.db.ExecContext(ctx, `
+INSERT INTO pull_request_auto_fix_policies(repo_full_name, pull_request, disabled, actor, reason)
+VALUES (?, ?, ?, ?, ?)
+ON CONFLICT(repo_full_name, pull_request) DO UPDATE SET
+	disabled = excluded.disabled,
+	actor = excluded.actor,
+	reason = excluded.reason,
+	updated_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now')`, repo, pullRequest, disabledValue, actor, reason)
+	if err != nil {
+		return fmt.Errorf("set pull request auto-fix policy: %w", err)
+	}
+	return nil
+}
+
+// PullRequestAutoFixPolicyFor returns the latest explicit policy. configured is
+// false when no operator has recorded a decision for this PR.
+func (s *Store) PullRequestAutoFixPolicyFor(ctx context.Context, repo string, pullRequest int) (policy PullRequestAutoFixPolicy, configured bool, err error) {
+	repo, err = normalizeAutoFixPolicySubject(repo, pullRequest)
+	if err != nil {
+		return PullRequestAutoFixPolicy{}, false, err
+	}
+	var disabled int
+	err = s.db.QueryRowContext(ctx, `
+SELECT repo_full_name, pull_request, disabled, actor, reason, created_at, updated_at
+FROM pull_request_auto_fix_policies
+WHERE repo_full_name = ? AND pull_request = ?`, repo, pullRequest).Scan(
+		&policy.RepoFullName,
+		&policy.PullRequest,
+		&disabled,
+		&policy.Actor,
+		&policy.Reason,
+		&policy.CreatedAt,
+		&policy.UpdatedAt,
+	)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return PullRequestAutoFixPolicy{}, false, nil
+		}
+		return PullRequestAutoFixPolicy{}, false, fmt.Errorf("get pull request auto-fix policy: %w", err)
+	}
+	policy.Disabled = disabled != 0
+	return policy, true, nil
+}

--- a/internal/db/auto_fix_policy_test.go
+++ b/internal/db/auto_fix_policy_test.go
@@ -1,0 +1,74 @@
+package db
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+)
+
+func openAutoFixPolicyTestStore(t *testing.T) *Store {
+	t.Helper()
+	store, err := openCachedTestStore(t, filepath.Join(t.TempDir(), "gitmoot.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+	return store
+}
+
+func TestPullRequestAutoFixPolicyPersistsDisableAndEnable(t *testing.T) {
+	ctx := context.Background()
+	store := openAutoFixPolicyTestStore(t)
+
+	if policy, configured, err := store.PullRequestAutoFixPolicyFor(ctx, "owner/repo", 1686); err != nil {
+		t.Fatalf("PullRequestAutoFixPolicyFor unset: %v", err)
+	} else if configured {
+		t.Fatalf("unset policy = %+v, configured=true", policy)
+	}
+
+	if err := store.SetPullRequestAutoFixPolicy(ctx, " Owner/Repo ", 1686, true, "gitmoot", "coordinator declined this round"); err != nil {
+		t.Fatalf("disable policy: %v", err)
+	}
+	policy, configured, err := store.PullRequestAutoFixPolicyFor(ctx, "owner/repo", 1686)
+	if err != nil {
+		t.Fatalf("read disabled policy: %v", err)
+	}
+	if !configured || !policy.Disabled || policy.RepoFullName != "owner/repo" || policy.PullRequest != 1686 || policy.Actor != "gitmoot" || policy.Reason != "coordinator declined this round" || policy.CreatedAt == "" || policy.UpdatedAt == "" {
+		t.Fatalf("disabled policy = %+v, configured=%v", policy, configured)
+	}
+
+	if err := store.SetPullRequestAutoFixPolicy(ctx, "owner/repo", 1686, false, "gitmoot", "owner resumed automatic fixes"); err != nil {
+		t.Fatalf("enable policy: %v", err)
+	}
+	policy, configured, err = store.PullRequestAutoFixPolicyFor(ctx, "OWNER/REPO", 1686)
+	if err != nil {
+		t.Fatalf("read enabled policy: %v", err)
+	}
+	if !configured || policy.Disabled || policy.Actor != "gitmoot" || policy.Reason != "owner resumed automatic fixes" {
+		t.Fatalf("enabled policy = %+v, configured=%v", policy, configured)
+	}
+}
+
+func TestPullRequestAutoFixPolicyRejectsUnattributedDecision(t *testing.T) {
+	ctx := context.Background()
+	store := openAutoFixPolicyTestStore(t)
+
+	for _, tc := range []struct {
+		name   string
+		repo   string
+		pr     int
+		actor  string
+		reason string
+	}{
+		{name: "bad repo", repo: "owner", pr: 1, actor: "role", reason: "reason"},
+		{name: "bad pr", repo: "owner/repo", pr: 0, actor: "role", reason: "reason"},
+		{name: "missing actor", repo: "owner/repo", pr: 1, reason: "reason"},
+		{name: "missing reason", repo: "owner/repo", pr: 1, actor: "role"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if err := store.SetPullRequestAutoFixPolicy(ctx, tc.repo, tc.pr, true, tc.actor, tc.reason); err == nil {
+				t.Fatal("SetPullRequestAutoFixPolicy succeeded, want validation error")
+			}
+		})
+	}
+}

--- a/internal/db/store_migrations.go
+++ b/internal/db/store_migrations.go
@@ -2254,4 +2254,18 @@ CREATE INDEX idx_wake_outbox_attempted
 	ON wake_outbox(attempted_at, id)
 	WHERE state = 'attempted';
 	`,
+	// #1686 per-PR auto-fix refusal. The scheduler reads this local durable
+	// policy before resolving an owner or allocating a fix worktree.
+	`
+CREATE TABLE pull_request_auto_fix_policies (
+	repo_full_name TEXT NOT NULL COLLATE NOCASE,
+	pull_request INTEGER NOT NULL CHECK(pull_request > 0),
+	disabled INTEGER NOT NULL CHECK(disabled IN (0, 1)),
+	actor TEXT NOT NULL,
+	reason TEXT NOT NULL,
+	created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+	updated_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+	PRIMARY KEY (repo_full_name, pull_request)
+);
+	`,
 }

--- a/internal/workflow/engine_routing_merge.go
+++ b/internal/workflow/engine_routing_merge.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -64,9 +65,22 @@ func validatePullRequestEvent(event PullRequestEvent) error {
 }
 
 func (e Engine) dispatchFix(ctx context.Context, reviewer string, payload JobPayload, result AgentResult, ref taskRef) error {
-	leadAgent, err := e.leadAgent(ctx, payload)
+	policy, configured, err := e.Store.PullRequestAutoFixPolicyFor(ctx, payload.Repo, payload.PullRequest)
 	if err != nil {
 		return err
+	}
+	if configured && policy.Disabled {
+		return e.blockAutoFix(ctx, ref, fmt.Sprintf(
+			"auto-fix disabled for %s pull request #%d by %s: %s",
+			payload.Repo,
+			payload.PullRequest,
+			policy.Actor,
+			policy.Reason,
+		))
+	}
+	leadAgent, err := e.autoFixOwner(ctx, payload)
+	if err != nil {
+		return e.blockAutoFix(ctx, ref, err.Error())
 	}
 	request := JobRequest{
 		PolicyExempt:  "exempt",
@@ -124,19 +138,47 @@ func (e Engine) dispatchFix(ctx context.Context, reviewer string, payload JobPay
 	return nil
 }
 
-func (e Engine) leadAgent(ctx context.Context, payload JobPayload) (string, error) {
-	leadAgent := strings.TrimSpace(payload.LeadAgent)
-	if leadAgent != "" {
-		return leadAgent, nil
+func (e Engine) autoFixOwner(ctx context.Context, payload JobPayload) (string, error) {
+	if role := strings.TrimSpace(payload.ActingOrgRole); role != "" {
+		return role, nil
 	}
-	lock, err := e.Store.GetBranchLock(ctx, payload.Repo, payload.Branch)
-	if err == nil {
-		return lock.Owner, nil
+	jobs, err := e.Store.ListJobs(ctx)
+	if err != nil {
+		return "", err
 	}
-	if errors.Is(err, sql.ErrNoRows) {
-		return "", errors.New("lead agent is required")
+	evidence := collectImplementerAttribution(jobs, payload)
+	switch {
+	case evidence.sawMalformedPayload:
+		return "", errors.New("auto-fix ownership unresolved: an implement job has a malformed payload")
+	case evidence.sawEmptyAgent:
+		return "", errors.New("auto-fix ownership unresolved: a matching implement job has no agent")
 	}
-	return "", err
+	agents := make([]string, 0, len(evidence.agents))
+	for agent := range evidence.agents {
+		agents = append(agents, agent)
+	}
+	sort.Strings(agents)
+	switch len(agents) {
+	case 0:
+		return "", fmt.Errorf("auto-fix ownership unresolved: %s", evidence.failureReason())
+	case 1:
+		return agents[0], nil
+	default:
+		return "", fmt.Errorf("auto-fix ownership ambiguous: task %s has implementing agents [%s]", payload.TaskID, strings.Join(agents, " "))
+	}
+}
+
+func (e Engine) blockAutoFix(ctx context.Context, ref taskRef, reason string) error {
+	if strings.TrimSpace(ref.ID) != "" {
+		if err := e.Store.AddTaskEvent(ctx, db.TaskEvent{
+			TaskID: ref.ID,
+			Kind:   "review_auto_fix_blocked",
+			Reason: reason,
+		}); err != nil {
+			return fmt.Errorf("record auto-fix block: %w", err)
+		}
+	}
+	return e.block(ctx, ref, reason)
 }
 
 func (e Engine) allRequiredReviewersApproved(ctx context.Context, currentReviewer string, payload JobPayload) (bool, error) {

--- a/internal/workflow/engine_routing_merge.go
+++ b/internal/workflow/engine_routing_merge.go
@@ -82,6 +82,10 @@ func (e Engine) dispatchFix(ctx context.Context, reviewer string, payload JobPay
 	if err != nil {
 		return e.blockAutoFix(ctx, ref, err.Error())
 	}
+	branchOwner, err := e.fixBranchLockOwner(ctx, payload, leadAgent)
+	if err != nil {
+		return e.blockAutoFix(ctx, ref, fmt.Sprintf("auto-fix branch lock owner unresolved: %v", err))
+	}
 	request := JobRequest{
 		PolicyExempt:  "exempt",
 		Agent:         leadAgent,
@@ -107,7 +111,7 @@ func (e Engine) dispatchFix(ctx context.Context, reviewer string, payload JobPay
 	if request.ID == "" {
 		request.ID = e.jobID(request)
 	}
-	if err := e.ensureAgentAllowed(ctx, request, ref); err != nil {
+	if err := e.ensureAgentAllowedWithBranchOwner(ctx, request, branchOwner, ref, false); err != nil {
 		return err
 	}
 	// Fail closed at the dispatch site. Falling through here would enqueue the fix
@@ -166,6 +170,24 @@ func (e Engine) autoFixOwner(ctx context.Context, payload JobPayload) (string, e
 	default:
 		return "", fmt.Errorf("auto-fix ownership ambiguous: task %s has implementing agents [%s]", payload.TaskID, strings.Join(agents, " "))
 	}
+}
+
+// fixBranchLockOwner preserves the task's existing serialization owner while an
+// acting org role executes the isolated fix. The lock is never an ownership
+// source: it cannot change the agent selected by autoFixOwner.
+func (e Engine) fixBranchLockOwner(ctx context.Context, payload JobPayload, executionAgent string) (string, error) {
+	lock, err := e.Store.GetBranchLock(ctx, payload.Repo, payload.Branch)
+	if errors.Is(err, sql.ErrNoRows) {
+		return executionAgent, nil
+	}
+	if err != nil {
+		return "", err
+	}
+	owner := strings.TrimSpace(lock.Owner)
+	if owner == "" {
+		return "", errors.New("existing branch lock has no owner")
+	}
+	return owner, nil
 }
 
 func (e Engine) blockAutoFix(ctx context.Context, ref taskRef, reason string) error {
@@ -435,6 +457,13 @@ func (e Engine) ensureJobExecutorAllowed(ctx context.Context, job db.Job, payloa
 	authorizationAgent := job.Agent
 	if job.Type == "implement" && payload.DelegationReason == "runtime_session_busy" && payload.DelegatedAgent == job.Agent && strings.TrimSpace(payload.OriginalAgent) != "" {
 		branchOwner = payload.OriginalAgent
+	}
+	if job.Type == "implement" && payload.FixWorktree {
+		fixOwner, err := e.fixBranchLockOwner(ctx, payload, branchOwner)
+		if err != nil {
+			return e.block(ctx, ref, fmt.Sprintf("auto-fix branch lock owner unresolved: %v", err))
+		}
+		branchOwner = fixOwner
 	}
 	if payload.DelegationReason == "runtime_session_busy" && payload.DelegatedAgent == job.Agent && strings.TrimSpace(payload.OriginalAgent) != "" {
 		authorizationAgent = payload.OriginalAgent

--- a/internal/workflow/engine_test.go
+++ b/internal/workflow/engine_test.go
@@ -1330,22 +1330,31 @@ func TestEngineRunJobPreflightsPolicyBeforeDelivery(t *testing.T) {
 func TestEngineAdvanceReviewChangesRequestedDispatchesFix(t *testing.T) {
 	ctx := context.Background()
 	store := openEngineStore(t)
-	seedAgent(t, store, "lead", []string{"implement"}, "gitmoot/gitmoot")
+	seedAgent(t, store, "owner-role", []string{"implement"}, "gitmoot/gitmoot")
+	seedAgent(t, store, "task-owner", []string{"implement"}, "gitmoot/gitmoot")
+	seedAgent(t, store, "payload-default", []string{"implement"}, "gitmoot/gitmoot")
 	seedAgent(t, store, "audit", []string{"review"}, "gitmoot/gitmoot")
 	engine := testEngine(store)
 	engine.RequireWorkflowPolicy = func(string) RequireWorkflowPolicy { return RequireWorkflowPolicy{Enabled: true, Mode: "strict"} }
+	insertCompletedJob(t, store, db.Job{
+		ID: "original-implement", Agent: "task-owner", Type: "implement",
+	}, JobPayload{
+		Repo: "gitmoot/gitmoot", Branch: "task-7", PullRequest: 7, TaskID: "task-7",
+		Result: &AgentResult{Decision: "implemented"},
+	})
 	insertCompletedJob(t, store, db.Job{
 		ID:    "review-job",
 		Agent: "audit",
 		Type:  "review",
 	}, JobPayload{
-		Repo:        "gitmoot/gitmoot",
-		Branch:      "task-7",
-		PullRequest: 7,
-		TaskID:      "task-7",
-		TaskTitle:   "Workflow Engine",
-		LeadAgent:   "lead",
-		Result:      &AgentResult{Decision: "changes_requested", Summary: "fix edge case"},
+		Repo:          "gitmoot/gitmoot",
+		Branch:        "task-7",
+		PullRequest:   7,
+		TaskID:        "task-7",
+		TaskTitle:     "Workflow Engine",
+		LeadAgent:     "payload-default",
+		ActingOrgRole: "owner-role",
+		Result:        &AgentResult{Decision: "changes_requested", Summary: "fix edge case"},
 	})
 
 	err := engine.AdvanceJob(ctx, "review-job")
@@ -1354,7 +1363,7 @@ func TestEngineAdvanceReviewChangesRequestedDispatchesFix(t *testing.T) {
 		t.Fatalf("AdvanceJob returned error: %v", err)
 	}
 	assertTaskState(t, store, "task-7", TaskChangesRequested)
-	job := mustJob(t, store, "implement-lead-task-7")
+	job := mustJob(t, store, "implement-owner-role-task-7")
 	if !strings.Contains(job.Payload, "fix edge case") {
 		t.Fatalf("fix job payload = %s", job.Payload)
 	}
@@ -1507,6 +1516,12 @@ func TestEngineAdvanceReviewChangesRequestedReplayIsIdempotent(t *testing.T) {
 	seedAgent(t, store, "lead", []string{"implement"}, "gitmoot/gitmoot")
 	engine := testEngine(store)
 	insertCompletedJob(t, store, db.Job{
+		ID: "original-implement", Agent: "lead", Type: "implement",
+	}, JobPayload{
+		Repo: "gitmoot/gitmoot", Branch: "task-7", PullRequest: 7, TaskID: "task-7",
+		Result: &AgentResult{Decision: "implemented"},
+	})
+	insertCompletedJob(t, store, db.Job{
 		ID:    "review-job",
 		Agent: "audit",
 		Type:  "review",
@@ -1543,14 +1558,18 @@ func TestEngineAdvanceReviewChangesRequestedReplayIsIdempotent(t *testing.T) {
 	assertTaskState(t, store, "task-7", TaskChangesRequested)
 }
 
-func TestEngineAdvanceReviewChangesRequestedUsesBranchLockLead(t *testing.T) {
+func TestEngineAdvanceReviewChangesRequestedUsesTaskImplementerWhenActingRoleAbsent(t *testing.T) {
 	ctx := context.Background()
 	store := openEngineStore(t)
-	seedAgent(t, store, "lead", []string{"implement"}, "gitmoot/gitmoot")
-	if acquired, err := store.AcquireLock(ctx, db.BranchLock{RepoFullName: "gitmoot/gitmoot", Branch: "task-7", Owner: "lead"}); err != nil || !acquired {
-		t.Fatalf("AcquireLock returned acquired=%v err=%v", acquired, err)
-	}
+	seedAgent(t, store, "task-owner", []string{"implement"}, "gitmoot/gitmoot")
+	seedAgent(t, store, "wrong-default", []string{"implement"}, "gitmoot/gitmoot")
 	engine := testEngine(store)
+	insertCompletedJob(t, store, db.Job{
+		ID: "original-implement", Agent: "task-owner", Type: "implement",
+	}, JobPayload{
+		Repo: "gitmoot/gitmoot", Branch: "task-7", PullRequest: 7, TaskID: "task-7",
+		Result: &AgentResult{Decision: "implemented"},
+	})
 	insertCompletedJob(t, store, db.Job{
 		ID:    "manual-review-job",
 		Agent: "audit",
@@ -1561,19 +1580,205 @@ func TestEngineAdvanceReviewChangesRequestedUsesBranchLockLead(t *testing.T) {
 		PullRequest: 7,
 		TaskID:      "task-7",
 		TaskTitle:   "Workflow Engine",
+		LeadAgent:   "wrong-default",
 		Result:      &AgentResult{Decision: "changes_requested", Summary: "fix manual review"},
 	})
 
-	err := engine.AdvanceJob(ctx, "manual-review-job")
-
-	if err != nil {
+	if err := engine.AdvanceJob(ctx, "manual-review-job"); err != nil {
 		t.Fatalf("AdvanceJob returned error: %v", err)
 	}
 	assertTaskState(t, store, "task-7", TaskChangesRequested)
-	job := mustJob(t, store, "implement-lead-task-7")
+	job := mustJob(t, store, "implement-task-owner-task-7")
 	if !strings.Contains(job.Payload, "fix manual review") {
 		t.Fatalf("fix job payload = %s", job.Payload)
 	}
+	if _, err := store.GetJob(ctx, "implement-wrong-default-task-7"); err == nil {
+		t.Fatal("branch-lock or payload default received auto-fix ownership")
+	}
+}
+
+func TestEngineAdvanceReviewChangesRequestedFailsClosedWithoutOwnership(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	seedAgent(t, store, "payload-default", []string{"implement"}, "gitmoot/gitmoot")
+	seedAgent(t, store, "audit", []string{"review"}, "gitmoot/gitmoot")
+	engine := testEngine(store)
+	allocations := 0
+	engine.FixWorktreeAllocator = func(_ context.Context, request FixWorktreeRequest) (FixWorktreeAllocation, error) {
+		allocations++
+		return FixWorktreeAllocation{Path: filepath.Join(t.TempDir(), request.JobID)}, nil
+	}
+	insertCompletedJob(t, store, db.Job{
+		ID: "review-without-owner", Agent: "audit", Type: "review",
+	}, JobPayload{
+		Repo:        "gitmoot/gitmoot",
+		Branch:      "task-7",
+		PullRequest: 7,
+		TaskID:      "task-7",
+		TaskTitle:   "Workflow Engine",
+		LeadAgent:   "payload-default",
+		Result:      &AgentResult{Decision: "changes_requested", Summary: "fix without guessing"},
+	})
+
+	err := engine.AdvanceJob(ctx, "review-without-owner")
+	var blocked BlockedError
+	if !errors.As(err, &blocked) || !strings.Contains(blocked.Reason, "auto-fix ownership unresolved") {
+		t.Fatalf("AdvanceJob error = %v, want ownership BlockedError", err)
+	}
+	assertTaskState(t, store, "task-7", TaskBlocked)
+	if allocations != 0 {
+		t.Fatalf("fix worktree allocations = %d, want zero", allocations)
+	}
+	if _, err := store.GetJob(ctx, "implement-payload-default-task-7"); err == nil {
+		t.Fatal("payload default received an ownership-unresolved auto-fix")
+	}
+	events, err := store.ListTaskEvents(ctx, "task-7")
+	if err != nil {
+		t.Fatalf("ListTaskEvents: %v", err)
+	}
+	found := false
+	for _, event := range events {
+		if event.Kind == "review_auto_fix_blocked" && strings.Contains(event.Reason, "ownership unresolved") {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("task events = %+v, want review_auto_fix_blocked ownership event", events)
+	}
+}
+
+func TestEngineAdvanceReviewChangesRequestedFailsClosedForAmbiguousTaskImplementers(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	seedAgent(t, store, "first-owner", []string{"implement"}, "gitmoot/gitmoot")
+	seedAgent(t, store, "second-owner", []string{"implement"}, "gitmoot/gitmoot")
+	for _, agent := range []string{"second-owner", "first-owner"} {
+		insertCompletedJob(t, store, db.Job{
+			ID: "original-implement-" + agent, Agent: agent, Type: "implement",
+		}, JobPayload{
+			Repo: "gitmoot/gitmoot", Branch: "task-7", PullRequest: 7, TaskID: "task-7",
+			Result: &AgentResult{Decision: "implemented"},
+		})
+	}
+	engine := testEngine(store)
+	allocations := 0
+	engine.FixWorktreeAllocator = func(_ context.Context, request FixWorktreeRequest) (FixWorktreeAllocation, error) {
+		allocations++
+		return FixWorktreeAllocation{Path: filepath.Join(t.TempDir(), request.JobID)}, nil
+	}
+	insertCompletedJob(t, store, db.Job{
+		ID: "review-ambiguous-owner", Agent: "audit", Type: "review",
+	}, JobPayload{
+		Repo: "gitmoot/gitmoot", Branch: "task-7", PullRequest: 7, TaskID: "task-7",
+		Result: &AgentResult{Decision: "changes_requested", Summary: "choose no default"},
+	})
+
+	err := engine.AdvanceJob(ctx, "review-ambiguous-owner")
+	var blocked BlockedError
+	if !errors.As(err, &blocked) || !strings.Contains(blocked.Reason, "auto-fix ownership ambiguous") || !strings.Contains(blocked.Reason, "[first-owner second-owner]") {
+		t.Fatalf("AdvanceJob error = %v, want sorted ambiguous-ownership BlockedError", err)
+	}
+	if allocations != 0 {
+		t.Fatalf("fix worktree allocations = %d, want zero", allocations)
+	}
+}
+
+func TestEngineAdvanceReviewChangesRequestedDoesNotBypassUnresolvableActingRole(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	seedAgent(t, store, "task-owner", []string{"implement"}, "gitmoot/gitmoot")
+	seedAgent(t, store, "payload-default", []string{"implement"}, "gitmoot/gitmoot")
+	insertCompletedJob(t, store, db.Job{
+		ID: "original-implement", Agent: "task-owner", Type: "implement",
+	}, JobPayload{
+		Repo: "gitmoot/gitmoot", Branch: "task-7", PullRequest: 7, TaskID: "task-7",
+		Result: &AgentResult{Decision: "implemented"},
+	})
+	engine := testEngine(store)
+	allocations := 0
+	engine.FixWorktreeAllocator = func(_ context.Context, request FixWorktreeRequest) (FixWorktreeAllocation, error) {
+		allocations++
+		return FixWorktreeAllocation{Path: filepath.Join(t.TempDir(), request.JobID)}, nil
+	}
+	insertCompletedJob(t, store, db.Job{
+		ID: "review-with-role", Agent: "audit", Type: "review",
+	}, JobPayload{
+		Repo:          "gitmoot/gitmoot",
+		Branch:        "task-7",
+		PullRequest:   7,
+		TaskID:        "task-7",
+		TaskTitle:     "Workflow Engine",
+		LeadAgent:     "payload-default",
+		ActingOrgRole: "gitmoot",
+		Result:        &AgentResult{Decision: "changes_requested", Summary: "respect coordinator ownership"},
+	})
+
+	err := engine.AdvanceJob(ctx, "review-with-role")
+	var blocked BlockedError
+	if !errors.As(err, &blocked) || !strings.Contains(blocked.Reason, `agent "gitmoot" is not subscribed`) {
+		t.Fatalf("AdvanceJob error = %v, want acting-role BlockedError", err)
+	}
+	if allocations != 0 {
+		t.Fatalf("fix worktree allocations = %d, want zero", allocations)
+	}
+	if _, err := store.GetJob(ctx, "implement-task-owner-task-7"); err == nil {
+		t.Fatal("task implementer bypassed an explicit but unresolvable acting role")
+	}
+	if _, err := store.GetJob(ctx, "implement-payload-default-task-7"); err == nil {
+		t.Fatal("payload default bypassed an explicit but unresolvable acting role")
+	}
+}
+
+func TestEngineAdvanceReviewChangesRequestedHonorsPersistentRefusal(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	seedAgent(t, store, "task-owner", []string{"implement"}, "gitmoot/gitmoot")
+	seedAgent(t, store, "audit", []string{"review"}, "gitmoot/gitmoot")
+	insertCompletedJob(t, store, db.Job{
+		ID: "original-implement", Agent: "task-owner", Type: "implement",
+	}, JobPayload{
+		Repo: "gitmoot/gitmoot", Branch: "task-7", PullRequest: 7, TaskID: "task-7",
+		Result: &AgentResult{Decision: "implemented"},
+	})
+	if err := store.SetPullRequestAutoFixPolicy(ctx, "gitmoot/gitmoot", 7, true, "gitmoot", "coordinator declined automatic patching"); err != nil {
+		t.Fatalf("disable auto-fix: %v", err)
+	}
+	engine := testEngine(store)
+	allocations := 0
+	engine.FixWorktreeAllocator = func(_ context.Context, request FixWorktreeRequest) (FixWorktreeAllocation, error) {
+		allocations++
+		return FixWorktreeAllocation{Path: filepath.Join(t.TempDir(), request.JobID)}, nil
+	}
+	insertCompletedJob(t, store, db.Job{
+		ID: "review-refused", Agent: "audit", Type: "review",
+	}, JobPayload{
+		Repo: "gitmoot/gitmoot", Branch: "task-7", PullRequest: 7, TaskID: "task-7",
+		TaskTitle: "Workflow Engine",
+		Result:    &AgentResult{Decision: "changes_requested", Summary: "do not patch automatically"},
+	})
+
+	err := engine.AdvanceJob(ctx, "review-refused")
+	var blocked BlockedError
+	if !errors.As(err, &blocked) || !strings.Contains(blocked.Reason, "auto-fix disabled") || !strings.Contains(blocked.Reason, "coordinator declined automatic patching") {
+		t.Fatalf("AdvanceJob error = %v, want durable refusal BlockedError", err)
+	}
+	if allocations != 0 {
+		t.Fatalf("fix worktree allocations = %d, want zero while disabled", allocations)
+	}
+	if _, err := store.GetJob(ctx, "implement-task-owner-task-7"); err == nil {
+		t.Fatal("disabled PR dispatched an auto-fix")
+	}
+
+	if err := store.SetPullRequestAutoFixPolicy(ctx, "gitmoot/gitmoot", 7, false, "gitmoot", "owner resumed automatic fixes"); err != nil {
+		t.Fatalf("enable auto-fix: %v", err)
+	}
+	if err := engine.AdvanceJob(ctx, "review-refused"); err != nil {
+		t.Fatalf("AdvanceJob after re-enable: %v", err)
+	}
+	if allocations != 1 {
+		t.Fatalf("fix worktree allocations = %d, want one after re-enable", allocations)
+	}
+	mustJob(t, store, "implement-task-owner-task-7")
 }
 
 func TestEngineAdvanceReviewApprovalRunsMergeGate(t *testing.T) {
@@ -1748,6 +1953,12 @@ func TestEngineAdvanceReviewApprovalPreservesChangesRequested(t *testing.T) {
 	gate := &fakeMergeGate{decision: MergeDecision{Ready: true}}
 	engine.MergeGate = gate
 	reviewers := []string{"audit", "security"}
+	insertCompletedJob(t, store, db.Job{
+		ID: "original-implement", Agent: "lead", Type: "implement",
+	}, JobPayload{
+		Repo: "gitmoot/gitmoot", Branch: "task-7", PullRequest: 7, TaskID: "task-7",
+		Result: &AgentResult{Decision: "implemented"},
+	})
 	insertCompletedJob(t, store, db.Job{
 		ID:    "audit-review",
 		Agent: "audit",

--- a/internal/workflow/engine_test.go
+++ b/internal/workflow/engine_test.go
@@ -1327,7 +1327,7 @@ func TestEngineRunJobPreflightsPolicyBeforeDelivery(t *testing.T) {
 	assertTaskState(t, store, "task-7", TaskBlocked)
 }
 
-func TestEngineAdvanceReviewChangesRequestedDispatchesFix(t *testing.T) {
+func TestEngineAdvanceReviewChangesRequestedDispatchesActingRoleAcrossTaskOwnerLock(t *testing.T) {
 	ctx := context.Background()
 	store := openEngineStore(t)
 	seedAgent(t, store, "owner-role", []string{"implement"}, "gitmoot/gitmoot")
@@ -1342,6 +1342,14 @@ func TestEngineAdvanceReviewChangesRequestedDispatchesFix(t *testing.T) {
 		Repo: "gitmoot/gitmoot", Branch: "task-7", PullRequest: 7, TaskID: "task-7",
 		Result: &AgentResult{Decision: "implemented"},
 	})
+	if acquired, err := store.AcquireLock(ctx, db.BranchLock{
+		RepoFullName:  "gitmoot/gitmoot",
+		Branch:        "task-7",
+		Owner:         "task-owner",
+		ActingOrgRole: "owner-role",
+	}); err != nil || !acquired {
+		t.Fatalf("AcquireLock returned acquired=%v err=%v", acquired, err)
+	}
 	insertCompletedJob(t, store, db.Job{
 		ID:    "review-job",
 		Agent: "audit",
@@ -1373,6 +1381,16 @@ func TestEngineAdvanceReviewChangesRequestedDispatchesFix(t *testing.T) {
 	}
 	if !payload.FixWorktree || strings.TrimSpace(payload.WorktreePath) == "" {
 		t.Fatalf("fix job payload lacks per-job writable worktree: %+v", payload)
+	}
+	if err := engine.ensureJobExecutorAllowed(ctx, job, payload, taskRef{ID: "task-7"}); err != nil {
+		t.Fatalf("fix executor preflight rejected acting role across task-owner lock: %v", err)
+	}
+	lock, err := store.GetBranchLock(ctx, "gitmoot/gitmoot", "task-7")
+	if err != nil {
+		t.Fatalf("GetBranchLock: %v", err)
+	}
+	if lock.Owner != "task-owner" || lock.ActingOrgRole != "owner-role" {
+		t.Fatalf("branch lock = %+v, want task-owner serialization with owner-role attribution", lock)
 	}
 }
 
@@ -1563,6 +1581,13 @@ func TestEngineAdvanceReviewChangesRequestedUsesTaskImplementerWhenActingRoleAbs
 	store := openEngineStore(t)
 	seedAgent(t, store, "task-owner", []string{"implement"}, "gitmoot/gitmoot")
 	seedAgent(t, store, "wrong-default", []string{"implement"}, "gitmoot/gitmoot")
+	if acquired, err := store.AcquireLock(ctx, db.BranchLock{
+		RepoFullName: "gitmoot/gitmoot",
+		Branch:       "task-7",
+		Owner:        "wrong-default",
+	}); err != nil || !acquired {
+		t.Fatalf("AcquireLock returned acquired=%v err=%v", acquired, err)
+	}
 	engine := testEngine(store)
 	insertCompletedJob(t, store, db.Job{
 		ID: "original-implement", Agent: "task-owner", Type: "implement",
@@ -1591,6 +1616,13 @@ func TestEngineAdvanceReviewChangesRequestedUsesTaskImplementerWhenActingRoleAbs
 	job := mustJob(t, store, "implement-task-owner-task-7")
 	if !strings.Contains(job.Payload, "fix manual review") {
 		t.Fatalf("fix job payload = %s", job.Payload)
+	}
+	payload, err := ParseJobPayload(job.Payload)
+	if err != nil {
+		t.Fatalf("ParseJobPayload: %v", err)
+	}
+	if err := engine.ensureJobExecutorAllowed(ctx, job, payload, taskRef{ID: "task-7"}); err != nil {
+		t.Fatalf("fix executor preflight routed ownership from branch lock: %v", err)
 	}
 	if _, err := store.GetJob(ctx, "implement-wrong-default-task-7"); err == nil {
 		t.Fatal("branch-lock or payload default received auto-fix ownership")

--- a/internal/workflow/fix_worktree_dispatch_test.go
+++ b/internal/workflow/fix_worktree_dispatch_test.go
@@ -17,6 +17,10 @@ func TestReviewFixAllocationFailureRefusesDispatch(t *testing.T) {
 	engine.FixWorktreeAllocator = func(context.Context, FixWorktreeRequest) (FixWorktreeAllocation, error) {
 		return FixWorktreeAllocation{}, errors.New("disk full")
 	}
+	insertCompletedJob(t, store, db.Job{ID: "original-implement", Agent: "lead", Type: "implement"}, JobPayload{
+		Repo: "gitmoot/gitmoot", Branch: "task-7", PullRequest: 7, TaskID: "task-7",
+		Result: &AgentResult{Decision: "implemented"},
+	})
 	insertCompletedJob(t, store, db.Job{ID: "review-job", Agent: "audit", Type: "review"}, JobPayload{
 		Repo: "gitmoot/gitmoot", Branch: "task-7", PullRequest: 7, TaskID: "task-7",
 		LeadAgent: "lead", Result: &AgentResult{Decision: "changes_requested", Summary: "fix edge case"},
@@ -28,8 +32,8 @@ func TestReviewFixAllocationFailureRefusesDispatch(t *testing.T) {
 		t.Fatalf("ListJobs: %v", err)
 	}
 	for _, job := range jobs {
-		if job.Type == "implement" {
-			t.Fatalf("allocation failure enqueued implement job %s", job.ID)
+		if job.Type == "implement" && job.ID != "original-implement" {
+			t.Fatalf("allocation failure enqueued auto-fix implement job %s", job.ID)
 		}
 	}
 	if advanceErr == nil || advanceErr.Error() != "allocate review fix worktree: disk full" {

--- a/skills/gitmoot/references/CLI.md
+++ b/skills/gitmoot/references/CLI.md
@@ -372,6 +372,8 @@ gitmoot events --repo owner/repo
 gitmoot repo add owner/repo --path <path> [--poll <duration>]
 gitmoot repo list
 gitmoot repo set-interval owner/repo (<duration>|default)
+gitmoot repo auto-fix owner/repo --pr <number> --disable --by <role-or-agent> --reason "<text>"
+gitmoot repo auto-fix owner/repo --pr <number> --enable --by <role-or-agent> --reason "<text>"
 gitmoot repo set-interval --all (<duration>|default)
 gitmoot repo remove owner/repo
 gitmoot repo doctor owner/repo
@@ -440,6 +442,10 @@ resolved `--poll` / `[daemon].poll` cadence; an explicit `--poll` stores a
 per-repo override. `repo list` renders the sentinel as `inherit`.
 `repo set-interval owner/repo <duration>` changes an override, `default` restores
 inheritance, and `--all` applies either value to every registered repo.
+`repo auto-fix` is a durable, per-PR scheduler control. `--disable` prevents a
+changes-requested auto-fix before ownership resolution or worktree allocation;
+`--enable` explicitly resumes it. Both forms require `--by` and `--reason`, and
+the latest attributed decision remains stored for that PR.
 `repo doctor owner/repo` checks a single repo's checkout/config health. If the
 registered checkout is missing or is no longer a Git worktree, Gitmoot verifies
 the recorded primary checkout, repairs the registration, and reports the

--- a/website/docs/reference/cli.md
+++ b/website/docs/reference/cli.md
@@ -305,6 +305,8 @@ what an update replaces.
 gitmoot repo add owner/repo --path <path> [--poll <duration>]
 gitmoot repo list
 gitmoot repo set-interval owner/repo (<duration>|default)
+gitmoot repo auto-fix owner/repo --pr <number> --disable --by <role-or-agent> --reason "<text>"
+gitmoot repo auto-fix owner/repo --pr <number> --enable --by <role-or-agent> --reason "<text>"
 gitmoot repo set-interval --all (<duration>|default)
 gitmoot repo remove owner/repo
 gitmoot repo doctor owner/repo
@@ -316,11 +318,16 @@ per Gitmoot home supervises every **enabled** registered repo. Omitting
 `--poll` / `[daemon].poll` cadence; an explicit value is a per-repo override.
 `repo list` prints `inherit`. Use `repo set-interval` with a duration to change
 an override, with `default` to restore inheritance, or with `--all` to update all
-registered repos. `repo doctor owner/repo` checks checkout/config health. If the
-registered checkout is missing or is no longer a Git worktree, Gitmoot verifies
-the recorded primary checkout, repairs the registration, and reports the
-self-heal. Implicit registration from inside a linked task worktree pins the
-repo to its primary checkout; an existing valid linked checkout remains usable.
+registered repos.
+`repo auto-fix` records a durable scheduler decision for one pull request.
+`--disable` stops changes-requested auto-fixes before ownership resolution or
+worktree allocation; `--enable` explicitly resumes them. Both require the audit
+fields `--by` and `--reason`, and the latest decision remains stored per PR.
+`repo doctor owner/repo` checks checkout/config health. If the registered
+checkout is missing or is no longer a Git worktree, Gitmoot verifies the
+recorded primary checkout, repairs the registration, and reports the self-heal.
+Implicit registration from inside a linked task worktree pins the repo to its
+primary checkout; an existing valid linked checkout remains usable.
 
 Use `daemon start` for the background daemon. Use `daemon run` only when the
 user explicitly wants a foreground process. Keep the default `--workers 1`


### PR DESCRIPTION
## Summary
- resolve changes-requested auto-fix ownership from `acting_org_role`, then the task's recorded implementer; block missing, ambiguous, or ineligible ownership
- add a durable per-PR disable/re-enable decision that the scheduler enforces before allocating work
- expose the decision as `gitmoot repo auto-fix ...` with mandatory actor and reason

Closes #1686

## Verification
- `go build ./...`
- `go generate ./...` plus generated-contract diff check
- `go vet ./...`
- `scripts/partition-race-tests_test.sh`
- `go test -timeout 25m ./...` (42 packages passed, 4 without tests)
- focused `go test -race` for changed db/cli/workflow ownership paths