### PR TITLE
feat(org): add sibling messaging and PR collision warnings (#1692)

### DIFF
--- a/internal/cli/event_rule_sink.go
+++ b/internal/cli/event_rule_sink.go
@@ -519,9 +519,13 @@ func eventRuleWakePrompt(kind string, event events.Event) string {
 		detail := truncateForWake(strings.TrimSpace(event.Detail), 320)
 		return fmt.Sprintf("gitmoot awaited fact for %s: %s", event.WakeTargetRole, detail)
 	}
-	// event.Detail is already redacted + absolute-path-scrubbed by events.NewEvent,
-	// so it is used as-is here (only trimmed and rune-safe truncated for the arg).
-	detail := truncateForWake(strings.TrimSpace(event.Detail), 320)
+	// event.Detail is already redacted and absolute-path-scrubbed by
+	// events.NewEvent. Reply batches are count-bounded and retain every retrieval
+	// command; other wake kinds keep the established argument cap.
+	detail := strings.TrimSpace(event.Detail)
+	if !strings.EqualFold(strings.TrimSpace(kind), db.WakeOutboxKindReply) {
+		detail = truncateForWake(detail, 320)
+	}
 	prompt := fmt.Sprintf("gitmoot %s event for job %s", kind, event.JobID)
 	if detail != "" {
 		prompt += ": " + detail

--- a/internal/cli/org.go
+++ b/internal/cli/org.go
@@ -118,6 +118,8 @@ func runOrg(args []string, stdout, stderr io.Writer) int {
 		return runOrgEscalate(args[1:], stdout, stderr)
 	case "directive":
 		return runOrgDirective(args[1:], stdout, stderr)
+	case "message":
+		return runOrgMessage(args[1:], stdout, stderr)
 	case "await":
 		return runOrgAwait(args[1:], stdout, stderr)
 	case "events":
@@ -143,6 +145,7 @@ func printOrgUsage(w io.Writer) {
 	fmt.Fprintln(w, "  gitmoot org seat add NAME --pane LABEL [--home DIR]")
 	fmt.Fprintln(w, "  gitmoot org seat rm NAME [--home DIR]")
 	fmt.Fprintln(w, "  gitmoot org escalate --to ROLE --workflow LABEL [--org-role ROLE] [--repo OWNER/REPO] [--json] [--home DIR] \"QUESTION\"")
+	fmt.Fprintln(w, "  gitmoot org message send --to ROLE --workflow LABEL [--org-role ROLE] [--repo OWNER/REPO] [--json] [--home DIR] \"MESSAGE\"")
 	fmt.Fprintln(w, "  gitmoot org escalate resolve NOTE_ID [--by ROLE] [--note ANSWER_NOTE_ID] [--home DIR]")
 	fmt.Fprintln(w, "  gitmoot org directive send --to ROLE --workflow LABEL (--stdin | -F FILE | TEXT) [--home DIR]")
 	fmt.Fprintln(w, "  gitmoot org directive ack ID [--by ROLE] [--home DIR]")
@@ -1462,7 +1465,7 @@ func runOrgEscalate(args []string, stdout, stderr io.Writer) int {
 	fromFlag := fs.String("org-role", "", "acting organization role")
 	repo := fs.String("repo", "", "repository binding for the escalation note")
 	jsonOutput := fs.Bool("json", false, "print the escalation as JSON")
-	question, flagArgs, ok := orgEscalateQuestionAndFlags(args)
+	question, flagArgs, ok := orgAddressedTextAndFlags(args)
 	if !ok {
 		fmt.Fprintln(stderr, "org escalate requires exactly one question")
 		return 2
@@ -1742,7 +1745,7 @@ func orgEscalateResolveIDAndFlags(args []string) (string, []string, bool) {
 	return strings.TrimSpace(args[idIndex]), flagArgs, strings.TrimSpace(args[idIndex]) != ""
 }
 
-func orgEscalateQuestionAndFlags(args []string) (string, []string, bool) {
+func orgAddressedTextAndFlags(args []string) (string, []string, bool) {
 	needsValue := map[string]bool{"--home": true, "--to": true, "--workflow": true, "--org-role": true, "--repo": true}
 	for i := 0; i < len(args); i++ {
 		arg := args[i]

--- a/internal/cli/org_message.go
+++ b/internal/cli/org_message.go
@@ -118,7 +118,13 @@ func runOrgMessageSend(args []string, stdout, stderr io.Writer) int {
 	}
 	var note db.WorkflowNote
 	if err := withStore(*home, func(store *db.Store) error {
-		var err error
+		count, err := store.CountJobsByWorkflow(context.Background(), label)
+		if err != nil {
+			return err
+		}
+		if count == 0 {
+			return fmt.Errorf("workflow %q has no jobs; refusing message to guard against a typo", label)
+		}
 		note, err = store.InsertWorkflowNote(context.Background(), db.WorkflowNote{
 			WorkflowID:      label,
 			Author:          from,

--- a/internal/cli/org_message.go
+++ b/internal/cli/org_message.go
@@ -1,0 +1,145 @@
+package cli
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/gitmoot/gitmoot/internal/config"
+	"github.com/gitmoot/gitmoot/internal/db"
+	"github.com/gitmoot/gitmoot/internal/workflow"
+)
+
+type orgMessageOutput struct {
+	ID       int64  `json:"id"`
+	From     string `json:"from"`
+	To       string `json:"to"`
+	Workflow string `json:"workflow"`
+	Message  string `json:"message"`
+}
+
+func runOrgMessage(args []string, stdout, stderr io.Writer) int {
+	if len(args) == 0 || args[0] == "-h" || args[0] == "--help" {
+		printOrgMessageUsage(stdout)
+		return 0
+	}
+	if args[0] != "send" {
+		fmt.Fprintf(stderr, "unknown org message command %q\n", args[0])
+		printOrgMessageUsage(stderr)
+		return 2
+	}
+	return runOrgMessageSend(args[1:], stdout, stderr)
+}
+
+func printOrgMessageUsage(w io.Writer) {
+	fmt.Fprintln(w, "Usage:")
+	fmt.Fprintln(w, "  gitmoot org message send --to ROLE --workflow LABEL [--org-role ROLE] [--repo OWNER/REPO] [--json] [--home DIR] MESSAGE")
+	fmt.Fprintln(w, "Messages are durable sender-attributed heads-ups with no acknowledgment or completion obligation.")
+	fmt.Fprintln(w, "The sender and recipient must be distinct roles with the same parent.")
+}
+
+func runOrgMessageSend(args []string, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("org message send", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	home := fs.String("home", "", "home directory to use instead of the current user's home")
+	toFlag := fs.String("to", "", "same-parent sibling role receiving the message")
+	workflowID := fs.String("workflow", "", "workflow label for the durable message note")
+	fromFlag := fs.String("org-role", "", "acting organization role")
+	repo := fs.String("repo", "", "repository binding for the message note")
+	jsonOutput := fs.Bool("json", false, "print the durable message as JSON")
+	message, flagArgs, ok := orgAddressedTextAndFlags(args)
+	if !ok {
+		fmt.Fprintln(stderr, "org message send requires exactly one non-empty message")
+		return 2
+	}
+	if err := fs.Parse(flagArgs); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return 0
+		}
+		return 2
+	}
+	if fs.NArg() != 0 {
+		fmt.Fprintln(stderr, "org message send requires exactly one non-empty message")
+		return 2
+	}
+
+	paths, err := pathsFromFlag(*home)
+	if err != nil {
+		fmt.Fprintf(stderr, "org message send: resolve paths: %v\n", err)
+		return 1
+	}
+	cfg, err := config.LoadOrg(paths)
+	if err != nil {
+		fmt.Fprintf(stderr, "org message send: %v\n", err)
+		return 1
+	}
+	if !cfg.Enabled() {
+		fmt.Fprintln(stderr, "org message send requires an [org] registry")
+		return 2
+	}
+	from := strings.ToLower(strings.TrimSpace(*fromFlag))
+	if from == "" {
+		from = strings.ToLower(strings.TrimSpace(os.Getenv("GITMOOT_ORG_ROLE")))
+	}
+	fromRole, ok := cfg.Role(from)
+	if !ok {
+		fmt.Fprintf(stderr, "org message send: unknown acting org role %q; set GITMOOT_ORG_ROLE or --org-role\n", from)
+		return 2
+	}
+	to := strings.ToLower(strings.TrimSpace(*toFlag))
+	toRole, ok := cfg.Role(to)
+	if !ok {
+		fmt.Fprintf(stderr, "org message send: unknown target org role %q\n", to)
+		return 2
+	}
+	if from == to {
+		fmt.Fprintf(stderr, "org message send: --to %q must differ from acting role %q\n", to, from)
+		return 2
+	}
+	if fromRole.Parent == "" || fromRole.Parent != toRole.Parent {
+		fmt.Fprintf(stderr, "org message send: roles %q and %q do not share a parent\n", from, to)
+		return 2
+	}
+
+	label := strings.TrimSpace(*workflowID)
+	if err := workflow.ValidateWorkflowID(label); err != nil {
+		fmt.Fprintf(stderr, "org message send: %v\n", err)
+		return 2
+	}
+	noteBody := workflow.FormatOrgMessageNote(from, to, label, message)
+	if noteBody == "" || len(noteBody) > workflowNoteBodyMax {
+		fmt.Fprintf(stderr, "org message send: message must produce a note of at most %d bytes\n", workflowNoteBodyMax)
+		return 2
+	}
+	var note db.WorkflowNote
+	if err := withStore(*home, func(store *db.Store) error {
+		var err error
+		note, err = store.InsertWorkflowNote(context.Background(), db.WorkflowNote{
+			WorkflowID:      label,
+			Author:          from,
+			Body:            noteBody,
+			Repo:            strings.TrimSpace(*repo),
+			AddressedTarget: to,
+		})
+		return err
+	}); err != nil {
+		fmt.Fprintf(stderr, "org message send: %v\n", err)
+		return 1
+	}
+
+	out := orgMessageOutput{ID: note.ID, From: from, To: to, Workflow: label, Message: message}
+	if *jsonOutput {
+		if err := json.NewEncoder(stdout).Encode(out); err != nil {
+			fmt.Fprintf(stderr, "org message send: %v\n", err)
+			return 1
+		}
+		return 0
+	}
+	fmt.Fprintf(stdout, "sent message %d from %s to %s in workflow %s\n", note.ID, from, to, label)
+	return 0
+}

--- a/internal/cli/org_message_test.go
+++ b/internal/cli/org_message_test.go
@@ -34,13 +34,13 @@ parent="owner"
 scope=["*"]
 [org.roles."gm-omp-nag"]
 parent="gitmoot"
-scope=["gitmoot/*"]
+scope=["gitmoot/nag"]
 [org.roles."gm-omp-impl"]
 parent="gitmoot"
-scope=["gitmoot/*"]
+scope=["gitmoot/implementation"]
 [org.roles."gm-omp-verdict"]
 parent="gitmoot"
-scope=["gitmoot/*"]
+scope=["gitmoot/review"]
 `
 	if err := os.WriteFile(paths.ConfigFile, []byte(configBody), 0o600); err != nil {
 		t.Fatal(err)
@@ -48,7 +48,7 @@ scope=["gitmoot/*"]
 	return home
 }
 
-func TestOrgMessageSendAllowsSameParentSibling(t *testing.T) {
+func TestOrgMessageSendAllowsDifferentlyScopedSameParentSiblings(t *testing.T) {
 	home := orgMessageTestHome(t)
 	t.Setenv("GITMOOT_ORG_ROLE", "gm-omp-nag")
 	var stdout, stderr bytes.Buffer
@@ -104,6 +104,34 @@ func TestOrgMessageSendAllowsOwnerChildrenAsOrdinarySiblings(t *testing.T) {
 	}, &stdout, &stderr)
 	if code != 0 {
 		t.Fatalf("owner-child sibling send code=%d out=%q err=%q", code, stdout.String(), stderr.String())
+	}
+}
+
+func TestOrgMessageSendRefusesOwnerAsEndpoint(t *testing.T) {
+	tests := []struct {
+		name string
+		from string
+		to   string
+		want string
+	}{
+		{name: "owner sender", from: "owner", to: "jarvis", want: `roles "owner" and "jarvis" do not share a parent`},
+		{name: "owner recipient", from: "jarvis", to: "owner", want: `roles "jarvis" and "owner" do not share a parent`},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			home := orgMessageTestHome(t)
+			t.Setenv("GITMOOT_ORG_ROLE", test.from)
+			var stdout, stderr bytes.Buffer
+			code := runOrg([]string{
+				"message", "send", "--home", home,
+				"--to", test.to,
+				"--workflow", "gitmoot/1692-owner-endpoint",
+				"Owner has no parent and gets no direct bypass",
+			}, &stdout, &stderr)
+			if code != 2 || !strings.Contains(stderr.String(), test.want) {
+				t.Fatalf("owner endpoint send code=%d out=%q err=%q, want %q", code, stdout.String(), stderr.String(), test.want)
+			}
+		})
 	}
 }
 

--- a/internal/cli/org_message_test.go
+++ b/internal/cli/org_message_test.go
@@ -107,8 +107,12 @@ func TestOrgMessageSendAllowsDifferentlyScopedSameParentSiblings(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if want := "gitmoot workflow show-note " + strconv.FormatInt(note.ID, 10); !strings.Contains(wakeEvent.Detail, want) {
-		t.Fatalf("wake detail=%q, want retrieval command %q", wakeEvent.Detail, want)
+	retrievalCommand := "gitmoot workflow show-note " + strconv.FormatInt(note.ID, 10)
+	if !strings.Contains(wakeEvent.Detail, retrievalCommand) {
+		t.Fatalf("wake detail=%q, want retrieval command %q", wakeEvent.Detail, retrievalCommand)
+	}
+	if prompt := eventRuleWakePrompt("reply", wakeEvent); !strings.Contains(prompt, retrievalCommand) {
+		t.Fatalf("recipient prompt=%q, want retrieval command %q", prompt, retrievalCommand)
 	}
 	unacknowledged, err := store.ListUnacknowledgedOrgDirectives(context.Background(), "gm-omp-impl")
 	if err != nil || len(unacknowledged) != 0 {

--- a/internal/cli/org_message_test.go
+++ b/internal/cli/org_message_test.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -50,8 +51,32 @@ scope=["gitmoot/review"]
 	return home
 }
 
+func orgMessageSeedWorkflow(t *testing.T, home, workflowID string) {
+	t.Helper()
+	paths := config.PathsForHome(home)
+	if err := config.Initialize(paths); err != nil {
+		t.Fatal(err)
+	}
+	store, err := dbtest.Open(t, paths.Database)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+	if err := store.CreateJob(context.Background(), db.Job{
+		ID:      "message-fixture-job",
+		Agent:   "worker",
+		Type:    "ask",
+		State:   "succeeded",
+		Repo:    "gitmoot/gitmoot",
+		Payload: fmt.Sprintf(`{"workflow_id":%q}`, workflowID),
+	}); err != nil {
+		t.Fatal(err)
+	}
+}
+
 func TestOrgMessageSendAllowsDifferentlyScopedSameParentSiblings(t *testing.T) {
 	home := orgMessageTestHome(t)
+	orgMessageSeedWorkflow(t, home, "gitmoot/1692-test")
 	t.Setenv("GITMOOT_ORG_ROLE", "gm-omp-nag")
 	var stdout, stderr bytes.Buffer
 	code := runOrg([]string{
@@ -122,6 +147,7 @@ func TestOrgMessageSendAllowsDifferentlyScopedSameParentSiblings(t *testing.T) {
 
 func TestOrgMessageSendAllowsOwnerChildrenAsOrdinarySiblings(t *testing.T) {
 	home := orgMessageTestHome(t)
+	orgMessageSeedWorkflow(t, home, "gitmoot/1692-owner-children")
 	t.Setenv("GITMOOT_ORG_ROLE", "jarvis")
 	var stdout, stderr bytes.Buffer
 	code := runOrg([]string{
@@ -132,6 +158,36 @@ func TestOrgMessageSendAllowsOwnerChildrenAsOrdinarySiblings(t *testing.T) {
 	}, &stdout, &stderr)
 	if code != 0 {
 		t.Fatalf("owner-child sibling send code=%d out=%q err=%q", code, stdout.String(), stderr.String())
+	}
+}
+
+func TestOrgMessageSendRefusesUnknownWorkflow(t *testing.T) {
+	home := orgMessageTestHome(t)
+	t.Setenv("GITMOOT_ORG_ROLE", "gm-omp-nag")
+	var stdout, stderr bytes.Buffer
+	code := runOrg([]string{
+		"message", "send", "--home", home,
+		"--to", "gm-omp-impl",
+		"--workflow", "gitmoot/1692-typo",
+		"Do not create a phantom workflow",
+	}, &stdout, &stderr)
+	want := `workflow "gitmoot/1692-typo" has no jobs; refusing message to guard against a typo`
+	if code != 1 || !strings.Contains(stderr.String(), want) {
+		t.Fatalf("unknown-workflow send code=%d out=%q err=%q, want %q", code, stdout.String(), stderr.String(), want)
+	}
+
+	store, err := dbtest.Open(t, config.PathsForHome(home).Database)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+	notes, err := store.ListWorkflowNotes(context.Background(), "gitmoot/1692-typo", 0)
+	if err != nil || len(notes) != 0 {
+		t.Fatalf("phantom workflow notes=%+v err=%v", notes, err)
+	}
+	pending, err := store.ListWakeOutbox(context.Background(), db.WakeOutboxStatePending)
+	if err != nil || len(pending) != 0 {
+		t.Fatalf("phantom workflow wakes=%+v err=%v", pending, err)
 	}
 }
 

--- a/internal/cli/org_message_test.go
+++ b/internal/cli/org_message_test.go
@@ -1,0 +1,139 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/gitmoot/gitmoot/internal/config"
+	"github.com/gitmoot/gitmoot/internal/db"
+	"github.com/gitmoot/gitmoot/internal/db/dbtest"
+	"github.com/gitmoot/gitmoot/internal/workflow"
+)
+
+func orgMessageTestHome(t *testing.T) string {
+	t.Helper()
+	home := t.TempDir()
+	paths := config.PathsForHome(home)
+	if err := os.MkdirAll(filepath.Dir(paths.ConfigFile), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	configBody := `[org.roles."owner"]
+scope=["*"]
+[org.roles."gitmoot"]
+parent="owner"
+scope=["*"]
+[org.roles."jarvis"]
+parent="owner"
+scope=["*"]
+[org.roles."deimos"]
+parent="owner"
+scope=["*"]
+[org.roles."gm-omp-nag"]
+parent="gitmoot"
+scope=["gitmoot/*"]
+[org.roles."gm-omp-impl"]
+parent="gitmoot"
+scope=["gitmoot/*"]
+[org.roles."gm-omp-verdict"]
+parent="gitmoot"
+scope=["gitmoot/*"]
+`
+	if err := os.WriteFile(paths.ConfigFile, []byte(configBody), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return home
+}
+
+func TestOrgMessageSendAllowsSameParentSibling(t *testing.T) {
+	home := orgMessageTestHome(t)
+	t.Setenv("GITMOOT_ORG_ROLE", "gm-omp-nag")
+	var stdout, stderr bytes.Buffer
+	code := runOrg([]string{
+		"message", "send", "--home", home,
+		"--to", "gm-omp-impl",
+		"--workflow", "gitmoot/1692-test",
+		"Our open PRs touch internal/cli/org.go",
+	}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("sibling send code=%d out=%q err=%q", code, stdout.String(), stderr.String())
+	}
+
+	store, err := dbtest.Open(t, config.PathsForHome(home).Database)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+	notes, err := store.ListWorkflowNotes(context.Background(), "gitmoot/1692-test", 0)
+	if err != nil || len(notes) != 1 {
+		t.Fatalf("notes=%+v err=%v, want one durable message", notes, err)
+	}
+	note := notes[0]
+	from, to, workflowID, message, ok := workflow.ParseOrgMessageNote(note.Body)
+	if !ok || from != "gm-omp-nag" || to != "gm-omp-impl" || workflowID != "gitmoot/1692-test" || message != "Our open PRs touch internal/cli/org.go" {
+		t.Fatalf("parsed message=(from=%q to=%q workflow=%q message=%q ok=%v)", from, to, workflowID, message, ok)
+	}
+	if note.Author != from {
+		t.Fatalf("durable author=%q, want sender %q", note.Author, from)
+	}
+	pending, err := store.ListWakeOutbox(context.Background(), db.WakeOutboxStatePending)
+	if err != nil || len(pending) != 1 {
+		t.Fatalf("pending wakes=%+v err=%v, want one direct wake", pending, err)
+	}
+	if pending[0].SourceKind != db.WakeOutboxSourceWorkflowNote || pending[0].TargetRole != "gm-omp-impl" || pending[0].CoalesceKey != db.WakeOutboxReplyCoalescePrefix+"gm-omp-impl" {
+		t.Fatalf("direct wake=%+v", pending[0])
+	}
+	unacknowledged, err := store.ListUnacknowledgedOrgDirectives(context.Background(), "gm-omp-impl")
+	if err != nil || len(unacknowledged) != 0 {
+		t.Fatalf("message created directive obligations=%+v err=%v", unacknowledged, err)
+	}
+}
+
+func TestOrgMessageSendAllowsOwnerChildrenAsOrdinarySiblings(t *testing.T) {
+	home := orgMessageTestHome(t)
+	t.Setenv("GITMOOT_ORG_ROLE", "jarvis")
+	var stdout, stderr bytes.Buffer
+	code := runOrg([]string{
+		"message", "send", "--home", home,
+		"--to", "deimos",
+		"--workflow", "gitmoot/1692-owner-children",
+		"Owner children use the ordinary sibling predicate",
+	}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("owner-child sibling send code=%d out=%q err=%q", code, stdout.String(), stderr.String())
+	}
+}
+
+func TestOrgMessageSendRefusesDifferentParentDespiteWildcardScope(t *testing.T) {
+	home := orgMessageTestHome(t)
+	t.Setenv("GITMOOT_ORG_ROLE", "gm-omp-nag")
+	var stdout, stderr bytes.Buffer
+	code := runOrg([]string{
+		"message", "send", "--home", home,
+		"--to", "jarvis",
+		"--workflow", "gitmoot/1692-cross-parent",
+		"Scopes must not grant this channel",
+	}, &stdout, &stderr)
+	want := `roles "gm-omp-nag" and "jarvis" do not share a parent`
+	if code != 2 || !strings.Contains(stderr.String(), want) {
+		t.Fatalf("cross-parent send code=%d out=%q err=%q, want %q", code, stdout.String(), stderr.String(), want)
+	}
+}
+
+func TestOrgMessageSendRefusesSelf(t *testing.T) {
+	home := orgMessageTestHome(t)
+	t.Setenv("GITMOOT_ORG_ROLE", "gm-omp-nag")
+	var stdout, stderr bytes.Buffer
+	code := runOrg([]string{
+		"message", "send", "--home", home,
+		"--to", "gm-omp-nag",
+		"--workflow", "gitmoot/1692-self",
+		"Self is not a second role",
+	}, &stdout, &stderr)
+	if code != 2 || !strings.Contains(stderr.String(), `must differ from acting role "gm-omp-nag"`) {
+		t.Fatalf("self send code=%d out=%q err=%q", code, stdout.String(), stderr.String())
+	}
+}

--- a/internal/cli/org_message_test.go
+++ b/internal/cli/org_message_test.go
@@ -5,8 +5,10 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/gitmoot/gitmoot/internal/config"
 	"github.com/gitmoot/gitmoot/internal/db"
@@ -79,12 +81,34 @@ func TestOrgMessageSendAllowsDifferentlyScopedSameParentSiblings(t *testing.T) {
 	if note.Author != from {
 		t.Fatalf("durable author=%q, want sender %q", note.Author, from)
 	}
+	stdout.Reset()
+	stderr.Reset()
+	if code := runWorkflowJournal([]string{"show-note", strconv.FormatInt(note.ID, 10), "--home", home}, &stdout, &stderr); code != 0 {
+		t.Fatalf("note show code=%d out=%q err=%q", code, stdout.String(), stderr.String())
+	}
+	for _, want := range []string{"note: " + strconv.FormatInt(note.ID, 10), "workflow: gitmoot/1692-test", "author: gm-omp-nag", note.Body} {
+		if !strings.Contains(stdout.String(), want) {
+			t.Fatalf("note show output=%q, want %q", stdout.String(), want)
+		}
+	}
 	pending, err := store.ListWakeOutbox(context.Background(), db.WakeOutboxStatePending)
 	if err != nil || len(pending) != 1 {
 		t.Fatalf("pending wakes=%+v err=%v, want one direct wake", pending, err)
 	}
 	if pending[0].SourceKind != db.WakeOutboxSourceWorkflowNote || pending[0].TargetRole != "gm-omp-impl" || pending[0].CoalesceKey != db.WakeOutboxReplyCoalescePrefix+"gm-omp-impl" {
 		t.Fatalf("direct wake=%+v", pending[0])
+	}
+	wakeEvent, err := wakeOutboxEvent([]db.WakeOutboxObligation{{
+		SourceKind:  pending[0].SourceKind,
+		SourceID:    pending[0].SourceID,
+		TargetRole:  pending[0].TargetRole,
+		CoalesceKey: pending[0].CoalesceKey,
+	}}, time.Now())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if want := "gitmoot workflow show-note " + strconv.FormatInt(note.ID, 10); !strings.Contains(wakeEvent.Detail, want) {
+		t.Fatalf("wake detail=%q, want retrieval command %q", wakeEvent.Detail, want)
 	}
 	unacknowledged, err := store.ListUnacknowledgedOrgDirectives(context.Background(), "gm-omp-impl")
 	if err != nil || len(unacknowledged) != 0 {

--- a/internal/cli/reply_wake_outbox.go
+++ b/internal/cli/reply_wake_outbox.go
@@ -365,6 +365,9 @@ func wakeOutboxEvent(batch []db.WakeOutboxObligation, now time.Time) (events.Eve
 			break
 		}
 		detail := fmt.Sprintf("%d new items, oldest id %s", len(batch), oldest.SourceID)
+		if oldest.SourceKind == db.WakeOutboxSourceWorkflowNote {
+			detail += "; inspect with gitmoot workflow show-note " + oldest.SourceID
+		}
 		event = events.NewEvent(
 			events.EventOrgReply,
 			"org-reply:"+role,

--- a/internal/cli/reply_wake_outbox.go
+++ b/internal/cli/reply_wake_outbox.go
@@ -18,7 +18,8 @@ const (
 	// replyWakeCoalescingWindow is long enough to absorb a burst of separate
 	// short-lived `org escalate` processes while keeping the daemon-tick wake
 	// latency small. Rolling windows start at the oldest pending item.
-	replyWakeCoalescingWindow = 5 * time.Second
+	replyWakeCoalescingWindow  = 5 * time.Second
+	replyWakeMaxCoalescedItems = 10
 	// A synchronous reply wake gets one 12s Herdr call plus bounded probes and
 	// its terminal store write. Thirty seconds leaves margin for a live owner;
 	// older attempted rows are crash residue whose delivery outcome is unknown.
@@ -112,7 +113,7 @@ func drainReplyWakeOutboxWithHealth(ctx context.Context, store *db.Store, now ti
 			}
 			deadline := startedAt.Add(replyWakeCoalescingWindow)
 			end := start + 1
-			for end < len(items) {
+			for end < len(items) && end-start < replyWakeMaxCoalescedItems {
 				createdAt, err := time.Parse(time.RFC3339Nano, items[end].CreatedAt)
 				if err != nil {
 					return replyWakeOutboxHealth{}, fmt.Errorf("parse wake outbox created_at for row %d: %w", items[end].ID, err)
@@ -365,8 +366,14 @@ func wakeOutboxEvent(batch []db.WakeOutboxObligation, now time.Time) (events.Eve
 			break
 		}
 		detail := fmt.Sprintf("%d new items, oldest id %s", len(batch), oldest.SourceID)
-		if oldest.SourceKind == db.WakeOutboxSourceWorkflowNote {
-			detail += "; inspect with gitmoot workflow show-note " + oldest.SourceID
+		retrievalCommands := make([]string, 0, len(batch))
+		for _, entry := range batch {
+			if entry.SourceKind == db.WakeOutboxSourceWorkflowNote {
+				retrievalCommands = append(retrievalCommands, "gitmoot workflow show-note "+entry.SourceID)
+			}
+		}
+		if len(retrievalCommands) > 0 {
+			detail += "; inspect with " + strings.Join(retrievalCommands, "; ")
 		}
 		event = events.NewEvent(
 			events.EventOrgReply,

--- a/internal/cli/reply_wake_outbox_test.go
+++ b/internal/cli/reply_wake_outbox_test.go
@@ -146,6 +146,52 @@ func TestWakeOutboxCoalescesPerKindAndRole(t *testing.T) {
 	}
 }
 
+func TestWakeOutboxCoalescedPromptNamesEveryWorkflowNote(t *testing.T) {
+	store, deliverySink, wake, _ := replyWakeTestHarness(
+		t,
+		[]replyWakeTestRole{{name: "owner", pane: "w1:p1"}},
+	)
+	ctx := context.Background()
+	thread, err := store.CreateChatThread(ctx, db.ChatThread{Slug: "mixed-note-wake", Repo: "owner/repo"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	chat, err := store.AddChatMessage(ctx, db.ChatMessage{
+		ThreadID: thread.ID, AuthorName: "human", Kind: db.ChatKindChat,
+		Body: "@owner first", Mentions: []string{"owner"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	notes := make([]db.WorkflowNote, 0, 2)
+	for _, body := range []string{"first message", "second message"} {
+		note, err := store.InsertWorkflowNote(ctx, db.WorkflowNote{
+			WorkflowID:      "release/distinct-note-wakes",
+			Author:          "worker",
+			Body:            body,
+			AddressedTarget: "owner",
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		notes = append(notes, note)
+	}
+
+	drainReplyWakeAfterAllRowsAreDue(t, store, deliverySink)
+	if wake.promptCalls != 1 {
+		t.Fatalf("wake calls=%d, want one coalesced wake: %q", wake.promptCalls, wake.prompts)
+	}
+	if want := "3 new items, oldest id " + chat.ID; !strings.Contains(wake.prompt, want) {
+		t.Fatalf("coalesced prompt=%q, want %q", wake.prompt, want)
+	}
+	for _, note := range notes {
+		command := "gitmoot workflow show-note " + fmt.Sprint(note.ID)
+		if matches := strings.Count(wake.prompt, command); matches != 1 {
+			t.Fatalf("retrieval command %q appeared %d times, want exactly one: %q", command, matches, wake.prompt)
+		}
+	}
+}
+
 func TestWakeOutboxTickHealthIncludesBlockedAndEscalation(t *testing.T) {
 	store := daemonWorkerStore(t)
 	ctx := context.Background()
@@ -465,6 +511,34 @@ func TestReplyWakeOutboxBurstCoalescesToExactlyOneWake(t *testing.T) {
 	delivered, err := store.ListWakeOutbox(ctx, db.WakeOutboxStateDelivered)
 	if err != nil || len(delivered) != 10 {
 		t.Fatalf("delivered rows = %+v, err=%v", delivered, err)
+	}
+}
+
+func TestReplyWakeOutboxSplitsOversizedAddressedNoteBatch(t *testing.T) {
+	store, sink, wake, _ := replyWakeTestHarness(t, []replyWakeTestRole{{"owner", "w1:p1"}})
+	ctx := context.Background()
+	noteIDs := make([]int64, 0, replyWakeMaxCoalescedItems+1)
+	for index := 0; index < replyWakeMaxCoalescedItems+1; index++ {
+		note, err := store.InsertWorkflowNote(ctx, db.WorkflowNote{
+			WorkflowID: "release/bounded-burst", Author: "worker",
+			Body: fmt.Sprintf("addressed item %d", index+1), AddressedTarget: "owner",
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		noteIDs = append(noteIDs, note.ID)
+	}
+
+	drainReplyWakeAfterAllRowsAreDue(t, store, sink)
+	if wake.promptCalls != 2 {
+		t.Fatalf("wake calls=%d, want two count-bounded batches: %q", wake.promptCalls, wake.prompts)
+	}
+	normalizedPrompts := strings.ReplaceAll(strings.Join(wake.prompts, "\n"), "\n", "; ") + ";"
+	for _, noteID := range noteIDs {
+		command := "gitmoot workflow show-note " + fmt.Sprint(noteID)
+		if matches := strings.Count(normalizedPrompts, command+";"); matches != 1 {
+			t.Fatalf("retrieval command %q appeared %d times, want exactly one: %q", command, matches, wake.prompts)
+		}
 	}
 }
 

--- a/internal/cli/repo.go
+++ b/internal/cli/repo.go
@@ -82,7 +82,7 @@ func printRepoUsage(w io.Writer) {
 	fmt.Fprintln(w, "  gitmoot repo set-interval --all (<duration>|default)")
 	fmt.Fprintln(w, "  gitmoot repo remove owner/repo")
 	fmt.Fprintln(w, "  gitmoot repo doctor owner/repo")
-	fmt.Fprintln(w, "  gitmoot repo collisions owner/repo [--json]")
+	fmt.Fprintln(w, "  gitmoot repo collisions owner/repo [--limit N] [--json]")
 	fmt.Fprintln(w, "")
 	fmt.Fprintln(w, "owner/repo may be given before or after the flags.")
 }

--- a/internal/cli/repo.go
+++ b/internal/cli/repo.go
@@ -37,6 +37,8 @@ func runRepo(args []string, stdout, stderr io.Writer) int {
 		return runRepoRemove(args[1:], stdout, stderr)
 	case "doctor":
 		return runRepoDoctor(args[1:], stdout, stderr)
+	case "collisions":
+		return runRepoCollisions(args[1:], stdout, stderr)
 	default:
 		fmt.Fprintf(stderr, "unknown repo command %q\n\n", args[0])
 		printRepoUsage(stderr)
@@ -77,6 +79,7 @@ func printRepoUsage(w io.Writer) {
 	fmt.Fprintln(w, "  gitmoot repo set-interval --all (<duration>|default)")
 	fmt.Fprintln(w, "  gitmoot repo remove owner/repo")
 	fmt.Fprintln(w, "  gitmoot repo doctor owner/repo")
+	fmt.Fprintln(w, "  gitmoot repo collisions owner/repo [--json]")
 	fmt.Fprintln(w, "")
 	fmt.Fprintln(w, "owner/repo may be given before or after the flags.")
 }

--- a/internal/cli/repo_collisions.go
+++ b/internal/cli/repo_collisions.go
@@ -1,0 +1,129 @@
+package cli
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"sort"
+	"strings"
+
+	"github.com/gitmoot/gitmoot/internal/daemon"
+	"github.com/gitmoot/gitmoot/internal/github"
+)
+
+type repoCollisionClient interface {
+	ListPullRequests(context.Context, github.Repository, string) ([]github.PullRequest, error)
+	ListPullRequestFiles(context.Context, github.Repository, int64) ([]github.PullRequestFile, error)
+}
+
+var newRepoCollisionClient = func() repoCollisionClient {
+	return github.NewClient("")
+}
+
+type repoPRCollision struct {
+	FirstPR  int64    `json:"first_pr"`
+	SecondPR int64    `json:"second_pr"`
+	Files    []string `json:"files"`
+}
+
+func runRepoCollisions(args []string, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("repo collisions", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	jsonOutput := fs.Bool("json", false, "print collisions as JSON")
+	if len(args) == 0 || args[0] == "-h" || args[0] == "--help" {
+		fs.Usage()
+		if len(args) == 0 {
+			fmt.Fprintln(stderr, "repo collisions requires owner/repo")
+			return 2
+		}
+		return 0
+	}
+	repoArg, code := parseRepoPositional(fs, "repo collisions", args, nil, map[string]struct{}{"json": {}}, stderr)
+	if code >= 0 {
+		return code
+	}
+	repo, err := daemon.ParseRepository(repoArg)
+	if err != nil {
+		fmt.Fprintf(stderr, "repo collisions: invalid repo: %v\n", err)
+		return 2
+	}
+	collisions, err := detectOpenPRFileCollisions(context.Background(), newRepoCollisionClient(), repo)
+	if err != nil {
+		fmt.Fprintf(stderr, "repo collisions: %v\n", err)
+		return 1
+	}
+	if *jsonOutput {
+		if err := json.NewEncoder(stdout).Encode(collisions); err != nil {
+			fmt.Fprintf(stderr, "repo collisions: %v\n", err)
+			return 1
+		}
+		if len(collisions) > 0 {
+			return 1
+		}
+		return 0
+	}
+	if len(collisions) == 0 {
+		fmt.Fprintf(stdout, "repo: %s no open PR file collisions\n", repo.FullName())
+		return 0
+	}
+	for _, collision := range collisions {
+		fmt.Fprintf(stdout, "WARN: PR #%d and PR #%d touch %d shared file(s): %s\n",
+			collision.FirstPR, collision.SecondPR, len(collision.Files), strings.Join(collision.Files, ", "))
+	}
+	return 1
+}
+
+func detectOpenPRFileCollisions(ctx context.Context, client repoCollisionClient, repo github.Repository) ([]repoPRCollision, error) {
+	if client == nil {
+		return nil, errors.New("GitHub client is required")
+	}
+	pulls, err := client.ListPullRequests(ctx, repo, "open")
+	if err != nil {
+		return nil, fmt.Errorf("list open pull requests for %s: %w", repo.FullName(), err)
+	}
+	sort.Slice(pulls, func(i, j int) bool { return pulls[i].Number < pulls[j].Number })
+	fileSets := make(map[int64]map[string]struct{}, len(pulls))
+	for _, pull := range pulls {
+		files, err := client.ListPullRequestFiles(ctx, repo, pull.Number)
+		if err != nil {
+			return nil, fmt.Errorf("list files for PR #%d: %w", pull.Number, err)
+		}
+		set := make(map[string]struct{}, len(files))
+		for _, file := range files {
+			if name := strings.TrimSpace(file.Filename); name != "" {
+				set[name] = struct{}{}
+			}
+		}
+		fileSets[pull.Number] = set
+	}
+
+	var collisions []repoPRCollision
+	for i := 0; i < len(pulls); i++ {
+		for j := i + 1; j < len(pulls); j++ {
+			first, second := pulls[i].Number, pulls[j].Number
+			shared := intersectPRFileSets(fileSets[first], fileSets[second])
+			if len(shared) == 0 {
+				continue
+			}
+			collisions = append(collisions, repoPRCollision{FirstPR: first, SecondPR: second, Files: shared})
+		}
+	}
+	return collisions, nil
+}
+
+func intersectPRFileSets(left, right map[string]struct{}) []string {
+	if len(left) > len(right) {
+		left, right = right, left
+	}
+	shared := make([]string, 0)
+	for file := range left {
+		if _, ok := right[file]; ok {
+			shared = append(shared, file)
+		}
+	}
+	sort.Strings(shared)
+	return shared
+}

--- a/internal/cli/repo_collisions.go
+++ b/internal/cli/repo_collisions.go
@@ -100,7 +100,7 @@ func detectOpenPRFileCollisions(ctx context.Context, client repoCollisionClient,
 		fileSets[pull.Number] = set
 	}
 
-	var collisions []repoPRCollision
+	collisions := make([]repoPRCollision, 0)
 	for i := 0; i < len(pulls); i++ {
 		for j := i + 1; j < len(pulls); j++ {
 			first, second := pulls[i].Number, pulls[j].Number

--- a/internal/cli/repo_collisions.go
+++ b/internal/cli/repo_collisions.go
@@ -14,6 +14,11 @@ import (
 	"github.com/gitmoot/gitmoot/internal/github"
 )
 
+const (
+	repoCollisionDefaultLimit = 25
+	repoCollisionMaxLimit     = 100
+)
+
 type repoCollisionClient interface {
 	ListPullRequests(context.Context, github.Repository, string) ([]github.PullRequest, error)
 	ListPullRequestFiles(context.Context, github.Repository, int64) ([]github.PullRequestFile, error)
@@ -33,6 +38,7 @@ func runRepoCollisions(args []string, stdout, stderr io.Writer) int {
 	fs := flag.NewFlagSet("repo collisions", flag.ContinueOnError)
 	fs.SetOutput(stderr)
 	jsonOutput := fs.Bool("json", false, "print collisions as JSON")
+	limit := fs.Int("limit", repoCollisionDefaultLimit, "maximum newest open pull requests to inspect (1-100)")
 	if len(args) == 0 || args[0] == "-h" || args[0] == "--help" {
 		fs.Usage()
 		if len(args) == 0 {
@@ -41,16 +47,20 @@ func runRepoCollisions(args []string, stdout, stderr io.Writer) int {
 		}
 		return 0
 	}
-	repoArg, code := parseRepoPositional(fs, "repo collisions", args, nil, map[string]struct{}{"json": {}}, stderr)
+	repoArg, code := parseRepoPositional(fs, "repo collisions", args, map[string]struct{}{"limit": {}}, map[string]struct{}{"json": {}}, stderr)
 	if code >= 0 {
 		return code
+	}
+	if *limit < 1 || *limit > repoCollisionMaxLimit {
+		fmt.Fprintf(stderr, "repo collisions: --limit must be between 1 and %d\n", repoCollisionMaxLimit)
+		return 2
 	}
 	repo, err := daemon.ParseRepository(repoArg)
 	if err != nil {
 		fmt.Fprintf(stderr, "repo collisions: invalid repo: %v\n", err)
 		return 2
 	}
-	collisions, err := detectOpenPRFileCollisions(context.Background(), newRepoCollisionClient(), repo)
+	collisions, err := detectOpenPRFileCollisions(context.Background(), newRepoCollisionClient(), repo, *limit)
 	if err != nil {
 		fmt.Fprintf(stderr, "repo collisions: %v\n", err)
 		return 1
@@ -76,13 +86,20 @@ func runRepoCollisions(args []string, stdout, stderr io.Writer) int {
 	return 1
 }
 
-func detectOpenPRFileCollisions(ctx context.Context, client repoCollisionClient, repo github.Repository) ([]repoPRCollision, error) {
+func detectOpenPRFileCollisions(ctx context.Context, client repoCollisionClient, repo github.Repository, limit int) ([]repoPRCollision, error) {
 	if client == nil {
 		return nil, errors.New("GitHub client is required")
+	}
+	if limit < 1 {
+		return nil, errors.New("pull request limit must be positive")
 	}
 	pulls, err := client.ListPullRequests(ctx, repo, "open")
 	if err != nil {
 		return nil, fmt.Errorf("list open pull requests for %s: %w", repo.FullName(), err)
+	}
+	sort.Slice(pulls, func(i, j int) bool { return pulls[i].Number > pulls[j].Number })
+	if len(pulls) > limit {
+		pulls = pulls[:limit]
 	}
 	sort.Slice(pulls, func(i, j int) bool { return pulls[i].Number < pulls[j].Number })
 	fileSets := make(map[int64]map[string]struct{}, len(pulls))

--- a/internal/cli/repo_collisions_test.go
+++ b/internal/cli/repo_collisions_test.go
@@ -36,7 +36,7 @@ func TestDetectOpenPRFileCollisionsUsesDistinctPRIntersections(t *testing.T) {
 			30: {{Filename: "README.md"}, {Filename: "README.md"}, {Filename: "internal/workflow/engine.go"}},
 		},
 	}
-	got, err := detectOpenPRFileCollisions(context.Background(), client, github.Repository{Owner: "gitmoot", Name: "gitmoot"})
+	got, err := detectOpenPRFileCollisions(context.Background(), client, github.Repository{Owner: "gitmoot", Name: "gitmoot"}, repoCollisionDefaultLimit)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -49,6 +49,34 @@ func TestDetectOpenPRFileCollisionsUsesDistinctPRIntersections(t *testing.T) {
 	}
 	if !reflect.DeepEqual(client.fileCalls, []int64{10, 20, 30}) {
 		t.Fatalf("file calls=%v, want sorted distinct PRs", client.fileCalls)
+	}
+}
+
+func TestDetectOpenPRFileCollisionsLimitsNewestPullRequests(t *testing.T) {
+	client := &fakeRepoCollisionClient{
+		pulls: []github.PullRequest{{Number: 1}, {Number: 4}, {Number: 2}, {Number: 3}},
+		files: map[int64][]github.PullRequestFile{
+			1: {{Filename: "old-one.txt"}},
+			2: {{Filename: "old-two.txt"}},
+			3: {{Filename: "shared.txt"}},
+			4: {{Filename: "shared.txt"}},
+		},
+	}
+	got, err := detectOpenPRFileCollisions(
+		context.Background(),
+		client,
+		github.Repository{Owner: "gitmoot", Name: "gitmoot"},
+		2,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []repoPRCollision{{FirstPR: 3, SecondPR: 4, Files: []string{"shared.txt"}}}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("collisions=%+v, want %+v", got, want)
+	}
+	if !reflect.DeepEqual(client.fileCalls, []int64{3, 4}) {
+		t.Fatalf("file calls=%v, want only two newest pull requests", client.fileCalls)
 	}
 }
 
@@ -105,5 +133,17 @@ func TestRunRepoCollisionsJSONReturnsEmptyArray(t *testing.T) {
 	code := runRepo([]string{"collisions", "gitmoot/gitmoot", "--json"}, &stdout, &stderr)
 	if code != 0 || stdout.String() != "[]\n" {
 		t.Fatalf("clean JSON code=%d out=%q err=%q, want []", code, stdout.String(), stderr.String())
+	}
+}
+
+func TestRunRepoCollisionsRejectsUnboundedLimits(t *testing.T) {
+	for _, limit := range []string{"0", "101"} {
+		t.Run(limit, func(t *testing.T) {
+			var stdout, stderr bytes.Buffer
+			code := runRepo([]string{"collisions", "gitmoot/gitmoot", "--limit", limit}, &stdout, &stderr)
+			if code != 2 || !strings.Contains(stderr.String(), "--limit must be between 1 and 100") {
+				t.Fatalf("limit=%s code=%d out=%q err=%q", limit, code, stdout.String(), stderr.String())
+			}
+		})
 	}
 }

--- a/internal/cli/repo_collisions_test.go
+++ b/internal/cli/repo_collisions_test.go
@@ -94,3 +94,16 @@ func TestRunRepoCollisionsReportsCleanDistinctFileSets(t *testing.T) {
 		t.Fatalf("clean code=%d out=%q err=%q", code, stdout.String(), stderr.String())
 	}
 }
+
+func TestRunRepoCollisionsJSONReturnsEmptyArray(t *testing.T) {
+	client := &fakeRepoCollisionClient{}
+	previous := newRepoCollisionClient
+	newRepoCollisionClient = func() repoCollisionClient { return client }
+	t.Cleanup(func() { newRepoCollisionClient = previous })
+
+	var stdout, stderr bytes.Buffer
+	code := runRepo([]string{"collisions", "gitmoot/gitmoot", "--json"}, &stdout, &stderr)
+	if code != 0 || stdout.String() != "[]\n" {
+		t.Fatalf("clean JSON code=%d out=%q err=%q, want []", code, stdout.String(), stderr.String())
+	}
+}

--- a/internal/cli/repo_collisions_test.go
+++ b/internal/cli/repo_collisions_test.go
@@ -1,0 +1,96 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/gitmoot/gitmoot/internal/github"
+)
+
+type fakeRepoCollisionClient struct {
+	pulls          []github.PullRequest
+	files          map[int64][]github.PullRequestFile
+	requestedState string
+	fileCalls      []int64
+}
+
+func (f *fakeRepoCollisionClient) ListPullRequests(_ context.Context, _ github.Repository, state string) ([]github.PullRequest, error) {
+	f.requestedState = state
+	return append([]github.PullRequest(nil), f.pulls...), nil
+}
+
+func (f *fakeRepoCollisionClient) ListPullRequestFiles(_ context.Context, _ github.Repository, number int64) ([]github.PullRequestFile, error) {
+	f.fileCalls = append(f.fileCalls, number)
+	return append([]github.PullRequestFile(nil), f.files[number]...), nil
+}
+
+func TestDetectOpenPRFileCollisionsUsesDistinctPRIntersections(t *testing.T) {
+	client := &fakeRepoCollisionClient{
+		pulls: []github.PullRequest{{Number: 30}, {Number: 10}, {Number: 20}},
+		files: map[int64][]github.PullRequestFile{
+			10: {{Filename: "internal/cli/repo.go"}, {Filename: "README.md"}},
+			20: {{Filename: "docs/events.md"}},
+			30: {{Filename: "README.md"}, {Filename: "README.md"}, {Filename: "internal/workflow/engine.go"}},
+		},
+	}
+	got, err := detectOpenPRFileCollisions(context.Background(), client, github.Repository{Owner: "gitmoot", Name: "gitmoot"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []repoPRCollision{{FirstPR: 10, SecondPR: 30, Files: []string{"README.md"}}}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("collisions=%+v, want %+v", got, want)
+	}
+	if client.requestedState != "open" {
+		t.Fatalf("requested pull request state=%q, want open", client.requestedState)
+	}
+	if !reflect.DeepEqual(client.fileCalls, []int64{10, 20, 30}) {
+		t.Fatalf("file calls=%v, want sorted distinct PRs", client.fileCalls)
+	}
+}
+
+func TestRunRepoCollisionsWarnsWithPairAndFiles(t *testing.T) {
+	client := &fakeRepoCollisionClient{
+		pulls: []github.PullRequest{{Number: 8}, {Number: 4}},
+		files: map[int64][]github.PullRequestFile{
+			4: {{Filename: "internal/cli/org.go"}, {Filename: "internal/cli/repo.go"}},
+			8: {{Filename: "internal/cli/repo.go"}, {Filename: "internal/cli/org.go"}},
+		},
+	}
+	previous := newRepoCollisionClient
+	newRepoCollisionClient = func() repoCollisionClient { return client }
+	t.Cleanup(func() { newRepoCollisionClient = previous })
+
+	var stdout, stderr bytes.Buffer
+	code := runRepo([]string{"collisions", "gitmoot/gitmoot"}, &stdout, &stderr)
+	if code != 1 {
+		t.Fatalf("collision code=%d out=%q err=%q, want warning exit 1", code, stdout.String(), stderr.String())
+	}
+	for _, want := range []string{"WARN: PR #4 and PR #8", "2 shared file(s)", "internal/cli/org.go, internal/cli/repo.go"} {
+		if !strings.Contains(stdout.String(), want) {
+			t.Fatalf("collision output=%q, want %q", stdout.String(), want)
+		}
+	}
+}
+
+func TestRunRepoCollisionsReportsCleanDistinctFileSets(t *testing.T) {
+	client := &fakeRepoCollisionClient{
+		pulls: []github.PullRequest{{Number: 4}, {Number: 8}},
+		files: map[int64][]github.PullRequestFile{
+			4: {{Filename: "internal/cli/org.go"}},
+			8: {{Filename: "internal/cli/repo.go"}},
+		},
+	}
+	previous := newRepoCollisionClient
+	newRepoCollisionClient = func() repoCollisionClient { return client }
+	t.Cleanup(func() { newRepoCollisionClient = previous })
+
+	var stdout, stderr bytes.Buffer
+	code := runRepo([]string{"collisions", "gitmoot/gitmoot"}, &stdout, &stderr)
+	if code != 0 || !strings.Contains(stdout.String(), "no open PR file collisions") {
+		t.Fatalf("clean code=%d out=%q err=%q", code, stdout.String(), stderr.String())
+	}
+}

--- a/internal/cli/workflow_journal.go
+++ b/internal/cli/workflow_journal.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"sort"
+	"strconv"
 	"strings"
 	"unicode"
 
@@ -33,6 +34,8 @@ func runWorkflowJournal(args []string, stdout, stderr io.Writer) int {
 		return runWorkflowList(args[1:], stdout, stderr)
 	case "show":
 		return runWorkflowShow(args[1:], stdout, stderr)
+	case "show-note":
+		return runWorkflowNoteShow(args[1:], stdout, stderr)
 	case "describe":
 		return runWorkflowDescribe(args[1:], stdout, stderr)
 	case "note":
@@ -51,6 +54,7 @@ func printWorkflowJournalUsage(w io.Writer) {
 	fmt.Fprintln(w)
 	fmt.Fprintln(w, "Usage:")
 	fmt.Fprintln(w, "  gitmoot workflow list [--json]")
+	fmt.Fprintln(w, "  gitmoot workflow show-note <id> [--json]")
 	fmt.Fprintln(w, "  gitmoot workflow show <label> [--json] [--limit N]")
 	fmt.Fprintln(w, "  gitmoot workflow describe <label> \"<text>\" [--json]")
 	fmt.Fprintln(w, "  gitmoot workflow note <label> \"<body>\" [--author A] [--pane P] [--session ID] [--workdir PATH] [--no-auto] [--summary DESCRIPTION] [--status STATUS] [--remember [--remember-status] [--agent NAME] [--repo R]]")
@@ -460,6 +464,62 @@ type workflowNoteOutput struct {
 	MemoryKey      string          `json:"memory_key,omitempty"`
 	AutoConfirmed  bool            `json:"auto_confirmed,omitempty"`
 	SkippedRetired bool            `json:"skipped_retired,omitempty"`
+}
+
+func runWorkflowNoteShow(args []string, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("workflow show-note", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	home := fs.String("home", "", "home directory to use instead of the current user's home")
+	jsonOutput := fs.Bool("json", false, "print the stored note as JSON")
+	parsedArgs, err := reorderFlagArgs(args, map[string]struct{}{"home": {}}, map[string]struct{}{"json": {}})
+	if err != nil {
+		fmt.Fprintf(stderr, "workflow show-note: %v\n", err)
+		return 2
+	}
+	if err := fs.Parse(parsedArgs); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return 0
+		}
+		return 2
+	}
+	if fs.NArg() != 1 {
+		fmt.Fprintln(stderr, "workflow show-note requires exactly one note id")
+		return 2
+	}
+	noteID, err := strconv.ParseInt(strings.TrimSpace(fs.Arg(0)), 10, 64)
+	if err != nil || noteID <= 0 {
+		fmt.Fprintf(stderr, "workflow show-note: invalid note id %q\n", fs.Arg(0))
+		return 2
+	}
+	var note db.WorkflowNote
+	if err := withStore(*home, func(store *db.Store) error {
+		var err error
+		note, err = store.GetWorkflowNote(context.Background(), noteID)
+		return err
+	}); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			fmt.Fprintf(stderr, "workflow note %d not found\n", noteID)
+			return 1
+		}
+		fmt.Fprintf(stderr, "workflow show-note: %v\n", err)
+		return 1
+	}
+	if *jsonOutput {
+		if err := writeJSON(stdout, note); err != nil {
+			fmt.Fprintf(stderr, "workflow show-note: %v\n", err)
+			return 1
+		}
+		return 0
+	}
+	writeLine(stdout, "note: %d", note.ID)
+	writeLine(stdout, "workflow: %s", note.WorkflowID)
+	writeLine(stdout, "author: %s", terminalSafeWorkflowText(note.Author))
+	if note.Repo != "" {
+		writeLine(stdout, "repo: %s", terminalSafeWorkflowText(note.Repo))
+	}
+	writeLine(stdout, "created: %s", note.CreatedAt)
+	writeLine(stdout, "body: %s", terminalSafeWorkflowText(note.Body))
+	return 0
 }
 
 func runWorkflowNote(args []string, stdout, stderr io.Writer) int {

--- a/internal/cli/workflow_journal.go
+++ b/internal/cli/workflow_journal.go
@@ -11,6 +11,7 @@ import (
 	"strconv"
 	"strings"
 	"unicode"
+	"unicode/utf8"
 
 	"github.com/gitmoot/gitmoot/internal/config"
 	"github.com/gitmoot/gitmoot/internal/db"
@@ -430,6 +431,14 @@ func terminalSafeWorkflowText(value string) string {
 	return string(out)
 }
 
+func terminalSafeWorkflowBody(value string) string {
+	rendered := terminalSafeWorkflowText(value)
+	if utf8.RuneCountInString(value) > workflowTextLineMaxRunes {
+		return rendered + " [truncated; use --json for the full body]"
+	}
+	return rendered
+}
+
 func mergeWorkflowTimeline(jobs []db.Job, notes []db.WorkflowNote) []workflowTimelineEntry {
 	entries := make([]workflowTimelineEntry, 0, len(jobs)+len(notes))
 	for _, job := range jobs {
@@ -518,7 +527,7 @@ func runWorkflowNoteShow(args []string, stdout, stderr io.Writer) int {
 		writeLine(stdout, "repo: %s", terminalSafeWorkflowText(note.Repo))
 	}
 	writeLine(stdout, "created: %s", note.CreatedAt)
-	writeLine(stdout, "body: %s", terminalSafeWorkflowText(note.Body))
+	writeLine(stdout, "body: %s", terminalSafeWorkflowBody(note.Body))
 	return 0
 }
 

--- a/internal/cli/workflow_journal_test.go
+++ b/internal/cli/workflow_journal_test.go
@@ -1240,3 +1240,36 @@ func TestWorkflowRememberHonorsAutoConfirmInSharedPool(t *testing.T) {
 		t.Fatalf("confirmed=%+v err=%v", confirmed, err)
 	}
 }
+
+func TestWorkflowShowNoteMarksTruncatedPlainBody(t *testing.T) {
+	home, store := workflowJournalTestHome(t)
+	body := strings.Repeat("x", workflowTextLineMaxRunes+20)
+	note, err := store.InsertWorkflowNote(context.Background(), db.WorkflowNote{
+		WorkflowID: "gitmoot/long-message",
+		Author:     "gm-omp-nag",
+		Body:       body,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	code := runWorkflowJournal([]string{"show-note", fmt.Sprint(note.ID), "--home", home}, &stdout, &stderr)
+	if code != 0 || !strings.Contains(stdout.String(), "[truncated; use --json for the full body]") {
+		t.Fatalf("plain show-note code=%d out=%q err=%q", code, stdout.String(), stderr.String())
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	code = runWorkflowJournal([]string{"show-note", fmt.Sprint(note.ID), "--home", home, "--json"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("JSON show-note code=%d out=%q err=%q", code, stdout.String(), stderr.String())
+	}
+	var decoded db.WorkflowNote
+	if err := json.Unmarshal(stdout.Bytes(), &decoded); err != nil {
+		t.Fatal(err)
+	}
+	if decoded.Body != body {
+		t.Fatalf("JSON body length=%d, want %d verbatim bytes", len(decoded.Body), len(body))
+	}
+}

--- a/internal/workflow/org_message.go
+++ b/internal/workflow/org_message.go
@@ -1,0 +1,23 @@
+package workflow
+
+import "strings"
+
+// FormatOrgMessageNote records a non-obligatory message between organization
+// roles. The marker keeps the sender and recipient citable with the note body.
+func FormatOrgMessageNote(from, to, workflowID, message string) string {
+	if strings.TrimSpace(message) == "" {
+		return ""
+	}
+	return formatAddressedOrgNote("message", []addressedOrgNoteField{
+		{key: "to", value: to}, {key: "from", value: from}, {key: "wf", value: workflowID},
+	}, message)
+}
+
+// ParseOrgMessageNote decodes a durable non-obligatory organization message.
+func ParseOrgMessageNote(body string) (from, to, workflowID, message string, ok bool) {
+	values, message, ok := parseAddressedOrgNote("message", body)
+	if !ok || message == "" || len(values) != 3 || values["from"] == "" || values["to"] == "" || values["wf"] == "" {
+		return "", "", "", "", false
+	}
+	return values["from"], values["to"], values["wf"], message, true
+}

--- a/internal/workflow/org_message_test.go
+++ b/internal/workflow/org_message_test.go
@@ -1,0 +1,21 @@
+package workflow
+
+import "testing"
+
+func TestOrgMessageNoteRoundTrip(t *testing.T) {
+	body := FormatOrgMessageNote("gm-omp-nag", "gm-omp-impl", "gitmoot/1692", "heads up: [internal/cli/org.go] overlaps")
+	from, to, workflowID, message, ok := ParseOrgMessageNote(body)
+	if !ok || from != "gm-omp-nag" || to != "gm-omp-impl" || workflowID != "gitmoot/1692" || message != "heads up: [internal/cli/org.go] overlaps" {
+		t.Fatalf("parsed message=(from=%q to=%q workflow=%q message=%q ok=%v)", from, to, workflowID, message, ok)
+	}
+	for _, invalid := range []string{
+		FormatOrgMessageNote("", "gm-omp-impl", "gitmoot/1692", "message"),
+		FormatOrgMessageNote("gm-omp-nag", "", "gitmoot/1692", "message"),
+		FormatOrgMessageNote("gm-omp-nag", "gm-omp-impl", "", "message"),
+		FormatOrgMessageNote("gm-omp-nag", "gm-omp-impl", "gitmoot/1692", "   "),
+	} {
+		if invalid != "" {
+			t.Fatalf("invalid message formatted as %q", invalid)
+		}
+	}
+}

--- a/skills/gitmoot/SKILL.md
+++ b/skills/gitmoot/SKILL.md
@@ -253,6 +253,9 @@ a note in persistent memory, and end a finished group. Workflow hygiene:
 work merges or completes — never-closed workflows accumulate and bury live
 work in the dashboard's active buckets and every workflow-picking surface. Linked PR lifecycle transitions also add deduped
 `daemon` journal notes and advance live status.
+In org mode, `gitmoot org message send --to <role> --workflow <label>
+"<message>"` gives distinct same-parent siblings a durable sender-attributed
+heads-up. It creates no acknowledgment, completion, TTL, or nag obligation.
 In org mode, obligations and questions have a full lifecycle and closing it is
 part of the work: `gitmoot org directive send --to <role> --workflow <label>`
 mints a tracked, TTL-nudged obligation; `org directive ack <id>` records

--- a/skills/gitmoot/SKILL.md
+++ b/skills/gitmoot/SKILL.md
@@ -244,8 +244,8 @@ can discover Gitmoot through an installed runtime plugin. Use
 adds the resolved `.gitmoot` home to the sandbox on Linux, macOS, and Windows.
 Use `gitmoot goal template` when
 writing a standard task-by-task goal file. Use `gitmoot workflow list`, `gitmoot
-workflow show`, `gitmoot workflow describe`, `gitmoot workflow note`, and
-`gitmoot workflow close` to
+workflow show`, `gitmoot workflow show-note`, `gitmoot workflow describe`,
+`gitmoot workflow note`, and `gitmoot workflow close` to
 inspect external-coordinator workflow groups, set their stable description, add
 verbatim journal entries, set a manual status escape hatch, optionally stage
 a note in persistent memory, and end a finished group. Workflow hygiene:

--- a/skills/gitmoot/references/CLI.md
+++ b/skills/gitmoot/references/CLI.md
@@ -1668,6 +1668,16 @@ code-level marker to migrate. The note and a `pending` wake outbox row commit
 atomically. With an opt-in `reply` rule, a daemon tick wakes the addressed role
 through its configured Herdr pane.
 
+`gitmoot org message send --to <role> --workflow <label> [--org-role
+<from-role>] [--repo <owner/repo>] [--json] "<message>"` records a durable
+sender-attributed heads-up between two distinct configured roles. The roles may
+message each other if and only if their non-empty `parent` values are equal.
+Repository scope does not grant this channel, and `owner` has no special case.
+The typed note
+`[org:message to=<to> from=<from> wf=<workflow>] <message>` and its addressed
+`reply:<role>` wake row commit atomically. Messages create no directive,
+acknowledgment, completion, TTL, or nag obligation.
+
 `gitmoot org escalate resolve <escalation-note-id> [--by <role>] [--note
 <answer-note-id>] [--home <dir>]` appends a typed resolution marker to the same
 workflow journal. `--by` defaults to the escalation's target role, and `--note`

--- a/skills/gitmoot/references/CLI.md
+++ b/skills/gitmoot/references/CLI.md
@@ -403,7 +403,7 @@ For structured local state, use `gitmoot dashboard --json` or
 distinct pair's changed-file sets, and prints one warning per non-empty
 intersection with both PR numbers and the sorted shared paths. It exits 1 when
 collisions exist, 0 when every open PR pair is disjoint, and supports structured
-output with `--json`.
+output with `--json`; a clean result is the iterable empty array `[]`.
 
 `gitmoot daemon status` always prints the configured daemon log path. For a
 running daemon, it also compares that file's last write with the daemon's
@@ -1688,8 +1688,11 @@ message each other if and only if their non-empty `parent` values are equal.
 Repository scope does not grant this channel, and `owner` has no special case.
 The typed note
 `[org:message to=<to> from=<from> wf=<workflow>] <message>` and its addressed
-`reply:<role>` wake row commit atomically. Messages create no directive,
-acknowledgment, completion, TTL, or nag obligation.
+`reply:<role>` wake row commit atomically. The wake includes the exact
+`gitmoot workflow show-note <id>` retrieval command; that command renders the
+citable row's workflow, author, optional repository, timestamp, and body, or
+returns the row as JSON. Messages create no directive, acknowledgment,
+completion, TTL, or nag obligation.
 
 `gitmoot org escalate resolve <escalation-note-id> [--by <role>] [--note
 <answer-note-id>] [--home <dir>]` appends a typed resolution marker to the same

--- a/skills/gitmoot/references/CLI.md
+++ b/skills/gitmoot/references/CLI.md
@@ -383,6 +383,7 @@ gitmoot repo set-interval owner/repo (<duration>|default)
 gitmoot repo set-interval --all (<duration>|default)
 gitmoot repo remove owner/repo
 gitmoot repo doctor owner/repo
+gitmoot repo collisions owner/repo [--json]
 gitmoot daemon start --poll 30s --workers 1
 gitmoot daemon start --session <root-job-id>
 gitmoot daemon start
@@ -395,6 +396,12 @@ gitmoot daemon stop
 For structured local state, use `gitmoot dashboard --json` or
 `gitmoot task list --repo owner/repo --json`. `gitmoot status --json` and
 `gitmoot task show` are not valid commands.
+
+`gitmoot repo collisions owner/repo` lists open pull requests, compares each
+distinct pair's changed-file sets, and prints one warning per non-empty
+intersection with both PR numbers and the sorted shared paths. It exits 1 when
+collisions exist, 0 when every open PR pair is disjoint, and supports structured
+output with `--json`.
 
 `gitmoot daemon status` always prints the configured daemon log path. For a
 running daemon, it also compares that file's last write with the daemon's

--- a/skills/gitmoot/references/CLI.md
+++ b/skills/gitmoot/references/CLI.md
@@ -1691,8 +1691,9 @@ The typed note
 `reply:<role>` wake row commit atomically. The wake includes the exact
 `gitmoot workflow show-note <id>` retrieval command; that command renders the
 citable row's workflow, author, optional repository, timestamp, and body, or
-returns the row as JSON. Messages create no directive, acknowledgment,
-completion, TTL, or nag obligation.
+returns the row as JSON. Plain output marks bodies above 512 runes as truncated
+and points to `--json`; JSON preserves the full stored body. Messages create no
+directive, acknowledgment, completion, TTL, or nag obligation.
 
 `gitmoot org escalate resolve <escalation-note-id> [--by <role>] [--note
 <answer-note-id>] [--home <dir>]` appends a typed resolution marker to the same

--- a/skills/gitmoot/references/CLI.md
+++ b/skills/gitmoot/references/CLI.md
@@ -385,7 +385,7 @@ gitmoot repo auto-fix owner/repo --pr <number> --enable --by <role-or-agent> --r
 gitmoot repo set-interval --all (<duration>|default)
 gitmoot repo remove owner/repo
 gitmoot repo doctor owner/repo
-gitmoot repo collisions owner/repo [--json]
+gitmoot repo collisions owner/repo [--limit N] [--json]
 gitmoot daemon start --poll 30s --workers 1
 gitmoot daemon start --session <root-job-id>
 gitmoot daemon start
@@ -399,11 +399,13 @@ For structured local state, use `gitmoot dashboard --json` or
 `gitmoot task list --repo owner/repo --json`. `gitmoot status --json` and
 `gitmoot task show` are not valid commands.
 
-`gitmoot repo collisions owner/repo` lists open pull requests, compares each
-distinct pair's changed-file sets, and prints one warning per non-empty
-intersection with both PR numbers and the sorted shared paths. It exits 1 when
-collisions exist, 0 when every open PR pair is disjoint, and supports structured
-output with `--json`; a clean result is the iterable empty array `[]`.
+`gitmoot repo collisions owner/repo` inspects at most the newest `--limit` open
+pull requests (default 25, maximum 100), compares each selected pair's current
+changed-filename sets, and prints one warning per non-empty intersection with
+both PR numbers and the sorted shared paths. It exits 1 when collisions exist, 0
+when every inspected pair is disjoint, and supports structured output with
+`--json`; a clean result is the iterable empty array `[]`. Rename history is not
+available, so a concurrent edit of a renamed path's old name may be missed.
 
 `gitmoot daemon status` always prints the configured daemon log path. For a
 running daemon, it also compares that file's last write with the daemon's
@@ -1914,6 +1916,7 @@ gitmoot workflow list
 gitmoot workflow show fable/dashboard-redesign --limit 100
 gitmoot workflow describe fable/dashboard-redesign "Coordinate and ship the dashboard redesign."
 gitmoot workflow note fable/dashboard-redesign "Implementation started." --author operator --status active
+gitmoot workflow show-note 42
 gitmoot workflow close fable/dashboard-redesign --reason "Shipped and verified."
 ```
 

--- a/website/docs/reference/cli.md
+++ b/website/docs/reference/cli.md
@@ -1479,6 +1479,16 @@ no code-level marker to migrate. The note and a `pending` wake outbox row commit
 atomically. With an opt-in `reply` rule, a daemon tick wakes the addressed role
 through its configured Herdr pane.
 
+`gitmoot org message send --to <role> --workflow <label> [--org-role
+<from-role>] [--repo <owner/repo>] [--json] "<message>"` records a durable
+sender-attributed heads-up between two distinct configured roles. The roles may
+message each other if and only if their non-empty `parent` values are equal.
+Repository scope does not grant this channel, and `owner` has no special case.
+The typed note
+`[org:message to=<to> from=<from> wf=<workflow>] <message>` and its addressed
+`reply:<role>` wake row commit atomically. Messages create no directive,
+acknowledgment, completion, TTL, or nag obligation.
+
 `gitmoot org escalate resolve <escalation-note-id> [--by <role>] [--note
 <answer-note-id>] [--home <dir>]` appends a typed resolution marker to the same
 workflow journal. `--by` defaults to the escalation's target role, and `--note`

--- a/website/docs/reference/cli.md
+++ b/website/docs/reference/cli.md
@@ -308,6 +308,7 @@ gitmoot repo set-interval owner/repo (<duration>|default)
 gitmoot repo set-interval --all (<duration>|default)
 gitmoot repo remove owner/repo
 gitmoot repo doctor owner/repo
+gitmoot repo collisions owner/repo [--json]
 ```
 
 The `gitmoot repo` commands manage the **watched-repo registry**: one daemon
@@ -321,6 +322,12 @@ registered checkout is missing or is no longer a Git worktree, Gitmoot verifies
 the recorded primary checkout, repairs the registration, and reports the
 self-heal. Implicit registration from inside a linked task worktree pins the
 repo to its primary checkout; an existing valid linked checkout remains usable.
+
+`gitmoot repo collisions owner/repo` lists open pull requests, compares each
+distinct pair's changed-file sets, and prints one warning per non-empty
+intersection with both PR numbers and the sorted shared paths. It exits 1 when
+collisions exist, 0 when every open PR pair is disjoint, and supports structured
+output with `--json`.
 
 Use `daemon start` for the background daemon. Use `daemon run` only when the
 user explicitly wants a foreground process. Keep the default `--workers 1`

--- a/website/docs/reference/cli.md
+++ b/website/docs/reference/cli.md
@@ -310,7 +310,7 @@ gitmoot repo auto-fix owner/repo --pr <number> --enable --by <role-or-agent> --r
 gitmoot repo set-interval --all (<duration>|default)
 gitmoot repo remove owner/repo
 gitmoot repo doctor owner/repo
-gitmoot repo collisions owner/repo [--json]
+gitmoot repo collisions owner/repo [--limit N] [--json]
 ```
 
 The `gitmoot repo` commands manage the **watched-repo registry**: one daemon
@@ -330,11 +330,13 @@ recorded primary checkout, repairs the registration, and reports the self-heal.
 Implicit registration from inside a linked task worktree pins the repo to its
 primary checkout; an existing valid linked checkout remains usable.
 
-`gitmoot repo collisions owner/repo` lists open pull requests, compares each
-distinct pair's changed-file sets, and prints one warning per non-empty
-intersection with both PR numbers and the sorted shared paths. It exits 1 when
-collisions exist, 0 when every open PR pair is disjoint, and supports structured
-output with `--json`; a clean result is the iterable empty array `[]`.
+`gitmoot repo collisions owner/repo` inspects at most the newest `--limit` open
+pull requests (default 25, maximum 100), compares each selected pair's current
+changed-filename sets, and prints one warning per non-empty intersection with
+both PR numbers and the sorted shared paths. It exits 1 when collisions exist, 0
+when every inspected pair is disjoint, and supports structured output with
+`--json`; a clean result is the iterable empty array `[]`. Rename history is not
+available, so a concurrent edit of a renamed path's old name may be missed.
 
 Use `daemon start` for the background daemon. Use `daemon run` only when the
 user explicitly wants a foreground process. Keep the default `--workers 1`
@@ -1687,6 +1689,7 @@ gitmoot workflow list
 gitmoot workflow show fable/dashboard-redesign --limit 100
 gitmoot workflow describe fable/dashboard-redesign "Coordinate and ship the dashboard redesign."
 gitmoot workflow note fable/dashboard-redesign "Implementation started." --author operator --status active
+gitmoot workflow show-note 42
 gitmoot workflow close fable/dashboard-redesign --reason "Shipped and verified."
 ```
 

--- a/website/docs/reference/cli.md
+++ b/website/docs/reference/cli.md
@@ -334,7 +334,7 @@ primary checkout; an existing valid linked checkout remains usable.
 distinct pair's changed-file sets, and prints one warning per non-empty
 intersection with both PR numbers and the sorted shared paths. It exits 1 when
 collisions exist, 0 when every open PR pair is disjoint, and supports structured
-output with `--json`.
+output with `--json`; a clean result is the iterable empty array `[]`.
 
 Use `daemon start` for the background daemon. Use `daemon run` only when the
 user explicitly wants a foreground process. Keep the default `--workers 1`
@@ -1500,8 +1500,11 @@ message each other if and only if their non-empty `parent` values are equal.
 Repository scope does not grant this channel, and `owner` has no special case.
 The typed note
 `[org:message to=<to> from=<from> wf=<workflow>] <message>` and its addressed
-`reply:<role>` wake row commit atomically. Messages create no directive,
-acknowledgment, completion, TTL, or nag obligation.
+`reply:<role>` wake row commit atomically. The wake includes the exact
+`gitmoot workflow show-note <id>` retrieval command; that command renders the
+citable row's workflow, author, optional repository, timestamp, and body, or
+returns the row as JSON. Messages create no directive, acknowledgment,
+completion, TTL, or nag obligation.
 
 `gitmoot org escalate resolve <escalation-note-id> [--by <role>] [--note
 <answer-note-id>] [--home <dir>]` appends a typed resolution marker to the same

--- a/website/docs/reference/cli.md
+++ b/website/docs/reference/cli.md
@@ -1503,8 +1503,9 @@ The typed note
 `reply:<role>` wake row commit atomically. The wake includes the exact
 `gitmoot workflow show-note <id>` retrieval command; that command renders the
 citable row's workflow, author, optional repository, timestamp, and body, or
-returns the row as JSON. Messages create no directive, acknowledgment,
-completion, TTL, or nag obligation.
+returns the row as JSON. Plain output marks bodies above 512 runes as truncated
+and points to `--json`; JSON preserves the full stored body. Messages create no
+directive, acknowledgment, completion, TTL, or nag obligation.
 
 `gitmoot org escalate resolve <escalation-note-id> [--by <role>] [--note
 <answer-note-id>] [--home <dir>]` appends a typed resolution marker to the same

--- a/website/static/llms-full.txt
+++ b/website/static/llms-full.txt
@@ -11897,8 +11897,9 @@ The typed note
 `reply:<role>` wake row commit atomically. The wake includes the exact
 `gitmoot workflow show-note <id>` retrieval command; that command renders the
 citable row's workflow, author, optional repository, timestamp, and body, or
-returns the row as JSON. Messages create no directive, acknowledgment,
-completion, TTL, or nag obligation.
+returns the row as JSON. Plain output marks bodies above 512 runes as truncated
+and points to `--json`; JSON preserves the full stored body. Messages create no
+directive, acknowledgment, completion, TTL, or nag obligation.
 
 `gitmoot org escalate resolve <escalation-note-id> [--by <role>] [--note
 <answer-note-id>] [--home <dir>]` appends a typed resolution marker to the same

--- a/website/static/llms-full.txt
+++ b/website/static/llms-full.txt
@@ -10595,7 +10595,7 @@ gitmoot repo set-interval owner/repo (<duration>|default)
 gitmoot repo set-interval --all (<duration>|default)
 gitmoot repo remove owner/repo
 gitmoot repo doctor owner/repo
-gitmoot repo collisions owner/repo [--json]
+gitmoot repo collisions owner/repo [--limit N] [--json]
 gitmoot daemon start --poll 30s --workers 1
 gitmoot daemon start --session <root-job-id>
 gitmoot daemon start
@@ -10609,11 +10609,13 @@ For structured local state, use `gitmoot dashboard --json` or
 `gitmoot task list --repo owner/repo --json`. `gitmoot status --json` and
 `gitmoot task show` are not valid commands.
 
-`gitmoot repo collisions owner/repo` lists open pull requests, compares each
-distinct pair's changed-file sets, and prints one warning per non-empty
-intersection with both PR numbers and the sorted shared paths. It exits 1 when
-collisions exist, 0 when every open PR pair is disjoint, and supports structured
-output with `--json`; a clean result is the iterable empty array `[]`.
+`gitmoot repo collisions owner/repo` inspects at most the newest `--limit` open
+pull requests (default 25, maximum 100), compares each selected pair's current
+changed-filename sets, and prints one warning per non-empty intersection with
+both PR numbers and the sorted shared paths. It exits 1 when collisions exist, 0
+when every inspected pair is disjoint, and supports structured output with
+`--json`; a clean result is the iterable empty array `[]`. Rename history is not
+available, so a concurrent edit of a renamed path's old name may be missed.
 
 `gitmoot daemon status` always prints the configured daemon log path. For a
 running daemon, it also compares that file's last write with the daemon's
@@ -12120,6 +12122,7 @@ gitmoot workflow list
 gitmoot workflow show fable/dashboard-redesign --limit 100
 gitmoot workflow describe fable/dashboard-redesign "Coordinate and ship the dashboard redesign."
 gitmoot workflow note fable/dashboard-redesign "Implementation started." --author operator --status active
+gitmoot workflow show-note 42
 gitmoot workflow close fable/dashboard-redesign --reason "Shipped and verified."
 ```
 

--- a/website/static/llms-full.txt
+++ b/website/static/llms-full.txt
@@ -11880,6 +11880,16 @@ code-level marker to migrate. The note and a `pending` wake outbox row commit
 atomically. With an opt-in `reply` rule, a daemon tick wakes the addressed role
 through its configured Herdr pane.
 
+`gitmoot org message send --to <role> --workflow <label> [--org-role
+<from-role>] [--repo <owner/repo>] [--json] "<message>"` records a durable
+sender-attributed heads-up between two distinct configured roles. The roles may
+message each other if and only if their non-empty `parent` values are equal.
+Repository scope does not grant this channel, and `owner` has no special case.
+The typed note
+`[org:message to=<to> from=<from> wf=<workflow>] <message>` and its addressed
+`reply:<role>` wake row commit atomically. Messages create no directive,
+acknowledgment, completion, TTL, or nag obligation.
+
 `gitmoot org escalate resolve <escalation-note-id> [--by <role>] [--note
 <answer-note-id>] [--home <dir>]` appends a typed resolution marker to the same
 workflow journal. `--by` defaults to the escalation's target role, and `--note`

--- a/website/static/llms-full.txt
+++ b/website/static/llms-full.txt
@@ -10595,6 +10595,7 @@ gitmoot repo set-interval owner/repo (<duration>|default)
 gitmoot repo set-interval --all (<duration>|default)
 gitmoot repo remove owner/repo
 gitmoot repo doctor owner/repo
+gitmoot repo collisions owner/repo [--json]
 gitmoot daemon start --poll 30s --workers 1
 gitmoot daemon start --session <root-job-id>
 gitmoot daemon start
@@ -10607,6 +10608,12 @@ gitmoot daemon stop
 For structured local state, use `gitmoot dashboard --json` or
 `gitmoot task list --repo owner/repo --json`. `gitmoot status --json` and
 `gitmoot task show` are not valid commands.
+
+`gitmoot repo collisions owner/repo` lists open pull requests, compares each
+distinct pair's changed-file sets, and prints one warning per non-empty
+intersection with both PR numbers and the sorted shared paths. It exits 1 when
+collisions exist, 0 when every open PR pair is disjoint, and supports structured
+output with `--json`.
 
 `gitmoot daemon status` always prints the configured daemon log path. For a
 running daemon, it also compares that file's last write with the daemon's

--- a/website/static/llms-full.txt
+++ b/website/static/llms-full.txt
@@ -10613,7 +10613,7 @@ For structured local state, use `gitmoot dashboard --json` or
 distinct pair's changed-file sets, and prints one warning per non-empty
 intersection with both PR numbers and the sorted shared paths. It exits 1 when
 collisions exist, 0 when every open PR pair is disjoint, and supports structured
-output with `--json`.
+output with `--json`; a clean result is the iterable empty array `[]`.
 
 `gitmoot daemon status` always prints the configured daemon log path. For a
 running daemon, it also compares that file's last write with the daemon's
@@ -11894,8 +11894,11 @@ message each other if and only if their non-empty `parent` values are equal.
 Repository scope does not grant this channel, and `owner` has no special case.
 The typed note
 `[org:message to=<to> from=<from> wf=<workflow>] <message>` and its addressed
-`reply:<role>` wake row commit atomically. Messages create no directive,
-acknowledgment, completion, TTL, or nag obligation.
+`reply:<role>` wake row commit atomically. The wake includes the exact
+`gitmoot workflow show-note <id>` retrieval command; that command renders the
+citable row's workflow, author, optional repository, timestamp, and body, or
+returns the row as JSON. Messages create no directive, acknowledgment,
+completion, TTL, or nag obligation.
 
 `gitmoot org escalate resolve <escalation-note-id> [--by <role>] [--note
 <answer-note-id>] [--home <dir>]` appends a typed resolution marker to the same


### PR DESCRIPTION
## Summary

- add durable sender-attributed `org message send` for distinct roles that share one parent
- refuse cross-parent messages with the exact failed predicate; add no scope or owner exception
- keep messages outside directive acknowledgments, completion, TTL, and nag ladders
- add `repo collisions` to warn on current changed-filename intersections between distinct open PR pairs
- inspect at most the newest 25 open PRs by default, with a hard maximum of 100 via `--limit`
- keep the channel and detector separable in commits `98edd3c5` and `151567ee`

## Known limitation

`repo collisions` compares current filenames only. The current GitHub client does not expose each renamed file's previous filename, so a rename in one PR and an edit of that old path in another PR can be missed. The detector is advisory, not a merge gate.

## Verification

- sibling message tests: 6/6 top-level matches passed
- changed collision detector tests: 6/6 top-level matches passed
- adjacent wake outbox tests: 27/27 top-level matches passed
- restored review regressions: 5/5 matched and passed
- original distinctness and strength mutants: applied=true, compiled, and killed by 1/1 matched test each
- coalesced retrieval, workflow typo guard, and request-bound mutants: applied=true, compiled with `go test -c -o /dev/null`, and killed by 1/1 matched test each
- full suite not run, per issue brief

Closes #1692