### PR TITLE
fix(execbackend): preflight configured local identity

### DIFF
--- a/docs/remote-exec.md
+++ b/docs/remote-exec.md
@@ -20,9 +20,9 @@ local_root = "/var/tmp/gitmoot-local"
 # credential_gateway_url = "https://broker.example.com:8443"
 ```
 
-`local` is the default and the only currently provisioned backend. `remote` is
-parseable, but its provider is not configured in this slice; unsupported routes
-refuse explicitly rather than falling back to host execution. For an
+`local` is the default. `remote` provisions E2B for engine-driven shell
+implement jobs; unsupported job types and model runtimes refuse before
+provider allocation. For an
 engine-driven daemon job, Gitmoot provisions one job-scoped instance, syncs the selected host
 checkout into a distinct detached Git worktree, streams runtime commands there,
 collects changes, and destroys the instance after the job. The same instance
@@ -61,6 +61,12 @@ traversable location and put that location first in the daemon's `PATH`; do not
 make `/root` traversable just to satisfy this requirement. An inaccessible
 runtime fails command startup rather than falling back to root.
 
+Runtime contract preflight evaluates UID-dependent requirements against
+`local_uid` when that identity is configured. This lets a root daemon dispatch
+Claude with `danger-full-access` to a non-root local backend without weakening
+Claude's root refusal. When `local_uid` is absent, preflight still evaluates the
+daemon identity, so the default root path remains refused.
+
 The local worktree's `.git` file points at an absolute gitdir in the source
 repository. That pointer resolves on the same filesystem, so `local` needs no
 bundle/base-ref hydration; hydration remains a remote-provider concern. Cancel
@@ -68,6 +74,38 @@ kills active command groups and destroys the instance. A restarted daemon reaps
 instances whose recorded owner process is gone. A partially-created non-empty
 directory that Git never registered remains the known orphaned-but-present
 cleanup limitation tracked in #1572.
+
+## Proving a Parallel Local Wave
+
+Run the proof with a dedicated `--home`; never point it at the live Gitmoot
+home. Keep the source checkout under a path the configured identity can
+traverse, set `backend = "local"`, and give every Claude leg a distinct
+`fresh:<suffix>` session:
+
+```sh
+gitmoot agent subscribe gate-a --runtime claude --session fresh:gate-a \
+  --role implementer --repo OWNER/REPO --policy danger-full-access \
+  --capability implement --home "$PROOF_HOME"
+gitmoot daemon run --repo OWNER/REPO --parallel 4 --poll 1s \
+  --home "$PROOF_HOME"
+gitmoot agent implement gate-a "record uid, gid, pwd, start, end, and visible markers" \
+  --repo OWNER/REPO --base HEAD --background --skip-native-review-fanout \
+  --home "$PROOF_HOME"
+```
+
+Dispatch the other legs together, not after the first settles. Every leg's
+`gitmoot_result` should include its UID, GID, workspace, start and end
+timestamps, and visible marker set in `summary`; its marker in `changes_made`;
+and the read-back and visibility checks in `tests_run`.
+
+The proof passes only when all of these are independently observed:
+
+- every runtime delivery returns a parsed `gitmoot_result`;
+- the reported UID/GID equal the configured non-root identity;
+- the intervals overlap with measured peak concurrency equal to the leg count;
+- every workspace path is distinct, and each leg sees only its own marker;
+- the isolated ledger contains zero remote execution attempts, and no E2B
+  credential or `remote` selector is present.
 
 Gitmoot reads `[remote_exec]` when it dispatches a job. Once the process starts
 a remote credential listener for a home, those listener coordinates are
@@ -104,5 +142,4 @@ an absent selector defaults to `local`, while `backend = ""` or an explicit
 Any value outside the allowed set (`local`, `remote`) **fails the job
 loudly at dispatch**: the failure names the offending value and the allowed
 set (for example `unknown execution backend "e2b" (allowed: local, remote)`).
-There is no silent fallback. Provider construction for `remote` lands in later
-phases of the parallel-isolated-execution epic (#1529).
+There is no silent fallback.

--- a/docs/remote-exec.md
+++ b/docs/remote-exec.md
@@ -61,11 +61,12 @@ traversable location and put that location first in the daemon's `PATH`; do not
 make `/root` traversable just to satisfy this requirement. An inaccessible
 runtime fails command startup rather than falling back to root.
 
-Runtime contract preflight evaluates UID-dependent requirements against
-`local_uid` when that identity is configured. This lets a root daemon dispatch
-Claude with `danger-full-access` to a non-root local backend without weakening
-Claude's root refusal. When `local_uid` is absent, preflight still evaluates the
-daemon identity, so the default root path remains refused.
+For daemon jobs that own an execution-backend lifecycle, runtime contract
+preflight evaluates UID-dependent requirements against configured `local_uid`.
+This lets a root daemon dispatch Claude with `danger-full-access` to a non-root
+local backend without weakening Claude's root refusal. Host-only paths such as
+`gitmoot job run` do not provision that lifecycle and still evaluate the host
+process identity. When `local_uid` is absent, daemon jobs do the same.
 
 The local worktree's `.git` file points at an absolute gitdir in the source
 repository. That pointer resolves on the same filesystem, so `local` needs no
@@ -86,8 +87,18 @@ traverse, set `backend = "local"`, and give every Claude leg a distinct
 gitmoot agent subscribe gate-a --runtime claude --session fresh:gate-a \
   --role implementer --repo OWNER/REPO --policy danger-full-access \
   --capability implement --home "$PROOF_HOME"
+```
+
+Keep the daemon running in its own shell:
+
+```sh
 gitmoot daemon run --repo OWNER/REPO --parallel 4 --poll 1s \
   --home "$PROOF_HOME"
+```
+
+From the dispatch shell, submit every leg together:
+
+```sh
 gitmoot agent implement gate-a "record uid, gid, pwd, start, end, and visible markers" \
   --repo OWNER/REPO --base HEAD --background --skip-native-review-fanout \
   --home "$PROOF_HOME"

--- a/internal/cli/agent_dispatch.go
+++ b/internal/cli/agent_dispatch.go
@@ -33,7 +33,8 @@ var localAgentDispatchRuntimeAdapterFor foregroundRuntimeAdapterFactory = func(h
 }
 
 var localAgentDispatchExecBackendFor = func(home string) (execbackend.Backend, error) {
-	return (jobWorker{ConfigHome: home, ConfigHomeExplicit: true}).resolveExecBackend("", false)
+	backend, _, err := (jobWorker{ConfigHome: home, ConfigHomeExplicit: true}).resolveExecBackend("", false)
+	return backend, err
 }
 
 func foregroundRuntimeAdapterFactoryFor(backend execbackend.Backend) (foregroundRuntimeAdapterFactory, error) {

--- a/internal/cli/daemon_worker.go
+++ b/internal/cli/daemon_worker.go
@@ -1037,6 +1037,16 @@ func (w jobWorker) runtimeContractPreflight(ctx context.Context, backend execbac
 	if w.RuntimePreflight == nil {
 		return runtime.RuntimeContractResult{}, false, nil
 	}
+	if backend == execbackend.Local {
+		cfg, err := w.executionBackendConfig()
+		if err != nil {
+			return runtime.RuntimeContractResult{}, false, err
+		}
+		if identity := cfg.LocalIdentity(); identity != nil {
+			request.EffectiveUID = int(identity.UID)
+			request.EffectiveUIDKnown = true
+		}
+	}
 	result, checked, err := runtimeContractPreflightForBackend(backend, func() runtime.RuntimeContractResult {
 		return w.RuntimePreflight(ctx, agent, request)
 	})

--- a/internal/cli/daemon_worker.go
+++ b/internal/cli/daemon_worker.go
@@ -55,8 +55,9 @@ type jobWorker struct {
 	// ExecutionBackendFactory is nil on hand-built/test workers that intentionally
 	// retain the pre-P2b host-only path. executionBackendJobWorker wires it for
 	// real daemon jobs, where one lifecycle instance is acquired after runtime
-	// admission and kept alive through every Mailbox delivery attempt.
-	ExecutionBackendFactory func(execbackend.Backend) (execbackend.ExecutionBackend, error)
+	// admission and kept alive through every Mailbox delivery attempt. The factory
+	// must consume the same config snapshot used for preflight.
+	ExecutionBackendFactory func(execbackend.Backend, config.RemoteExecConfig) (execbackend.ExecutionBackend, error)
 	// GITMOOT-IMPL: RemoteEnvdEndpointResolver is an offline-test seam. Production leaves it
 	// nil and resolves envd from [remote_exec].e2b_domain or the provider response.
 	RemoteEnvdEndpointResolver func(sandboxID string, port int) string
@@ -205,18 +206,20 @@ func executionBackendJobWorker(store *db.Store, stdout io.Writer, home string) j
 	// set stranded by a switch to remote, then reconcile the configured provider.
 	// The attempts are independent so a local disk failure cannot suppress remote
 	// account reconciliation (or vice versa).
-	startupBackends := []execbackend.Backend{execbackend.Local}
-	if cfg, err := worker.executionBackendConfig(); err != nil {
+	cfg, err := worker.executionBackendConfig()
+	if err != nil {
 		writeLine(stdout, "execution backend startup config failed: %v", err)
 		return worker
-	} else if configured, err := execbackend.ParseImplemented(cfg.Backend); err != nil {
+	}
+	startupBackends := []execbackend.Backend{execbackend.Local}
+	if configured, err := execbackend.ParseImplemented(cfg.Backend); err != nil {
 		writeLine(stdout, "execution backend startup config failed: %v", err)
 		return worker
 	} else if configured != execbackend.Local {
 		startupBackends = append(startupBackends, configured)
 	}
 	for _, backend := range startupBackends {
-		if _, err := worker.ExecutionBackendFactory(backend); err != nil {
+		if _, err := worker.ExecutionBackendFactory(backend, cfg); err != nil {
 			writeLine(stdout, "execution backend startup reap failed for %s: %v", backend, err)
 		}
 	}
@@ -235,7 +238,7 @@ func (w jobWorker) run(ctx context.Context, job db.Job) error {
 	// runtime below, so delaying this decision until after agent lookup would let
 	// them bypass the backend boundary entirely.
 	jobExecBackend, jobExecBackendPresent := payload.ExecBackendOverride()
-	execBackend, err := daemonJobExecBackendFor(w, jobExecBackend, jobExecBackendPresent)
+	execBackend, execConfig, err := daemonJobExecBackendFor(w, jobExecBackend, jobExecBackendPresent)
 	if err != nil {
 		if finishErr := w.finishQueuedJob(ctx, job, workflow.JobFailed, err); finishErr != nil {
 			return finishErr
@@ -348,7 +351,7 @@ func (w jobWorker) run(ctx context.Context, job db.Job) error {
 	// secondary adapter rebuild consumes the same backend selection.
 	agent.ExecBackend = string(execBackend)
 	preflightRequest := runtime.RuntimeContractRequest{Plan: payload.Plan}
-	if result, checked, preflightErr := w.runtimeContractPreflight(ctx, execBackend, agent, preflightRequest); preflightErr != nil {
+	if result, checked, preflightErr := w.runtimeContractPreflight(ctx, execBackend, execConfig, agent, preflightRequest); preflightErr != nil {
 		if finishErr := w.finishQueuedJob(ctx, job, workflow.JobFailed, preflightErr); finishErr != nil {
 			return finishErr
 		}
@@ -626,7 +629,7 @@ func (w jobWorker) run(ctx context.Context, job db.Job) error {
 	// delivery and is destroyed synchronously on every return path. Host checkout,
 	// git, observation, and finalization remain on checkout/jobRunner; only runtime
 	// delivery executes in the distinct backend workspace.
-	lifecycle, instance, credentialLease, credentialEnv, lifecycleErr := w.provisionExecutionBackend(ctx, execBackend, agent.Runtime, job, jobTimeout+runtimeLeaseTeardownGrace, checkout)
+	lifecycle, instance, credentialLease, credentialEnv, lifecycleErr := w.provisionExecutionBackend(ctx, execBackend, execConfig, agent.Runtime, job, jobTimeout+runtimeLeaseTeardownGrace, checkout)
 	if instance != nil {
 		defer w.destroyExecutionBackend(job.ID, lifecycle, instance)
 	}
@@ -1033,15 +1036,11 @@ func runtimeContractPreflightForBackend(backend execbackend.Backend, local func(
 	return consumed.contract, consumed.checked, err
 }
 
-func (w jobWorker) runtimeContractPreflight(ctx context.Context, backend execbackend.Backend, agent runtime.Agent, request runtime.RuntimeContractRequest) (runtime.RuntimeContractResult, bool, error) {
+func (w jobWorker) runtimeContractPreflight(ctx context.Context, backend execbackend.Backend, cfg config.RemoteExecConfig, agent runtime.Agent, request runtime.RuntimeContractRequest) (runtime.RuntimeContractResult, bool, error) {
 	if w.RuntimePreflight == nil {
 		return runtime.RuntimeContractResult{}, false, nil
 	}
-	if backend == execbackend.Local {
-		cfg, err := w.executionBackendConfig()
-		if err != nil {
-			return runtime.RuntimeContractResult{}, false, err
-		}
+	if backend == execbackend.Local && w.ExecutionBackendFactory != nil {
 		if identity := cfg.LocalIdentity(); identity != nil {
 			request.EffectiveUID = int(identity.UID)
 			request.EffectiveUIDKnown = true
@@ -1447,30 +1446,20 @@ func (w jobWorker) parallelSessionPolicy() (config.ParallelSessionPolicy, error)
 // plumbing. A missing config file or section resolves to local; an unknown
 // value (config or override) is a hard error naming the value and the allowed
 // set — the fail-loud contract, never a silent fallback.
-func (w jobWorker) resolveExecBackend(jobOverride string, jobOverridePresent bool) (execbackend.Backend, error) {
-	cfg := config.DefaultRemoteExecConfig()
-	if w.ConfigHomeExplicit || strings.TrimSpace(w.ConfigHome) != "" {
-		paths, err := w.configPaths()
-		if err != nil {
-			return "", err
-		}
-		loaded, loadErr := config.LoadRemoteExecConfig(paths)
-		switch {
-		case loadErr == nil:
-			cfg = loaded
-		case errors.Is(loadErr, os.ErrNotExist):
-			// No config file: the local default applies.
-		default:
-			return "", fmt.Errorf("load [remote_exec] config: %w", loadErr)
-		}
+func (w jobWorker) resolveExecBackend(jobOverride string, jobOverridePresent bool) (execbackend.Backend, config.RemoteExecConfig, error) {
+	cfg, err := w.executionBackendConfig()
+	if err != nil {
+		return "", config.RemoteExecConfig{}, err
 	}
 	if jobOverridePresent {
-		return execbackend.Resolve(cfg.Backend, &jobOverride)
+		backend, err := execbackend.Resolve(cfg.Backend, &jobOverride)
+		return backend, cfg, err
 	}
-	return execbackend.Resolve(cfg.Backend, nil)
+	backend, err := execbackend.Resolve(cfg.Backend, nil)
+	return backend, cfg, err
 }
 
-var daemonJobExecBackendFor = func(w jobWorker, jobOverride string, jobOverridePresent bool) (execbackend.Backend, error) {
+var daemonJobExecBackendFor = func(w jobWorker, jobOverride string, jobOverridePresent bool) (execbackend.Backend, config.RemoteExecConfig, error) {
 	return w.resolveExecBackend(jobOverride, jobOverridePresent)
 }
 
@@ -2915,7 +2904,7 @@ func (w jobWorker) advanceJob(ctx context.Context, job db.Job) error {
 	}
 	agent := runtimeAgent(dbAgent)
 	jobBackend, jobBackendPresent := payload.ExecBackendOverride()
-	backend, err := daemonJobExecBackendFor(w, jobBackend, jobBackendPresent)
+	backend, _, err := daemonJobExecBackendFor(w, jobBackend, jobBackendPresent)
 	if err != nil {
 		return w.recordAdvanceRetryOnce(ctx, job.ID, "post-delivery workflow retry backend resolution failed: "+err.Error())
 	}

--- a/internal/cli/execbackend_credentials.go
+++ b/internal/cli/execbackend_credentials.go
@@ -33,7 +33,7 @@ type remoteCredentialGatewayPlan struct {
 // prepareRemoteCredentialGateway performs every check that can fail before a
 // billed sandbox exists. It starts only the host listener and does not read the
 // upstream provider credential.
-func (w jobWorker) prepareRemoteCredentialGateway(ttl time.Duration) (remoteCredentialGatewayPlan, error) {
+func (w jobWorker) prepareRemoteCredentialGateway(remoteCfg config.RemoteExecConfig, ttl time.Duration) (remoteCredentialGatewayPlan, error) {
 	paths, err := w.configPaths()
 	if err != nil {
 		return remoteCredentialGatewayPlan{}, err
@@ -47,10 +47,6 @@ func (w jobWorker) prepareRemoteCredentialGateway(ttl time.Duration) (remoteCred
 	}
 	if !credentialsCfg.ModelGateway {
 		return remoteCredentialGatewayPlan{}, nil
-	}
-	remoteCfg, err := w.executionBackendConfig()
-	if err != nil {
-		return remoteCredentialGatewayPlan{}, err
 	}
 	if strings.TrimSpace(remoteCfg.CredentialGatewayListen) == "" || strings.TrimSpace(remoteCfg.CredentialGatewayURL) == "" {
 		return remoteCredentialGatewayPlan{}, errors.New("remote model gateway requires [remote_exec].credential_gateway_listen and credential_gateway_url")

--- a/internal/cli/execbackend_credentials_test.go
+++ b/internal/cli/execbackend_credentials_test.go
@@ -94,9 +94,11 @@ credential_gateway_url = %q
 	lifecycle := &credentialRevokingExecutionBackend{inner: inner, home: paths.Home}
 	worker := jobWorker{
 		ConfigHome: baseHome, ConfigHomeExplicit: true,
-		ExecutionBackendFactory: func(execbackend.Backend) (execbackend.ExecutionBackend, error) { return lifecycle, nil },
+		ExecutionBackendFactory: func(_ execbackend.Backend, _ config.RemoteExecConfig) (execbackend.ExecutionBackend, error) {
+			return lifecycle, nil
+		},
 	}
-	gotLifecycle, instance, lease, env, err := worker.provisionExecutionBackend(context.Background(), execbackend.Remote, runtime.ShellRuntime, db.Job{ID: "job-brokered"}, time.Minute, "/checkout")
+	gotLifecycle, instance, lease, env, err := worker.provisionExecutionBackend(context.Background(), execbackend.Remote, executionBackendConfigForTest(t, worker), runtime.ShellRuntime, db.Job{ID: "job-brokered"}, time.Minute, "/checkout")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -205,11 +207,11 @@ credential_gateway_url = %q
 
 func TestRemoteModelRuntimeRefusesBeforeProviderSpend(t *testing.T) {
 	var factoryCalls atomic.Int32
-	worker := jobWorker{ExecutionBackendFactory: func(execbackend.Backend) (execbackend.ExecutionBackend, error) {
+	worker := jobWorker{ExecutionBackendFactory: func(_ execbackend.Backend, _ config.RemoteExecConfig) (execbackend.ExecutionBackend, error) {
 		factoryCalls.Add(1)
 		return nil, errors.New("must not construct")
 	}}
-	_, instance, lease, env, err := worker.provisionExecutionBackend(context.Background(), execbackend.Remote, runtime.ClaudeRuntime, db.Job{ID: "job-no-fallback"}, time.Minute, "/checkout")
+	_, instance, lease, env, err := worker.provisionExecutionBackend(context.Background(), execbackend.Remote, executionBackendConfigForTest(t, worker), runtime.ClaudeRuntime, db.Job{ID: "job-no-fallback"}, time.Minute, "/checkout")
 	if err == nil || !strings.Contains(err.Error(), "raw-key fallback is forbidden") || instance != nil || lease != nil || len(env) != 0 || factoryCalls.Load() != 0 {
 		t.Fatalf("refusal instance=%+v lease=%v env=%v factory=%d err=%v", instance, lease, env, factoryCalls.Load(), err)
 	}
@@ -253,12 +255,12 @@ e2b_template = "template-test"
 			var factoryCalls atomic.Int32
 			worker := jobWorker{
 				ConfigHome: baseHome, ConfigHomeExplicit: true,
-				ExecutionBackendFactory: func(execbackend.Backend) (execbackend.ExecutionBackend, error) {
+				ExecutionBackendFactory: func(_ execbackend.Backend, _ config.RemoteExecConfig) (execbackend.ExecutionBackend, error) {
 					factoryCalls.Add(1)
 					return nil, errors.New("must not construct")
 				},
 			}
-			_, instance, lease, env, err := worker.provisionExecutionBackend(context.Background(), execbackend.Remote, runtime.ShellRuntime, db.Job{ID: "job-invalid-gateway"}, time.Minute, "/checkout")
+			_, instance, lease, env, err := worker.provisionExecutionBackend(context.Background(), execbackend.Remote, executionBackendConfigForTest(t, worker), runtime.ShellRuntime, db.Job{ID: "job-invalid-gateway"}, time.Minute, "/checkout")
 			if err == nil || !strings.Contains(err.Error(), test.wantErrorContains) || instance != nil || lease != nil || len(env) != 0 || factoryCalls.Load() != 0 {
 				t.Fatalf("preflight instance=%+v lease=%v env=%v factory=%d err=%v", instance, lease, env, factoryCalls.Load(), err)
 			}

--- a/internal/cli/execbackend_e2e_test.go
+++ b/internal/cli/execbackend_e2e_test.go
@@ -335,8 +335,8 @@ func TestExecBackendResolvedNonLocalCannotRunLocallyDaemonE2E(t *testing.T) {
 	jobID := execBackendDispatchImplement(t, store)
 
 	previousResolver := daemonJobExecBackendFor
-	daemonJobExecBackendFor = func(jobWorker, string, bool) (execbackend.Backend, error) {
-		return execbackend.Backend("p2-probe"), nil
+	daemonJobExecBackendFor = func(jobWorker, string, bool) (execbackend.Backend, config.RemoteExecConfig, error) {
+		return execbackend.Backend("p2-probe"), config.DefaultRemoteExecConfig(), nil
 	}
 	t.Cleanup(func() { daemonJobExecBackendFor = previousResolver })
 
@@ -411,10 +411,10 @@ func TestP2GapEveryJobSubprocessRouteRefusesLocalFallback(t *testing.T) {
 	previousResolver := daemonJobExecBackendFor
 	var resolvedName string
 	var resolvedPresent bool
-	daemonJobExecBackendFor = func(_ jobWorker, name string, present bool) (execbackend.Backend, error) {
+	daemonJobExecBackendFor = func(_ jobWorker, name string, present bool) (execbackend.Backend, config.RemoteExecConfig, error) {
 		resolvedName = name
 		resolvedPresent = present
-		return backend, nil
+		return backend, config.DefaultRemoteExecConfig(), nil
 	}
 	t.Cleanup(func() { daemonJobExecBackendFor = previousResolver })
 
@@ -540,10 +540,10 @@ func TestP2GapSupervisorAdvanceResolvesJobSubprocessRunner(t *testing.T) {
 	previousResolver := daemonJobExecBackendFor
 	var resolvedName string
 	var resolvedPresent bool
-	daemonJobExecBackendFor = func(_ jobWorker, name string, present bool) (execbackend.Backend, error) {
+	daemonJobExecBackendFor = func(_ jobWorker, name string, present bool) (execbackend.Backend, config.RemoteExecConfig, error) {
 		resolvedName = name
 		resolvedPresent = present
-		return execbackend.Backend("p2-probe"), nil
+		return execbackend.Backend("p2-probe"), config.DefaultRemoteExecConfig(), nil
 	}
 	t.Cleanup(func() { daemonJobExecBackendFor = previousResolver })
 
@@ -569,10 +569,10 @@ func TestP2GapSingleRepoSupervisorAdvanceResolvesJobSubprocessRunner(t *testing.
 	previousResolver := daemonJobExecBackendFor
 	var resolvedName string
 	var resolvedPresent bool
-	daemonJobExecBackendFor = func(_ jobWorker, name string, present bool) (execbackend.Backend, error) {
+	daemonJobExecBackendFor = func(_ jobWorker, name string, present bool) (execbackend.Backend, config.RemoteExecConfig, error) {
 		resolvedName = name
 		resolvedPresent = present
-		return execbackend.Backend("p2-probe"), nil
+		return execbackend.Backend("p2-probe"), config.DefaultRemoteExecConfig(), nil
 	}
 	t.Cleanup(func() { daemonJobExecBackendFor = previousResolver })
 
@@ -849,7 +849,7 @@ func TestRemoteBackendRefusesEveryHostOnlyRoute(t *testing.T) {
 	// GITMOOT-IMPL: Slice D converts only the configured lifecycle route; an
 	// unconfigured remote backend must still refuse before provider construction.
 	t.Run("lifecycle provider requires credential config", func(t *testing.T) {
-		if _, err := worker.defaultExecutionBackend(execbackend.Remote); err == nil || !strings.Contains(err.Error(), "e2b_api_key_file is required") {
+		if _, err := worker.defaultExecutionBackend(execbackend.Remote, executionBackendConfigForTest(t, worker)); err == nil || !strings.Contains(err.Error(), "e2b_api_key_file is required") {
 			t.Fatalf("remote lifecycle error = %v, want credential-config refusal", err)
 		}
 	})
@@ -964,8 +964,8 @@ func TestExecBackendEphemeralResolvesBeforeRuntimeStart(t *testing.T) {
 	})
 
 	previousResolver := daemonJobExecBackendFor
-	daemonJobExecBackendFor = func(jobWorker, string, bool) (execbackend.Backend, error) {
-		return "", errors.New("backend preflight refused")
+	daemonJobExecBackendFor = func(jobWorker, string, bool) (execbackend.Backend, config.RemoteExecConfig, error) {
+		return "", config.RemoteExecConfig{}, errors.New("backend preflight refused")
 	}
 	t.Cleanup(func() { daemonJobExecBackendFor = previousResolver })
 

--- a/internal/cli/execbackend_ledger_test.go
+++ b/internal/cli/execbackend_ledger_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/gitmoot/gitmoot/internal/config"
 	"github.com/gitmoot/gitmoot/internal/db"
 	"github.com/gitmoot/gitmoot/internal/db/dbtest"
 	"github.com/gitmoot/gitmoot/internal/execbackend"
@@ -30,10 +31,10 @@ func TestProvisionExecutionBackendPreservesInstanceOnProvisionError(t *testing.T
 	inner := &ledgerTestBackend{provision: func(execbackend.JobScope) (*execbackend.Instance, error) {
 		return instance, errors.New("persist running row")
 	}}
-	worker := jobWorker{ExecutionBackendFactory: func(execbackend.Backend) (execbackend.ExecutionBackend, error) {
+	worker := jobWorker{ExecutionBackendFactory: func(_ execbackend.Backend, _ config.RemoteExecConfig) (execbackend.ExecutionBackend, error) {
 		return inner, nil
 	}}
-	lifecycle, got, lease, env, err := worker.provisionExecutionBackend(context.Background(), execbackend.Remote, "shell", db.Job{ID: instance.JobID}, time.Minute, "/checkout")
+	lifecycle, got, lease, env, err := worker.provisionExecutionBackend(context.Background(), execbackend.Remote, executionBackendConfigForTest(t, worker), "shell", db.Job{ID: instance.JobID}, time.Minute, "/checkout")
 	if err == nil || !strings.Contains(err.Error(), "persist running row") {
 		t.Fatalf("provision error = %v", err)
 	}

--- a/internal/cli/execbackend_lifecycle.go
+++ b/internal/cli/execbackend_lifecycle.go
@@ -31,15 +31,11 @@ var reapedExecutionBackendRoots sync.Map
 
 var executionBackendFencingToken = sync.OnceValues(newRuntimeLockOwnerToken)
 
-func (w jobWorker) defaultExecutionBackend(backend execbackend.Backend) (execbackend.ExecutionBackend, error) {
+func (w jobWorker) defaultExecutionBackend(backend execbackend.Backend, cfg config.RemoteExecConfig) (execbackend.ExecutionBackend, error) {
 	return execbackend.Consume(backend, func() (execbackend.ExecutionBackend, error) {
 		home := strings.TrimSpace(w.workflowHome())
 		if home == "" {
 			return nil, errors.New("resolve local execution-backend home")
-		}
-		cfg, err := w.executionBackendConfig()
-		if err != nil {
-			return nil, err
 		}
 		root := filepath.Join(home, "execbackends", string(execbackend.Local))
 		if cfg.LocalRoot != "" {
@@ -62,10 +58,6 @@ func (w jobWorker) defaultExecutionBackend(backend execbackend.Backend) (execbac
 		}
 		return local, nil
 	}, func() (execbackend.ExecutionBackend, error) {
-		cfg, err := w.executionBackendConfig()
-		if err != nil {
-			return nil, err
-		}
 		if err := cfg.ValidateE2BProvider(); err != nil {
 			return nil, err
 		}
@@ -142,7 +134,7 @@ func (w jobWorker) executionBackendConfig() (config.RemoteExecConfig, error) {
 	}
 }
 
-func (w jobWorker) provisionExecutionBackend(ctx context.Context, backend execbackend.Backend, runtimeName string, job db.Job, ttl time.Duration, checkout string) (execbackend.ExecutionBackend, *execbackend.Instance, *credgw.Lease, []string, error) {
+func (w jobWorker) provisionExecutionBackend(ctx context.Context, backend execbackend.Backend, cfg config.RemoteExecConfig, runtimeName string, job db.Job, ttl time.Duration, checkout string) (execbackend.ExecutionBackend, *execbackend.Instance, *credgw.Lease, []string, error) {
 	if w.ExecutionBackendFactory == nil {
 		return nil, nil, nil, nil, nil
 	}
@@ -152,12 +144,12 @@ func (w jobWorker) provisionExecutionBackend(ctx context.Context, backend execba
 	var credentialPlan remoteCredentialGatewayPlan
 	if backend == execbackend.Remote {
 		var err error
-		credentialPlan, err = w.prepareRemoteCredentialGateway(ttl)
+		credentialPlan, err = w.prepareRemoteCredentialGateway(cfg, ttl)
 		if err != nil {
 			return nil, nil, nil, nil, err
 		}
 	}
-	lifecycle, err := w.ExecutionBackendFactory(backend)
+	lifecycle, err := w.ExecutionBackendFactory(backend, cfg)
 	if err != nil {
 		return nil, nil, nil, nil, fmt.Errorf("construct %s execution backend: %w", backend, err)
 	}

--- a/internal/cli/execbackend_lifecycle_e2e_test.go
+++ b/internal/cli/execbackend_lifecycle_e2e_test.go
@@ -77,16 +77,23 @@ func (*localProvisionBackend) Destroy(context.Context, *execbackend.Instance) er
 
 func TestProvisionExecutionBackendLocalBehaviorUnchanged(t *testing.T) {
 	backend := &localProvisionBackend{}
-	worker := jobWorker{ExecutionBackendFactory: func(got execbackend.Backend) (execbackend.ExecutionBackend, error) {
+	uid, gid := uint32(996), uint32(986)
+	cfg := config.DefaultRemoteExecConfig()
+	cfg.LocalUID, cfg.LocalGID = &uid, &gid
+	worker := jobWorker{ExecutionBackendFactory: func(got execbackend.Backend, gotCfg config.RemoteExecConfig) (execbackend.ExecutionBackend, error) {
 		if got != execbackend.Local {
 			t.Fatalf("factory backend = %q, want %q", got, execbackend.Local)
+		}
+		identity := gotCfg.LocalIdentity()
+		if identity == nil || identity.UID != uid || identity.GID != gid {
+			t.Fatalf("factory config identity = %+v, want uid %d gid %d", identity, uid, gid)
 		}
 		return backend, nil
 	}}
 	job := db.Job{ID: "local-credential-gate", LifecycleGeneration: 4}
 
 	const ttl = 9 * time.Minute
-	lifecycle, instance, lease, env, err := worker.provisionExecutionBackend(context.Background(), execbackend.Local, runtime.ShellRuntime, job, ttl, "/checkout")
+	lifecycle, instance, lease, env, err := worker.provisionExecutionBackend(context.Background(), execbackend.Local, cfg, runtime.ShellRuntime, job, ttl, "/checkout")
 	if err != nil {
 		t.Fatalf("provisionExecutionBackend(local): %v", err)
 	}
@@ -198,7 +205,13 @@ func TestDefaultExecutionBackendUsesConfiguredIdentity(t *testing.T) {
 	}
 
 	worker := jobWorker{ConfigHome: home, ConfigHomeExplicit: true}
-	lifecycle, err := worker.defaultExecutionBackend(execbackend.Local)
+	cfg := executionBackendConfigForTest(t, worker)
+	// Delivery must consume the resolved snapshot, not re-read a config that may
+	// change after preflight and select a different execution identity.
+	if err := os.WriteFile(paths.ConfigFile, []byte("[remote_exec]\nbackend = \"local\"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	lifecycle, err := worker.defaultExecutionBackend(execbackend.Local, cfg)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -224,20 +237,30 @@ func TestDefaultExecutionBackendUsesConfiguredIdentity(t *testing.T) {
 	}
 }
 
-func TestRuntimeContractPreflightUsesExecutionIdentityOnlyWhenConfigured(t *testing.T) {
+func TestRuntimeContractPreflightUsesConfiguredExecutionIdentityOnlyForLifecycleDelivery(t *testing.T) {
+	const configured = "[remote_exec]\nbackend = \"local\"\nlocal_uid = 996\nlocal_gid = 986\nlocal_root = \"/var/tmp/gitmoot-local\"\n"
 	tests := []struct {
-		name      string
-		config    string
-		wantUID   int
-		wantKnown bool
+		name          string
+		config        string
+		withLifecycle bool
+		wantUID       int
+		wantKnown     bool
 	}{
 		{
-			name:      "configured non-root identity",
-			config:    "[remote_exec]\nbackend = \"local\"\nlocal_uid = 996\nlocal_gid = 986\nlocal_root = \"/var/tmp/gitmoot-local\"\n",
-			wantUID:   996,
-			wantKnown: true,
+			name:          "configured identity with lifecycle delivery",
+			config:        configured,
+			withLifecycle: true,
+			wantUID:       996,
+			wantKnown:     true,
 		},
-		{name: "default daemon identity"},
+		{
+			name:   "configured identity without lifecycle delivery",
+			config: configured,
+		},
+		{
+			name:          "default daemon identity with lifecycle delivery",
+			withLifecycle: true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -263,7 +286,13 @@ func TestRuntimeContractPreflightUsesExecutionIdentityOnlyWhenConfigured(t *test
 					return runtime.RuntimeContractResult{State: runtime.RuntimeContractSupported}
 				},
 			}
-			_, checked, err := worker.runtimeContractPreflight(context.Background(), execbackend.Local, runtime.Agent{}, runtime.RuntimeContractRequest{})
+			if tt.withLifecycle {
+				worker.ExecutionBackendFactory = func(execbackend.Backend, config.RemoteExecConfig) (execbackend.ExecutionBackend, error) {
+					return nil, nil
+				}
+			}
+			cfg := executionBackendConfigForTest(t, worker)
+			_, checked, err := worker.runtimeContractPreflight(context.Background(), execbackend.Local, cfg, runtime.Agent{}, runtime.RuntimeContractRequest{})
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -272,6 +301,15 @@ func TestRuntimeContractPreflightUsesExecutionIdentityOnlyWhenConfigured(t *test
 			}
 		})
 	}
+}
+
+func executionBackendConfigForTest(t *testing.T, worker jobWorker) config.RemoteExecConfig {
+	t.Helper()
+	cfg, err := worker.executionBackendConfig()
+	if err != nil {
+		t.Fatal(err)
+	}
+	return cfg
 }
 
 func configuredLocalTestIdentity(t *testing.T) (uint32, uint32) {
@@ -987,7 +1025,7 @@ func TestExecutionBackendJobWorkerReportsAndRetriesRemoteStartupReapFailure(t *t
 	if !strings.Contains(output.String(), "execution backend startup reap failed for remote: reap remote execution backends") {
 		t.Fatalf("startup output = %q, want loud remote reap failure", output.String())
 	}
-	if _, err := worker.ExecutionBackendFactory(execbackend.Remote); err == nil || !strings.Contains(err.Error(), "reap remote execution backends") {
+	if _, err := worker.ExecutionBackendFactory(execbackend.Remote, executionBackendConfigForTest(t, worker)); err == nil || !strings.Contains(err.Error(), "reap remote execution backends") {
 		t.Fatalf("retry remote startup reap error = %v, want loud reconciliation failure", err)
 	}
 	_, _, listCalls, _, _ := harness.snapshot()
@@ -1032,7 +1070,7 @@ func TestRemoteExecutionBackendRefusesNonImplementBeforeProvision(t *testing.T) 
 	}
 	factoryCalls := 0
 	worker := defaultJobWorker(store, io.Discard, home)
-	worker.ExecutionBackendFactory = func(execbackend.Backend) (execbackend.ExecutionBackend, error) {
+	worker.ExecutionBackendFactory = func(_ execbackend.Backend, _ config.RemoteExecConfig) (execbackend.ExecutionBackend, error) {
 		factoryCalls++
 		return nil, errors.New("factory must not be called")
 	}

--- a/internal/cli/execbackend_lifecycle_e2e_test.go
+++ b/internal/cli/execbackend_lifecycle_e2e_test.go
@@ -224,6 +224,56 @@ func TestDefaultExecutionBackendUsesConfiguredIdentity(t *testing.T) {
 	}
 }
 
+func TestRuntimeContractPreflightUsesExecutionIdentityOnlyWhenConfigured(t *testing.T) {
+	tests := []struct {
+		name      string
+		config    string
+		wantUID   int
+		wantKnown bool
+	}{
+		{
+			name:      "configured non-root identity",
+			config:    "[remote_exec]\nbackend = \"local\"\nlocal_uid = 996\nlocal_gid = 986\nlocal_root = \"/var/tmp/gitmoot-local\"\n",
+			wantUID:   996,
+			wantKnown: true,
+		},
+		{name: "default daemon identity"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			home := t.TempDir()
+			if tt.config != "" {
+				paths := config.PathsForHome(home)
+				if err := os.MkdirAll(filepath.Dir(paths.ConfigFile), 0o700); err != nil {
+					t.Fatal(err)
+				}
+				if err := os.WriteFile(paths.ConfigFile, []byte(tt.config), 0o600); err != nil {
+					t.Fatal(err)
+				}
+			}
+			calls := 0
+			worker := jobWorker{
+				ConfigHome:         home,
+				ConfigHomeExplicit: true,
+				RuntimePreflight: func(_ context.Context, _ runtime.Agent, request runtime.RuntimeContractRequest) runtime.RuntimeContractResult {
+					calls++
+					if request.EffectiveUIDKnown != tt.wantKnown || request.EffectiveUID != tt.wantUID {
+						t.Fatalf("runtime preflight effective uid = %d known %t, want %d known %t", request.EffectiveUID, request.EffectiveUIDKnown, tt.wantUID, tt.wantKnown)
+					}
+					return runtime.RuntimeContractResult{State: runtime.RuntimeContractSupported}
+				},
+			}
+			_, checked, err := worker.runtimeContractPreflight(context.Background(), execbackend.Local, runtime.Agent{}, runtime.RuntimeContractRequest{})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !checked || calls != 1 {
+				t.Fatalf("runtime preflight = checked %t calls %d, want checked with one call", checked, calls)
+			}
+		})
+	}
+}
+
 func configuredLocalTestIdentity(t *testing.T) (uint32, uint32) {
 	t.Helper()
 	data, err := os.ReadFile("/etc/passwd")

--- a/internal/cli/execbackend_subprocess.go
+++ b/internal/cli/execbackend_subprocess.go
@@ -26,7 +26,7 @@ func (w jobWorker) subprocessRunnerForJob(job db.Job) (subprocess.Runner, error)
 		return nil, err
 	}
 	name, present := payload.ExecBackendOverride()
-	backend, err := daemonJobExecBackendFor(w, name, present)
+	backend, _, err := daemonJobExecBackendFor(w, name, present)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/cli/job_blocker_auth_probe.go
+++ b/internal/cli/job_blocker_auth_probe.go
@@ -160,7 +160,7 @@ func (w jobWorker) defaultAuthProbe(ctx context.Context, job db.Job, payload wor
 		return authProbeUnknown
 	}
 	jobBackend, jobBackendPresent := payload.ExecBackendOverride()
-	backend, err := daemonJobExecBackendFor(w, jobBackend, jobBackendPresent)
+	backend, _, err := daemonJobExecBackendFor(w, jobBackend, jobBackendPresent)
 	if err != nil {
 		// run() owns the loud terminal selector failure. This scheduler gate is
 		// advisory; an unresolved backend must not launch a host probe, and Unknown

--- a/internal/cli/runtime_preflight_e2e_test.go
+++ b/internal/cli/runtime_preflight_e2e_test.go
@@ -79,6 +79,60 @@ func TestRuntimePreflightStubBinaryE2E(t *testing.T) {
 	})
 }
 
+func TestRuntimePreflightDefaultWorkerDoesNotAssumeConfiguredExecutionIdentity(t *testing.T) {
+	rawHome := t.TempDir()
+	paths, err := pathsFromFlag(rawHome)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(paths.Home, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(paths.ConfigFile, []byte("[remote_exec]\nbackend = \"local\"\nlocal_uid = 996\nlocal_gid = 986\nlocal_root = \"/var/tmp/gitmoot-local\"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	store, err := dbtest.Open(t, paths.Database)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+	checkout := createDaemonWorkerGitCheckout(t, "host-only-preflight")
+	seedDaemonWorkerRepo(t, store, "owner/repo", checkout)
+	seedDaemonWorkerAgentWithPolicy(t, store, "root-claude", runtime.ClaudeRuntime, "fresh:host-only", []string{"implement"}, "owner/repo", runtime.AutonomyPolicyDangerFullAccess)
+	const jobID = "host-only-preflight"
+	enqueueDaemonWorkerJob(t, store, workflow.JobRequest{ID: jobID, Agent: "root-claude", Action: "implement", Repo: "owner/repo", Branch: "main"})
+
+	preflightCalls := 0
+	worker := defaultJobWorker(store, io.Discard, rawHome)
+	worker.RuntimePreflight = func(_ context.Context, agent runtime.Agent, request runtime.RuntimeContractRequest) runtime.RuntimeContractResult {
+		preflightCalls++
+		if request.EffectiveUIDKnown {
+			t.Fatalf("host-only worker preflight received execution uid %d", request.EffectiveUID)
+		}
+		return runtime.RuntimeContractResult{
+			Runtime: agent.Runtime, State: runtime.RuntimeContractUnsupported, Instrument: "effective-uid",
+			Requirements: []runtime.RuntimeRequirementResult{{
+				Kind: runtime.RuntimeRequirementNonRootEUID, Name: "effective uid must be non-root",
+				Remedy: "run as non-root", State: runtime.RuntimeContractUnsupported, Instrument: "effective-uid",
+			}},
+		}
+	}
+	job, err := store.GetJob(context.Background(), jobID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := worker.run(context.Background(), job); err != nil {
+		t.Fatal(err)
+	}
+	completed, err := store.GetJob(context.Background(), jobID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if preflightCalls != 1 || completed.State != string(workflow.JobBlocked) {
+		t.Fatalf("host-only preflight calls = %d, job state = %q; want one call and blocked", preflightCalls, completed.State)
+	}
+}
+
 func writeRuntimePreflightStub(t *testing.T, path, mode string) {
 	t.Helper()
 	help := "Usage: kimi [options]\\n  --print\\n  -p, --prompt\\n  --output-format\\n"

--- a/internal/cli/runtime_preflight_e2e_test.go
+++ b/internal/cli/runtime_preflight_e2e_test.go
@@ -80,6 +80,56 @@ func TestRuntimePreflightStubBinaryE2E(t *testing.T) {
 }
 
 func TestRuntimePreflightDefaultWorkerDoesNotAssumeConfiguredExecutionIdentity(t *testing.T) {
+	rawHome, store, job := configuredClaudePreflightJob(t, "host-only-preflight")
+
+	preflightCalls := 0
+	worker := defaultJobWorker(store, io.Discard, rawHome)
+	worker.RuntimePreflight = func(_ context.Context, agent runtime.Agent, request runtime.RuntimeContractRequest) runtime.RuntimeContractResult {
+		preflightCalls++
+		if request.EffectiveUIDKnown {
+			t.Fatalf("host-only worker preflight received execution uid %d", request.EffectiveUID)
+		}
+		return unsupportedEffectiveUIDPreflight(agent)
+	}
+	if err := worker.run(context.Background(), job); err != nil {
+		t.Fatal(err)
+	}
+	completed, err := store.GetJob(context.Background(), job.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if preflightCalls != 1 || completed.State != string(workflow.JobBlocked) {
+		t.Fatalf("host-only preflight calls = %d, job state = %q; want one call and blocked", preflightCalls, completed.State)
+	}
+}
+
+func TestRuntimePreflightLifecycleWorkerUsesConfiguredExecutionIdentity(t *testing.T) {
+	rawHome, store, job := configuredClaudePreflightJob(t, "lifecycle-preflight")
+
+	preflightCalls := 0
+	worker := defaultJobWorker(store, io.Discard, rawHome)
+	worker.ExecutionBackendFactory = worker.defaultExecutionBackend
+	worker.RuntimePreflight = func(_ context.Context, agent runtime.Agent, request runtime.RuntimeContractRequest) runtime.RuntimeContractResult {
+		preflightCalls++
+		if !request.EffectiveUIDKnown || request.EffectiveUID != 996 {
+			t.Fatalf("lifecycle worker preflight effective uid = %d known %t, want 996 known", request.EffectiveUID, request.EffectiveUIDKnown)
+		}
+		return unsupportedEffectiveUIDPreflight(agent)
+	}
+	if err := worker.run(context.Background(), job); err != nil {
+		t.Fatal(err)
+	}
+	completed, err := store.GetJob(context.Background(), job.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if preflightCalls != 1 || completed.State != string(workflow.JobBlocked) {
+		t.Fatalf("lifecycle preflight calls = %d, job state = %q; want one call and blocked", preflightCalls, completed.State)
+	}
+}
+
+func configuredClaudePreflightJob(t *testing.T, jobID string) (string, *db.Store, db.Job) {
+	t.Helper()
 	rawHome := t.TempDir()
 	paths, err := pathsFromFlag(rawHome)
 	if err != nil {
@@ -96,40 +146,24 @@ func TestRuntimePreflightDefaultWorkerDoesNotAssumeConfiguredExecutionIdentity(t
 		t.Fatal(err)
 	}
 	t.Cleanup(func() { _ = store.Close() })
-	checkout := createDaemonWorkerGitCheckout(t, "host-only-preflight")
+	checkout := createDaemonWorkerGitCheckout(t, jobID)
 	seedDaemonWorkerRepo(t, store, "owner/repo", checkout)
-	seedDaemonWorkerAgentWithPolicy(t, store, "root-claude", runtime.ClaudeRuntime, "fresh:host-only", []string{"implement"}, "owner/repo", runtime.AutonomyPolicyDangerFullAccess)
-	const jobID = "host-only-preflight"
+	seedDaemonWorkerAgentWithPolicy(t, store, "root-claude", runtime.ClaudeRuntime, "fresh:"+jobID, []string{"implement"}, "owner/repo", runtime.AutonomyPolicyDangerFullAccess)
 	enqueueDaemonWorkerJob(t, store, workflow.JobRequest{ID: jobID, Agent: "root-claude", Action: "implement", Repo: "owner/repo", Branch: "main"})
-
-	preflightCalls := 0
-	worker := defaultJobWorker(store, io.Discard, rawHome)
-	worker.RuntimePreflight = func(_ context.Context, agent runtime.Agent, request runtime.RuntimeContractRequest) runtime.RuntimeContractResult {
-		preflightCalls++
-		if request.EffectiveUIDKnown {
-			t.Fatalf("host-only worker preflight received execution uid %d", request.EffectiveUID)
-		}
-		return runtime.RuntimeContractResult{
-			Runtime: agent.Runtime, State: runtime.RuntimeContractUnsupported, Instrument: "effective-uid",
-			Requirements: []runtime.RuntimeRequirementResult{{
-				Kind: runtime.RuntimeRequirementNonRootEUID, Name: "effective uid must be non-root",
-				Remedy: "run as non-root", State: runtime.RuntimeContractUnsupported, Instrument: "effective-uid",
-			}},
-		}
-	}
 	job, err := store.GetJob(context.Background(), jobID)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := worker.run(context.Background(), job); err != nil {
-		t.Fatal(err)
-	}
-	completed, err := store.GetJob(context.Background(), jobID)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if preflightCalls != 1 || completed.State != string(workflow.JobBlocked) {
-		t.Fatalf("host-only preflight calls = %d, job state = %q; want one call and blocked", preflightCalls, completed.State)
+	return rawHome, store, job
+}
+
+func unsupportedEffectiveUIDPreflight(agent runtime.Agent) runtime.RuntimeContractResult {
+	return runtime.RuntimeContractResult{
+		Runtime: agent.Runtime, State: runtime.RuntimeContractUnsupported, Instrument: "effective-uid",
+		Requirements: []runtime.RuntimeRequirementResult{{
+			Kind: runtime.RuntimeRequirementNonRootEUID, Name: "effective uid must be non-root",
+			Remedy: "run as non-root", State: runtime.RuntimeContractUnsupported, Instrument: "effective-uid",
+		}},
 	}
 }
 

--- a/internal/runtime/preflight.go
+++ b/internal/runtime/preflight.go
@@ -54,11 +54,16 @@ type RuntimeContract struct {
 	Requirements []RuntimeRequirement
 }
 
-// RuntimeContractRequest carries only request-scoped axes that select adapter
-// argv requirements. It is deliberately not runtime.Job: constructing the job
-// delivered to an adapter remains the mailbox gate's single responsibility.
+// RuntimeContractRequest carries request-scoped axes used to evaluate adapter
+// requirements before delivery. It is deliberately not runtime.Job:
+// constructing the delivered job remains the mailbox gate's responsibility.
 type RuntimeContractRequest struct {
 	Plan bool
+	// EffectiveUIDKnown means the delivery target will run with EffectiveUID
+	// instead of the checker process identity. Only the resolved execution
+	// backend may set this override.
+	EffectiveUID      int
+	EffectiveUIDKnown bool
 }
 
 func (c RuntimeContract) clone() RuntimeContract {
@@ -162,7 +167,7 @@ func (c *RuntimeContractChecker) CheckRequest(ctx context.Context, agent Agent, 
 	if !ok {
 		return RuntimeContractResult{Runtime: agent.Runtime, Version: "unknown", State: RuntimeContractUnknown, Instrument: "runtime-registry"}
 	}
-	return c.check(ctx, meta, func(req RuntimeRequirement) bool { return requirementApplies(req, agent, request) })
+	return c.check(ctx, meta, request, func(req RuntimeRequirement) bool { return requirementApplies(req, agent, request) })
 }
 
 // Inspect evaluates a runtime's requirements for doctor. It deliberately SKIPS
@@ -184,7 +189,7 @@ func (c *RuntimeContractChecker) Inspect(ctx context.Context, runtimeName string
 	if !ok {
 		return RuntimeContractResult{Runtime: runtimeName, Version: "unknown", State: RuntimeContractUnknown, Instrument: "runtime-registry"}
 	}
-	return c.check(ctx, meta, func(req RuntimeRequirement) bool { return !req.PlanMode })
+	return c.check(ctx, meta, RuntimeContractRequest{}, func(req RuntimeRequirement) bool { return !req.PlanMode })
 }
 
 func (c *RuntimeContractChecker) registry() Registry {
@@ -194,7 +199,7 @@ func (c *RuntimeContractChecker) registry() Registry {
 	return c.Registry
 }
 
-func (c *RuntimeContractChecker) check(ctx context.Context, meta RuntimeMetadata, applies func(RuntimeRequirement) bool) RuntimeContractResult {
+func (c *RuntimeContractChecker) check(ctx context.Context, meta RuntimeMetadata, request RuntimeContractRequest, applies func(RuntimeRequirement) bool) RuntimeContractResult {
 	result := RuntimeContractResult{Runtime: meta.Name, Binary: meta.Contract.Binary, Version: "unknown", State: RuntimeContractSupported, Instrument: "declaration"}
 	var flagRequirements []RuntimeRequirement
 	for _, req := range meta.Contract.Requirements {
@@ -205,7 +210,7 @@ func (c *RuntimeContractChecker) check(ctx context.Context, meta RuntimeMetadata
 			flagRequirements = append(flagRequirements, req)
 			continue
 		}
-		rr := c.evaluatePrecondition(req)
+		rr := c.evaluatePrecondition(req, request)
 		result.Requirements = append(result.Requirements, rr)
 		mergeContractState(&result, rr)
 	}
@@ -237,17 +242,20 @@ func (c *RuntimeContractChecker) check(ctx context.Context, meta RuntimeMetadata
 	return result
 }
 
-func (c *RuntimeContractChecker) evaluatePrecondition(req RuntimeRequirement) RuntimeRequirementResult {
+func (c *RuntimeContractChecker) evaluatePrecondition(req RuntimeRequirement, request RuntimeContractRequest) RuntimeRequirementResult {
 	rr := RuntimeRequirementResult{Kind: req.Kind, Name: req.Name, Flag: req.Flag, Source: req.Source, Remedy: req.Remedy, Instrument: req.Instrument}
 	switch req.Kind {
 	case RuntimeRequirementNonRootEUID:
-		lookup := c.EffectiveUID
-		if lookup == nil {
-			rr.State = RuntimeContractUnknown
-			rr.Detail = "effective uid is unavailable"
-			return rr
+		euid, known := request.EffectiveUID, request.EffectiveUIDKnown
+		if !known {
+			lookup := c.EffectiveUID
+			if lookup == nil {
+				rr.State = RuntimeContractUnknown
+				rr.Detail = "effective uid is unavailable"
+				return rr
+			}
+			euid, known = lookup()
 		}
-		euid, known := lookup()
 		if !known {
 			rr.State = RuntimeContractUnknown
 			rr.Detail = "effective uid is unavailable"

--- a/internal/runtime/preflight_test.go
+++ b/internal/runtime/preflight_test.go
@@ -218,6 +218,16 @@ func TestRuntimePreflightHonorsDeclaredPrecondition(t *testing.T) {
 	if err := RuntimeContractDispatchError(agent, result); err == nil || !strings.Contains(err.Error(), "--permission-mode bypassPermissions") {
 		t.Fatalf("precondition error = %v, want exact argv", err)
 	}
+	result = checker.CheckRequest(context.Background(), agent, RuntimeContractRequest{
+		EffectiveUID:      996,
+		EffectiveUIDKnown: true,
+	})
+	if result.State != RuntimeContractSupported || len(result.Requirements) != 1 ||
+		result.Requirements[0].State != RuntimeContractSupported ||
+		result.Requirements[0].Instrument != "effective-uid" ||
+		!strings.Contains(result.Requirements[0].Detail, "996") {
+		t.Fatalf("configured execution identity result = %#v, want supported effective uid 996", result)
+	}
 	checker.EffectiveUID = func() (int, bool) { return 0, false }
 	result = checker.Check(context.Background(), agent)
 	if result.State != RuntimeContractUnknown || result.Instrument != "effective-uid" {

--- a/skills/gitmoot/references/CLI.md
+++ b/skills/gitmoot/references/CLI.md
@@ -323,6 +323,20 @@ an accessible location and put it first in the daemon's `PATH`; do not loosen
 `/root` permissions. An inaccessible executable fails startup with no root
 fallback.
 
+Runtime contract preflight evaluates UID-dependent requirements against
+`local_uid` when that identity is configured. This lets a root daemon dispatch
+Claude with `danger-full-access` to a non-root local backend without weakening
+Claude's root refusal. When `local_uid` is absent, preflight still evaluates the
+daemon identity, so the default root path remains refused.
+
+To prove a parallel local wave, use an isolated `--home`, one distinct
+`fresh:<suffix>` session per Claude leg, and a daemon started with `--parallel
+N`. Dispatch all implement legs together with `--background` and
+`--skip-native-review-fanout`. Each parsed `gitmoot_result` should report UID,
+GID, workspace, start/end timestamps, and visible markers. The gate passes only
+when peak overlap is N, workspace paths are distinct, each leg sees only its own
+marker, and the isolated ledger contains zero remote execution attempts.
+
 ## Transcript Retention
 
 Runtime transcript retention is default-on. Every engine delivery appends its

--- a/skills/gitmoot/references/CLI.md
+++ b/skills/gitmoot/references/CLI.md
@@ -323,11 +323,12 @@ an accessible location and put it first in the daemon's `PATH`; do not loosen
 `/root` permissions. An inaccessible executable fails startup with no root
 fallback.
 
-Runtime contract preflight evaluates UID-dependent requirements against
-`local_uid` when that identity is configured. This lets a root daemon dispatch
-Claude with `danger-full-access` to a non-root local backend without weakening
-Claude's root refusal. When `local_uid` is absent, preflight still evaluates the
-daemon identity, so the default root path remains refused.
+For daemon jobs that own an execution-backend lifecycle, runtime contract
+preflight evaluates UID-dependent requirements against configured `local_uid`.
+This lets a root daemon dispatch Claude with `danger-full-access` to a non-root
+local backend without weakening Claude's root refusal. Host-only paths such as
+`gitmoot job run` do not provision that lifecycle and still evaluate the host
+process identity. When `local_uid` is absent, daemon jobs do the same.
 
 To prove a parallel local wave, use an isolated `--home`, one distinct
 `fresh:<suffix>` session per Claude leg, and a daemon started with `--parallel

--- a/website/docs/reference/remote-exec.md
+++ b/website/docs/reference/remote-exec.md
@@ -60,6 +60,12 @@ traversable location and put that location first in the daemon's `PATH`; do not
 make `/root` traversable just to satisfy this requirement. An inaccessible
 runtime fails command startup rather than falling back to root.
 
+Runtime contract preflight evaluates UID-dependent requirements against
+`local_uid` when that identity is configured. This lets a root daemon dispatch
+Claude with `danger-full-access` to a non-root local backend without weakening
+Claude's root refusal. When `local_uid` is absent, preflight still evaluates the
+daemon identity, so the default root path remains refused.
+
 The local worktree's `.git` file points at an absolute gitdir in the source
 repository. That pointer resolves on the same filesystem, so `local` needs no
 bundle/base-ref hydration; hydration remains a remote-provider concern. Cancel
@@ -67,6 +73,38 @@ kills active command groups and destroys the instance. A restarted daemon reaps
 instances whose recorded owner process is gone. A partially-created non-empty
 directory that Git never registered remains the known orphaned-but-present
 cleanup limitation tracked in #1572.
+
+## Proving a Parallel Local Wave
+
+Run the proof with a dedicated `--home`; never point it at the live Gitmoot
+home. Keep the source checkout under a path the configured identity can
+traverse, set `backend = "local"`, and give every Claude leg a distinct
+`fresh:<suffix>` session:
+
+```sh
+gitmoot agent subscribe gate-a --runtime claude --session fresh:gate-a \
+  --role implementer --repo OWNER/REPO --policy danger-full-access \
+  --capability implement --home "$PROOF_HOME"
+gitmoot daemon run --repo OWNER/REPO --parallel 4 --poll 1s \
+  --home "$PROOF_HOME"
+gitmoot agent implement gate-a "record uid, gid, pwd, start, end, and visible markers" \
+  --repo OWNER/REPO --base HEAD --background --skip-native-review-fanout \
+  --home "$PROOF_HOME"
+```
+
+Dispatch the other legs together, not after the first settles. Every leg's
+`gitmoot_result` should include its UID, GID, workspace, start and end
+timestamps, and visible marker set in `summary`; its marker in `changes_made`;
+and the read-back and visibility checks in `tests_run`.
+
+The proof passes only when all of these are independently observed:
+
+- every runtime delivery returns a parsed `gitmoot_result`;
+- the reported UID/GID equal the configured non-root identity;
+- the intervals overlap with measured peak concurrency equal to the leg count;
+- every workspace path is distinct, and each leg sees only its own marker;
+- the isolated ledger contains zero remote execution attempts, and no E2B
+  credential or `remote` selector is present.
 
 Gitmoot reads `[remote_exec]` when it dispatches a job. Once the process starts
 a remote credential listener for a home, those listener coordinates are

--- a/website/docs/reference/remote-exec.md
+++ b/website/docs/reference/remote-exec.md
@@ -60,11 +60,12 @@ traversable location and put that location first in the daemon's `PATH`; do not
 make `/root` traversable just to satisfy this requirement. An inaccessible
 runtime fails command startup rather than falling back to root.
 
-Runtime contract preflight evaluates UID-dependent requirements against
-`local_uid` when that identity is configured. This lets a root daemon dispatch
-Claude with `danger-full-access` to a non-root local backend without weakening
-Claude's root refusal. When `local_uid` is absent, preflight still evaluates the
-daemon identity, so the default root path remains refused.
+For daemon jobs that own an execution-backend lifecycle, runtime contract
+preflight evaluates UID-dependent requirements against configured `local_uid`.
+This lets a root daemon dispatch Claude with `danger-full-access` to a non-root
+local backend without weakening Claude's root refusal. Host-only paths such as
+`gitmoot job run` do not provision that lifecycle and still evaluate the host
+process identity. When `local_uid` is absent, daemon jobs do the same.
 
 The local worktree's `.git` file points at an absolute gitdir in the source
 repository. That pointer resolves on the same filesystem, so `local` needs no
@@ -85,8 +86,18 @@ traverse, set `backend = "local"`, and give every Claude leg a distinct
 gitmoot agent subscribe gate-a --runtime claude --session fresh:gate-a \
   --role implementer --repo OWNER/REPO --policy danger-full-access \
   --capability implement --home "$PROOF_HOME"
+```
+
+Keep the daemon running in its own shell:
+
+```sh
 gitmoot daemon run --repo OWNER/REPO --parallel 4 --poll 1s \
   --home "$PROOF_HOME"
+```
+
+From the dispatch shell, submit every leg together:
+
+```sh
 gitmoot agent implement gate-a "record uid, gid, pwd, start, end, and visible markers" \
   --repo OWNER/REPO --base HEAD --background --skip-native-review-fanout \
   --home "$PROOF_HOME"

--- a/website/docs/reference/remote-exec.md
+++ b/website/docs/reference/remote-exec.md
@@ -121,8 +121,8 @@ Gitmoot reads `[remote_exec]` when it dispatches a job. Once the process starts
 a remote credential listener for a home, those listener coordinates are
 immutable: a later dispatch with changed coordinates fails loudly until the
 daemon restarts instead of silently reusing a stale endpoint. Foreground
-dispatch retains the host runner path because the lifecycle is acquired at the
-daemon job-worker boundary.
+dispatch refuses `remote` because it has no daemon-owned lifecycle, ledger, or
+reaper.
 
 When `[credentials].model_gateway = true`, a remote shell job receives the
 non-secret route in `GITMOOT_CREDENTIAL_GATEWAY_URL` and a path to an owner-only

--- a/website/static/llms-full.txt
+++ b/website/static/llms-full.txt
@@ -387,8 +387,8 @@ gitmoot job events <job-id>
 gitmoot job gates <job-id>
 gitmoot job gates clear <job-id> --need "<text>"|--all
 gitmoot job open --agent <name> --repo owner/repo --type ask|review|implement [--title "..."]
-gitmoot job close <job-id> --decision approved|changes_requested|blocked|implemented|failed [--summary "..."]
-gitmoot job record --agent <name> --repo owner/repo --type ask|review|implement --decision implemented [--summary "..."]
+gitmoot job close <job-id> --decision approved|changes_requested|blocked|implemented|failed [--severity P0|P1|P2|P3] [--summary "..."]
+gitmoot job record --agent <name> --repo owner/repo --type ask|review|implement --decision implemented [--severity P0|P1|P2|P3] [--summary "..."]
 gitmoot report bug --job <job-id> --preview
 gitmoot report bug --job <job-id> --create --yes
 gitmoot lock list --repo owner/repo
@@ -1967,9 +1967,9 @@ local_root = "/var/tmp/gitmoot-local"
 # credential_gateway_url = "https://broker.example.com:8443"
 ```
 
-`local` is the default and the only currently provisioned backend. `remote` is
-parseable, but its provider is not configured in this slice; unsupported routes
-refuse explicitly rather than falling back to host execution. For an
+`local` is the default. `remote` provisions E2B for engine-driven shell
+implement jobs; unsupported job types and model runtimes refuse before
+provider allocation. For an
 engine-driven daemon job, Gitmoot provisions one job-scoped instance, syncs the selected host
 checkout into a distinct detached Git worktree, streams runtime commands there,
 collects changes, and destroys the instance after the job. The same instance
@@ -2008,6 +2008,12 @@ traversable location and put that location first in the daemon's `PATH`; do not
 make `/root` traversable just to satisfy this requirement. An inaccessible
 runtime fails command startup rather than falling back to root.
 
+Runtime contract preflight evaluates UID-dependent requirements against
+`local_uid` when that identity is configured. This lets a root daemon dispatch
+Claude with `danger-full-access` to a non-root local backend without weakening
+Claude's root refusal. When `local_uid` is absent, preflight still evaluates the
+daemon identity, so the default root path remains refused.
+
 The local worktree's `.git` file points at an absolute gitdir in the source
 repository. That pointer resolves on the same filesystem, so `local` needs no
 bundle/base-ref hydration; hydration remains a remote-provider concern. Cancel
@@ -2015,6 +2021,38 @@ kills active command groups and destroys the instance. A restarted daemon reaps
 instances whose recorded owner process is gone. A partially-created non-empty
 directory that Git never registered remains the known orphaned-but-present
 cleanup limitation tracked in #1572.
+
+## Proving a Parallel Local Wave
+
+Run the proof with a dedicated `--home`; never point it at the live Gitmoot
+home. Keep the source checkout under a path the configured identity can
+traverse, set `backend = "local"`, and give every Claude leg a distinct
+`fresh:<suffix>` session:
+
+```sh
+gitmoot agent subscribe gate-a --runtime claude --session fresh:gate-a \
+  --role implementer --repo OWNER/REPO --policy danger-full-access \
+  --capability implement --home "$PROOF_HOME"
+gitmoot daemon run --repo OWNER/REPO --parallel 4 --poll 1s \
+  --home "$PROOF_HOME"
+gitmoot agent implement gate-a "record uid, gid, pwd, start, end, and visible markers" \
+  --repo OWNER/REPO --base HEAD --background --skip-native-review-fanout \
+  --home "$PROOF_HOME"
+```
+
+Dispatch the other legs together, not after the first settles. Every leg's
+`gitmoot_result` should include its UID, GID, workspace, start and end
+timestamps, and visible marker set in `summary`; its marker in `changes_made`;
+and the read-back and visibility checks in `tests_run`.
+
+The proof passes only when all of these are independently observed:
+
+- every runtime delivery returns a parsed `gitmoot_result`;
+- the reported UID/GID equal the configured non-root identity;
+- the intervals overlap with measured peak concurrency equal to the leg count;
+- every workspace path is distinct, and each leg sees only its own marker;
+- the isolated ledger contains zero remote execution attempts, and no E2B
+  credential or `remote` selector is present.
 
 Gitmoot reads `[remote_exec]` when it dispatches a job. Once the process starts
 a remote credential listener for a home, those listener coordinates are
@@ -2051,8 +2089,7 @@ an absent selector defaults to `local`, while `backend = ""` or an explicit
 Any value outside the allowed set (`local`, `remote`) **fails the job
 loudly at dispatch**: the failure names the offending value and the allowed
 set (for example `unknown execution backend "e2b" (allowed: local, remote)`).
-There is no silent fallback. Provider construction for `remote` lands in later
-phases of the parallel-isolated-execution epic (#1529).
+There is no silent fallback.
 
 ---
 
@@ -3815,8 +3852,9 @@ stages:
   may merge after review and CI (see [Gate stages](#gate-stages)).
 - **Declared review suppresses native fan-out.** When an implement stage has a
   downstream `action: review` stage with `source` pointing to it, its job carries
-  `SkipNativeReviewFanout`. Gitmoot does not also enqueue the ordinary native
-  reviewers; without that declaration, native review behavior is unchanged.
+  `SkipNativeReviewFanout`. Gitmoot does not also enqueue native reviewers;
+  without that declaration, scheduling follows `[review].native_fanout_enabled`
+  (off by default, with repository overrides).
 - Still a **leaf** — it may mutate but never fan out.
 
 ### Source-bound review stages
@@ -9681,7 +9719,8 @@ For an in-session PR review, clock in with `--type review --pr <n> --head-sha
 `review_status`, alongside `review_status_grade: reported` and
 `review_status_authority: non_authoritative`. This is display-only,
 caller-reported activity: it does not satisfy, block, or otherwise feed the
-merge gate. Close the session job after posting the verdict.
+merge gate. Close the session job after posting the verdict. A
+`changes_requested` review close must pass `--severity P0|P1|P2|P3`.
 
 For a running engine-dispatched review with an isolated worktree, `job list`
 uses the verified daemon's descendant process tree instead: a runtime descendant
@@ -10534,6 +10573,20 @@ root daemon resolves `claude` or `codex` below `/root`, install the runtime at
 an accessible location and put it first in the daemon's `PATH`; do not loosen
 `/root` permissions. An inaccessible executable fails startup with no root
 fallback.
+
+Runtime contract preflight evaluates UID-dependent requirements against
+`local_uid` when that identity is configured. This lets a root daemon dispatch
+Claude with `danger-full-access` to a non-root local backend without weakening
+Claude's root refusal. When `local_uid` is absent, preflight still evaluates the
+daemon identity, so the default root path remains refused.
+
+To prove a parallel local wave, use an isolated `--home`, one distinct
+`fresh:<suffix>` session per Claude leg, and a daemon started with `--parallel
+N`. Dispatch all implement legs together with `--background` and
+`--skip-native-review-fanout`. Each parsed `gitmoot_result` should report UID,
+GID, workspace, start/end timestamps, and visible markers. The gate passes only
+when peak overlap is N, workspace paths are distinct, each leg sees only its own
+marker, and the isolated ledger contains zero remote execution attempts.
 
 ## Transcript Retention
 
@@ -12570,15 +12623,16 @@ gitmoot job open --agent <name> --repo owner/repo --type ask|review|implement \
 
 # Clock out: apply the result and move the job to its terminal state.
 gitmoot job close <id> --decision approved|changes_requested|blocked|implemented|failed|skipped \
-                 [--summary "..."] [--pr <n>] [--head-sha <sha>] \
-                 [--branch <name>] [--model <name>] \
-                 [--input-tokens <n>] [--output-tokens <n>] [--json]
+                 [--severity P0|P1|P2|P3] [--summary "..."] \
+                 [--pr <n>] [--head-sha <sha>] [--branch <name>] \
+                 [--model <name>] [--input-tokens <n>] [--output-tokens <n>] [--json]
 
 # One-shot post-hoc: create an already-terminal job (open + close in one).
 gitmoot job record --agent <name> --repo owner/repo --type ask|review|implement \
-                 --decision <decision> [--title "..."] [--summary "..."] \
-                 [--task <id>] [--parent-job-id <id>] [--pr <n>] \
-                 [--head-sha <sha>] [--branch <name>] [--model <name>] \
+                 --decision <decision> [--severity P0|P1|P2|P3] \
+                 [--title "..."] [--summary "..."] [--task <id>] \
+                 [--parent-job-id <id>] [--pr <n>] [--head-sha <sha>] \
+                 [--branch <name>] [--model <name>] \
                  [--input-tokens <n>] [--output-tokens <n>] [--json]
 ```
 
@@ -12600,6 +12654,10 @@ caller-reported evidence: Gitmoot records only values supplied explicitly to
 `close` or `record`, and leaves the model empty and token counts zero when they
 are omitted.
 
+A review recorded with `changes_requested` must pass `--severity` with the
+highest finding severity. Other decisions and non-review session jobs may omit
+it.
+
 For a seat's internal fan-out, the recording convention is to use the seat's
 registered agent name, link each recorded unit to the seat job with
 `--parent-job-id`, and give it a descriptive `--title`. This is a convention,
@@ -12615,7 +12673,7 @@ gitmoot job open --agent <name> --repo owner/repo --type review \
 gitmoot workflow note <label> "reviewed tests and error paths"
 # Post the verdict, then:
 gitmoot job close <id> --decision approved|changes_requested|blocked \
-  --summary "..."
+  --summary "..." [--severity P0|P1|P2|P3]
 ```
 
 For a running externally-driven review, `job list` and `job show` derive
@@ -17085,6 +17143,21 @@ truthful, and tied to work that actually happened.
   }
 }
 ```
+
+## Review severity
+
+Review results may add a top-level `"severity": "P0"` field. A
+`changes_requested` review must set it to the highest-severity finding, using
+one of `P0`, `P1`, `P2`, or `P3` (`P0` is most severe). Approved reviews may
+include it when reporting non-blocking findings; approved reviews with no
+findings and non-review jobs omit it.
+
+This field is the engine-readable round severity. A `severity` key nested inside
+an individual `findings[]` object remains useful for display, but does not
+replace the top-level field.
+
+Session review jobs use the same rule. Pass `--severity P0|P1|P2|P3` to
+`job close` or `job record` when the decision is `changes_requested`.
 
 ## Display-only in-session review state
 

--- a/website/static/llms-full.txt
+++ b/website/static/llms-full.txt
@@ -2008,11 +2008,12 @@ traversable location and put that location first in the daemon's `PATH`; do not
 make `/root` traversable just to satisfy this requirement. An inaccessible
 runtime fails command startup rather than falling back to root.
 
-Runtime contract preflight evaluates UID-dependent requirements against
-`local_uid` when that identity is configured. This lets a root daemon dispatch
-Claude with `danger-full-access` to a non-root local backend without weakening
-Claude's root refusal. When `local_uid` is absent, preflight still evaluates the
-daemon identity, so the default root path remains refused.
+For daemon jobs that own an execution-backend lifecycle, runtime contract
+preflight evaluates UID-dependent requirements against configured `local_uid`.
+This lets a root daemon dispatch Claude with `danger-full-access` to a non-root
+local backend without weakening Claude's root refusal. Host-only paths such as
+`gitmoot job run` do not provision that lifecycle and still evaluate the host
+process identity. When `local_uid` is absent, daemon jobs do the same.
 
 The local worktree's `.git` file points at an absolute gitdir in the source
 repository. That pointer resolves on the same filesystem, so `local` needs no
@@ -2033,8 +2034,18 @@ traverse, set `backend = "local"`, and give every Claude leg a distinct
 gitmoot agent subscribe gate-a --runtime claude --session fresh:gate-a \
   --role implementer --repo OWNER/REPO --policy danger-full-access \
   --capability implement --home "$PROOF_HOME"
+```
+
+Keep the daemon running in its own shell:
+
+```sh
 gitmoot daemon run --repo OWNER/REPO --parallel 4 --poll 1s \
   --home "$PROOF_HOME"
+```
+
+From the dispatch shell, submit every leg together:
+
+```sh
 gitmoot agent implement gate-a "record uid, gid, pwd, start, end, and visible markers" \
   --repo OWNER/REPO --base HEAD --background --skip-native-review-fanout \
   --home "$PROOF_HOME"
@@ -10574,11 +10585,12 @@ an accessible location and put it first in the daemon's `PATH`; do not loosen
 `/root` permissions. An inaccessible executable fails startup with no root
 fallback.
 
-Runtime contract preflight evaluates UID-dependent requirements against
-`local_uid` when that identity is configured. This lets a root daemon dispatch
-Claude with `danger-full-access` to a non-root local backend without weakening
-Claude's root refusal. When `local_uid` is absent, preflight still evaluates the
-daemon identity, so the default root path remains refused.
+For daemon jobs that own an execution-backend lifecycle, runtime contract
+preflight evaluates UID-dependent requirements against configured `local_uid`.
+This lets a root daemon dispatch Claude with `danger-full-access` to a non-root
+local backend without weakening Claude's root refusal. Host-only paths such as
+`gitmoot job run` do not provision that lifecycle and still evaluate the host
+process identity. When `local_uid` is absent, daemon jobs do the same.
 
 To prove a parallel local wave, use an isolated `--home`, one distinct
 `fresh:<suffix>` session per Claude leg, and a daemon started with `--parallel


### PR DESCRIPTION
Closes #1541.

## Problem

A root daemon configured to run the local backend as a non-root UID still evaluated Claude's non-root runtime contract against the daemon UID. Valid `danger-full-access` work was refused before local backend provisioning.

## Change

- carry the resolved local execution UID in `RuntimeContractRequest`;
- use it for UID-dependent runtime requirements while preserving the daemon-identity default;
- cover configured, default, root-refusal, and unknown-UID paths;
- document the isolated non-root parallel proof procedure and regenerate `llms-full.txt`.

## Local gate evidence

- single real Claude implement delivery: parsed `implemented`, UID 996, GID 986, non-root workspace;
- three fresh Claude implement deliveries: peak concurrency 3, all-three overlap 21.166900158s, three distinct workspaces, zero cross-visible markers;
- isolated remote attempt rows: 0; live sandbox count: 0; no E2B API or provider call;
- workflow evidence: `campaign/e2b-execbackend` entry 98376.

The proof repository deliberately had no GitHub repository. Runtime deliveries completed; the parallel legs' later host PR finalizers blocked at the expected nonexistent remote boundary.

## Verification

- `TestRuntimePreflightHonorsDeclaredPrecondition`: match count 1, pass;
- `TestRuntimeContractPreflightUsesExecutionIdentityOnlyWhenConfigured`: match count 1, pass;
- `internal/runtime` and `internal/cli` test binaries compiled;
- request-UID mutant: applied and compiled, strength 1/1 failed, unrelated distinctness 1/1 passed;
- daemon-forwarding mutant: applied and compiled, strength 1/1 failed, default-local distinctness 1/1 passed;
- `npm run build:llms` passed.

No full suite or provider integration test was run.

Authorization: durable directive 65642.

Signed: GM-OMP-E2B