### PR TITLE
fix: return review findings to requester by default (#1712)

### DIFF
--- a/docs/parallel-jobs.md
+++ b/docs/parallel-jobs.md
@@ -64,10 +64,11 @@ Parallelism under `pool` is bounded by **two** independent locks:
    their own worktree from the workflow engine, so they parallelize. Every local
    `review` gets a detached per-job worktree at its requested head; background
    taskless `ask` jobs can be auto-isolated at checkout `HEAD`. An engine review
-   that requests changes dispatches its fix into an independent writable
-   per-job clone attached to the task branch at its fetched remote head; failure
-   to allocate refuses the dispatch instead of falling back to the registered
-   checkout. A
+   reports requested changes back to the requester's org role by default. If
+   that PR has explicit auto-fix opt-in, Gitmoot dispatches the fix into an
+   independent writable per-job clone attached to the task branch at its
+   fetched remote head; allocation failure refuses the dispatch instead of
+   falling back to the registered checkout. A
    plain, top-level same-repo `implement` job with no worktree still shares the
    `repo:<repo>` key and serializes even under `pool`.
 

--- a/internal/cli/agent_dispatch_test.go
+++ b/internal/cli/agent_dispatch_test.go
@@ -658,6 +658,16 @@ func TestReviewDispatchRoutesChangesRequestedFixToTaskImplementer(t *testing.T) 
 			home := t.TempDir()
 			store := openCLIJobStore(t, home)
 			defer store.Close()
+			if err := store.SetPullRequestAutoFixPolicy(
+				context.Background(),
+				"owner/repo",
+				7,
+				false,
+				"test",
+				"explicit autonomous-chain opt-in",
+			); err != nil {
+				t.Fatalf("SetPullRequestAutoFixPolicy returned error: %v", err)
+			}
 			checkout := createDaemonWorkerGitCheckout(t, "main")
 			makeReviewFixOriginFetchable(t, checkout, "feature/review")
 			seedDaemonWorkerRepo(t, store, "owner/repo", checkout)

--- a/internal/cli/implementation_advance_preflight_test.go
+++ b/internal/cli/implementation_advance_preflight_test.go
@@ -950,6 +950,11 @@ func expireImplementationPreflightHold(t *testing.T, store *db.Store, job db.Job
 func enqueueAdvanceCreatedHeadlessFixJob(t *testing.T, store *db.Store, jobID, branch, fixWorktree string) {
 	t.Helper()
 	ctx := context.Background()
+	if err := store.SetPullRequestAutoFixPolicy(
+		ctx, "owner/repo", 1514, false, "test", "exercise opted-in headless fix preflight",
+	); err != nil {
+		t.Fatalf("SetPullRequestAutoFixPolicy returned error: %v", err)
+	}
 	seedDaemonWorkerAgent(t, store, "audit", runtime.ShellRuntime, "unused", []string{"review"}, "owner/repo")
 	enqueueDaemonWorkerJob(t, store, workflow.JobRequest{
 		ID: "original-headless-implement", Agent: "lead", Action: "implement", Repo: "owner/repo",

--- a/internal/cli/repo.go
+++ b/internal/cli/repo.go
@@ -349,7 +349,7 @@ func runRepoAutoFix(args []string, stdout, stderr io.Writer) int {
 	fs.SetOutput(stderr)
 	home := fs.String("home", "", "home directory to use instead of the current user's home")
 	pullRequest := fs.Int("pr", 0, "pull request number")
-	disable := fs.Bool("disable", false, "disable automatic changes-requested fix dispatch")
+	disable := fs.Bool("disable", false, "revoke the changes-requested auto-fix opt-in (report-only default)")
 	enable := fs.Bool("enable", false, "opt in to automatic changes-requested fix dispatch")
 	actor := fs.String("by", "", "role or agent recording the decision")
 	reason := fs.String("reason", "", "durable reason for the decision")

--- a/internal/cli/repo.go
+++ b/internal/cli/repo.go
@@ -350,7 +350,7 @@ func runRepoAutoFix(args []string, stdout, stderr io.Writer) int {
 	home := fs.String("home", "", "home directory to use instead of the current user's home")
 	pullRequest := fs.Int("pr", 0, "pull request number")
 	disable := fs.Bool("disable", false, "disable automatic changes-requested fix dispatch")
-	enable := fs.Bool("enable", false, "re-enable automatic changes-requested fix dispatch")
+	enable := fs.Bool("enable", false, "opt in to automatic changes-requested fix dispatch")
 	actor := fs.String("by", "", "role or agent recording the decision")
 	reason := fs.String("reason", "", "durable reason for the decision")
 	repoArg, code := parseRepoPositional(

--- a/internal/db/auto_fix_policy.go
+++ b/internal/db/auto_fix_policy.go
@@ -32,9 +32,9 @@ func normalizeAutoFixPolicySubject(repo string, pullRequest int) (string, error)
 	return repo, nil
 }
 
-// SetPullRequestAutoFixPolicy records an explicit disable or re-enable decision.
+// SetPullRequestAutoFixPolicy records an explicit disable or opt-in decision.
 // Rows are retained for both states so the latest operator decision remains
-// auditable instead of disappearing when auto-fix is re-enabled.
+// auditable instead of disappearing when auto-fix is disabled again.
 func (s *Store) SetPullRequestAutoFixPolicy(ctx context.Context, repo string, pullRequest int, disabled bool, actor string, reason string) error {
 	repo, err := normalizeAutoFixPolicySubject(repo, pullRequest)
 	if err != nil {

--- a/internal/workflow/engine_run_budgets.go
+++ b/internal/workflow/engine_run_budgets.go
@@ -525,13 +525,22 @@ func (e Engine) AdvanceJob(ctx context.Context, jobID string) (retErr error) {
 			if err := e.setTaskState(ctx, ref, TaskChangesRequested); err != nil {
 				return err
 			}
-			if err := e.dispatchFix(ctx, reviewer, payload, *payload.Result, ref); err != nil {
+			policy, configured, err := e.Store.PullRequestAutoFixPolicyFor(ctx, payload.Repo, payload.PullRequest)
+			if err != nil {
 				return err
 			}
+			// Report-only is the safe default: the requester already owns the
+			// context and worktree. A durable per-PR enable is the explicit
+			// unattended-chain opt-in for dispatching a fresh implement job (#1712).
+			if configured && !policy.Disabled {
+				if err := e.dispatchFix(ctx, reviewer, payload, *payload.Result, ref); err != nil {
+					return err
+				}
+			}
 			// Verifiable graded negative (#465): a review asked for changes, so the
-			// implement job's diff did not pass review. Harvested AFTER dispatchFix so a
-			// harvest error can never affect the (already-completed) fix dispatch. The
-			// fix-round count (the review round number, round 1 = first) grades severity:
+			// implement job's diff did not pass review. Harvested AFTER requester
+			// routing and optional dispatch so a harvest error can affect neither.
+			// The fix-round count (the review round number, round 1 = first) grades severity:
 			// more rounds => a worse score.
 			e.harvestOutcomeForMergeGate(ctx, payload, Outcome{
 				Kind:        OutcomeChangesRequested,

--- a/internal/workflow/engine_test.go
+++ b/internal/workflow/engine_test.go
@@ -1330,6 +1330,7 @@ func TestEngineRunJobPreflightsPolicyBeforeDelivery(t *testing.T) {
 func TestEngineAdvanceReviewChangesRequestedDispatchesActingRoleAcrossTaskOwnerLock(t *testing.T) {
 	ctx := context.Background()
 	store := openEngineStore(t)
+	enableAutoFix(t, store, 7)
 	seedAgent(t, store, "owner-role", []string{"implement"}, "gitmoot/gitmoot")
 	seedAgent(t, store, "task-owner", []string{"implement"}, "gitmoot/gitmoot")
 	seedAgent(t, store, "payload-default", []string{"implement"}, "gitmoot/gitmoot")
@@ -1531,6 +1532,7 @@ func TestEngineAdvanceReviewApprovedSkipsMergeGateWhenNoPullRequest(t *testing.T
 func TestEngineAdvanceReviewChangesRequestedReplayIsIdempotent(t *testing.T) {
 	ctx := context.Background()
 	store := openEngineStore(t)
+	enableAutoFix(t, store, 7)
 	seedAgent(t, store, "lead", []string{"implement"}, "gitmoot/gitmoot")
 	engine := testEngine(store)
 	insertCompletedJob(t, store, db.Job{
@@ -1579,6 +1581,7 @@ func TestEngineAdvanceReviewChangesRequestedReplayIsIdempotent(t *testing.T) {
 func TestEngineAdvanceReviewChangesRequestedUsesTaskImplementerWhenActingRoleAbsent(t *testing.T) {
 	ctx := context.Background()
 	store := openEngineStore(t)
+	enableAutoFix(t, store, 7)
 	seedAgent(t, store, "task-owner", []string{"implement"}, "gitmoot/gitmoot")
 	seedAgent(t, store, "wrong-default", []string{"implement"}, "gitmoot/gitmoot")
 	if acquired, err := store.AcquireLock(ctx, db.BranchLock{
@@ -1632,6 +1635,7 @@ func TestEngineAdvanceReviewChangesRequestedUsesTaskImplementerWhenActingRoleAbs
 func TestEngineAdvanceReviewChangesRequestedFailsClosedWithoutOwnership(t *testing.T) {
 	ctx := context.Background()
 	store := openEngineStore(t)
+	enableAutoFix(t, store, 7)
 	seedAgent(t, store, "payload-default", []string{"implement"}, "gitmoot/gitmoot")
 	seedAgent(t, store, "audit", []string{"review"}, "gitmoot/gitmoot")
 	engine := testEngine(store)
@@ -1682,6 +1686,7 @@ func TestEngineAdvanceReviewChangesRequestedFailsClosedWithoutOwnership(t *testi
 func TestEngineAdvanceReviewChangesRequestedFailsClosedForAmbiguousTaskImplementers(t *testing.T) {
 	ctx := context.Background()
 	store := openEngineStore(t)
+	enableAutoFix(t, store, 7)
 	seedAgent(t, store, "first-owner", []string{"implement"}, "gitmoot/gitmoot")
 	seedAgent(t, store, "second-owner", []string{"implement"}, "gitmoot/gitmoot")
 	for _, agent := range []string{"second-owner", "first-owner"} {
@@ -1718,6 +1723,7 @@ func TestEngineAdvanceReviewChangesRequestedFailsClosedForAmbiguousTaskImplement
 func TestEngineAdvanceReviewChangesRequestedDoesNotBypassUnresolvableActingRole(t *testing.T) {
 	ctx := context.Background()
 	store := openEngineStore(t)
+	enableAutoFix(t, store, 7)
 	seedAgent(t, store, "task-owner", []string{"implement"}, "gitmoot/gitmoot")
 	seedAgent(t, store, "payload-default", []string{"implement"}, "gitmoot/gitmoot")
 	insertCompletedJob(t, store, db.Job{
@@ -1761,7 +1767,7 @@ func TestEngineAdvanceReviewChangesRequestedDoesNotBypassUnresolvableActingRole(
 	}
 }
 
-func TestEngineAdvanceReviewChangesRequestedHonorsPersistentRefusal(t *testing.T) {
+func TestEngineAdvanceReviewChangesRequestedRequiresPersistentOptIn(t *testing.T) {
 	ctx := context.Background()
 	store := openEngineStore(t)
 	seedAgent(t, store, "task-owner", []string{"implement"}, "gitmoot/gitmoot")
@@ -1789,11 +1795,10 @@ func TestEngineAdvanceReviewChangesRequestedHonorsPersistentRefusal(t *testing.T
 		Result:    &AgentResult{Decision: "changes_requested", Summary: "do not patch automatically"},
 	})
 
-	err := engine.AdvanceJob(ctx, "review-refused")
-	var blocked BlockedError
-	if !errors.As(err, &blocked) || !strings.Contains(blocked.Reason, "auto-fix disabled") || !strings.Contains(blocked.Reason, "coordinator declined automatic patching") {
-		t.Fatalf("AdvanceJob error = %v, want durable refusal BlockedError", err)
+	if err := engine.AdvanceJob(ctx, "review-refused"); err != nil {
+		t.Fatalf("AdvanceJob while disabled returned error: %v", err)
 	}
+	assertTaskState(t, store, "task-7", TaskChangesRequested)
 	if allocations != 0 {
 		t.Fatalf("fix worktree allocations = %d, want zero while disabled", allocations)
 	}
@@ -2649,6 +2654,20 @@ func seedAgent(t *testing.T, store *db.Store, name string, capabilities []string
 		HealthStatus:   "ok",
 	}); err != nil {
 		t.Fatalf("UpsertAgent returned error: %v", err)
+	}
+}
+
+func enableAutoFix(t *testing.T, store *db.Store, pullRequest int) {
+	t.Helper()
+	if err := store.SetPullRequestAutoFixPolicy(
+		context.Background(),
+		"gitmoot/gitmoot",
+		pullRequest,
+		false,
+		"test",
+		"explicit autonomous-chain opt-in",
+	); err != nil {
+		t.Fatalf("SetPullRequestAutoFixPolicy returned error: %v", err)
 	}
 }
 

--- a/internal/workflow/engine_types.go
+++ b/internal/workflow/engine_types.go
@@ -188,12 +188,12 @@ func (e Engine) mailbox() Mailbox {
 				event.PullRequest = payload.PullRequest
 				event.ReviewDecision = decision
 				if decision == "changes_requested" {
-					// The requester already has the implementation context and
-					// worktree. Wake it with the persisted verdict instead of
-					// routing a fresh fix session; legacy jobs with no sender keep
+					// Sender is a transport or agent identity, not necessarily a
+					// routable org role. ActingOrgRole is the persisted requester
+					// role paired with that sender; legacy jobs without one keep
 					// the resolved PR owner fallback above (#1712).
-					if requester := NormalizeActingOrgRole(payload.Sender); requester != "" {
-						wakeTargetRole = requester
+					if requesterRole := NormalizeActingOrgRole(payload.ActingOrgRole); requesterRole != "" {
+						wakeTargetRole = requesterRole
 					}
 				}
 			}

--- a/internal/workflow/engine_types.go
+++ b/internal/workflow/engine_types.go
@@ -187,6 +187,15 @@ func (e Engine) mailbox() Mailbox {
 				wakeTargetRole = owner
 				event.PullRequest = payload.PullRequest
 				event.ReviewDecision = decision
+				if decision == "changes_requested" {
+					// The requester already has the implementation context and
+					// worktree. Wake it with the persisted verdict instead of
+					// routing a fresh fix session; legacy jobs with no sender keep
+					// the resolved PR owner fallback above (#1712).
+					if requester := NormalizeActingOrgRole(payload.Sender); requester != "" {
+						wakeTargetRole = requester
+					}
+				}
 			}
 		}
 		event.WakeTargetRole = wakeTargetRole

--- a/internal/workflow/event_sink_test.go
+++ b/internal/workflow/event_sink_test.go
@@ -111,9 +111,20 @@ func TestEngineEmitsJobFinishedOnSucceededTerminal(t *testing.T) {
 	}
 }
 
-func TestEngineEmitsChangesRequestedReviewVerdict(t *testing.T) {
+func TestEngineReturnsChangesRequestedToRequesterWithoutDefaultAutoFix(t *testing.T) {
 	ctx := context.Background()
 	store := openEngineStore(t)
+	seedAgent(t, store, "author", []string{"implement"}, "gitmoot/gitmoot")
+	seedAgent(t, store, "audit", []string{"review"}, "gitmoot/gitmoot")
+	if err := store.UpsertTask(ctx, db.Task{
+		ID:           "task-43",
+		RepoFullName: "gitmoot/gitmoot",
+		Title:        "Review routing",
+		State:        string(TaskReviewing),
+		Branch:       "task-43",
+	}); err != nil {
+		t.Fatalf("UpsertTask returned error: %v", err)
+	}
 	if acquired, err := store.AcquireLock(ctx, db.BranchLock{
 		RepoFullName:  "gitmoot/gitmoot",
 		Branch:        "task-43",
@@ -122,27 +133,65 @@ func TestEngineEmitsChangesRequestedReviewVerdict(t *testing.T) {
 	}); err != nil || !acquired {
 		t.Fatalf("AcquireLock returned acquired=%v err=%v", acquired, err)
 	}
-	if err := store.CreateJob(ctx, db.Job{
-		ID: "review-43", Agent: "audit", Type: "review", State: string(JobSucceeded), Payload: "{}",
-	}); err != nil {
-		t.Fatalf("CreateJob returned error: %v", err)
-	}
 	sink := &recordingSink{}
 	engine := testEngine(store)
 	engine.EventSink = sink
-	mailbox := engine.mailbox()
-
-	mailbox.emitTerminal(ctx, "review-43", JobSucceeded, JobPayload{
+	if _, err := engine.mailbox().Enqueue(ctx, JobRequest{
+		ID:            "review-43",
+		Agent:         "audit",
+		Action:        "review",
 		Repo:          "gitmoot/gitmoot",
 		Branch:        "task-43",
 		PullRequest:   43,
-		ActingOrgRole: "auditor",
-		Result: &AgentResult{
-			Decision: "changes_requested",
-			Summary:  "one blocking issue",
-		},
-	})
+		HeadSHA:       "head43",
+		TaskID:        "task-43",
+		TaskTitle:     "Review routing",
+		LeadAgent:     "author",
+		Reviewers:     []string{"audit"},
+		ReviewRound:   "review-1",
+		Sender:        "requester",
+		ActingOrgRole: "author",
+	}); err != nil {
+		t.Fatalf("Enqueue returned error: %v", err)
+	}
+	agent := runtime.Agent{
+		Name:       "audit",
+		Runtime:    runtime.ShellRuntime,
+		RuntimeRef: "printf ok",
+		RepoScope:  "gitmoot/gitmoot",
+		Role:       "reviewer",
+	}
+	adapter := &fakeDelivery{outputs: []string{
+		`{"gitmoot_result":{"decision":"changes_requested","severity":"P2","summary":"one blocking issue","findings":[{"severity":"P2","file":"x.go","line":1,"title":"edge","body":"fix it"}],"changes_made":[],"tests_run":[],"needs":[],"delegations":[]}}`,
+	}}
 
+	result, err := engine.RunJob(ctx, "review-43", agent, adapter)
+	if err != nil {
+		t.Fatalf("RunJob returned error: %v", err)
+	}
+	if result.Decision != "changes_requested" || result.Summary != "one blocking issue" {
+		t.Fatalf("result = %+v", result)
+	}
+	reviewJob := mustJob(t, store, "review-43")
+	persisted, err := ParseJobPayload(reviewJob.Payload)
+	if err != nil {
+		t.Fatalf("ParseJobPayload returned error: %v", err)
+	}
+	if persisted.Result == nil ||
+		persisted.Result.Decision != "changes_requested" ||
+		len(persisted.Result.Findings) != 1 {
+		t.Fatalf("persisted requester verdict = %+v", persisted.Result)
+	}
+	assertTaskState(t, store, "task-43", TaskChangesRequested)
+	jobs, err := store.ListJobs(ctx)
+	if err != nil {
+		t.Fatalf("ListJobs returned error: %v", err)
+	}
+	for _, job := range jobs {
+		if job.Type == "implement" {
+			t.Fatalf("default changes_requested route dispatched implement job %s", job.ID)
+		}
+	}
 	finished := sink.byType(events.EventJobFinished)
 	if len(finished) != 1 {
 		t.Fatalf("job.finished emissions = %d, want 1; all=%+v", len(finished), sink.snapshot())
@@ -151,7 +200,8 @@ func TestEngineEmitsChangesRequestedReviewVerdict(t *testing.T) {
 	if event.Cause != events.EventCauseReviewVerdict ||
 		event.ReviewDecision != "changes_requested" ||
 		event.PullRequest != 43 ||
-		event.WakeTargetRole != "author" {
+		event.WakeTargetRole != "requester" ||
+		event.Detail != "one blocking issue" {
 		t.Fatalf("changes-requested verdict event = %+v", event)
 	}
 }

--- a/internal/workflow/event_sink_test.go
+++ b/internal/workflow/event_sink_test.go
@@ -149,8 +149,8 @@ func TestEngineReturnsChangesRequestedToRequesterWithoutDefaultAutoFix(t *testin
 		LeadAgent:     "author",
 		Reviewers:     []string{"audit"},
 		ReviewRound:   "review-1",
-		Sender:        "requester",
-		ActingOrgRole: "author",
+		Sender:        "local",
+		ActingOrgRole: "requester",
 	}); err != nil {
 		t.Fatalf("Enqueue returned error: %v", err)
 	}

--- a/internal/workflow/fix_worktree_dispatch_test.go
+++ b/internal/workflow/fix_worktree_dispatch_test.go
@@ -11,6 +11,7 @@ import (
 func TestReviewFixAllocationFailureRefusesDispatch(t *testing.T) {
 	ctx := context.Background()
 	store := openEngineStore(t)
+	enableAutoFix(t, store, 7)
 	seedAgent(t, store, "lead", []string{"implement"}, "gitmoot/gitmoot")
 	seedAgent(t, store, "audit", []string{"review"}, "gitmoot/gitmoot")
 	engine := testEngine(store)

--- a/internal/workflow/outcome_harvester_test.go
+++ b/internal/workflow/outcome_harvester_test.go
@@ -299,6 +299,7 @@ func TestRunMergeGateNonDeferredNotReadyStillBlocks(t *testing.T) {
 func TestEngineHarvestsChangesRequestedOnce(t *testing.T) {
 	ctx := context.Background()
 	store := openEngineStore(t)
+	enableAutoFix(t, store, 7)
 	seedAgent(t, store, "lead", []string{"implement"}, "gitmoot/gitmoot")
 	seedAgent(t, store, "audit", []string{"review"}, "gitmoot/gitmoot")
 	engine := testEngine(store)

--- a/skills/gitmoot/references/CLI.md
+++ b/skills/gitmoot/references/CLI.md
@@ -465,10 +465,11 @@ resolved `--poll` / `[daemon].poll` cadence; an explicit `--poll` stores a
 per-repo override. `repo list` renders the sentinel as `inherit`.
 `repo set-interval owner/repo <duration>` changes an override, `default` restores
 inheritance, and `--all` applies either value to every registered repo.
-`repo auto-fix` is a durable, per-PR scheduler control. `--disable` prevents a
-changes-requested auto-fix before ownership resolution or worktree allocation;
-`--enable` explicitly resumes it. Both forms require `--by` and `--reason`, and
-the latest attributed decision remains stored for that PR.
+`repo auto-fix` stores a durable, per-PR opt-in for unattended fix dispatch.
+By default, a changes-requested review reports its verdict to the requester and
+does not create an implement job. `--enable` opts that PR into auto-fix;
+`--disable` revokes the opt-in. Both forms require `--by` and `--reason`, and the
+latest attributed decision remains stored for that PR.
 `repo doctor owner/repo` checks a single repo's checkout/config health. If the
 registered checkout is missing or is no longer a Git worktree, Gitmoot verifies
 the recorded primary checkout, repairs the registration, and reports the
@@ -1118,14 +1119,16 @@ from PR comments continue to validate their fix target when the workflow
 advances until [gitmoot#1433](https://github.com/gitmoot/gitmoot/issues/1433)
 adds the corresponding ingress preflight.
 
-When an engine review returns `changes_requested`, its implement fix job gets an
-independent writable per-job clone checked out on the task branch at the fetched
-remote head. It does not execute in the review Task's empty worktree path or the
-registered checkout, so it cannot interleave with an operator's uncommitted
-files. Allocation fails closed before enqueue; there is no registered-checkout
-fallback. The clone stays attached to the real branch so the fix can commit and
-push, then terminal cleanup (with the delegation-worktree TTL as a backstop)
-removes only the clone.
+When an engine review returns `changes_requested`, Gitmoot persists the verdict
+and wakes the requester's org role without creating an implement job. If that
+PR has an explicit `repo auto-fix --enable` policy, the resulting implement fix
+job gets an independent writable per-job clone checked out on the task branch
+at the fetched remote head. It does not execute in the review Task's empty
+worktree path or the registered checkout, so it cannot interleave with an
+operator's uncommitted files. Allocation fails closed before enqueue; there is
+no registered-checkout fallback. The clone stays attached to the real branch so
+the fix can commit and push, then terminal cleanup (with the
+delegation-worktree TTL as a backstop) removes only the clone.
 
 Before delivery, these dispatch commands scan commit-shaped tokens against the
 target repository. Ask and implement preserve their existing scanner input;

--- a/website/docs/reference/cli.md
+++ b/website/docs/reference/cli.md
@@ -319,10 +319,11 @@ per Gitmoot home supervises every **enabled** registered repo. Omitting
 `repo list` prints `inherit`. Use `repo set-interval` with a duration to change
 an override, with `default` to restore inheritance, or with `--all` to update all
 registered repos.
-`repo auto-fix` records a durable scheduler decision for one pull request.
-`--disable` stops changes-requested auto-fixes before ownership resolution or
-worktree allocation; `--enable` explicitly resumes them. Both require the audit
-fields `--by` and `--reason`, and the latest decision remains stored per PR.
+`repo auto-fix` records a durable, per-PR opt-in for unattended fix dispatch.
+By default, a changes-requested review reports its verdict to the requester and
+does not create an implement job. `--enable` opts that PR into auto-fix;
+`--disable` revokes the opt-in. Both forms require the audit fields `--by` and
+`--reason`, and the latest decision remains stored per PR.
 `repo doctor owner/repo` checks checkout/config health. If the registered
 checkout is missing or is no longer a Git worktree, Gitmoot verifies the
 recorded primary checkout, repairs the registration, and reports the self-heal.
@@ -900,14 +901,16 @@ from PR comments continue to validate their fix target when the workflow
 advances until [gitmoot#1433](https://github.com/gitmoot/gitmoot/issues/1433)
 adds the corresponding ingress preflight.
 
-When an engine review returns `changes_requested`, its implement fix job gets an
-independent writable per-job clone checked out on the task branch at the fetched
-remote head. It does not execute in the review Task's empty worktree path or the
-registered checkout, so it cannot interleave with an operator's uncommitted
-files. Allocation fails closed before enqueue; there is no registered-checkout
-fallback. The clone stays attached to the real branch so the fix can commit and
-push, then terminal cleanup (with the delegation-worktree TTL as a backstop)
-removes only the clone.
+When an engine review returns `changes_requested`, Gitmoot persists the verdict
+and wakes the requester's org role without creating an implement job. If that
+PR has an explicit `repo auto-fix --enable` policy, the resulting implement fix
+job gets an independent writable per-job clone checked out on the task branch
+at the fetched remote head. It does not execute in the review Task's empty
+worktree path or the registered checkout, so it cannot interleave with an
+operator's uncommitted files. Allocation fails closed before enqueue; there is
+no registered-checkout fallback. The clone stays attached to the real branch so
+the fix can commit and push, then terminal cleanup (with the
+delegation-worktree TTL as a backstop) removes only the clone.
 
 Before delivery, these dispatch commands scan commit-shaped tokens against the
 target repository. Ask and implement preserve their existing scanner input;

--- a/website/docs/workflows/parallel-jobs-workflow.md
+++ b/website/docs/workflows/parallel-jobs-workflow.md
@@ -81,10 +81,12 @@ Parallelism under `pool` is bounded by **two** independent locks, not one:
    get their own worktree from the workflow engine, so they parallelize. Every
    local `review` gets a detached per-job worktree at its requested head;
    background taskless `ask` jobs can be auto-isolated at checkout `HEAD`.
-   An engine review that requests changes dispatches its fix into an independent
-   writable per-job clone attached to the task branch at its fetched remote head;
-   failure to allocate refuses the dispatch instead of falling back to the
-   registered checkout.
+   An engine review that requests changes reports the verdict back to the
+   requester's org role and allocates no implement job by default. If that PR
+   has an explicit `repo auto-fix --enable` policy, Gitmoot dispatches the fix
+   into an independent writable per-job clone attached to the task branch at its
+   fetched remote head; failure to allocate refuses the dispatch instead of
+   falling back to the registered checkout.
    A plain, top-level same-repo `implement` job with **no** worktree still shares
    the `repo:<repo>` key and serializes even under `pool`.
 

--- a/website/static/llms-full.txt
+++ b/website/static/llms-full.txt
@@ -4765,10 +4765,11 @@ Parallelism under `pool` is bounded by **two** independent locks:
    their own worktree from the workflow engine, so they parallelize. Every local
    `review` gets a detached per-job worktree at its requested head; background
    taskless `ask` jobs can be auto-isolated at checkout `HEAD`. An engine review
-   that requests changes dispatches its fix into an independent writable
-   per-job clone attached to the task branch at its fetched remote head; failure
-   to allocate refuses the dispatch instead of falling back to the registered
-   checkout. A
+   reports requested changes back to the requester's org role by default. If
+   that PR has explicit auto-fix opt-in, Gitmoot dispatches the fix into an
+   independent writable per-job clone attached to the task branch at its
+   fetched remote head; allocation failure refuses the dispatch instead of
+   falling back to the registered checkout. A
    plain, top-level same-repo `implement` job with no worktree still shares the
    `repo:<repo>` key and serializes even under `pool`.
 
@@ -10657,6 +10658,8 @@ gitmoot events --repo owner/repo
 gitmoot repo add owner/repo --path <path> [--poll <duration>]
 gitmoot repo list
 gitmoot repo set-interval owner/repo (<duration>|default)
+gitmoot repo auto-fix owner/repo --pr <number> --disable --by <role-or-agent> --reason "<text>"
+gitmoot repo auto-fix owner/repo --pr <number> --enable --by <role-or-agent> --reason "<text>"
 gitmoot repo set-interval --all (<duration>|default)
 gitmoot repo remove owner/repo
 gitmoot repo doctor owner/repo
@@ -10725,6 +10728,11 @@ resolved `--poll` / `[daemon].poll` cadence; an explicit `--poll` stores a
 per-repo override. `repo list` renders the sentinel as `inherit`.
 `repo set-interval owner/repo <duration>` changes an override, `default` restores
 inheritance, and `--all` applies either value to every registered repo.
+`repo auto-fix` stores a durable, per-PR opt-in for unattended fix dispatch.
+By default, a changes-requested review reports its verdict to the requester and
+does not create an implement job. `--enable` opts that PR into auto-fix;
+`--disable` revokes the opt-in. Both forms require `--by` and `--reason`, and the
+latest attributed decision remains stored for that PR.
 `repo doctor owner/repo` checks a single repo's checkout/config health. If the
 registered checkout is missing or is no longer a Git worktree, Gitmoot verifies
 the recorded primary checkout, repairs the registration, and reports the
@@ -11374,14 +11382,16 @@ from PR comments continue to validate their fix target when the workflow
 advances until [gitmoot#1433](https://github.com/gitmoot/gitmoot/issues/1433)
 adds the corresponding ingress preflight.
 
-When an engine review returns `changes_requested`, its implement fix job gets an
-independent writable per-job clone checked out on the task branch at the fetched
-remote head. It does not execute in the review Task's empty worktree path or the
-registered checkout, so it cannot interleave with an operator's uncommitted
-files. Allocation fails closed before enqueue; there is no registered-checkout
-fallback. The clone stays attached to the real branch so the fix can commit and
-push, then terminal cleanup (with the delegation-worktree TTL as a backstop)
-removes only the clone.
+When an engine review returns `changes_requested`, Gitmoot persists the verdict
+and wakes the requester's org role without creating an implement job. If that
+PR has an explicit `repo auto-fix --enable` policy, the resulting implement fix
+job gets an independent writable per-job clone checked out on the task branch
+at the fetched remote head. It does not execute in the review Task's empty
+worktree path or the registered checkout, so it cannot interleave with an
+operator's uncommitted files. Allocation fails closed before enqueue; there is
+no registered-checkout fallback. The clone stays attached to the real branch so
+the fix can commit and push, then terminal cleanup (with the
+delegation-worktree TTL as a backstop) removes only the clone.
 
 Before delivery, these dispatch commands scan commit-shaped tokens against the
 target repository. Ask and implement preserve their existing scanner input;

--- a/website/static/llms.txt
+++ b/website/static/llms.txt
@@ -11,6 +11,9 @@ This file is the machine-readable index of the Gitmoot docs — agents should
 start here, then open [`llms-full.txt`](https://gitmoot.io/llms-full.txt) for the
 full expanded context.
 
+Native review verdicts return `changes_requested` to the requester's org role
+by default. Unattended implement fix dispatch is a durable per-PR opt-in.
+
 ## Start Here
 
 - [Introduction](https://gitmoot.io/docs/intro): What Gitmoot is and when to use it.


### PR DESCRIPTION
## Problem

A `changes_requested` review automatically dispatched a fresh implement job. That session lacked the requester's context and worktree, then frequently collided with the requester fixing the same branch.

## Decision

- Persist the full review verdict and findings as before.
- Wake the requester's persisted `ActingOrgRole`, not the transport or agent identity in `sender`.
- Default to report-only and dispatch zero implement jobs.
- Preserve autonomous remediation through the existing durable per-PR opt-in: `gitmoot repo auto-fix owner/repo --pr N --enable --by ... --reason ...`.
- Keep legacy jobs without a requester role routed to the resolved PR owner.

## Verification

- Exact repaired target matrix: `MATCH_COUNT=19`, PASS across workflow, CLI, and DB.
- Default-dispatch mutant compiled; report-only strength test failed; explicit opt-in distinctness control passed.
- Sender-identity routing mutant compiled; requester-route strength test failed with `WakeTargetRole=local`; approved-review distinctness control passed.
- `npm run build:llms`: PASS.
- `git diff --check`: PASS.
- Full suite not run, per assignment.

## Review repair

Exact-head Tier 1 review job `local-review-g7-review-18d0d34ab7c69757` found that production `sender` values include `local`, `github`, and agent names. The repaired head routes through the sender's separately persisted acting org role, explicitly opts the existing headless preflight fixture into auto-fix, and updates the skill, docs, site, curated LLM index, and generated full LLM context.

## Coordination

PR #1701 changes `dispatchFix` instructions. This PR deliberately leaves `dispatchFix` untouched and guards the earlier `AdvanceJob` review arm, avoiding same-function overlap.

Implementer-attribution cleanup is independent and tracked in #1713.

Authorization provenance: owner-authored issue #1712.

Closes #1712

GM-OMP-E2B