### PR TITLE
fix(daemon): give a transient merge-gate block an exit (#1562)

### DIFF
--- a/internal/cli/daemon_merge_gate_active_job_test.go
+++ b/internal/cli/daemon_merge_gate_active_job_test.go
@@ -2,14 +2,22 @@ package cli
 
 import (
 	"context"
+	"database/sql"
 	"encoding/json"
+	"errors"
+	"fmt"
 	"os"
+	"reflect"
 	"strings"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/gitmoot/gitmoot/internal/config"
+	"github.com/gitmoot/gitmoot/internal/daemon"
 	"github.com/gitmoot/gitmoot/internal/db"
 	"github.com/gitmoot/gitmoot/internal/github"
+	"github.com/gitmoot/gitmoot/internal/subprocess"
 	"github.com/gitmoot/gitmoot/internal/workflow"
 )
 
@@ -633,5 +641,448 @@ func seedDaemonMergeGateJob(t *testing.T, store *db.Store, job db.Job, payload w
 	job.Payload = string(raw)
 	if err := store.CreateJobWithEvent(context.Background(), job, db.JobEvent{Kind: job.State, Message: "test fixture"}); err != nil {
 		t.Fatalf("CreateJobWithEvent(%s): %v", job.ID, err)
+	}
+}
+
+func TestPollOnceDaemonMergeGateRecoversMergedClaimDespiteActiveBranchJob(t *testing.T) {
+	runDaemonMergeGateTerminalPolls(t, true, false)
+}
+
+func TestPollOnceDaemonMergeGateRunsTerminalEffectsOnceForTwoReadyIdentities(t *testing.T) {
+	runDaemonMergeGateTerminalPolls(t, false, true)
+}
+
+func runDaemonMergeGateTerminalPolls(t *testing.T, withActiveJob, withAdditionalReadyTask bool) {
+	t.Helper()
+	t.Setenv("GITMOOT_DISABLE_NATIVE_MERGE_GATE", "")
+	ctx := context.Background()
+	const (
+		repoName     = "owner/repo"
+		taskID       = "review-pr-1732-retained"
+		additionalID = "task-1732"
+		workflowID   = "gitmoot4/daemon-wrapper-1732"
+		headBranch   = "fix/1732"
+		headSHA      = "head-1732"
+		pullRequest  = int64(1732)
+		mergeCommit  = "merge-1732"
+	)
+	repo := github.Repository{Owner: "owner", Name: "repo"}
+	store := daemonWorkerStore(t)
+	checkout := createDaemonWorkerGitCheckout(t, "main")
+	seedDaemonWorkerRepo(t, store, repoName, checkout)
+	worktreePath := t.TempDir()
+	if err := store.UpsertTask(ctx, db.Task{
+		ID: taskID, RepoFullName: repoName, GoalID: workflowID, Title: "Review PR 1732",
+		State: string(workflow.TaskReadyToMerge), WorktreePath: worktreePath,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if acquired, err := store.AcquireLock(ctx, db.BranchLock{
+		RepoFullName: repoName, Branch: headBranch, Owner: "builder",
+	}); err != nil || !acquired {
+		t.Fatalf("AcquireLock = acquired %v err %v", acquired, err)
+	}
+	if err := store.UpsertPullRequest(ctx, db.PullRequest{
+		RepoFullName: repoName, Number: pullRequest,
+		URL: "https://github.com/owner/repo/pull/1732", HeadBranch: headBranch,
+		BaseBranch: "main", HeadSHA: headSHA, State: "open",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	seedDaemonMergeGateJob(t, store, db.Job{
+		ID: "implement-1732", Agent: "builder", Type: "implement", State: string(workflow.JobSucceeded),
+	}, workflow.JobPayload{
+		Repo: repoName, Branch: headBranch, PullRequest: int(pullRequest), HeadSHA: headSHA,
+		TaskID: taskID, WorkflowID: workflowID,
+		Result: &workflow.AgentResult{Decision: "implemented", Summary: "implemented"},
+	})
+	seedDaemonMergeGateJob(t, store, db.Job{
+		ID: "review-1732", Agent: "reviewer", Type: "review", State: string(workflow.JobSucceeded),
+	}, workflow.JobPayload{
+		Repo: repoName, Branch: headBranch, PullRequest: int(pullRequest), HeadSHA: headSHA,
+		TaskID: taskID, WorkflowID: workflowID, ReviewRound: "review-1",
+		Result: &workflow.AgentResult{Decision: "approved", Summary: "approved"},
+	})
+	mergeable := true
+	gh := &terminalPollMergeGateGitHub{pr: github.PullRequest{
+		Number: pullRequest, Title: "PR 1732", State: "open",
+		URL:     "https://github.com/owner/repo/pull/1732",
+		HeadRef: headBranch, BaseRef: "main", BaseSHA: "base-1732", HeadSHA: headSHA,
+		Mergeable: &mergeable,
+	}}
+	mergeRunner := &terminalPollGitHubRunner{poll: gh}
+	mergeClient := &github.GhClient{Runner: mergeRunner, MaxRetries: 1}
+	postMergeGit := &terminalPollMergeGateGit{}
+	worktrees := &terminalPollWorktreeCleaner{}
+	nextTasks := &terminalPollNextTasks{}
+	effects := newTerminalPollEffects()
+	gate := daemonMergeGate{
+		Store: store, GitHub: mergeClient, FallbackCheckout: checkout, Runner: mergeRunner,
+		Home: daemonMergeGateLiveOrgHome(t), Git: postMergeGit,
+		Worktrees: worktrees, NextTasks: nextTasks,
+	}
+	engine := workflow.Engine{
+		Store: store, MergeGate: gate, RequiredReviewers: []string{"reviewer"},
+		OutcomeHarvester: effects, ReviewLegDispatcher: effects,
+		DeterministicCheckerDispatcher: effects, HardVerifierDispatcher: effects,
+	}
+	poller := daemon.Daemon{Repo: repo, Store: store, GitHub: gh, Workflow: &engine}
+
+	if err := poller.PollOnce(ctx); err != nil {
+		t.Fatalf("queued PollOnce: %v", err)
+	}
+	queuedTask, err := store.GetTask(ctx, taskID)
+	if err != nil || queuedTask.State != string(workflow.TaskReadyToMerge) || queuedTask.Branch != "" {
+		t.Fatalf("queued task = %+v err=%v, want retained branchless ready task", queuedTask, err)
+	}
+	claimed, err := store.HasTaskStateClaim(ctx, taskID)
+	if err != nil || !claimed {
+		t.Fatalf("queued claim = %v err=%v, want durable claim", claimed, err)
+	}
+	queuedGate, err := store.GetMergeGate(ctx, repoName, pullRequest)
+	if err != nil || queuedGate.State != "pending" {
+		t.Fatalf("queued gate = %+v err=%v, want pending", queuedGate, err)
+	}
+	if mergeRunner.mergeCommands != 1 {
+		t.Fatalf("queued merge commands = %d, want 1", mergeRunner.mergeCommands)
+	}
+	if len(worktrees.paths) != 0 || len(postMergeGit.updates) != 0 || len(nextTasks.taskIDs) != 0 {
+		t.Fatalf("queued terminal effects removals=%v updates=%v continuations=%v, want none",
+			worktrees.paths, postMergeGit.updates, nextTasks.taskIDs)
+	}
+
+	if withAdditionalReadyTask {
+		if err := store.UpsertTask(ctx, db.Task{
+			ID: additionalID, RepoFullName: repoName, GoalID: workflowID,
+			Title: "Implement PR 1732", State: string(workflow.TaskReadyToMerge), Branch: headBranch,
+		}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if withActiveJob {
+		seedDaemonMergeGateJob(t, store, db.Job{
+			ID: "active-branch-job", Agent: "worker", Type: "ask", State: string(workflow.JobQueued),
+		}, workflow.JobPayload{Repo: repoName, Branch: headBranch, TaskID: "active-task"})
+		active, found, err := findActiveJobForBranch(ctx, store, repoName, headBranch)
+		if err != nil || !found || active.ID != "active-branch-job" {
+			t.Fatalf("active branch job = %+v found=%v err=%v", active, found, err)
+		}
+	}
+	gh.pr.State = "closed"
+	gh.pr.Merged = true
+	gh.pr.MergeSHA = mergeCommit
+
+	if err := poller.PollOnce(ctx); err != nil {
+		t.Fatalf("merged PollOnce: %v", err)
+	}
+	assertTerminalPollTask(t, store, taskID)
+	if withAdditionalReadyTask {
+		assertTerminalPollTask(t, store, additionalID)
+	}
+	claimed, err = store.HasTaskStateClaim(ctx, taskID)
+	if err != nil || claimed {
+		t.Fatalf("terminal claim = %v err=%v, want removed", claimed, err)
+	}
+	pr, err := store.GetPullRequest(ctx, repoName, pullRequest)
+	if err != nil || pr.State != "merged" || pr.MergeCommitSHA != mergeCommit {
+		t.Fatalf("terminal PR = %+v err=%v, want merged %s", pr, err, mergeCommit)
+	}
+	terminalGate, err := store.GetMergeGate(ctx, repoName, pullRequest)
+	if err != nil || terminalGate.State != "merged" {
+		t.Fatalf("terminal gate = %+v err=%v, want merged", terminalGate, err)
+	}
+	if _, err := store.GetBranchLock(ctx, repoName, headBranch); !errors.Is(err, sql.ErrNoRows) {
+		t.Fatalf("terminal branch lock error = %v, want released", err)
+	}
+	lockEvents, err := store.ListBranchLockEvents(ctx, repoName, headBranch)
+	if err != nil || len(lockEvents) != 1 || lockEvents[0].Kind != "released" {
+		t.Fatalf("terminal lock events = %+v err=%v, want one release", lockEvents, err)
+	}
+	terminalTask, err := store.GetTask(ctx, taskID)
+	if err != nil || terminalTask.WorktreePath != "" ||
+		!reflect.DeepEqual(worktrees.paths, []string{worktreePath}) {
+		t.Fatalf("terminal worktree task=%+v removals=%v err=%v, want one cleanup", terminalTask, worktrees.paths, err)
+	}
+	if !reflect.DeepEqual(postMergeGit.updates, []string{"origin/main"}) {
+		t.Fatalf("terminal base updates = %v, want [origin/main]", postMergeGit.updates)
+	}
+	if !reflect.DeepEqual(nextTasks.taskIDs, []string{taskID}) {
+		t.Fatalf("terminal continuations = %v, want [%s]", nextTasks.taskIDs, taskID)
+	}
+	if mergeRunner.mergeCommands != 1 {
+		t.Fatalf("terminal merge commands = %d, want 1 total", mergeRunner.mergeCommands)
+	}
+	effects.waitForDetached(t)
+	effectSnapshot := effects.snapshot()
+	if !reflect.DeepEqual(effectSnapshot.harvestKinds, []workflow.OutcomeKind{workflow.OutcomeMerged}) ||
+		effectSnapshot.reviewCalls != 1 || effectSnapshot.checkerCalls != 1 || effectSnapshot.verifierCalls != 1 {
+		t.Fatalf("terminal engine effects = %+v, want one merge harvest and one of each detached leg", effectSnapshot)
+	}
+	taskEvents := terminalPollTaskEvents(t, store, taskID)
+	additionalEvents := []db.TaskEvent(nil)
+	if withAdditionalReadyTask {
+		additionalEvents = terminalPollTaskEvents(t, store, additionalID)
+	}
+	notes, err := store.ListWorkflowNotes(ctx, workflowID, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := poller.PollOnce(ctx); err != nil {
+		t.Fatalf("stable PollOnce: %v", err)
+	}
+	assertTerminalPollTask(t, store, taskID)
+	if withAdditionalReadyTask {
+		assertTerminalPollTask(t, store, additionalID)
+	}
+	claimed, err = store.HasTaskStateClaim(ctx, taskID)
+	if err != nil || claimed {
+		t.Fatalf("stable claim = %v err=%v, want absent", claimed, err)
+	}
+	if _, err := store.GetBranchLock(ctx, repoName, headBranch); !errors.Is(err, sql.ErrNoRows) {
+		t.Fatalf("stable branch lock error = %v, want absent", err)
+	}
+	stablePR, err := store.GetPullRequest(ctx, repoName, pullRequest)
+	if err != nil || !reflect.DeepEqual(stablePR, pr) {
+		t.Fatalf("stable PR = %+v err=%v, want %+v", stablePR, err, pr)
+	}
+	stableGate, err := store.GetMergeGate(ctx, repoName, pullRequest)
+	if err != nil || stableGate.State != terminalGate.State || stableGate.Reason != terminalGate.Reason {
+		t.Fatalf("stable gate = %+v err=%v, want %+v", stableGate, err, terminalGate)
+	}
+	if got := terminalPollTaskEvents(t, store, taskID); !reflect.DeepEqual(got, taskEvents) {
+		t.Fatalf("stable canonical task events = %+v, want %+v", got, taskEvents)
+	}
+	if withAdditionalReadyTask {
+		if got := terminalPollTaskEvents(t, store, additionalID); !reflect.DeepEqual(got, additionalEvents) {
+			t.Fatalf("stable additional task events = %+v, want %+v", got, additionalEvents)
+		}
+	}
+	stableNotes, err := store.ListWorkflowNotes(ctx, workflowID, 0)
+	if err != nil || !reflect.DeepEqual(stableNotes, notes) {
+		t.Fatalf("stable notes = %+v err=%v, want %+v", stableNotes, err, notes)
+	}
+	stableLockEvents, err := store.ListBranchLockEvents(ctx, repoName, headBranch)
+	if err != nil || !reflect.DeepEqual(stableLockEvents, lockEvents) {
+		t.Fatalf("stable lock events = %+v err=%v, want %+v", stableLockEvents, err, lockEvents)
+	}
+	if mergeRunner.mergeCommands != 1 ||
+		!reflect.DeepEqual(worktrees.paths, []string{worktreePath}) ||
+		!reflect.DeepEqual(postMergeGit.updates, []string{"origin/main"}) ||
+		!reflect.DeepEqual(nextTasks.taskIDs, []string{taskID}) ||
+		!reflect.DeepEqual(effects.snapshot(), effectSnapshot) {
+		t.Fatalf("stable effects merges=%d removals=%v updates=%v continuations=%v engine=%+v",
+			mergeRunner.mergeCommands, worktrees.paths, postMergeGit.updates, nextTasks.taskIDs, effects.snapshot())
+	}
+}
+
+func assertTerminalPollTask(t *testing.T, store *db.Store, taskID string) {
+	t.Helper()
+	task, err := store.GetTask(context.Background(), taskID)
+	if err != nil || task.State != string(workflow.TaskMerged) {
+		t.Fatalf("task %s = %+v err=%v, want merged", taskID, task, err)
+	}
+	events := terminalPollTaskEvents(t, store, taskID)
+	mergedEvents := 0
+	for _, event := range events {
+		if event.Kind == "pull_request_merged" {
+			mergedEvents++
+		}
+	}
+	if mergedEvents != 1 {
+		t.Fatalf("task %s events = %+v, want one pull_request_merged", taskID, events)
+	}
+}
+
+func terminalPollTaskEvents(t *testing.T, store *db.Store, taskID string) []db.TaskEvent {
+	t.Helper()
+	events, err := store.ListTaskEvents(context.Background(), taskID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return events
+}
+
+type terminalPollMergeGateGitHub struct {
+	github.NoopClient
+	pr       github.PullRequest
+	statuses []github.CommitStatusInput
+}
+
+func (g *terminalPollMergeGateGitHub) ListPullRequests(_ context.Context, _ github.Repository, state string) ([]github.PullRequest, error) {
+	switch strings.ToLower(strings.TrimSpace(state)) {
+	case "open":
+		if strings.EqualFold(g.pr.State, "open") {
+			return []github.PullRequest{g.pr}, nil
+		}
+	case "closed":
+		if strings.EqualFold(g.pr.State, "closed") {
+			return []github.PullRequest{g.pr}, nil
+		}
+	}
+	return nil, nil
+}
+
+func (g *terminalPollMergeGateGitHub) ListIssueComments(context.Context, github.Repository, int64) ([]github.IssueComment, error) {
+	return nil, nil
+}
+
+func (g *terminalPollMergeGateGitHub) GetPullRequest(context.Context, github.Repository, int64) (github.PullRequest, error) {
+	return g.pr, nil
+}
+
+func (g *terminalPollMergeGateGitHub) GetCombinedStatus(context.Context, github.Repository, string) (github.CombinedStatus, error) {
+	return github.CombinedStatus{State: "success"}, nil
+}
+
+func (g *terminalPollMergeGateGitHub) CreateCommitStatus(_ context.Context, input github.CommitStatusInput) (github.CommitStatus, error) {
+	g.statuses = append(g.statuses, input)
+	return github.CommitStatus{State: input.State, Context: input.Context}, nil
+}
+
+type terminalPollGitHubRunner struct {
+	poll          *terminalPollMergeGateGitHub
+	mergeCommands int
+}
+
+func (r *terminalPollGitHubRunner) Run(_ context.Context, _ string, _ string, args ...string) (subprocess.Result, error) {
+	if len(args) >= 2 && args[0] == "pr" && args[1] == "merge" {
+		r.mergeCommands++
+		return subprocess.Result{Stdout: "queued"}, nil
+	}
+	joined := strings.Join(args, " ")
+	switch {
+	case strings.Contains(joined, "/pulls/1732"):
+		pr := r.poll.pr
+		body := fmt.Sprintf(
+			`{"number":%d,"title":%q,"state":%q,"merged":%t,"html_url":%q,"merge_commit_sha":%q,"mergeable":true,"head":{"ref":%q,"sha":%q},"base":{"ref":%q,"sha":%q}}`,
+			pr.Number, pr.Title, pr.State, pr.Merged, pr.URL, pr.MergeSHA,
+			pr.HeadRef, pr.HeadSHA, pr.BaseRef, pr.BaseSHA,
+		)
+		return subprocess.Result{Stdout: body}, nil
+	case strings.Contains(joined, "/commits/head-1732/status"):
+		return subprocess.Result{Stdout: `{"state":"success","statuses":[]}`}, nil
+	case strings.Contains(joined, "/commits/head-1732/check-runs"):
+		return subprocess.Result{Stdout: `{"name":"build","status":"completed","conclusion":"success"}`}, nil
+	case strings.Contains(joined, "/compare/"):
+		return subprocess.Result{Stdout: `{"status":"ahead","ahead_by":1,"behind_by":0}`}, nil
+	case len(args) >= 2 && args[0] == "pr" && args[1] == "checks":
+		return subprocess.Result{Stdout: `[{"name":"build","state":"SUCCESS","bucket":"pass"}]`}, nil
+	case strings.Contains(joined, "/statuses/head-1732"):
+		return subprocess.Result{Stdout: `{"state":"pending","context":"gitmoot/merge-gate"}`}, nil
+	default:
+		return subprocess.Result{}, fmt.Errorf("unexpected production GitHub adapter call: %s", joined)
+	}
+}
+
+func (*terminalPollGitHubRunner) LookPath(file string) (string, error) {
+	return file, nil
+}
+
+type terminalPollMergeGateGit struct {
+	updates []string
+}
+
+func (*terminalPollMergeGateGit) WorktreeClean(context.Context) (bool, error) {
+	return true, nil
+}
+
+func (g *terminalPollMergeGateGit) UpdateBase(_ context.Context, remote, branch string) error {
+	g.updates = append(g.updates, remote+"/"+branch)
+	return nil
+}
+
+type terminalPollWorktreeCleaner struct {
+	paths []string
+}
+
+func (c *terminalPollWorktreeCleaner) RemoveWorktree(_ context.Context, path string) error {
+	c.paths = append(c.paths, path)
+	return nil
+}
+
+type terminalPollNextTasks struct {
+	taskIDs []string
+}
+
+func (n *terminalPollNextTasks) EnqueueNextTask(_ context.Context, taskID string) error {
+	n.taskIDs = append(n.taskIDs, taskID)
+	return nil
+}
+
+type terminalPollEffectSnapshot struct {
+	harvestKinds  []workflow.OutcomeKind
+	reviewCalls   int
+	checkerCalls  int
+	verifierCalls int
+}
+
+type terminalPollEffects struct {
+	mu            sync.Mutex
+	harvestKinds  []workflow.OutcomeKind
+	reviewCalls   int
+	checkerCalls  int
+	verifierCalls int
+	reviewDone    chan struct{}
+	checkerDone   chan struct{}
+	verifierDone  chan struct{}
+}
+
+func newTerminalPollEffects() *terminalPollEffects {
+	return &terminalPollEffects{
+		reviewDone: make(chan struct{}, 1), checkerDone: make(chan struct{}, 1), verifierDone: make(chan struct{}, 1),
+	}
+}
+
+func (e *terminalPollEffects) Harvest(_ context.Context, _ db.Job, _ workflow.JobPayload, outcome workflow.Outcome) error {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	e.harvestKinds = append(e.harvestKinds, outcome.Kind)
+	return nil
+}
+
+func (e *terminalPollEffects) Review(context.Context, db.Job, workflow.JobPayload, string) (workflow.Outcome, bool, error) {
+	e.mu.Lock()
+	e.reviewCalls++
+	e.mu.Unlock()
+	e.reviewDone <- struct{}{}
+	return workflow.Outcome{}, false, nil
+}
+
+func (e *terminalPollEffects) Check(context.Context, db.Job, workflow.JobPayload, string) (workflow.Outcome, bool, error) {
+	e.mu.Lock()
+	e.checkerCalls++
+	e.mu.Unlock()
+	e.checkerDone <- struct{}{}
+	return workflow.Outcome{}, false, nil
+}
+
+func (e *terminalPollEffects) Verify(context.Context, db.Job, workflow.JobPayload, string) (workflow.Outcome, bool, error) {
+	e.mu.Lock()
+	e.verifierCalls++
+	e.mu.Unlock()
+	e.verifierDone <- struct{}{}
+	return workflow.Outcome{}, false, nil
+}
+
+func (e *terminalPollEffects) waitForDetached(t *testing.T) {
+	t.Helper()
+	for name, done := range map[string]<-chan struct{}{
+		"review": e.reviewDone, "checker": e.checkerDone, "verifier": e.verifierDone,
+	} {
+		select {
+		case <-done:
+		case <-time.After(5 * time.Second):
+			t.Fatalf("timed out waiting for detached %s effect", name)
+		}
+	}
+}
+
+func (e *terminalPollEffects) snapshot() terminalPollEffectSnapshot {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	return terminalPollEffectSnapshot{
+		harvestKinds: append([]workflow.OutcomeKind(nil), e.harvestKinds...),
+		reviewCalls:  e.reviewCalls, checkerCalls: e.checkerCalls, verifierCalls: e.verifierCalls,
 	}
 }

--- a/internal/cli/daemon_merge_gate_active_job_test.go
+++ b/internal/cli/daemon_merge_gate_active_job_test.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"path/filepath"
 	"reflect"
 	"strings"
 	"sync"
@@ -587,6 +588,28 @@ scope = ["owner/repo"]
 	return paths.Home
 }
 
+func disableTerminalPollMergeGate(t *testing.T, home, mode string) {
+	t.Helper()
+	switch mode {
+	case "":
+		return
+	case "native":
+		t.Setenv("GITMOOT_DISABLE_NATIVE_MERGE_GATE", "1")
+	case "policy":
+		configFile := filepath.Join(home, "config.toml")
+		raw, err := os.ReadFile(configFile)
+		if err != nil {
+			t.Fatal(err)
+		}
+		updated := string(raw) + "\n[merge_gate]\nauto_merge = false\n"
+		if err := os.WriteFile(configFile, []byte(updated), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	default:
+		t.Fatalf("unknown merge-gate disable mode %q", mode)
+	}
+}
+
 func daemonMergeGateActiveJobFixture(t *testing.T, seedReview ...bool) (*db.Store, string, *activeJobMergeGateGitHub, workflow.MergeRequest) {
 	t.Helper()
 	t.Setenv("GITMOOT_DISABLE_NATIVE_MERGE_GATE", "")
@@ -645,21 +668,56 @@ func seedDaemonMergeGateJob(t *testing.T, store *db.Store, job db.Job, payload w
 }
 
 func TestPollOnceDaemonMergeGateRecoversMergedClaimDespiteActiveBranchJob(t *testing.T) {
-	runDaemonMergeGateTerminalPolls(t, true, false)
+	runDaemonMergeGateTerminalPolls(t, terminalPollOptions{withActiveJob: true, secondPollMerged: true})
 }
 
 func TestPollOnceDaemonMergeGateRunsTerminalEffectsOnceForTwoReadyIdentities(t *testing.T) {
-	runDaemonMergeGateTerminalPolls(t, false, true)
+	runDaemonMergeGateTerminalPolls(t, terminalPollOptions{withAdditionalReadyTask: true, secondPollMerged: true})
 }
 
-func runDaemonMergeGateTerminalPolls(t *testing.T, withActiveJob, withAdditionalReadyTask bool) {
+func TestPollOnceDaemonMergeGateRecoversMergedClaimAfterPolicySwitchOff(t *testing.T) {
+	for _, mode := range []string{"policy", "native"} {
+		t.Run(mode, func(t *testing.T) {
+			runDaemonMergeGateTerminalPolls(t, terminalPollOptions{secondPollMerged: true, disableBeforeSecondPoll: mode})
+		})
+	}
+}
+
+func TestPollOnceDaemonMergeGateDoesNotMergeOpenPullAfterPolicySwitchOff(t *testing.T) {
+	for _, mode := range []string{"policy", "native"} {
+		t.Run(mode, func(t *testing.T) {
+			runDaemonMergeGateTerminalPolls(t, terminalPollOptions{
+				secondPollMerged: true, authoritativeRecoveryOpen: true, disableBeforeSecondPoll: mode,
+			})
+		})
+	}
+}
+
+func TestPollOnceDaemonMergeGateRestartSettlesSecondaryWithoutReplayingEffects(t *testing.T) {
+	runDaemonMergeGateTerminalPolls(t, terminalPollOptions{
+		withAdditionalReadyTask: true,
+		secondPollMerged:        true,
+		interruptAfterCanonical: true,
+	})
+}
+
+type terminalPollOptions struct {
+	withActiveJob             bool
+	withAdditionalReadyTask   bool
+	secondPollMerged          bool
+	authoritativeRecoveryOpen bool
+	disableBeforeSecondPoll   string
+	interruptAfterCanonical   bool
+}
+
+func runDaemonMergeGateTerminalPolls(t *testing.T, options terminalPollOptions) {
 	t.Helper()
 	t.Setenv("GITMOOT_DISABLE_NATIVE_MERGE_GATE", "")
 	ctx := context.Background()
 	const (
 		repoName     = "owner/repo"
 		taskID       = "review-pr-1732-retained"
-		additionalID = "task-1732"
+		additionalID = "review-pr-1732-secondary"
 		workflowID   = "gitmoot4/daemon-wrapper-1732"
 		headBranch   = "fix/1732"
 		headSHA      = "head-1732"
@@ -716,9 +774,10 @@ func runDaemonMergeGateTerminalPolls(t *testing.T, withActiveJob, withAdditional
 	worktrees := &terminalPollWorktreeCleaner{}
 	nextTasks := &terminalPollNextTasks{}
 	effects := newTerminalPollEffects()
+	home := daemonMergeGateLiveOrgHome(t)
 	gate := daemonMergeGate{
 		Store: store, GitHub: mergeClient, FallbackCheckout: checkout, Runner: mergeRunner,
-		Home: daemonMergeGateLiveOrgHome(t), Git: postMergeGit,
+		Home: home, Git: postMergeGit,
 		Worktrees: worktrees, NextTasks: nextTasks,
 	}
 	engine := workflow.Engine{
@@ -751,15 +810,15 @@ func runDaemonMergeGateTerminalPolls(t *testing.T, withActiveJob, withAdditional
 			worktrees.paths, postMergeGit.updates, nextTasks.taskIDs)
 	}
 
-	if withAdditionalReadyTask {
+	if options.withAdditionalReadyTask {
 		if err := store.UpsertTask(ctx, db.Task{
 			ID: additionalID, RepoFullName: repoName, GoalID: workflowID,
-			Title: "Implement PR 1732", State: string(workflow.TaskReadyToMerge), Branch: headBranch,
+			Title: "Review PR 1732 secondary", State: string(workflow.TaskReadyToMerge),
 		}); err != nil {
 			t.Fatal(err)
 		}
 	}
-	if withActiveJob {
+	if options.withActiveJob {
 		seedDaemonMergeGateJob(t, store, db.Job{
 			ID: "active-branch-job", Agent: "worker", Type: "ask", State: string(workflow.JobQueued),
 		}, workflow.JobPayload{Repo: repoName, Branch: headBranch, TaskID: "active-task"})
@@ -768,15 +827,85 @@ func runDaemonMergeGateTerminalPolls(t *testing.T, withActiveJob, withAdditional
 			t.Fatalf("active branch job = %+v found=%v err=%v", active, found, err)
 		}
 	}
-	gh.pr.State = "closed"
-	gh.pr.Merged = true
-	gh.pr.MergeSHA = mergeCommit
+	disableTerminalPollMergeGate(t, home, options.disableBeforeSecondPoll)
+	if options.secondPollMerged {
+		gh.pr.State = "closed"
+		gh.pr.Merged = true
+		gh.pr.MergeSHA = mergeCommit
+	}
+	if options.authoritativeRecoveryOpen {
+		openRecovery := gh.pr
+		openRecovery.State = "open"
+		openRecovery.Merged = false
+		openRecovery.MergeSHA = ""
+		mergeRunner.recoveryPR = &openRecovery
+	}
+	interruption := errors.New("simulated process interruption after canonical terminal effects")
+	if options.interruptAfterCanonical {
+		poller.AfterCanonicalTerminalEffects = func(context.Context, db.PullRequestTerminalReconciliation) error {
+			return interruption
+		}
+	}
 
-	if err := poller.PollOnce(ctx); err != nil {
-		t.Fatalf("merged PollOnce: %v", err)
+	secondPollErr := poller.PollOnce(ctx)
+	if options.authoritativeRecoveryOpen {
+		if secondPollErr != nil {
+			t.Fatalf("disabled recovery-only open PollOnce: %v", secondPollErr)
+		}
+		openTask, taskErr := store.GetTask(ctx, taskID)
+		if taskErr != nil || openTask.State != string(workflow.TaskReadyToMerge) {
+			t.Fatalf("disabled open task = %+v err=%v, want retained ready_to_merge", openTask, taskErr)
+		}
+		claimRetained, claimErr := store.HasTaskStateClaim(ctx, taskID)
+		if claimErr != nil || !claimRetained {
+			t.Fatalf("disabled open claim = %v err=%v, want retained", claimRetained, claimErr)
+		}
+		reconciliation, reconciliationErr := store.GetPullRequestTerminalReconciliation(ctx, repoName, pullRequest, headSHA)
+		if reconciliationErr != nil || reconciliation.EffectsCompleted || reconciliation.OwnerTaskID != taskID {
+			t.Fatalf("disabled open reconciliation = %+v err=%v, want incomplete owner %s", reconciliation, reconciliationErr, taskID)
+		}
+		if mergeRunner.mergeCommands != 1 || len(worktrees.paths) != 0 ||
+			len(postMergeGit.updates) != 0 || len(nextTasks.taskIDs) != 0 ||
+			len(effects.snapshot().harvestKinds) != 0 {
+			t.Fatalf("disabled open effects merges=%d removals=%v updates=%v continuations=%v engine=%+v, want no second merge or terminal effects",
+				mergeRunner.mergeCommands, worktrees.paths, postMergeGit.updates, nextTasks.taskIDs, effects.snapshot())
+		}
+		return
+	}
+	if options.interruptAfterCanonical {
+		if !errors.Is(secondPollErr, interruption) {
+			t.Fatalf("interrupted merged PollOnce error = %v, want %v", secondPollErr, interruption)
+		}
+		reconciliation, err := store.GetPullRequestTerminalReconciliation(ctx, repoName, pullRequest, headSHA)
+		if err != nil || !reconciliation.EffectsCompleted || reconciliation.OwnerTaskID != taskID {
+			t.Fatalf("terminal reconciliation = %+v err=%v, want completed owner %s", reconciliation, err, taskID)
+		}
+		assertTerminalPollTask(t, store, taskID)
+		additional, err := store.GetTask(ctx, additionalID)
+		if err != nil || additional.State != string(workflow.TaskReadyToMerge) {
+			t.Fatalf("interrupted secondary task = %+v err=%v, want ready_to_merge", additional, err)
+		}
+		databasePath := store.DatabasePath()
+		if err := store.Close(); err != nil {
+			t.Fatal(err)
+		}
+		store, err = db.OpenAlreadyMigrated(databasePath)
+		if err != nil {
+			t.Fatalf("reopen store: %v", err)
+		}
+		t.Cleanup(func() { _ = store.Close() })
+		gate.Store = store
+		engine.Store = store
+		engine.MergeGate = gate
+		poller = daemon.Daemon{Repo: repo, Store: store, GitHub: gh, Workflow: &engine}
+		if err := poller.PollOnce(ctx); err != nil {
+			t.Fatalf("restart PollOnce: %v", err)
+		}
+	} else if secondPollErr != nil {
+		t.Fatalf("merged PollOnce: %v", secondPollErr)
 	}
 	assertTerminalPollTask(t, store, taskID)
-	if withAdditionalReadyTask {
+	if options.withAdditionalReadyTask {
 		assertTerminalPollTask(t, store, additionalID)
 	}
 	claimed, err = store.HasTaskStateClaim(ctx, taskID)
@@ -820,7 +949,7 @@ func runDaemonMergeGateTerminalPolls(t *testing.T, withActiveJob, withAdditional
 	}
 	taskEvents := terminalPollTaskEvents(t, store, taskID)
 	additionalEvents := []db.TaskEvent(nil)
-	if withAdditionalReadyTask {
+	if options.withAdditionalReadyTask {
 		additionalEvents = terminalPollTaskEvents(t, store, additionalID)
 	}
 	notes, err := store.ListWorkflowNotes(ctx, workflowID, 0)
@@ -832,7 +961,7 @@ func runDaemonMergeGateTerminalPolls(t *testing.T, withActiveJob, withAdditional
 		t.Fatalf("stable PollOnce: %v", err)
 	}
 	assertTerminalPollTask(t, store, taskID)
-	if withAdditionalReadyTask {
+	if options.withAdditionalReadyTask {
 		assertTerminalPollTask(t, store, additionalID)
 	}
 	claimed, err = store.HasTaskStateClaim(ctx, taskID)
@@ -853,7 +982,7 @@ func runDaemonMergeGateTerminalPolls(t *testing.T, withActiveJob, withAdditional
 	if got := terminalPollTaskEvents(t, store, taskID); !reflect.DeepEqual(got, taskEvents) {
 		t.Fatalf("stable canonical task events = %+v, want %+v", got, taskEvents)
 	}
-	if withAdditionalReadyTask {
+	if options.withAdditionalReadyTask {
 		if got := terminalPollTaskEvents(t, store, additionalID); !reflect.DeepEqual(got, additionalEvents) {
 			t.Fatalf("stable additional task events = %+v, want %+v", got, additionalEvents)
 		}
@@ -942,6 +1071,7 @@ func (g *terminalPollMergeGateGitHub) CreateCommitStatus(_ context.Context, inpu
 
 type terminalPollGitHubRunner struct {
 	poll          *terminalPollMergeGateGitHub
+	recoveryPR    *github.PullRequest
 	mergeCommands int
 }
 
@@ -954,6 +1084,9 @@ func (r *terminalPollGitHubRunner) Run(_ context.Context, _ string, _ string, ar
 	switch {
 	case strings.Contains(joined, "/pulls/1732"):
 		pr := r.poll.pr
+		if r.recoveryPR != nil {
+			pr = *r.recoveryPR
+		}
 		body := fmt.Sprintf(
 			`{"number":%d,"title":%q,"state":%q,"merged":%t,"html_url":%q,"merge_commit_sha":%q,"mergeable":true,"head":{"ref":%q,"sha":%q},"base":{"ref":%q,"sha":%q}}`,
 			pr.Number, pr.Title, pr.State, pr.Merged, pr.URL, pr.MergeSHA,

--- a/internal/cli/daemon_worker.go
+++ b/internal/cli/daemon_worker.go
@@ -3383,6 +3383,7 @@ func blockTaskForPermissionBlockedJob(ctx context.Context, store *db.Store, job 
 		State:        string(workflow.TaskBlocked),
 		Branch:       payload.Branch,
 	}
+	fromState := ""
 	existing, err := store.GetTask(ctx, payload.TaskID)
 	if err != nil && !errors.Is(err, sql.ErrNoRows) {
 		return err
@@ -3391,6 +3392,7 @@ func blockTaskForPermissionBlockedJob(ctx context.Context, store *db.Store, job 
 		if existing.State == string(workflow.TaskDismissed) {
 			return fmt.Errorf("task %s is dismissed; permission-blocked job cannot resurrect it", existing.ID)
 		}
+		fromState = existing.State
 		if task.RepoFullName == "" {
 			task.RepoFullName = existing.RepoFullName
 		}
@@ -3404,7 +3406,23 @@ func blockTaskForPermissionBlockedJob(ctx context.Context, store *db.Store, job 
 			task.Branch = existing.Branch
 		}
 	}
-	return store.UpsertTask(ctx, task)
+	reason := fmt.Sprintf("permission-blocked job %s", job.ID)
+	if payload.Result != nil && strings.TrimSpace(payload.Result.Summary) != "" {
+		reason = strings.TrimSpace(payload.Result.Summary)
+	}
+	blocked, err := store.BlockTaskWithEvent(ctx, task, db.TaskEvent{
+		Kind:      "permission_job_blocked",
+		FromState: fromState,
+		Reason:    reason,
+	})
+	if err != nil {
+		if !blocked {
+			return err
+		}
+		return errors.Join(workflow.BlockedError{Reason: reason},
+			fmt.Errorf("record permission block for task %s: %w", task.ID, err))
+	}
+	return nil
 }
 
 func (w jobWorker) jobNeedsAdvanceRetry(ctx context.Context, jobID string) (bool, error) {

--- a/internal/cli/daemon_worker_test.go
+++ b/internal/cli/daemon_worker_test.go
@@ -546,3 +546,37 @@ func TestPermissionBlockedJobCannotResurrectDismissedTask(t *testing.T) {
 		t.Fatalf("task resurrected to %s", task.State)
 	}
 }
+
+func TestPermissionBlockedJobWritesCurrentTaskOwnership(t *testing.T) {
+	ctx := context.Background()
+	store := daemonWorkerStore(t)
+	if err := store.UpsertTask(ctx, db.Task{
+		ID: "task-2", RepoFullName: "owner/repo",
+		State: string(workflow.TaskImplementing), Branch: "feature/two",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	payload, err := json.Marshal(workflow.JobPayload{
+		TaskID: "task-2", Repo: "owner/repo", Branch: "feature/two",
+		Result: &workflow.AgentResult{Decision: "blocked", Summary: "permission denied"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := blockTaskForPermissionBlockedJob(ctx, store, db.Job{ID: "job-2", Payload: string(payload)}); err != nil {
+		t.Fatal(err)
+	}
+	task, err := store.GetTask(ctx, "task-2")
+	if err != nil || task.State != string(workflow.TaskBlocked) {
+		t.Fatalf("task = %+v err %v, want blocked", task, err)
+	}
+	events, err := store.ListTaskEvents(ctx, "task-2")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(events) != 1 || events[0].Kind != "permission_job_blocked" ||
+		events[0].FromState != string(workflow.TaskImplementing) ||
+		events[0].ToState != string(workflow.TaskBlocked) {
+		t.Fatalf("task events = %+v, want permission block ownership", events)
+	}
+}

--- a/internal/cli/daemon_workflow.go
+++ b/internal/cli/daemon_workflow.go
@@ -744,8 +744,11 @@ type daemonMergeGate struct {
 	// Home is the resolved <home>/.gitmoot root (or raw --home) used to load the
 	// [merge_gate] policy (#596). Empty uses the default mandatory review-and-CI
 	// merge gate.
-	Home   string
-	Runner subprocess.Runner
+	Home      string
+	Runner    subprocess.Runner
+	Git       workflow.MergeGateGit
+	Worktrees workflow.WorktreeCleaner
+	NextTasks workflow.NextTaskEnqueuer
 }
 
 func newDaemonMergeGate(store *db.Store, gh github.Client, checkout, home string, runner subprocess.Runner) daemonMergeGate {
@@ -765,15 +768,16 @@ func (g daemonMergeGate) Evaluate(ctx context.Context, request workflow.MergeReq
 			Reason: workflow.PlainReason("native Gitmoot merge gate disabled by GITMOOT_DISABLE_NATIVE_MERGE_GATE; use external gate"),
 		}, nil
 	}
-	// Never make a merge-or-human decision while a job still owns this branch.
-	// This is a local store query, so preserving the #1017 hold does not weaken
-	// the default path's zero GitHub side effects. An explicit @gitmoot merge
-	// request bypasses only the auto_merge policy, not this branch-safety hold.
+	// Never make an open merge-or-human decision while a job still owns this
+	// branch. An authoritative merged observation bypasses only this local hold;
+	// PolicyMergeGate still re-reads GitHub and owns all terminal recovery.
+	// This is a local store query, so the ordinary hold retains zero GitHub
+	// side effects. An explicit @gitmoot merge request does not bypass it.
 	active, found, err := findActiveJobForBranch(ctx, g.Store, request.Repo, request.Branch)
 	if err != nil {
 		return workflow.MergeDecision{}, fmt.Errorf("inspect active jobs on merge branch: %w", err)
 	}
-	if found {
+	if found && !request.PullRequestMerged {
 		return workflow.MergeDecision{
 			Ready:      false,
 			Merged:     false,
@@ -803,6 +807,13 @@ func (g daemonMergeGate) Evaluate(ctx context.Context, request workflow.MergeReq
 	}
 	gate := newDaemonPolicyMergeGateForRunner(g.Store, g.githubClient(checkout), checkout, g.Runner)
 	applyResolvedMergeGatePolicy(&gate, policy)
+	if g.Git != nil {
+		gate.Git = g.Git
+	}
+	if g.Worktrees != nil {
+		gate.Worktrees = g.Worktrees
+	}
+	gate.NextTasks = g.NextTasks
 	// The check above minimizes but does not eliminate the enqueue-to-merge race:
 	// gate.Evaluate still performs review/CI reads before the squash merge, so a job
 	// enqueued in that window can escape the check. A branch-activity lease/barrier

--- a/internal/cli/daemon_workflow.go
+++ b/internal/cli/daemon_workflow.go
@@ -762,10 +762,14 @@ func newHostDaemonMergeGate(store *db.Store, gh github.Client, checkout, home st
 }
 
 func (g daemonMergeGate) Evaluate(ctx context.Context, request workflow.MergeRequest) (workflow.MergeDecision, error) {
-	if workflow.NativeMergeGateDisabled() {
+	recoveryOnly := request.PullRequestMerged
+	request.TerminalRecoveryOnly = recoveryOnly
+	if workflow.NativeMergeGateDisabled() && !recoveryOnly {
 		return workflow.MergeDecision{
-			Ready:  false,
-			Reason: workflow.PlainReason("native Gitmoot merge gate disabled by GITMOOT_DISABLE_NATIVE_MERGE_GATE; use external gate"),
+			Ready:      false,
+			Deferred:   true,
+			BlockClass: workflow.MergeBlockTransient,
+			Reason:     workflow.PlainReason("native Gitmoot merge gate disabled by GITMOOT_DISABLE_NATIVE_MERGE_GATE; use external gate"),
 		}, nil
 	}
 	// Never make an open merge-or-human decision while a job still owns this
@@ -793,12 +797,25 @@ func (g daemonMergeGate) Evaluate(ctx context.Context, request workflow.MergeReq
 	// again by the fully built gate below still parks before any merge operation.
 	policy, ok := resolvedMergeGatePolicy(g.Home, request.Repo)
 	if !ok {
-		if strings.TrimSpace(g.Home) != "" {
+		if strings.TrimSpace(g.Home) != "" && !recoveryOnly {
 			return (workflow.PolicyMergeGate{}).Evaluate(ctx, request)
 		}
 		policy = config.DefaultMergeGatePolicy()
 	}
-	if !policy.AutoMerge && !request.HumanMergeRequested {
+	if !policy.AutoMerge && !request.HumanMergeRequested && !recoveryOnly {
+		if g.Store != nil && strings.TrimSpace(request.TaskID) != "" {
+			claimed, claimErr := g.Store.HasTaskStateClaim(ctx, request.TaskID)
+			if claimErr != nil {
+				return workflow.MergeDecision{}, fmt.Errorf("inspect retained merge claim for task %s: %w", request.TaskID, claimErr)
+			}
+			if claimed {
+				return workflow.MergeDecision{
+					Deferred:   true,
+					BlockClass: workflow.MergeBlockTransient,
+					Reason:     workflow.PlainReason("auto_merge disabled while retained external merge claim awaits authoritative terminal state"),
+				}, nil
+			}
+		}
 		return (workflow.PolicyMergeGate{}).Evaluate(ctx, request)
 	}
 	checkout, err := mergeGateCheckout(ctx, g.Store, request.Repo, g.FallbackCheckout)

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -87,6 +87,10 @@ type Daemon struct {
 	// repository. When it turns on, only tasks parked by the auto-merge-disabled
 	// leave-open reason are re-armed. Nil preserves direct daemon users' behavior.
 	AutoMergeEnabled func(repo string) bool
+	// AfterCanonicalTerminalEffects is an optional interruption/observability
+	// hook invoked only after durable completion is recorded and before
+	// secondary identities settle.
+	AfterCanonicalTerminalEffects func(context.Context, db.PullRequestTerminalReconciliation) error
 	// parseCommentCommand is an injectable test seam for proving that the
 	// system-verified author gate runs before untrusted comment text reaches the
 	// command parser. Nil uses ParseCommand.
@@ -841,48 +845,130 @@ func (d Daemon) reconcileExternallyMergedTasks(ctx context.Context, openPullNumb
 			}
 			continue
 		}
-		event, eventErr := d.reconciledPullRequestEvent(ctx, pull, canonicalTask, group.number)
-		if eventErr != nil {
-			if firstErr == nil {
-				firstErr = eventErr
-			}
-			continue
-		}
-		if canonicalTask.State == string(workflow.TaskReadyToMerge) && d.Workflow.MergeGate != nil {
-			// Exactly one ready identity owns the per-PR boundary: atomic claim
-			// recovery, merge-gate finalization, branch/worktree cleanup,
-			// harvesting and detached signals, and continuation.
-			if readyErr := d.handleReadyToMergeWorkflow(ctx, pull, canonicalTask); readyErr != nil {
-				if firstErr == nil {
-					firstErr = readyErr
-				}
-				continue
-			}
-		} else if canonicalTask.State == string(workflow.TaskReadyToMerge) && strings.TrimSpace(canonicalTask.Branch) == "" {
-			// Defensive fallback for a gate removed between polls. There is no
-			// configured canonical continuation to run, but the retained claim
-			// must still resolve into the authoritative merged state.
-			if _, _, recoverErr := d.Store.RecoverClaimedTaskState(ctx, canonicalTask.ID,
-				string(workflow.TaskMerged), "pull_request_merged",
-				fmt.Sprintf("recovered merged pull request #%d from retained branchless task claim", group.number)); recoverErr != nil {
-				if firstErr == nil {
-					firstErr = recoverErr
-				}
-				continue
-			}
-		}
-		if closeErr := d.Workflow.HandleReviewPullRequestClosed(ctx, event, true); closeErr != nil {
-			if firstErr == nil {
-				firstErr = closeErr
-			}
-			continue
-		}
+		taskIDs := make([]string, 0, len(group.tasks))
 		for _, task := range group.tasks {
-			if task.ID == canonicalTask.ID {
+			taskIDs = append(taskIDs, task.ID)
+		}
+		reconciliation, reconcileErr := d.Store.BeginPullRequestTerminalReconciliation(ctx, db.PullRequestTerminalReconciliation{
+			RepoFullName: d.Repo.FullName(),
+			PullRequest:  group.number,
+			HeadSHA:      strings.TrimSpace(pull.HeadSHA),
+			OwnerTaskID:  canonicalTask.ID,
+		}, taskIDs)
+		if reconcileErr != nil {
+			if firstErr == nil {
+				firstErr = reconcileErr
+			}
+			continue
+		}
+		if reconciliation.OwnerTaskID != canonicalTask.ID {
+			if reconciliation.EffectsCompleted {
+				canonicalTask = db.Task{ID: reconciliation.OwnerTaskID}
+			} else {
+				canonicalTask, reconcileErr = d.Store.GetTask(ctx, reconciliation.OwnerTaskID)
+				if reconcileErr != nil {
+					if firstErr == nil {
+						firstErr = fmt.Errorf("load canonical terminal-effects owner %s: %w", reconciliation.OwnerTaskID, reconcileErr)
+					}
+					continue
+				}
+			}
+		}
+		if !reconciliation.EffectsCompleted {
+			event, eventErr := d.reconciledPullRequestEvent(ctx, pull, canonicalTask, group.number)
+			if eventErr != nil {
+				if firstErr == nil {
+					firstErr = eventErr
+				}
 				continue
 			}
-			if reconcileErr := d.reconcileAdditionalMergedTask(ctx, task, canonicalTask.ID, group.number); reconcileErr != nil && firstErr == nil {
-				firstErr = reconcileErr
+			if canonicalTask.State == string(workflow.TaskReadyToMerge) && d.Workflow.MergeGate != nil {
+				// Exactly one ready identity owns the per-PR boundary: atomic claim
+				// recovery, merge-gate finalization, branch/worktree cleanup,
+				// harvesting and detached signals, and continuation.
+				if readyErr := d.handleReadyToMergeWorkflow(ctx, pull, canonicalTask); readyErr != nil {
+					if firstErr == nil {
+						firstErr = readyErr
+					}
+					continue
+				}
+				canonicalTask, reconcileErr = d.Store.GetTask(ctx, canonicalTask.ID)
+				if reconcileErr != nil {
+					if firstErr == nil {
+						firstErr = reconcileErr
+					}
+					continue
+				}
+				if canonicalTask.State != string(workflow.TaskMerged) {
+					// The wrapper's authoritative re-read did not confirm the
+					// daemon's merged hint. Retain owner/debt and retry; never
+					// apply terminal effects or settle another identity.
+					continue
+				}
+			} else if canonicalTask.State == string(workflow.TaskReadyToMerge) && strings.TrimSpace(canonicalTask.Branch) == "" {
+				// Defensive fallback for a gate removed between polls. There is no
+				// configured canonical continuation to run, but the retained claim
+				// must still resolve into the authoritative merged state.
+				if _, _, recoverErr := d.Store.RecoverClaimedTaskState(ctx, canonicalTask.ID,
+					string(workflow.TaskMerged), "pull_request_merged",
+					fmt.Sprintf("recovered merged pull request #%d from retained branchless task claim", group.number)); recoverErr != nil {
+					if firstErr == nil {
+						firstErr = recoverErr
+					}
+					continue
+				}
+			}
+			if closeErr := d.Workflow.HandleReviewPullRequestClosed(ctx, event, true); closeErr != nil {
+				if firstErr == nil {
+					firstErr = closeErr
+				}
+				continue
+			}
+			if completeErr := d.Store.CompletePullRequestTerminalEffects(ctx, reconciliation); completeErr != nil {
+				if firstErr == nil {
+					firstErr = completeErr
+				}
+				continue
+			}
+			reconciliation.EffectsCompleted = true
+			if d.AfterCanonicalTerminalEffects != nil {
+				if interruptErr := d.AfterCanonicalTerminalEffects(ctx, reconciliation); interruptErr != nil {
+					if firstErr == nil {
+						firstErr = interruptErr
+					}
+					continue
+				}
+			}
+		}
+		settlements, settlementErr := d.Store.ListPullRequestTerminalSettlements(ctx, reconciliation)
+		if settlementErr != nil {
+			if firstErr == nil {
+				firstErr = settlementErr
+			}
+			continue
+		}
+		for _, taskID := range settlements {
+			task, taskErr := d.Store.GetTask(ctx, taskID)
+			if errors.Is(taskErr, sql.ErrNoRows) {
+				taskErr = d.Store.ResolvePullRequestTerminalSettlement(ctx, reconciliation, taskID)
+			}
+			if taskErr != nil {
+				if firstErr == nil {
+					firstErr = taskErr
+				}
+				continue
+			}
+			if task.ID == "" {
+				continue
+			}
+			if taskErr := d.reconcileAdditionalMergedTask(ctx, task, reconciliation.OwnerTaskID, group.number); taskErr != nil {
+				if firstErr == nil {
+					firstErr = taskErr
+				}
+				continue
+			}
+			if resolveErr := d.Store.ResolvePullRequestTerminalSettlement(ctx, reconciliation, task.ID); resolveErr != nil && firstErr == nil {
+				firstErr = resolveErr
 			}
 		}
 	}

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -225,12 +225,12 @@ func (d Daemon) PollOnce(ctx context.Context) error {
 			// HandlePullRequestOpened runs the gate itself when no reviewers are
 			// configured; avoid evaluating it twice in that one composition.
 			if !mergeReadinessHandled {
-				retry, err := d.pullRequestReadyToMerge(ctx, pull)
-				if err != nil {
+				task, err := d.lookupReadyPullRequestTask(ctx, pull, reviewMemo)
+				if err != nil && !errors.Is(err, sql.ErrNoRows) {
 					return err
 				}
-				if retry {
-					if err := d.handleReadyToMergeWorkflow(ctx, pull); err != nil && firstErr == nil {
+				if err == nil {
+					if err := d.handleReadyToMergeWorkflow(ctx, pull, task); err != nil && firstErr == nil {
 						firstErr = err
 					}
 				}
@@ -552,6 +552,8 @@ func (d Daemon) reconcilePROpenTasks(ctx context.Context, pulls []github.PullReq
 // the wedged population is precisely the branchless local review task: a
 // pull.HeadRef lookup cannot find it, which is why the branch-keyed poll predicate
 // is the wrong seam for this exit.
+const transientMergeGateRetryInterval = time.Minute
+
 func (d Daemon) reconcileTransientlyBlockedMergeGates(ctx context.Context, openPullNumbers map[int64]struct{}) error {
 	tasks, err := d.Store.ListTasksByRepo(ctx, d.Repo.FullName())
 	if err != nil {
@@ -598,30 +600,28 @@ func (d Daemon) reconcileTransientlyBlockedMergeGates(ctx context.Context, openP
 		if gate.State != "blocked" || gate.BlockClass != int(workflow.MergeBlockTransient) {
 			continue
 		}
-		// The gate row says the CONDITION is self-clearing. It does not say the gate
-		// is still the REASON this task is blocked. e.block is shared with the
-		// coordinator failure paths (block_parent, and the vote/quorum synthesis
-		// gates), so a task carrying a stale transient gate row and then blocked by a
-		// delegation quorum failure satisfies every test above — and releasing it
-		// would discard a quorum failure as self-clearing infrastructure. Require the
-		// task's most recent blocking event to attribute the CURRENT block to the
-		// merge gate. A task blocked before merge-gate blocks were attributed has no
-		// such event and stays blocked, which is the safe direction.
-		// (Found by gm-omp-fanout while coordinating the PR #1731 collision.)
-		attributed, attrErr := d.mergeGateOwnsCurrentBlock(ctx, task.ID)
+		// The latest blocking event owns the current state. Retry its unchanged
+		// transient condition indefinitely, but no more than once per interval.
+		// The release transition preserves tasks.updated_at, so retries cannot
+		// disguise the original blocked age.
+		attributed, unattributed, lastRetryAt, attrErr := d.mergeGateOwnsCurrentBlock(ctx, task.ID, gate.Reason)
 		if attrErr != nil {
 			if firstErr == nil {
 				firstErr = attrErr
 			}
 			continue
 		}
-		if !attributed {
+		if !attributed && !unattributed {
 			continue
 		}
-		changed, _, transitionErr := d.Store.TransitionTaskStateWithEvent(ctx, task.ID,
+		now := d.now()
+		if !lastRetryAt.IsZero() && now.Before(lastRetryAt.Add(transientMergeGateRetryInterval)) {
+			continue
+		}
+		changed, _, transitionErr := d.Store.TransitionTaskStateWithEventPreserveAgeAt(ctx, task.ID,
 			[]string{string(workflow.TaskBlocked)},
 			string(workflow.TaskReadyToMerge), "merge_gate_transient_retry",
-			fmt.Sprintf("re-evaluating transient merge-gate block on open PR #%d: %s", number, gate.Reason))
+			fmt.Sprintf("re-evaluating transient merge-gate block on open PR #%d: %s", number, gate.Reason), now)
 		if transitionErr != nil {
 			if firstErr == nil {
 				firstErr = transitionErr
@@ -635,47 +635,87 @@ func (d Daemon) reconcileTransientlyBlockedMergeGates(ctx context.Context, openP
 	return firstErr
 }
 
-// mergeGateOwnsCurrentBlock reports whether the merge gate owns the task's CURRENT
-// block (#1562). Task events are append-only, so the LATEST blocking event is the
-// current cause: a later synthesis-gate or auto-fix block supersedes an earlier
-// merge-gate block and must not be cleared by the transient exit.
-//
-// The second return value distinguishes the UPGRADE population. Before this
-// change neither the merge gate nor the coordinator synthesis gates wrote an
-// attributed event — both reached blocked through the shared e.block — so a task
-// with NO blocking event at all is neither a gate block nor a quorum failure that
-// we can prove; it is a row blocked before attribution existed. Refusing those
-// outright would strand exactly the population that motivated #1562, including the
-// 95-minute review-pr-1699-3f3a1026 wedge, so the caller heals them once.
-// (Cause-vs-state and the upgrade path both raised by gm-omp-fanout; the
-// unknown-blocker closure and the write-after-block ordering by a review advisory.)
-func (d Daemon) mergeGateOwnsCurrentBlock(ctx context.Context, taskID string) (attributed bool, unattributed bool, err error) {
+// mergeGateOwnsCurrentBlock reports whether the merge gate owns the task's
+// current block, whether the task predates block attribution, and the most
+// recent retry in the unchanged condition episode. Another blocker supersedes
+// the merge gate; a changed reason permits an immediate retry.
+func (d Daemon) mergeGateOwnsCurrentBlock(ctx context.Context, taskID string, currentGateReason string) (attributed bool, unattributed bool, lastRetryAt time.Time, err error) {
 	events, err := d.Store.ListTaskEvents(ctx, taskID)
 	if err != nil {
-		return false, err
+		return false, false, time.Time{}, err
 	}
-	// Newest-first: the most recent BLOCKING event is the current cause. The
-	// predicate is deliberately a union rather than a list of known kinds. A fixed
-	// list is not closed under future blockers: a new mechanism blocking a task
-	// would simply not match, and an older merge_gate_blocked would win and
-	// authorize releasing a block it did not cause. ToState alone is not enough
-	// either, because blockAutoFix records its event without one, so an
-	// auto-fix block would be invisible to a ToState-only filter.
+	currentOwner := -1
 	for i := len(events) - 1; i >= 0; i-- {
-		event := events[i]
-		blocking := event.ToState == string(workflow.TaskBlocked)
-		switch event.Kind {
-		case "merge_gate_blocked", "review_auto_fix_blocked", "pr_closed_unmerged",
-			"delegation_vote_unmet", "delegation_quorum_unmet", "delegation_child_failed",
-			"block_parent", "quorum_unmet":
-			blocking = true
+		if taskEventIsBlocking(events[i]) {
+			currentOwner = i
+			break
 		}
-		if !blocking {
+	}
+	if currentOwner < 0 {
+		for _, event := range events {
+			if event.Kind != "merge_gate_transient_retry" {
+				continue
+			}
+			parsed, parseErr := parseTaskStoreTime(event.CreatedAt)
+			if parseErr != nil {
+				return false, false, time.Time{}, fmt.Errorf("parse transient retry time for task %s: %w", taskID, parseErr)
+			}
+			if parsed.After(lastRetryAt) {
+				lastRetryAt = parsed
+			}
+		}
+		return false, true, lastRetryAt, nil
+	}
+	if events[currentOwner].Kind != "merge_gate_blocked" {
+		return false, false, time.Time{}, nil
+	}
+	if strings.TrimSpace(events[currentOwner].Reason) != strings.TrimSpace(currentGateReason) {
+		return true, false, time.Time{}, nil
+	}
+
+	episodeActive := false
+	episodeReason := ""
+	for _, event := range events {
+		if taskEventIsBlocking(event) {
+			if event.Kind != "merge_gate_blocked" {
+				episodeActive = false
+				episodeReason = ""
+				lastRetryAt = time.Time{}
+				continue
+			}
+			if !episodeActive || event.Reason != episodeReason {
+				episodeActive = true
+				episodeReason = event.Reason
+				lastRetryAt = time.Time{}
+			}
 			continue
 		}
-		return event.Kind == "merge_gate_blocked", false, nil
+		if event.Kind != "merge_gate_transient_retry" || !episodeActive {
+			continue
+		}
+		parsed, parseErr := parseTaskStoreTime(event.CreatedAt)
+		if parseErr != nil {
+			return false, false, time.Time{}, fmt.Errorf("parse transient retry time for task %s: %w", taskID, parseErr)
+		}
+		if parsed.After(lastRetryAt) {
+			lastRetryAt = parsed
+		}
 	}
-	return false, nil
+	return true, false, lastRetryAt, nil
+}
+
+func taskEventIsBlocking(event db.TaskEvent) bool {
+	if event.ToState == string(workflow.TaskBlocked) {
+		return true
+	}
+	switch event.Kind {
+	case "merge_gate_blocked", "review_auto_fix_blocked", "pr_closed_unmerged",
+		"delegation_vote_unmet", "delegation_quorum_unmet", "delegation_child_failed",
+		"block_parent", "quorum_unmet":
+		return true
+	default:
+		return false
+	}
 }
 
 // reconcileExternallyMergedTasks advances PR lifecycle tasks, plus blocked
@@ -755,15 +795,11 @@ func (d Daemon) reconcileExternallyMergedTasks(ctx context.Context, openPullNumb
 			continue
 		}
 		if !pullRequestListedAsMerged(pull) {
-			// The PR left the open set without merging. If it is closed
-			// (abandoned), record a closed status breadcrumb for any linked
-			// workflow so a pr_open/changes_requested task does not leave its
-			// workflow status frozen at "open". This pass remains observability-
-			// only: reconcileClosedReviewingTasks is the single authoritative home
-			// for the closed-unmerged -> blocked transition, avoiding two passes
-			// racing the same task. The #953 conservatism against advancing or
-			// un-blocking on any ambiguous PR state is preserved. Idempotent and
-			// non-fatal.
+			// The PR left the open set without merging. Closed branch-bearing
+			// lifecycle tasks remain owned by their dedicated reconciliation
+			// passes. A branchless ready task has no path through those branch
+			// indexes, so resolve its retained merge claim here before applying
+			// the terminal non-merge transition.
 			if strings.EqualFold(strings.TrimSpace(pull.State), "closed") {
 				if _, err := workflow.RecordPullRequestWorkflowTransition(ctx, d.Store, workflow.PullRequestEvent{
 					Repo:        d.Repo.FullName(),
@@ -772,59 +808,189 @@ func (d Daemon) reconcileExternallyMergedTasks(ctx context.Context, openPullNumb
 				}, workflow.PullRequestJournalClosed); err != nil {
 					d.logf("workflow journal PR-closed breadcrumb failed for %s#%d: %v", d.Repo.FullName(), group.number, err)
 				}
+				for _, task := range group.tasks {
+					if task.State != string(workflow.TaskReadyToMerge) || strings.TrimSpace(task.Branch) != "" {
+						continue
+					}
+					event, eventErr := d.reconciledPullRequestEvent(ctx, pull, task, group.number)
+					if eventErr != nil {
+						if firstErr == nil {
+							firstErr = eventErr
+						}
+						continue
+					}
+					if _, _, recoverErr := d.Store.RecoverClaimedTaskState(ctx, task.ID,
+						string(workflow.TaskBlocked), "pr_closed_unmerged",
+						fmt.Sprintf("pull request #%d closed without merging while holding a retained merge claim", group.number)); recoverErr != nil {
+						if firstErr == nil {
+							firstErr = recoverErr
+						}
+						continue
+					}
+					if closeErr := d.Workflow.HandleReviewPullRequestClosed(ctx, event, false); closeErr != nil && firstErr == nil {
+						firstErr = closeErr
+					}
+				}
+			}
+			continue
+		}
+		canonicalTask, selectErr := d.selectCanonicalMergedTask(ctx, group.tasks)
+		if selectErr != nil {
+			if firstErr == nil {
+				firstErr = selectErr
+			}
+			continue
+		}
+		event, eventErr := d.reconciledPullRequestEvent(ctx, pull, canonicalTask, group.number)
+		if eventErr != nil {
+			if firstErr == nil {
+				firstErr = eventErr
+			}
+			continue
+		}
+		if canonicalTask.State == string(workflow.TaskReadyToMerge) && d.Workflow.MergeGate != nil {
+			// Exactly one ready identity owns the per-PR boundary: atomic claim
+			// recovery, merge-gate finalization, branch/worktree cleanup,
+			// harvesting and detached signals, and continuation.
+			if readyErr := d.handleReadyToMergeWorkflow(ctx, pull, canonicalTask); readyErr != nil {
+				if firstErr == nil {
+					firstErr = readyErr
+				}
+				continue
+			}
+		} else if canonicalTask.State == string(workflow.TaskReadyToMerge) && strings.TrimSpace(canonicalTask.Branch) == "" {
+			// Defensive fallback for a gate removed between polls. There is no
+			// configured canonical continuation to run, but the retained claim
+			// must still resolve into the authoritative merged state.
+			if _, _, recoverErr := d.Store.RecoverClaimedTaskState(ctx, canonicalTask.ID,
+				string(workflow.TaskMerged), "pull_request_merged",
+				fmt.Sprintf("recovered merged pull request #%d from retained branchless task claim", group.number)); recoverErr != nil {
+				if firstErr == nil {
+					firstErr = recoverErr
+				}
+				continue
+			}
+		}
+		if closeErr := d.Workflow.HandleReviewPullRequestClosed(ctx, event, true); closeErr != nil {
+			if firstErr == nil {
+				firstErr = closeErr
 			}
 			continue
 		}
 		for _, task := range group.tasks {
-			branch := strings.TrimSpace(pull.HeadRef)
-			if branch == "" {
-				branch = strings.TrimSpace(task.Branch)
-			}
-			if branch == "" {
-				if firstErr == nil {
-					firstErr = fmt.Errorf("reconcile externally merged PR #%d: head branch is empty", pull.Number)
-				}
+			if task.ID == canonicalTask.ID {
 				continue
 			}
-			leadAgent := "github"
-			if lock, err := d.Store.GetBranchLock(ctx, d.Repo.FullName(), branch); err == nil {
-				if owner := strings.TrimSpace(lock.Owner); owner != "" {
-					leadAgent = owner
-				}
-			} else if !errors.Is(err, sql.ErrNoRows) {
-				if firstErr == nil {
-					firstErr = err
-				}
-				continue
-			}
-			event := workflow.PullRequestEvent{
-				Repo:        d.Repo.FullName(),
-				Branch:      branch,
-				PullRequest: int(group.number),
-				HeadSHA:     pull.HeadSHA,
-				GoalID:      task.GoalID,
-				TaskID:      task.ID,
-				TaskTitle:   task.Title,
-				LeadAgent:   leadAgent,
-				Sender:      "github",
-			}
-			// Preserve the existing ready-to-merge path's merge-gate cleanup and
-			// outcome side effects. The closure handler below remains the durable
-			// backstop and also updates the local PR mirror for custom test gates.
-			if task.State == string(workflow.TaskReadyToMerge) && strings.TrimSpace(task.Branch) != "" && d.Workflow.MergeGate != nil {
-				if err := d.handleReadyToMergeWorkflow(ctx, pull); err != nil {
-					if firstErr == nil {
-						firstErr = err
-					}
-					continue
-				}
-			}
-			if err := d.Workflow.HandleReviewPullRequestClosed(ctx, event, true); err != nil && firstErr == nil {
-				firstErr = err
+			if reconcileErr := d.reconcileAdditionalMergedTask(ctx, task, canonicalTask.ID, group.number); reconcileErr != nil && firstErr == nil {
+				firstErr = reconcileErr
 			}
 		}
 	}
 	return firstErr
+}
+
+// selectCanonicalMergedTask chooses one identity to own per-PR terminal effects.
+// A ready task with a durable merge claim wins, followed by a branch-owning
+// ready task, then another ready task. Groups without a ready identity preserve
+// the branch-owning lifecycle task as the canonical cleanup owner.
+func (d Daemon) selectCanonicalMergedTask(ctx context.Context, tasks []db.Task) (db.Task, error) {
+	claimedReady := -1
+	branchReady := -1
+	anyReady := -1
+	branchFallback := -1
+	anyFallback := -1
+	for index := range tasks {
+		task := tasks[index]
+		if anyFallback < 0 || task.ID < tasks[anyFallback].ID {
+			anyFallback = index
+		}
+		if strings.TrimSpace(task.Branch) != "" &&
+			(branchFallback < 0 || task.ID < tasks[branchFallback].ID) {
+			branchFallback = index
+		}
+		if task.State != string(workflow.TaskReadyToMerge) {
+			continue
+		}
+		if anyReady < 0 || task.ID < tasks[anyReady].ID {
+			anyReady = index
+		}
+		if strings.TrimSpace(task.Branch) != "" &&
+			(branchReady < 0 || task.ID < tasks[branchReady].ID) {
+			branchReady = index
+		}
+		claimed, err := d.Store.HasTaskStateClaim(ctx, task.ID)
+		if err != nil {
+			return db.Task{}, fmt.Errorf("inspect merge claim for task %s: %w", task.ID, err)
+		}
+		if claimed && (claimedReady < 0 || task.ID < tasks[claimedReady].ID) {
+			claimedReady = index
+		}
+	}
+	for _, index := range []int{claimedReady, branchReady, anyReady, branchFallback, anyFallback} {
+		if index >= 0 {
+			return tasks[index], nil
+		}
+	}
+	return db.Task{}, errors.New("select canonical merged task from empty PR group")
+}
+
+// reconcileAdditionalMergedTask advances an additional local identity without
+// replaying per-PR cleanup, harvesting, detached legs, or continuation.
+func (d Daemon) reconcileAdditionalMergedTask(ctx context.Context, task db.Task, canonicalTaskID string, number int64) error {
+	reason := fmt.Sprintf("reconciled merged pull request #%d; canonical terminal effects owned by task %s", number, canonicalTaskID)
+	changed, current, err := d.Store.RecoverClaimedTaskState(ctx, task.ID,
+		string(workflow.TaskMerged), "pull_request_merged", reason)
+	if err != nil {
+		return err
+	}
+	if changed || current == string(workflow.TaskMerged) {
+		return nil
+	}
+	changed, current, err = d.Store.TransitionTaskStateWithEvent(ctx, task.ID, []string{
+		string(workflow.TaskPullRequestOpen),
+		string(workflow.TaskReviewing),
+		string(workflow.TaskChangesRequested),
+		string(workflow.TaskReadyToMerge),
+		string(workflow.TaskAwaitingHumanMerge),
+		string(workflow.TaskBlocked),
+	}, string(workflow.TaskMerged), "pull_request_merged", reason)
+	if err != nil {
+		return err
+	}
+	if !changed && current != string(workflow.TaskMerged) {
+		return fmt.Errorf("%w: additional task %s reached %q while reconciling merged PR #%d",
+			db.ErrTaskStateConflict, task.ID, current, number)
+	}
+	return nil
+}
+
+func (d Daemon) reconciledPullRequestEvent(ctx context.Context, pull github.PullRequest, task db.Task, number int64) (workflow.PullRequestEvent, error) {
+	branch := strings.TrimSpace(pull.HeadRef)
+	if branch == "" {
+		branch = strings.TrimSpace(task.Branch)
+	}
+	if branch == "" {
+		return workflow.PullRequestEvent{}, fmt.Errorf("reconcile terminal PR #%d: head branch is empty", number)
+	}
+	leadAgent := "github"
+	if lock, err := d.Store.GetBranchLock(ctx, d.Repo.FullName(), branch); err == nil {
+		if owner := strings.TrimSpace(lock.Owner); owner != "" {
+			leadAgent = owner
+		}
+	} else if !errors.Is(err, sql.ErrNoRows) {
+		return workflow.PullRequestEvent{}, err
+	}
+	return workflow.PullRequestEvent{
+		Repo:        d.Repo.FullName(),
+		Branch:      branch,
+		PullRequest: int(number),
+		HeadSHA:     pull.HeadSHA,
+		GoalID:      task.GoalID,
+		TaskID:      task.ID,
+		TaskTitle:   task.Title,
+		LeadAgent:   leadAgent,
+		Sender:      "github",
+	}, nil
 }
 
 func externalMergeCandidateState(state string) bool {
@@ -1387,83 +1553,112 @@ func workflowReviewJobMatchesPull(repoFullName string, pull github.PullRequest, 
 		len(payload.Reviewers) > 0
 }
 
-// lookupReadyPullRequestTask resolves the task driving a pull request for the
-// ready-to-merge path. Two rows can legitimately describe one PR: the implement
-// task that owns (repo, head branch), and a BRANCHLESS local review task keyed by
-// its durable review-pr-<number>-<hash> id. A branchless row is invisible to a
-// pull.HeadRef lookup, so without the fallback a task released from a transient
-// merge-gate block is never re-evaluated and the release restores an operator exit
-// (`task resume-work` accepts ready_to_merge) and nothing else (#1562).
-//
-// Selection prefers a candidate that is ACTUALLY ready_to_merge, because a
-// branch-first lookup strands the released review task whenever its branch has a
-// canonical implementation task in some other state — a supported coexistence.
-// When both are ready, or neither is, the branch-keyed row wins, so this differs
-// from the previous behaviour in exactly one case: the branch owner is not ready
-// and a branchless review task is.
-//
-// The fallback is deliberately scoped to this path rather than widened into
-// lookupPullRequestTask, whose other callers reason about branch-owned work.
-func (d Daemon) lookupReadyPullRequestTask(ctx context.Context, pull github.PullRequest) (db.Task, error) {
+// lookupReadyPullRequestTask resolves exactly one ready task for the current PR
+// head. A ready branch owner is canonical only when the stored PR mirror binds
+// that branch to this PR number and head SHA. A branchless local-review task is
+// eligible only when a succeeded review job supplies the same exact binding.
+// Multiple eligible branchless rows fail closed.
+func (d Daemon) lookupReadyPullRequestTask(ctx context.Context, pull github.PullRequest, memo *reviewJobsMemo) (db.Task, error) {
+	if !d.pullRequestHeadIsLocal(pull) {
+		return db.Task{}, sql.ErrNoRows
+	}
 	branchTask, branchErr := d.lookupPullRequestTask(ctx, d.Repo.FullName(), pull.HeadRef)
 	if branchErr != nil && !errors.Is(branchErr, sql.ErrNoRows) {
 		return db.Task{}, branchErr
 	}
-	branchFound := branchErr == nil
-	if branchFound && branchTask.State == string(workflow.TaskReadyToMerge) {
-		return branchTask, nil
+	if branchErr == nil && branchTask.State == string(workflow.TaskReadyToMerge) {
+		stored, err := d.Store.GetPullRequestByRepoBranch(ctx, d.Repo.FullName(), pull.HeadRef)
+		if err != nil && !errors.Is(err, sql.ErrNoRows) {
+			return db.Task{}, err
+		}
+		if err == nil && stored.Number == pull.Number &&
+			strings.TrimSpace(stored.HeadSHA) == strings.TrimSpace(pull.HeadSHA) {
+			return branchTask, nil
+		}
 	}
-	tasks, listErr := d.Store.ListTasksByRepo(ctx, d.Repo.FullName())
-	if listErr != nil {
-		return db.Task{}, listErr
+
+	tasks, err := d.Store.ListTasksByRepo(ctx, d.Repo.FullName())
+	if err != nil {
+		return db.Task{}, err
 	}
-	var branchless db.Task
-	var branchlessFound bool
+	jobs, err := d.reviewJobs(ctx, memo)
+	if err != nil {
+		return db.Task{}, err
+	}
+	candidates := make([]db.Task, 0, 1)
 	for _, candidate := range tasks {
-		if strings.TrimSpace(candidate.Branch) != "" {
+		if strings.TrimSpace(candidate.Branch) != "" ||
+			candidate.State != string(workflow.TaskReadyToMerge) {
 			continue
 		}
 		number, ok := reviewTaskPullRequestNumber(candidate.ID)
 		if !ok || number != pull.Number {
 			continue
 		}
-		if candidate.State == string(workflow.TaskReadyToMerge) {
-			return candidate, nil
+		bound, err := reviewTaskBoundToPullHead(candidate, d.Repo.FullName(), pull, jobs)
+		if err != nil {
+			return db.Task{}, err
 		}
-		if !branchlessFound {
-			branchless, branchlessFound = candidate, true
+		if bound {
+			candidates = append(candidates, candidate)
 		}
 	}
-	if branchFound {
-		return branchTask, nil
+	switch len(candidates) {
+	case 0:
+		return db.Task{}, sql.ErrNoRows
+	case 1:
+		return candidates[0], nil
+	default:
+		ids := make([]string, 0, len(candidates))
+		for _, candidate := range candidates {
+			ids = append(ids, candidate.ID)
+		}
+		return db.Task{}, fmt.Errorf("ambiguous ready tasks for %s#%d at head %s: %s",
+			d.Repo.FullName(), pull.Number, pull.HeadSHA, strings.Join(ids, ", "))
 	}
-	if branchlessFound {
-		return branchless, nil
+}
+
+func reviewTaskBoundToPullHead(task db.Task, repoFullName string, pull github.PullRequest, jobs []db.Job) (bool, error) {
+	for _, job := range jobs {
+		if job.State != string(workflow.JobSucceeded) {
+			continue
+		}
+		var payload workflow.JobPayload
+		if err := json.Unmarshal([]byte(job.Payload), &payload); err != nil {
+			return false, fmt.Errorf("parse job payload %q: %w", job.ID, err)
+		}
+		if payload.TaskID == task.ID &&
+			payload.Repo == repoFullName &&
+			payload.PullRequest == int(pull.Number) &&
+			payload.Branch == pull.HeadRef &&
+			strings.TrimSpace(payload.HeadSHA) == strings.TrimSpace(pull.HeadSHA) {
+			return true, nil
+		}
 	}
-	return db.Task{}, sql.ErrNoRows
+	return false, nil
 }
 
 func (d Daemon) pullRequestReadyToMerge(ctx context.Context, pull github.PullRequest) (bool, error) {
-	task, err := d.lookupReadyPullRequestTask(ctx, pull)
+	_, err := d.lookupReadyPullRequestTask(ctx, pull, nil)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return false, nil
 		}
 		return false, err
 	}
-	// TaskReadyToMerge is the retry authority. SkipNativeReviewFanout controls
-	// PR-open review routing only; a direct review can leave this task pending
-	// on CI, and suppressing its poll here strands gitmoot/merge-gate (#1708).
-	return task.State == string(workflow.TaskReadyToMerge), nil
+	return true, nil
 }
 
-func (d Daemon) handleReadyToMergeWorkflow(ctx context.Context, pull github.PullRequest) error {
+func (d Daemon) handleReadyToMergeWorkflow(ctx context.Context, pull github.PullRequest, task db.Task) error {
 	if d.Workflow == nil {
 		return nil
 	}
-	task, err := d.lookupReadyPullRequestTask(ctx, pull)
+	ready, _, err := d.Store.RevalidateTaskState(ctx, task.ID, string(workflow.TaskReadyToMerge))
 	if err != nil {
 		return err
+	}
+	if !ready {
+		return nil
 	}
 	lock, err := d.Store.GetBranchLock(ctx, d.Repo.FullName(), pull.HeadRef)
 	if err != nil && !errors.Is(err, sql.ErrNoRows) {
@@ -1477,12 +1672,13 @@ func (d Daemon) handleReadyToMergeWorkflow(ctx context.Context, pull github.Pull
 	if branch == "" {
 		branch = pull.HeadRef
 	}
-	return d.Workflow.HandlePullRequestReadyToMerge(ctx, workflow.PullRequestEvent{
+	err = d.Workflow.HandlePullRequestReadyToMerge(ctx, workflow.PullRequestEvent{
 		Repo:                    d.Repo.FullName(),
 		Branch:                  branch,
 		PullRequest:             int(pull.Number),
 		PullRequestDraft:        pull.Draft,
 		PullRequestDraftUnknown: pull.DraftUnknown,
+		PullRequestMerged:       pullRequestListedAsMerged(pull),
 		HeadSHA:                 pull.HeadSHA,
 		GoalID:                  task.GoalID,
 		TaskID:                  task.ID,
@@ -1490,6 +1686,10 @@ func (d Daemon) handleReadyToMergeWorkflow(ctx context.Context, pull github.Pull
 		LeadAgent:               leadAgent,
 		Sender:                  "github",
 	})
+	if errors.Is(err, workflow.ErrMergeTaskStateChanged) {
+		return nil
+	}
+	return err
 }
 
 func (d Daemon) reconcileReviewingPullRequest(ctx context.Context, pull github.PullRequest, memo *reviewJobsMemo) error {
@@ -1585,6 +1785,7 @@ func (d Daemon) retryClosedReadyToMerge(ctx context.Context, openBranches map[st
 	type readyPullRequest struct {
 		number  int64
 		headSHA string
+		task    db.Task
 	}
 	readyBranches := map[string]readyPullRequest{}
 	for _, task := range tasks {
@@ -1606,7 +1807,7 @@ func (d Daemon) retryClosedReadyToMerge(ctx context.Context, openBranches map[st
 			}
 			return err
 		}
-		readyBranches[task.Branch] = readyPullRequest{number: stored.Number, headSHA: stored.HeadSHA}
+		readyBranches[task.Branch] = readyPullRequest{number: stored.Number, headSHA: stored.HeadSHA, task: task}
 	}
 	if len(readyBranches) == 0 {
 		return nil
@@ -1626,7 +1827,7 @@ func (d Daemon) retryClosedReadyToMerge(ctx context.Context, openBranches map[st
 		if ready.headSHA != "" && pull.HeadSHA != ready.headSHA {
 			continue
 		}
-		if err := d.handleReadyToMergeWorkflow(ctx, pull); err != nil {
+		if err := d.handleReadyToMergeWorkflow(ctx, pull, ready.task); err != nil {
 			return err
 		}
 		delete(readyBranches, pull.HeadRef)

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -1324,8 +1324,42 @@ func workflowReviewJobMatchesPull(repoFullName string, pull github.PullRequest, 
 		len(payload.Reviewers) > 0
 }
 
+// lookupReadyPullRequestTask resolves the task driving a pull request for the
+// ready-to-merge path. It prefers the branch-keyed lookup every other caller
+// uses, then falls back to the durable review-pr-<number>-<hash> id for a
+// BRANCHLESS local review task (#1562). Without the fallback a task released from
+// a transient merge-gate block is never re-evaluated, because a branchless row is
+// invisible to a pull.HeadRef lookup — the release would restore an operator exit
+// (`task resume-work` accepts ready_to_merge) and nothing else.
+//
+// The fallback is deliberately scoped to this path rather than widened into
+// lookupPullRequestTask, whose other callers reason about branch-owned work.
+func (d Daemon) lookupReadyPullRequestTask(ctx context.Context, pull github.PullRequest) (db.Task, error) {
+	task, err := d.lookupPullRequestTask(ctx, d.Repo.FullName(), pull.HeadRef)
+	if err == nil {
+		return task, nil
+	}
+	if !errors.Is(err, sql.ErrNoRows) {
+		return db.Task{}, err
+	}
+	tasks, listErr := d.Store.ListTasksByRepo(ctx, d.Repo.FullName())
+	if listErr != nil {
+		return db.Task{}, listErr
+	}
+	for _, candidate := range tasks {
+		if strings.TrimSpace(candidate.Branch) != "" {
+			continue
+		}
+		number, ok := reviewTaskPullRequestNumber(candidate.ID)
+		if ok && number == pull.Number {
+			return candidate, nil
+		}
+	}
+	return db.Task{}, sql.ErrNoRows
+}
+
 func (d Daemon) pullRequestReadyToMerge(ctx context.Context, pull github.PullRequest) (bool, error) {
-	task, err := d.lookupPolledPullRequestTask(ctx, pull)
+	task, err := d.lookupReadyPullRequestTask(ctx, pull)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return false, nil
@@ -1335,11 +1369,6 @@ func (d Daemon) pullRequestReadyToMerge(ctx context.Context, pull github.PullReq
 	// TaskReadyToMerge is the retry authority. SkipNativeReviewFanout controls
 	// PR-open review routing only; a direct review can leave this task pending
 	// on CI, and suppressing its poll here strands gitmoot/merge-gate (#1708).
-	//
-	// This predicate is deliberately NOT the #1562 transient-block exit: it
-	// resolves its task from pull.HeadRef, and the population that actually wedges
-	// is the branchless local review-pr-<number>-<hash> task, which no HeadRef
-	// lookup can find. reconcileTransientlyBlockedMergeGates owns that exit.
 	return task.State == string(workflow.TaskReadyToMerge), nil
 }
 
@@ -1347,7 +1376,7 @@ func (d Daemon) handleReadyToMergeWorkflow(ctx context.Context, pull github.Pull
 	if d.Workflow == nil {
 		return nil
 	}
-	task, err := d.lookupPolledPullRequestTask(ctx, pull)
+	task, err := d.lookupReadyPullRequestTask(ctx, pull)
 	if err != nil {
 		return err
 	}

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -1325,35 +1325,57 @@ func workflowReviewJobMatchesPull(repoFullName string, pull github.PullRequest, 
 }
 
 // lookupReadyPullRequestTask resolves the task driving a pull request for the
-// ready-to-merge path. It prefers the branch-keyed lookup every other caller
-// uses, then falls back to the durable review-pr-<number>-<hash> id for a
-// BRANCHLESS local review task (#1562). Without the fallback a task released from
-// a transient merge-gate block is never re-evaluated, because a branchless row is
-// invisible to a pull.HeadRef lookup — the release would restore an operator exit
-// (`task resume-work` accepts ready_to_merge) and nothing else.
+// ready-to-merge path. Two rows can legitimately describe one PR: the implement
+// task that owns (repo, head branch), and a BRANCHLESS local review task keyed by
+// its durable review-pr-<number>-<hash> id. A branchless row is invisible to a
+// pull.HeadRef lookup, so without the fallback a task released from a transient
+// merge-gate block is never re-evaluated and the release restores an operator exit
+// (`task resume-work` accepts ready_to_merge) and nothing else (#1562).
+//
+// Selection prefers a candidate that is ACTUALLY ready_to_merge, because a
+// branch-first lookup strands the released review task whenever its branch has a
+// canonical implementation task in some other state — a supported coexistence.
+// When both are ready, or neither is, the branch-keyed row wins, so this differs
+// from the previous behaviour in exactly one case: the branch owner is not ready
+// and a branchless review task is.
 //
 // The fallback is deliberately scoped to this path rather than widened into
 // lookupPullRequestTask, whose other callers reason about branch-owned work.
 func (d Daemon) lookupReadyPullRequestTask(ctx context.Context, pull github.PullRequest) (db.Task, error) {
-	task, err := d.lookupPullRequestTask(ctx, d.Repo.FullName(), pull.HeadRef)
-	if err == nil {
-		return task, nil
+	branchTask, branchErr := d.lookupPullRequestTask(ctx, d.Repo.FullName(), pull.HeadRef)
+	if branchErr != nil && !errors.Is(branchErr, sql.ErrNoRows) {
+		return db.Task{}, branchErr
 	}
-	if !errors.Is(err, sql.ErrNoRows) {
-		return db.Task{}, err
+	branchFound := branchErr == nil
+	if branchFound && branchTask.State == string(workflow.TaskReadyToMerge) {
+		return branchTask, nil
 	}
 	tasks, listErr := d.Store.ListTasksByRepo(ctx, d.Repo.FullName())
 	if listErr != nil {
 		return db.Task{}, listErr
 	}
+	var branchless db.Task
+	var branchlessFound bool
 	for _, candidate := range tasks {
 		if strings.TrimSpace(candidate.Branch) != "" {
 			continue
 		}
 		number, ok := reviewTaskPullRequestNumber(candidate.ID)
-		if ok && number == pull.Number {
+		if !ok || number != pull.Number {
+			continue
+		}
+		if candidate.State == string(workflow.TaskReadyToMerge) {
 			return candidate, nil
 		}
+		if !branchlessFound {
+			branchless, branchlessFound = candidate, true
+		}
+	}
+	if branchFound {
+		return branchTask, nil
+	}
+	if branchlessFound {
+		return branchless, nil
 	}
 	return db.Task{}, sql.ErrNoRows
 }

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -274,6 +274,9 @@ func (d Daemon) PollOnce(ctx context.Context) error {
 	if err := d.reconcileExternallyMergedTasks(ctx, openPullNumbers); err != nil && firstErr == nil {
 		firstErr = err
 	}
+	if err := d.reconcileTransientlyBlockedMergeGates(ctx, openPullNumbers); err != nil && firstErr == nil {
+		firstErr = err
+	}
 	if err := d.retryClosedReadyToMerge(ctx, openBranches); err != nil && firstErr == nil {
 		firstErr = err
 	}
@@ -519,6 +522,94 @@ func (d Daemon) reconcilePROpenTasks(ctx context.Context, pulls []github.PullReq
 			PullRequest: int(pull.Number),
 		}, workflow.PullRequestJournalOpened); err != nil {
 			d.logf("workflow journal PR-open breadcrumb failed for %s#%d: %v", d.Repo.FullName(), pull.Number, err)
+		}
+	}
+	return firstErr
+}
+
+// reconcileTransientlyBlockedMergeGates gives a TRANSIENTLY blocked task an exit
+// (#1562). The merge gate already separates an operational/branch-staleness/infra
+// condition from an authoritative quality rejection, but that classification used
+// to live only on the returned decision, so nothing outside the blocking call
+// stack could act on it: daemon.pullRequestReadyToMerge admits ready_to_merge
+// only, engine_pr_lifecycle's non-merged close branch omits blocked, and
+// `task resume-work` refuses blocked. Measured on review-pr-1699-3f3a1026, whose
+// dirty-worktree block outlived the dirt by 95 minutes and cleared only when a
+// human merged the PR by hand.
+//
+// Release requires BOTH halves. The persisted class is the SELECTION filter — the
+// gate's own statement that this condition is self-clearing — and returning the
+// row to ready_to_merge is what restores it to the population that is
+// re-evaluated, which is the same remedy the engine already applies to a deferred
+// decision for the identical wedge ("a state that poll does not re-evaluate",
+// engine_routing_merge.go). The gate is NOT re-run here: it runs on the
+// ready_to_merge path, so a condition that has not actually cleared blocks again
+// and the row simply returns here next tick. A quality-classed row is never
+// selected, so an authoritative rejection stays blocked by construction rather
+// than by a re-evaluation happening to agree.
+//
+// PR-number resolution mirrors reconcileExternallyMergedTasks exactly, because
+// the wedged population is precisely the branchless local review task: a
+// pull.HeadRef lookup cannot find it, which is why the branch-keyed poll predicate
+// is the wrong seam for this exit.
+func (d Daemon) reconcileTransientlyBlockedMergeGates(ctx context.Context, openPullNumbers map[int64]struct{}) error {
+	tasks, err := d.Store.ListTasksByRepo(ctx, d.Repo.FullName())
+	if err != nil {
+		return err
+	}
+	var firstErr error
+	for _, task := range tasks {
+		if task.State != string(workflow.TaskBlocked) {
+			continue
+		}
+		branch := strings.TrimSpace(task.Branch)
+		var number int64
+		if branch == "" {
+			var ok bool
+			number, ok = reviewTaskPullRequestNumber(task.ID)
+			if !ok {
+				continue
+			}
+		} else {
+			stored, storedErr := d.Store.GetPullRequestByRepoBranch(ctx, d.Repo.FullName(), branch)
+			if storedErr != nil {
+				if errors.Is(storedErr, sql.ErrNoRows) {
+					continue
+				}
+				return storedErr
+			}
+			number = stored.Number
+		}
+		if number <= 0 {
+			continue
+		}
+		// Only a still-open PR can clear a transient condition. A closed or merged
+		// PR belongs to the external-merge and closed-reviewing reconcilers.
+		if _, open := openPullNumbers[number]; !open {
+			continue
+		}
+		gate, gateErr := d.Store.GetMergeGate(ctx, d.Repo.FullName(), number)
+		if gateErr != nil {
+			if errors.Is(gateErr, sql.ErrNoRows) {
+				continue
+			}
+			return gateErr
+		}
+		if gate.State != "blocked" || gate.BlockClass != int(workflow.MergeBlockTransient) {
+			continue
+		}
+		changed, _, transitionErr := d.Store.TransitionTaskStateWithEvent(ctx, task.ID,
+			[]string{string(workflow.TaskBlocked)},
+			string(workflow.TaskReadyToMerge), "merge_gate_transient_retry",
+			fmt.Sprintf("re-evaluating transient merge-gate block on open PR #%d: %s", number, gate.Reason))
+		if transitionErr != nil {
+			if firstErr == nil {
+				firstErr = transitionErr
+			}
+			continue
+		}
+		if changed {
+			d.logf("task %s released blocked -> ready_to_merge: transient merge-gate block on open PR #%d (%s)", task.ID, number, gate.Reason)
 		}
 	}
 	return firstErr
@@ -1244,6 +1335,11 @@ func (d Daemon) pullRequestReadyToMerge(ctx context.Context, pull github.PullReq
 	// TaskReadyToMerge is the retry authority. SkipNativeReviewFanout controls
 	// PR-open review routing only; a direct review can leave this task pending
 	// on CI, and suppressing its poll here strands gitmoot/merge-gate (#1708).
+	//
+	// This predicate is deliberately NOT the #1562 transient-block exit: it
+	// resolves its task from pull.HeadRef, and the population that actually wedges
+	// is the branchless local review-pr-<number>-<hash> task, which no HeadRef
+	// lookup can find. reconcileTransientlyBlockedMergeGates owns that exit.
 	return task.State == string(workflow.TaskReadyToMerge), nil
 }
 

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -635,24 +635,45 @@ func (d Daemon) reconcileTransientlyBlockedMergeGates(ctx context.Context, openP
 	return firstErr
 }
 
-// mergeGateOwnsCurrentBlock reports whether the task's most recent blocking event
-// attributes the block to the merge gate (#1562). Task events are append-only, so
-// the LATEST blocking event is the current cause: a later block_parent or quorum
-// failure supersedes an earlier merge-gate block and must not be cleared by the
-// transient exit. Absence of any attributed event is not evidence of a gate block
-// and returns false.
-func (d Daemon) mergeGateOwnsCurrentBlock(ctx context.Context, taskID string) (bool, error) {
+// mergeGateOwnsCurrentBlock reports whether the merge gate owns the task's CURRENT
+// block (#1562). Task events are append-only, so the LATEST blocking event is the
+// current cause: a later synthesis-gate or auto-fix block supersedes an earlier
+// merge-gate block and must not be cleared by the transient exit.
+//
+// The second return value distinguishes the UPGRADE population. Before this
+// change neither the merge gate nor the coordinator synthesis gates wrote an
+// attributed event — both reached blocked through the shared e.block — so a task
+// with NO blocking event at all is neither a gate block nor a quorum failure that
+// we can prove; it is a row blocked before attribution existed. Refusing those
+// outright would strand exactly the population that motivated #1562, including the
+// 95-minute review-pr-1699-3f3a1026 wedge, so the caller heals them once.
+// (Cause-vs-state and the upgrade path both raised by gm-omp-fanout; the
+// unknown-blocker closure and the write-after-block ordering by a review advisory.)
+func (d Daemon) mergeGateOwnsCurrentBlock(ctx context.Context, taskID string) (attributed bool, unattributed bool, err error) {
 	events, err := d.Store.ListTaskEvents(ctx, taskID)
 	if err != nil {
 		return false, err
 	}
+	// Newest-first: the most recent BLOCKING event is the current cause. The
+	// predicate is deliberately a union rather than a list of known kinds. A fixed
+	// list is not closed under future blockers: a new mechanism blocking a task
+	// would simply not match, and an older merge_gate_blocked would win and
+	// authorize releasing a block it did not cause. ToState alone is not enough
+	// either, because blockAutoFix records its event without one, so an
+	// auto-fix block would be invisible to a ToState-only filter.
 	for i := len(events) - 1; i >= 0; i-- {
-		switch events[i].Kind {
-		case "merge_gate_blocked":
-			return true, nil
-		case "review_auto_fix_blocked", "pr_closed_unmerged", "delegation_child_failed", "block_parent", "quorum_unmet":
-			return false, nil
+		event := events[i]
+		blocking := event.ToState == string(workflow.TaskBlocked)
+		switch event.Kind {
+		case "merge_gate_blocked", "review_auto_fix_blocked", "pr_closed_unmerged",
+			"delegation_vote_unmet", "delegation_quorum_unmet", "delegation_child_failed",
+			"block_parent", "quorum_unmet":
+			blocking = true
 		}
+		if !blocking {
+			continue
+		}
+		return event.Kind == "merge_gate_blocked", false, nil
 	}
 	return false, nil
 }

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -598,6 +598,26 @@ func (d Daemon) reconcileTransientlyBlockedMergeGates(ctx context.Context, openP
 		if gate.State != "blocked" || gate.BlockClass != int(workflow.MergeBlockTransient) {
 			continue
 		}
+		// The gate row says the CONDITION is self-clearing. It does not say the gate
+		// is still the REASON this task is blocked. e.block is shared with the
+		// coordinator failure paths (block_parent, and the vote/quorum synthesis
+		// gates), so a task carrying a stale transient gate row and then blocked by a
+		// delegation quorum failure satisfies every test above — and releasing it
+		// would discard a quorum failure as self-clearing infrastructure. Require the
+		// task's most recent blocking event to attribute the CURRENT block to the
+		// merge gate. A task blocked before merge-gate blocks were attributed has no
+		// such event and stays blocked, which is the safe direction.
+		// (Found by gm-omp-fanout while coordinating the PR #1731 collision.)
+		attributed, attrErr := d.mergeGateOwnsCurrentBlock(ctx, task.ID)
+		if attrErr != nil {
+			if firstErr == nil {
+				firstErr = attrErr
+			}
+			continue
+		}
+		if !attributed {
+			continue
+		}
 		changed, _, transitionErr := d.Store.TransitionTaskStateWithEvent(ctx, task.ID,
 			[]string{string(workflow.TaskBlocked)},
 			string(workflow.TaskReadyToMerge), "merge_gate_transient_retry",
@@ -613,6 +633,28 @@ func (d Daemon) reconcileTransientlyBlockedMergeGates(ctx context.Context, openP
 		}
 	}
 	return firstErr
+}
+
+// mergeGateOwnsCurrentBlock reports whether the task's most recent blocking event
+// attributes the block to the merge gate (#1562). Task events are append-only, so
+// the LATEST blocking event is the current cause: a later block_parent or quorum
+// failure supersedes an earlier merge-gate block and must not be cleared by the
+// transient exit. Absence of any attributed event is not evidence of a gate block
+// and returns false.
+func (d Daemon) mergeGateOwnsCurrentBlock(ctx context.Context, taskID string) (bool, error) {
+	events, err := d.Store.ListTaskEvents(ctx, taskID)
+	if err != nil {
+		return false, err
+	}
+	for i := len(events) - 1; i >= 0; i-- {
+		switch events[i].Kind {
+		case "merge_gate_blocked":
+			return true, nil
+		case "review_auto_fix_blocked", "pr_closed_unmerged", "delegation_child_failed", "block_parent", "quorum_unmet":
+			return false, nil
+		}
+	}
+	return false, nil
 }
 
 // reconcileExternallyMergedTasks advances PR lifecycle tasks, plus blocked

--- a/internal/daemon/daemon_draft_propagation_test.go
+++ b/internal/daemon/daemon_draft_propagation_test.go
@@ -29,7 +29,11 @@ func TestDaemonReadyToMergeDraftDoesNotParkTask(t *testing.T) {
 	engine := workflow.Engine{Store: store, MergeGate: gate}
 	daemon := Daemon{Repo: repo, Store: store, Workflow: &engine}
 
-	if err := daemon.handleReadyToMergeWorkflow(ctx, pull); err != nil {
+	task, err := store.GetTask(ctx, "task-draft")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := daemon.handleReadyToMergeWorkflow(ctx, pull, task); err != nil {
 		t.Fatalf("handleReadyToMergeWorkflow returned error: %v", err)
 	}
 	assertDaemonDraftReachedGateAndTaskState(t, store, gate, workflow.TaskReadyToMerge)

--- a/internal/daemon/daemon_draft_unknown_test.go
+++ b/internal/daemon/daemon_draft_unknown_test.go
@@ -33,7 +33,11 @@ func TestDaemonDraftFieldNullDoesNotParkTask(t *testing.T) {
 	engine := workflow.Engine{Store: store, MergeGate: gate}
 	daemon := Daemon{Repo: repo, Store: store, Workflow: &engine}
 
-	if err := daemon.handleReadyToMergeWorkflow(ctx, pull); err != nil {
+	task, err := store.GetTask(ctx, "task-draft")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := daemon.handleReadyToMergeWorkflow(ctx, pull, task); err != nil {
 		t.Fatalf("handleReadyToMergeWorkflow returned error: %v", err)
 	}
 	assertDraftTaskState(t, store, workflow.TaskReadyToMerge)
@@ -64,7 +68,11 @@ func TestDaemonConfirmedNonDraftParksTask(t *testing.T) {
 	engine := workflow.Engine{Store: store, MergeGate: gate}
 	daemon := Daemon{Repo: repo, Store: store, Workflow: &engine}
 
-	if err := daemon.handleReadyToMergeWorkflow(ctx, pull); err != nil {
+	task, err := store.GetTask(ctx, "task-draft")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := daemon.handleReadyToMergeWorkflow(ctx, pull, task); err != nil {
 		t.Fatalf("handleReadyToMergeWorkflow returned error: %v", err)
 	}
 	assertDraftTaskState(t, store, workflow.TaskAwaitingHumanMerge)

--- a/internal/daemon/external_merge_reconcile_test.go
+++ b/internal/daemon/external_merge_reconcile_test.go
@@ -2,12 +2,18 @@ package daemon
 
 import (
 	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
 	"fmt"
 	"reflect"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/gitmoot/gitmoot/internal/db"
 	"github.com/gitmoot/gitmoot/internal/github"
+	"github.com/gitmoot/gitmoot/internal/subprocess"
 	"github.com/gitmoot/gitmoot/internal/workflow"
 )
 
@@ -218,6 +224,320 @@ func TestPollOnceReconcilesEmptyBranchReviewTaskByPullRequestNumber(t *testing.T
 	if err != nil || pr.State != "merged" || pr.HeadBranch != "feature/eleven" {
 		t.Fatalf("PR mirror = %+v, err=%v", pr, err)
 	}
+}
+
+func TestPollOnceReconcilesBranchlessQueuedMergeAsMerged(t *testing.T) {
+	runBranchlessQueuedMergeTerminalPolls(t, mergedPull(1732, "task-1732"),
+		workflow.TaskMerged, "merged", "pull_request_merged")
+}
+
+func TestPollOnceReconcilesBranchlessQueuedMergeAsClosedUnmerged(t *testing.T) {
+	runBranchlessQueuedMergeTerminalPolls(t, github.PullRequest{
+		Number: 1732, Title: "Review PR #1732", State: "closed",
+		HeadRef: "task-1732", BaseRef: "main", HeadSHA: "queued-head",
+	}, workflow.TaskBlocked, "closed", "pr_closed_unmerged")
+}
+
+func runBranchlessQueuedMergeTerminalPolls(t *testing.T, terminal github.PullRequest, wantTask workflow.TaskState, wantPRState, wantEvent string) {
+	t.Helper()
+	ctx := context.Background()
+	repo := github.Repository{Owner: "gitmoot", Name: "gitmoot"}
+	store := testStore(t)
+	mergeable := true
+	open := github.PullRequest{
+		Number: 1732, Title: "Review PR #1732", State: "open",
+		HeadRef: "task-1732", BaseRef: "main", HeadSHA: "queued-head",
+		Mergeable: &mergeable,
+	}
+	taskID := "review-pr-1732-retained"
+	workflowID := "gitmoot4/branchless-cleanup-1732"
+	seedReadyBranchlessReviewTask(t, store, repo, taskID, open, open.HeadSHA)
+	worktreePath := t.TempDir()
+	if err := store.UpsertTask(ctx, db.Task{
+		ID: taskID, RepoFullName: repo.FullName(), State: string(workflow.TaskReadyToMerge),
+		WorktreePath: worktreePath,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.UpsertAgent(ctx, db.Agent{
+		Name: "builder", Role: "implementer", Runtime: "codex", RuntimeRef: "last",
+		RepoScope: repo.FullName(), Capabilities: []string{"implement"},
+		AutonomyPolicy: "danger-full-access", HealthStatus: "ok",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if acquired, err := store.AcquireLock(ctx, db.BranchLock{
+		RepoFullName: repo.FullName(), Branch: open.HeadRef, Owner: "builder",
+	}); err != nil || !acquired {
+		t.Fatalf("AcquireLock = acquired %v err %v", acquired, err)
+	}
+	if err := store.SetBranchLockReviewFanout(ctx, repo.FullName(), open.HeadRef, true); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.UpsertPullRequest(ctx, db.PullRequest{
+		RepoFullName: repo.FullName(), Number: open.Number,
+		URL:        "https://github.com/gitmoot/gitmoot/pull/1732",
+		HeadBranch: open.HeadRef, BaseBranch: open.BaseRef, HeadSHA: open.HeadSHA, State: "open",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	implementPayload, err := json.Marshal(workflow.JobPayload{
+		Repo: repo.FullName(), Branch: open.HeadRef, PullRequest: int(open.Number),
+		HeadSHA: open.HeadSHA, TaskID: taskID, WorkflowID: workflowID,
+		Result: &workflow.AgentResult{Decision: "implemented", Summary: "implemented"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := store.CreateJobWithEvent(ctx, db.Job{
+		ID: "implement-1732", Agent: "builder", Type: "implement",
+		State: string(workflow.JobSucceeded), Payload: string(implementPayload),
+	}, db.JobEvent{Kind: string(workflow.JobSucceeded), Message: "done"}); err != nil {
+		t.Fatal(err)
+	}
+	base := &fakeGitHub{
+		pullsByState:  map[string][]github.PullRequest{"open": {open}, "closed": nil},
+		pullsByNumber: map[int64]github.PullRequest{open.Number: open},
+		comments:      map[int64][]github.IssueComment{open.Number: {}},
+	}
+	runner := &queuedPollMergeRunner{}
+	client := &queuedMergePollGitHub{
+		mergeGateRaceGitHub: &mergeGateRaceGitHub{
+			fakeGitHub: base,
+			checks: []github.PullRequestCheck{{
+				Name: "ci", Bucket: "pass", State: "SUCCESS",
+			}},
+		},
+		mergeClient: github.GhClient{Runner: runner},
+	}
+	postMergeGit := &canonicalPostMergeGit{}
+	worktrees := &recordingWorktreeCleaner{}
+	nextTasks := &recordingNextTaskEnqueuer{}
+	gate := &workflow.PolicyMergeGate{
+		AutoMerge: true, Store: store, GitHub: client, Git: postMergeGit,
+		Worktrees: worktrees, NextTasks: nextTasks,
+	}
+	engine := workflow.Engine{Store: store, MergeGate: gate, RequiredReviewers: []string{"reviewer"}}
+	daemon := Daemon{Repo: repo, Store: store, GitHub: client, Workflow: &engine}
+
+	if err := daemon.PollOnce(ctx); err != nil {
+		t.Fatalf("queued PollOnce: %v", err)
+	}
+	task, err := store.GetTask(ctx, taskID)
+	if err != nil || task.State != string(workflow.TaskReadyToMerge) || task.Branch != "" {
+		gateState, _ := store.GetMergeGate(ctx, repo.FullName(), open.Number)
+		events, _ := store.ListTaskEvents(ctx, taskID)
+		t.Fatalf("queued task = %+v err=%v gate=%+v events=%+v, want branchless ready_to_merge", task, err, gateState, events)
+	}
+	if len(client.merges) != 1 || runner.calls != 2 {
+		t.Fatalf("queued production merge attempts=%d adapter calls=%d, want one command and one confirmation",
+			len(client.merges), runner.calls)
+	}
+	queuedGate, err := store.GetMergeGate(ctx, repo.FullName(), open.Number)
+	if err != nil || queuedGate.State != "pending" {
+		t.Fatalf("queued merge gate = %+v err=%v, want pending", queuedGate, err)
+	}
+	writer, err := db.OpenAlreadyMigrated(store.DatabasePath())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer writer.Close()
+	changed, _, writeErr := writer.CompareAndSwapTaskState(ctx, taskID,
+		string(workflow.TaskReadyToMerge), string(workflow.TaskDismissed))
+	if writeErr == nil || changed || !strings.Contains(writeErr.Error(), "claimed for an external merge") {
+		t.Fatalf("queued conflicting writer = changed %v err %v, want retained claim rejection", changed, writeErr)
+	}
+
+	base.pullsByState["open"] = nil
+	base.pullsByState["closed"] = []github.PullRequest{terminal}
+	base.pullsByNumber[terminal.Number] = terminal
+	if err := daemon.PollOnce(ctx); err != nil {
+		t.Fatalf("terminal PollOnce: %v", err)
+	}
+	task, err = store.GetTask(ctx, taskID)
+	if err != nil || task.State != string(wantTask) || task.Branch != "" {
+		t.Fatalf("terminal task = %+v err=%v, want branchless %s", task, err, wantTask)
+	}
+	pr, err := store.GetPullRequest(ctx, repo.FullName(), terminal.Number)
+	if err != nil || pr.State != wantPRState || pr.HeadBranch != terminal.HeadRef {
+		t.Fatalf("terminal PR mirror = %+v err=%v, want state %q branch %q", pr, err, wantPRState, terminal.HeadRef)
+	}
+	events, err := store.ListTaskEvents(ctx, taskID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	matches := 0
+	for _, event := range events {
+		if event.Kind == wantEvent {
+			matches++
+		}
+	}
+	if matches != 1 {
+		t.Fatalf("terminal task events = %+v, want one %q", events, wantEvent)
+	}
+	notes, err := store.ListWorkflowNotes(ctx, workflowID, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	wantNote := fmt.Sprintf("[auto:pr:%d:merged] PR #%d merged", terminal.Number, terminal.Number)
+	if wantTask != workflow.TaskMerged {
+		wantNote = fmt.Sprintf("[auto:pr:%d:closed] PR #%d closed without merging", terminal.Number, terminal.Number)
+	}
+	terminalNotes := 0
+	for _, note := range notes {
+		if note.Author == db.WorkflowAutoNoteAuthor && note.Body == wantNote {
+			terminalNotes++
+		}
+	}
+	if terminalNotes != 1 {
+		t.Fatalf("terminal workflow notes = %+v, want one %q", notes, wantNote)
+	}
+	token, claimed, current, err := store.ClaimTaskState(ctx, taskID, string(wantTask),
+		db.TaskStateClaimKindExternalMerge, time.Minute)
+	if err != nil || !claimed || current != string(wantTask) {
+		t.Fatalf("post-reconcile claim = token %q claimed %v current %q err %v, want resolved retained claim",
+			token, claimed, current, err)
+	}
+	if err := store.ReleaseTaskStateClaim(ctx, taskID, token); err != nil {
+		t.Fatal(err)
+	}
+	mergedOutcome := wantTask == workflow.TaskMerged
+	terminalGate, err := store.GetMergeGate(ctx, repo.FullName(), terminal.Number)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if mergedOutcome {
+		if terminalGate.State != "merged" {
+			t.Fatalf("terminal merge gate = %+v, want merged", terminalGate)
+		}
+		if _, err := store.GetBranchLock(ctx, repo.FullName(), open.HeadRef); !errors.Is(err, sql.ErrNoRows) {
+			t.Fatalf("branch lock after merged PollOnce = %v, want released", err)
+		}
+		if task.WorktreePath != "" || len(worktrees.paths) != 1 || worktrees.paths[0] != worktreePath {
+			t.Fatalf("merged worktree task=%+v removals=%v, want one canonical cleanup", task, worktrees.paths)
+		}
+		if len(postMergeGit.updates) != 1 || postMergeGit.updates[0] != "origin/main" {
+			t.Fatalf("post-merge base updates = %v, want [origin/main]", postMergeGit.updates)
+		}
+		if len(nextTasks.taskIDs) != 1 || nextTasks.taskIDs[0] != taskID {
+			t.Fatalf("post-merge continuations = %v, want [%s]", nextTasks.taskIDs, taskID)
+		}
+	} else {
+		if terminalGate.State != "pending" {
+			t.Fatalf("closed-unmerged merge gate = %+v, want retained pending history", terminalGate)
+		}
+		if _, err := store.GetBranchLock(ctx, repo.FullName(), open.HeadRef); err != nil {
+			t.Fatalf("closed-unmerged branch lock = %v, want preserved", err)
+		}
+		if task.WorktreePath != worktreePath || len(worktrees.paths) != 0 ||
+			len(postMergeGit.updates) != 0 || len(nextTasks.taskIDs) != 0 {
+			t.Fatalf("closed-unmerged cleanup task=%+v removals=%v updates=%v continuations=%v, want none",
+				task, worktrees.paths, postMergeGit.updates, nextTasks.taskIDs)
+		}
+	}
+
+	if err := daemon.PollOnce(ctx); err != nil {
+		t.Fatalf("stable PollOnce: %v", err)
+	}
+	task, err = store.GetTask(ctx, taskID)
+	if err != nil || task.State != string(wantTask) {
+		t.Fatalf("stable task = %+v err=%v, want %s", task, err, wantTask)
+	}
+	stablePR, err := store.GetPullRequest(ctx, repo.FullName(), terminal.Number)
+	if err != nil || stablePR.State != pr.State || stablePR.HeadBranch != pr.HeadBranch {
+		t.Fatalf("stable PR mirror = %+v err=%v, want unchanged from %+v", stablePR, err, pr)
+	}
+	stableGate, err := store.GetMergeGate(ctx, repo.FullName(), terminal.Number)
+	if err != nil || stableGate.State != terminalGate.State || stableGate.Reason != terminalGate.Reason {
+		t.Fatalf("stable merge gate = %+v err=%v, want unchanged from %+v", stableGate, err, terminalGate)
+	}
+	stableEvents, err := store.ListTaskEvents(ctx, taskID)
+	if err != nil || len(stableEvents) != len(events) {
+		t.Fatalf("stable task events = %+v err=%v, want %d events", stableEvents, err, len(events))
+	}
+	stableNotes, err := store.ListWorkflowNotes(ctx, workflowID, 0)
+	if err != nil || !reflect.DeepEqual(stableNotes, notes) {
+		t.Fatalf("stable workflow notes = %+v err=%v, want unchanged from %+v", stableNotes, err, notes)
+	}
+	wantCleanupCount := 0
+	if mergedOutcome {
+		wantCleanupCount = 1
+	}
+	if len(worktrees.paths) != wantCleanupCount || len(postMergeGit.updates) != wantCleanupCount ||
+		len(nextTasks.taskIDs) != wantCleanupCount {
+		t.Fatalf("stable cleanup removals=%v updates=%v continuations=%v, want count %d",
+			worktrees.paths, postMergeGit.updates, nextTasks.taskIDs, wantCleanupCount)
+	}
+	if len(client.merges) != 1 || runner.calls != 2 {
+		t.Fatalf("stable production merge attempts=%d adapter calls=%d, want one merge command total",
+			len(client.merges), runner.calls)
+	}
+	if mergedOutcome {
+		if _, err := store.GetBranchLock(ctx, repo.FullName(), open.HeadRef); !errors.Is(err, sql.ErrNoRows) {
+			t.Fatalf("stable merged branch lock = %v, want absent", err)
+		}
+	}
+}
+
+type canonicalPostMergeGit struct {
+	updates []string
+}
+
+func (*canonicalPostMergeGit) WorktreeClean(context.Context) (bool, error) {
+	return true, nil
+}
+
+func (g *canonicalPostMergeGit) UpdateBase(_ context.Context, remote, branch string) error {
+	g.updates = append(g.updates, remote+"/"+branch)
+	return nil
+}
+
+type recordingWorktreeCleaner struct {
+	paths []string
+}
+
+func (c *recordingWorktreeCleaner) RemoveWorktree(_ context.Context, path string) error {
+	c.paths = append(c.paths, path)
+	return nil
+}
+
+type recordingNextTaskEnqueuer struct {
+	taskIDs []string
+}
+
+func (e *recordingNextTaskEnqueuer) EnqueueNextTask(_ context.Context, completedTaskID string) error {
+	e.taskIDs = append(e.taskIDs, completedTaskID)
+	return nil
+}
+
+type queuedMergePollGitHub struct {
+	*mergeGateRaceGitHub
+	mergeClient github.GhClient
+}
+
+func (g *queuedMergePollGitHub) MergePullRequest(ctx context.Context, input github.MergePullRequestInput) (github.MergeResult, error) {
+	g.merges = append(g.merges, input)
+	return g.mergeClient.MergePullRequest(ctx, input)
+}
+
+type queuedPollMergeRunner struct {
+	calls int
+}
+
+func (r *queuedPollMergeRunner) Run(_ context.Context, _ string, _ string, _ ...string) (subprocess.Result, error) {
+	r.calls++
+	switch r.calls {
+	case 1:
+		return subprocess.Result{Stdout: "queued"}, nil
+	case 2:
+		return subprocess.Result{Stdout: `{"number":1732,"title":"Review PR #1732","state":"open","html_url":"https://github.com/gitmoot/gitmoot/pull/1732","head":{"ref":"task-1732","sha":"queued-head"},"base":{"ref":"main"}}`}, nil
+	default:
+		return subprocess.Result{}, fmt.Errorf("unexpected queued merge adapter call %d", r.calls)
+	}
+}
+
+func (*queuedPollMergeRunner) LookPath(file string) (string, error) {
+	return file, nil
 }
 
 func TestExternalMergeReconcileCapsTargetedLookupsPerTick(t *testing.T) {

--- a/internal/daemon/merge_gate_transient_exit_test.go
+++ b/internal/daemon/merge_gate_transient_exit_test.go
@@ -2,7 +2,12 @@ package daemon
 
 import (
 	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/gitmoot/gitmoot/internal/db"
 	"github.com/gitmoot/gitmoot/internal/github"
@@ -22,6 +27,11 @@ import (
 // would therefore pass against a fix that never runs.
 func seedBlockedReviewTask(t *testing.T, store *db.Store, repo github.Repository, class workflow.MergeBlockClass, reason string) github.PullRequest {
 	t.Helper()
+	return seedBlockedReviewTaskAttributed(t, store, repo, class, reason, true)
+}
+
+func seedBlockedReviewTaskAttributed(t *testing.T, store *db.Store, repo github.Repository, class workflow.MergeBlockClass, reason string, attribute bool) github.PullRequest {
+	t.Helper()
 	ctx := context.Background()
 	if err := store.UpsertTask(ctx, db.Task{
 		ID:           "review-pr-1699-3f3a1026",
@@ -32,6 +42,20 @@ func seedBlockedReviewTask(t *testing.T, store *db.Store, repo github.Repository
 	}); err != nil {
 		t.Fatalf("UpsertTask returned error: %v", err)
 	}
+	payload, err := json.Marshal(workflow.JobPayload{
+		Repo: repo.FullName(), Branch: "task-1699", PullRequest: 1699,
+		HeadSHA: "3f3a1026", TaskID: "review-pr-1699-3f3a1026",
+		Result: &workflow.AgentResult{Decision: "approved", Summary: "approved current head"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := store.CreateJob(ctx, db.Job{
+		ID: "review-current-1699", Agent: "reviewer", Type: "review",
+		State: string(workflow.JobSucceeded), Payload: string(payload),
+	}); err != nil {
+		t.Fatalf("CreateJob(review-current-1699) returned error: %v", err)
+	}
 	if err := store.UpsertMergeGate(ctx, db.MergeGate{
 		RepoFullName: repo.FullName(),
 		PullRequest:  1699,
@@ -41,16 +65,15 @@ func seedBlockedReviewTask(t *testing.T, store *db.Store, repo github.Repository
 	}); err != nil {
 		t.Fatalf("UpsertMergeGate returned error: %v", err)
 	}
-	// The merge gate attributes its own block on the task (blockMergeGate), which is
-	// what distinguishes it from a coordinator block_parent or quorum failure
-	// reaching the same state through the shared e.block helper.
-	if err := store.AddTaskEvent(ctx, db.TaskEvent{
-		TaskID:  "review-pr-1699-3f3a1026",
-		Kind:    "merge_gate_blocked",
-		ToState: string(workflow.TaskBlocked),
-		Reason:  reason,
-	}); err != nil {
-		t.Fatalf("AddTaskEvent(merge_gate_blocked) returned error: %v", err)
+	if attribute {
+		if err := store.AddTaskEvent(ctx, db.TaskEvent{
+			TaskID:  "review-pr-1699-3f3a1026",
+			Kind:    "merge_gate_blocked",
+			ToState: string(workflow.TaskBlocked),
+			Reason:  reason,
+		}); err != nil {
+			t.Fatalf("AddTaskEvent(merge_gate_blocked) returned error: %v", err)
+		}
 	}
 	return github.PullRequest{
 		Number:  1699,
@@ -74,6 +97,20 @@ func blockedReviewTaskDaemon(t *testing.T, store *db.Store, repo github.Reposito
 	return Daemon{Repo: repo, Store: store, GitHub: client, Workflow: &engine}, gate
 }
 
+type delayedClearanceMergeGateGit struct {
+	clean  bool
+	checks int
+}
+
+func (g *delayedClearanceMergeGateGit) WorktreeClean(context.Context) (bool, error) {
+	g.checks++
+	return g.clean, nil
+}
+
+func (*delayedClearanceMergeGateGit) UpdateBase(context.Context, string, string) error {
+	return nil
+}
+
 func hasTaskEventKind(events []db.TaskEvent, kind string) bool {
 	for _, event := range events {
 		if event.Kind == kind {
@@ -83,21 +120,42 @@ func hasTaskEventKind(events []db.TaskEvent, kind string) bool {
 	return false
 }
 
+func seedReadyBranchlessReviewTask(t *testing.T, store *db.Store, repo github.Repository, taskID string, pull github.PullRequest, headSHA string) {
+	t.Helper()
+	ctx := context.Background()
+	if err := store.UpsertTask(ctx, db.Task{
+		ID: taskID, RepoFullName: repo.FullName(), State: string(workflow.TaskReadyToMerge),
+	}); err != nil {
+		t.Fatal(err)
+	}
+	payload, err := json.Marshal(workflow.JobPayload{
+		Repo: repo.FullName(), Branch: pull.HeadRef, PullRequest: int(pull.Number),
+		HeadSHA: headSHA, TaskID: taskID,
+		Result: &workflow.AgentResult{Decision: "approved", Summary: "approved"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := store.CreateJob(ctx, db.Job{
+		ID: "review-" + taskID, Agent: "reviewer", Type: "review",
+		State: string(workflow.JobSucceeded), Payload: string(payload),
+	}); err != nil {
+		t.Fatal(err)
+	}
+}
+
 // TestPollOnceLeavesTaskBlockedByDelegationFailureBlocked is the cause-attribution
 // direction, found by gm-omp-fanout while we coordinated the PR #1731 collision.
 //
-// e.block is SHARED: the merge gate uses it, and so do the coordinator failure
-// paths — block_parent and the vote/quorum synthesis gates in
-// engine_continuation_synthesis.go. So `state == blocked` says nothing about WHICH
-// mechanism blocked the task. A task carrying a stale transient merge-gate row from
-// an earlier evaluation, then blocked by a delegation quorum failure, satisfies
-// every other test in the reconciler — and releasing it would discard a quorum
-// failure as though it were self-clearing infrastructure. The gate row describes the
+// All real block paths now converge on the shared blockTask choke point, but the
+// latest ownership event still matters: a task carrying a stale transient
+// merge-gate row and then blocked by a delegation quorum failure satisfies every
+// state/gate check in the reconciler. Releasing it would discard a quorum failure
+// as though it were self-clearing infrastructure. The gate row describes the
 // CONDITION; only the task's latest blocking event establishes the CURRENT CAUSE.
 //
-// Mutant M5 ("cause ignored"): delete the mergeGateOwnsCurrentBlock guard from
-// reconcileTransientlyBlockedMergeGates. Only this test fails; every other
-// direction, including both two-poll tests, still passes.
+// Compile-valid mutant M5 ("cause ignored"): force the ownership result to true.
+// This test and the unknown-blocker direction both fail.
 func TestPollOnceLeavesTaskBlockedByDelegationFailureBlocked(t *testing.T) {
 	ctx := context.Background()
 	store := testStore(t)
@@ -140,22 +198,17 @@ func TestPollOnceLeavesTaskBlockedByDelegationFailureBlocked(t *testing.T) {
 }
 
 // TestPollOnceHealsPreAttributionBlockOnce is the UPGRADE path, raised by
-// gm-omp-fanout: every task blocked before this change has no attributed blocking
-// event, because neither the merge gate nor the synthesis gates wrote one — both
-// reached blocked through the shared e.block. A strict "no event means not
-// gate-owned" rule would refuse exactly the population that motivated #1562,
-// including the 95-minute review-pr-1699-3f3a1026 wedge, and the feature would
-// clear only blocks created after the deploy.
+// gm-omp-fanout: tasks blocked by an old binary may have no ownership event. A
+// strict "no event means not gate-owned" rule would refuse exactly the population
+// that motivated #1562, including the 95-minute review-pr-1699-3f3a1026 wedge.
 //
-// So a row with a transient gate row and NO competing blocking event is healed
-// once. "Once" is structural rather than counted: the release writes
-// merge_gate_transient_retry, so the row is no longer unattributed, and any later
-// real block arrives through an attributed path.
+// A row with a transient gate row and no competing blocking event is healed once.
+// The release writes merge_gate_transient_retry, and the reconciler treats that
+// durable marker as a consumed retry even if a later gate evaluation blocks the
+// task again.
 //
-// Mutant M6 ("no upgrade path"): make mergeGateOwnsCurrentBlock return
-// (false, false, nil) for an unattributed row. Only this test fails — every other
-// direction, including the delegation-failure refusal, still passes, which is what
-// makes the two behaviours distinguishable rather than a matter of opinion.
+// Compile-valid mutant M6 ("no upgrade path"): return unattributed=false for a
+// row with no blocking event. This test fails while attributed release remains.
 func TestPollOnceHealsPreAttributionBlockOnce(t *testing.T) {
 	ctx := context.Background()
 	store := testStore(t)
@@ -224,6 +277,7 @@ func TestPollOnceLeavesTaskBlockedByUnknownMechanismBlocked(t *testing.T) {
 		t.Fatalf("merge gate evaluations = %d, want 0", len(gate.requests))
 	}
 }
+
 // TestPollOnceReleasesTransientlyBlockedReviewTask is the release direction of
 // #1562. A task blocked on "local worktree is not clean" — a condition the gate
 // itself classified MergeBlockTransient — must regain an exit from the ordinary
@@ -338,9 +392,9 @@ func TestSecondPollEvaluatesGateAfterTransientRelease(t *testing.T) {
 // consumes. The one-row fixture cannot see this, which is why it passed against
 // the branch-first version at head 9ba794d8.
 //
-// Mutant M4 ("branch owner wins"): in lookupReadyPullRequestTask, return branchTask
-// whenever branchFound, before the branchless scan. Only this test fails; the
-// single-row two-poll test still passes.
+// Compile-valid mutant M4 ("branch owner wins"): return branchTask whenever
+// branchErr == nil before the branchless scan. This and the current-head
+// branchless selection test fail; the single-row two-poll direction still passes.
 func TestSecondPollEvaluatesGateWhenBranchOwnerIsNotReady(t *testing.T) {
 	ctx := context.Background()
 	store := testStore(t)
@@ -397,6 +451,230 @@ func TestSecondPollEvaluatesGateWhenBranchOwnerIsNotReady(t *testing.T) {
 	}
 	if implementation.State != string(workflow.TaskPullRequestOpen) {
 		t.Fatalf("implementation task state = %q, want pull_request_open left alone", implementation.State)
+	}
+}
+
+func TestTransientMergeGateRetryRecoversAfterDelayedClearanceAndStaysBounded(t *testing.T) {
+	ctx := context.Background()
+	store := testStore(t)
+	repo := github.Repository{Owner: "gitmoot", Name: "gitmoot"}
+	pull := seedBlockedReviewTask(t, store, repo, workflow.MergeBlockTransient, "local worktree is not clean")
+	initialTask, err := store.GetTask(ctx, "review-pr-1699-3f3a1026")
+	if err != nil {
+		t.Fatal(err)
+	}
+	implementPayload, err := json.Marshal(workflow.JobPayload{
+		Repo: repo.FullName(), Branch: pull.HeadRef, PullRequest: int(pull.Number),
+		HeadSHA: pull.HeadSHA, TaskID: initialTask.ID,
+		Result: &workflow.AgentResult{Decision: "implemented", Summary: "implemented current head"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := store.CreateJob(ctx, db.Job{
+		ID: "implement-current-1699", Agent: "implementer", Type: "implement",
+		State: string(workflow.JobSucceeded), Payload: string(implementPayload),
+	}); err != nil {
+		t.Fatalf("CreateJob(implement-current-1699) returned error: %v", err)
+	}
+	baseClient := &fakeGitHub{
+		pulls:    []github.PullRequest{pull},
+		comments: map[int64][]github.IssueComment{pull.Number: {}},
+	}
+	client := &mergeGateRaceGitHub{
+		fakeGitHub: baseClient,
+		checks: []github.PullRequestCheck{{
+			Name: "ci", Bucket: "pass", State: "SUCCESS",
+		}},
+		statuses: []github.CommitStatusInput{{
+			Repo: repo, SHA: pull.HeadSHA, State: "success", Context: "ci",
+		}},
+		statusSucceeded: []bool{true},
+	}
+	git := &delayedClearanceMergeGateGit{}
+	gate := &workflow.PolicyMergeGate{
+		AutoMerge: true, Store: store, GitHub: client, Git: git,
+	}
+	engine := workflow.Engine{Store: store, MergeGate: gate}
+	now := time.Now().UTC().Add(time.Hour)
+	daemon := Daemon{
+		Repo: repo, Store: store, GitHub: client, Workflow: &engine,
+		Now: func() time.Time { return now },
+	}
+	poll := func(label string) {
+		t.Helper()
+		pollErr := daemon.PollOnce(ctx)
+		var blocked workflow.BlockedError
+		if pollErr != nil && !errors.As(pollErr, &blocked) {
+			t.Fatalf("%s: %v", label, pollErr)
+		}
+	}
+
+	for attempt := 1; attempt <= 3; attempt++ {
+		poll(fmt.Sprintf("release %d", attempt))
+		poll(fmt.Sprintf("dirty evaluation %d", attempt))
+		task, loadErr := store.GetTask(ctx, initialTask.ID)
+		if loadErr != nil || task.State != string(workflow.TaskBlocked) {
+			events, _ := store.ListTaskEvents(ctx, initialTask.ID)
+			t.Fatalf("attempt %d task=%+v err=%v checks=%d auto_merge=%v events=%+v, want still blocked",
+				attempt, task, loadErr, git.checks, gate.AutoMerge, events)
+		}
+		now = now.Add(transientMergeGateRetryInterval + time.Second)
+	}
+	if git.checks != 3 {
+		t.Fatalf("dirty worktree evaluations = %d, want 3 beyond the former lifetime budget", git.checks)
+	}
+	blockedTask, err := store.GetTask(ctx, initialTask.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if blockedTask.UpdatedAt != initialTask.UpdatedAt {
+		t.Fatalf("blocked age refreshed from %q to %q across transient retries", initialTask.UpdatedAt, blockedTask.UpdatedAt)
+	}
+
+	git.clean = true
+	poll("release after real condition clearance")
+	poll("merge after real condition clearance")
+	mergedTask, err := store.GetTask(ctx, initialTask.ID)
+	if err != nil || mergedTask.State != string(workflow.TaskMerged) {
+		t.Fatalf("task after delayed clearance = %+v err=%v, want merged", mergedTask, err)
+	}
+	if git.checks != 4 || len(client.merges) != 1 {
+		t.Fatalf("worktree evaluations=%d merges=%d, want four evaluations and one merge", git.checks, len(client.merges))
+	}
+	events, err := store.ListTaskEvents(ctx, initialTask.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	retries := 0
+	for _, event := range events {
+		if event.Kind == "merge_gate_transient_retry" {
+			retries++
+		}
+	}
+	if retries != 4 {
+		t.Fatalf("transient retry events = %d, want recurring release through delayed clearance", retries)
+	}
+}
+
+func TestPollOnceBindsBranchlessReadyTaskToCurrentHead(t *testing.T) {
+	ctx := context.Background()
+	store := testStore(t)
+	repo := github.Repository{Owner: "gitmoot", Name: "gitmoot"}
+	pull := github.PullRequest{
+		Number: 1699, State: "open", HeadRef: "task-1699", BaseRef: "main",
+		HeadSHA: "current-head",
+	}
+	if err := store.UpsertTask(ctx, db.Task{
+		ID: "implementation-task", RepoFullName: repo.FullName(),
+		Branch: pull.HeadRef, State: string(workflow.TaskPullRequestOpen),
+	}); err != nil {
+		t.Fatal(err)
+	}
+	seedReadyBranchlessReviewTask(t, store, repo, "review-pr-1699-legacy", pull, "stale-head")
+	seedReadyBranchlessReviewTask(t, store, repo, "review-pr-1699-current", pull, pull.HeadSHA)
+	if err := store.UpsertPullRequest(ctx, db.PullRequest{
+		RepoFullName: repo.FullName(), Number: pull.Number, HeadBranch: pull.HeadRef,
+		BaseBranch: pull.BaseRef, HeadSHA: pull.HeadSHA, State: "open",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	daemon, gate := blockedReviewTaskDaemon(t, store, repo, pull)
+
+	if err := daemon.PollOnce(ctx); err != nil {
+		t.Fatal(err)
+	}
+	if len(gate.requests) != 1 || gate.requests[0].TaskID != "review-pr-1699-current" ||
+		gate.requests[0].HeadSHA != pull.HeadSHA {
+		t.Fatalf("merge gate requests = %+v, want current-head task only", gate.requests)
+	}
+}
+
+func TestReadyResolverRejectsBranchTaskBoundToStaleHead(t *testing.T) {
+	ctx := context.Background()
+	store := testStore(t)
+	repo := github.Repository{Owner: "gitmoot", Name: "gitmoot"}
+	pull := github.PullRequest{
+		Number: 1699, State: "open", HeadRef: "task-1699", BaseRef: "main",
+		HeadSHA: "current-head",
+	}
+	if err := store.UpsertTask(ctx, db.Task{
+		ID: "implementation-task", RepoFullName: repo.FullName(),
+		Branch: pull.HeadRef, State: string(workflow.TaskReadyToMerge),
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.UpsertPullRequest(ctx, db.PullRequest{
+		RepoFullName: repo.FullName(), Number: pull.Number, HeadBranch: pull.HeadRef,
+		BaseBranch: pull.BaseRef, HeadSHA: "stale-head", State: "open",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	daemon, gate := blockedReviewTaskDaemon(t, store, repo, pull)
+
+	ready, err := daemon.pullRequestReadyToMerge(ctx, pull)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ready {
+		t.Fatal("stale-head branch task reported ready for current PR head")
+	}
+	if len(gate.requests) != 0 {
+		t.Fatalf("merge gate requests = %+v, want none for stale-head task", gate.requests)
+	}
+}
+
+func TestPollOnceRejectsAmbiguousBranchlessReadyTasks(t *testing.T) {
+	ctx := context.Background()
+	store := testStore(t)
+	repo := github.Repository{Owner: "gitmoot", Name: "gitmoot"}
+	pull := github.PullRequest{
+		Number: 1699, State: "open", HeadRef: "task-1699", BaseRef: "main",
+		HeadSHA: "current-head",
+	}
+	seedReadyBranchlessReviewTask(t, store, repo, "review-pr-1699-first", pull, pull.HeadSHA)
+	seedReadyBranchlessReviewTask(t, store, repo, "review-pr-1699-second", pull, pull.HeadSHA)
+	if err := store.UpsertPullRequest(ctx, db.PullRequest{
+		RepoFullName: repo.FullName(), Number: pull.Number, HeadBranch: pull.HeadRef,
+		BaseBranch: pull.BaseRef, HeadSHA: pull.HeadSHA, State: "open",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	daemon, gate := blockedReviewTaskDaemon(t, store, repo, pull)
+
+	err := daemon.PollOnce(ctx)
+	if err == nil || !strings.Contains(err.Error(), "ambiguous ready tasks") {
+		t.Fatalf("PollOnce error = %v, want ambiguous ready tasks", err)
+	}
+	if len(gate.requests) != 0 {
+		t.Fatalf("merge gate requests = %+v, want none on ambiguous identity", gate.requests)
+	}
+}
+
+func TestReadyHandlerRevalidatesResolvedTaskBeforeGate(t *testing.T) {
+	ctx := context.Background()
+	store := testStore(t)
+	repo := github.Repository{Owner: "gitmoot", Name: "gitmoot"}
+	pull := github.PullRequest{
+		Number: 1699, State: "open", HeadRef: "task-1699", BaseRef: "main",
+		HeadSHA: "current-head",
+	}
+	seedReadyBranchlessReviewTask(t, store, repo, "review-pr-1699-current", pull, pull.HeadSHA)
+	daemon, gate := blockedReviewTaskDaemon(t, store, repo, pull)
+	task, err := daemon.lookupReadyPullRequestTask(ctx, pull, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	task.State = string(workflow.TaskBlocked)
+	if err := store.UpsertTask(ctx, task); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := daemon.handleReadyToMergeWorkflow(ctx, pull, task); err != nil {
+		t.Fatal(err)
+	}
+	if len(gate.requests) != 0 {
+		t.Fatalf("merge gate requests = %+v, want none after ready state changed", gate.requests)
 	}
 }
 

--- a/internal/daemon/merge_gate_transient_exit_test.go
+++ b/internal/daemon/merge_gate_transient_exit_test.go
@@ -174,6 +174,80 @@ func TestSecondPollEvaluatesGateAfterTransientRelease(t *testing.T) {
 	}
 }
 
+// TestSecondPollEvaluatesGateWhenBranchOwnerIsNotReady is the two-row form of the
+// release direction, and it is the shape production actually has. Two rows
+// legitimately describe one PR: the implement task owning (repo, head branch), and
+// the branchless local review task keyed by its durable id. That coexistence is
+// already modeled at external_merge_reconcile_test.go:190-196.
+//
+// A branch-FIRST ready lookup strands the released review task here: it finds the
+// implementation task, sees pull_request_open, reports not-ready, and performs zero
+// merge-gate evaluations, so the transient release is again a state change nothing
+// consumes. The one-row fixture cannot see this, which is why it passed against
+// the branch-first version at head 9ba794d8.
+//
+// Mutant M4 ("branch owner wins"): in lookupReadyPullRequestTask, return branchTask
+// whenever branchFound, before the branchless scan. Only this test fails; the
+// single-row two-poll test still passes.
+func TestSecondPollEvaluatesGateWhenBranchOwnerIsNotReady(t *testing.T) {
+	ctx := context.Background()
+	store := testStore(t)
+	repo := github.Repository{Owner: "gitmoot", Name: "gitmoot"}
+	pull := seedBlockedReviewTask(t, store, repo, workflow.MergeBlockTransient, "local worktree is not clean")
+	// The implement task owns the unique (repo, branch) slot and is NOT ready.
+	if err := store.UpsertTask(ctx, db.Task{
+		ID:           "implementation-task",
+		RepoFullName: repo.FullName(),
+		GoalID:       "goal-1699",
+		Title:        "Implement 1699",
+		State:        string(workflow.TaskPullRequestOpen),
+		Branch:       "task-1699",
+	}); err != nil {
+		t.Fatalf("UpsertTask(implementation-task) returned error: %v", err)
+	}
+	daemon, gate := blockedReviewTaskDaemon(t, store, repo, pull)
+
+	if err := daemon.PollOnce(ctx); err != nil {
+		t.Fatalf("poll 1 PollOnce returned error: %v", err)
+	}
+	review, err := store.GetTask(ctx, "review-pr-1699-3f3a1026")
+	if err != nil {
+		t.Fatalf("GetTask(review) after poll 1 returned error: %v", err)
+	}
+	if review.State != string(workflow.TaskReadyToMerge) {
+		t.Fatalf("poll 1 review task state = %q, want ready_to_merge", review.State)
+	}
+
+	ready, err := daemon.pullRequestReadyToMerge(ctx, pull)
+	if err != nil {
+		t.Fatalf("pullRequestReadyToMerge returned error: %v", err)
+	}
+	if !ready {
+		t.Fatalf("pullRequestReadyToMerge = false: the released review task is hidden by the non-ready branch owner")
+	}
+
+	if err := daemon.PollOnce(ctx); err != nil {
+		t.Fatalf("poll 2 PollOnce returned error: %v", err)
+	}
+	if len(gate.requests) == 0 {
+		t.Fatalf("merge gate evaluations after release = 0, want the released review task re-evaluated despite the branch owner")
+	}
+	for _, request := range gate.requests {
+		if request.TaskID != "review-pr-1699-3f3a1026" {
+			t.Fatalf("merge gate evaluated task %q, want the released review task, never the branch owner", request.TaskID)
+		}
+	}
+	// The implementation task must be untouched: this path may not advance work it
+	// does not own.
+	implementation, err := store.GetTask(ctx, "implementation-task")
+	if err != nil {
+		t.Fatalf("GetTask(implementation-task) returned error: %v", err)
+	}
+	if implementation.State != string(workflow.TaskPullRequestOpen) {
+		t.Fatalf("implementation task state = %q, want pull_request_open left alone", implementation.State)
+	}
+}
+
 // TestPollOnceLeavesQualityBlockedReviewTaskBlocked is the direction that stops
 // the obvious wrong fix. An authoritative quality rejection must stay blocked.
 //

--- a/internal/daemon/merge_gate_transient_exit_test.go
+++ b/internal/daemon/merge_gate_transient_exit_test.go
@@ -1,0 +1,247 @@
+package daemon
+
+import (
+	"context"
+	"testing"
+
+	"github.com/gitmoot/gitmoot/internal/db"
+	"github.com/gitmoot/gitmoot/internal/github"
+	"github.com/gitmoot/gitmoot/internal/workflow"
+)
+
+// seedBlockedReviewTask stages the exact live shape from #1562: the local review
+// task review-pr-1699-3f3a1026, blocked by the merge gate while its pull request
+// is still open.
+//
+// The empty Branch is load-bearing, not incidental. A local review task
+// deliberately carries no branch so it cannot collide with the implement task that
+// owns (repo, head branch), and that is precisely why the wedge survived: every
+// branch-keyed path — daemon.pullRequestReadyToMerge, handleReadyToMergeWorkflow,
+// reconcilePROpenTasks — resolves tasks from pull.HeadRef and cannot see this row.
+// A fixture with a branch would be released by reconcilePROpenTasks instead and
+// would therefore pass against a fix that never runs.
+func seedBlockedReviewTask(t *testing.T, store *db.Store, repo github.Repository, class workflow.MergeBlockClass, reason string) github.PullRequest {
+	t.Helper()
+	ctx := context.Background()
+	if err := store.UpsertTask(ctx, db.Task{
+		ID:           "review-pr-1699-3f3a1026",
+		RepoFullName: repo.FullName(),
+		GoalID:       "goal-1699",
+		Title:        "Review PR #1699",
+		State:        string(workflow.TaskBlocked),
+	}); err != nil {
+		t.Fatalf("UpsertTask returned error: %v", err)
+	}
+	if err := store.UpsertMergeGate(ctx, db.MergeGate{
+		RepoFullName: repo.FullName(),
+		PullRequest:  1699,
+		State:        "blocked",
+		Reason:       reason,
+		BlockClass:   int(class),
+	}); err != nil {
+		t.Fatalf("UpsertMergeGate returned error: %v", err)
+	}
+	return github.PullRequest{
+		Number:  1699,
+		Title:   "Review PR #1699",
+		State:   "open",
+		URL:     "https://github.com/gitmoot/gitmoot/pull/1699",
+		HeadRef: "task-1699",
+		BaseRef: "main",
+		HeadSHA: "3f3a1026",
+	}
+}
+
+func blockedReviewTaskDaemon(t *testing.T, store *db.Store, repo github.Repository, pull github.PullRequest) (Daemon, *fakeWorkflowMergeGate) {
+	t.Helper()
+	client := &fakeGitHub{
+		pulls:    []github.PullRequest{pull},
+		comments: map[int64][]github.IssueComment{pull.Number: {}},
+	}
+	gate := &fakeWorkflowMergeGate{decision: workflow.MergeDecision{Ready: true}}
+	engine := workflow.Engine{Store: store, MergeGate: gate}
+	return Daemon{Repo: repo, Store: store, GitHub: client, Workflow: &engine}, gate
+}
+
+func hasTaskEventKind(events []db.TaskEvent, kind string) bool {
+	for _, event := range events {
+		if event.Kind == kind {
+			return true
+		}
+	}
+	return false
+}
+
+// TestPollOnceReleasesTransientlyBlockedReviewTask is the release direction of
+// #1562. A task blocked on "local worktree is not clean" — a condition the gate
+// itself classified MergeBlockTransient — must regain an exit from the ordinary
+// poll, WITHOUT a human merging the pull request. ready_to_merge is that exit: it
+// is the documented retry authority and it is also the state `task resume-work`
+// accepts, so the row becomes reachable both automatically and by an operator.
+//
+// Mutant M1 ("releases nothing"): delete the
+// reconcileTransientlyBlockedMergeGates call from PollOnce, or invert its class
+// test to MergeBlockQuality. The task then stays blocked and this test fails,
+// while TestPollOnceLeavesQualityBlockedReviewTaskBlocked still passes.
+func TestPollOnceReleasesTransientlyBlockedReviewTask(t *testing.T) {
+	ctx := context.Background()
+	store := testStore(t)
+	repo := github.Repository{Owner: "gitmoot", Name: "gitmoot"}
+	pull := seedBlockedReviewTask(t, store, repo, workflow.MergeBlockTransient, "local worktree is not clean")
+	daemon, _ := blockedReviewTaskDaemon(t, store, repo, pull)
+
+	if err := daemon.PollOnce(ctx); err != nil {
+		t.Fatalf("PollOnce returned error: %v", err)
+	}
+
+	task, err := store.GetTask(ctx, "review-pr-1699-3f3a1026")
+	if err != nil {
+		t.Fatalf("GetTask returned error: %v", err)
+	}
+	if task.State != string(workflow.TaskReadyToMerge) {
+		t.Fatalf("task state = %q, want ready_to_merge once the transient block is re-evaluated", task.State)
+	}
+	events, err := store.ListTaskEvents(ctx, "review-pr-1699-3f3a1026")
+	if err != nil {
+		t.Fatalf("ListTaskEvents returned error: %v", err)
+	}
+	if !hasTaskEventKind(events, "merge_gate_transient_retry") {
+		t.Fatalf("task events = %+v, want an auditable merge_gate_transient_retry release", events)
+	}
+}
+
+// TestPollOnceLeavesQualityBlockedReviewTaskBlocked is the direction that stops
+// the obvious wrong fix. An authoritative quality rejection must stay blocked.
+//
+// Mutant M2 ("releases everything"): drop the BlockClass condition from
+// reconcileTransientlyBlockedMergeGates so any blocked row with a blocked gate is
+// released. This test then fails while
+// TestPollOnceReleasesTransientlyBlockedReviewTask still passes.
+func TestPollOnceLeavesQualityBlockedReviewTaskBlocked(t *testing.T) {
+	ctx := context.Background()
+	store := testStore(t)
+	repo := github.Repository{Owner: "gitmoot", Name: "gitmoot"}
+	pull := seedBlockedReviewTask(t, store, repo, workflow.MergeBlockQuality, "external CI failed")
+	daemon, _ := blockedReviewTaskDaemon(t, store, repo, pull)
+
+	if err := daemon.PollOnce(ctx); err != nil {
+		t.Fatalf("PollOnce returned error: %v", err)
+	}
+
+	task, err := store.GetTask(ctx, "review-pr-1699-3f3a1026")
+	if err != nil {
+		t.Fatalf("GetTask returned error: %v", err)
+	}
+	if task.State != string(workflow.TaskBlocked) {
+		t.Fatalf("task state = %q, want blocked to persist for an authoritative quality rejection", task.State)
+	}
+}
+
+// TestPollOnceLeavesUnclassifiedBlockedReviewTaskBlocked covers the migration
+// boundary: every merge-gate row that predates the block_class column reads 0
+// (MergeBlockNone). Those rows must not be released, because an unclassified block
+// is not evidence of a self-clearing condition.
+func TestPollOnceLeavesUnclassifiedBlockedReviewTaskBlocked(t *testing.T) {
+	ctx := context.Background()
+	store := testStore(t)
+	repo := github.Repository{Owner: "gitmoot", Name: "gitmoot"}
+	pull := seedBlockedReviewTask(t, store, repo, workflow.MergeBlockNone, "legacy row with no class")
+	daemon, _ := blockedReviewTaskDaemon(t, store, repo, pull)
+
+	if err := daemon.PollOnce(ctx); err != nil {
+		t.Fatalf("PollOnce returned error: %v", err)
+	}
+
+	task, err := store.GetTask(ctx, "review-pr-1699-3f3a1026")
+	if err != nil {
+		t.Fatalf("GetTask returned error: %v", err)
+	}
+	if task.State != string(workflow.TaskBlocked) {
+		t.Fatalf("task state = %q, want an unclassified legacy block to stay blocked", task.State)
+	}
+}
+
+// TestPollOnceLeavesTransientBlockOnClosedPullRequestBlocked pins the open-PR
+// requirement. A closed PR cannot clear a transient condition, and releasing it to
+// ready_to_merge would hand a moot subject to the merge path; that population
+// belongs to the external-merge and closed-reviewing reconcilers.
+func TestPollOnceLeavesTransientBlockOnClosedPullRequestBlocked(t *testing.T) {
+	ctx := context.Background()
+	store := testStore(t)
+	repo := github.Repository{Owner: "gitmoot", Name: "gitmoot"}
+	// Seed the blocked row, then present a poll in which PR #1699 is NOT open.
+	_ = seedBlockedReviewTask(t, store, repo, workflow.MergeBlockTransient, "local worktree is not clean")
+	closed := github.PullRequest{Number: 1699, State: "closed", HeadRef: "task-1699", BaseRef: "main", HeadSHA: "3f3a1026"}
+	client := &fakeGitHub{
+		pulls:         []github.PullRequest{},
+		comments:      map[int64][]github.IssueComment{},
+		pullsByNumber: map[int64]github.PullRequest{1699: closed},
+	}
+	gate := &fakeWorkflowMergeGate{decision: workflow.MergeDecision{Ready: true}}
+	engine := workflow.Engine{Store: store, MergeGate: gate}
+	daemon := Daemon{Repo: repo, Store: store, GitHub: client, Workflow: &engine}
+
+	if err := daemon.PollOnce(ctx); err != nil {
+		t.Fatalf("PollOnce returned error: %v", err)
+	}
+
+	task, err := store.GetTask(ctx, "review-pr-1699-3f3a1026")
+	if err != nil {
+		t.Fatalf("GetTask returned error: %v", err)
+	}
+	if task.State != string(workflow.TaskBlocked) {
+		t.Fatalf("task state = %q, want blocked while the pull request is not open", task.State)
+	}
+}
+
+// TestMergeGateBlockClassSurvivesTheBlockingCallStack pins the #1562 root cause
+// directly: before this fix the class existed only on the returned MergeDecision,
+// so no exit path outside the blocking call stack could read it.
+func TestMergeGateBlockClassSurvivesTheBlockingCallStack(t *testing.T) {
+	ctx := context.Background()
+	store := testStore(t)
+	repo := github.Repository{Owner: "gitmoot", Name: "gitmoot"}
+	for _, tt := range []struct {
+		name  string
+		class workflow.MergeBlockClass
+	}{
+		{"transient", workflow.MergeBlockTransient},
+		{"quality", workflow.MergeBlockQuality},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := store.UpsertMergeGate(ctx, db.MergeGate{
+				RepoFullName: repo.FullName(),
+				PullRequest:  4242,
+				State:        "blocked",
+				Reason:       tt.name,
+				BlockClass:   int(tt.class),
+			}); err != nil {
+				t.Fatalf("UpsertMergeGate returned error: %v", err)
+			}
+			gate, err := store.GetMergeGate(ctx, repo.FullName(), 4242)
+			if err != nil {
+				t.Fatalf("GetMergeGate returned error: %v", err)
+			}
+			if gate.BlockClass != int(tt.class) {
+				t.Fatalf("persisted block class = %d, want %d", gate.BlockClass, int(tt.class))
+			}
+		})
+	}
+	// A pending row is not a block: it must store the zero class so it can never be
+	// selected for release.
+	if err := store.UpsertMergeGate(ctx, db.MergeGate{
+		RepoFullName: repo.FullName(),
+		PullRequest:  4242,
+		State:        "pending",
+		Reason:       "waiting on CI",
+	}); err != nil {
+		t.Fatalf("UpsertMergeGate(pending) returned error: %v", err)
+	}
+	gate, err := store.GetMergeGate(ctx, repo.FullName(), 4242)
+	if err != nil {
+		t.Fatalf("GetMergeGate returned error: %v", err)
+	}
+	if gate.BlockClass != int(workflow.MergeBlockNone) {
+		t.Fatalf("pending row block class = %d, want MergeBlockNone", gate.BlockClass)
+	}
+}

--- a/internal/daemon/merge_gate_transient_exit_test.go
+++ b/internal/daemon/merge_gate_transient_exit_test.go
@@ -110,6 +110,70 @@ func TestPollOnceReleasesTransientlyBlockedReviewTask(t *testing.T) {
 	}
 }
 
+// TestSecondPollEvaluatesGateAfterTransientRelease is the reviewer-requested
+// completion of the release direction, and the one that distinguishes a REAL exit
+// from a merely cosmetic state change. Releasing the row to ready_to_merge is
+// worthless if nothing consumes that state: a branchless review task is invisible
+// to a pull.HeadRef lookup, so before lookupReadyPullRequestTask existed the
+// released task sat in ready_to_merge and the gate was never re-run — the
+// automatic self-clearing retry #1562 asks for did not happen, only manual
+// `task resume-work` recovery.
+//
+// Poll 1 releases; poll 2 MUST reach the merge gate.
+//
+// Mutant M3 ("released but never consumed"): revert
+// pullRequestReadyToMerge/handleReadyToMergeWorkflow to
+// d.lookupPullRequestTask(ctx, d.Repo.FullName(), pull.HeadRef). Poll 1 still
+// releases and every other test in this file still passes; only this one fails,
+// which is exactly the gap the reviewer found at head d73d3d9c.
+func TestSecondPollEvaluatesGateAfterTransientRelease(t *testing.T) {
+	ctx := context.Background()
+	store := testStore(t)
+	repo := github.Repository{Owner: "gitmoot", Name: "gitmoot"}
+	pull := seedBlockedReviewTask(t, store, repo, workflow.MergeBlockTransient, "local worktree is not clean")
+	daemon, gate := blockedReviewTaskDaemon(t, store, repo, pull)
+
+	if err := daemon.PollOnce(ctx); err != nil {
+		t.Fatalf("poll 1 PollOnce returned error: %v", err)
+	}
+	task, err := store.GetTask(ctx, "review-pr-1699-3f3a1026")
+	if err != nil {
+		t.Fatalf("GetTask after poll 1 returned error: %v", err)
+	}
+	if task.State != string(workflow.TaskReadyToMerge) {
+		t.Fatalf("poll 1 task state = %q, want ready_to_merge", task.State)
+	}
+
+	ready, err := daemon.pullRequestReadyToMerge(ctx, pull)
+	if err != nil {
+		t.Fatalf("pullRequestReadyToMerge returned error: %v", err)
+	}
+	if !ready {
+		t.Fatalf("pullRequestReadyToMerge = false for a released branchless review task; the ready path cannot see it")
+	}
+
+	if err := daemon.PollOnce(ctx); err != nil {
+		t.Fatalf("poll 2 PollOnce returned error: %v", err)
+	}
+	if len(gate.requests) == 0 {
+		t.Fatalf("merge gate evaluations after release = 0, want the released task re-evaluated by a later poll")
+	}
+	for _, request := range gate.requests {
+		if request.PullRequest != 1699 {
+			t.Fatalf("merge gate evaluated the wrong pull request: %+v", request)
+		}
+	}
+	// The ref must name the review task, never the branch's canonical implement
+	// task: a branchless row carrying the PR branch would advance the wrong task.
+	events, err := store.ListTaskEvents(ctx, "review-pr-1699-3f3a1026")
+	if err != nil {
+		t.Fatalf("ListTaskEvents returned error: %v", err)
+	}
+	if !hasTaskEventKind(events, "merge_gate_transient_retry") {
+		t.Fatalf("task events = %+v, want the release recorded on the review task itself", events)
+	}
+}
+
 // TestPollOnceLeavesQualityBlockedReviewTaskBlocked is the direction that stops
 // the obvious wrong fix. An authoritative quality rejection must stay blocked.
 //

--- a/internal/daemon/merge_gate_transient_exit_test.go
+++ b/internal/daemon/merge_gate_transient_exit_test.go
@@ -41,6 +41,17 @@ func seedBlockedReviewTask(t *testing.T, store *db.Store, repo github.Repository
 	}); err != nil {
 		t.Fatalf("UpsertMergeGate returned error: %v", err)
 	}
+	// The merge gate attributes its own block on the task (blockMergeGate), which is
+	// what distinguishes it from a coordinator block_parent or quorum failure
+	// reaching the same state through the shared e.block helper.
+	if err := store.AddTaskEvent(ctx, db.TaskEvent{
+		TaskID:  "review-pr-1699-3f3a1026",
+		Kind:    "merge_gate_blocked",
+		ToState: string(workflow.TaskBlocked),
+		Reason:  reason,
+	}); err != nil {
+		t.Fatalf("AddTaskEvent(merge_gate_blocked) returned error: %v", err)
+	}
 	return github.PullRequest{
 		Number:  1699,
 		Title:   "Review PR #1699",
@@ -70,6 +81,62 @@ func hasTaskEventKind(events []db.TaskEvent, kind string) bool {
 		}
 	}
 	return false
+}
+
+// TestPollOnceLeavesTaskBlockedByDelegationFailureBlocked is the cause-attribution
+// direction, found by gm-omp-fanout while we coordinated the PR #1731 collision.
+//
+// e.block is SHARED: the merge gate uses it, and so do the coordinator failure
+// paths — block_parent and the vote/quorum synthesis gates in
+// engine_continuation_synthesis.go. So `state == blocked` says nothing about WHICH
+// mechanism blocked the task. A task carrying a stale transient merge-gate row from
+// an earlier evaluation, then blocked by a delegation quorum failure, satisfies
+// every other test in the reconciler — and releasing it would discard a quorum
+// failure as though it were self-clearing infrastructure. The gate row describes the
+// CONDITION; only the task's latest blocking event establishes the CURRENT CAUSE.
+//
+// Mutant M5 ("cause ignored"): delete the mergeGateOwnsCurrentBlock guard from
+// reconcileTransientlyBlockedMergeGates. Only this test fails; every other
+// direction, including both two-poll tests, still passes.
+func TestPollOnceLeavesTaskBlockedByDelegationFailureBlocked(t *testing.T) {
+	ctx := context.Background()
+	store := testStore(t)
+	repo := github.Repository{Owner: "gitmoot", Name: "gitmoot"}
+	// A genuine transient gate block happened earlier and its row is still on disk.
+	pull := seedBlockedReviewTask(t, store, repo, workflow.MergeBlockTransient, "local worktree is not clean")
+	// Then a delegation quorum failure blocked the task through the shared helper.
+	// It is LATER, so it is the current cause.
+	if err := store.AddTaskEvent(ctx, db.TaskEvent{
+		TaskID:  "review-pr-1699-3f3a1026",
+		Kind:    "quorum_unmet",
+		ToState: string(workflow.TaskBlocked),
+		Reason:  "2 of 3 delegation children failed",
+	}); err != nil {
+		t.Fatalf("AddTaskEvent(quorum_unmet) returned error: %v", err)
+	}
+	daemon, gate := blockedReviewTaskDaemon(t, store, repo, pull)
+
+	if err := daemon.PollOnce(ctx); err != nil {
+		t.Fatalf("PollOnce returned error: %v", err)
+	}
+
+	task, err := store.GetTask(ctx, "review-pr-1699-3f3a1026")
+	if err != nil {
+		t.Fatalf("GetTask returned error: %v", err)
+	}
+	if task.State != string(workflow.TaskBlocked) {
+		t.Fatalf("task state = %q, want blocked: a quorum failure is not a self-clearing merge-gate condition", task.State)
+	}
+	if len(gate.requests) != 0 {
+		t.Fatalf("merge gate evaluations = %d, want 0 for a task blocked by a delegation failure", len(gate.requests))
+	}
+	events, err := store.ListTaskEvents(ctx, "review-pr-1699-3f3a1026")
+	if err != nil {
+		t.Fatalf("ListTaskEvents returned error: %v", err)
+	}
+	if hasTaskEventKind(events, "merge_gate_transient_retry") {
+		t.Fatalf("task events = %+v, want no transient release recorded", events)
+	}
 }
 
 // TestPollOnceReleasesTransientlyBlockedReviewTask is the release direction of

--- a/internal/daemon/merge_gate_transient_exit_test.go
+++ b/internal/daemon/merge_gate_transient_exit_test.go
@@ -139,6 +139,91 @@ func TestPollOnceLeavesTaskBlockedByDelegationFailureBlocked(t *testing.T) {
 	}
 }
 
+// TestPollOnceHealsPreAttributionBlockOnce is the UPGRADE path, raised by
+// gm-omp-fanout: every task blocked before this change has no attributed blocking
+// event, because neither the merge gate nor the synthesis gates wrote one — both
+// reached blocked through the shared e.block. A strict "no event means not
+// gate-owned" rule would refuse exactly the population that motivated #1562,
+// including the 95-minute review-pr-1699-3f3a1026 wedge, and the feature would
+// clear only blocks created after the deploy.
+//
+// So a row with a transient gate row and NO competing blocking event is healed
+// once. "Once" is structural rather than counted: the release writes
+// merge_gate_transient_retry, so the row is no longer unattributed, and any later
+// real block arrives through an attributed path.
+//
+// Mutant M6 ("no upgrade path"): make mergeGateOwnsCurrentBlock return
+// (false, false, nil) for an unattributed row. Only this test fails — every other
+// direction, including the delegation-failure refusal, still passes, which is what
+// makes the two behaviours distinguishable rather than a matter of opinion.
+func TestPollOnceHealsPreAttributionBlockOnce(t *testing.T) {
+	ctx := context.Background()
+	store := testStore(t)
+	repo := github.Repository{Owner: "gitmoot", Name: "gitmoot"}
+	// Seeded WITHOUT attribution: exactly what the old binary left behind.
+	pull := seedBlockedReviewTaskAttributed(t, store, repo, workflow.MergeBlockTransient, "local worktree is not clean", false)
+	daemon, _ := blockedReviewTaskDaemon(t, store, repo, pull)
+
+	if err := daemon.PollOnce(ctx); err != nil {
+		t.Fatalf("PollOnce returned error: %v", err)
+	}
+	task, err := store.GetTask(ctx, "review-pr-1699-3f3a1026")
+	if err != nil {
+		t.Fatalf("GetTask returned error: %v", err)
+	}
+	if task.State != string(workflow.TaskReadyToMerge) {
+		t.Fatalf("task state = %q, want a pre-attribution wedge healed to ready_to_merge", task.State)
+	}
+	events, err := store.ListTaskEvents(ctx, "review-pr-1699-3f3a1026")
+	if err != nil {
+		t.Fatalf("ListTaskEvents returned error: %v", err)
+	}
+	if !hasTaskEventKind(events, "merge_gate_transient_retry") {
+		t.Fatalf("task events = %+v, want the heal recorded so the row is no longer unattributed", events)
+	}
+}
+
+// TestPollOnceLeavesTaskBlockedByUnknownMechanismBlocked closes the guard over
+// mechanisms this change does not know about. Raised by a review advisory: a fixed
+// list of blocking kinds is not closed under future blockers, so a NEW mechanism
+// blocking a task would simply not match, an older merge_gate_blocked would remain
+// the newest RECOGNISED event, and the exit would release a block it did not cause.
+//
+// The event here carries ToState=blocked with a kind this code has never heard of,
+// which is exactly the shape a future blocker will have.
+//
+// Mutant M7 ("kind list only"): drop the `event.ToState == blocked` arm from
+// mergeGateOwnsCurrentBlock so only the enumerated kinds count as blocking. Only
+// this test fails.
+func TestPollOnceLeavesTaskBlockedByUnknownMechanismBlocked(t *testing.T) {
+	ctx := context.Background()
+	store := testStore(t)
+	repo := github.Repository{Owner: "gitmoot", Name: "gitmoot"}
+	pull := seedBlockedReviewTask(t, store, repo, workflow.MergeBlockTransient, "local worktree is not clean")
+	if err := store.AddTaskEvent(ctx, db.TaskEvent{
+		TaskID:  "review-pr-1699-3f3a1026",
+		Kind:    "some_future_guard_blocked",
+		ToState: string(workflow.TaskBlocked),
+		Reason:  "a mechanism this change has never heard of",
+	}); err != nil {
+		t.Fatalf("AddTaskEvent(some_future_guard_blocked) returned error: %v", err)
+	}
+	daemon, gate := blockedReviewTaskDaemon(t, store, repo, pull)
+
+	if err := daemon.PollOnce(ctx); err != nil {
+		t.Fatalf("PollOnce returned error: %v", err)
+	}
+	task, err := store.GetTask(ctx, "review-pr-1699-3f3a1026")
+	if err != nil {
+		t.Fatalf("GetTask returned error: %v", err)
+	}
+	if task.State != string(workflow.TaskBlocked) {
+		t.Fatalf("task state = %q, want blocked: the newest blocking event is not the merge gate's", task.State)
+	}
+	if len(gate.requests) != 0 {
+		t.Fatalf("merge gate evaluations = %d, want 0", len(gate.requests))
+	}
+}
 // TestPollOnceReleasesTransientlyBlockedReviewTask is the release direction of
 // #1562. A task blocked on "local worktree is not clean" — a condition the gate
 // itself classified MergeBlockTransient — must regain an exit from the ordinary

--- a/internal/db/store.go
+++ b/internal/db/store.go
@@ -477,6 +477,14 @@ func newCockpitPaneID() (string, error) {
 	return "cockpit-pane-" + hex.EncodeToString(raw[:]), nil
 }
 
+func newTaskStateClaimToken() (string, error) {
+	var raw [16]byte
+	if _, err := rand.Read(raw[:]); err != nil {
+		return "", err
+	}
+	return "task-claim-" + hex.EncodeToString(raw[:]), nil
+}
+
 func requireAffected(result sql.Result, subject string, id string) error {
 	affected, err := result.RowsAffected()
 	if err != nil {

--- a/internal/db/store_locks.go
+++ b/internal/db/store_locks.go
@@ -626,22 +626,23 @@ func (s *Store) ListBranchLockEvents(ctx context.Context, repoFullName string, b
 }
 
 func (s *Store) UpsertMergeGate(ctx context.Context, gate MergeGate) error {
-	_, err := s.db.ExecContext(ctx, `INSERT INTO merge_gates(repo_full_name, pull_request, state, reason, updated_at)
-		VALUES (?, ?, ?, ?, CURRENT_TIMESTAMP)
+	_, err := s.db.ExecContext(ctx, `INSERT INTO merge_gates(repo_full_name, pull_request, state, reason, block_class, updated_at)
+		VALUES (?, ?, ?, ?, ?, CURRENT_TIMESTAMP)
 		ON CONFLICT(repo_full_name, pull_request) DO UPDATE SET
 			state = excluded.state,
 			reason = excluded.reason,
+			block_class = excluded.block_class,
 			updated_at = CURRENT_TIMESTAMP`,
-		gate.RepoFullName, gate.PullRequest, gate.State, gate.Reason)
+		gate.RepoFullName, gate.PullRequest, gate.State, gate.Reason, gate.BlockClass)
 	return err
 }
 
 func (s *Store) GetMergeGate(ctx context.Context, repoFullName string, pullRequest int64) (MergeGate, error) {
-	row := s.db.QueryRowContext(ctx, `SELECT repo_full_name, pull_request, state, reason
+	row := s.db.QueryRowContext(ctx, `SELECT repo_full_name, pull_request, state, reason, block_class
 		FROM merge_gates WHERE repo_full_name = ? AND pull_request = ?`,
 		repoFullName, pullRequest)
 	var gate MergeGate
-	if err := row.Scan(&gate.RepoFullName, &gate.PullRequest, &gate.State, &gate.Reason); err != nil {
+	if err := row.Scan(&gate.RepoFullName, &gate.PullRequest, &gate.State, &gate.Reason, &gate.BlockClass); err != nil {
 		return MergeGate{}, err
 	}
 	return gate, nil

--- a/internal/db/store_migrations.go
+++ b/internal/db/store_migrations.go
@@ -2306,4 +2306,42 @@ CREATE TABLE IF NOT EXISTS merge_gates (
 );
 ALTER TABLE merge_gates ADD COLUMN block_class INTEGER NOT NULL DEFAULT 0;
 	`,
+	// Durable cross-process task-state claim for the irreversible native merge
+	// boundary. SQLite triggers make every state writer participate, including
+	// independent processes. An unresolved external outcome remains fenced
+	// without expiry until an authoritative remote observation resolves it.
+	`
+CREATE TABLE task_state_claims (
+	task_id TEXT PRIMARY KEY REFERENCES tasks(id) ON DELETE CASCADE,
+	kind TEXT NOT NULL,
+	token TEXT NOT NULL UNIQUE,
+	expected_state TEXT NOT NULL,
+	acquired_at INTEGER NOT NULL,
+	expires_at INTEGER NOT NULL
+);
+CREATE INDEX idx_task_state_claims_expires_at ON task_state_claims(expires_at);
+CREATE TRIGGER guard_claimed_task_state_update
+BEFORE UPDATE OF state ON tasks
+WHEN OLD.state <> NEW.state
+	AND EXISTS (
+		SELECT 1 FROM task_state_claims
+		WHERE task_id = OLD.id
+			AND (kind = 'external_merge_uncertain'
+				OR expires_at > CAST(strftime('%s', 'now') AS INTEGER))
+	)
+BEGIN
+	SELECT RAISE(ABORT, 'task state is claimed for an external merge');
+END;
+CREATE TRIGGER guard_claimed_task_delete
+BEFORE DELETE ON tasks
+WHEN EXISTS (
+	SELECT 1 FROM task_state_claims
+	WHERE task_id = OLD.id
+		AND (kind = 'external_merge_uncertain'
+			OR expires_at > CAST(strftime('%s', 'now') AS INTEGER))
+)
+BEGIN
+	SELECT RAISE(ABORT, 'task state is claimed for an external merge');
+END;
+	`,
 }

--- a/internal/db/store_migrations.go
+++ b/internal/db/store_migrations.go
@@ -2281,4 +2281,29 @@ CREATE TABLE merge_gate_status_observations (
 	PRIMARY KEY (repo_full_name, pull_request)
 );
 	`,
+	// #1562 durable merge-gate block classification. The gate already separates a
+	// transient/infra block from an authoritative quality rejection, but that
+	// classification lived only in the returned decision, so no exit path could
+	// read it and a transient block became permanent. Existing rows default to 0
+	// (MergeBlockNone), which is never selected for automatic re-evaluation.
+	//
+	// The CREATE is not redundant. A database can legitimately reach this version
+	// without merge_gates: seeding schema_migrations forward past the migration
+	// that created it leaves the table absent, and a bare ALTER then fails the
+	// whole Migrate call, which is a refusal to start rather than a test artifact.
+	// Both paths converge on the same shape, and this migration is APPENDED, never
+	// reordered, so an already-migrated database still applies exactly this step.
+	`
+CREATE TABLE IF NOT EXISTS merge_gates (
+	id INTEGER PRIMARY KEY AUTOINCREMENT,
+	repo_full_name TEXT NOT NULL,
+	pull_request INTEGER NOT NULL,
+	state TEXT NOT NULL,
+	reason TEXT NOT NULL DEFAULT '',
+	created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+	updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+	UNIQUE(repo_full_name, pull_request)
+);
+ALTER TABLE merge_gates ADD COLUMN block_class INTEGER NOT NULL DEFAULT 0;
+	`,
 }

--- a/internal/db/store_migrations.go
+++ b/internal/db/store_migrations.go
@@ -2344,4 +2344,32 @@ BEGIN
 	SELECT RAISE(ABORT, 'task state is claimed for an external merge');
 END;
 	`,
+	// Canonical terminal-effects ownership and secondary task-settlement debt
+	// survive a daemon exit between the two phases. The exact head is part of
+	// every key so a later push cannot inherit an earlier terminal decision.
+	`
+CREATE TABLE pull_request_terminal_reconciliations (
+	repo_full_name TEXT NOT NULL COLLATE NOCASE,
+	pull_request INTEGER NOT NULL CHECK(pull_request > 0),
+	head_sha TEXT NOT NULL CHECK(length(trim(head_sha)) > 0),
+	owner_task_id TEXT NOT NULL CHECK(length(trim(owner_task_id)) > 0),
+	effects_completed INTEGER NOT NULL DEFAULT 0 CHECK(effects_completed IN (0, 1)),
+	created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+	updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+	PRIMARY KEY(repo_full_name, pull_request, head_sha)
+);
+CREATE TABLE pull_request_terminal_settlements (
+	repo_full_name TEXT NOT NULL COLLATE NOCASE,
+	pull_request INTEGER NOT NULL CHECK(pull_request > 0),
+	head_sha TEXT NOT NULL CHECK(length(trim(head_sha)) > 0),
+	task_id TEXT NOT NULL CHECK(length(trim(task_id)) > 0),
+	created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+	PRIMARY KEY(repo_full_name, pull_request, head_sha, task_id),
+	FOREIGN KEY(repo_full_name, pull_request, head_sha)
+		REFERENCES pull_request_terminal_reconciliations(repo_full_name, pull_request, head_sha)
+		ON DELETE CASCADE
+);
+CREATE INDEX idx_pull_request_terminal_settlements_task
+	ON pull_request_terminal_settlements(task_id);
+	`,
 }

--- a/internal/db/store_tasks.go
+++ b/internal/db/store_tasks.go
@@ -427,6 +427,109 @@ func (s *Store) AddTaskEvent(ctx context.Context, event TaskEvent) error {
 	return err
 }
 
+var (
+	ErrTaskStateConflict = errors.New("task state changed before guarded transition")
+	ErrTaskStateClaimed  = errors.New("task state is claimed for an external merge")
+)
+
+const (
+	TaskStateClaimKindExternalMerge          = "external_merge"
+	TaskStateClaimKindExternalMergeUncertain = "external_merge_uncertain"
+)
+
+// BlockTaskWithEvent atomically compares the caller's observed state, persists
+// the blocked task row, and appends the event that owns that block. blocked is
+// true only after both writes commit.
+func (s *Store) BlockTaskWithEvent(ctx context.Context, task Task, event TaskEvent) (blocked bool, err error) {
+	task.ID = strings.TrimSpace(task.ID)
+	if task.ID == "" {
+		return false, errors.New("blocked task id is required")
+	}
+	if strings.TrimSpace(task.State) != "blocked" {
+		return false, fmt.Errorf("blocked task %s has state %q", task.ID, task.State)
+	}
+	event.TaskID = task.ID
+	event.ToState = "blocked"
+
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return false, err
+	}
+	defer tx.Rollback()
+
+	var activeClaim string
+	claimErr := tx.QueryRowContext(ctx, `SELECT token FROM task_state_claims
+		WHERE task_id = ? AND expires_at > CAST(strftime('%s', 'now') AS INTEGER)`, task.ID).Scan(&activeClaim)
+	if claimErr == nil {
+		return false, fmt.Errorf("%w: task %s", ErrTaskStateClaimed, task.ID)
+	}
+	if !errors.Is(claimErr, sql.ErrNoRows) {
+		return false, claimErr
+	}
+
+	var currentState string
+	stateErr := tx.QueryRowContext(ctx, `SELECT state FROM tasks WHERE id = ?`, task.ID).Scan(&currentState)
+	switch {
+	case errors.Is(stateErr, sql.ErrNoRows):
+		if strings.TrimSpace(event.FromState) != "" {
+			return false, fmt.Errorf("%w: task %s no longer exists", ErrTaskStateConflict, task.ID)
+		}
+		if _, err := tx.ExecContext(ctx, `INSERT INTO tasks(id, repo_full_name, goal_id, title, state, branch, worktree_path, updated_at)
+			VALUES (?, ?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP)`,
+			task.ID, task.RepoFullName, task.GoalID, task.Title, task.State, task.Branch, task.WorktreePath); err != nil {
+			return false, err
+		}
+	case stateErr != nil:
+		return false, stateErr
+	default:
+		switch currentState {
+		case "merged", "dismissed", "superseded", "stranded":
+			return false, fmt.Errorf("%w: task %s is terminal in state %q",
+				ErrTaskStateConflict, task.ID, currentState)
+		}
+		expectedState := strings.TrimSpace(event.FromState)
+		if expectedState == "" || currentState != expectedState {
+			return false, fmt.Errorf("%w: task %s expected %q, current %q",
+				ErrTaskStateConflict, task.ID, expectedState, currentState)
+		}
+		preserveAge := false
+		if event.Kind == "merge_gate_blocked" && expectedState == "ready_to_merge" {
+			var latestKind string
+			if err := tx.QueryRowContext(ctx, `SELECT kind FROM task_events
+				WHERE task_id = ? ORDER BY id DESC LIMIT 1`, task.ID).Scan(&latestKind); err != nil && !errors.Is(err, sql.ErrNoRows) {
+				return false, err
+			} else {
+				preserveAge = latestKind == "merge_gate_transient_retry"
+			}
+		}
+		result, err := tx.ExecContext(ctx, `UPDATE tasks SET
+				repo_full_name = ?, goal_id = ?, title = ?, state = ?, branch = ?,
+				worktree_path = CASE WHEN ? <> '' THEN ? ELSE worktree_path END,
+				updated_at = CASE WHEN ? THEN updated_at ELSE CURRENT_TIMESTAMP END
+			WHERE id = ? AND state = ?`,
+			task.RepoFullName, task.GoalID, task.Title, task.State, task.Branch,
+			task.WorktreePath, task.WorktreePath, preserveAge, task.ID, expectedState)
+		if err != nil {
+			return false, err
+		}
+		affected, err := result.RowsAffected()
+		if err != nil {
+			return false, err
+		}
+		if affected != 1 {
+			return false, fmt.Errorf("%w: task %s expected %q", ErrTaskStateConflict, task.ID, expectedState)
+		}
+	}
+	if _, err := tx.ExecContext(ctx, `INSERT INTO task_events(task_id, kind, from_state, to_state, reason)
+		VALUES (?, ?, ?, ?, ?)`, task.ID, event.Kind, event.FromState, event.ToState, event.Reason); err != nil {
+		return false, err
+	}
+	if err := tx.Commit(); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
 func (s *Store) ListTaskEvents(ctx context.Context, taskID string) ([]TaskEvent, error) {
 	rows, err := s.db.QueryContext(ctx, `SELECT id, task_id, kind, from_state, to_state, reason, created_at
 		FROM task_events WHERE task_id = ? ORDER BY id`, strings.TrimSpace(taskID))
@@ -471,11 +574,310 @@ func (s *Store) CompareAndSwapTaskState(ctx context.Context, taskID, from, to st
 	return false, currentState, nil
 }
 
+// RevalidateTaskState performs a single-statement compare without changing the
+// task or refreshing updated_at. It is used immediately before an external side
+// effect when an earlier read selected the task by identity.
+func (s *Store) RevalidateTaskState(ctx context.Context, taskID string, expected string) (matched bool, currentState string, err error) {
+	taskID = strings.TrimSpace(taskID)
+	expected = strings.TrimSpace(expected)
+	result, err := s.db.ExecContext(ctx, `UPDATE tasks SET state = state WHERE id = ? AND state = ?`, taskID, expected)
+	if err != nil {
+		return false, "", err
+	}
+	affected, err := result.RowsAffected()
+	if err != nil {
+		return false, "", err
+	}
+	if affected > 0 {
+		return true, expected, nil
+	}
+	if err := s.db.QueryRowContext(ctx, `SELECT state FROM tasks WHERE id = ?`, taskID).Scan(&currentState); err != nil {
+		return false, "", err
+	}
+	return false, currentState, nil
+}
+
+// HasTaskStateClaim reports whether a task has a durable external-merge claim.
+// Terminal PR-group reconciliation uses it to select the one claim-owning task
+// that may execute per-PR post-merge effects.
+func (s *Store) HasTaskStateClaim(ctx context.Context, taskID string) (bool, error) {
+	var exists int
+	err := s.db.QueryRowContext(ctx, `SELECT 1 FROM task_state_claims WHERE task_id = ?`,
+		strings.TrimSpace(taskID)).Scan(&exists)
+	if errors.Is(err, sql.ErrNoRows) {
+		return false, nil
+	}
+	if err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+// ClaimTaskState durably fences every state-changing SQL writer across Store
+// handles and processes while an irreversible external operation is in flight.
+// The schema trigger enforces the claim; the token restricts completion to its
+// owner. Expired claims are reclaimed at acquisition.
+func (s *Store) ClaimTaskState(ctx context.Context, taskID, expectedState, kind string, ttl time.Duration) (token string, claimed bool, currentState string, err error) {
+	taskID = strings.TrimSpace(taskID)
+	expectedState = strings.TrimSpace(expectedState)
+	kind = strings.TrimSpace(kind)
+	if taskID == "" || expectedState == "" || kind == "" {
+		return "", false, "", errors.New("task claim requires task id, expected state, and kind")
+	}
+	ttlSeconds, err := taskStateClaimTTLSeconds(ttl)
+	if err != nil {
+		return "", false, "", err
+	}
+	token, err = newTaskStateClaimToken()
+	if err != nil {
+		return "", false, "", err
+	}
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return "", false, "", err
+	}
+	defer tx.Rollback()
+	if _, err := tx.ExecContext(ctx, `DELETE FROM task_state_claims
+		WHERE task_id = ? AND kind <> ? AND expires_at <= CAST(strftime('%s', 'now') AS INTEGER)`,
+		taskID, TaskStateClaimKindExternalMergeUncertain); err != nil {
+		return "", false, "", err
+	}
+	if err := tx.QueryRowContext(ctx, `SELECT state FROM tasks WHERE id = ?`, taskID).Scan(&currentState); err != nil {
+		return "", false, "", err
+	}
+	if currentState != expectedState {
+		return "", false, currentState, tx.Commit()
+	}
+	_, err = tx.ExecContext(ctx, `INSERT INTO task_state_claims(
+			task_id, kind, token, expected_state, acquired_at, expires_at
+		) VALUES (?, ?, ?, ?, CAST(strftime('%s', 'now') AS INTEGER),
+			CAST(strftime('%s', 'now') AS INTEGER) + ?)`,
+		taskID, kind, token, expectedState, ttlSeconds)
+	if err != nil {
+		var existing int
+		if queryErr := tx.QueryRowContext(ctx, `SELECT 1 FROM task_state_claims
+			WHERE task_id = ? AND (kind = ? OR expires_at > CAST(strftime('%s', 'now') AS INTEGER))`,
+			taskID, TaskStateClaimKindExternalMergeUncertain).Scan(&existing); queryErr == nil {
+			return "", false, currentState, fmt.Errorf("%w: task %s", ErrTaskStateClaimed, taskID)
+		}
+		return "", false, currentState, err
+	}
+	if err := tx.Commit(); err != nil {
+		return "", false, currentState, err
+	}
+	return token, true, currentState, nil
+}
+
+func taskStateClaimTTLSeconds(ttl time.Duration) (int64, error) {
+	if ttl <= 0 {
+		return 0, errors.New("task claim ttl must be positive")
+	}
+	seconds := int64(ttl / time.Second)
+	if ttl%time.Second != 0 {
+		seconds++
+	}
+	if seconds == 0 {
+		seconds = 1
+	}
+	return seconds, nil
+}
+
+// ReleaseTaskStateClaim abandons an uncompleted external operation. The token
+// prevents one claimant from releasing a later claimant's lease.
+func (s *Store) ReleaseTaskStateClaim(ctx context.Context, taskID, token string) error {
+	_, err := s.db.ExecContext(ctx, `DELETE FROM task_state_claims WHERE task_id = ? AND token = ?`,
+		strings.TrimSpace(taskID), strings.TrimSpace(token))
+	return err
+}
+
+// RenewTaskStateClaim extends an active claim from the database clock. A claim
+// that already expired or changed owners is never revived.
+func (s *Store) RenewTaskStateClaim(ctx context.Context, taskID, token string, ttl time.Duration) (bool, error) {
+	ttlSeconds, err := taskStateClaimTTLSeconds(ttl)
+	if err != nil {
+		return false, err
+	}
+	result, err := s.db.ExecContext(ctx, `UPDATE task_state_claims
+		SET expires_at = CAST(strftime('%s', 'now') AS INTEGER) + ?
+		WHERE task_id = ? AND token = ? AND kind <> ?
+			AND expires_at > CAST(strftime('%s', 'now') AS INTEGER)`,
+		ttlSeconds, strings.TrimSpace(taskID), strings.TrimSpace(token),
+		TaskStateClaimKindExternalMergeUncertain)
+	if err != nil {
+		return false, err
+	}
+	affected, err := result.RowsAffected()
+	return affected == 1, err
+}
+
+// RetainTaskStateClaim marks an unresolved external outcome as non-expiring.
+// The state check and kind change share one SQL statement: either a writer won
+// after lease expiry, or every later writer observes the retained claim.
+func (s *Store) RetainTaskStateClaim(ctx context.Context, taskID, token, expectedState, retainedKind string) (bool, error) {
+	result, err := s.db.ExecContext(ctx, `UPDATE task_state_claims
+		SET kind = ?
+		WHERE task_id = ? AND token = ? AND expected_state = ?
+			AND EXISTS (SELECT 1 FROM tasks WHERE id = ? AND state = ?)`,
+		strings.TrimSpace(retainedKind), strings.TrimSpace(taskID), strings.TrimSpace(token),
+		strings.TrimSpace(expectedState), strings.TrimSpace(taskID), strings.TrimSpace(expectedState))
+	if err != nil {
+		return false, err
+	}
+	affected, err := result.RowsAffected()
+	return affected == 1, err
+}
+
+// ReleaseRetainedTaskStateClaim resolves a retained claim after the caller has
+// authoritatively observed that the remote operation cannot still occur.
+// The expected-state check prevents clearing ownership after a local transition.
+func (s *Store) ReleaseRetainedTaskStateClaim(ctx context.Context, taskID, expectedState, retainedKind string) (released bool, currentState string, err error) {
+	taskID = strings.TrimSpace(taskID)
+	expectedState = strings.TrimSpace(expectedState)
+	retainedKind = strings.TrimSpace(retainedKind)
+	if taskID == "" || expectedState == "" || retainedKind == "" {
+		return false, "", errors.New("retained task claim release requires task id, expected state, and claim kind")
+	}
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return false, "", err
+	}
+	defer tx.Rollback()
+	if err := tx.QueryRowContext(ctx, `SELECT state FROM tasks WHERE id = ?`, taskID).Scan(&currentState); err != nil {
+		return false, "", err
+	}
+	if currentState != expectedState {
+		return false, currentState, tx.Commit()
+	}
+	result, err := tx.ExecContext(ctx, `DELETE FROM task_state_claims WHERE task_id = ? AND kind = ?`,
+		taskID, retainedKind)
+	if err != nil {
+		return false, currentState, err
+	}
+	affected, err := result.RowsAffected()
+	if err != nil {
+		return false, currentState, err
+	}
+	if err := tx.Commit(); err != nil {
+		return false, currentState, err
+	}
+	return affected == 1, currentState, nil
+}
+
+// CompleteTaskStateClaim atomically removes the caller's claim, applies the
+// claimed state transition, and records its event.
+func (s *Store) CompleteTaskStateClaim(ctx context.Context, taskID, token, to, kind, reason string) (changed bool, currentState string, err error) {
+	taskID = strings.TrimSpace(taskID)
+	token = strings.TrimSpace(token)
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return false, "", err
+	}
+	defer tx.Rollback()
+	var claimToken, expectedState string
+	if err := tx.QueryRowContext(ctx, `SELECT token, expected_state FROM task_state_claims WHERE task_id = ?`,
+		taskID).Scan(&claimToken, &expectedState); err != nil {
+		return false, "", err
+	}
+	if claimToken != token {
+		return false, "", fmt.Errorf("%w: task %s claim token changed", ErrTaskStateClaimed, taskID)
+	}
+	if err := tx.QueryRowContext(ctx, `SELECT state FROM tasks WHERE id = ?`, taskID).Scan(&currentState); err != nil {
+		return false, "", err
+	}
+	if currentState != expectedState {
+		return false, currentState, fmt.Errorf("%w: task %s expected %q, current %q",
+			ErrTaskStateConflict, taskID, expectedState, currentState)
+	}
+	if _, err := tx.ExecContext(ctx, `DELETE FROM task_state_claims WHERE task_id = ? AND token = ?`, taskID, token); err != nil {
+		return false, currentState, err
+	}
+	result, err := tx.ExecContext(ctx, `UPDATE tasks SET state = ?, updated_at = CURRENT_TIMESTAMP WHERE id = ? AND state = ?`,
+		strings.TrimSpace(to), taskID, expectedState)
+	if err != nil {
+		return false, currentState, err
+	}
+	affected, err := result.RowsAffected()
+	if err != nil {
+		return false, currentState, err
+	}
+	if affected != 1 {
+		return false, currentState, fmt.Errorf("%w: task %s expected %q", ErrTaskStateConflict, taskID, expectedState)
+	}
+	if _, err := tx.ExecContext(ctx, `INSERT INTO task_events(task_id, kind, from_state, to_state, reason)
+		VALUES (?, ?, ?, ?, ?)`, taskID, strings.TrimSpace(kind), expectedState, strings.TrimSpace(to), strings.TrimSpace(reason)); err != nil {
+		return false, currentState, err
+	}
+	if err := tx.Commit(); err != nil {
+		return false, currentState, err
+	}
+	return true, strings.TrimSpace(to), nil
+}
+
+// RecoverClaimedTaskState applies a remotely observed terminal fact after a
+// claimant crashed between the external operation and local finalization. Any
+// surviving claim is removed in the same transaction as the reconciled state.
+func (s *Store) RecoverClaimedTaskState(ctx context.Context, taskID, to, kind, reason string) (changed bool, currentState string, err error) {
+	taskID = strings.TrimSpace(taskID)
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return false, "", err
+	}
+	defer tx.Rollback()
+	var claimToken string
+	if err := tx.QueryRowContext(ctx, `SELECT token FROM task_state_claims WHERE task_id = ?`, taskID).Scan(&claimToken); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			if stateErr := tx.QueryRowContext(ctx, `SELECT state FROM tasks WHERE id = ?`, taskID).Scan(&currentState); stateErr != nil {
+				return false, "", stateErr
+			}
+			return false, currentState, tx.Commit()
+		}
+		return false, "", err
+	}
+	if err := tx.QueryRowContext(ctx, `SELECT state FROM tasks WHERE id = ?`, taskID).Scan(&currentState); err != nil {
+		return false, "", err
+	}
+	if _, err := tx.ExecContext(ctx, `DELETE FROM task_state_claims WHERE task_id = ?`, taskID); err != nil {
+		return false, currentState, err
+	}
+	to = strings.TrimSpace(to)
+	if currentState == to {
+		return false, currentState, tx.Commit()
+	}
+	result, err := tx.ExecContext(ctx, `UPDATE tasks SET state = ?, updated_at = CURRENT_TIMESTAMP WHERE id = ? AND state = ?`,
+		to, taskID, currentState)
+	if err != nil {
+		return false, currentState, err
+	}
+	affected, err := result.RowsAffected()
+	if err != nil {
+		return false, currentState, err
+	}
+	if affected != 1 {
+		return false, currentState, fmt.Errorf("%w: task %s changed during claim recovery", ErrTaskStateConflict, taskID)
+	}
+	if _, err := tx.ExecContext(ctx, `INSERT INTO task_events(task_id, kind, from_state, to_state, reason)
+		VALUES (?, ?, ?, ?, ?)`, taskID, strings.TrimSpace(kind), currentState, to, strings.TrimSpace(reason)); err != nil {
+		return false, currentState, err
+	}
+	if err := tx.Commit(); err != nil {
+		return false, currentState, err
+	}
+	return true, to, nil
+}
+
 // TransitionTaskStateWithEvent atomically compares and moves a task state and
 // appends its audit event. A failed comparison writes no event and returns the
 // current state so callers can distinguish idempotence from a conflicting move.
 func (s *Store) TransitionTaskStateWithEvent(ctx context.Context, taskID string, fromStates []string, to string, kind string, reason string) (changed bool, currentState string, err error) {
-	changed, _, currentState, err = s.transitionTaskStateWithEvent(ctx, taskID, fromStates, to, kind, reason, false)
+	changed, _, currentState, err = s.transitionTaskStateWithEvent(ctx, taskID, fromStates, to, kind, reason, false, false, time.Time{})
+	return changed, currentState, err
+}
+
+// TransitionTaskStateWithEventPreserveAgeAt records a retry transition without
+// refreshing the task's lifecycle age. The explicit event timestamp lets a
+// daemon clock enforce retry cadence deterministically.
+func (s *Store) TransitionTaskStateWithEventPreserveAgeAt(ctx context.Context, taskID string, fromStates []string, to string, kind string, reason string, at time.Time) (changed bool, currentState string, err error) {
+	changed, _, currentState, err = s.transitionTaskStateWithEvent(ctx, taskID, fromStates, to, kind, reason, false, true, at)
 	return changed, currentState, err
 }
 
@@ -484,7 +886,7 @@ func (s *Store) TransitionTaskStateWithEvent(ctx context.Context, taskID string,
 // observed before it attempted the update. Callers that need follow-up cleanup
 // tied to the actual transition, rather than a stale pre-read, should use it.
 func (s *Store) TransitionTaskStateWithEventObserved(ctx context.Context, taskID string, fromStates []string, to string, kind string, reason string) (changed bool, observedState string, currentState string, err error) {
-	return s.transitionTaskStateWithEvent(ctx, taskID, fromStates, to, kind, reason, false)
+	return s.transitionTaskStateWithEvent(ctx, taskID, fromStates, to, kind, reason, false, false, time.Time{})
 }
 
 // TransitionTaskStateWithEventIfNoActiveJob adds a queued/running job guard to
@@ -492,7 +894,7 @@ func (s *Store) TransitionTaskStateWithEventObserved(ctx context.Context, taskID
 // checks before entering this transaction; this guard closes the window in
 // which a newly queued/running job could acquire the task.
 func (s *Store) TransitionTaskStateWithEventIfNoActiveJob(ctx context.Context, taskID string, fromStates []string, to string, kind string, reason string) (changed bool, currentState string, err error) {
-	changed, _, currentState, err = s.transitionTaskStateWithEvent(ctx, taskID, fromStates, to, kind, reason, true)
+	changed, _, currentState, err = s.transitionTaskStateWithEvent(ctx, taskID, fromStates, to, kind, reason, true, false, time.Time{})
 	return changed, currentState, err
 }
 
@@ -587,7 +989,7 @@ func insertTaskDisposalEscalationTx(ctx context.Context, tx *sql.Tx, event, role
 	return nil
 }
 
-func (s *Store) transitionTaskStateWithEvent(ctx context.Context, taskID string, fromStates []string, to string, kind string, reason string, rejectActiveJob bool) (changed bool, observedState string, currentState string, err error) {
+func (s *Store) transitionTaskStateWithEvent(ctx context.Context, taskID string, fromStates []string, to string, kind string, reason string, rejectActiveJob bool, preserveUpdatedAt bool, eventAt time.Time) (changed bool, observedState string, currentState string, err error) {
 	tx, err := s.db.BeginTx(ctx, nil)
 	if err != nil {
 		return false, "", "", err
@@ -617,8 +1019,10 @@ func (s *Store) transitionTaskStateWithEvent(ctx context.Context, taskID string,
 			return false, observedState, observedState, fmt.Errorf("%w: %s", ErrTaskHasActiveJob, jobID)
 		}
 	}
-	result, err := tx.ExecContext(ctx, `UPDATE tasks SET state = ?, updated_at = CURRENT_TIMESTAMP WHERE id = ? AND state = ?`,
-		strings.TrimSpace(to), strings.TrimSpace(taskID), observedState)
+	result, err := tx.ExecContext(ctx, `UPDATE tasks
+		SET state = ?, updated_at = CASE WHEN ? THEN updated_at ELSE CURRENT_TIMESTAMP END
+		WHERE id = ? AND state = ?`,
+		strings.TrimSpace(to), preserveUpdatedAt, strings.TrimSpace(taskID), observedState)
 	if err != nil {
 		return false, observedState, "", err
 	}
@@ -632,8 +1036,14 @@ func (s *Store) transitionTaskStateWithEvent(ctx context.Context, taskID string,
 		}
 		return false, observedState, currentState, tx.Commit()
 	}
-	if _, err := tx.ExecContext(ctx, `INSERT INTO task_events(task_id, kind, from_state, to_state, reason)
-		VALUES (?, ?, ?, ?, ?)`, strings.TrimSpace(taskID), strings.TrimSpace(kind), observedState, strings.TrimSpace(to), strings.TrimSpace(reason)); err != nil {
+	if eventAt.IsZero() {
+		_, err = tx.ExecContext(ctx, `INSERT INTO task_events(task_id, kind, from_state, to_state, reason)
+			VALUES (?, ?, ?, ?, ?)`, strings.TrimSpace(taskID), strings.TrimSpace(kind), observedState, strings.TrimSpace(to), strings.TrimSpace(reason))
+	} else {
+		_, err = tx.ExecContext(ctx, `INSERT INTO task_events(task_id, kind, from_state, to_state, reason, created_at)
+			VALUES (?, ?, ?, ?, ?, ?)`, strings.TrimSpace(taskID), strings.TrimSpace(kind), observedState, strings.TrimSpace(to), strings.TrimSpace(reason), eventAt.UTC().Format(time.RFC3339Nano))
+	}
+	if err != nil {
 		return false, observedState, "", err
 	}
 	if err := tx.Commit(); err != nil {

--- a/internal/db/store_terminal_reconciliation.go
+++ b/internal/db/store_terminal_reconciliation.go
@@ -1,0 +1,124 @@
+package db
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+)
+
+// BeginPullRequestTerminalReconciliation atomically pins the first canonical
+// owner for an exact PR head and records every other current identity as
+// settlement debt. Later callers may add identities, but cannot replace owner.
+func (s *Store) BeginPullRequestTerminalReconciliation(ctx context.Context, proposed PullRequestTerminalReconciliation, taskIDs []string) (PullRequestTerminalReconciliation, error) {
+	proposed.RepoFullName = strings.TrimSpace(proposed.RepoFullName)
+	proposed.HeadSHA = strings.TrimSpace(proposed.HeadSHA)
+	proposed.OwnerTaskID = strings.TrimSpace(proposed.OwnerTaskID)
+	if proposed.RepoFullName == "" || proposed.PullRequest <= 0 || proposed.HeadSHA == "" || proposed.OwnerTaskID == "" {
+		return PullRequestTerminalReconciliation{}, errors.New("terminal reconciliation requires repository, pull request, head SHA, and owner task")
+	}
+
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return PullRequestTerminalReconciliation{}, err
+	}
+	defer tx.Rollback()
+
+	if _, err := tx.ExecContext(ctx, `INSERT OR IGNORE INTO pull_request_terminal_reconciliations(
+		repo_full_name, pull_request, head_sha, owner_task_id, effects_completed, updated_at)
+		VALUES (?, ?, ?, ?, 0, CURRENT_TIMESTAMP)`, proposed.RepoFullName, proposed.PullRequest, proposed.HeadSHA, proposed.OwnerTaskID); err != nil {
+		return PullRequestTerminalReconciliation{}, err
+	}
+
+	var reconciliation PullRequestTerminalReconciliation
+	var effectsCompleted int
+	if err := tx.QueryRowContext(ctx, `SELECT repo_full_name, pull_request, head_sha, owner_task_id, effects_completed
+		FROM pull_request_terminal_reconciliations
+		WHERE repo_full_name = ? AND pull_request = ? AND head_sha = ?`, proposed.RepoFullName, proposed.PullRequest, proposed.HeadSHA).Scan(
+		&reconciliation.RepoFullName, &reconciliation.PullRequest, &reconciliation.HeadSHA,
+		&reconciliation.OwnerTaskID, &effectsCompleted); err != nil {
+		return PullRequestTerminalReconciliation{}, err
+	}
+	reconciliation.EffectsCompleted = effectsCompleted != 0
+
+	seen := make(map[string]struct{}, len(taskIDs))
+	for _, taskID := range taskIDs {
+		taskID = strings.TrimSpace(taskID)
+		if taskID == "" || taskID == reconciliation.OwnerTaskID {
+			continue
+		}
+		if _, ok := seen[taskID]; ok {
+			continue
+		}
+		seen[taskID] = struct{}{}
+		if _, err := tx.ExecContext(ctx, `INSERT OR IGNORE INTO pull_request_terminal_settlements(
+			repo_full_name, pull_request, head_sha, task_id)
+			VALUES (?, ?, ?, ?)`, reconciliation.RepoFullName, reconciliation.PullRequest, reconciliation.HeadSHA, taskID); err != nil {
+			return PullRequestTerminalReconciliation{}, err
+		}
+	}
+	if err := tx.Commit(); err != nil {
+		return PullRequestTerminalReconciliation{}, err
+	}
+	return reconciliation, nil
+}
+
+func (s *Store) CompletePullRequestTerminalEffects(ctx context.Context, reconciliation PullRequestTerminalReconciliation) error {
+	result, err := s.db.ExecContext(ctx, `UPDATE pull_request_terminal_reconciliations
+		SET effects_completed = 1, updated_at = CURRENT_TIMESTAMP
+		WHERE repo_full_name = ? AND pull_request = ? AND head_sha = ? AND owner_task_id = ?`,
+		reconciliation.RepoFullName, reconciliation.PullRequest, reconciliation.HeadSHA, reconciliation.OwnerTaskID)
+	if err != nil {
+		return err
+	}
+	changed, err := result.RowsAffected()
+	if err != nil {
+		return err
+	}
+	if changed != 1 {
+		return fmt.Errorf("terminal reconciliation owner %s for %s#%d at %s not found", reconciliation.OwnerTaskID, reconciliation.RepoFullName, reconciliation.PullRequest, reconciliation.HeadSHA)
+	}
+	return nil
+}
+
+func (s *Store) ListPullRequestTerminalSettlements(ctx context.Context, reconciliation PullRequestTerminalReconciliation) ([]string, error) {
+	rows, err := s.db.QueryContext(ctx, `SELECT task_id FROM pull_request_terminal_settlements
+		WHERE repo_full_name = ? AND pull_request = ? AND head_sha = ?
+		ORDER BY task_id`, reconciliation.RepoFullName, reconciliation.PullRequest, reconciliation.HeadSHA)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var taskIDs []string
+	for rows.Next() {
+		var taskID string
+		if err := rows.Scan(&taskID); err != nil {
+			return nil, err
+		}
+		taskIDs = append(taskIDs, taskID)
+	}
+	return taskIDs, rows.Err()
+}
+
+func (s *Store) ResolvePullRequestTerminalSettlement(ctx context.Context, reconciliation PullRequestTerminalReconciliation, taskID string) error {
+	_, err := s.db.ExecContext(ctx, `DELETE FROM pull_request_terminal_settlements
+		WHERE repo_full_name = ? AND pull_request = ? AND head_sha = ? AND task_id = ?`,
+		reconciliation.RepoFullName, reconciliation.PullRequest, reconciliation.HeadSHA, strings.TrimSpace(taskID))
+	return err
+}
+
+func (s *Store) GetPullRequestTerminalReconciliation(ctx context.Context, repoFullName string, pullRequest int64, headSHA string) (PullRequestTerminalReconciliation, error) {
+	var reconciliation PullRequestTerminalReconciliation
+	var effectsCompleted int
+	err := s.db.QueryRowContext(ctx, `SELECT repo_full_name, pull_request, head_sha, owner_task_id, effects_completed
+		FROM pull_request_terminal_reconciliations
+		WHERE repo_full_name = ? AND pull_request = ? AND head_sha = ?`, strings.TrimSpace(repoFullName), pullRequest, strings.TrimSpace(headSHA)).Scan(
+		&reconciliation.RepoFullName, &reconciliation.PullRequest, &reconciliation.HeadSHA,
+		&reconciliation.OwnerTaskID, &effectsCompleted)
+	if err != nil {
+		return PullRequestTerminalReconciliation{}, err
+	}
+	reconciliation.EffectsCompleted = effectsCompleted != 0
+	return reconciliation, nil
+}

--- a/internal/db/store_terminal_reconciliation_test.go
+++ b/internal/db/store_terminal_reconciliation_test.go
@@ -1,0 +1,67 @@
+package db
+
+import (
+	"context"
+	"path/filepath"
+	"reflect"
+	"testing"
+)
+
+func TestPullRequestTerminalReconciliationPinsOwnerAndScopesDebtToHead(t *testing.T) {
+	ctx := context.Background()
+	store, err := openCachedTestStore(t, filepath.Join(t.TempDir(), "gitmoot.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+
+	first, err := store.BeginPullRequestTerminalReconciliation(ctx, PullRequestTerminalReconciliation{
+		RepoFullName: "owner/repo", PullRequest: 17, HeadSHA: "head-one", OwnerTaskID: "task-a",
+	}, []string{"task-a", "task-b"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if first.OwnerTaskID != "task-a" || first.EffectsCompleted {
+		t.Fatalf("first reconciliation = %+v, want incomplete task-a owner", first)
+	}
+	if err := store.CompletePullRequestTerminalEffects(ctx, first); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.ResolvePullRequestTerminalSettlement(ctx, first, "task-b"); err != nil {
+		t.Fatal(err)
+	}
+
+	retry, err := store.BeginPullRequestTerminalReconciliation(ctx, PullRequestTerminalReconciliation{
+		RepoFullName: "OWNER/REPO", PullRequest: 17, HeadSHA: "head-one", OwnerTaskID: "task-b",
+	}, []string{"task-b", "task-c"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if retry.OwnerTaskID != "task-a" || !retry.EffectsCompleted {
+		t.Fatalf("retry reconciliation = %+v, want completed original task-a owner", retry)
+	}
+	settlements, err := store.ListPullRequestTerminalSettlements(ctx, retry)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(settlements, []string{"task-b", "task-c"}) {
+		t.Fatalf("retry settlements = %v, want newly observed task-b and task-c debt", settlements)
+	}
+
+	newHead, err := store.BeginPullRequestTerminalReconciliation(ctx, PullRequestTerminalReconciliation{
+		RepoFullName: "owner/repo", PullRequest: 17, HeadSHA: "head-two", OwnerTaskID: "task-b",
+	}, []string{"task-b"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if newHead.OwnerTaskID != "task-b" || newHead.EffectsCompleted {
+		t.Fatalf("new-head reconciliation = %+v, want fresh incomplete task-b owner", newHead)
+	}
+	settlements, err = store.ListPullRequestTerminalSettlements(ctx, newHead)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(settlements) != 0 {
+		t.Fatalf("new-head settlements = %v, want no inherited debt", settlements)
+	}
+}

--- a/internal/db/store_types.go
+++ b/internal/db/store_types.go
@@ -590,6 +590,16 @@ type MergeGate struct {
 	BlockClass int
 }
 
+// PullRequestTerminalReconciliation pins one canonical terminal-effects owner
+// to an exact pull request head across daemon restarts.
+type PullRequestTerminalReconciliation struct {
+	RepoFullName     string
+	PullRequest      int64
+	HeadSHA          string
+	OwnerTaskID      string
+	EffectsCompleted bool
+}
+
 // MergeGateStatusObservation records the exact PR head most recently reconciled
 // with the visible gitmoot/merge-gate context. Kind distinguishes a generic
 // marker, an observed policy verdict, and an inactive head that needs no marker.

--- a/internal/db/store_types.go
+++ b/internal/db/store_types.go
@@ -583,6 +583,11 @@ type MergeGate struct {
 	PullRequest  int64
 	State        string
 	Reason       string
+	// BlockClass persists the merge gate's own transient-vs-quality classification
+	// of a blocked row (#1562). Only the block path sets it; a pending or merged
+	// row is not a block and correctly stores the zero value. It is durable
+	// precisely so an exit path outside the blocking call stack can read it.
+	BlockClass int
 }
 
 // MergeGateStatusObservation records the exact PR head most recently reconciled

--- a/internal/db/task_events_test.go
+++ b/internal/db/task_events_test.go
@@ -3,9 +3,12 @@ package db
 import (
 	"context"
 	"errors"
+	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestTaskEventsMigrationAppliesToExistingDatabase(t *testing.T) {
@@ -67,6 +70,292 @@ func TestTransitionTaskStateWithEventAtomicCASAndOrdering(t *testing.T) {
 	}
 	if len(events) != 2 || events[0].Kind != "task_dismissed_manual" || events[0].FromState != "implementing" || events[0].ToState != "dismissed" || events[1].Kind != "note" || events[0].ID >= events[1].ID {
 		t.Fatalf("events = %+v", events)
+	}
+}
+
+func TestRevalidateTaskStateDoesNotRefreshTaskAge(t *testing.T) {
+	store := openWorkflowTestStore(t)
+	ctx := context.Background()
+	if err := store.UpsertTask(ctx, Task{ID: "task-ready", State: "ready_to_merge"}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.db.ExecContext(ctx, `UPDATE tasks SET updated_at = '2000-01-01 00:00:00' WHERE id = ?`, "task-ready"); err != nil {
+		t.Fatal(err)
+	}
+	var before string
+	if err := store.db.QueryRowContext(ctx, `SELECT updated_at FROM tasks WHERE id = ?`, "task-ready").Scan(&before); err != nil {
+		t.Fatal(err)
+	}
+	matched, current, err := store.RevalidateTaskState(ctx, "task-ready", "ready_to_merge")
+	if err != nil || !matched || current != "ready_to_merge" {
+		t.Fatalf("matching revalidation = matched %v current %q err %v", matched, current, err)
+	}
+	var after string
+	if err := store.db.QueryRowContext(ctx, `SELECT updated_at FROM tasks WHERE id = ?`, "task-ready").Scan(&after); err != nil {
+		t.Fatal(err)
+	}
+	if after != before {
+		t.Fatalf("updated_at changed from %q to %q during revalidation", before, after)
+	}
+	if _, err := store.db.ExecContext(ctx, `UPDATE tasks SET state = 'blocked' WHERE id = ?`, "task-ready"); err != nil {
+		t.Fatal(err)
+	}
+	matched, current, err = store.RevalidateTaskState(ctx, "task-ready", "ready_to_merge")
+	if err != nil || matched || current != "blocked" {
+		t.Fatalf("conflicting revalidation = matched %v current %q err %v", matched, current, err)
+	}
+}
+
+func TestBlockTaskWithEventRollsBackStateWhenOwnershipInsertFails(t *testing.T) {
+	store := openWorkflowTestStore(t)
+	ctx := context.Background()
+	if err := store.UpsertTask(ctx, Task{ID: "task-block", State: "implementing"}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.db.ExecContext(ctx, `
+CREATE TRIGGER reject_task_block_event
+BEFORE INSERT ON task_events
+WHEN NEW.task_id = 'task-block'
+BEGIN
+	SELECT RAISE(ABORT, 'forced task block attribution failure');
+END`); err != nil {
+		t.Fatal(err)
+	}
+	blocked, err := store.BlockTaskWithEvent(ctx,
+		Task{ID: "task-block", State: "blocked"},
+		TaskEvent{Kind: "workflow_blocked", FromState: "implementing", Reason: "failed"},
+	)
+	if blocked || err == nil || !strings.Contains(err.Error(), "forced task block attribution failure") {
+		t.Fatalf("BlockTaskWithEvent = blocked %v err %v", blocked, err)
+	}
+	task, getErr := store.GetTask(ctx, "task-block")
+	if getErr != nil || task.State != "implementing" {
+		t.Fatalf("task = %+v err %v, want original implementing state", task, getErr)
+	}
+	events, listErr := store.ListTaskEvents(ctx, "task-block")
+	if listErr != nil || len(events) != 0 {
+		t.Fatalf("events = %+v err %v, want atomic rollback", events, listErr)
+	}
+}
+
+func TestBlockTaskWithEventPreservesPriorOwnerWhenReplacementInsertFails(t *testing.T) {
+	store := openWorkflowTestStore(t)
+	ctx := context.Background()
+	if err := store.UpsertTask(ctx, Task{ID: "task-block", State: "blocked"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.AddTaskEvent(ctx, TaskEvent{
+		TaskID: "task-block", Kind: "merge_gate_blocked", FromState: "ready_to_merge",
+		ToState: "blocked", Reason: "dirty worktree",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.db.ExecContext(ctx, `
+CREATE TRIGGER reject_replacement_block_owner
+BEFORE INSERT ON task_events
+WHEN NEW.kind = 'workflow_blocked'
+BEGIN
+	SELECT RAISE(ABORT, 'forced replacement ownership failure');
+END`); err != nil {
+		t.Fatal(err)
+	}
+	blocked, err := store.BlockTaskWithEvent(ctx,
+		Task{ID: "task-block", State: "blocked"},
+		TaskEvent{Kind: "workflow_blocked", FromState: "blocked", Reason: "new workflow failure"},
+	)
+	if blocked || err == nil || !strings.Contains(err.Error(), "forced replacement ownership failure") {
+		t.Fatalf("BlockTaskWithEvent = blocked %v err %v", blocked, err)
+	}
+	events, listErr := store.ListTaskEvents(ctx, "task-block")
+	if listErr != nil || len(events) != 1 || events[0].Kind != "merge_gate_blocked" {
+		t.Fatalf("events = %+v err %v, want only prior owner", events, listErr)
+	}
+}
+
+func TestBlockTaskWithEventRejectsStaleAndTerminalStateObservations(t *testing.T) {
+	store := openWorkflowTestStore(t)
+	ctx := context.Background()
+	if err := store.UpsertTask(ctx, Task{ID: "task-block", State: "ready_to_merge"}); err != nil {
+		t.Fatal(err)
+	}
+	if changed, _, err := store.CompareAndSwapTaskState(ctx, "task-block", "ready_to_merge", "merged"); err != nil || !changed {
+		t.Fatalf("terminal transition = changed %v err %v", changed, err)
+	}
+	blocked, err := store.BlockTaskWithEvent(ctx,
+		Task{ID: "task-block", State: "blocked"},
+		TaskEvent{Kind: "workflow_blocked", FromState: "ready_to_merge", Reason: "late failure"},
+	)
+	if blocked || !errors.Is(err, ErrTaskStateConflict) {
+		t.Fatalf("BlockTaskWithEvent = blocked %v err %v, want guarded conflict", blocked, err)
+	}
+	task, getErr := store.GetTask(ctx, "task-block")
+	events, listErr := store.ListTaskEvents(ctx, "task-block")
+	if getErr != nil || listErr != nil || task.State != "merged" || len(events) != 0 {
+		t.Fatalf("task=%+v events=%+v getErr=%v listErr=%v", task, events, getErr, listErr)
+	}
+}
+
+func TestTaskStateClaimFencesIndependentStoreStateWriters(t *testing.T) {
+	store := openWorkflowTestStore(t)
+	ctx := context.Background()
+	if err := store.UpsertTask(ctx, Task{ID: "task-claim", State: "ready_to_merge"}); err != nil {
+		t.Fatal(err)
+	}
+	writer, err := OpenAlreadyMigrated(store.DatabasePath())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer writer.Close()
+
+	token, claimed, current, err := store.ClaimTaskState(ctx, "task-claim", "ready_to_merge", "external_merge", time.Minute)
+	if err != nil || !claimed || current != "ready_to_merge" {
+		t.Fatalf("claim = token %q claimed %v current %q err %v", token, claimed, current, err)
+	}
+	assertRejected := func(name string, err error) {
+		t.Helper()
+		if err == nil {
+			t.Fatalf("%s unexpectedly changed a task with an active durable claim", name)
+		}
+		task, getErr := writer.GetTask(ctx, "task-claim")
+		if getErr != nil || task.State != "ready_to_merge" {
+			t.Fatalf("%s left task %+v, err %v", name, task, getErr)
+		}
+	}
+
+	_, err = writer.BlockTaskWithEvent(ctx,
+		Task{ID: "task-claim", State: "blocked"},
+		TaskEvent{Kind: "workflow_blocked", FromState: "ready_to_merge", Reason: "late failure"})
+	assertRejected("BlockTaskWithEvent", err)
+	_, _, err = writer.TransitionTaskStateWithEvent(ctx, "task-claim",
+		[]string{"ready_to_merge"}, "blocked", "workflow_blocked", "late transition")
+	assertRejected("TransitionTaskStateWithEvent", err)
+	_, _, err = writer.CompareAndSwapTaskState(ctx, "task-claim", "ready_to_merge", "blocked")
+	assertRejected("CompareAndSwapTaskState", err)
+	_, _, err = writer.DisposeTask(ctx, "task-claim", []string{"ready_to_merge"}, "dismissed",
+		"stale", "late disposal", "", "task_disposed", time.Now())
+	assertRejected("DisposeTask", err)
+	assertRejected("UpsertTask", writer.UpsertTask(ctx, Task{ID: "task-claim", State: "blocked"}))
+
+	changed, current, err := store.CompleteTaskStateClaim(ctx, "task-claim", token,
+		"merged", "pull_request_merged", "external merge completed")
+	if err != nil || !changed || current != "merged" {
+		t.Fatalf("complete claim = changed %v current %q err %v", changed, current, err)
+	}
+	events, err := writer.ListTaskEvents(ctx, "task-claim")
+	if err != nil || len(events) != 1 || events[0].Kind != "pull_request_merged" {
+		t.Fatalf("events = %+v, err %v", events, err)
+	}
+}
+
+func TestTaskStateClaimCollisionReleasesLosingTransaction(t *testing.T) {
+	ctx := context.Background()
+	winner := openWorkflowTestStore(t)
+	if err := winner.UpsertTask(ctx, Task{ID: "task-collision", State: "ready_to_merge"}); err != nil {
+		t.Fatal(err)
+	}
+	loser, err := OpenAlreadyMigrated(winner.DatabasePath())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer loser.Close()
+
+	token, claimed, _, err := winner.ClaimTaskState(ctx, "task-collision", "ready_to_merge",
+		TaskStateClaimKindExternalMerge, time.Minute)
+	if err != nil || !claimed {
+		t.Fatalf("winning claim = claimed %v err %v", claimed, err)
+	}
+	collisionCtx, cancelCollision := context.WithTimeout(ctx, 2*time.Second)
+	defer cancelCollision()
+	if _, claimed, _, err := loser.ClaimTaskState(collisionCtx, "task-collision", "ready_to_merge",
+		TaskStateClaimKindExternalMerge, time.Minute); !errors.Is(err, ErrTaskStateClaimed) || claimed {
+		t.Fatalf("losing claim = claimed %v err %v, want prompt ErrTaskStateClaimed", claimed, err)
+	}
+
+	usableCtx, cancelUsable := context.WithTimeout(ctx, 2*time.Second)
+	defer cancelUsable()
+	if task, err := loser.GetTask(usableCtx, "task-collision"); err != nil || task.State != "ready_to_merge" {
+		t.Fatalf("losing Store after collision = task %+v err %v, want usable connection", task, err)
+	}
+	if renewed, err := winner.RenewTaskStateClaim(usableCtx, "task-collision", token, time.Minute); err != nil || !renewed {
+		t.Fatalf("winning claim renewal after collision = renewed %v err %v", renewed, err)
+	}
+	if changed, current, err := winner.CompleteTaskStateClaim(usableCtx, "task-collision", token,
+		"merged", "pull_request_merged", "external merge completed after collision"); err != nil || !changed || current != "merged" {
+		t.Fatalf("winning claim completion = changed %v current %q err %v", changed, current, err)
+	}
+	if task, err := loser.GetTask(usableCtx, "task-collision"); err != nil || task.State != "merged" {
+		t.Fatalf("losing Store final read = task %+v err %v, want merged", task, err)
+	}
+}
+
+func TestTaskStateClaimFencesCrossProcessWriter(t *testing.T) {
+	const helperPathEnv = "GITMOOT_TASK_STATE_CLAIM_HELPER_PATH"
+	ctx := context.Background()
+	if path := os.Getenv(helperPathEnv); path != "" {
+		writer, err := OpenAlreadyMigrated(path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer writer.Close()
+		changed, current, err := writer.CompareAndSwapTaskState(ctx, "task-cross-process", "ready_to_merge", "blocked")
+		if err == nil || changed || current != "" {
+			t.Fatalf("cross-process writer = changed %v current %q err %v, want schema-trigger rejection", changed, current, err)
+		}
+		return
+	}
+
+	store := openWorkflowTestStore(t)
+	if err := store.UpsertTask(ctx, Task{ID: "task-cross-process", State: "ready_to_merge"}); err != nil {
+		t.Fatal(err)
+	}
+	if _, claimed, _, err := store.ClaimTaskState(ctx, "task-cross-process", "ready_to_merge", "external_merge", time.Minute); err != nil || !claimed {
+		t.Fatalf("ClaimTaskState = claimed %v err %v", claimed, err)
+	}
+	cmd := exec.CommandContext(ctx, os.Args[0], "-test.run=^TestTaskStateClaimFencesCrossProcessWriter$")
+	cmd.Env = append(os.Environ(), helperPathEnv+"="+store.DatabasePath())
+	if output, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("cross-process writer helper: %v\n%s", err, output)
+	}
+	task, err := store.GetTask(ctx, "task-cross-process")
+	if err != nil || task.State != "ready_to_merge" {
+		t.Fatalf("task = %+v err %v, want claimed ready_to_merge state", task, err)
+	}
+}
+
+func TestRetainedAmbiguousTaskClaimDoesNotExpireBeforeAuthoritativeResolution(t *testing.T) {
+	ctx := context.Background()
+	store := openWorkflowTestStore(t)
+	if err := store.UpsertTask(ctx, Task{ID: "task-uncertain", State: "ready_to_merge"}); err != nil {
+		t.Fatal(err)
+	}
+	writer, err := OpenAlreadyMigrated(store.DatabasePath())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer writer.Close()
+	token, claimed, _, err := store.ClaimTaskState(ctx, "task-uncertain", "ready_to_merge",
+		TaskStateClaimKindExternalMerge, time.Second)
+	if err != nil || !claimed {
+		t.Fatalf("ClaimTaskState = claimed %v err %v", claimed, err)
+	}
+	retained, err := store.RetainTaskStateClaim(ctx, "task-uncertain", token,
+		"ready_to_merge", TaskStateClaimKindExternalMergeUncertain)
+	if err != nil || !retained {
+		t.Fatalf("RetainTaskStateClaim = retained %v err %v", retained, err)
+	}
+	time.Sleep(1100 * time.Millisecond)
+	changed, _, err := writer.CompareAndSwapTaskState(ctx, "task-uncertain", "ready_to_merge", "dismissed")
+	if err == nil || changed || !strings.Contains(err.Error(), "claimed for an external merge") {
+		t.Fatalf("expired retained claim writer = changed %v err %v, want durable rejection", changed, err)
+	}
+	released, current, err := store.ReleaseRetainedTaskStateClaim(ctx, "task-uncertain",
+		"ready_to_merge", TaskStateClaimKindExternalMergeUncertain)
+	if err != nil || !released || current != "ready_to_merge" {
+		t.Fatalf("ReleaseRetainedTaskStateClaim = released %v current %q err %v", released, current, err)
+	}
+	changed, current, err = writer.CompareAndSwapTaskState(ctx, "task-uncertain", "ready_to_merge", "dismissed")
+	if err != nil || !changed || current != "dismissed" {
+		t.Fatalf("resolved claim writer = changed %v current %q err %v", changed, current, err)
 	}
 }
 

--- a/internal/workflow/engine.go
+++ b/internal/workflow/engine.go
@@ -404,15 +404,66 @@ type Engine struct {
 }
 
 func (e Engine) block(ctx context.Context, ref taskRef, reason string) error {
-	if err := e.setTaskState(ctx, ref, TaskBlocked); err != nil {
+	return e.blockTask(ctx, ref, "workflow_blocked", reason, "workflow")
+}
+
+// blockTask is the single task-blocking choke point. Every durable block
+// atomically writes the state and the event that owns it. A stale state
+// observation or failed attribution write commits neither half.
+func (e Engine) blockTask(ctx context.Context, ref taskRef, kind string, reason string, label string) error {
+	task, err := e.resolveTaskState(ctx, ref, TaskBlocked)
+	if err != nil {
 		return err
 	}
-	return BlockedError{Reason: reason}
+	blockErr := BlockedError{Reason: reason}
+	if strings.TrimSpace(task.ID) == "" {
+		return blockErr
+	}
+	fromState := ""
+	current, err := e.Store.GetTask(ctx, task.ID)
+	if err != nil && !errors.Is(err, sql.ErrNoRows) {
+		return err
+	}
+	if err == nil {
+		fromState = current.State
+	}
+	blocked, err := e.Store.BlockTaskWithEvent(ctx, task, db.TaskEvent{
+		Kind:      kind,
+		FromState: fromState,
+		Reason:    reason,
+	})
+	if err != nil {
+		return fmt.Errorf("record %s block for task %s: %w", label, task.ID, err)
+	}
+	if !blocked {
+		return fmt.Errorf("record %s block for task %s: state transition did not commit", label, task.ID)
+	}
+	return blockErr
 }
 
 func (e Engine) setTaskState(ctx context.Context, ref taskRef, state TaskState) error {
+	_, err := e.setTaskStateResolved(ctx, ref, state)
+	return err
+}
+
+// setTaskStateResolved returns the task row actually advanced. A branch ref can
+// resolve to an existing canonical task.
+func (e Engine) setTaskStateResolved(ctx context.Context, ref taskRef, state TaskState) (string, error) {
+	task, err := e.resolveTaskState(ctx, ref, state)
+	if err != nil || strings.TrimSpace(task.ID) == "" {
+		return "", err
+	}
+	if err := e.Store.UpsertTask(ctx, task); err != nil {
+		return "", err
+	}
+	return task.ID, nil
+}
+
+// resolveTaskState preserves the branch-canonical identity rule without writing,
+// allowing all blocked transitions to use Store.BlockTaskWithEvent.
+func (e Engine) resolveTaskState(ctx context.Context, ref taskRef, state TaskState) (db.Task, error) {
 	if strings.TrimSpace(ref.ID) == "" {
-		return nil
+		return db.Task{}, nil
 	}
 	task := db.Task{
 		ID:           ref.ID,
@@ -424,11 +475,11 @@ func (e Engine) setTaskState(ctx context.Context, ref taskRef, state TaskState) 
 	}
 	existing, err := e.Store.GetTask(ctx, ref.ID)
 	if err != nil && !errors.Is(err, sql.ErrNoRows) {
-		return err
+		return db.Task{}, err
 	}
 	if err == nil {
 		if IsDisposedTaskState(existing.State) && existing.State != string(state) {
-			return fmt.Errorf("task %s is %s; workflow advancement cannot move it to %s", existing.ID, existing.State, state)
+			return db.Task{}, fmt.Errorf("task %s is %s; workflow advancement cannot move it to %s", existing.ID, existing.State, state)
 		}
 		if task.GoalID == "" {
 			task.GoalID = existing.GoalID
@@ -445,25 +496,22 @@ func (e Engine) setTaskState(ctx context.Context, ref taskRef, state TaskState) 
 	}
 	// One task per (repo, branch) is enforced by the tasks(repo_full_name, branch)
 	// partial-unique index. If this ref carries a non-empty branch already owned by a
-	// DIFFERENT task -- e.g. workflow advancement re-running a phase on the same branch
-	// under a fresh task id -- upserting `task` would fail with
-	// "UNIQUE constraint failed: tasks.repo_full_name, tasks.branch" and wedge the
-	// advancement. Advance the branch's canonical task in place instead of inserting a
-	// duplicate (the same branch-reuse invariant used by task creation).
+	// different task, advance the branch's canonical row instead of inserting a
+	// duplicate.
 	if task.Branch != "" {
 		byBranch, berr := e.Store.GetTaskByRepoBranch(ctx, task.RepoFullName, task.Branch)
 		if berr != nil && !errors.Is(berr, sql.ErrNoRows) {
-			return berr
+			return db.Task{}, berr
 		}
 		if berr == nil && byBranch.ID != task.ID {
 			if IsDisposedTaskState(byBranch.State) && byBranch.State != string(state) {
-				return fmt.Errorf("task %s is %s; workflow advancement cannot move it to %s", byBranch.ID, byBranch.State, state)
+				return db.Task{}, fmt.Errorf("task %s is %s; workflow advancement cannot move it to %s", byBranch.ID, byBranch.State, state)
 			}
 			byBranch.State = string(state)
-			return e.Store.UpsertTask(ctx, byBranch)
+			return byBranch, nil
 		}
 	}
-	return e.Store.UpsertTask(ctx, task)
+	return task, nil
 }
 
 func (e Engine) jobID(request JobRequest) string {

--- a/internal/workflow/engine_continuation_synthesis.go
+++ b/internal/workflow/engine_continuation_synthesis.go
@@ -81,7 +81,7 @@ func (e Engine) maybeEnqueueContinuation(ctx context.Context, parentJob db.Job, 
 		if e.isPipelineOrchestrateRoot(ctx, parentJob, parentPayload) {
 			return e.enqueueFinalizeContinuation(ctx, parentJob, parentPayload, reason)
 		}
-		return e.block(ctx, ref, reason)
+		return e.blockSynthesisGate(ctx, ref, "delegation_vote_unmet", reason)
 	}
 
 	// synthesis_rule "quorum": block the parent unless at least K children
@@ -100,7 +100,7 @@ func (e Engine) maybeEnqueueContinuation(ctx context.Context, parentJob db.Job, 
 			if e.isPipelineOrchestrateRoot(ctx, parentJob, parentPayload) {
 				return e.enqueueFinalizeContinuation(ctx, parentJob, parentPayload, reason)
 			}
-			return e.block(ctx, ref, reason)
+			return e.blockSynthesisGate(ctx, ref, "delegation_quorum_unmet", reason)
 		}
 	}
 

--- a/internal/workflow/engine_pr_lifecycle.go
+++ b/internal/workflow/engine_pr_lifecycle.go
@@ -531,6 +531,13 @@ func (e Engine) HandlePullRequestReadyToMerge(ctx context.Context, event PullReq
 	// primary merge-gate path. Repeated polls are deduped durably by the store.
 	_, _ = RecordPullRequestWorkflowTransition(ctx, e.Store, event, PullRequestJournalReady)
 	ref := taskRefFromPullRequest(event)
+	// A local review task deliberately owns no branch so it cannot collide with the
+	// implement task that owns (repo, head branch). Carrying the PR's branch into
+	// its ref would let setTaskState's branch-reuse fallback advance that OTHER
+	// task instead of this one. Mirrors the same guard on the PR-closed path.
+	if stored, storedErr := e.Store.GetTask(ctx, event.TaskID); storedErr == nil && strings.TrimSpace(stored.Branch) == "" {
+		ref.Branch = ""
+	}
 	_, err := e.runMergeGateWithHumanMerge(ctx, "", JobPayload{
 		Repo:                    event.Repo,
 		Branch:                  event.Branch,

--- a/internal/workflow/engine_pr_lifecycle.go
+++ b/internal/workflow/engine_pr_lifecycle.go
@@ -117,7 +117,7 @@ func (e Engine) HandlePullRequestOpened(ctx context.Context, event PullRequestEv
 			TaskID:                  event.TaskID,
 			TaskTitle:               event.TaskTitle,
 			LeadAgent:               event.LeadAgent,
-		}, ref)
+		}, ref, TaskPullRequestOpen)
 		if err != nil {
 			return err
 		}
@@ -544,13 +544,14 @@ func (e Engine) HandlePullRequestReadyToMerge(ctx context.Context, event PullReq
 		PullRequest:             event.PullRequest,
 		PullRequestDraft:        event.PullRequestDraft,
 		PullRequestDraftUnknown: event.PullRequestDraftUnknown,
+		PullRequestMerged:       event.PullRequestMerged,
 		HeadSHA:                 event.HeadSHA,
 		GoalID:                  event.GoalID,
 		TaskID:                  event.TaskID,
 		TaskTitle:               event.TaskTitle,
 		LeadAgent:               event.LeadAgent,
 		Reviewers:               compactStrings(append([]string{}, event.RequiredReviewers...)),
-	}, ref, event.HumanMergeRequested)
+	}, ref, event.HumanMergeRequested, string(TaskReadyToMerge))
 	return err
 }
 
@@ -560,12 +561,12 @@ func (e Engine) HandlePullRequestReadyToMerge(ctx context.Context, event PullReq
 // while its task and local PR mirror remain stale.
 //
 // Merged PRs resolve any of
-// pr_open/reviewing/changes_requested/ready_to_merge/awaiting_human_merge/blocked; an already-merged
-// task is accepted only to repair its stale PR mirror. A clean closed-unmerged
-// detection resolves pr_open/reviewing/changes_requested/awaiting_human_merge to
-// blocked. The daemon's
-// closed-PR reconcile pass is the sole caller for that transition; the external-
-// merge pass only records its workflow breadcrumb, avoiding double handling.
+// pr_open/reviewing/changes_requested/ready_to_merge/awaiting_human_merge/blocked;
+// an already-merged task is accepted only to repair its stale PR mirror. A
+// clean closed-unmerged detection resolves pr_open/reviewing/changes_requested/
+// awaiting_human_merge, plus branchless ready_to_merge tasks, to blocked. An
+// already-blocked branchless task is accepted to repair its stale PR mirror.
+// The daemon's closed-PR reconcile pass owns that transition.
 // Existing PR row fields (url/base/merge SHA) are preserved.
 func (e Engine) HandleReviewPullRequestClosed(ctx context.Context, event PullRequestEvent, merged bool) error {
 	if err := e.validate(); err != nil {
@@ -584,6 +585,7 @@ func (e Engine) HandleReviewPullRequestClosed(ctx context.Context, event PullReq
 	}
 	taskState := TaskState(task.State)
 	alreadyMerged := false
+	alreadyBlocked := false
 	if merged {
 		switch taskState {
 		case TaskPullRequestOpen, TaskReviewing, TaskChangesRequested, TaskReadyToMerge, TaskAwaitingHumanMerge, TaskBlocked:
@@ -597,6 +599,15 @@ func (e Engine) HandleReviewPullRequestClosed(ctx context.Context, event PullReq
 	} else {
 		switch taskState {
 		case TaskPullRequestOpen, TaskReviewing, TaskChangesRequested, TaskAwaitingHumanMerge:
+		case TaskReadyToMerge:
+			if strings.TrimSpace(task.Branch) != "" {
+				return nil
+			}
+		case TaskBlocked:
+			if strings.TrimSpace(task.Branch) != "" {
+				return nil
+			}
+			alreadyBlocked = true
 		default:
 			return nil
 		}
@@ -607,7 +618,7 @@ func (e Engine) HandleReviewPullRequestClosed(ctx context.Context, event PullReq
 		prState = "merged"
 		nextTaskState = TaskMerged
 	}
-	if !alreadyMerged {
+	if !alreadyMerged && !alreadyBlocked {
 		stateRef := ref
 		if strings.TrimSpace(task.Branch) == "" {
 			// Legacy/local review-pr tasks intentionally have no branch because the
@@ -622,7 +633,7 @@ func (e Engine) HandleReviewPullRequestClosed(ctx context.Context, event PullReq
 			}
 		} else {
 			changed, observedState, _, err := e.Store.TransitionTaskStateWithEventObserved(ctx, task.ID,
-				[]string{string(TaskPullRequestOpen), string(TaskReviewing), string(TaskChangesRequested), string(TaskAwaitingHumanMerge)},
+				[]string{string(TaskPullRequestOpen), string(TaskReviewing), string(TaskChangesRequested), string(TaskReadyToMerge), string(TaskAwaitingHumanMerge)},
 				string(TaskBlocked), "pr_closed_unmerged", "pull request closed without merging")
 			if err != nil {
 				return err

--- a/internal/workflow/engine_routing_merge.go
+++ b/internal/workflow/engine_routing_merge.go
@@ -639,12 +639,11 @@ func (e Engine) runMergeGateWithHumanMerge(ctx context.Context, reviewer string,
 		if decision.Deferred {
 			// Park the task in ready_to_merge (NOT whatever state it arrived in) so
 			// the daemon's pullRequestReadyToMerge poll re-drives it every tick until
-			// the in-flight branch job settles. This matters for the no-reviewers
-			// auto-merge path: HandlePullRequestOpened reaches here with the task in
-			// pull_request_open, a state that poll does not re-evaluate — without this
-			// the deferred PR would wedge unmerged. Mirrors PolicyMergeGate.pending
-			// (which parks via a Ready:true tail); a deferred decision is never
-			// blocked, failed, or harvested.
+			// the hold settles. A task-owned retry already expected in ready_to_merge
+			// needs no write; this also preserves a retained external-merge claim.
+			if expectedTaskState == string(TaskReadyToMerge) {
+				return decision, nil
+			}
 			return decision, e.setTaskState(ctx, ref, TaskReadyToMerge)
 		}
 		reason := decision.Reason.Render()

--- a/internal/workflow/engine_routing_merge.go
+++ b/internal/workflow/engine_routing_merge.go
@@ -207,19 +207,50 @@ func (e Engine) blockAutoFix(ctx context.Context, ref taskRef, reason string) er
 // task is blocked and that some merge-gate row exists, and would clear a quorum
 // failure as though it were self-clearing infrastructure. Mirrors blockAutoFix.
 func (e Engine) blockMergeGate(ctx context.Context, ref taskRef, reason string) error {
-	if strings.TrimSpace(ref.ID) != "" {
-		if err := e.Store.AddTaskEvent(ctx, db.TaskEvent{
-			TaskID:  ref.ID,
-			Kind:    "merge_gate_blocked",
-			ToState: string(TaskBlocked),
-			Reason:  reason,
-		}); err != nil {
-			return fmt.Errorf("record merge-gate block: %w", err)
-		}
-	}
-	return e.block(ctx, ref, reason)
+	return e.blockAttributed(ctx, ref, "merge_gate_blocked", reason, "merge-gate")
 }
 
+// blockSynthesisGate attributes a coordinator synthesis-gate block (vote or
+// quorum unmet) on the task, mirroring blockMergeGate and blockAutoFix (#1562).
+//
+// Attributing BOTH sides is what makes absence meaningful. With only the merge
+// gate attributed, a task carrying no blocking event is ambiguous — it could be a
+// pre-attribution legacy block OR a fresh quorum failure — so an exit path can
+// neither release legacy wedges nor refuse quorum failures without guessing. Once
+// both write an event, "no blocking event at all" identifies exactly one
+// population: rows blocked before this shipped.
+func (e Engine) blockSynthesisGate(ctx context.Context, ref taskRef, kind string, reason string) error {
+	return e.blockAttributed(ctx, ref, kind, reason, "synthesis-gate")
+}
+
+// blockAttributed blocks the task and records WHICH mechanism did it, in that
+// order. The order is load-bearing: e.block signals success by returning a
+// BlockedError and a store failure by returning a plain error, so writing the
+// attribution first would leave a durable "this task is blocked by X" event behind
+// a transition that never happened — and a later block from a mechanism that
+// writes no event of its own would then be released on the strength of that stale
+// claim. Attribution failure is logged into the returned error but never converts a
+// successful block into a failure, because the block itself is already durable.
+func (e Engine) blockAttributed(ctx context.Context, ref taskRef, kind string, reason string, label string) error {
+	blockErr := e.block(ctx, ref, reason)
+	var blocked BlockedError
+	if !errors.As(blockErr, &blocked) {
+		// The transition itself failed; there is no block to attribute.
+		return blockErr
+	}
+	if strings.TrimSpace(ref.ID) == "" {
+		return blockErr
+	}
+	if err := e.Store.AddTaskEvent(ctx, db.TaskEvent{
+		TaskID:  ref.ID,
+		Kind:    kind,
+		ToState: string(TaskBlocked),
+		Reason:  reason,
+	}); err != nil {
+		return fmt.Errorf("record %s block for task %s: %w", label, ref.ID, err)
+	}
+	return blockErr
+}
 func (e Engine) allRequiredReviewersApproved(ctx context.Context, currentReviewer string, payload JobPayload) (bool, error) {
 	required := e.requiredReviewers(payload)
 	if len(required) == 0 {

--- a/internal/workflow/engine_routing_merge.go
+++ b/internal/workflow/engine_routing_merge.go
@@ -187,70 +187,31 @@ func (e Engine) fixBranchLockOwner(ctx context.Context, payload JobPayload, exec
 }
 
 func (e Engine) blockAutoFix(ctx context.Context, ref taskRef, reason string) error {
-	if strings.TrimSpace(ref.ID) != "" {
-		if err := e.Store.AddTaskEvent(ctx, db.TaskEvent{
-			TaskID: ref.ID,
-			Kind:   "review_auto_fix_blocked",
-			Reason: reason,
-		}); err != nil {
-			return fmt.Errorf("record auto-fix block: %w", err)
-		}
-	}
-	return e.block(ctx, ref, reason)
+	return e.blockAttributed(ctx, ref, "review_auto_fix_blocked", reason, "auto-fix")
 }
 
-// blockMergeGate attributes a merge-gate block on the task itself before making
-// the transition (#1562). e.block is shared with the coordinator failure paths —
-// block_parent and the vote/quorum synthesis gates in
-// engine_continuation_synthesis.go — so `state == blocked` alone cannot say WHICH
-// mechanism blocked a task. Without this event an exit path can only see that a
-// task is blocked and that some merge-gate row exists, and would clear a quorum
-// failure as though it were self-clearing infrastructure. Mirrors blockAutoFix.
+// blockMergeGate attributes a merge-gate block on the task itself (#1562).
+// All block writers converge on blockTask, so the event naming the owner is
+// written only after the durable blocked transition.
 func (e Engine) blockMergeGate(ctx context.Context, ref taskRef, reason string) error {
 	return e.blockAttributed(ctx, ref, "merge_gate_blocked", reason, "merge-gate")
 }
 
 // blockSynthesisGate attributes a coordinator synthesis-gate block (vote or
 // quorum unmet) on the task, mirroring blockMergeGate and blockAutoFix (#1562).
-//
-// Attributing BOTH sides is what makes absence meaningful. With only the merge
-// gate attributed, a task carrying no blocking event is ambiguous — it could be a
-// pre-attribution legacy block OR a fresh quorum failure — so an exit path can
-// neither release legacy wedges nor refuse quorum failures without guessing. Once
-// both write an event, "no blocking event at all" identifies exactly one
-// population: rows blocked before this shipped.
+// Generic workflow blocks use workflow_blocked at the same choke point, making
+// the latest blocking event a complete ownership record rather than a selective
+// list of callers.
 func (e Engine) blockSynthesisGate(ctx context.Context, ref taskRef, kind string, reason string) error {
 	return e.blockAttributed(ctx, ref, kind, reason, "synthesis-gate")
 }
 
-// blockAttributed blocks the task and records WHICH mechanism did it, in that
-// order. The order is load-bearing: e.block signals success by returning a
-// BlockedError and a store failure by returning a plain error, so writing the
-// attribution first would leave a durable "this task is blocked by X" event behind
-// a transition that never happened — and a later block from a mechanism that
-// writes no event of its own would then be released on the strength of that stale
-// claim. Attribution failure is logged into the returned error but never converts a
-// successful block into a failure, because the block itself is already durable.
+// blockAttributed routes named blockers through the shared block-first,
+// attribute-second choke point.
 func (e Engine) blockAttributed(ctx context.Context, ref taskRef, kind string, reason string, label string) error {
-	blockErr := e.block(ctx, ref, reason)
-	var blocked BlockedError
-	if !errors.As(blockErr, &blocked) {
-		// The transition itself failed; there is no block to attribute.
-		return blockErr
-	}
-	if strings.TrimSpace(ref.ID) == "" {
-		return blockErr
-	}
-	if err := e.Store.AddTaskEvent(ctx, db.TaskEvent{
-		TaskID:  ref.ID,
-		Kind:    kind,
-		ToState: string(TaskBlocked),
-		Reason:  reason,
-	}); err != nil {
-		return fmt.Errorf("record %s block for task %s: %w", label, ref.ID, err)
-	}
-	return blockErr
+	return e.blockTask(ctx, ref, kind, reason, label)
 }
+
 func (e Engine) allRequiredReviewersApproved(ctx context.Context, currentReviewer string, payload JobPayload) (bool, error) {
 	required := e.requiredReviewers(payload)
 	if len(required) == 0 {
@@ -626,11 +587,14 @@ func (e Engine) ensureBranchLock(ctx context.Context, repo string, branch string
 	return nil
 }
 
-func (e Engine) runMergeGate(ctx context.Context, reviewer string, payload JobPayload, ref taskRef) (MergeDecision, error) {
-	return e.runMergeGateWithHumanMerge(ctx, reviewer, payload, ref, false)
+func (e Engine) runMergeGate(ctx context.Context, reviewer string, payload JobPayload, ref taskRef, expectedTaskState TaskState) (MergeDecision, error) {
+	return e.runMergeGateWithHumanMerge(ctx, reviewer, payload, ref, false, string(expectedTaskState))
 }
 
-func (e Engine) runMergeGateWithHumanMerge(ctx context.Context, reviewer string, payload JobPayload, ref taskRef, humanMergeRequested bool) (MergeDecision, error) {
+func (e Engine) runMergeGateWithHumanMerge(ctx context.Context, reviewer string, payload JobPayload, ref taskRef, humanMergeRequested bool, expectedTaskState string) (MergeDecision, error) {
+	if strings.TrimSpace(ref.ID) != "" && strings.TrimSpace(expectedTaskState) == "" {
+		return MergeDecision{}, errors.New("task-owned merge gate requires an expected task state")
+	}
 	if e.MergeGate == nil {
 		return MergeDecision{Ready: true}, e.setTaskState(ctx, ref, TaskReadyToMerge)
 	}
@@ -644,12 +608,14 @@ func (e Engine) runMergeGateWithHumanMerge(ctx context.Context, reviewer string,
 		PullRequest:             payload.PullRequest,
 		PullRequestDraft:        payload.PullRequestDraft,
 		PullRequestDraftUnknown: payload.PullRequestDraftUnknown,
+		PullRequestMerged:       payload.PullRequestMerged,
 		HeadSHA:                 payload.HeadSHA,
 		TaskID:                  payload.TaskID,
 		WorkflowID:              payload.WorkflowID,
 		Reviewer:                reviewer,
 		ReviewOptional:          !reviewRequired,
 		ReviewBlockingSeverity:  e.reviewBlockingSeverity(payload.Repo),
+		ExpectedTaskState:       expectedTaskState,
 		HumanMergeRequested:     humanMergeRequested,
 	})
 	if err != nil {

--- a/internal/workflow/engine_routing_merge.go
+++ b/internal/workflow/engine_routing_merge.go
@@ -199,6 +199,27 @@ func (e Engine) blockAutoFix(ctx context.Context, ref taskRef, reason string) er
 	return e.block(ctx, ref, reason)
 }
 
+// blockMergeGate attributes a merge-gate block on the task itself before making
+// the transition (#1562). e.block is shared with the coordinator failure paths —
+// block_parent and the vote/quorum synthesis gates in
+// engine_continuation_synthesis.go — so `state == blocked` alone cannot say WHICH
+// mechanism blocked a task. Without this event an exit path can only see that a
+// task is blocked and that some merge-gate row exists, and would clear a quorum
+// failure as though it were self-clearing infrastructure. Mirrors blockAutoFix.
+func (e Engine) blockMergeGate(ctx context.Context, ref taskRef, reason string) error {
+	if strings.TrimSpace(ref.ID) != "" {
+		if err := e.Store.AddTaskEvent(ctx, db.TaskEvent{
+			TaskID:  ref.ID,
+			Kind:    "merge_gate_blocked",
+			ToState: string(TaskBlocked),
+			Reason:  reason,
+		}); err != nil {
+			return fmt.Errorf("record merge-gate block: %w", err)
+		}
+	}
+	return e.block(ctx, ref, reason)
+}
+
 func (e Engine) allRequiredReviewersApproved(ctx context.Context, currentReviewer string, payload JobPayload) (bool, error) {
 	required := e.requiredReviewers(payload)
 	if len(required) == 0 {
@@ -645,7 +666,7 @@ func (e Engine) runMergeGateWithHumanMerge(ctx context.Context, reviewer string,
 		// INFRA-NOISE-FILTERED). A real store error skips the harvest and returns up.
 		// Best-effort and nil-safe: a harvest error can never affect the (already-
 		// durable) block.
-		err := e.block(ctx, ref, reason)
+		err := e.blockMergeGate(ctx, ref, reason)
 		var blocked BlockedError
 		if errors.As(err, &blocked) && decision.BlockClass == MergeBlockQuality {
 			// Only an AUTHORITATIVE template-quality block (external CI failed, a

--- a/internal/workflow/engine_run_budgets.go
+++ b/internal/workflow/engine_run_budgets.go
@@ -622,7 +622,7 @@ func (e Engine) AdvanceJob(ctx context.Context, jobID string) (retErr error) {
 			if !ready {
 				return e.setReviewingIfNotChangesRequested(ctx, ref)
 			}
-			_, err = e.runMergeGate(ctx, reviewer, payload, ref)
+			_, err = e.runMergeGate(ctx, reviewer, payload, ref, TaskReviewing)
 			return err
 		}
 	}

--- a/internal/workflow/engine_test.go
+++ b/internal/workflow/engine_test.go
@@ -2195,12 +2195,137 @@ func TestEngineAdvanceReviewChangesRequestedFailsClosedWithoutOwnership(t *testi
 	}
 	found := false
 	for _, event := range events {
-		if event.Kind == "review_auto_fix_blocked" && strings.Contains(event.Reason, "ownership unresolved") {
+		if event.Kind == "review_auto_fix_blocked" &&
+			event.ToState == string(TaskBlocked) &&
+			strings.Contains(event.Reason, "ownership unresolved") {
 			found = true
 		}
 	}
 	if !found {
 		t.Fatalf("task events = %+v, want review_auto_fix_blocked ownership event", events)
+	}
+}
+
+func TestEngineFailedResultWritesCurrentBlockOwnership(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	engine := testEngine(store)
+	insertCompletedJob(t, store, db.Job{ID: "failed-result", Agent: "worker", Type: "ask"}, JobPayload{
+		Repo:      "gitmoot/gitmoot",
+		Branch:    "task-8",
+		TaskID:    "task-8",
+		TaskTitle: "Failed result",
+		Result:    &AgentResult{Decision: "failed", Summary: "production failure"},
+	})
+
+	err := engine.AdvanceJob(ctx, "failed-result")
+	var blocked BlockedError
+	if !errors.As(err, &blocked) {
+		t.Fatalf("AdvanceJob error = %v, want BlockedError", err)
+	}
+	assertTaskState(t, store, "task-8", TaskBlocked)
+	events, err := store.ListTaskEvents(ctx, "task-8")
+	if err != nil {
+		t.Fatalf("ListTaskEvents: %v", err)
+	}
+	if len(events) != 1 || events[0].Kind != "workflow_blocked" ||
+		events[0].ToState != string(TaskBlocked) ||
+		events[0].Reason != "production failure" {
+		t.Fatalf("task events = %+v, want current workflow_blocked ownership", events)
+	}
+}
+
+func TestHandlePullRequestReadyToMergeWritesMergeGateBlockOwnership(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	if err := store.UpsertTask(ctx, db.Task{
+		ID: "task-9", RepoFullName: "gitmoot/gitmoot", Branch: "task-9",
+		State: string(TaskReadyToMerge),
+	}); err != nil {
+		t.Fatal(err)
+	}
+	engine := testEngine(store)
+	expectedState := ""
+	engine.MergeGate = &fakeMergeGate{
+		decision: MergeDecision{
+			Ready: false, Reason: PlainReason("dirty worktree"), BlockClass: MergeBlockTransient,
+		},
+		onEvaluate: func(request MergeRequest) {
+			expectedState = request.ExpectedTaskState
+		},
+	}
+
+	err := engine.HandlePullRequestReadyToMerge(ctx, PullRequestEvent{
+		Repo: "gitmoot/gitmoot", Branch: "task-9", PullRequest: 9,
+		HeadSHA: "head-9", TaskID: "task-9", LeadAgent: "lead",
+	})
+	var blocked BlockedError
+	if !errors.As(err, &blocked) {
+		t.Fatalf("HandlePullRequestReadyToMerge error = %v, want BlockedError", err)
+	}
+	if expectedState != string(TaskReadyToMerge) {
+		t.Fatalf("merge request expected state = %q, want ready_to_merge", expectedState)
+	}
+	assertTaskState(t, store, "task-9", TaskBlocked)
+	events, err := store.ListTaskEvents(ctx, "task-9")
+	if err != nil {
+		t.Fatalf("ListTaskEvents: %v", err)
+	}
+	if len(events) != 1 || events[0].Kind != "merge_gate_blocked" ||
+		events[0].ToState != string(TaskBlocked) {
+		t.Fatalf("task events = %+v, want merge_gate_blocked ownership", events)
+	}
+}
+
+// The block state and its owner are one transaction. If ownership persistence
+// fails, neither half commits and callers receive the store error rather than a
+// false durable BlockedError.
+func TestMergeGateAttributionFailureRollsBackBlockedState(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	if err := store.UpsertTask(ctx, db.Task{
+		ID: "task-10", RepoFullName: "gitmoot/gitmoot", Branch: "task-10",
+		State: string(TaskReadyToMerge),
+	}); err != nil {
+		t.Fatal(err)
+	}
+	raw, err := sql.Open("sqlite", store.DatabasePath())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer raw.Close()
+	if _, err := raw.ExecContext(ctx, `
+CREATE TRIGGER fail_merge_gate_block_attribution
+BEFORE INSERT ON task_events
+WHEN NEW.kind = 'merge_gate_blocked'
+BEGIN
+	SELECT RAISE(ABORT, 'forced merge gate attribution failure');
+END`); err != nil {
+		t.Fatal(err)
+	}
+	engine := testEngine(store)
+	engine.MergeGate = &fakeMergeGate{decision: MergeDecision{
+		Ready: false, Reason: PlainReason("dirty worktree"), BlockClass: MergeBlockTransient,
+	}}
+
+	err = engine.HandlePullRequestReadyToMerge(ctx, PullRequestEvent{
+		Repo: "gitmoot/gitmoot", Branch: "task-10", PullRequest: 10,
+		HeadSHA: "head-10", TaskID: "task-10", LeadAgent: "lead",
+	})
+	var blocked BlockedError
+	if errors.As(err, &blocked) {
+		t.Fatalf("error = %v, must not claim a durable block", err)
+	}
+	if !strings.Contains(err.Error(), "forced merge gate attribution failure") {
+		t.Fatalf("error = %v, want attribution store failure", err)
+	}
+	assertTaskState(t, store, "task-10", TaskReadyToMerge)
+	events, listErr := store.ListTaskEvents(ctx, "task-10")
+	if listErr != nil {
+		t.Fatalf("ListTaskEvents: %v", listErr)
+	}
+	if len(events) != 0 {
+		t.Fatalf("task events = %+v, want atomic rollback", events)
 	}
 }
 
@@ -5393,6 +5518,19 @@ func TestEngineDelegationSynthesisRuleVoteBlocksOnFailure(t *testing.T) {
 		t.Fatal("vote failure must not enqueue the continuation")
 	}
 	assertTaskState(t, store, "task-5", TaskBlocked)
+	events, err := store.ListTaskEvents(ctx, "task-5")
+	if err != nil {
+		t.Fatalf("ListTaskEvents: %v", err)
+	}
+	found := false
+	for _, event := range events {
+		if event.Kind == "delegation_vote_unmet" && event.ToState == string(TaskBlocked) {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("task events = %+v, want delegation_vote_unmet blocked ownership event", events)
+	}
 }
 
 func TestEngineDelegationSynthesisRuleVotePassesWhenAllApproved(t *testing.T) {

--- a/internal/workflow/engine_types.go
+++ b/internal/workflow/engine_types.go
@@ -247,13 +247,17 @@ type PullRequestEvent struct {
 	// merge-gate eligible and do not represent a pending human merge decision.
 	PullRequestDraft        bool
 	PullRequestDraftUnknown bool
-	HeadSHA                 string
-	GoalID                  string
-	TaskID                  string
-	TaskTitle               string
-	LeadAgent               string
-	Sender                  string
-	RequiredReviewers       []string
+	// PullRequestMerged is an authoritative forge observation. It permits only
+	// the production wrapper's active-job deferral bypass; PolicyMergeGate still
+	// re-reads the pull request before applying terminal effects.
+	PullRequestMerged bool
+	HeadSHA           string
+	GoalID            string
+	TaskID            string
+	TaskTitle         string
+	LeadAgent         string
+	Sender            string
+	RequiredReviewers []string
 	// ActingOrgRole is the org attribution carried from the branch lock (#1250).
 	// BOTH PR-open triggers read it from that one durable source, so native review
 	// fanout children inherit an attribution instead of being enqueued
@@ -311,11 +315,18 @@ type MergeRequest struct {
 	PullRequest             int
 	PullRequestDraft        bool
 	PullRequestDraftUnknown bool
-	HeadSHA                 string
-	TaskID                  string
-	WorkflowID              string
-	Reviewer                string
-	ReviewOptional          bool
+	// PullRequestMerged carries an authoritative forge observation through the
+	// production wrapper. It never decides the merge outcome by itself.
+	PullRequestMerged bool
+	HeadSHA           string
+	TaskID            string
+	// ExpectedTaskState asks PolicyMergeGate to revalidate and hold this task
+	// state through the irreversible MergePullRequest call. Empty preserves
+	// callers that do not own a task-state precondition.
+	ExpectedTaskState string
+	WorkflowID        string
+	Reviewer          string
+	ReviewOptional    bool
 	// ReviewBlockingSeverity is the resolved repository threshold carried into
 	// the merge gate. Empty preserves the historical block-all behavior.
 	ReviewBlockingSeverity string

--- a/internal/workflow/engine_types.go
+++ b/internal/workflow/engine_types.go
@@ -318,8 +318,12 @@ type MergeRequest struct {
 	// PullRequestMerged carries an authoritative forge observation through the
 	// production wrapper. It never decides the merge outcome by itself.
 	PullRequestMerged bool
-	HeadSHA           string
-	TaskID            string
+	// TerminalRecoveryOnly permits an authoritative merged hint to re-read the
+	// forge and finish terminal recovery while merge initiation is disabled.
+	// An open or closed-unmerged pull request must still leave without merging.
+	TerminalRecoveryOnly bool
+	HeadSHA              string
+	TaskID               string
 	// ExpectedTaskState asks PolicyMergeGate to revalidate and hold this task
 	// state through the irreversible MergePullRequest call. Empty preserves
 	// callers that do not own a task-state precondition.

--- a/internal/workflow/mailbox.go
+++ b/internal/workflow/mailbox.go
@@ -400,6 +400,7 @@ type JobPayload struct {
 	// intent so routing decisions consume what the forge actually reports.
 	PullRequestDraft        bool         `json:"pull_request_draft,omitempty"`
 	PullRequestDraftUnknown bool         `json:"pull_request_draft_unknown,omitempty"`
+	PullRequestMerged       bool         `json:"pull_request_merged,omitempty"`
 	HeadSHA                 string       `json:"head_sha,omitempty"`
 	GoalID                  string       `json:"goal_id,omitempty"`
 	TaskID                  string       `json:"task_id"`

--- a/internal/workflow/merge_gate.go
+++ b/internal/workflow/merge_gate.go
@@ -27,7 +27,14 @@ const (
 	MergeLeaveOpenAutoMergeKillSwitchReason = "native auto-merge is disabled by the repository kill-switch; leave the pull request open for a human merge"
 	commitStatusDescriptionMaxRunes         = 140
 	mergeQueueLockTTL                       = 30 * time.Minute
+	// The initial lease outlives the maximum eight-hour worker context by one
+	// hour. Hourly renewal also protects daemon-owned calls without a deadline.
+	mergeTaskStateClaimTTL             = 9 * time.Hour
+	mergeTaskStateClaimRenewalInterval = time.Hour
+	mergeOutcomeConfirmationTimeout    = 30 * time.Second
 )
+
+var ErrMergeTaskStateChanged = errors.New("merge task state changed before external merge")
 
 // NativeMergeGateDisabled reports whether the operator handed the merge decision
 // to an external gate via GITMOOT_DISABLE_NATIVE_MERGE_GATE (#545). It is the
@@ -98,7 +105,12 @@ type PolicyMergeGate struct {
 	// of wedging forever. Zero means use the built-in default (defaultMaxCIWait).
 	MaxCIWait time.Duration
 	// Clock is injectable for deterministic tests. Nil means time.Now.
-	Clock func() time.Time
+	Clock                      func() time.Time
+	taskClaimTTL               time.Duration
+	taskClaimRenewalInterval   time.Duration
+	taskClaimRenewalTicks      func(context.Context, time.Duration) <-chan time.Time
+	afterTaskClaimRenewal      func()
+	outcomeConfirmationTimeout time.Duration
 }
 
 // defaultMinCIWait is the built-in grace window used when MinCIWait is unset. It
@@ -135,6 +147,94 @@ func (g PolicyMergeGate) maxCIWait() time.Duration {
 	return defaultMaxCIWait
 }
 
+func (g PolicyMergeGate) taskStateClaimTTL() time.Duration {
+	if g.taskClaimTTL > 0 {
+		return g.taskClaimTTL
+	}
+	return mergeTaskStateClaimTTL
+}
+
+func (g PolicyMergeGate) taskStateClaimRenewalInterval() time.Duration {
+	if g.taskClaimRenewalInterval > 0 {
+		return g.taskClaimRenewalInterval
+	}
+	return mergeTaskStateClaimRenewalInterval
+}
+
+func (g PolicyMergeGate) taskStateClaimRenewalTickSource(ctx context.Context, interval time.Duration) <-chan time.Time {
+	if g.taskClaimRenewalTicks != nil {
+		return g.taskClaimRenewalTicks(ctx, interval)
+	}
+	out := make(chan time.Time)
+	go func() {
+		defer close(out)
+		ticker := time.NewTicker(interval)
+		defer ticker.Stop()
+		for {
+			select {
+			case tick := <-ticker.C:
+				select {
+				case out <- tick:
+				case <-ctx.Done():
+					return
+				}
+			case <-ctx.Done():
+				return
+			}
+		}
+	}()
+	return out
+}
+
+func (g PolicyMergeGate) startTaskStateClaimRenewal(taskID, token string) func() error {
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() {
+		ticks := g.taskStateClaimRenewalTickSource(ctx, g.taskStateClaimRenewalInterval())
+		var lastErr error
+		for {
+			select {
+			case _, ok := <-ticks:
+				if !ok {
+					if ctx.Err() != nil {
+						done <- lastErr
+					} else {
+						done <- errors.Join(lastErr, errors.New("task claim renewal clock stopped"))
+					}
+					return
+				}
+				renewed, err := g.Store.RenewTaskStateClaim(context.Background(), taskID, token, g.taskStateClaimTTL())
+				if err != nil {
+					lastErr = fmt.Errorf("renew task state claim: %w", err)
+					continue
+				}
+				if !renewed {
+					done <- fmt.Errorf("%w: durable task claim for %s expired or changed owners", ErrMergeTaskStateChanged, taskID)
+					return
+				}
+				lastErr = nil
+				if g.afterTaskClaimRenewal != nil {
+					g.afterTaskClaimRenewal()
+				}
+			case <-ctx.Done():
+				done <- lastErr
+				return
+			}
+		}
+	}()
+	return func() error {
+		cancel()
+		return <-done
+	}
+}
+
+func (g PolicyMergeGate) mergeOutcomeConfirmationTimeout() time.Duration {
+	if g.outcomeConfirmationTimeout > 0 {
+		return g.outcomeConfirmationTimeout
+	}
+	return mergeOutcomeConfirmationTimeout
+}
+
 // workflowAwareGitHub is an OPTIONAL capability the merge gate probes for on its
 // GitHub client (#596, layer 2). The real *github.GhClient implements it; a
 // client that does not is treated as "workflows unknown", which fails safe
@@ -169,6 +269,18 @@ func (g PolicyMergeGate) Evaluate(ctx context.Context, request MergeRequest) (Me
 	pr, err := g.GitHub.GetPullRequest(ctx, repo, int64(request.PullRequest))
 	if err != nil {
 		return MergeDecision{}, err
+	}
+	if !pullRequestMerged(pr) && strings.TrimSpace(pr.State) == "closed" &&
+		strings.TrimSpace(request.TaskID) != "" && strings.TrimSpace(request.ExpectedTaskState) != "" {
+		released, _, releaseErr := g.Store.ReleaseRetainedTaskStateClaim(ctx,
+			request.TaskID, request.ExpectedTaskState, db.TaskStateClaimKindExternalMergeUncertain)
+		if releaseErr != nil {
+			return MergeDecision{}, fmt.Errorf("resolve retained task claim after authoritative non-merged observation: %w", releaseErr)
+		}
+		if released {
+			log.Printf("merge gate released retained external merge claim for task %s after pull request #%d reached a terminal non-merge state",
+				request.TaskID, request.PullRequest)
+		}
 	}
 	headSHA := strings.TrimSpace(pr.HeadSHA)
 	if headSHA == "" {
@@ -208,6 +320,12 @@ func (g PolicyMergeGate) Evaluate(ctx context.Context, request MergeRequest) (Me
 		}()
 	}
 	if pullRequestMerged(pr) {
+		if strings.TrimSpace(request.TaskID) != "" && strings.TrimSpace(request.ExpectedTaskState) != "" {
+			if _, _, err := g.Store.RecoverClaimedTaskState(ctx, request.TaskID, string(TaskMerged),
+				"pull_request_merged", fmt.Sprintf("recovered merged pull request #%d from durable task claim", request.PullRequest)); err != nil {
+				return MergeDecision{}, err
+			}
+		}
 		return g.finishMerged(ctx, request, pr, strings.TrimSpace(pr.MergeSHA))
 	}
 	if strings.TrimSpace(pr.State) == "closed" {
@@ -241,7 +359,7 @@ func (g PolicyMergeGate) Evaluate(ctx context.Context, request MergeRequest) (Me
 	if pr.Mergeable != nil && !*pr.Mergeable {
 		return g.block(ctx, request, headSHA, "pull request is not mergeable; rebase or update the branch", MergeBlockTransient)
 	}
-	result, err := executePullRequestMerge(ctx, g.GitHub, github.MergePullRequestInput{
+	result, err := g.executePullRequestMergeFenced(ctx, request, github.MergePullRequestInput{
 		Repo:            repo,
 		Number:          int64(request.PullRequest),
 		Method:          mergeMethod(g.MergeMethod),
@@ -317,6 +435,92 @@ func (g PolicyMergeGate) reviewAndCIGateMiss(ctx context.Context, repo github.Re
 		}
 	}
 	return MergeDecision{}, false, miss, nil
+}
+
+// executePullRequestMergeFenced durably claims the task's expected state before
+// the irreversible GitHub merge. The active lease renews while the external
+// call is in flight. Accepted queued merges and outcomes that cannot be
+// confirmed remain fenced without expiry until a later authoritative merged or
+// terminal non-merge observation resolves them.
+func (g PolicyMergeGate) executePullRequestMergeFenced(ctx context.Context, request MergeRequest, input github.MergePullRequestInput) (github.MergeResult, error) {
+	expectedState := strings.TrimSpace(request.ExpectedTaskState)
+	taskID := strings.TrimSpace(request.TaskID)
+	if expectedState == "" || taskID == "" {
+		return executePullRequestMerge(ctx, g.GitHub, input)
+	}
+	token, claimed, currentState, err := g.Store.ClaimTaskState(
+		ctx, taskID, expectedState, db.TaskStateClaimKindExternalMerge, g.taskStateClaimTTL())
+	if err != nil {
+		return github.MergeResult{}, err
+	}
+	if !claimed {
+		return github.MergeResult{}, fmt.Errorf("%w: task %s expected %q, current %q",
+			ErrMergeTaskStateChanged, taskID, expectedState, currentState)
+	}
+	stopRenewal := g.startTaskStateClaimRenewal(taskID, token)
+	result, mergeErr := executePullRequestMerge(ctx, g.GitHub, input)
+	renewalErr := stopRenewal()
+
+	if mergeErr != nil {
+		confirmedPR, confirmationErr := g.confirmExternalMergeOutcome(ctx, input)
+		switch {
+		case confirmationErr == nil && pullRequestMerged(confirmedPR):
+			result = github.MergeResult{Merged: true, SHA: strings.TrimSpace(confirmedPR.MergeSHA)}
+			mergeErr = nil
+		case confirmationErr == nil && strings.TrimSpace(confirmedPR.State) == "closed":
+			releaseErr := g.Store.ReleaseTaskStateClaim(ctx, taskID, token)
+			return result, errors.Join(mergeErr, renewalErr, releaseErr)
+		default:
+			retained, retainErr := g.Store.RetainTaskStateClaim(ctx, taskID, token,
+				expectedState, db.TaskStateClaimKindExternalMergeUncertain)
+			outcomeErr := errors.Join(mergeErr, renewalErr, retainErr)
+			if confirmationErr != nil {
+				outcomeErr = errors.Join(outcomeErr, fmt.Errorf("confirm external merge outcome: %w", confirmationErr))
+			}
+			if !retained {
+				return result, fmt.Errorf("external merge outcome is unresolved and durable task ownership could not be retained: %w",
+					errors.Join(outcomeErr, ErrMergeTaskStateChanged))
+			}
+			if confirmationErr == nil {
+				return result, fmt.Errorf("external merge returned an error while the pull request remains open; durable task ownership retained for reconciliation: %w",
+					outcomeErr)
+			}
+			return result, fmt.Errorf("external merge outcome is ambiguous; durable task ownership retained for reconciliation: %w",
+				outcomeErr)
+		}
+	}
+	if !result.Merged {
+		retained, retainErr := g.Store.RetainTaskStateClaim(ctx, taskID, token,
+			expectedState, db.TaskStateClaimKindExternalMergeUncertain)
+		if !retained {
+			return result, fmt.Errorf("external merge is pending and durable task ownership could not be retained: %w",
+				errors.Join(renewalErr, retainErr, ErrMergeTaskStateChanged))
+		}
+		if renewalErr != nil {
+			log.Printf("merge gate retained pending task %s after claim renewal warning: %v", taskID, renewalErr)
+		}
+		return result, nil
+	}
+	changed, currentState, err := g.Store.CompleteTaskStateClaim(ctx, taskID, token,
+		string(TaskMerged), "pull_request_merged",
+		fmt.Sprintf("merged pull request #%d while holding durable task-state claim", request.PullRequest))
+	if err != nil {
+		return result, fmt.Errorf("external merge succeeded but task %s claim completion failed: %w", taskID, err)
+	}
+	if !changed {
+		return result, fmt.Errorf("external merge succeeded but %w: task %s expected %q, current %q",
+			ErrMergeTaskStateChanged, taskID, expectedState, currentState)
+	}
+	if renewalErr != nil {
+		log.Printf("merge gate completed task %s after claim renewal warning: %v", taskID, renewalErr)
+	}
+	return result, nil
+}
+
+func (g PolicyMergeGate) confirmExternalMergeOutcome(ctx context.Context, input github.MergePullRequestInput) (github.PullRequest, error) {
+	confirmCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), g.mergeOutcomeConfirmationTimeout())
+	defer cancel()
+	return g.GitHub.GetPullRequest(confirmCtx, input.Repo, input.Number)
 }
 
 // executePullRequestMerge is the single low-level GitHub merge path shared by

--- a/internal/workflow/merge_gate.go
+++ b/internal/workflow/merge_gate.go
@@ -244,16 +244,16 @@ type workflowAwareGitHub interface {
 }
 
 func (g PolicyMergeGate) Evaluate(ctx context.Context, request MergeRequest) (MergeDecision, error) {
-	// An explicit operator kill-switch must remain before validation and every
-	// GitHub/local-store operation. An authenticated human merge request may
-	// override this policy, but not the independently verified evidence below.
-	if !g.AutoMerge && !request.HumanMergeRequested {
+	// An explicit operator kill-switch remains before validation and every
+	// GitHub/local-store operation except terminal recovery. Recovery re-reads
+	// the forge and may only finish an already-merged pull request.
+	if !g.AutoMerge && !request.HumanMergeRequested && !request.TerminalRecoveryOnly {
 		return MergeDecision{LeaveOpen: true, Reason: PlainReason(MergeLeaveOpenAutoMergeKillSwitchReason)}, nil
 	}
-	if request.PullRequestDraftUnknown {
+	if request.PullRequestDraftUnknown && !request.TerminalRecoveryOnly {
 		return MergeDecision{LeaveOpen: true, Reason: PlainReason("pull request draft state is unknown")}, nil
 	}
-	if request.PullRequestDraft {
+	if request.PullRequestDraft && !request.TerminalRecoveryOnly {
 		return MergeDecision{LeaveOpen: true, Reason: PlainReason("pull request is draft")}, nil
 	}
 	if err := g.validate(); err != nil {
@@ -281,6 +281,13 @@ func (g PolicyMergeGate) Evaluate(ctx context.Context, request MergeRequest) (Me
 			log.Printf("merge gate released retained external merge claim for task %s after pull request #%d reached a terminal non-merge state",
 				request.TaskID, request.PullRequest)
 		}
+	}
+	if request.TerminalRecoveryOnly && !pullRequestMerged(pr) {
+		return MergeDecision{
+			Deferred:   true,
+			BlockClass: MergeBlockTransient,
+			Reason:     PlainReason("authoritative pull request re-read has not confirmed a merge"),
+		}, nil
 	}
 	headSHA := strings.TrimSpace(pr.HeadSHA)
 	if headSHA == "" {

--- a/internal/workflow/merge_gate.go
+++ b/internal/workflow/merge_gate.go
@@ -1270,12 +1270,15 @@ func reviewRoundAfter(left string, right string) bool {
 }
 
 // block records a not-ready block at the given quality classification (#465). The
-// class is advisory metadata for the Mode-A trace-harvester only; it never changes
-// the block transition itself. Call sites pass MergeBlockQuality for authoritative
-// template-quality rejections (external CI failed, blocking review captured, closed
-// without merge) and MergeBlockTransient for branch-staleness/infra conditions.
+// class drives the Mode-A trace-harvester AND is persisted on the merge-gate row
+// (#1562): a transient/infra block is self-clearing, so an exit path outside this
+// call stack must be able to tell it apart from an authoritative rejection. It
+// still never changes the block transition itself. Call sites pass
+// MergeBlockQuality for authoritative template-quality rejections (external CI
+// failed, blocking review captured, closed without merge) and MergeBlockTransient
+// for branch-staleness/infra conditions.
 func (g PolicyMergeGate) block(ctx context.Context, request MergeRequest, sha string, reason string, class MergeBlockClass) (MergeDecision, error) {
-	if err := g.Store.UpsertMergeGate(ctx, db.MergeGate{RepoFullName: request.Repo, PullRequest: int64(request.PullRequest), State: "blocked", Reason: reason}); err != nil {
+	if err := g.Store.UpsertMergeGate(ctx, db.MergeGate{RepoFullName: request.Repo, PullRequest: int64(request.PullRequest), State: "blocked", Reason: reason, BlockClass: int(class)}); err != nil {
 		return MergeDecision{}, err
 	}
 	if sha != "" {

--- a/internal/workflow/merge_gate_store_surface_test.go
+++ b/internal/workflow/merge_gate_store_surface_test.go
@@ -12,20 +12,27 @@ import (
 )
 
 // TestMergeGateStoreAccessSurface is the interface-level firewall between the
-// merge authority and display-only review evidence. The eleven calls below are
+// merge authority and display-only review evidence. The eighteen calls below are
 // the complete *db.Store surface used by PolicyMergeGate, plus the native review
 // aggregation read in allRequiredReviewersApproved. Adding any store call makes
 // this test fail until its authority implications are reviewed explicitly.
 func TestMergeGateStoreAccessSurface(t *testing.T) {
 	want := []string{
 		"AcquireResourceLock",
+		"ClaimTaskState",
 		"ClearTaskWorktreePath",
+		"CompleteTaskStateClaim",
 		"GetBranchLock",
 		"GetNoCIObservation",
 		"GetTask",
 		"ListJobs",
+		"RecoverClaimedTaskState",
+		"ReleaseRetainedTaskStateClaim",
 		"ReleaseLockWithEvent",
 		"ReleaseResourceLock",
+		"ReleaseTaskStateClaim",
+		"RenewTaskStateClaim",
+		"RetainTaskStateClaim",
 		"UpsertMergeGate",
 		"UpsertNoCIObservation",
 		"UpsertPullRequest",

--- a/internal/workflow/merge_gate_test.go
+++ b/internal/workflow/merge_gate_test.go
@@ -5,6 +5,8 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"os"
+	"os/exec"
 	"strings"
 	"testing"
 	"time"
@@ -12,6 +14,7 @@ import (
 	"github.com/gitmoot/gitmoot/internal/db"
 	"github.com/gitmoot/gitmoot/internal/github"
 	"github.com/gitmoot/gitmoot/internal/reviewseverity"
+	"github.com/gitmoot/gitmoot/internal/subprocess"
 )
 
 func insertIndependentMergeGateReview(t *testing.T, store *db.Store, reviewJob db.Job, reviewPayload JobPayload) {
@@ -272,6 +275,483 @@ func TestPolicyMergeGateMergesPassingPullRequest(t *testing.T) {
 	}
 }
 
+func TestPolicyMergeGateFencesReadyStateThroughExternalMerge(t *testing.T) {
+	ctx := context.Background()
+	store, gh, gate, request := newMergeGateQuorumScenario(t)
+	insertMergeGateReviewFixture(t, store, mergeGateReviewFixture{
+		id: "review-job", agent: "audit", decision: "approved", hasResult: true,
+	})
+	if err := store.UpsertTask(ctx, db.Task{
+		ID: "task-9", RepoFullName: "gitmoot/gitmoot", Branch: "task-9",
+		State: string(TaskReadyToMerge),
+	}); err != nil {
+		t.Fatal(err)
+	}
+	request.Reviewer = "audit"
+	request.ExpectedTaskState = string(TaskReadyToMerge)
+	writer, err := db.OpenAlreadyMigrated(store.DatabasePath())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer writer.Close()
+	var blocked bool
+	var blockErr error
+	gh.beforeMerge = func() {
+		blocked, blockErr = writer.BlockTaskWithEvent(ctx, db.Task{
+			ID: "task-9", RepoFullName: "gitmoot/gitmoot", Branch: "task-9",
+			State: string(TaskBlocked),
+		}, db.TaskEvent{
+			Kind: "workflow_blocked", FromState: string(TaskReadyToMerge),
+			Reason: "concurrent production block",
+		})
+	}
+	decision, err := gate.Evaluate(ctx, request)
+	if err != nil {
+		t.Fatalf("Evaluate returned error: %v", err)
+	}
+	if !decision.Merged || len(gh.merges) != 1 {
+		t.Fatalf("decision=%+v merges=%d, want one completed external merge", decision, len(gh.merges))
+	}
+	if blocked || !errors.Is(blockErr, db.ErrTaskStateClaimed) {
+		t.Fatalf("concurrent block = blocked %v err %v, want durable claim conflict", blocked, blockErr)
+	}
+	task, taskErr := store.GetTask(ctx, "task-9")
+	events, eventsErr := store.ListTaskEvents(ctx, "task-9")
+	if taskErr != nil || eventsErr != nil || task.State != string(TaskMerged) {
+		t.Fatalf("task=%+v events=%+v taskErr=%v eventsErr=%v", task, events, taskErr, eventsErr)
+	}
+	for _, event := range events {
+		if event.Kind == "workflow_blocked" {
+			t.Fatalf("events=%+v, concurrent block must not commit after merge claim", events)
+		}
+	}
+}
+
+func TestPolicyMergeGateRetainsClaimAcrossAmbiguousPostMergeConfirmation(t *testing.T) {
+	const helperPathEnv = "GITMOOT_AMBIGUOUS_MERGE_CLAIM_HELPER_PATH"
+	ctx := context.Background()
+	if path := os.Getenv(helperPathEnv); path != "" {
+		writer, err := db.OpenAlreadyMigrated(path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer writer.Close()
+		changed, _, err := writer.DisposeTask(ctx, "task-9", []string{string(TaskReadyToMerge)},
+			string(TaskDismissed), "stale", "cross-process ambiguous-outcome disposal", "", "task_disposed", time.Now())
+		if err == nil || changed || !strings.Contains(err.Error(), "claimed for an external merge") {
+			t.Fatalf("cross-process disposal = changed %v err %v, want retained-claim rejection", changed, err)
+		}
+		return
+	}
+
+	store, base, gate, request := newMergeGateQuorumScenario(t)
+	insertMergeGateReviewFixture(t, store, mergeGateReviewFixture{
+		id: "review-job", agent: "audit", decision: "approved", hasResult: true,
+	})
+	if err := store.UpsertTask(ctx, db.Task{
+		ID: "task-9", RepoFullName: "gitmoot/gitmoot", Branch: "task-9",
+		State: string(TaskReadyToMerge),
+	}); err != nil {
+		t.Fatal(err)
+	}
+	request.Reviewer = "audit"
+	request.ExpectedTaskState = string(TaskReadyToMerge)
+	base.getPullRequest = func(call int) (github.PullRequest, error) {
+		if call == 2 {
+			return github.PullRequest{}, errors.New("secondary confirmation unavailable")
+		}
+		return base.pr, nil
+	}
+	runner := &mergeConfirmationFailureRunner{onMerge: func() {
+		base.pr.State = "closed"
+		base.pr.Merged = true
+		base.pr.MergeSHA = "merge-ambiguous"
+	}}
+	composed := &productionMergeGateGitHub{
+		fakeMergeGateGitHub: base,
+		mergeClient:         github.GhClient{Runner: runner},
+	}
+	gate.GitHub = composed
+
+	decision, err := gate.Evaluate(ctx, request)
+	if err == nil || !strings.Contains(err.Error(), "durable task ownership retained") {
+		t.Fatalf("first Evaluate decision=%+v err=%v, want retained ambiguous outcome", decision, err)
+	}
+	if runner.calls != 2 || len(composed.merges) != 1 {
+		t.Fatalf("production adapter calls=%d merge attempts=%d, want one command plus failed confirmation", runner.calls, len(composed.merges))
+	}
+	cmd := exec.CommandContext(ctx, os.Args[0], "-test.run=^TestPolicyMergeGateRetainsClaimAcrossAmbiguousPostMergeConfirmation$")
+	cmd.Env = append(os.Environ(), helperPathEnv+"="+store.DatabasePath())
+	if output, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("cross-process ambiguous-outcome writer: %v\n%s", err, output)
+	}
+
+	decision, err = gate.Evaluate(ctx, request)
+	if err != nil || !decision.Merged || decision.MergeCommitSHA != "merge-ambiguous" {
+		t.Fatalf("reconciliation decision=%+v err=%v, want recovered remote merge", decision, err)
+	}
+	task, taskErr := store.GetTask(ctx, "task-9")
+	if taskErr != nil || task.State != string(TaskMerged) {
+		t.Fatalf("task=%+v err=%v, want merged after reconciliation", task, taskErr)
+	}
+	if len(composed.merges) != 1 {
+		t.Fatalf("merge attempts=%d, reconciliation must not issue a second merge", len(composed.merges))
+	}
+}
+
+func TestPolicyMergeGateRetainsClaimForAcceptedQueuedMerge(t *testing.T) {
+	ctx := context.Background()
+	store, base, gate, request := newMergeGateQuorumScenario(t)
+	insertMergeGateReviewFixture(t, store, mergeGateReviewFixture{
+		id: "review-job", agent: "audit", decision: "approved", hasResult: true,
+	})
+	if err := store.UpsertTask(ctx, db.Task{
+		ID: "task-9", RepoFullName: "gitmoot/gitmoot", Branch: "task-9",
+		State: string(TaskReadyToMerge),
+	}); err != nil {
+		t.Fatal(err)
+	}
+	writer, err := db.OpenAlreadyMigrated(store.DatabasePath())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer writer.Close()
+	request.Reviewer = "audit"
+	request.ExpectedTaskState = string(TaskReadyToMerge)
+	runner := &queuedMergeRunner{}
+	composed := &productionMergeGateGitHub{
+		fakeMergeGateGitHub: base,
+		mergeClient:         github.GhClient{Runner: runner},
+	}
+	gate.GitHub = composed
+
+	decision, err := gate.Evaluate(ctx, request)
+	if err != nil || !decision.Ready || decision.Merged || !strings.Contains(decision.Reason.Render(), "pending") {
+		t.Fatalf("queued Evaluate decision=%+v err=%v, want accepted pending merge", decision, err)
+	}
+	if runner.calls != 2 || len(composed.merges) != 1 {
+		t.Fatalf("production adapter calls=%d merge attempts=%d, want one accepted command and open-state confirmation",
+			runner.calls, len(composed.merges))
+	}
+	changed, _, writeErr := writer.DisposeTask(ctx, "task-9", []string{string(TaskReadyToMerge)},
+		string(TaskDismissed), "stale", "queued merge disposal", "", "task_disposed", time.Now())
+	if writeErr == nil || changed || !strings.Contains(writeErr.Error(), "claimed for an external merge") {
+		t.Fatalf("conflicting queued-merge disposal = changed %v err %v, want durable claim rejection", changed, writeErr)
+	}
+
+	base.pr.State = "closed"
+	base.pr.Merged = true
+	base.pr.MergeSHA = "merge-completed-from-queue"
+	decision, err = gate.Evaluate(ctx, request)
+	if err != nil || !decision.Merged || decision.MergeCommitSHA != "merge-completed-from-queue" {
+		t.Fatalf("queued reconciliation decision=%+v err=%v, want recovered merge", decision, err)
+	}
+	task, taskErr := store.GetTask(ctx, "task-9")
+	if taskErr != nil || task.State != string(TaskMerged) {
+		t.Fatalf("task=%+v err=%v, want merged after queued reconciliation", task, taskErr)
+	}
+	if len(composed.merges) != 1 {
+		t.Fatalf("merge attempts=%d, reconciliation must not issue a second merge", len(composed.merges))
+	}
+}
+
+func TestPolicyMergeGateRetainsFailedMergeWhileRemoteOpenUntilClosure(t *testing.T) {
+	ctx := context.Background()
+	store, gh, gate, request := newMergeGateQuorumScenario(t)
+	insertMergeGateReviewFixture(t, store, mergeGateReviewFixture{
+		id: "review-job", agent: "audit", decision: "approved", hasResult: true,
+	})
+	if err := store.UpsertTask(ctx, db.Task{
+		ID: "task-9", RepoFullName: "gitmoot/gitmoot", Branch: "task-9",
+		State: string(TaskReadyToMerge),
+	}); err != nil {
+		t.Fatal(err)
+	}
+	writer, err := db.OpenAlreadyMigrated(store.DatabasePath())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer writer.Close()
+	request.Reviewer = "audit"
+	request.ExpectedTaskState = string(TaskReadyToMerge)
+	gh.mergeErr = errors.New("merge command failed after submission")
+
+	decision, err := gate.Evaluate(ctx, request)
+	if err == nil || !strings.Contains(err.Error(), "pull request remains open") ||
+		!strings.Contains(err.Error(), "durable task ownership retained") {
+		t.Fatalf("open confirmation decision=%+v err=%v, want retained unresolved merge", decision, err)
+	}
+	changed, _, writeErr := writer.DisposeTask(ctx, "task-9", []string{string(TaskReadyToMerge)},
+		string(TaskDismissed), "stale", "open merge disposal", "", "task_disposed", time.Now())
+	if writeErr == nil || changed || !strings.Contains(writeErr.Error(), "claimed for an external merge") {
+		t.Fatalf("conflicting open-merge disposal = changed %v err %v, want durable claim rejection", changed, writeErr)
+	}
+
+	gh.pr.State = "closed"
+	decision, err = gate.Evaluate(ctx, request)
+	if err != nil || !strings.Contains(decision.Reason.Render(), "closed without being merged") {
+		t.Fatalf("closed reconciliation decision=%+v err=%v, want terminal non-merge block", decision, err)
+	}
+	changed, current, writeErr := writer.DisposeTask(ctx, "task-9", []string{string(TaskReadyToMerge)},
+		string(TaskDismissed), "stale", "terminal non-merge disposal", "", "task_disposed", time.Now())
+	if writeErr != nil || !changed || current != string(TaskDismissed) {
+		t.Fatalf("terminal non-merge disposal = changed %v current %q err %v, want released claim", changed, current, writeErr)
+	}
+}
+
+func TestPolicyMergeGateCompletesClaimWhenPostErrorConfirmationShowsMerged(t *testing.T) {
+	ctx := context.Background()
+	store, gh, gate, request := newMergeGateQuorumScenario(t)
+	insertMergeGateReviewFixture(t, store, mergeGateReviewFixture{
+		id: "review-job", agent: "audit", decision: "approved", hasResult: true,
+	})
+	if err := store.UpsertTask(ctx, db.Task{
+		ID: "task-9", RepoFullName: "gitmoot/gitmoot", Branch: "task-9",
+		State: string(TaskReadyToMerge),
+	}); err != nil {
+		t.Fatal(err)
+	}
+	request.Reviewer = "audit"
+	request.ExpectedTaskState = string(TaskReadyToMerge)
+	gh.mergeErr = errors.New("fetch merged pull request: HTTP 502")
+	gh.beforeMerge = func() {
+		gh.pr.State = "closed"
+		gh.pr.Merged = true
+		gh.pr.MergeSHA = "merge-confirmed-after-error"
+	}
+
+	decision, err := gate.Evaluate(ctx, request)
+	if err != nil || !decision.Merged || decision.MergeCommitSHA != "merge-confirmed-after-error" {
+		t.Fatalf("Evaluate decision=%+v err=%v, want authoritative post-error merge completion", decision, err)
+	}
+	task, taskErr := store.GetTask(ctx, "task-9")
+	if taskErr != nil || task.State != string(TaskMerged) {
+		t.Fatalf("task=%+v err=%v, want merged claim completion", task, taskErr)
+	}
+}
+
+func TestPolicyMergeGateRenewsClaimBeyondLeaseAcrossProcess(t *testing.T) {
+	const helperPathEnv = "GITMOOT_RENEWED_MERGE_CLAIM_HELPER_PATH"
+	ctx := context.Background()
+	if path := os.Getenv(helperPathEnv); path != "" {
+		writer, err := db.OpenAlreadyMigrated(path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer writer.Close()
+		changed, _, err := writer.DisposeTask(ctx, "task-9", []string{string(TaskReadyToMerge)},
+			string(TaskDismissed), "stale", "cross-process lease-expiry disposal", "", "task_disposed", time.Now())
+		if err == nil || changed || !strings.Contains(err.Error(), "claimed for an external merge") {
+			t.Fatalf("cross-process disposal = changed %v err %v, want renewed-claim rejection", changed, err)
+		}
+		return
+	}
+
+	store, gh, gate, request := newMergeGateQuorumScenario(t)
+	insertMergeGateReviewFixture(t, store, mergeGateReviewFixture{
+		id: "review-job", agent: "audit", decision: "approved", hasResult: true,
+	})
+	if err := store.UpsertTask(ctx, db.Task{
+		ID: "task-9", RepoFullName: "gitmoot/gitmoot", Branch: "task-9",
+		State: string(TaskReadyToMerge),
+	}); err != nil {
+		t.Fatal(err)
+	}
+	request.Reviewer = "audit"
+	request.ExpectedTaskState = string(TaskReadyToMerge)
+	mergeStarted := make(chan struct{})
+	allowMerge := make(chan struct{})
+	gh.beforeMerge = func() {
+		close(mergeStarted)
+		<-allowMerge
+	}
+	ticks := make(chan time.Time)
+	renewed := make(chan struct{}, 1)
+	gate.taskClaimTTL = 4 * time.Second
+	gate.taskClaimRenewalInterval = 2 * time.Second
+	gate.taskClaimRenewalTicks = func(context.Context, time.Duration) <-chan time.Time {
+		return ticks
+	}
+	gate.afterTaskClaimRenewal = func() {
+		renewed <- struct{}{}
+	}
+	type evaluateResult struct {
+		decision MergeDecision
+		err      error
+	}
+	evaluated := make(chan evaluateResult, 1)
+	go func() {
+		decision, err := gate.Evaluate(ctx, request)
+		evaluated <- evaluateResult{decision: decision, err: err}
+	}()
+	select {
+	case <-mergeStarted:
+	case <-time.After(5 * time.Second):
+		t.Fatal("merge did not reach the production external-call boundary")
+	}
+	time.Sleep(2100 * time.Millisecond)
+	ticks <- time.Now()
+	select {
+	case <-renewed:
+	case <-time.After(5 * time.Second):
+		t.Fatal("durable claim renewal did not complete")
+	}
+	time.Sleep(2100 * time.Millisecond)
+	cmd := exec.CommandContext(ctx, os.Args[0], "-test.run=^TestPolicyMergeGateRenewsClaimBeyondLeaseAcrossProcess$")
+	cmd.Env = append(os.Environ(), helperPathEnv+"="+store.DatabasePath())
+	if output, err := cmd.CombinedOutput(); err != nil {
+		close(allowMerge)
+		t.Fatalf("cross-process lease-expiry writer: %v\n%s", err, output)
+	}
+	close(allowMerge)
+	result := <-evaluated
+	if result.err != nil || !result.decision.Merged {
+		t.Fatalf("Evaluate decision=%+v err=%v, want successful merge after lease renewal", result.decision, result.err)
+	}
+	task, taskErr := store.GetTask(ctx, "task-9")
+	if taskErr != nil || task.State != string(TaskMerged) {
+		t.Fatalf("task=%+v err=%v, want merged after renewed in-flight claim", task, taskErr)
+	}
+}
+
+func TestHandlePullRequestOpenedFencesNoReviewerMergeFromPROpenState(t *testing.T) {
+	ctx := context.Background()
+	store, gh, gate, _ := newMergeGateQuorumScenario(t)
+	seedAgent(t, store, "implementer", []string{"implement"}, "gitmoot/gitmoot")
+	insertMergeGateReviewFixture(t, store, mergeGateReviewFixture{
+		id: "review-job", agent: "audit", decision: "approved", hasResult: true,
+	})
+	writer, err := db.OpenAlreadyMigrated(store.DatabasePath())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer writer.Close()
+	var blocked bool
+	var blockErr error
+	gate.Git.(*fakeMergeGateGit).onClean = func() {
+		blocked, blockErr = writer.BlockTaskWithEvent(ctx, db.Task{
+			ID: "task-9", RepoFullName: "gitmoot/gitmoot", Branch: "task-9",
+			State: string(TaskBlocked),
+		}, db.TaskEvent{
+			Kind: "workflow_blocked", FromState: string(TaskPullRequestOpen),
+			Reason: "concurrent PR-open block",
+		})
+	}
+	engine := testEngine(store)
+	engine.MergeGate = gate
+
+	err = engine.HandlePullRequestOpened(ctx, PullRequestEvent{
+		Repo: "gitmoot/gitmoot", Branch: "task-9", PullRequest: 9,
+		HeadSHA: "head123", TaskID: "task-9", LeadAgent: "implementer",
+	})
+	if !errors.Is(err, ErrMergeTaskStateChanged) {
+		t.Fatalf("HandlePullRequestOpened error = %v, want PR-open state fence conflict", err)
+	}
+	if !blocked || blockErr != nil {
+		t.Fatalf("concurrent block = blocked %v err %v, want committed PR-open block", blocked, blockErr)
+	}
+	if len(gh.merges) != 0 {
+		t.Fatalf("external merges = %d, want none after PR-open state changed", len(gh.merges))
+	}
+	task, taskErr := store.GetTask(ctx, "task-9")
+	if taskErr != nil || task.State != string(TaskBlocked) {
+		t.Fatalf("task=%+v err=%v, want blocked", task, taskErr)
+	}
+}
+
+func TestAdvanceApprovedReviewFencesMergeFromReviewingState(t *testing.T) {
+	ctx := context.Background()
+	store, gh, gate, _ := newMergeGateQuorumScenario(t)
+	insertMergeGateReviewFixture(t, store, mergeGateReviewFixture{
+		id: "review-job", agent: "audit", decision: "approved", hasResult: true,
+	})
+	if err := store.UpsertTask(ctx, db.Task{
+		ID: "task-9", RepoFullName: "gitmoot/gitmoot", Branch: "task-9",
+		State: string(TaskReviewing),
+	}); err != nil {
+		t.Fatal(err)
+	}
+	writer, err := db.OpenAlreadyMigrated(store.DatabasePath())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer writer.Close()
+	var blocked bool
+	var blockErr error
+	gate.Git.(*fakeMergeGateGit).onClean = func() {
+		blocked, blockErr = writer.BlockTaskWithEvent(ctx, db.Task{
+			ID: "task-9", RepoFullName: "gitmoot/gitmoot", Branch: "task-9",
+			State: string(TaskBlocked),
+		}, db.TaskEvent{
+			Kind: "workflow_blocked", FromState: string(TaskReviewing),
+			Reason: "concurrent review completion block",
+		})
+	}
+	engine := testEngine(store)
+	engine.MergeGate = gate
+
+	err = engine.AdvanceJob(ctx, "review-job")
+	if !errors.Is(err, ErrMergeTaskStateChanged) {
+		t.Fatalf("AdvanceJob error = %v, want reviewing-state fence conflict", err)
+	}
+	if !blocked || blockErr != nil {
+		t.Fatalf("concurrent block = blocked %v err %v, want committed reviewing block", blocked, blockErr)
+	}
+	if len(gh.merges) != 0 {
+		t.Fatalf("external merges = %d, want none after reviewing state changed", len(gh.merges))
+	}
+	task, taskErr := store.GetTask(ctx, "task-9")
+	if taskErr != nil || task.State != string(TaskBlocked) {
+		t.Fatalf("task=%+v err=%v, want blocked", task, taskErr)
+	}
+}
+
+func TestPolicyMergeGateRejectsBlockAfterInitialReadyValidation(t *testing.T) {
+	ctx := context.Background()
+	store, gh, gate, request := newMergeGateQuorumScenario(t)
+	insertMergeGateReviewFixture(t, store, mergeGateReviewFixture{
+		id: "review-job", agent: "audit", decision: "approved", hasResult: true,
+	})
+	if err := store.UpsertTask(ctx, db.Task{
+		ID: "task-9", RepoFullName: "gitmoot/gitmoot", Branch: "task-9",
+		State: string(TaskReadyToMerge),
+	}); err != nil {
+		t.Fatal(err)
+	}
+	matched, current, err := store.RevalidateTaskState(ctx, "task-9", string(TaskReadyToMerge))
+	if err != nil || !matched || current != string(TaskReadyToMerge) {
+		t.Fatalf("initial ready validation = matched %v current %q err %v", matched, current, err)
+	}
+	request.Reviewer = "audit"
+	request.ExpectedTaskState = string(TaskReadyToMerge)
+	var blocked bool
+	var blockErr error
+	gate.Git.(*fakeMergeGateGit).onClean = func() {
+		blocked, blockErr = store.BlockTaskWithEvent(ctx, db.Task{
+			ID: "task-9", RepoFullName: "gitmoot/gitmoot", Branch: "task-9",
+			State: string(TaskBlocked),
+		}, db.TaskEvent{
+			Kind: "workflow_blocked", FromState: string(TaskReadyToMerge),
+			Reason: "production block after initial validation",
+		})
+	}
+
+	decision, err := gate.Evaluate(ctx, request)
+	if !errors.Is(err, ErrMergeTaskStateChanged) {
+		t.Fatalf("Evaluate error = %v, want ready-state fence conflict", err)
+	}
+	if !blocked || blockErr != nil {
+		t.Fatalf("production block = blocked %v err %v, want committed block", blocked, blockErr)
+	}
+	if decision.Merged || len(gh.merges) != 0 {
+		t.Fatalf("decision=%+v merges=%d, external merge must not run after block", decision, len(gh.merges))
+	}
+	task, taskErr := store.GetTask(ctx, "task-9")
+	if taskErr != nil || task.State != string(TaskBlocked) {
+		t.Fatalf("task=%+v err=%v, want blocked", task, taskErr)
+	}
+}
+
 func TestPolicyMergeGateMergeFailureDoesNotPostSuccess(t *testing.T) {
 	ctx := context.Background()
 	store := openEngineStore(t)
@@ -284,6 +764,12 @@ func TestPolicyMergeGateMergeFailureDoesNotPostSuccess(t *testing.T) {
 		ReviewRound: "review-1",
 		Result:      &AgentResult{Decision: "approved", Summary: "ready"},
 	})
+	if err := store.UpsertTask(ctx, db.Task{
+		ID: "task-9", RepoFullName: "gitmoot/gitmoot", Branch: "task-9",
+		State: string(TaskReadyToMerge),
+	}); err != nil {
+		t.Fatal(err)
+	}
 	mergeable := true
 	mergeErr := errors.New("draft pull request cannot be merged")
 	gh := &fakeMergeGateGitHub{
@@ -304,13 +790,26 @@ func TestPolicyMergeGateMergeFailureDoesNotPostSuccess(t *testing.T) {
 	}
 	gate := PolicyMergeGate{AutoMerge: true, Store: store, GitHub: gh, Git: &fakeMergeGateGit{clean: true}}
 
-	_, err := gate.Evaluate(ctx, MergeRequest{Repo: "gitmoot/gitmoot", PullRequest: 9, TaskID: "task-9"})
+	_, err := gate.Evaluate(ctx, MergeRequest{
+		Repo: "gitmoot/gitmoot", PullRequest: 9, TaskID: "task-9",
+		ExpectedTaskState: string(TaskReadyToMerge),
+	})
 
 	if !errors.Is(err, mergeErr) {
 		t.Fatalf("Evaluate error = %v, want %v", err, mergeErr)
 	}
 	if hasStatus(gh.statuses, GitmootMergeGateContext, "success") {
 		t.Fatalf("statuses after failed merge = %+v, must not contain merge-gate success", gh.statuses)
+	}
+	blocked, blockErr := store.BlockTaskWithEvent(ctx, db.Task{
+		ID: "task-9", RepoFullName: "gitmoot/gitmoot", Branch: "task-9",
+		State: string(TaskBlocked),
+	}, db.TaskEvent{
+		Kind: "workflow_blocked", FromState: string(TaskReadyToMerge),
+		Reason: "merge failure remained unresolved",
+	})
+	if blockErr == nil || blocked || !strings.Contains(blockErr.Error(), "claimed for an external merge") {
+		t.Fatalf("post-failure block = blocked %v err %v, want retained unresolved merge claim", blocked, blockErr)
 	}
 }
 
@@ -326,6 +825,12 @@ func TestPolicyMergeGateStatusFailureAfterMergeIsBestEffort(t *testing.T) {
 		ReviewRound: "review-1",
 		Result:      &AgentResult{Decision: "approved", Summary: "ready"},
 	})
+	if err := store.UpsertTask(ctx, db.Task{
+		ID: "task-9", RepoFullName: "gitmoot/gitmoot", Branch: "task-9",
+		State: string(TaskReadyToMerge),
+	}); err != nil {
+		t.Fatal(err)
+	}
 	mergeable := true
 	gh := &fakeMergeGateGitHub{
 		pr: github.PullRequest{
@@ -346,7 +851,10 @@ func TestPolicyMergeGateStatusFailureAfterMergeIsBestEffort(t *testing.T) {
 	}
 	gate := PolicyMergeGate{AutoMerge: true, Store: store, GitHub: gh, Git: &fakeMergeGateGit{clean: true}}
 
-	decision, err := gate.Evaluate(ctx, MergeRequest{Repo: "gitmoot/gitmoot", PullRequest: 9, TaskID: "task-9"})
+	decision, err := gate.Evaluate(ctx, MergeRequest{
+		Repo: "gitmoot/gitmoot", PullRequest: 9, TaskID: "task-9",
+		ExpectedTaskState: string(TaskReadyToMerge),
+	})
 
 	if err != nil {
 		t.Fatalf("Evaluate returned error after completed merge: %v", err)
@@ -356,6 +864,10 @@ func TestPolicyMergeGateStatusFailureAfterMergeIsBestEffort(t *testing.T) {
 	}
 	if got := strings.Join(gh.operations, ","); got != "merge,status:gitmoot/merge-gate:success" {
 		t.Fatalf("GitHub write order = %q, want merge before best-effort success status", got)
+	}
+	task, taskErr := store.GetTask(ctx, "task-9")
+	if taskErr != nil || task.State != string(TaskMerged) {
+		t.Fatalf("task=%+v err=%v, want durable claim completion", task, taskErr)
 	}
 }
 
@@ -1216,7 +1728,7 @@ func TestRunMergeGateExplicitKillSwitchParksReviewedAndUnreviewedTasks(t *testin
 				})
 			}
 			for attempt := 0; attempt < 2; attempt++ {
-				decision, err := engine.runMergeGate(ctx, "", payload, taskRef{ID: tc.taskID, Repo: "owner/repo", Title: tc.name, Branch: tc.taskID})
+				decision, err := engine.runMergeGate(ctx, "", payload, taskRef{ID: tc.taskID, Repo: "owner/repo", Title: tc.name, Branch: tc.taskID}, TaskReadyToMerge)
 				if err != nil {
 					t.Fatalf("runMergeGate attempt %d: %v", attempt+1, err)
 				}
@@ -1257,7 +1769,7 @@ func TestRunMergeGateDraftPullRequestDoesNotParkTaskAwaitingHumanMerge(t *testin
 
 	decision, err := engine.runMergeGate(ctx, "", payload, taskRef{
 		ID: taskID, Repo: "owner/repo", Title: "Draft task", Branch: "task-draft",
-	})
+	}, TaskReadyToMerge)
 	if err != nil {
 		t.Fatalf("runMergeGate: %v", err)
 	}
@@ -2143,6 +2655,16 @@ func TestPolicyMergeGateRecordsAlreadyMergedPullRequest(t *testing.T) {
 	if acquired, err := store.AcquireLock(ctx, db.BranchLock{RepoFullName: "gitmoot/gitmoot", Branch: "task-9", Owner: "lead"}); err != nil || !acquired {
 		t.Fatalf("AcquireLock returned acquired=%v err=%v", acquired, err)
 	}
+	if err := store.UpsertTask(ctx, db.Task{
+		ID: "task-9", RepoFullName: "gitmoot/gitmoot", Branch: "task-9",
+		State: string(TaskReadyToMerge),
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if _, claimed, _, err := store.ClaimTaskState(ctx, "task-9", string(TaskReadyToMerge),
+		"external_merge", time.Minute); err != nil || !claimed {
+		t.Fatalf("seed crashed merge claim = claimed %v err %v", claimed, err)
+	}
 	gh := &fakeMergeGateGitHub{
 		pr: github.PullRequest{
 			Number:   9,
@@ -2157,7 +2679,10 @@ func TestPolicyMergeGateRecordsAlreadyMergedPullRequest(t *testing.T) {
 	}
 	gate := PolicyMergeGate{AutoMerge: true, Store: store, GitHub: gh, Git: &fakeMergeGateGit{clean: false}}
 
-	decision, err := gate.Evaluate(ctx, MergeRequest{Repo: "gitmoot/gitmoot", PullRequest: 9, TaskID: "task-9"})
+	decision, err := gate.Evaluate(ctx, MergeRequest{
+		Repo: "gitmoot/gitmoot", PullRequest: 9, TaskID: "task-9",
+		ExpectedTaskState: string(TaskReadyToMerge),
+	})
 
 	if err != nil {
 		t.Fatalf("Evaluate returned error: %v", err)
@@ -2170,6 +2695,10 @@ func TestPolicyMergeGateRecordsAlreadyMergedPullRequest(t *testing.T) {
 	}
 	if _, err := store.GetBranchLock(ctx, "gitmoot/gitmoot", "task-9"); !errors.Is(err, sql.ErrNoRows) {
 		t.Fatalf("branch lock after merge error = %v, want sql.ErrNoRows", err)
+	}
+	task, taskErr := store.GetTask(ctx, "task-9")
+	if taskErr != nil || task.State != string(TaskMerged) {
+		t.Fatalf("task=%+v err=%v, want recovered merged state", task, taskErr)
 	}
 }
 
@@ -3720,31 +4249,91 @@ func TestPolicyMergeGateBlocksMissingFinalReview(t *testing.T) {
 	}
 }
 
+type mergeConfirmationFailureRunner struct {
+	onMerge func()
+	calls   int
+}
+
+func (r *mergeConfirmationFailureRunner) Run(_ context.Context, _ string, _ string, _ ...string) (subprocess.Result, error) {
+	r.calls++
+	switch r.calls {
+	case 1:
+		if r.onMerge != nil {
+			r.onMerge()
+		}
+		return subprocess.Result{Stdout: "merged"}, nil
+	case 2:
+		return subprocess.Result{Stderr: "HTTP 502"}, errors.New("exit status 1")
+	default:
+		return subprocess.Result{}, fmt.Errorf("unexpected merge adapter call %d", r.calls)
+	}
+}
+
+func (*mergeConfirmationFailureRunner) LookPath(file string) (string, error) {
+	return file, nil
+}
+
+type queuedMergeRunner struct {
+	calls int
+}
+
+func (r *queuedMergeRunner) Run(_ context.Context, _ string, _ string, _ ...string) (subprocess.Result, error) {
+	r.calls++
+	switch r.calls {
+	case 1:
+		return subprocess.Result{Stdout: "queued"}, nil
+	case 2:
+		return subprocess.Result{Stdout: `{"number":9,"title":"Task","state":"open","html_url":"https://github.com/gitmoot/gitmoot/pull/9","head":{"ref":"task-9","sha":"head123"},"base":{"ref":"main"}}`}, nil
+	default:
+		return subprocess.Result{}, fmt.Errorf("unexpected queued merge adapter call %d", r.calls)
+	}
+}
+
+func (*queuedMergeRunner) LookPath(file string) (string, error) {
+	return file, nil
+}
+
+type productionMergeGateGitHub struct {
+	*fakeMergeGateGitHub
+	mergeClient github.GhClient
+}
+
+func (g *productionMergeGateGitHub) MergePullRequest(ctx context.Context, input github.MergePullRequestInput) (github.MergeResult, error) {
+	g.merges = append(g.merges, input)
+	g.operations = append(g.operations, "merge")
+	return g.mergeClient.MergePullRequest(ctx, input)
+}
+
 type fakeMergeGateGitHub struct {
-	pr           github.PullRequest
-	status       github.CombinedStatus
-	compare      github.CompareResult
-	checks       []github.PullRequestCheck
-	mergeResult  github.MergeResult
-	mergeErr     error
-	statusErr    error
-	updateErr    error
-	statuses     []github.CommitStatusInput
-	merges       []github.MergePullRequestInput
-	updates      []github.UpdatePullRequestBranchInput
-	comments     []string
-	operations   []string
-	getCalls     int
-	statusCalls  int
-	compareCalls int
-	checkCalls   int
-	prCheckCalls int
-	checkRefs    []string
-	noChecks     bool
+	pr             github.PullRequest
+	status         github.CombinedStatus
+	compare        github.CompareResult
+	checks         []github.PullRequestCheck
+	mergeResult    github.MergeResult
+	getPullRequest func(int) (github.PullRequest, error)
+	mergeErr       error
+	statusErr      error
+	beforeMerge    func()
+	updateErr      error
+	statuses       []github.CommitStatusInput
+	merges         []github.MergePullRequestInput
+	updates        []github.UpdatePullRequestBranchInput
+	comments       []string
+	operations     []string
+	getCalls       int
+	statusCalls    int
+	compareCalls   int
+	checkCalls     int
+	prCheckCalls   int
+	checkRefs      []string
+	noChecks       bool
 }
 
 func (f *fakeMergeGateGitHub) GetPullRequest(context.Context, github.Repository, int64) (github.PullRequest, error) {
 	f.getCalls++
+	if f.getPullRequest != nil {
+		return f.getPullRequest(f.getCalls)
+	}
 	return f.pr, nil
 }
 
@@ -3792,6 +4381,9 @@ func (f *fakeMergeGateGitHub) UpdatePullRequestBranch(_ context.Context, input g
 }
 
 func (f *fakeMergeGateGitHub) MergePullRequest(_ context.Context, input github.MergePullRequestInput) (github.MergeResult, error) {
+	if f.beforeMerge != nil {
+		f.beforeMerge()
+	}
 	f.merges = append(f.merges, input)
 	f.operations = append(f.operations, "merge")
 	return f.mergeResult, f.mergeErr
@@ -3799,11 +4391,15 @@ func (f *fakeMergeGateGitHub) MergePullRequest(_ context.Context, input github.M
 
 type fakeMergeGateGit struct {
 	clean    bool
+	onClean  func()
 	onUpdate func()
 	updated  []string
 }
 
 func (f *fakeMergeGateGit) WorktreeClean(context.Context) (bool, error) {
+	if f.onClean != nil {
+		f.onClean()
+	}
 	return f.clean, nil
 }
 

--- a/internal/workflow/outcome_harvester_test.go
+++ b/internal/workflow/outcome_harvester_test.go
@@ -215,7 +215,7 @@ func TestRunMergeGateDeferredLeavesTaskReadyToMerge(t *testing.T) {
 	}, taskRef{
 		ID: "task-deferred", Repo: "gitmoot/gitmoot", GoalID: "goal-1",
 		Title: "Deferred merge", Branch: "fix-round",
-	})
+	}, TaskReadyToMerge)
 	if err != nil {
 		t.Fatalf("runMergeGate returned error for deferred decision: %v", err)
 	}
@@ -253,7 +253,7 @@ func TestRunMergeGateDeferredParksPullRequestOpenTaskAtReadyToMerge(t *testing.T
 	}, taskRef{
 		ID: "task-pr-open", Repo: "gitmoot/gitmoot", GoalID: "goal-1",
 		Title: "No-reviewers merge", Branch: "auto-round",
-	})
+	}, TaskPullRequestOpen)
 	if err != nil {
 		t.Fatalf("runMergeGate returned error for deferred decision: %v", err)
 	}
@@ -283,7 +283,7 @@ func TestRunMergeGateNonDeferredNotReadyStillBlocks(t *testing.T) {
 	}, taskRef{
 		ID: "task-blocked", Repo: "gitmoot/gitmoot", GoalID: "goal-1",
 		Title: "Blocked merge", Branch: "blocked-round",
-	})
+	}, TaskReadyToMerge)
 	var blocked BlockedError
 	if !errors.As(err, &blocked) || blocked.Reason != "external CI failed" {
 		t.Fatalf("runMergeGate error = %v, want BlockedError for unchanged block path", err)

--- a/internal/workflow/worktree.go
+++ b/internal/workflow/worktree.go
@@ -1794,19 +1794,19 @@ func blockTaskForDirtyWorktree(ctx context.Context, store *db.Store, task db.Tas
 	if task.Title == "" {
 		task.Title = request.TaskTitle
 	}
-	if err := store.UpsertTask(ctx, task); err != nil {
-		return err
-	}
-	if err := store.AddTaskEvent(ctx, db.TaskEvent{
-		TaskID:    task.ID,
+	blockErr := BlockedError{Reason: reason}
+	blocked, err := store.BlockTaskWithEvent(ctx, task, db.TaskEvent{
 		Kind:      "stale_worktree_dirty_blocked",
 		FromState: fromState,
-		ToState:   string(TaskBlocked),
 		Reason:    reason,
-	}); err != nil {
-		return err
+	})
+	if err != nil {
+		if !blocked {
+			return err
+		}
+		return errors.Join(blockErr, fmt.Errorf("record dirty-worktree block for task %s: %w", task.ID, err))
 	}
-	return BlockedError{Reason: reason}
+	return blockErr
 }
 
 func TaskWorktreePath(home string, repo string, taskID string) (string, error) {


### PR DESCRIPTION
## Problem

The merge gate classifies a block as `MergeBlockTransient` — its own type comment calls the class "operational/branch-staleness/infra" — and then that classification never leaves the call stack. `merge_gate.go` said so outright: *"advisory metadata for the Mode-A trace-harvester only"*. So nothing could act on it, and a self-clearing condition became permanent:

- `internal/daemon/daemon.go:1080` re-evaluates `ready_to_merge` only
- `internal/workflow/engine_pr_lifecycle.go:591` (non-merged close) omits `TaskBlocked`
- `internal/cli/workflow.go:796` — `task resume-work` refuses `blocked`

Measured on `review-pr-1699-3f3a1026`: blocked on "local worktree is not clean" for 95 minutes after the dirt cleared; the only exit was a human merging the PR.

## Decision

Release requires **both** halves:

1. the **persisted class** is the selection filter — the gate's own statement that the condition is self-clearing;
2. returning the row to `ready_to_merge` restores it to the population that is actually re-evaluated, which is the same remedy the engine already applies to a `Deferred` decision for the identical wedge (`engine_routing_merge.go:620-628`).

A quality-classed row is **never selected**, so an authoritative rejection stays blocked by construction rather than by a re-evaluation happening to agree. The gate is not re-run in the reconciler: it runs on the `ready_to_merge` path, so a condition that has not cleared simply blocks again.

## Two findings worth reviewing on their own

**The obvious seam was the wrong one.** Extending `pullRequestReadyToMerge` looks right and is inert: it resolves its task from `pull.HeadRef`, and the population that wedges is the **branchless** local `review-pr-<n>-<hash>` task, which no HeadRef lookup can find. My first fixture used a branch, passed, and was testing nothing. PR-number resolution now mirrors `reconcileExternallyMergedTasks`.

**`blocked` is not universally a dead end.** `reconcilePROpenTasks` (`daemon.go:448`, #920) already promotes *any* branch-bearing blocked task to `pr_open` every poll, **regardless of class** — so a quality block on a branch-bearing task is silently lost today, and that promoter feeds the growing no-exit `pr_open` population in #1723. Pre-existing, out of scope here, reported not fixed.

## Family analysis (requested)

Three families, not one and not four:

- **A** — no automatic re-entry for a condition the system itself called transient: #1562, this PR.
- **B** — operator disposal verbs don't cover live task states: #1723 (`pr_open`) and #1391 (`changes_requested`) are the *same* defect, two instances. Must stay separate from A: A releases *without* an operator, B only *with* one.
- **C** — job rows have no non-terminal wait: #1452, plus the original #1562 body (a blocked task naming a *succeeded* job as its live blocker). Different object and vocabulary.

## Verification

- 5 new tests, both directions plus migration and closed-PR boundaries: PASS.
- 7/7 including two pre-existing neighbours (`ready_to_merge` retry, dismissed escalation): PASS.
- `./internal/db` full package: PASS (schema change blast radius).
- `./internal/workflow -run 'MergeGate|MergeBlock'`: PASS.
- Mutant **M2** "releases everything" (drop the class filter): kills the quality and unclassified directions, release test survives.
- Mutant **M1** "releases nothing" (remove the reconciler call): kills only the release test.
- Both mutants reverted; full set re-confirmed green.
- Full suite deliberately not run, per assignment.

## Migration note

The new migration is **appended, never reordered**, and pairs `CREATE TABLE IF NOT EXISTS merge_gates` with the `ALTER`. A database can legitimately reach this version without that table — seeding `schema_migrations` forward leaves it absent — and a bare `ALTER` then fails the whole `Migrate`, i.e. a refusal to start. I fixed the migration rather than the fixture that exposed it.

Closes #1562

GM-OMP-E2B