### PR TITLE
fix(review): make the routine scope union deterministic and pin its prompt

### DIFF
--- a/internal/workflow/engine_review_refanout_test.go
+++ b/internal/workflow/engine_review_refanout_test.go
@@ -84,10 +84,14 @@ func TestFollowUpReviewScopesFindingsAndFilesFromReviewerHead(t *testing.T) {
 	if !strings.Contains(fixPayload.Instructions, `"id":"F-1"`) {
 		t.Fatalf("fix instructions lost the named finding: %q", fixPayload.Instructions)
 	}
+	// scopeOnlySentinel appears ONLY in the changed-file range: no finding, summary or
+	// fixed prompt sentence mentions it. That is what makes the changed-file section
+	// assertion below non-vacuous.
+	const scopeOnlySentinel = "internal/sentinel_changed_files_only.go"
 	var gotPrevious, gotCurrent string
 	engine.ReviewChangedFiles = func(_ context.Context, _ string, _ int, previousHead, currentHead string) ([]string, error) {
 		gotPrevious, gotCurrent = previousHead, currentHead
-		return []string{"internal/z.go", "internal/boundary.go", "internal/boundary.go"}, nil
+		return []string{"internal/z.go", "internal/boundary.go", "internal/boundary.go", scopeOnlySentinel}, nil
 	}
 
 	if err := engine.HandlePullRequestOpened(ctx, reviewRefanoutEvent("head-two")); err != nil {
@@ -110,13 +114,27 @@ func TestFollowUpReviewScopesFindingsAndFilesFromReviewerHead(t *testing.T) {
 	if len(payload.ReviewScope.Findings) != 1 || !strings.Contains(payload.ReviewScope.Findings[0], `"id":"F-1"`) {
 		t.Fatalf("scope findings = %#v, want named F-1", payload.ReviewScope.Findings)
 	}
-	wantFiles := []string{"internal/boundary.go", "internal/z.go"}
+	wantFiles := []string{"internal/boundary.go", scopeOnlySentinel, "internal/z.go"}
 	if strings.Join(payload.ReviewScope.ChangedFiles, ",") != strings.Join(wantFiles, ",") {
 		t.Fatalf("scope changed files = %#v, want %#v", payload.ReviewScope.ChangedFiles, wantFiles)
 	}
-	if !strings.Contains(payload.Instructions, "Do not re-review the full PR-to-base diff") ||
-		!strings.Contains(payload.Instructions, "internal/boundary.go") {
+	if !strings.Contains(payload.Instructions, "Do not re-review the full PR-to-base diff") {
 		t.Fatalf("scoped review instructions do not constrain the follow-up: %q", payload.Instructions)
+	}
+	// The changed-file SECTION of the prompt, pinned as exact text. The assertion this
+	// replaces — Contains(Instructions, "internal/boundary.go") — was vacuous: that path
+	// is also embedded in the F-1 finding JSON rendered in the findings section above,
+	// so mutating the section's guard so the prompt always said "- none" still passed.
+	wantSection := "Files changed since the reviewer last saw the branch:\n" +
+		"- internal/boundary.go\n" +
+		"- " + scopeOnlySentinel + "\n" +
+		"- internal/z.go\n"
+	if !strings.Contains(payload.Instructions, wantSection) {
+		t.Fatalf("scoped review instructions omit the changed-file range: %q", payload.Instructions)
+	}
+	// The sentinel really is reachable only through that section.
+	if got := strings.Count(payload.Instructions, scopeOnlySentinel); got != 1 {
+		t.Fatalf("sentinel path occurs %d times in the prompt, want exactly 1: %q", got, payload.Instructions)
 	}
 }
 

--- a/internal/workflow/review_loop.go
+++ b/internal/workflow/review_loop.go
@@ -286,10 +286,16 @@ func reviewScopeForRoutine(scopes map[reviewScopeKey]*ReviewScope, reviewer stri
 // dropped, and the OLDEST baseline head is named because its changed-file range is the
 // superset that covers every merged baseline. A reviewer with a single bare candidate
 // aggregates to a copy of it, so the no-lens path is unchanged.
+//
+// Candidates are visited in a SORTED order rather than in map order. The merged finding
+// list keeps first-seen order, so map-order iteration made the union's finding order —
+// and therefore the reviewer's prompt, and therefore Engine.jobID, which hashes
+// Instructions — differ between runs on identical inputs.
 func routineScopeAggregates(candidates map[reviewScopeKey]reviewScopeCandidate, scopes map[reviewScopeKey]*ReviewScope) map[reviewScopeKey]*ReviewScope {
 	merged := make(map[reviewScopeKey]*ReviewScope, len(candidates))
 	rounds := make(map[reviewScopeKey]int, len(candidates))
-	for key, candidate := range candidates {
+	for _, key := range sortedReviewScopeKeys(candidates) {
+		candidate := candidates[key]
 		scope := scopes[key]
 		if scope == nil {
 			continue
@@ -317,6 +323,28 @@ func routineScopeAggregates(candidates map[reviewScopeKey]reviewScopeCandidate, 
 		scope.ChangedFiles = sortedUniqueStrings(scope.ChangedFiles)
 	}
 	return merged
+}
+
+// sortedReviewScopeKeys orders a candidate set so every derived union is byte-identical
+// across runs. The order groups by reviewer, then that reviewer's own bare routine
+// verdict (its lens id is empty, which sorts first), then each lens id: sorting the
+// CANDIDATES rather than the merged finding text keeps the grouping the reviewer reads
+// in its prompt — its own routine findings, then one stable block per lens.
+func sortedReviewScopeKeys(candidates map[reviewScopeKey]reviewScopeCandidate) []reviewScopeKey {
+	keys := make([]reviewScopeKey, 0, len(candidates))
+	for key := range candidates {
+		keys = append(keys, key)
+	}
+	sort.Slice(keys, func(i, j int) bool {
+		if keys[i].reviewer != keys[j].reviewer {
+			return keys[i].reviewer < keys[j].reviewer
+		}
+		if keys[i].routine != keys[j].routine {
+			return !keys[i].routine
+		}
+		return keys[i].lens < keys[j].lens
+	})
+	return keys
 }
 
 // olderRoutineBaseline reports whether a candidate scope is the older baseline: the

--- a/internal/workflow/review_scope_identity_test.go
+++ b/internal/workflow/review_scope_identity_test.go
@@ -69,11 +69,17 @@ func TestRoutineRoundUnionsBareAndLensScopes(t *testing.T) {
 	if payload.ReviewScope == nil {
 		t.Fatal("routine round 3 lost the scope")
 	}
-	joined := strings.Join(payload.ReviewScope.Findings, " ")
-	for _, want := range []string{`"id":"R-1"`, `"id":"C-2"`, `"id":"S-2"`} {
-		if !strings.Contains(joined, want) {
-			t.Fatalf("routine scope findings = %#v, want %s carried forward", payload.ReviewScope.Findings, want)
-		}
+	// EXACT order, not membership: the reviewer's own routine findings first, then each
+	// lens in sorted lens id order. Map-order iteration over the candidate set left this
+	// nondeterministic, and the order reaches production identity through
+	// scopedReviewInstructions -> JobRequest.Instructions -> Engine.jobID.
+	wantFindings := []string{
+		`{"id":"R-1","summary":"routine finding"}`,
+		`{"lens":"correctness","id":"C-2","summary":"correctness finding"}`,
+		`{"lens":"security","id":"S-2","summary":"security finding"}`,
+	}
+	if strings.Join(payload.ReviewScope.Findings, "\n") != strings.Join(wantFindings, "\n") {
+		t.Fatalf("routine scope findings = %#v, want %#v in that order", payload.ReviewScope.Findings, wantFindings)
 	}
 	// The OLDEST baseline is named, because its file range covers the newer one.
 	if payload.ReviewScope.PreviousHeadSHA != "head-one" {
@@ -82,6 +88,91 @@ func TestRoutineRoundUnionsBareAndLensScopes(t *testing.T) {
 	files := strings.Join(payload.ReviewScope.ChangedFiles, ",")
 	if files != "internal/from_head_one.go,internal/from_head_two.go" {
 		t.Fatalf("scope files = %#v, want the union of both baselines", payload.ReviewScope.ChangedFiles)
+	}
+}
+
+// TestRoutineScopeAggregateOrderAndJobIDAreDeterministic pins the P2 finding from the
+// exact-head verdict. routineScopeAggregates finalized the union with
+// stableUniqueStrings, whose first-seen order came from MAP iteration over the candidate
+// set, so a routine round with more than one live scope for one reviewer emitted its
+// findings in a random order. That order reaches the reviewer through
+// scopedReviewInstructions -> JobRequest.Instructions, and production's Engine.jobID
+// (engine.go) fnv-hashes Instructions, so two runs on byte-identical inputs derived two
+// different job ids for the same work.
+//
+// One bare candidate plus three lenses has 24 map orders, only one of which is the
+// wanted one; the loop iterates enough times that any surviving nondeterminism fails
+// rather than flakes.
+func TestRoutineScopeAggregateOrderAndJobIDAreDeterministic(t *testing.T) {
+	candidates := map[reviewScopeKey]reviewScopeCandidate{
+		lensScopeKey("audit", ""):              {round: 1},
+		lensScopeKey("audit", LensCorrectness): {round: 2},
+		lensScopeKey("audit", LensSecurity):    {round: 2},
+		lensScopeKey("audit", LensRegression):  {round: 2},
+	}
+	scopes := map[reviewScopeKey]*ReviewScope{
+		lensScopeKey("audit", ""): {
+			PreviousHeadSHA: "head-one",
+			Findings:        []string{"routine finding"},
+			ChangedFiles:    []string{"internal/routine.go"},
+		},
+		lensScopeKey("audit", LensCorrectness): {
+			PreviousHeadSHA: "head-two",
+			Findings:        []string{"correctness finding"},
+			ChangedFiles:    []string{"internal/correctness.go"},
+		},
+		lensScopeKey("audit", LensSecurity): {
+			PreviousHeadSHA: "head-two",
+			Findings:        []string{"security finding"},
+			ChangedFiles:    []string{"internal/security.go"},
+		},
+		lensScopeKey("audit", LensRegression): {
+			PreviousHeadSHA: "head-two",
+			Findings:        []string{"regression finding"},
+			ChangedFiles:    []string{"internal/regression.go"},
+		},
+	}
+	// The reviewer's own routine findings first, then one block per lens in sorted lens
+	// id order: correctness, regression, security.
+	wantFindings := []string{
+		"routine finding",
+		"correctness finding",
+		"regression finding",
+		"security finding",
+	}
+	// A zero-value Engine has no JobID seam, so this is the PRODUCTION identity hash
+	// that consumes Instructions — testEngine's stub id would hide the whole finding.
+	engine := Engine{}
+	event := reviewRefanoutEvent("head-three")
+	var wantID string
+	for i := range 200 {
+		aggregate := routineScopeAggregates(candidates, scopes)[routineScopeKey("audit")]
+		if aggregate == nil {
+			t.Fatalf("iteration %d: no routine aggregate", i)
+		}
+		if strings.Join(aggregate.Findings, "\n") != strings.Join(wantFindings, "\n") {
+			t.Fatalf("iteration %d: aggregate findings = %#v, want %#v in that order", i, aggregate.Findings, wantFindings)
+		}
+		if aggregate.PreviousHeadSHA != "head-one" {
+			t.Fatalf("iteration %d: aggregate baseline = %q, want head-one", i, aggregate.PreviousHeadSHA)
+		}
+		id := engine.jobID(JobRequest{
+			Repo:         event.Repo,
+			Branch:       event.Branch,
+			PullRequest:  event.PullRequest,
+			TaskID:       event.TaskID,
+			Agent:        "audit",
+			Action:       "review",
+			ReviewRound:  "review-3",
+			Instructions: scopedReviewInstructions(event, aggregate),
+		})
+		if i == 0 {
+			wantID = id
+			continue
+		}
+		if id != wantID {
+			t.Fatalf("iteration %d: derived job id = %s, want %s — the scoped prompt is not byte-stable", i, id, wantID)
+		}
 	}
 }
 


### PR DESCRIPTION
Follow-up to #1701, which was **merged at 11:02Z** (`138e493c`) before its exact-head verdict arrived. Job `local-review-gm-review-opus-18d0e08f2cf3cd1e` reviewed the merged head `b35dd465` and returned changes_requested with two findings; both are in code that is now on `main`, so they need their own PR rather than a push to a closed branch.

## P2 — the routine scope union's finding ORDER was nondeterministic

`routineScopeAggregates` finalized findings with `stableUniqueStrings`, whose first-seen order came from MAP ITERATION, while the line immediately below it sorted `ChangedFiles`. The reviewer measured 4 distinct orderings across 200 runs with one bare plus three lens candidates (130/22/25/23), and because `Engine.jobID` (`internal/workflow/engine.go:466`) fnv-hashes `Instructions`, two orderings produced two different deterministic job ids **from the finding order alone** — measured as `workflow-3oay10iwbrk0e` vs `workflow-1rz83w022j0cm`.

Fixed by sorting the CANDIDATE ITERATION rather than the finding text, so the prompt keeps its meaningful grouping — the reviewer's own routine findings first, then one contiguous block per lens — while the id is a function of the inputs again. The union's CONTENTS are unchanged: files are still `sortedUniqueStrings`, the baseline is still the oldest.

## P3 — the changed-file list in the reviewer's prompt was untested

Mutating `if len(scope.ChangedFiles) == 0` to `if true`, so the prompt always says `Files changed since the reviewer last saw the branch: - none`, passed the entire `internal/workflow` package, the entire `internal/daemon` package, and every native-review test in `internal/cli`. The assertion that looked like coverage — `strings.Contains(payload.Instructions, "internal/boundary.go")` — was vacuous, because that same path is embedded in the F-1 finding JSON printed above it in the same prompt.

The changed-files section is now pinned with a sentinel path that cannot appear anywhere else in the prompt.

## Verification

`go build ./...`, `go vet ./internal/workflow`, `go test -count=1 ./internal/workflow` — ok 77.8s on a clean checkout of current `main` plus this commit.

Both mutants run and killed:

1. revert the determinism fix → the order/id-stability test fails
2. the reviewer's own `if true` mutation of the ChangedFiles branch → the sentinel-path test fails

Not verified: full suite and race gate (coordinator's detached gates).

GM-OMP-FANOUT