### PR TITLE
fix(workflow): order empty review rounds by creation time (#1737)

### DIFF
--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -2249,8 +2249,19 @@ func TestPollOnceDoesNotTreatManualReviewJobAsWorkflowRoute(t *testing.T) {
 	if err := daemon.PollOnce(ctx); err != nil {
 		t.Fatalf("PollOnce returned error: %v", err)
 	}
-	if _, err := store.GetJob(ctx, "review-audit-task-7-review-2"); err != nil {
+	workflowJob, err := store.GetJob(ctx, "review-audit-task-7-review-1")
+	if err != nil {
 		t.Fatalf("GetJob workflow review round returned error: %v", err)
+	}
+	var workflowPayload workflow.JobPayload
+	if err := json.Unmarshal([]byte(workflowJob.Payload), &workflowPayload); err != nil {
+		t.Fatalf("Unmarshal workflow review payload returned error: %v", err)
+	}
+	if workflowPayload.ReviewRound != "review-1" {
+		t.Fatalf("workflow review round = %q, want review-1", workflowPayload.ReviewRound)
+	}
+	if _, err := store.GetJob(ctx, "review-audit-task-7-review-2"); !errors.Is(err, sql.ErrNoRows) {
+		t.Fatalf("manual empty round counted as numbered workflow history: %v", err)
 	}
 	if pr, err := store.GetPullRequest(ctx, repo.FullName(), 7); err != nil || pr.HeadSHA != "abc123" {
 		t.Fatalf("stored pull request = %+v err=%v", pr, err)

--- a/internal/workflow/engine_pr_lifecycle.go
+++ b/internal/workflow/engine_pr_lifecycle.go
@@ -940,7 +940,7 @@ func (e Engine) nextReviewRound(ctx context.Context, event PullRequestEvent) (st
 		return "", nil, err
 	}
 	current := JobPayload{Repo: event.Repo, PullRequest: event.PullRequest, TaskID: event.TaskID}
-	rounds := map[string]bool{}
+	maxReviewRound := 0
 	existingHeadRound := ""
 	for _, job := range jobs {
 		if job.Type != "review" {
@@ -954,18 +954,20 @@ func (e Engine) nextReviewRound(ctx context.Context, event PullRequestEvent) (st
 			continue
 		}
 		round := strings.TrimSpace(payload.ReviewRound)
+		if number, ok := reviewRoundNumber(round); ok && number > maxReviewRound {
+			maxReviewRound = number
+		}
 		if round == "" {
 			round = job.ID
 		}
 		if payload.HeadSHA != "" && payload.HeadSHA == event.HeadSHA {
 			existingHeadRound = round
 		}
-		rounds[round] = true
 	}
 	if existingHeadRound != "" {
 		return existingHeadRound, jobs, nil
 	}
-	return "review-" + strconv.Itoa(len(rounds)+1), jobs, nil
+	return "review-" + strconv.Itoa(maxReviewRound+1), jobs, nil
 }
 
 func (e Engine) reviewApprovalAlreadyAdvanced(ctx context.Context, ref taskRef) (bool, error) {

--- a/internal/workflow/engine_test.go
+++ b/internal/workflow/engine_test.go
@@ -2131,6 +2131,68 @@ func TestEngineReviewLoopAllowsNewHead(t *testing.T) {
 	}
 }
 
+func TestEngineReviewLoopSparseHistoryDispatchesNextNumericRound(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	seedAgent(t, store, "lead", []string{"implement"}, "gitmoot/gitmoot")
+	seedAgent(t, store, "audit", []string{"review"}, "gitmoot/gitmoot")
+	for _, prior := range []struct {
+		id    string
+		round string
+	}{
+		{id: "prior-review-10-a", round: "review-10"},
+		{id: "prior-review-10-b", round: "review-10"},
+		{id: "prior-review-malformed", round: "manual-round"},
+		{id: "prior-review-empty", round: ""},
+	} {
+		insertCompletedJob(t, store, db.Job{ID: prior.id, Agent: "audit", Type: "review"}, JobPayload{
+			Repo: "gitmoot/gitmoot", Branch: "task-7", PullRequest: 7, HeadSHA: "head-a",
+			TaskID: "task-7", ReviewRound: prior.round,
+			Result: &AgentResult{Decision: "changes_requested", Summary: "fix it"},
+		})
+	}
+	engine := testEngine(store)
+	gate := &fakeMergeGate{decision: MergeDecision{Ready: true}}
+	engine.MergeGate = gate
+	engine.ReviewChangedFiles = func(context.Context, string, int, string, string) ([]string, error) {
+		return []string{"internal/workflow/engine.go"}, nil
+	}
+	if err := engine.HandlePullRequestOpened(ctx, PullRequestEvent{
+		Repo: "gitmoot/gitmoot", Branch: "task-7", PullRequest: 7, HeadSHA: "head-b",
+		TaskID: "task-7", LeadAgent: "lead", RequiredReviewers: []string{"audit"},
+	}); err != nil {
+		t.Fatalf("new-head dispatch: %v", err)
+	}
+
+	const jobID = "review-audit-task-7-review-11"
+	job := mustJob(t, store, jobID)
+	payload, err := unmarshalPayload(job.Payload)
+	if err != nil {
+		t.Fatalf("unmarshalPayload: %v", err)
+	}
+	if payload.ReviewRound != "review-11" {
+		t.Fatalf("review round = %q, want review-11", payload.ReviewRound)
+	}
+	payload.Result = &AgentResult{Decision: "approved", Summary: "ready"}
+	encoded, err := marshalPayload(payload)
+	if err != nil {
+		t.Fatalf("marshalPayload: %v", err)
+	}
+	if err := store.UpdateJobPayload(ctx, jobID, encoded); err != nil {
+		t.Fatalf("UpdateJobPayload: %v", err)
+	}
+	if err := store.UpdateJobState(ctx, jobID, string(JobSucceeded)); err != nil {
+		t.Fatalf("UpdateJobState: %v", err)
+	}
+	if err := engine.AdvanceJob(ctx, jobID); err != nil {
+		t.Fatalf("AdvanceJob: %v", err)
+	}
+	assertTaskState(t, store, "task-7", TaskReadyToMerge)
+	if len(gate.requests) != 1 {
+		t.Fatalf("merge gate requests = %d, want 1", len(gate.requests))
+	}
+}
+
 // TestEngineReviewLoopAllowsMixedDecisionsAtSameHead kills a decision-blind
 // mutant. A verdict flip is unstable evidence and must not freeze progress.
 func TestEngineReviewLoopAllowsMixedDecisionsAtSameHead(t *testing.T) {

--- a/internal/workflow/merge_gate.go
+++ b/internal/workflow/merge_gate.go
@@ -475,10 +475,10 @@ func (g PolicyMergeGate) ensureFinalReviewCaptured(ctx context.Context, request 
 	missingImplementerReason := implementerAttribution.failureReason()
 	delegationChildrenByParent := make(map[string][]db.Job)
 	for _, job := range jobs {
-		parentID := strings.TrimSpace(job.ParentJobID)
-		if parentID == "" || strings.TrimSpace(job.DelegationID) == "" {
+		if !isDelegationChild(job) {
 			continue
 		}
+		parentID := strings.TrimSpace(job.ParentJobID)
 		delegationChildrenByParent[parentID] = append(delegationChildrenByParent[parentID], job)
 	}
 	// A round can order remediation, but it must not hide a blocking verdict or
@@ -489,7 +489,7 @@ func (g PolicyMergeGate) ensureFinalReviewCaptured(ctx context.Context, request 
 	}
 	var reviewsAtHead []reviewAtHead
 	for _, job := range jobs {
-		if job.Type != "review" {
+		if job.Type != "review" || isDelegationChild(job) {
 			continue
 		}
 		payload, err := unmarshalPayload(job.Payload)
@@ -601,9 +601,10 @@ func (g PolicyMergeGate) ensureFinalReviewCaptured(ctx context.Context, request 
 		}
 		return nil
 	}
-	latest := ""
+	var latest reviewRoundKey
+	haveLatest := false
 	for _, job := range jobs {
-		if job.Type != "review" {
+		if job.Type != "review" || isDelegationChild(job) {
 			continue
 		}
 		payload, err := unmarshalPayload(job.Payload)
@@ -616,15 +617,13 @@ func (g PolicyMergeGate) ensureFinalReviewCaptured(ctx context.Context, request 
 		if _, superseded := supersededReviewIDs[job.ID]; superseded {
 			continue
 		}
-		round := strings.TrimSpace(payload.ReviewRound)
-		if round == "" {
-			round = job.ID
-		}
-		if latest == "" || reviewRoundAfter(round, latest) {
-			latest = round
+		candidate := reviewRoundKeyForJob(job, payload)
+		if !haveLatest || reviewRoundKeyAfter(candidate, latest) {
+			latest = candidate
+			haveLatest = true
 		}
 	}
-	if latest == "" {
+	if !haveLatest {
 		return errors.New("final agent review is not captured")
 	}
 	approved := false
@@ -637,18 +636,15 @@ func (g PolicyMergeGate) ensureFinalReviewCaptured(ctx context.Context, request 
 	}
 	var eligible []eligibleReview
 	for _, job := range jobs {
-		if job.Type != "review" {
+		if job.Type != "review" || isDelegationChild(job) {
 			continue
 		}
 		payload, err := unmarshalPayload(job.Payload)
 		if err != nil {
 			return err
 		}
-		round := strings.TrimSpace(payload.ReviewRound)
-		if round == "" {
-			round = job.ID
-		}
-		if !sameTask(current, payload) || round != latest || payload.Result == nil {
+		candidate := reviewRoundKeyForJob(job, payload)
+		if !sameTask(current, payload) || !sameReviewRoundKey(candidate, latest) || payload.Result == nil {
 			continue
 		}
 		if _, superseded := supersededReviewIDs[job.ID]; superseded {
@@ -915,6 +911,52 @@ func reviewJobRecordedAfter(left db.Job, right db.Job) bool {
 		return after
 	}
 	return false
+}
+
+type reviewRoundKey struct {
+	name      string
+	createdAt string
+}
+
+func reviewRoundKeyForJob(job db.Job, payload JobPayload) reviewRoundKey {
+	round := strings.TrimSpace(payload.ReviewRound)
+	if round != "" {
+		return reviewRoundKey{name: round}
+	}
+	return reviewRoundKey{createdAt: job.CreatedAt}
+}
+
+func reviewRoundKeyAfter(left reviewRoundKey, right reviewRoundKey) bool {
+	leftExplicit := left.name != ""
+	rightExplicit := right.name != ""
+	if leftExplicit != rightExplicit {
+		return leftExplicit
+	}
+	if leftExplicit {
+		return reviewRoundAfter(left.name, right.name)
+	}
+	after, decided := recordedTimestampAfter(left.createdAt, right.createdAt)
+	return decided && after
+}
+
+func sameReviewRoundKey(left reviewRoundKey, right reviewRoundKey) bool {
+	leftExplicit := left.name != ""
+	rightExplicit := right.name != ""
+	if leftExplicit || rightExplicit {
+		return leftExplicit && rightExplicit && left.name == right.name
+	}
+	leftTime, leftOK := parseStoredJobTime(left.createdAt)
+	rightTime, rightOK := parseStoredJobTime(right.createdAt)
+	if !leftOK || !rightOK {
+		// An unparseable persisted timestamp cannot establish recency. Treat the
+		// fallback reviews as one conservative round instead of ordering by ID.
+		return true
+	}
+	return leftTime.Equal(rightTime)
+}
+
+func isDelegationChild(job db.Job) bool {
+	return strings.TrimSpace(job.ParentJobID) != "" && strings.TrimSpace(job.DelegationID) != ""
 }
 
 func isReviewReplacementDecision(decision string) bool {

--- a/internal/workflow/merge_gate.go
+++ b/internal/workflow/merge_gate.go
@@ -489,7 +489,7 @@ func (g PolicyMergeGate) ensureFinalReviewCaptured(ctx context.Context, request 
 	}
 	var reviewsAtHead []reviewAtHead
 	for _, job := range jobs {
-		if job.Type != "review" || isDelegationChild(job) {
+		if job.Type != "review" {
 			continue
 		}
 		payload, err := unmarshalPayload(job.Payload)
@@ -915,6 +915,9 @@ func reviewJobRecordedAfter(left db.Job, right db.Job) bool {
 func reviewJobSupersedes(leftJob db.Job, leftPayload JobPayload, rightJob db.Job, rightPayload JobPayload) bool {
 	leftRound := reviewRoundKeyForJob(leftJob, leftPayload)
 	rightRound := reviewRoundKeyForJob(rightJob, rightPayload)
+	if (leftRound.name != "") != (rightRound.name != "") {
+		return false
+	}
 	if reviewRoundKeyAfter(leftRound, rightRound) {
 		return true
 	}

--- a/internal/workflow/merge_gate.go
+++ b/internal/workflow/merge_gate.go
@@ -908,7 +908,23 @@ func reviewJobSupersedes(leftJob db.Job, leftPayload JobPayload, rightJob db.Job
 	leftRound := reviewRoundKeyForJob(leftJob, leftPayload)
 	rightRound := reviewRoundKeyForJob(rightJob, rightPayload)
 	if (leftRound.name != "") != (rightRound.name != "") {
-		return false
+		// The two rows come from different dispatch paths and their rounds cannot be
+		// ordered against each other: the engine always stamps review-N, while
+		// `gitmoot agent review <reviewer> --repo <o/r> --pr <N> --head-sha <H>`
+		// creates a row with the head set and NO round. Ranking them would let one
+		// path hide the other's live or blocking evidence, so a real verdict may
+		// resolve only a row that has already settled WITHOUT one -- no result at
+		// all, or a decision that is not a verdict (for example "skipped").
+		//
+		// That single exception is load-bearing: such a row is a settled non-answer,
+		// so nothing is hidden by resolving it, and it is otherwise inescapable.
+		// `gitmoot job retry` and `gitmoot job cancel` both refuse a succeeded job,
+		// and re-polling the same head dispatches nothing because the round already
+		// has a job, so the CLI re-review this gate's own error message asks for is
+		// the only exit. Queued, running, failed and cancelled rows keep blocking:
+		// their exits are settlement and `gitmoot job retry`, which mutate the row
+		// itself rather than adding a second one.
+		return isSettledNonVerdictReview(rightJob, rightPayload) && reviewJobRecordedAfter(leftJob, rightJob)
 	}
 	if reviewRoundKeyAfter(leftRound, rightRound) {
 		return true
@@ -917,6 +933,20 @@ func reviewJobSupersedes(leftJob db.Job, leftPayload JobPayload, rightJob db.Job
 		return false
 	}
 	return reviewJobRecordedAfter(leftJob, rightJob)
+}
+
+// isSettledNonVerdictReview reports whether a review row has reached a terminal
+// state carrying no verdict: succeeded with no result, or with a decision the
+// gate does not recognize as one. Such a row can never become a verdict on its
+// own, and its state alone proves no reviewer work is still in flight.
+func isSettledNonVerdictReview(job db.Job, payload JobPayload) bool {
+	if JobState(job.State) != JobSucceeded {
+		return false
+	}
+	if payload.Result == nil {
+		return true
+	}
+	return !isReviewReplacementDecision(payload.Result.Decision)
 }
 
 // isRoundHistoryDuplicate reports whether a delegated review row is a SUB-REVIEW

--- a/internal/workflow/merge_gate.go
+++ b/internal/workflow/merge_gate.go
@@ -547,7 +547,7 @@ func (g PolicyMergeGate) ensureFinalReviewCaptured(ctx context.Context, request 
 		case JobQueued, JobRunning:
 			return mergePending{reason: fmt.Sprintf("waiting for reviewer %s at evaluated head (job %s is %s)", strings.TrimSpace(review.job.Agent), review.job.ID, review.job.State)}
 		case JobFailed, JobCancelled:
-			return fmt.Errorf("crashed reviewer %s at evaluated head (job %s is %s); requeue or reassign the review", strings.TrimSpace(review.job.Agent), review.job.ID, review.job.State)
+			return fmt.Errorf("crashed reviewer %s at evaluated head (job %s is %s); retry or settle that same job, or push a new head. Reassigning the review to a different agent cannot clear this reviewer's slot", strings.TrimSpace(review.job.Agent), review.job.ID, review.job.State)
 		}
 	}
 	for _, review := range activeAtHead {
@@ -569,7 +569,7 @@ func (g PolicyMergeGate) ensureFinalReviewCaptured(ctx context.Context, request 
 				return fmt.Errorf("reviewer %s at evaluated head has unusable job state %s (job %s)", reviewer, review.job.State, review.job.ID)
 			}
 			if review.payload.Result == nil {
-				return fmt.Errorf("abstaining reviewer %s at evaluated head has no recognized decision (job %s); requeue or reassign the review", reviewer, review.job.ID)
+				return fmt.Errorf("abstaining reviewer %s at evaluated head has no recognized decision (job %s); dispatch a fresh review for that same agent at this head, or push a new head. Reassigning to a different agent cannot clear this reviewer's slot", reviewer, review.job.ID)
 			}
 			switch review.payload.Result.Decision {
 			case "approved":
@@ -593,7 +593,7 @@ func (g PolicyMergeGate) ensureFinalReviewCaptured(ctx context.Context, request 
 			case "changes_requested", "blocked", "failed":
 				return mergeBlocked{reason: fmt.Sprintf("review at evaluated head has blocking result from %s", reviewer)}
 			default:
-				return fmt.Errorf("abstaining reviewer %s at evaluated head returned unrecognized decision %q (job %s); requeue or reassign the review", reviewer, review.payload.Result.Decision, review.job.ID)
+				return fmt.Errorf("abstaining reviewer %s at evaluated head returned unrecognized decision %q (job %s); dispatch a fresh review for that same agent at this head, or push a new head. Reassigning to a different agent cannot clear this reviewer's slot", reviewer, review.payload.Result.Decision, review.job.ID)
 			}
 		}
 		if reason := reviewAuthorshipFailureReason(selfApprovalReason, unknownImplementerReason, unattributedReviewerReason); reason != "" {
@@ -968,9 +968,21 @@ func isRoundHistoryDuplicate(job db.Job, taskReviewIDs map[string]struct{}) bool
 	return parentIsTaskReview
 }
 
+// reviewRoundKey is the ONE ordering key for the review rows of a task, shared by
+// every decision that ranks them: supersession, latest-round selection and
+// eligibility. An engine round orders by its number. A row dispatched by
+// `gitmoot agent review <reviewer> --repo <o/r> --pr <N> --head-sha <H>` carries
+// no round and orders by when its verdict was RECORDED -- UpdatedAt, falling back
+// to CreatedAt -- never by dispatch time alone.
+//
+// Dispatch time cannot express verdict recency: `gitmoot job retry` re-runs a row
+// IN PLACE, keeping created_at and bumping updated_at, so the EARLIEST-created row
+// can hold the NEWEST verdict. Ranking by created_at let a later-created but
+// earlier-recorded approval discard a retried row's changes_requested and merge.
 type reviewRoundKey struct {
-	name      string
-	createdAt string
+	name       string
+	recordedAt string
+	createdAt  string
 }
 
 func reviewRoundKeyForJob(job db.Job, payload JobPayload) reviewRoundKey {
@@ -978,7 +990,17 @@ func reviewRoundKeyForJob(job db.Job, payload JobPayload) reviewRoundKey {
 	if round != "" {
 		return reviewRoundKey{name: round}
 	}
-	return reviewRoundKey{createdAt: job.CreatedAt}
+	return reviewRoundKey{recordedAt: job.UpdatedAt, createdAt: job.CreatedAt}
+}
+
+// reviewRoundKeyRecency is the single recency comparison behind both key
+// operations below. Its precedence is the same as reviewJobRecordedAfter's, so a
+// round key and a job row can never disagree about which of two rows is newer.
+func reviewRoundKeyRecency(left reviewRoundKey, right reviewRoundKey) (after bool, decided bool) {
+	if after, decided := recordedTimestampAfter(left.recordedAt, right.recordedAt); decided {
+		return after, true
+	}
+	return recordedTimestampAfter(left.createdAt, right.createdAt)
 }
 
 func reviewRoundKeyAfter(left reviewRoundKey, right reviewRoundKey) bool {
@@ -990,7 +1012,7 @@ func reviewRoundKeyAfter(left reviewRoundKey, right reviewRoundKey) bool {
 	if leftExplicit {
 		return reviewRoundAfter(left.name, right.name)
 	}
-	after, decided := recordedTimestampAfter(left.createdAt, right.createdAt)
+	after, decided := reviewRoundKeyRecency(left, right)
 	return decided && after
 }
 
@@ -1000,14 +1022,12 @@ func sameReviewRoundKey(left reviewRoundKey, right reviewRoundKey) bool {
 	if leftExplicit || rightExplicit {
 		return leftExplicit && rightExplicit && left.name == right.name
 	}
-	leftTime, leftOK := parseStoredJobTime(left.createdAt)
-	rightTime, rightOK := parseStoredJobTime(right.createdAt)
-	if !leftOK || !rightOK {
-		// An unparseable persisted timestamp cannot establish recency. Treat the
-		// fallback reviews as one conservative round instead of ordering by ID.
-		return true
-	}
-	return leftTime.Equal(rightTime)
+	// Two roundless rows are the same round exactly when no persisted timestamp
+	// separates them: recordedTimestampAfter decides only when both values parse
+	// and differ, so an unparseable or equal pair stays one conservative round
+	// rather than being ordered by job id.
+	_, decided := reviewRoundKeyRecency(left, right)
+	return !decided
 }
 
 func isDelegationChild(job db.Job) bool {

--- a/internal/workflow/merge_gate.go
+++ b/internal/workflow/merge_gate.go
@@ -483,11 +483,12 @@ func (g PolicyMergeGate) ensureFinalReviewCaptured(ctx context.Context, request 
 	}
 	// A round can order remediation, but it must not hide a blocking verdict or
 	// an unfinished reviewer slot captured at the head currently being evaluated.
-	type reviewAtHead struct {
+	type taskReview struct {
 		job     db.Job
 		payload JobPayload
 	}
-	var reviewsAtHead []reviewAtHead
+	var taskReviews []taskReview
+	taskReviewIDs := make(map[string]struct{})
 	for _, job := range jobs {
 		if job.Type != "review" {
 			continue
@@ -499,40 +500,24 @@ func (g PolicyMergeGate) ensureFinalReviewCaptured(ctx context.Context, request 
 		if !sameTask(current, payload) {
 			continue
 		}
-		reviewHead := strings.TrimSpace(payload.HeadSHA)
+		taskReviews = append(taskReviews, taskReview{job: job, payload: payload})
+		taskReviewIDs[job.ID] = struct{}{}
+	}
+	var reviewsAtHead []taskReview
+	for _, review := range taskReviews {
+		reviewHead := strings.TrimSpace(review.payload.HeadSHA)
 		if reviewHead == "" || reviewHead != headSHA {
 			continue
 		}
-		reviewsAtHead = append(reviewsAtHead, reviewAtHead{job: job, payload: payload})
+		reviewsAtHead = append(reviewsAtHead, review)
 	}
-	latestReviewByReviewer := map[string]reviewAtHead{}
-	var reviewerOrder []string
-	for _, review := range reviewsAtHead {
-		reviewer := strings.TrimSpace(review.job.Agent)
-		latest, exists := latestReviewByReviewer[reviewer]
-		if !exists {
-			reviewerOrder = append(reviewerOrder, reviewer)
-			latestReviewByReviewer[reviewer] = review
-			continue
-		}
-		if reviewJobSupersedes(review.job, review.payload, latest.job, latest.payload) {
-			latestReviewByReviewer[reviewer] = review
-		}
-	}
-	for _, reviewer := range reviewerOrder {
-		review := latestReviewByReviewer[reviewer]
-		switch JobState(review.job.State) {
-		case JobQueued, JobRunning:
-			return mergePending{reason: fmt.Sprintf("waiting for reviewer %s at evaluated head (job %s is %s)", reviewer, review.job.ID, review.job.State)}
-		case JobFailed, JobCancelled:
-			return fmt.Errorf("crashed reviewer %s at evaluated head (job %s is %s); requeue or reassign the review", reviewer, review.job.ID, review.job.State)
-		}
-	}
+	// Supersession is resolved BEFORE any state or verdict scan, and it covers a
+	// row in any state: a strictly later terminal verdict from the same reviewer
+	// is what clears a crashed or requeued slot. Rows whose order cannot be
+	// established -- one explicit review-N against one empty round -- supersede
+	// in neither direction, so no row is ever hidden by ListJobs' id order.
 	supersededReviewIDs := map[string]struct{}{}
 	for _, review := range reviewsAtHead {
-		if review.payload.Result == nil {
-			continue
-		}
 		reviewer := strings.TrimSpace(review.job.Agent)
 		if reviewer == "" {
 			continue
@@ -547,11 +532,26 @@ func (g PolicyMergeGate) ensureFinalReviewCaptured(ctx context.Context, request 
 			}
 		}
 	}
+	var activeAtHead []taskReview
 	for _, review := range reviewsAtHead {
-		if review.payload.Result == nil {
+		if _, superseded := supersededReviewIDs[review.job.ID]; superseded {
 			continue
 		}
-		if _, superseded := supersededReviewIDs[review.job.ID]; superseded {
+		activeAtHead = append(activeAtHead, review)
+	}
+	// EVERY unsuperseded slot at the evaluated head is inspected, not one row per
+	// reviewer: an unfinished or crashed reviewer must not be hidden by a sibling
+	// row of the same reviewer whose recency cannot be decided.
+	for _, review := range activeAtHead {
+		switch JobState(review.job.State) {
+		case JobQueued, JobRunning:
+			return mergePending{reason: fmt.Sprintf("waiting for reviewer %s at evaluated head (job %s is %s)", strings.TrimSpace(review.job.Agent), review.job.ID, review.job.State)}
+		case JobFailed, JobCancelled:
+			return fmt.Errorf("crashed reviewer %s at evaluated head (job %s is %s); requeue or reassign the review", strings.TrimSpace(review.job.Agent), review.job.ID, review.job.State)
+		}
+	}
+	for _, review := range activeAtHead {
+		if review.payload.Result == nil {
 			continue
 		}
 		switch review.payload.Result.Decision {
@@ -559,12 +559,12 @@ func (g PolicyMergeGate) ensureFinalReviewCaptured(ctx context.Context, request 
 			return mergeBlocked{reason: fmt.Sprintf("review at evaluated head has blocking result from %s", review.job.Agent)}
 		}
 	}
-	if len(latestReviewByReviewer) > 0 {
+	if len(activeAtHead) > 0 {
 		var selfApprovalReason string
 		var unknownImplementerReason string
 		var unattributedReviewerReason string
-		for _, reviewer := range reviewerOrder {
-			review := latestReviewByReviewer[reviewer]
+		for _, review := range activeAtHead {
+			reviewer := strings.TrimSpace(review.job.Agent)
 			if JobState(review.job.State) != JobSucceeded {
 				return fmt.Errorf("reviewer %s at evaluated head has unusable job state %s (job %s)", reviewer, review.job.State, review.job.ID)
 			}
@@ -603,21 +603,14 @@ func (g PolicyMergeGate) ensureFinalReviewCaptured(ctx context.Context, request 
 	}
 	var latest reviewRoundKey
 	haveLatest := false
-	for _, job := range jobs {
-		if job.Type != "review" || isDelegationChild(job) {
+	for _, review := range taskReviews {
+		if isRoundHistoryDuplicate(review.job, taskReviewIDs) {
 			continue
 		}
-		payload, err := unmarshalPayload(job.Payload)
-		if err != nil {
-			return err
-		}
-		if !sameTask(current, payload) {
+		if _, superseded := supersededReviewIDs[review.job.ID]; superseded {
 			continue
 		}
-		if _, superseded := supersededReviewIDs[job.ID]; superseded {
-			continue
-		}
-		candidate := reviewRoundKeyForJob(job, payload)
+		candidate := reviewRoundKeyForJob(review.job, review.payload)
 		if !haveLatest || reviewRoundKeyAfter(candidate, latest) {
 			latest = candidate
 			haveLatest = true
@@ -635,16 +628,14 @@ func (g PolicyMergeGate) ensureFinalReviewCaptured(ctx context.Context, request 
 		payload JobPayload
 	}
 	var eligible []eligibleReview
-	for _, job := range jobs {
-		if job.Type != "review" || isDelegationChild(job) {
+	for _, review := range taskReviews {
+		job := review.job
+		payload := review.payload
+		if isRoundHistoryDuplicate(job, taskReviewIDs) {
 			continue
 		}
-		payload, err := unmarshalPayload(job.Payload)
-		if err != nil {
-			return err
-		}
 		candidate := reviewRoundKeyForJob(job, payload)
-		if !sameTask(current, payload) || !sameReviewRoundKey(candidate, latest) || payload.Result == nil {
+		if !sameReviewRoundKey(candidate, latest) || payload.Result == nil {
 			continue
 		}
 		if _, superseded := supersededReviewIDs[job.ID]; superseded {
@@ -912,6 +903,7 @@ func reviewJobRecordedAfter(left db.Job, right db.Job) bool {
 	}
 	return false
 }
+
 func reviewJobSupersedes(leftJob db.Job, leftPayload JobPayload, rightJob db.Job, rightPayload JobPayload) bool {
 	leftRound := reviewRoundKeyForJob(leftJob, leftPayload)
 	rightRound := reviewRoundKeyForJob(rightJob, rightPayload)
@@ -925,6 +917,25 @@ func reviewJobSupersedes(leftJob db.Job, leftPayload JobPayload, rightJob db.Job
 		return false
 	}
 	return reviewJobRecordedAfter(leftJob, rightJob)
+}
+
+// isRoundHistoryDuplicate reports whether a delegated review row is a SUB-REVIEW
+// of another review job for the same task. Those rows are round-history
+// duplicates of their parent (#1737: a lens child's id is its parent's id plus a
+// suffix, and its verdict is already validated as the parent's evidence by
+// ensureDelegatedReviewEvidence), so they must not compete for the latest round.
+//
+// A delegated review whose parent is NOT a review job for this task is the
+// gate's own required review, not a duplicate of one. A #332 integration-worktree
+// review is exactly that shape -- the engine clears its HeadSHA, so it can never
+// appear in reviewsAtHead -- and excluding it from round selection deadlocks the
+// merge (#388).
+func isRoundHistoryDuplicate(job db.Job, taskReviewIDs map[string]struct{}) bool {
+	if !isDelegationChild(job) {
+		return false
+	}
+	_, parentIsTaskReview := taskReviewIDs[strings.TrimSpace(job.ParentJobID)]
+	return parentIsTaskReview
 }
 
 type reviewRoundKey struct {

--- a/internal/workflow/merge_gate.go
+++ b/internal/workflow/merge_gate.go
@@ -515,7 +515,7 @@ func (g PolicyMergeGate) ensureFinalReviewCaptured(ctx context.Context, request 
 			latestReviewByReviewer[reviewer] = review
 			continue
 		}
-		if reviewJobRecordedAfter(review.job, latest.job) {
+		if reviewJobSupersedes(review.job, review.payload, latest.job, latest.payload) {
 			latestReviewByReviewer[reviewer] = review
 		}
 	}
@@ -541,7 +541,7 @@ func (g PolicyMergeGate) ensureFinalReviewCaptured(ctx context.Context, request 
 			if candidate.payload.Result != nil &&
 				strings.TrimSpace(candidate.job.Agent) == reviewer &&
 				isReviewReplacementDecision(candidate.payload.Result.Decision) &&
-				reviewJobRecordedAfter(candidate.job, review.job) {
+				reviewJobSupersedes(candidate.job, candidate.payload, review.job, review.payload) {
 				supersededReviewIDs[review.job.ID] = struct{}{}
 				break
 			}
@@ -911,6 +911,17 @@ func reviewJobRecordedAfter(left db.Job, right db.Job) bool {
 		return after
 	}
 	return false
+}
+func reviewJobSupersedes(leftJob db.Job, leftPayload JobPayload, rightJob db.Job, rightPayload JobPayload) bool {
+	leftRound := reviewRoundKeyForJob(leftJob, leftPayload)
+	rightRound := reviewRoundKeyForJob(rightJob, rightPayload)
+	if reviewRoundKeyAfter(leftRound, rightRound) {
+		return true
+	}
+	if reviewRoundKeyAfter(rightRound, leftRound) || !sameReviewRoundKey(leftRound, rightRound) {
+		return false
+	}
+	return reviewJobRecordedAfter(leftJob, rightJob)
 }
 
 type reviewRoundKey struct {

--- a/internal/workflow/merge_gate_test.go
+++ b/internal/workflow/merge_gate_test.go
@@ -38,6 +38,9 @@ type mergeGateReviewFixture struct {
 	decision  string
 	hasResult bool
 	recorded  string
+	// emptyRound reproduces a CLI-dispatched review: `gitmoot agent review` sets
+	// HeadSHA and never sets ReviewRound.
+	emptyRound bool
 }
 
 func newMergeGateQuorumScenario(t *testing.T) (*db.Store, *fakeMergeGateGitHub, PolicyMergeGate, MergeRequest) {
@@ -80,6 +83,9 @@ func insertMergeGateReviewFixture(t *testing.T, store *db.Store, fixture mergeGa
 		HeadSHA:     headSHA,
 		TaskID:      "task-9",
 		ReviewRound: "review-1",
+	}
+	if fixture.emptyRound {
+		payload.ReviewRound = ""
 	}
 	if fixture.hasResult {
 		payload.Result = &AgentResult{Decision: fixture.decision, Summary: "fixture verdict"}
@@ -129,9 +135,13 @@ func insertMergeGateDelegationChild(t *testing.T, store *db.Store, parentID, del
 func insertMergeGateHeadlessIntegrationParent(t *testing.T, store *db.Store, parentID string) {
 	t.Helper()
 	insertCompletedJob(t, store, db.Job{
-		ID:           parentID,
-		Agent:        "reviewer-a",
-		Type:         "review",
+		ID:    parentID,
+		Agent: "reviewer-a",
+		Type:  "review",
+		// Production shape: mailbox.Enqueue writes ParentJobID AND DelegationID for
+		// every delegated review, so isDelegationChild is true for this row. The
+		// quorum scenario's implement job is the delegator.
+		ParentJobID:  "implement-job",
 		DelegationID: "verify-parent",
 	}, JobPayload{
 		Repo:         "gitmoot/gitmoot",
@@ -963,6 +973,128 @@ func TestPolicyMergeGateBlockingDelegationChildUnderNonReviewParent(t *testing.T
 	}
 	if !strings.Contains(decision.Reason.Render(), "blocking result from security") {
 		t.Fatalf("decision reason = %q, want delegated blocking verdict", decision.Reason)
+	}
+}
+
+// TestPolicyMergeGateUndecidedRoundOrderNeverHidesUnfinishedReviewer pins the
+// property that replaced per-reviewer "latest row wins" selection: when two rows
+// from one reviewer at the evaluated head cannot be ordered (one explicit
+// review-N, one CLI-dispatched empty round), an unfinished or crashed slot must
+// still block. It is asserted in BOTH job-id orders, so an implementation that
+// resolves the tie through ListJobs' ORDER BY id fails one direction, and the
+// approval is recorded LATER than the unfinished row, so a "latest timestamp
+// wins" implementation fails both.
+func TestPolicyMergeGateUndecidedRoundOrderNeverHidesUnfinishedReviewer(t *testing.T) {
+	for _, tc := range []struct {
+		name        string
+		state       JobState
+		wantReason  string
+		wantPending bool
+	}{
+		{name: "queued", state: JobQueued, wantReason: "waiting for reviewer audit", wantPending: true},
+		{name: "running", state: JobRunning, wantReason: "waiting for reviewer audit", wantPending: true},
+		{name: "failed", state: JobFailed, wantReason: "crashed reviewer audit"},
+		{name: "cancelled", state: JobCancelled, wantReason: "crashed reviewer audit"},
+	} {
+		for _, order := range []struct {
+			name       string
+			manualID   string
+			numberedID string
+		}{
+			{name: "manual id sorts first", manualID: "aaa-manual-review", numberedID: "zzz-dispatched-review"},
+			{name: "numbered id sorts first", manualID: "zzz-manual-review", numberedID: "aaa-dispatched-review"},
+		} {
+			t.Run(tc.name+"/"+order.name, func(t *testing.T) {
+				store, gh, gate, request := newMergeGateQuorumScenario(t)
+				insertMergeGateReviewFixture(t, store, mergeGateReviewFixture{
+					id: order.numberedID, agent: "audit", state: tc.state,
+					recorded: "2026-07-31 12:00:00",
+				})
+				insertMergeGateReviewFixture(t, store, mergeGateReviewFixture{
+					id: order.manualID, agent: "audit", hasResult: true, decision: "approved",
+					recorded: "2026-07-31 12:01:00", emptyRound: true,
+				})
+
+				decision, err := gate.Evaluate(context.Background(), request)
+				if err != nil {
+					t.Fatalf("Evaluate returned error: %v", err)
+				}
+				if decision.Merged {
+					t.Fatalf("decision = %+v, want unfinished reviewer slot to hold the merge", decision)
+				}
+				if tc.wantPending && decision.Reason.IsGateMiss() {
+					t.Fatalf("decision = %+v, want unfinished slot to wait without escalating", decision)
+				}
+				if !tc.wantPending && (!decision.LeaveOpen || !decision.Reason.IsGateMiss()) {
+					t.Fatalf("decision = %+v, want crashed slot parked as a gate miss", decision)
+				}
+				if !strings.Contains(decision.Reason.Render(), tc.wantReason) ||
+					!strings.Contains(decision.Reason.Render(), order.numberedID) {
+					t.Fatalf("decision reason = %q, want %q naming %s", decision.Reason, tc.wantReason, order.numberedID)
+				}
+				if len(gh.merges) != 0 {
+					t.Fatalf("merge calls = %+v, want none", gh.merges)
+				}
+			})
+		}
+	}
+}
+
+// TestPolicyMergeGateAdvancesIntegrationWorktreeReviewAsDelegationChild is the
+// #388 regression in its PRODUCTION row shape: mailbox.Enqueue writes both
+// ParentJobID and DelegationID, so the gate-required #332 integration review IS a
+// delegation child. Its HeadSHA is cleared by the engine, so it can never appear
+// in the exact-head scan; excluding it from round selection as a round-history
+// duplicate deadlocks the merge. Its parent is an orchestrating job, not a review,
+// so it is nobody's sub-review.
+func TestPolicyMergeGateAdvancesIntegrationWorktreeReviewAsDelegationChild(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	if err := store.UpsertPullRequest(ctx, db.PullRequest{
+		RepoFullName: "gitmoot/gitmoot",
+		Number:       9,
+		HeadBranch:   "task-9",
+		BaseBranch:   "main",
+		HeadSHA:      "head123",
+		State:        "open",
+	}); err != nil {
+		t.Fatalf("UpsertPullRequest returned error: %v", err)
+	}
+	insertCompletedJob(t, store, db.Job{ID: "coordinator-job", Agent: "coordinator", Type: "ask"}, JobPayload{
+		Repo:        "gitmoot/gitmoot",
+		PullRequest: 9,
+		TaskID:      "task-9",
+		Result:      &AgentResult{Decision: "approved", Summary: "verify gate fanned out"},
+	})
+	insertIndependentMergeGateReview(t, store, db.Job{
+		ID:           "coordinator-job/delegation/verify-gate",
+		Agent:        "audit",
+		Type:         "review",
+		ParentJobID:  "coordinator-job",
+		DelegationID: "verify-gate",
+	}, JobPayload{
+		Repo:         "gitmoot/gitmoot",
+		PullRequest:  9,
+		TaskID:       "task-9",
+		ReviewRound:  "review-1",
+		DelegationID: "verify-gate",
+		WorktreePath: "/tmp/gitmoot/integration-verify-gate",
+		Result:       &AgentResult{Decision: "approved", Summary: "integration verified"},
+	})
+	mergeable := true
+	gh := &fakeMergeGateGitHub{
+		pr:          github.PullRequest{Number: 9, HeadRef: "task-9", BaseRef: "main", HeadSHA: "head123", Mergeable: &mergeable},
+		status:      github.CombinedStatus{State: "success", Statuses: []github.CommitStatus{{Context: "ci", State: "success"}}},
+		mergeResult: github.MergeResult{Merged: true, SHA: "merge123"},
+	}
+	gate := PolicyMergeGate{AutoMerge: true, Store: store, GitHub: gh, Git: &fakeMergeGateGit{clean: true}}
+
+	decision, err := gate.Evaluate(ctx, MergeRequest{Repo: "gitmoot/gitmoot", PullRequest: 9, TaskID: "task-9"})
+	if err != nil {
+		t.Fatalf("Evaluate returned error: %v", err)
+	}
+	if !decision.Merged {
+		t.Fatalf("production-shape integration review did not advance to merge: decision = %+v", decision)
 	}
 }
 
@@ -2714,9 +2846,11 @@ func TestPolicyMergeGateAcceptsHeadlessIntegrationParentWhenDelegationChildrenSu
 	store, gh, gate, request := newMergeGateQuorumScenario(t)
 	const parentID = "review-parent-healthy"
 	insertCompletedJob(t, store, db.Job{
-		ID:           parentID,
-		Agent:        "reviewer-a",
-		Type:         "review",
+		ID:    parentID,
+		Agent: "reviewer-a",
+		Type:  "review",
+		// Production shape: a delegated review row carries both ids.
+		ParentJobID:  "implement-job",
 		DelegationID: "verify-parent",
 	}, JobPayload{
 		Repo:         "gitmoot/gitmoot",
@@ -3535,7 +3669,13 @@ func TestPolicyMergeGateAdvancesIntegrationWorktreeReviewWithoutHeadSHA(t *testi
 	}
 	// An integration-worktree review: a delegation child (DelegationID +
 	// WorktreePath set) whose HeadSHA the engine intentionally cleared.
-	insertIndependentMergeGateReview(t, store, db.Job{ID: "review-job", Agent: "audit", Type: "review", DelegationID: "verify-gate"}, JobPayload{
+	insertIndependentMergeGateReview(t, store, db.Job{
+		ID:           "review-job",
+		Agent:        "audit",
+		Type:         "review",
+		ParentJobID:  "review-job-implement-author",
+		DelegationID: "verify-gate",
+	}, JobPayload{
 		Repo:         "gitmoot/gitmoot",
 		PullRequest:  9,
 		TaskID:       "task-9",
@@ -3570,7 +3710,13 @@ func TestPolicyMergeGateAdvancesIntegrationWorktreeReviewWithoutHeadSHA(t *testi
 func TestPolicyMergeGateBlocksDelegationReviewForMismatchedHead(t *testing.T) {
 	ctx := context.Background()
 	store := openEngineStore(t)
-	insertIndependentMergeGateReview(t, store, db.Job{ID: "review-job", Agent: "audit", Type: "review", DelegationID: "verify-gate"}, JobPayload{
+	insertIndependentMergeGateReview(t, store, db.Job{
+		ID:           "review-job",
+		Agent:        "audit",
+		Type:         "review",
+		ParentJobID:  "review-job-implement-author",
+		DelegationID: "verify-gate",
+	}, JobPayload{
 		Repo:         "gitmoot/gitmoot",
 		PullRequest:  9,
 		HeadSHA:      "stale999",

--- a/internal/workflow/merge_gate_test.go
+++ b/internal/workflow/merge_gate_test.go
@@ -797,6 +797,67 @@ func TestPolicyMergeGateEmptyReviewRoundUsesRecordedRecency(t *testing.T) {
 	}
 }
 
+func TestPolicyMergeGateExplicitRoundPrecedesNewerSameReviewerVerdict(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		newerRound string
+	}{
+		{name: "empty round", newerRound: ""},
+		{name: "lower explicit round", newerRound: "review-1"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+			store := openEngineStore(t)
+			basePayload := JobPayload{
+				Repo:        "gitmoot/gitmoot",
+				Branch:      "task-9",
+				PullRequest: 9,
+				TaskID:      "task-9",
+			}
+			implementPayload := basePayload
+			implementPayload.Result = &AgentResult{Decision: "implemented", Summary: "implemented"}
+			insertCompletedJob(t, store, db.Job{ID: "implement-job", Agent: "implementer", Type: "implement"}, implementPayload)
+
+			blockingReview := basePayload
+			blockingReview.HeadSHA = "head123"
+			blockingReview.ReviewRound = "review-2"
+			blockingReview.Result = &AgentResult{Decision: "changes_requested", Summary: "blocking"}
+			insertCompletedJob(t, store, db.Job{ID: "review-blocking", Agent: "audit", Type: "review"}, blockingReview)
+			setMergeGateJobTimestamps(t, store, "review-blocking", "2026-08-31 10:00:00")
+
+			newerApproval := basePayload
+			newerApproval.HeadSHA = "head123"
+			newerApproval.ReviewRound = tc.newerRound
+			newerApproval.Result = &AgentResult{Decision: "approved", Summary: "lower round approval"}
+			insertCompletedJob(t, store, db.Job{ID: "review-newer", Agent: "audit", Type: "review"}, newerApproval)
+			setMergeGateJobTimestamps(t, store, "review-newer", "2026-08-31 11:00:00")
+
+			mergeable := true
+			gh := &fakeMergeGateGitHub{
+				pr: github.PullRequest{
+					Number: 9, State: "open", HeadRef: "task-9", BaseRef: "main",
+					HeadSHA: "head123", Mergeable: &mergeable,
+				},
+				status:      github.CombinedStatus{State: "success", Statuses: []github.CommitStatus{{Context: "ci", State: "success"}}},
+				checks:      []github.PullRequestCheck{{Name: "ci", Bucket: "pass", State: "SUCCESS"}},
+				mergeResult: github.MergeResult{Merged: true, SHA: "merge123"},
+			}
+			gate := PolicyMergeGate{AutoMerge: true, Store: store, GitHub: gh, Git: &fakeMergeGateGit{clean: true}}
+
+			decision, err := gate.Evaluate(ctx, MergeRequest{Repo: "gitmoot/gitmoot", PullRequest: 9, TaskID: "task-9"})
+			if err != nil {
+				t.Fatalf("Evaluate returned error: %v", err)
+			}
+			if !decision.LeaveOpen || decision.Merged {
+				t.Fatalf("decision = %+v, want blocking review to keep PR open", decision)
+			}
+			if !strings.Contains(decision.Reason.Render(), "blocking result from audit") {
+				t.Fatalf("decision reason = %q, want higher explicit round's blocking verdict", decision.Reason)
+			}
+		})
+	}
+}
+
 func TestPolicyMergeGatePreservesSelfApprovalReasonWhenHeadMismatchSortsFirst(t *testing.T) {
 	ctx := context.Background()
 	store := openEngineStore(t)

--- a/internal/workflow/merge_gate_test.go
+++ b/internal/workflow/merge_gate_test.go
@@ -744,6 +744,59 @@ func TestImplementerAttributionAnomalyDeclinesRemainByteStable(t *testing.T) {
 	}
 }
 
+func TestPolicyMergeGateEmptyReviewRoundUsesRecordedRecency(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	basePayload := JobPayload{
+		Repo:        "gitmoot/gitmoot",
+		Branch:      "task-9",
+		PullRequest: 9,
+		TaskID:      "task-9",
+	}
+	implementPayload := basePayload
+	implementPayload.Result = &AgentResult{Decision: "implemented", Summary: "implemented"}
+	insertCompletedJob(t, store, db.Job{ID: "implement-job", Agent: "implementer", Type: "implement"}, implementPayload)
+
+	olderReview := basePayload
+	olderReview.HeadSHA = "older-head"
+	olderReview.Result = &AgentResult{Decision: "approved", Summary: "older approval"}
+	const olderJobID = "local-review-zulu-older"
+	insertCompletedJob(t, store, db.Job{ID: olderJobID, Agent: "zulu-reviewer", Type: "review"}, olderReview)
+	setMergeGateJobTimestamps(t, store, olderJobID, "2026-08-31 10:00:00")
+
+	newerReview := basePayload
+	newerReview.HeadSHA = "newer-head"
+	newerReview.Result = &AgentResult{Decision: "approved", Summary: "newer approval"}
+	const newerJobID = "local-review-alpha-newer"
+	insertCompletedJob(t, store, db.Job{ID: newerJobID, Agent: "alpha-reviewer", Type: "review"}, newerReview)
+	setMergeGateJobTimestamps(t, store, newerJobID, "2026-08-31 11:00:00")
+
+	insertMergeGateDelegationChild(t, store, olderJobID, "lens-latest", JobFailed, nil)
+	setMergeGateJobTimestamps(t, store, olderJobID+"/delegation/lens-latest", "2026-08-31 12:00:00")
+
+	mergeable := true
+	gh := &fakeMergeGateGitHub{
+		pr: github.PullRequest{
+			Number: 9, State: "open", HeadRef: "task-9", BaseRef: "main",
+			HeadSHA: "current-head", Mergeable: &mergeable,
+		},
+		status: github.CombinedStatus{State: "success", Statuses: []github.CommitStatus{{Context: "ci", State: "success"}}},
+		checks: []github.PullRequestCheck{{Name: "ci", Bucket: "pass", State: "SUCCESS"}},
+	}
+	gate := PolicyMergeGate{AutoMerge: true, Store: store, GitHub: gh, Git: &fakeMergeGateGit{clean: true}}
+
+	decision, err := gate.Evaluate(ctx, MergeRequest{Repo: "gitmoot/gitmoot", PullRequest: 9, TaskID: "task-9"})
+	if err != nil {
+		t.Fatalf("Evaluate returned error: %v", err)
+	}
+	if !decision.LeaveOpen || !decision.Reason.IsGateMiss() || decision.Ready || decision.Merged {
+		t.Fatalf("decision = %+v, want escalating LeaveOpen", decision)
+	}
+	if !strings.Contains(decision.Reason.Render(), "latest review from alpha-reviewer is for a different head SHA") {
+		t.Fatalf("decision reason = %q, want newer root review selected by recorded time", decision.Reason)
+	}
+}
+
 func TestPolicyMergeGatePreservesSelfApprovalReasonWhenHeadMismatchSortsFirst(t *testing.T) {
 	ctx := context.Background()
 	store := openEngineStore(t)

--- a/internal/workflow/merge_gate_test.go
+++ b/internal/workflow/merge_gate_test.go
@@ -2741,6 +2741,12 @@ func TestPolicyMergeGateLatestCrashOverridesStaleApproval(t *testing.T) {
 	}
 }
 
+// TestPolicyMergeGateRequeueClearsCrashedReviewerPark pins the PRODUCTION requeue
+// shape. `gitmoot job retry` transitions the SAME row in place and preserves its
+// id, head and round, so a requeue is one row whose state changes -- never a
+// second row sharing the first's explicit round, which no dispatch path can
+// create. Pinning the two-row shape hid a regression that refused every
+// cross-round supersession.
 func TestPolicyMergeGateRequeueClearsCrashedReviewerPark(t *testing.T) {
 	store, gh, gate, request := newMergeGateQuorumScenario(t)
 	insertMergeGateReviewFixture(t, store, mergeGateReviewFixture{
@@ -2764,10 +2770,9 @@ func TestPolicyMergeGateRequeueClearsCrashedReviewerPark(t *testing.T) {
 		t.Fatalf("first decision reason = %q, want crashed reviewer and job", parked.Reason)
 	}
 
-	insertMergeGateReviewFixture(t, store, mergeGateReviewFixture{
-		id: "review-requeued-approved", agent: "reviewer-b", hasResult: true, decision: "approved",
-		recorded: "2026-07-31 12:02:00",
-	})
+	settleMergeGateReviewInPlace(t, store, "review-crashed", JobSucceeded,
+		&AgentResult{Decision: "approved", Summary: "requeued verdict"}, "2026-07-31 12:02:00")
+
 	merged, err := gate.Evaluate(context.Background(), request)
 	if err != nil {
 		t.Fatalf("second Evaluate returned error: %v", err)
@@ -2777,6 +2782,118 @@ func TestPolicyMergeGateRequeueClearsCrashedReviewerPark(t *testing.T) {
 	}
 	if len(gh.merges) != 1 {
 		t.Fatalf("merge calls = %+v, want one after requeue approval", gh.merges)
+	}
+}
+
+// TestPolicyMergeGateCLIReviewResolvesOnlySettledNonVerdictEngineRound pins the
+// exception that makes the mixed-round refusal survivable. The engine always
+// stamps review-N; `gitmoot agent review <reviewer> --repo gitmoot/gitmoot
+// --pr <N> --head-sha <H>` creates a second row with the head set and NO round.
+// A later CLI verdict may resolve an engine round that SETTLED WITHOUT a verdict
+// -- no result, or a decision like "skipped" -- because that row is inescapable
+// otherwise: `gitmoot job retry` and `gitmoot job cancel` both refuse a succeeded
+// job and a re-poll of the same head dispatches nothing. It must NOT resolve a
+// live, crashed or blocking row: those exits mutate the row itself.
+func TestPolicyMergeGateCLIReviewResolvesOnlySettledNonVerdictEngineRound(t *testing.T) {
+	const engineJobID = "review-audit-task-9-review-1"
+	const cliJobID = "local-review-audit-18d0f3d229cc7aa3"
+	for _, tc := range []struct {
+		name        string
+		state       JobState
+		hasResult   bool
+		decision    string
+		cliRecorded string
+		wantMerged  bool
+		wantPending bool
+		wantReason  string
+	}{
+		{
+			name: "unrecognized decision is resolved", hasResult: true, decision: "skipped",
+			cliRecorded: "2026-07-31 12:02:00", wantMerged: true,
+		},
+		{
+			name:        "missing result is resolved",
+			cliRecorded: "2026-07-31 12:02:00", wantMerged: true,
+		},
+		{
+			name: "unrecognized decision parks without a cli review", hasResult: true, decision: "skipped",
+			wantReason: `unrecognized decision "skipped"`,
+		},
+		{
+			name:       "missing result parks without a cli review",
+			wantReason: "abstaining reviewer audit",
+		},
+		{
+			name: "earlier cli review does not resolve", hasResult: true, decision: "skipped",
+			cliRecorded: "2026-07-31 12:00:00", wantReason: `unrecognized decision "skipped"`,
+		},
+		{
+			name: "crashed row keeps blocking", state: JobFailed,
+			cliRecorded: "2026-07-31 12:02:00", wantReason: "crashed reviewer audit",
+		},
+		{
+			name: "cancelled row keeps blocking", state: JobCancelled,
+			cliRecorded: "2026-07-31 12:02:00", wantReason: "crashed reviewer audit",
+		},
+		{
+			name: "queued row keeps waiting", state: JobQueued,
+			cliRecorded: "2026-07-31 12:02:00", wantPending: true, wantReason: "waiting for reviewer audit",
+		},
+		{
+			name: "running row keeps waiting", state: JobRunning,
+			cliRecorded: "2026-07-31 12:02:00", wantPending: true, wantReason: "waiting for reviewer audit",
+		},
+		{
+			name: "blocking verdict is not a non-verdict", hasResult: true, decision: "changes_requested",
+			cliRecorded: "2026-07-31 12:02:00", wantReason: "blocking result from audit",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			store, gh, gate, request := newMergeGateQuorumScenario(t)
+			state := tc.state
+			if state == "" {
+				state = JobSucceeded
+			}
+			insertMergeGateReviewFixture(t, store, mergeGateReviewFixture{
+				id: engineJobID, agent: "audit", state: state,
+				hasResult: tc.hasResult, decision: tc.decision,
+				recorded: "2026-07-31 12:01:00",
+			})
+			if tc.cliRecorded != "" {
+				insertMergeGateReviewFixture(t, store, mergeGateReviewFixture{
+					id: cliJobID, agent: "audit", hasResult: true, decision: "approved",
+					recorded: tc.cliRecorded, emptyRound: true,
+				})
+			}
+
+			decision, err := gate.Evaluate(context.Background(), request)
+			if err != nil {
+				t.Fatalf("Evaluate returned error: %v", err)
+			}
+			switch {
+			case tc.wantMerged:
+				if !decision.Merged {
+					t.Fatalf("decision = %+v, want cli verdict to resolve the settled non-verdict round", decision)
+				}
+				if len(gh.merges) != 1 {
+					t.Fatalf("merge calls = %+v, want one", gh.merges)
+				}
+			case tc.wantPending:
+				if decision.Merged || decision.Reason.IsGateMiss() {
+					t.Fatalf("decision = %+v, want live reviewer slot to wait without escalating", decision)
+				}
+			default:
+				if decision.Merged || !decision.LeaveOpen || !decision.Reason.IsGateMiss() {
+					t.Fatalf("decision = %+v, want the engine round to keep holding the merge", decision)
+				}
+			}
+			if !strings.Contains(decision.Reason.Render(), tc.wantReason) {
+				t.Fatalf("decision reason = %q, want %q", decision.Reason, tc.wantReason)
+			}
+			if !tc.wantMerged && len(gh.merges) != 0 {
+				t.Fatalf("merge calls = %+v, want none", gh.merges)
+			}
+		})
 	}
 }
 
@@ -3894,4 +4011,32 @@ func setMergeGateJobTimestamps(t *testing.T, store *db.Store, jobID string, time
 	if err != nil || affected != 1 {
 		t.Fatalf("set job %s timestamps affected=%d, err=%v; want 1", jobID, affected, err)
 	}
+}
+
+// settleMergeGateReviewInPlace mirrors `gitmoot job retry` settling a review row:
+// the SAME row transitions to a terminal state carrying a result, keeping its id,
+// head and round. No production path adds a second row for the same round.
+func settleMergeGateReviewInPlace(t *testing.T, store *db.Store, jobID string, state JobState, result *AgentResult, recorded string) {
+	t.Helper()
+	ctx := context.Background()
+	job, err := store.GetJob(ctx, jobID)
+	if err != nil {
+		t.Fatalf("GetJob(%s) returned error: %v", jobID, err)
+	}
+	payload, err := unmarshalPayload(job.Payload)
+	if err != nil {
+		t.Fatalf("unmarshalPayload(%s) returned error: %v", jobID, err)
+	}
+	payload.Result = result
+	encoded, err := marshalPayload(payload)
+	if err != nil {
+		t.Fatalf("marshalPayload(%s) returned error: %v", jobID, err)
+	}
+	if err := store.UpdateJobPayload(ctx, jobID, encoded); err != nil {
+		t.Fatalf("UpdateJobPayload(%s) returned error: %v", jobID, err)
+	}
+	if err := store.UpdateJobState(ctx, jobID, string(state)); err != nil {
+		t.Fatalf("UpdateJobState(%s) returned error: %v", jobID, err)
+	}
+	setMergeGateJobTimestamps(t, store, jobID, recorded)
 }

--- a/internal/workflow/merge_gate_test.go
+++ b/internal/workflow/merge_gate_test.go
@@ -858,6 +858,114 @@ func TestPolicyMergeGateExplicitRoundPrecedesNewerSameReviewerVerdict(t *testing
 	}
 }
 
+func TestPolicyMergeGateNewerManualBlockingReviewSurvivesExplicitApproval(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	basePayload := JobPayload{
+		Repo:        "gitmoot/gitmoot",
+		Branch:      "task-9",
+		PullRequest: 9,
+		TaskID:      "task-9",
+	}
+	implementPayload := basePayload
+	implementPayload.Result = &AgentResult{Decision: "implemented", Summary: "implemented"}
+	insertCompletedJob(t, store, db.Job{ID: "implement-job", Agent: "implementer", Type: "implement"}, implementPayload)
+
+	explicitApproval := basePayload
+	explicitApproval.HeadSHA = "head123"
+	explicitApproval.ReviewRound = "review-2"
+	explicitApproval.Result = &AgentResult{Decision: "approved", Summary: "older approval"}
+	insertCompletedJob(t, store, db.Job{ID: "review-explicit", Agent: "audit", Type: "review"}, explicitApproval)
+	setMergeGateJobTimestamps(t, store, "review-explicit", "2026-08-31 10:00:00")
+
+	manualBlock := basePayload
+	manualBlock.HeadSHA = "head123"
+	manualBlock.Result = &AgentResult{Decision: "changes_requested", Summary: "newer manual block"}
+	insertCompletedJob(t, store, db.Job{ID: "review-manual", Agent: "audit", Type: "review"}, manualBlock)
+	setMergeGateJobTimestamps(t, store, "review-manual", "2026-08-31 11:00:00")
+
+	mergeable := true
+	gh := &fakeMergeGateGitHub{
+		pr: github.PullRequest{
+			Number: 9, State: "open", HeadRef: "task-9", BaseRef: "main",
+			HeadSHA: "head123", Mergeable: &mergeable,
+		},
+		status:      github.CombinedStatus{State: "success", Statuses: []github.CommitStatus{{Context: "ci", State: "success"}}},
+		checks:      []github.PullRequestCheck{{Name: "ci", Bucket: "pass", State: "SUCCESS"}},
+		mergeResult: github.MergeResult{Merged: true, SHA: "merge123"},
+	}
+	gate := PolicyMergeGate{AutoMerge: true, Store: store, GitHub: gh, Git: &fakeMergeGateGit{clean: true}}
+
+	decision, err := gate.Evaluate(ctx, MergeRequest{Repo: "gitmoot/gitmoot", PullRequest: 9, TaskID: "task-9"})
+	if err != nil {
+		t.Fatalf("Evaluate returned error: %v", err)
+	}
+	if !decision.LeaveOpen || decision.Merged {
+		t.Fatalf("decision = %+v, want newer manual block to keep PR open", decision)
+	}
+	if !strings.Contains(decision.Reason.Render(), "blocking result from audit") {
+		t.Fatalf("decision reason = %q, want manual blocking verdict", decision.Reason)
+	}
+}
+
+func TestPolicyMergeGateBlockingDelegationChildUnderNonReviewParent(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	basePayload := JobPayload{
+		Repo:        "gitmoot/gitmoot",
+		Branch:      "task-9",
+		PullRequest: 9,
+		TaskID:      "task-9",
+		HeadSHA:     "head123",
+	}
+	implementPayload := basePayload
+	implementPayload.HeadSHA = ""
+	implementPayload.Result = &AgentResult{Decision: "implemented", Summary: "implemented"}
+	insertCompletedJob(t, store, db.Job{ID: "implement-job", Agent: "implementer", Type: "implement"}, implementPayload)
+
+	approvalPayload := basePayload
+	approvalPayload.ReviewRound = "review-1"
+	approvalPayload.Result = &AgentResult{Decision: "approved", Summary: "root approval"}
+	insertCompletedJob(t, store, db.Job{ID: "review-approval", Agent: "audit", Type: "review"}, approvalPayload)
+
+	parentPayload := basePayload
+	parentPayload.Result = &AgentResult{Decision: "approved", Summary: "orchestration complete"}
+	insertCompletedJob(t, store, db.Job{ID: "orchestrate-parent", Agent: "coordinator", Type: "ask"}, parentPayload)
+
+	childPayload := basePayload
+	childPayload.Result = &AgentResult{Decision: "changes_requested", Summary: "delegated blocker"}
+	insertCompletedJob(t, store, db.Job{
+		ID:           "orchestrate-parent/delegation/security",
+		Agent:        "security",
+		Type:         "review",
+		ParentJobID:  "orchestrate-parent",
+		DelegationID: "security",
+	}, childPayload)
+
+	mergeable := true
+	gh := &fakeMergeGateGitHub{
+		pr: github.PullRequest{
+			Number: 9, State: "open", HeadRef: "task-9", BaseRef: "main",
+			HeadSHA: "head123", Mergeable: &mergeable,
+		},
+		status:      github.CombinedStatus{State: "success", Statuses: []github.CommitStatus{{Context: "ci", State: "success"}}},
+		checks:      []github.PullRequestCheck{{Name: "ci", Bucket: "pass", State: "SUCCESS"}},
+		mergeResult: github.MergeResult{Merged: true, SHA: "merge123"},
+	}
+	gate := PolicyMergeGate{AutoMerge: true, Store: store, GitHub: gh, Git: &fakeMergeGateGit{clean: true}}
+
+	decision, err := gate.Evaluate(ctx, MergeRequest{Repo: "gitmoot/gitmoot", PullRequest: 9, TaskID: "task-9"})
+	if err != nil {
+		t.Fatalf("Evaluate returned error: %v", err)
+	}
+	if !decision.LeaveOpen || decision.Merged {
+		t.Fatalf("decision = %+v, want delegated blocker to keep PR open", decision)
+	}
+	if !strings.Contains(decision.Reason.Render(), "blocking result from security") {
+		t.Fatalf("decision reason = %q, want delegated blocking verdict", decision.Reason)
+	}
+}
+
 func TestPolicyMergeGatePreservesSelfApprovalReasonWhenHeadMismatchSortsFirst(t *testing.T) {
 	ctx := context.Background()
 	store := openEngineStore(t)

--- a/internal/workflow/merge_gate_test.go
+++ b/internal/workflow/merge_gate_test.go
@@ -37,7 +37,13 @@ type mergeGateReviewFixture struct {
 	headSHA   string
 	decision  string
 	hasResult bool
+	// recorded sets created_at AND updated_at to one value. createdAt/updatedAt
+	// set them INDEPENDENTLY, which is the only way to express a row retried in
+	// place: `gitmoot job retry` keeps created_at and bumps updated_at, so the
+	// earliest-created row can hold the newest verdict.
 	recorded  string
+	createdAt string
+	updatedAt string
 	// emptyRound reproduces a CLI-dispatched review: `gitmoot agent review` sets
 	// HeadSHA and never sets ReviewRound.
 	emptyRound bool
@@ -103,7 +109,13 @@ func insertMergeGateReviewFixture(t *testing.T, store *db.Store, fixture mergeGa
 	}, db.JobEvent{Kind: string(state), Message: "fixture state"}); err != nil {
 		t.Fatalf("CreateJobWithEvent returned error: %v", err)
 	}
-	if fixture.recorded != "" {
+	switch {
+	case fixture.createdAt != "" || fixture.updatedAt != "":
+		if fixture.recorded != "" {
+			t.Fatalf("fixture %s sets recorded together with createdAt/updatedAt", fixture.id)
+		}
+		setMergeGateJobRecordedTimes(t, store, fixture.id, fixture.createdAt, fixture.updatedAt)
+	case fixture.recorded != "":
 		setMergeGateJobTimestamps(t, store, fixture.id, fixture.recorded)
 	}
 }
@@ -2541,16 +2553,18 @@ func TestPolicyMergeGateWaitsForRunningReviewAtEvaluatedHead(t *testing.T) {
 	}
 }
 
+// TestPolicyMergeGateLatestQueuedReviewWaitsOverEarlierObjection uses the
+// PRODUCTION requeue shape: `gitmoot job retry` re-runs the SAME row, nilling its
+// result and returning it to queued, so an objection followed by a requeue is one
+// row whose state changed -- not two rows sharing round review-1, which no
+// dispatch path can create.
 func TestPolicyMergeGateLatestQueuedReviewWaitsOverEarlierObjection(t *testing.T) {
 	store, gh, gate, request := newMergeGateQuorumScenario(t)
 	insertMergeGateReviewFixture(t, store, mergeGateReviewFixture{
-		id: "review-objected", agent: "reviewer-a", hasResult: true, decision: "changes_requested",
+		id: "review-requeued", agent: "reviewer-a", hasResult: true, decision: "changes_requested",
 		recorded: "2026-07-31 12:00:00",
 	})
-	insertMergeGateReviewFixture(t, store, mergeGateReviewFixture{
-		id: "review-requeued", agent: "reviewer-a", state: JobQueued,
-		recorded: "2026-07-31 12:01:00",
-	})
+	settleMergeGateReviewInPlace(t, store, "review-requeued", JobQueued, nil, "2026-07-31 12:01:00")
 	insertMergeGateReviewFixture(t, store, mergeGateReviewFixture{
 		id: "review-other-approved", agent: "reviewer-b", hasResult: true, decision: "approved",
 		recorded: "2026-07-31 12:02:00",
@@ -2681,14 +2695,18 @@ func TestPolicyMergeGateUsesLatestReviewJobPerReviewer(t *testing.T) {
 		id: "workflow-1hulo51pzm01f", agent: "joltra-sol-review",
 		hasResult: true, decision: "approved", recorded: "2026-07-31 18:01:24",
 	})
+	// The two local-review-* rows are CLI dispatches: `gitmoot agent review` sets
+	// the head and never a round, so in production they carry EMPTY rounds. Only
+	// the workflow-* row is an engine round.
 	insertMergeGateReviewFixture(t, store, mergeGateReviewFixture{
 		id:    "local-review-joltra-sol-review-18c723c7768aa61d",
-		agent: "joltra-sol-review", state: JobFailed, recorded: "2026-07-31 18:11:56",
+		agent: "joltra-sol-review", state: JobFailed, emptyRound: true,
+		recorded: "2026-07-31 18:11:56",
 	})
 	insertMergeGateReviewFixture(t, store, mergeGateReviewFixture{
 		id:    "local-review-joltra-sol-review-18c7245ac25c6980",
 		agent: "joltra-sol-review", hasResult: true, decision: "changes_requested",
-		recorded: "2026-07-31 18:22:29",
+		emptyRound: true, recorded: "2026-07-31 18:22:29",
 	})
 
 	decision, err := gate.Evaluate(context.Background(), request)
@@ -2710,16 +2728,18 @@ func TestPolicyMergeGateUsesLatestReviewJobPerReviewer(t *testing.T) {
 	}
 }
 
+// TestPolicyMergeGateLatestCrashOverridesStaleApproval uses the PRODUCTION crash
+// shape: one row that carried an approval and was then retried in place and
+// crashed. `gitmoot job retry` keeps the id, head, round and created_at, nils the
+// result and advances updated_at, so the reviewer's slot is a single row -- never
+// an approval row plus a separate failed row sharing round review-1.
 func TestPolicyMergeGateLatestCrashOverridesStaleApproval(t *testing.T) {
 	store, gh, gate, request := newMergeGateQuorumScenario(t)
 	insertMergeGateReviewFixture(t, store, mergeGateReviewFixture{
-		id: "review-z-stale-approved", agent: "reviewer-a",
+		id: "review-retried-crashed", agent: "reviewer-a",
 		hasResult: true, decision: "approved", recorded: "2026-07-31 12:00:00",
 	})
-	insertMergeGateReviewFixture(t, store, mergeGateReviewFixture{
-		id: "review-a-latest-failed", agent: "reviewer-a",
-		state: JobFailed, recorded: "2026-07-31 12:01:00",
-	})
+	settleMergeGateReviewInPlace(t, store, "review-retried-crashed", JobFailed, nil, "2026-07-31 12:01:00")
 
 	decision, err := gate.Evaluate(context.Background(), request)
 
@@ -2727,17 +2747,86 @@ func TestPolicyMergeGateLatestCrashOverridesStaleApproval(t *testing.T) {
 		t.Fatalf("Evaluate returned error: %v", err)
 	}
 	if !decision.LeaveOpen || !decision.Reason.IsGateMiss() || decision.Merged {
-		t.Fatalf("decision = %+v, want latest crashed reviewer parked", decision)
+		t.Fatalf("decision = %+v, want crashed reviewer parked despite the row's earlier approval", decision)
 	}
 	if !strings.Contains(decision.Reason.Render(), "crashed reviewer reviewer-a") ||
-		!strings.Contains(decision.Reason.Render(), "review-a-latest-failed") {
-		t.Fatalf("decision reason = %q, want latest crashed reviewer and job", decision.Reason)
-	}
-	if strings.Contains(decision.Reason.Render(), "review-z-stale-approved") {
-		t.Fatalf("decision reason = %q, stale approval must not govern reviewer slot", decision.Reason)
+		!strings.Contains(decision.Reason.Render(), "review-retried-crashed") {
+		t.Fatalf("decision reason = %q, want crashed reviewer and job", decision.Reason)
 	}
 	if len(gh.merges) != 0 {
 		t.Fatalf("merge calls = %+v, want none", gh.merges)
+	}
+}
+
+// TestPolicyMergeGateEmptyRoundSupersessionUsesVerdictRecency pins the ordering
+// invariant for two CLI-dispatched rows of one reviewer at the evaluated head:
+// recency is when the VERDICT was recorded (updated_at, then created_at), never
+// dispatch time. `gitmoot job retry` re-runs a row in place, keeping created_at
+// and bumping updated_at, so the EARLIEST-created row can hold the NEWEST verdict;
+// ordering by created_at let a later-created but earlier-recorded approval discard
+// a retried row's changes_requested and merge the PR.
+//
+// The second case is the control: with the approval genuinely recorded last,
+// supersession must still work and the PR must merge, so the first case cannot
+// pass by refusing every supersession.
+func TestPolicyMergeGateEmptyRoundSupersessionUsesVerdictRecency(t *testing.T) {
+	for _, tc := range []struct {
+		name           string
+		retriedUpdated string
+		freshUpdated   string
+		wantMerged     bool
+	}{
+		{
+			name:           "retried row records the newer objection",
+			retriedUpdated: "2026-07-31 10:40:00",
+			freshUpdated:   "2026-07-31 10:20:00",
+		},
+		{
+			name:           "fresh row records the newer approval",
+			retriedUpdated: "2026-07-31 10:20:00",
+			freshUpdated:   "2026-07-31 10:40:00",
+			wantMerged:     true,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			store, gh, gate, request := newMergeGateQuorumScenario(t)
+			// Dispatched FIRST (oldest created_at) and later retried in place, so its
+			// verdict is carried by updated_at.
+			insertMergeGateReviewFixture(t, store, mergeGateReviewFixture{
+				id: "local-review-audit-retried", agent: "audit", emptyRound: true,
+				hasResult: true, decision: "changes_requested",
+				createdAt: "2026-07-31 10:00:00", updatedAt: tc.retriedUpdated,
+			})
+			// Dispatched SECOND (newer created_at) and ran once.
+			insertMergeGateReviewFixture(t, store, mergeGateReviewFixture{
+				id: "local-review-audit-fresh", agent: "audit", emptyRound: true,
+				hasResult: true, decision: "approved",
+				createdAt: "2026-07-31 10:10:00", updatedAt: tc.freshUpdated,
+			})
+
+			decision, err := gate.Evaluate(context.Background(), request)
+			if err != nil {
+				t.Fatalf("Evaluate returned error: %v", err)
+			}
+			if tc.wantMerged {
+				if !decision.Merged {
+					t.Fatalf("decision = %+v, want the later-recorded approval to supersede", decision)
+				}
+				if len(gh.merges) != 1 {
+					t.Fatalf("merge calls = %+v, want one", gh.merges)
+				}
+				return
+			}
+			if decision.Merged || !decision.LeaveOpen || !decision.Reason.IsGateMiss() {
+				t.Fatalf("decision = %+v, want the later-recorded objection to hold the merge", decision)
+			}
+			if !strings.Contains(decision.Reason.Render(), "blocking result from audit") {
+				t.Fatalf("decision reason = %q, want the retried row's objection", decision.Reason)
+			}
+			if len(gh.merges) != 0 {
+				t.Fatalf("merge calls = %+v, want none", gh.merges)
+			}
+		})
 	}
 }
 
@@ -3994,28 +4083,53 @@ func hasStatus(statuses []github.CommitStatusInput, context string, state string
 	return false
 }
 
+// setMergeGateJobTimestamps stamps created_at and updated_at to the SAME value,
+// which is what a row that ran once looks like.
 func setMergeGateJobTimestamps(t *testing.T, store *db.Store, jobID string, timestamp string) {
 	t.Helper()
+	setMergeGateJobRecordedTimes(t, store, jobID, timestamp, timestamp)
+}
+
+// setMergeGateJobRecordedTimes stamps created_at and updated_at INDEPENDENTLY; an
+// empty value leaves that column untouched. This is the only way a fixture can
+// express a row retried in place, where created_at is old and updated_at is new,
+// and it is exactly the shape no merge-gate fixture could express before.
+func setMergeGateJobRecordedTimes(t *testing.T, store *db.Store, jobID string, createdAt string, updatedAt string) {
+	t.Helper()
+	if createdAt == "" && updatedAt == "" {
+		t.Fatalf("set job %s recorded times: both values empty", jobID)
+	}
 	raw, err := sql.Open("sqlite", store.DatabasePath())
 	if err != nil {
 		t.Fatalf("open store for timestamp update: %v", err)
 	}
 	defer raw.Close()
+	assignments := make([]string, 0, 2)
+	args := make([]any, 0, 3)
+	if createdAt != "" {
+		assignments = append(assignments, "created_at = ?")
+		args = append(args, createdAt)
+	}
+	if updatedAt != "" {
+		assignments = append(assignments, "updated_at = ?")
+		args = append(args, updatedAt)
+	}
+	args = append(args, jobID)
 	result, err := raw.ExecContext(context.Background(),
-		`UPDATE jobs SET created_at = ?, updated_at = ? WHERE id = ?`,
-		timestamp, timestamp, jobID)
+		`UPDATE jobs SET `+strings.Join(assignments, ", ")+` WHERE id = ?`, args...)
 	if err != nil {
-		t.Fatalf("set job %s timestamps: %v", jobID, err)
+		t.Fatalf("set job %s recorded times: %v", jobID, err)
 	}
 	affected, err := result.RowsAffected()
 	if err != nil || affected != 1 {
-		t.Fatalf("set job %s timestamps affected=%d, err=%v; want 1", jobID, affected, err)
+		t.Fatalf("set job %s recorded times affected=%d, err=%v; want 1", jobID, affected, err)
 	}
 }
 
 // settleMergeGateReviewInPlace mirrors `gitmoot job retry` settling a review row:
-// the SAME row transitions to a terminal state carrying a result, keeping its id,
-// head and round. No production path adds a second row for the same round.
+// the SAME row transitions to a state carrying (or losing) a result, keeping its
+// id, head, round and CREATED_AT while only updated_at advances. No production
+// path adds a second row for the same round.
 func settleMergeGateReviewInPlace(t *testing.T, store *db.Store, jobID string, state JobState, result *AgentResult, recorded string) {
 	t.Helper()
 	ctx := context.Background()
@@ -4038,5 +4152,5 @@ func settleMergeGateReviewInPlace(t *testing.T, store *db.Store, jobID string, s
 	if err := store.UpdateJobState(ctx, jobID, string(state)); err != nil {
 		t.Fatalf("UpdateJobState(%s) returned error: %v", jobID, err)
 	}
-	setMergeGateJobTimestamps(t, store, jobID, recorded)
+	setMergeGateJobRecordedTimes(t, store, jobID, "", recorded)
 }


### PR DESCRIPTION
Closes #1737.

Assignment authority: directive 100388, assignment note 100445.

## Summary

- select reviews with an empty `review_round` by persisted `created_at`, not by the lexicographic job ID
- preserve explicit `review-N` ordering
- exclude delegation children from review-round candidates while retaining them as evidence for their parent review
- add an entry-path regression with opposite lexical job IDs and timestamps plus a newer failed delegation child

## Collision reconciliation

The repository collision scan reported open PRs #1725 and #1732 in `internal/workflow/merge_gate.go`. Their changes concern verdict integrity and transient block classification. This patch changes the empty-round fallback selection loop and does not overlap those semantic hunks.

## Verification

- Baseline regression: failed before the source fix with `required reviewer approval is missing`
- `GOTOOLCHAIN=local GOFLAGS=-buildvcs=false /root/.local/toolchains/go1.26.4/bin/go test ./internal/workflow -run '^TestPolicyMergeGateEmptyReviewRoundUsesRecordedRecency$' -count=1`
- `GOTOOLCHAIN=local GOFLAGS=-buildvcs=false /root/.local/toolchains/go1.26.4/bin/go test ./internal/workflow -run '^TestPolicyMergeGate' -count=1`

Not verified: full repository test suite, per assignment.