### PR TITLE
fix(events): address review verdicts to implementing seats

### DIFF
--- a/docs/events.md
+++ b/docs/events.md
@@ -211,8 +211,9 @@ also use substring matching; empty matches all. Pass only one of `--match` and
 `--repo`. A successful review terminal whose decision is `approved` or
 `changes_requested` matches both `job-terminal` and `review-verdict`. Addressed
 rules may deliver that verdict to both the requesting org role and the pull
-request's implementing role; the review's persisted lead identifies a
-persistent implementing seat when no implement job or branch lock does. If
+request's implementing role. When a successful ownership lookup finds no
+implement job or branch lock attribution, the review's persisted lead
+identifies a persistent implementing seat; lookup errors remain fail-closed. If
 neither role can be resolved, addressed rules fail closed while observer rules
 can still receive the verdict. A plain
 `job.blocked` event matches both `job-terminal` and `blocked`, while

--- a/docs/events.md
+++ b/docs/events.md
@@ -209,9 +209,12 @@ case-insensitive and exact. Job IDs always use case-insensitive substring
 matching, including slash-bearing delegation IDs. Without a slash, repositories
 also use substring matching; empty matches all. Pass only one of `--match` and
 `--repo`. A successful review terminal whose decision is `approved` or
-`changes_requested` matches both `job-terminal` and `review-verdict` and
-addresses the pull request owner's role. If no role can be resolved, addressed
-rules fail closed while observer rules can still receive the verdict. A plain
+`changes_requested` matches both `job-terminal` and `review-verdict`. Addressed
+rules may deliver that verdict to both the requesting org role and the pull
+request's implementing role; the review's persisted lead identifies a
+persistent implementing seat when no implement job or branch lock does. If
+neither role can be resolved, addressed rules fail closed while observer rules
+can still receive the verdict. A plain
 `job.blocked` event matches both `job-terminal` and `blocked`, while
 guard-caused blocks match `guard` first. A synthesized `blocked_since` event
 matches only `blocked`. Task episodes due in

--- a/internal/cli/event_rule_sink.go
+++ b/internal/cli/event_rule_sink.go
@@ -314,13 +314,24 @@ func (s *eventRuleSink) evaluateRules(ctx context.Context, event events.Event, r
 // eventRuleMatchesAddressee is the single scope gate shared by durable enqueue
 // and live evaluation. Addressed rules require positive target evidence;
 // observer rules deliberately retain fleet-wide oversight for address-less and
-// directed events alike.
+// directed events alike. Multi-address events match any listed role.
 func eventRuleMatchesAddressee(rule db.EventRule, event events.Event) bool {
 	if rule.Scope == db.EventRuleScopeObserver {
 		return true
 	}
-	target := strings.TrimSpace(event.WakeTargetRole)
-	return target != "" && strings.EqualFold(strings.TrimSpace(rule.WakeRole), target)
+	role := strings.TrimSpace(rule.WakeRole)
+	if role == "" {
+		return false
+	}
+	if target := strings.TrimSpace(event.WakeTargetRole); target != "" && strings.EqualFold(role, target) {
+		return true
+	}
+	for _, target := range event.WakeTargetRoles {
+		if target = strings.TrimSpace(target); target != "" && strings.EqualFold(role, target) {
+			return true
+		}
+	}
+	return false
 }
 
 // addressBlockedEvent enriches every blocked event at the event-sink source

--- a/internal/cli/event_rule_sink_test.go
+++ b/internal/cli/event_rule_sink_test.go
@@ -861,7 +861,7 @@ func TestEventRuleWakeFiresEachMatchingRule(t *testing.T) {
 		t.Fatalf("want a wake for each of the 2 matching rules, got %d", wake.promptCalls)
 	}
 }
-func TestReviewVerdictWakeTargetsOwnerAndObservers(t *testing.T) {
+func TestReviewVerdictWakeTargetsRequesterImplementerAndObservers(t *testing.T) {
 	home := t.TempDir()
 	paths := config.PathsForHome(home)
 	if err := os.MkdirAll(filepath.Dir(paths.ConfigFile), 0o700); err != nil {
@@ -875,6 +875,10 @@ pane="w1:p0"
 parent="owner"
 scope=["*"]
 pane="w1:p1"
+[org.roles."requester"]
+parent="owner"
+scope=["*"]
+pane="w1:p4"
 [org.roles."other"]
 parent="owner"
 scope=["*"]
@@ -894,6 +898,7 @@ pane="w1:p3"
 	defer store.Close()
 	for _, rule := range []db.EventRule{
 		{ID: "author", OnKind: eventRuleKindReviewVerdict, WakeRole: "author", Scope: db.EventRuleScopeAddressed, Enabled: true},
+		{ID: "requester", OnKind: eventRuleKindReviewVerdict, WakeRole: "requester", Scope: db.EventRuleScopeAddressed, Enabled: true},
 		{ID: "other", OnKind: eventRuleKindReviewVerdict, WakeRole: "other", Scope: db.EventRuleScopeAddressed, Enabled: true},
 		{ID: "auditor", OnKind: eventRuleKindReviewVerdict, WakeRole: "auditor", Scope: db.EventRuleScopeObserver, Enabled: true},
 	} {
@@ -904,17 +909,18 @@ pane="w1:p3"
 	wake := &fakeEventWake{}
 	sink := &eventRuleSink{store: store, home: home, wake: wake}
 	sink.evaluate(context.Background(), events.Event{
-		Type:           events.EventJobFinished,
-		Cause:          events.EventCauseReviewVerdict,
-		JobID:          "review-42",
-		Repo:           "owner/repo",
-		WakeTargetRole: "author",
-		PullRequest:    42,
-		ReviewDecision: "approved",
+		Type:            events.EventJobFinished,
+		Cause:           events.EventCauseReviewVerdict,
+		JobID:           "review-42",
+		Repo:            "owner/repo",
+		WakeTargetRole:  "author",
+		WakeTargetRoles: []string{"requester", "author"},
+		PullRequest:     42,
+		ReviewDecision:  "approved",
 	})
 
 	sort.Strings(wake.panes)
-	if got, want := fmt.Sprint(wake.panes), "[w1:p1 w1:p3]"; got != want {
+	if got, want := fmt.Sprint(wake.panes), "[w1:p1 w1:p3 w1:p4]"; got != want {
 		t.Fatalf("woken panes = %s, want %s", got, want)
 	}
 }

--- a/internal/events/sink.go
+++ b/internal/events/sink.go
@@ -149,14 +149,17 @@ type Event struct {
 	// EventType. It is assigned by trusted emit sites and deliberately bypasses
 	// free-text redaction and path scrubbing.
 	Cause string `json:"cause,omitempty"`
-	// WakeKind, WakeTargetRole, WakeOutboxIDs, PullRequest, and ReviewDecision
-	// are internal delivery metadata. They never alter the public event JSON
-	// contract.
-	WakeKind       string  `json:"-"`
-	WakeTargetRole string  `json:"-"`
-	WakeOutboxIDs  []int64 `json:"-"`
-	PullRequest    int     `json:"-"`
-	ReviewDecision string  `json:"-"`
+	// WakeKind, WakeTargetRole, WakeTargetRoles, WakeOutboxIDs, PullRequest, and
+	// ReviewDecision are internal delivery metadata. WakeTargetRole remains the
+	// primary target for single-address producers; WakeTargetRoles carries the
+	// complete target set for multi-address events. Neither alters the public
+	// event JSON contract.
+	WakeKind        string   `json:"-"`
+	WakeTargetRole  string   `json:"-"`
+	WakeTargetRoles []string `json:"-"`
+	WakeOutboxIDs   []int64  `json:"-"`
+	PullRequest     int      `json:"-"`
+	ReviewDecision  string   `json:"-"`
 }
 
 // Sink is the injected outbound seam the engine and daemon call from the

--- a/internal/workflow/engine_types.go
+++ b/internal/workflow/engine_types.go
@@ -169,7 +169,8 @@ func (e Engine) mailbox() Mailbox {
 			e.now(),
 			RedactCommentText,
 		)
-		wakeTargetRole := NormalizeActingOrgRole(payload.ActingOrgRole)
+		requesterRole := NormalizeActingOrgRole(payload.ActingOrgRole)
+		wakeTargetRole := requesterRole
 		if state == JobSucceeded && payload.PullRequest > 0 && payload.Result != nil && e.Store != nil {
 			decision := strings.ToLower(strings.TrimSpace(payload.Result.Decision))
 			job, jobErr := e.Store.GetJob(ctx, jobID)
@@ -183,6 +184,12 @@ func (e Engine) mailbox() Mailbox {
 				if resolveErr == nil {
 					owner = NormalizeActingOrgRole(resolved)
 				}
+				if owner == "" {
+					// Persistent seats implement directly rather than through
+					// implement jobs. Review dispatch still persists the
+					// registered implementing seat as LeadAgent.
+					owner = NormalizeActingOrgRole(payload.LeadAgent)
+				}
 				event.Cause = events.EventCauseReviewVerdict
 				wakeTargetRole = owner
 				event.PullRequest = payload.PullRequest
@@ -192,9 +199,15 @@ func (e Engine) mailbox() Mailbox {
 					// routable org role. ActingOrgRole is the persisted requester
 					// role paired with that sender; legacy jobs without one keep
 					// the resolved PR owner fallback above (#1712).
-					if requesterRole := NormalizeActingOrgRole(payload.ActingOrgRole); requesterRole != "" {
+					if requesterRole != "" {
 						wakeTargetRole = requesterRole
 					}
+				}
+				if requesterRole != "" {
+					event.WakeTargetRoles = append(event.WakeTargetRoles, requesterRole)
+				}
+				if owner != "" && !strings.EqualFold(owner, requesterRole) {
+					event.WakeTargetRoles = append(event.WakeTargetRoles, owner)
 				}
 			}
 		}

--- a/internal/workflow/engine_types.go
+++ b/internal/workflow/engine_types.go
@@ -184,7 +184,7 @@ func (e Engine) mailbox() Mailbox {
 				if resolveErr == nil {
 					owner = NormalizeActingOrgRole(resolved)
 				}
-				if owner == "" {
+				if resolveErr == nil && owner == "" {
 					// Persistent seats implement directly rather than through
 					// implement jobs. Review dispatch still persists the
 					// registered implementing seat as LeadAgent.

--- a/internal/workflow/event_sink_test.go
+++ b/internal/workflow/event_sink_test.go
@@ -56,14 +56,6 @@ func TestEngineEmitsJobFinishedOnSucceededTerminal(t *testing.T) {
 	ctx := context.Background()
 	store := openEngineStore(t)
 	seedAgent(t, store, "audit", []string{"review"}, "gitmoot/gitmoot")
-	if acquired, err := store.AcquireLock(ctx, db.BranchLock{
-		RepoFullName:  "gitmoot/gitmoot",
-		Branch:        "task-9",
-		Owner:         "audit",
-		ActingOrgRole: "author",
-	}); err != nil || !acquired {
-		t.Fatalf("AcquireLock returned acquired=%v err=%v", acquired, err)
-	}
 	sink := &recordingSink{}
 	engine := testEngine(store)
 	engine.EventSink = sink
@@ -80,6 +72,7 @@ func TestEngineEmitsJobFinishedOnSucceededTerminal(t *testing.T) {
 		PullRequest:   42,
 		TaskID:        "task-9",
 		TaskTitle:     "Review",
+		LeadAgent:     "author",
 		ActingOrgRole: "reviewer",
 	}); err != nil {
 		t.Fatalf("Enqueue returned error: %v", err)
@@ -99,6 +92,9 @@ func TestEngineEmitsJobFinishedOnSucceededTerminal(t *testing.T) {
 	}
 	if ev.WakeTargetRole != "author" {
 		t.Fatalf("wake target role = %q, want author", ev.WakeTargetRole)
+	}
+	if got := ev.WakeTargetRoles; len(got) != 2 || got[0] != "reviewer" || got[1] != "author" {
+		t.Fatalf("wake target roles = %v, want [reviewer author]", got)
 	}
 	if ev.Cause != events.EventCauseReviewVerdict || ev.PullRequest != 42 || ev.ReviewDecision != "approved" {
 		t.Fatalf("review verdict metadata = %+v", ev)
@@ -203,6 +199,9 @@ func TestEngineReturnsChangesRequestedToRequesterWithoutDefaultAutoFix(t *testin
 		event.WakeTargetRole != "requester" ||
 		event.Detail != "one blocking issue" {
 		t.Fatalf("changes-requested verdict event = %+v", event)
+	}
+	if got := event.WakeTargetRoles; len(got) != 2 || got[0] != "requester" || got[1] != "author" {
+		t.Fatalf("wake target roles = %v, want [requester author]", got)
 	}
 }
 func TestEngineDoesNotClassifyNonReviewApprovedResult(t *testing.T) {

--- a/internal/workflow/event_sink_test.go
+++ b/internal/workflow/event_sink_test.go
@@ -2,6 +2,7 @@ package workflow
 
 import (
 	"context"
+	"database/sql"
 	"errors"
 	"strings"
 	"sync"
@@ -107,9 +108,55 @@ func TestEngineEmitsJobFinishedOnSucceededTerminal(t *testing.T) {
 	}
 }
 
+func TestEngineReviewVerdictResolverErrorDoesNotFallbackToLead(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	if err := store.CreateJob(ctx, db.Job{
+		ID: "review-resolver-error", Agent: "audit", Type: "review", State: string(JobSucceeded), Payload: "{}",
+	}); err != nil {
+		t.Fatalf("CreateJob returned error: %v", err)
+	}
+	raw, err := sql.Open("sqlite", store.DatabasePath())
+	if err != nil {
+		t.Fatalf("open raw database: %v", err)
+	}
+	defer raw.Close()
+	if _, err := raw.ExecContext(ctx, `DROP TABLE branch_locks`); err != nil {
+		t.Fatalf("drop branch_locks: %v", err)
+	}
+
+	sink := &recordingSink{}
+	engine := testEngine(store)
+	engine.EventSink = sink
+	engine.mailbox().emitTerminal(ctx, "review-resolver-error", JobSucceeded, JobPayload{
+		Repo:          "gitmoot/gitmoot",
+		Branch:        "task-resolver-error",
+		PullRequest:   46,
+		TaskID:        "task-resolver-error",
+		LeadAgent:     "stale-lead",
+		ActingOrgRole: "requester",
+		Result:        &AgentResult{Decision: "approved", Summary: "lookup failed"},
+	})
+
+	finished := sink.byType(events.EventJobFinished)
+	if len(finished) != 1 {
+		t.Fatalf("job.finished emissions = %d, want 1; all=%+v", len(finished), sink.snapshot())
+	}
+	event := finished[0]
+	if event.Cause != events.EventCauseReviewVerdict {
+		t.Fatalf("review verdict metadata = %+v", event)
+	}
+	if event.WakeTargetRole != "" {
+		t.Fatalf("primary wake target = %q, want empty after resolver error", event.WakeTargetRole)
+	}
+	if got := event.WakeTargetRoles; len(got) != 1 || got[0] != "requester" {
+		t.Fatalf("wake target roles = %v, want [requester]", got)
+	}
+}
 func TestEngineReturnsChangesRequestedToRequesterWithoutDefaultAutoFix(t *testing.T) {
 	ctx := context.Background()
 	store := openEngineStore(t)
+
 	seedAgent(t, store, "author", []string{"implement"}, "gitmoot/gitmoot")
 	seedAgent(t, store, "audit", []string{"review"}, "gitmoot/gitmoot")
 	if err := store.UpsertTask(ctx, db.Task{

--- a/skills/gitmoot/references/CLI.md
+++ b/skills/gitmoot/references/CLI.md
@@ -1877,9 +1877,12 @@ gitmoot org events rule rm --home /alternate/home <rule-id>
 `review-verdict`, `blocked`, `recycle-overdue`, `pane_input_pending`, `reply`,
 `directive`, or `fact`. A successful review terminal whose decision is
 `approved` or `changes_requested` matches both `job-terminal` and
-`review-verdict` and addresses the resolved pull request owner. If no owner can
-be resolved, addressed rules fail closed while observer rules remain eligible.
-`pane_input_pending` matches the
+`review-verdict` and addresses both the requesting org role and the resolved
+implementing role. When a successful ownership lookup finds no implement job
+or branch lock attribution, the review's persisted lead identifies a
+persistent implementing seat; lookup errors remain fail-closed. If neither
+role can be resolved, addressed rules fail closed while observer rules remain
+eligible. `pane_input_pending` matches the
 `org.input_pending` event emitted when Herdr continuously reports
 `input_pending: true` for a role's pane longer than
 `[orchestrate].blocked_role_wake_after`; it re-nudges at most once per that

--- a/website/docs/reference/cli.md
+++ b/website/docs/reference/cli.md
@@ -1672,9 +1672,12 @@ gitmoot org events rule rm --home /alternate/home <rule-id>
 `review-verdict`, `blocked`, `recycle-overdue`, `pane_input_pending`, `reply`,
 `directive`, or `fact`. A successful review terminal whose decision is
 `approved` or `changes_requested` matches both `job-terminal` and
-`review-verdict` and addresses the resolved pull request owner. If no owner can
-be resolved, addressed rules fail closed while observer rules remain eligible.
-`pane_input_pending` matches the
+`review-verdict` and addresses both the requesting org role and the resolved
+implementing role. When a successful ownership lookup finds no implement job
+or branch lock attribution, the review's persisted lead identifies a
+persistent implementing seat; lookup errors remain fail-closed. If neither
+role can be resolved, addressed rules fail closed while observer rules remain
+eligible. `pane_input_pending` matches the
 `org.input_pending` event emitted when Herdr continuously reports
 `input_pending: true` for a role's pane longer than
 `[orchestrate].blocked_role_wake_after`; it re-nudges at most once per that

--- a/website/docs/reference/event-stream.md
+++ b/website/docs/reference/event-stream.md
@@ -214,9 +214,13 @@ case-insensitive and exact. Job IDs always use case-insensitive substring
 matching, including slash-bearing delegation IDs. Without a slash, repositories
 also use substring matching; empty matches all. Pass only one of `--match` and
 `--repo`. A successful review terminal whose decision is `approved` or
-`changes_requested` matches both `job-terminal` and `review-verdict` and
-addresses the pull request owner's role. If no role can be resolved, addressed
-rules fail closed while observer rules can still receive the verdict. A plain
+`changes_requested` matches both `job-terminal` and `review-verdict`. Addressed
+rules may deliver that verdict to both the requesting org role and the pull
+request's implementing role. When a successful ownership lookup finds no
+implement job or branch lock attribution, the review's persisted lead
+identifies a persistent implementing seat; lookup errors remain fail-closed. If
+neither role can be resolved, addressed rules fail closed while observer rules
+can still receive the verdict. A plain
 `job.blocked` event matches both `job-terminal` and `blocked`, while
 guard-caused blocks match `guard` first. A synthesized `blocked_since` event
 matches only `blocked`. Task episodes due in

--- a/website/static/llms-full.txt
+++ b/website/static/llms-full.txt
@@ -2736,6 +2736,8 @@ Symptoms:
 - The PR remains `ready_to_merge`.
 - `gitmoot/merge-gate` is pending or failing.
 - The daemon retries a queued merge.
+- `gitmoot/merge-gate` is pending with `Gitmoot merge gate has not cleared
+  this head` before the policy gate has produced a more specific verdict.
 
 Checks:
 
@@ -2747,6 +2749,21 @@ git status --short
 
 Fixes:
 
+- The generic `has not cleared this head` status makes an active managed head
+  visibly unjudged, so an unevaluated head stops reading as an approved one. A
+  later gate evaluation replaces it with the specific pending, failure, or
+  success verdict for that same head.
+- Gitmoot publishes it only while it owns the merge decision. With
+  `[merge_gate] auto_merge = false`, with `GITMOOT_DISABLE_NATIVE_MERGE_GATE=1`,
+  or once a task reaches `awaiting_human_merge`, `dismissed`, `superseded`,
+  `stranded` or `merged`, Gitmoot replaces only its own generic marker with
+  `Gitmoot merge gate is not applied to this head` and preserves a real gate
+  failure or a specific pending verdict.
+- A `blocked` or `awaiting_human` task KEEPS the generic marker, because that
+  head genuinely has not been cleared and Gitmoot can still resolve it when the
+  task resumes.
+- A draft pull request keeps the generic marker until it is undrafted, because
+  the gate deliberately withholds a verdict on a draft head.
 - Clean the local worktree before the daemon attempts the merge.
 - If the reason says an active job is in flight on the PR branch, let that queued
   or running job settle (or cancel it deliberately). This is a transient safety
@@ -3064,9 +3081,13 @@ case-insensitive and exact. Job IDs always use case-insensitive substring
 matching, including slash-bearing delegation IDs. Without a slash, repositories
 also use substring matching; empty matches all. Pass only one of `--match` and
 `--repo`. A successful review terminal whose decision is `approved` or
-`changes_requested` matches both `job-terminal` and `review-verdict` and
-addresses the pull request owner's role. If no role can be resolved, addressed
-rules fail closed while observer rules can still receive the verdict. A plain
+`changes_requested` matches both `job-terminal` and `review-verdict`. Addressed
+rules may deliver that verdict to both the requesting org role and the pull
+request's implementing role. When a successful ownership lookup finds no
+implement job or branch lock attribution, the review's persisted lead
+identifies a persistent implementing seat; lookup errors remain fail-closed. If
+neither role can be resolved, addressed rules fail closed while observer rules
+can still receive the verdict. A plain
 `job.blocked` event matches both `job-terminal` and `blocked`, while
 guard-caused blocks match `guard` first. A synthesized `blocked_since` event
 matches only `blocked`. Task episodes due in
@@ -9918,8 +9939,8 @@ can discover Gitmoot through an installed runtime plugin. Use
 adds the resolved `.gitmoot` home to the sandbox on Linux, macOS, and Windows.
 Use `gitmoot goal template` when
 writing a standard task-by-task goal file. Use `gitmoot workflow list`, `gitmoot
-workflow show`, `gitmoot workflow describe`, `gitmoot workflow note`, and
-`gitmoot workflow close` to
+workflow show`, `gitmoot workflow show-note`, `gitmoot workflow describe`,
+`gitmoot workflow note`, and `gitmoot workflow close` to
 inspect external-coordinator workflow groups, set their stable description, add
 verbatim journal entries, set a manual status escape hatch, optionally stage
 a note in persistent memory, and end a finished group. Workflow hygiene:
@@ -9927,6 +9948,9 @@ a note in persistent memory, and end a finished group. Workflow hygiene:
 work merges or completes — never-closed workflows accumulate and bury live
 work in the dashboard's active buckets and every workflow-picking surface. Linked PR lifecycle transitions also add deduped
 `daemon` journal notes and advance live status.
+In org mode, `gitmoot org message send --to <role> --workflow <label>
+"<message>"` gives distinct same-parent siblings a durable sender-attributed
+heads-up. It creates no acknowledgment, completion, TTL, or nag obligation.
 In org mode, obligations and questions have a full lifecycle and closing it is
 part of the work: `gitmoot org directive send --to <role> --workflow <label>`
 mints a tracked, TTL-nudged obligation; `org directive ack <id>` records
@@ -11885,8 +11909,8 @@ whichever current pane uniquely carries that cosmetic value. `org seat add`
 canonicalizes new bindings to ids. Roles without a binding report unknown live
 presence, and event wakes for them are skipped with an observable log and
 increment the role's missed-wake counter rather than being inferred from a pane
-label. There is exactly one root named `owner`; accepted scopes are `*`,
-`owner/*`, and
+label. There is
+exactly one root named `owner`; accepted scopes are `*`, `owner/*`, and
 `owner/repo`, and each child scope must be covered by its parent. Malformed
 org configuration fails closed and loudly. `brief` records passive last-seen
 presence for its role and can render static context with provider state
@@ -12140,9 +12164,12 @@ gitmoot org events rule rm --home /alternate/home <rule-id>
 `review-verdict`, `blocked`, `recycle-overdue`, `pane_input_pending`, `reply`,
 `directive`, or `fact`. A successful review terminal whose decision is
 `approved` or `changes_requested` matches both `job-terminal` and
-`review-verdict` and addresses the resolved pull request owner. If no owner can
-be resolved, addressed rules fail closed while observer rules remain eligible.
-`pane_input_pending` matches the
+`review-verdict` and addresses both the requesting org role and the resolved
+implementing role. When a successful ownership lookup finds no implement job
+or branch lock attribution, the review's persisted lead identifies a
+persistent implementing seat; lookup errors remain fail-closed. If neither
+role can be resolved, addressed rules fail closed while observer rules remain
+eligible. `pane_input_pending` matches the
 `org.input_pending` event emitted when Herdr continuously reports
 `input_pending: true` for a role's pane longer than
 `[orchestrate].blocked_role_wake_after`; it re-nudges at most once per that


### PR DESCRIPTION
Closes #1738

## Summary
- carry the requester and implementing-seat roles on review-verdict events
- resolve a persistent implementing seat from the review lead when no implement job or branch lock exists
- match addressed event rules against every verdict addressee while preserving observer delivery
- document the multi-addressee contract

## Tests
- PASS: `go test ./internal/workflow -run '^(TestEngineEmitsJobFinishedOnSucceededTerminal|TestEngineReturnsChangesRequestedToRequesterWithoutDefaultAutoFix)$' -count=1 -v` (2 tests)
- PASS: `go test ./internal/cli -run '^TestReviewVerdictWakeTargetsRequesterImplementerAndObservers$' -count=1 -v` (1 test; author, requester, and observer wakes delivered)
- PASS: `go test ./internal/events ./internal/workflow ./internal/cli -count=1` for internal/events and internal/workflow
- Known unrelated environment failure in the broader focused run: internal/cli `TestClaudeProduceHookAutoReadLandlockE2E` exited 41

Implementation authorization: directive 100388 / durable assignment note 100445. Persistent seat `gm-omp-e2b` is the sole implementer; no implementation job was dispatched.