### PR TITLE
fix(review): keep native fanout off task checkouts

### DIFF
--- a/internal/cli/daemon_checkout_test.go
+++ b/internal/cli/daemon_checkout_test.go
@@ -213,6 +213,30 @@ func TestTaskWorktreeCheckoutPrefersDelegationPayloadWorktree(t *testing.T) {
 	}
 }
 
+func TestQueuedPRReviewCheckoutKeyNeverFallsBackToOwningTaskWorktree(t *testing.T) {
+	ctx := context.Background()
+	store := daemonWorkerStore(t)
+	taskCheckout := t.TempDir()
+	if err := store.UpsertTask(ctx, db.Task{
+		ID: "task-1", RepoFullName: "owner/repo", Branch: "feature/review", WorktreePath: taskCheckout,
+	}); err != nil {
+		t.Fatalf("UpsertTask returned error: %v", err)
+	}
+	job := db.Job{
+		ID:   "review-job",
+		Type: "review",
+		Payload: mustJobPayload(t, workflow.JobPayload{
+			Repo: "owner/repo", Branch: "feature/review", PullRequest: 42,
+			HeadSHA: "exact-review-head", TaskID: "task-1", ReviewRound: "1",
+			Reviewers: []string{"reviewer"},
+		}),
+	}
+
+	if key := queuedJobCheckoutKey(ctx, store, job); key != "job:review-job" {
+		t.Fatalf("pathless PR review checkout key = %q, want job-local key; task checkout %q is not the review head", key, taskCheckout)
+	}
+}
+
 func TestResolveJobCheckoutSelfHealsDanglingLinkedWorktree(t *testing.T) {
 	ctx := context.Background()
 	home := t.TempDir()

--- a/internal/cli/daemon_scheduler.go
+++ b/internal/cli/daemon_scheduler.go
@@ -2422,6 +2422,21 @@ func queuedJobCheckoutKey(ctx context.Context, store *db.Store, job db.Job) stri
 	if err != nil || strings.TrimSpace(payload.Repo) == "" {
 		return "job:" + job.ID
 	}
+	// A PR review's TaskID names the owning implementation task. Its task-table
+	// worktree may therefore be the registered implementation checkout, never the
+	// exact review head. Normal native and local review dispatches are born with an
+	// owned payload WorktreePath; a legacy or misconfigured pathless review gets a
+	// job-local scheduler key until the worker allocates that exact-head worktree.
+	// It must not inherit either the task checkout key or repo:<repo>.
+	if job.Type == "review" && payload.PullRequest > 0 && strings.TrimSpace(payload.HeadSHA) != "" {
+		if path := strings.TrimSpace(payload.WorktreePath); path != "" {
+			normalized, normalizeErr := normalizeTaskWorktreePath(path)
+			if normalizeErr == nil && normalized != "" {
+				return "worktree:" + normalized
+			}
+		}
+		return "job:" + job.ID
+	}
 	if path, ok := queuedJobTaskWorktreePath(ctx, store, payload); ok {
 		return "worktree:" + path
 	}

--- a/internal/cli/native_review_worktree_test.go
+++ b/internal/cli/native_review_worktree_test.go
@@ -285,13 +285,14 @@ func cleanupNativeReviewWorktrees(t *testing.T, checkout string, paths ...string
 
 // TestRoutineNativeReviewLegsGetDistinctSchedulerCheckoutKeys is F2. Two reviewer
 // legs for ONE pull request used to be admitted on the same repo:<repo> checkout
-// key, because queuedJobCheckoutKey reads payload.WorktreePath and the routine leg
-// carried none until the worker allocated one AFTER admission. Scheduler
-// exclusivity is strict (`if s.checkouts[checkoutKey] { return false }`), so only
-// one leg ran per tick and it held that key for a full LLM review.
+// key, because queuedJobCheckoutKey saw no payload WorktreePath until the worker
+// allocated one AFTER admission. Scheduler exclusivity is strict
+// (`if s.checkouts[checkoutKey] { return false }`), so only one leg ran per tick
+// and it held that key for a full LLM review.
 //
-// MUTATION PROOF: make prepareNativeReviewWorktree return its request untouched
-// and both keys collapse to "repo:owner/repo".
+// MUTATION PROOF: make prepareNativeReviewWorktree return its request untouched.
+// The payload assertions fail even though the scheduler's defensive job-local key
+// prevents TaskID from redirecting the leg to the implementation checkout.
 func TestRoutineNativeReviewLegsGetDistinctSchedulerCheckoutKeys(t *testing.T) {
 	ctx := context.Background()
 	store, home := blockerE2EHome(t)
@@ -300,6 +301,12 @@ func TestRoutineNativeReviewLegsGetDistinctSchedulerCheckoutKeys(t *testing.T) {
 	seedDaemonWorkerAgentWithPolicy(t, store, "reviewer-a", runtime.ClaudeRuntime, runtime.LastRef, []string{"review"}, "owner/repo", runtime.AutonomyPolicyReadOnly)
 	seedDaemonWorkerAgentWithPolicy(t, store, "reviewer-b", runtime.ClaudeRuntime, runtime.LastRef, []string{"review"}, "owner/repo", runtime.AutonomyPolicyReadOnly)
 	seedDaemonWorkerAgentWithPolicy(t, store, "implementer", runtime.ShellRuntime, "true", []string{"implement"}, "owner/repo", runtime.AutonomyPolicyWorkspaceWrite)
+	if err := store.UpsertTask(ctx, db.Task{
+		ID: "task-1698", RepoFullName: "owner/repo", State: string(workflow.TaskImplementing),
+		Branch: "feature/review", WorktreePath: sharedCheckout,
+	}); err != nil {
+		t.Fatalf("seed owning implementation task: %v", err)
+	}
 
 	fanout := routineNativeReviewFanoutEngine(store, sharedCheckout, home)
 	if err := fanout.HandlePullRequestOpened(ctx, workflow.PullRequestEvent{
@@ -344,8 +351,9 @@ func TestRoutineNativeReviewLegsGetDistinctSchedulerCheckoutKeys(t *testing.T) {
 			t.Fatalf("leg %s worktree head = %q, want the review head %q", job.ID, head, reviewHead)
 		}
 		key := queuedJobCheckoutKey(ctx, store, job)
-		if !strings.HasPrefix(key, "worktree:") {
-			t.Fatalf("leg %s checkout key = %q, want worktree:<path> (it would serialize on the shared repo key)", job.ID, key)
+		wantKey := "worktree:" + payload.WorktreePath
+		if key != wantKey {
+			t.Fatalf("leg %s checkout key = %q, want exact review worktree key %q, not owning task checkout %q", job.ID, key, wantKey, sharedCheckout)
 		}
 		keys[job.ID] = key
 		// The SAME configuration must not also allocate in the worker: the helper's


### PR DESCRIPTION
Closes #1741.

Directive: workflow row 100485.

## What changed
- exact-head PR reviews never derive their scheduler checkout key from the owning implementation task
- pathless legacy/native review rows stay job-local until the worker allocates the exact-head read-only worktree
- production native fanout regression seeds the owning task with the registered checkout and proves queued payloads are born with a distinct exact-head read-only WorktreePath

## Verification
- `/tmp/go1.26/bin/go test -count=1 ./internal/cli -run '^Test(NativeReviewWorkerRunsInOwnedExactHeadWorktree|RoutineNativeReviewLegsGetDistinctSchedulerCheckoutKeys|QueuedPRReviewCheckoutKeyNeverFallsBackToOwningTaskWorktree)$'`
- `git diff --check`

The previously reported `events.Event.WakeTargetRole` compile baseline is separate and does not reproduce on fresh main: the field exists in `internal/events/sink.go`, and the focused CLI package tests compile and pass.