### PR TITLE
docs: define throughput and drain modes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -329,16 +329,19 @@ that PR's `mergedAt` time. At the next check-in, the coordinator must:
 2. comment on the merged mode-switch PR with this exact transition record:
    `[workload-mode-transition]`, `mode: <THROUGHPUT|DRAIN>`,
    `effective_commit: <40-character SHA>`, `observed_at: <RFC3339>`, zero or more
-   `implementer: <seat> pr=<number>` lines, zero or more
-   `review: <job-id> pr=<number>` lines, then
+   `implementer: <seat> issue=<number> pr=<number|none> accepted_at=<RFC3339>`
+   lines, zero or more `review: <job-id> pr=<number> created_at=<RFC3339>`
+   lines, then
    `[/workload-mode-transition]`.
 
 For DRAIN, the listed transition wave is derived from durable timestamps:
 implementation assignments accepted before `mergedAt` that have not reached a
 terminal handoff, plus review jobs created before `mergedAt` that were queued or
-running then. The merged PR always exists, so this record does not depend on a
-pre-existing workflow. The mode changes how much work may start; it never
-relaxes correctness, exact-head review, CI, or owner merge authority.
+running then. `accepted_at` is the timestamp of the Herdr pane's first
+`working` status event after the issue-backed assignment prompt; `created_at` is
+the job-store timestamp. The merged PR always exists, so this record does not
+depend on a pre-existing workflow. The mode changes how much work may start; it
+never relaxes correctness, exact-head review, CI, or owner merge authority.
 
 Across both modes, use exactly one independent reviewer per corrected head.
 Parallel review lanes mean different PRs, not multiple reviewers on one head.
@@ -366,11 +369,19 @@ specific incident; an incident does not override this rule by itself.
   explicit cancellation. Once occupancy reaches the cap, it must not rise above
   it again; never replace a completed transition-wave item with new work.
 - After activation, cap the `gitmoot/*` scope at **two active implementers and
-  one admitted review job**. An active implementer is a persistent seat
-  currently changing code or a running engine implementation job. An admitted
-  review job is in `queued` or `running`. Only the coordinator may enqueue
-  reviews in DRAIN, serially, after confirming there is no queued or running
-  review job across `gitmoot/*`.
+  one running reviewer**. An active implementer is a persistent seat currently
+  changing code or a running engine implementation job.
+- A DRAIN mode-switch PR is not merge-ready until the coordinator configures
+  the shared daemon with `[daemon] workers = 1`, applies the warm reload, and
+  verifies the effective worker count. This is the atomic runtime gate shared by
+  native PR fanout, heartbeats, and manual background reviews. All DRAIN reviews
+  must run as background engine jobs; never bypass the gate with a foreground or
+  persistent-seat reviewer.
+- Before that PR merges, disable every `action=review` heartbeat and allow
+  exactly one review-capable agent on each active `gitmoot/*` repository. For a
+  PR with a branch lock, the native PR watcher is the sole producer; do not also
+  dispatch a manual review. For a PR without a branch lock, native fanout cannot
+  run, so only the coordinator may enqueue its single manual review.
 - Prioritize merge-ready work and merge-gate integrity, then serial dependency
   chains, then resource-safety work. Rebase conflicted branches only after
   upstream merges settle. Keep drafts and backlog work parked.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -321,28 +321,48 @@ quota).
 
 **Current mode: DRAIN.**
 
-Update the line above whenever the owner switches modes. The mode changes how
-much work may start; it never relaxes correctness, exact-head review, CI, or
-owner merge authority.
+A mode switch has two required records:
+
+1. Update the line above through the normal repository process. This is the
+   durable default for new checkouts and sessions.
+2. Write an `[operating-mode ...]` note to `gitmoot/worktree-lifecycle`. The note
+   takes effect immediately for already-running coordinators and seats.
+
+At every check-in, the coordinator reads the latest mode note and steers active
+seats that still have an older `AGENTS.md`. If the repository line and latest
+note disagree, enforce the more restrictive mode until they are synchronized.
+The mode changes how much work may start; it never relaxes correctness,
+exact-head review, CI, or owner merge authority.
+
+Across both modes, use exactly one independent reviewer per corrected head.
+Parallel review lanes mean different PRs, not multiple reviewers on one head.
+Review panels and fanout require explicit, durable owner authorization for that
+specific incident; an incident does not override this rule by itself.
 
 ### Throughput mode
 
 - Start independent, issue-backed work when ownership and integration order are
   clear.
-- Parallelize genuinely independent implementation and review lanes under the
-  repository's normal safety and review rules.
+- Parallelize genuinely independent implementation lanes and reviews of
+  different PRs under the repository's normal safety rules.
 - Stop opening new lanes when work queues behind shared files, unresolved
   integration order, or repeated review findings.
 
 ### Drain mode
 
 - Finish and merge the active queue; do not expand it. Do not start new issues,
-  PRs, experiments, speculative cleanup, or review panels unless a security,
-  data-loss, or live-service incident requires it.
-- Let work already in flight reach its next stable reviewed head. After that
-  wave, cap concurrency at **two implementation seats and one independent
-  reviewer**.
-- Use one independent reviewer per corrected head. Do not fan reviews out.
+  PRs, experiments, or speculative cleanup unless a security, data-loss, or
+  live-service incident requires containment.
+- The activation note must enumerate the grandfathered running implementation
+  seats and review jobs. An unlisted item is not part of the transition wave.
+  Each listed item loses its exemption at its first subsequent terminal handoff:
+  review verdict, blocked or parked seat, merged PR, or explicit cancellation.
+- After activation, cap the `gitmoot/*` scope at **two active implementers and
+  one running reviewer**. An active implementer is a persistent seat currently
+  changing code or a running engine implementation job. A running reviewer is a
+  review job in `running`; queued reviews do not consume the slot. Do not
+  enqueue another review while the running slot is occupied. Never replace a
+  completed transition-wave item with new work.
 - Prioritize merge-ready work and merge-gate integrity, then serial dependency
   chains, then resource-safety work. Rebase conflicted branches only after
   upstream merges settle. Keep drafts and backlog work parked.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -321,18 +321,24 @@ quota).
 
 **Current mode: DRAIN.**
 
-A mode switch has two required records:
+A mode switch is a merged PR that changes the line above. It takes effect at
+that PR's `mergedAt` time. At the next check-in, the coordinator must:
 
-1. Update the line above through the normal repository process. This is the
-   durable default for new checkouts and sessions.
-2. Write an `[operating-mode ...]` note to `gitmoot/worktree-lifecycle`. The note
-   takes effect immediately for already-running coordinators and seats.
+1. fetch `origin/main`, read the marker from `origin/main:AGENTS.md` rather than
+   the seat's worktree, and steer every active seat to the merged mode;
+2. comment on the merged mode-switch PR with this exact transition record:
+   `[workload-mode-transition]`, `mode: <THROUGHPUT|DRAIN>`,
+   `effective_commit: <40-character SHA>`, `observed_at: <RFC3339>`, zero or more
+   `implementer: <seat> pr=<number>` lines, zero or more
+   `review: <job-id> pr=<number>` lines, then
+   `[/workload-mode-transition]`.
 
-At every check-in, the coordinator reads the latest mode note and steers active
-seats that still have an older `AGENTS.md`. If the repository line and latest
-note disagree, enforce the more restrictive mode until they are synchronized.
-The mode changes how much work may start; it never relaxes correctness,
-exact-head review, CI, or owner merge authority.
+For DRAIN, the listed transition wave is derived from durable timestamps:
+implementation assignments accepted before `mergedAt` that have not reached a
+terminal handoff, plus review jobs created before `mergedAt` that were queued or
+running then. The merged PR always exists, so this record does not depend on a
+pre-existing workflow. The mode changes how much work may start; it never
+relaxes correctness, exact-head review, CI, or owner merge authority.
 
 Across both modes, use exactly one independent reviewer per corrected head.
 Parallel review lanes mean different PRs, not multiple reviewers on one head.
@@ -353,16 +359,18 @@ specific incident; an incident does not override this rule by itself.
 - Finish and merge the active queue; do not expand it. Do not start new issues,
   PRs, experiments, or speculative cleanup unless a security, data-loss, or
   live-service incident requires containment.
-- The activation note must enumerate the grandfathered running implementation
-  seats and review jobs. An unlisted item is not part of the transition wave.
-  Each listed item loses its exemption at its first subsequent terminal handoff:
-  review verdict, blocked or parked seat, merged PR, or explicit cancellation.
+- Grandfathered transition-wave items may temporarily exceed the normal cap,
+  but they count toward occupancy. No unlisted work may start while occupancy
+  exceeds the cap. Each listed item loses its exemption at its first subsequent
+  terminal handoff: review verdict, blocked or parked seat, merged PR, or
+  explicit cancellation. Once occupancy reaches the cap, it must not rise above
+  it again; never replace a completed transition-wave item with new work.
 - After activation, cap the `gitmoot/*` scope at **two active implementers and
-  one running reviewer**. An active implementer is a persistent seat currently
-  changing code or a running engine implementation job. A running reviewer is a
-  review job in `running`; queued reviews do not consume the slot. Do not
-  enqueue another review while the running slot is occupied. Never replace a
-  completed transition-wave item with new work.
+  one admitted review job**. An active implementer is a persistent seat
+  currently changing code or a running engine implementation job. An admitted
+  review job is in `queued` or `running`. Only the coordinator may enqueue
+  reviews in DRAIN, serially, after confirming there is no queued or running
+  review job across `gitmoot/*`.
 - Prioritize merge-ready work and merge-gate integrity, then serial dependency
   chains, then resource-safety work. Rebase conflicted branches only after
   upstream merges settle. Keep drafts and backlog work parked.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -372,11 +372,15 @@ specific incident; an incident does not override this rule by itself.
   one running reviewer**. An active implementer is a persistent seat currently
   changing code or a running engine implementation job.
 - A DRAIN mode-switch PR is not merge-ready until the coordinator configures
-  the shared daemon with `[daemon] workers = 1`, applies the warm reload, and
-  verifies the effective worker count. This is the atomic runtime gate shared by
-  native PR fanout, heartbeats, and manual background reviews. All DRAIN reviews
-  must run as background engine jobs; never bypass the gate with a foreground or
-  persistent-seat reviewer.
+  the shared daemon with `[daemon] workers = 1`; every active
+  `[repos."gitmoot/*"].max_parallel` override must be absent, zero, or one.
+  Apply the warm reload and verify both the effective global worker count and
+  every effective per-repository limit. This is the atomic runtime gate shared
+  by native PR fanout, heartbeats, and manual background reviews.
+- Before that PR merges, every foreground or persistent-seat review already in
+  progress must reach a terminal handoff; those reviews cannot be grandfathered.
+  All DRAIN reviews then run as background engine jobs. Never bypass the shared
+  gate with a foreground or persistent-seat reviewer.
 - Before that PR merges, disable every `action=review` heartbeat and allow
   exactly one review-capable agent on each active `gitmoot/*` repository. For a
   PR with a branch lock, the native PR watcher is the sole producer; do not also

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -317,6 +317,42 @@ live-probe before close. The **OWNER holds merge authority**. Under ultracode,
 orchestrate via the Workflow tool with opus sub-agents (protect the scarcer fable
 quota).
 
+## Workload mode
+
+**Current mode: DRAIN.**
+
+Update the line above whenever the owner switches modes. The mode changes how
+much work may start; it never relaxes correctness, exact-head review, CI, or
+owner merge authority.
+
+### Throughput mode
+
+- Start independent, issue-backed work when ownership and integration order are
+  clear.
+- Parallelize genuinely independent implementation and review lanes under the
+  repository's normal safety and review rules.
+- Stop opening new lanes when work queues behind shared files, unresolved
+  integration order, or repeated review findings.
+
+### Drain mode
+
+- Finish and merge the active queue; do not expand it. Do not start new issues,
+  PRs, experiments, speculative cleanup, or review panels unless a security,
+  data-loss, or live-service incident requires it.
+- Let work already in flight reach its next stable reviewed head. After that
+  wave, cap concurrency at **two implementation seats and one independent
+  reviewer**.
+- Use one independent reviewer per corrected head. Do not fan reviews out.
+- Prioritize merge-ready work and merge-gate integrity, then serial dependency
+  chains, then resource-safety work. Rebase conflicted branches only after
+  upstream merges settle. Keep drafts and backlog work parked.
+- If another correction receives a new substantive P1, stop the patch loop and
+  re-plan the defect class before writing more code.
+- Run routine coordinator check-ins hourly. Owner messages, directives, and
+  review verdicts remain immediate.
+- Zero-model-token operational pipelines, including the hourly PR report, may
+  continue.
+
 ## Escalation: ping your org parent, and ping again
 
 When you need something from your **org parent** — a dispatch you cannot make, a


### PR DESCRIPTION
## Summary
- define throughput and drain workload modes in AGENTS.md
- set the current mode to DRAIN
- cap post-wave drain concurrency at two implementation seats and one reviewer
- require one reviewer per corrected head, no fanout, hourly routine check-ins, and re-planning after a repeated substantive P1

Closes #1746.

## Verification
- `git diff --check -- AGENTS.md`

Owner authorization: Gitmoot workflow note 100849.