### PR TITLE
fix(org): park malformed directives

### DIFF
--- a/internal/cli/blocked_since.go
+++ b/internal/cli/blocked_since.go
@@ -471,7 +471,12 @@ func evaluateOrgDirectiveTTLs(ctx context.Context, store *db.Store, sink events.
 	for _, item := range items {
 		from, to, _, _, ok := workflow.ParseOrgDirectiveNote(item.Body)
 		if !ok {
-			writeLine(stdout, "org directive %d TTL skipped: malformed directive marker", item.ID)
+			parked, parkErr := store.ParkMalformedOrgDirective(ctx, item.ID, now, "malformed directive marker")
+			if parkErr != nil {
+				writeLine(stdout, "org directive %d malformed marker park failed: %v", item.ID, parkErr)
+			} else if parked {
+				writeLine(stdout, "org directive %d parked: malformed directive marker", item.ID)
+			}
 			continue
 		}
 		anchor, ttl, phase, unacked, due := directiveTTLDue(item, orgConfig, now)

--- a/internal/cli/blocked_since.go
+++ b/internal/cli/blocked_since.go
@@ -471,7 +471,7 @@ func evaluateOrgDirectiveTTLs(ctx context.Context, store *db.Store, sink events.
 	for _, item := range items {
 		from, to, _, _, ok := workflow.ParseOrgDirectiveNote(item.Body)
 		if !ok {
-			parked, parkErr := store.ParkMalformedOrgDirective(ctx, item.ID, now, "malformed directive marker")
+			parked, parkErr := store.ParkMalformedOrgDirective(ctx, item.ID, now)
 			if parkErr != nil {
 				writeLine(stdout, "org directive %d malformed marker park failed: %v", item.ID, parkErr)
 			} else if parked {

--- a/internal/cli/org_directive_ttl_test.go
+++ b/internal/cli/org_directive_ttl_test.go
@@ -110,7 +110,7 @@ func TestEvaluateOrgDirectiveTTLsParksMalformedDirectiveOnce(t *testing.T) {
 	malformed, err := store.InsertWorkflowNote(context.Background(), db.WorkflowNote{
 		WorkflowID: "release/ttl",
 		Author:     "sender",
-		Body:       "[org:directive malformed]",
+		Body:       "[org:directive to=worker from=sender] missing-wf",
 		Repo:       "gitmoot/gitmoot",
 	})
 	if err != nil {
@@ -141,6 +141,25 @@ func TestEvaluateOrgDirectiveTTLsParksMalformedDirectiveOnce(t *testing.T) {
 	}
 	if len(parked) != 1 || parked[0].ID != malformed.ID || parked[0].ParkedAt == "" || parked[0].ParkedReason != "malformed directive marker" {
 		t.Fatalf("parked directives = %+v, want malformed directive %d with durable reason", parked, malformed.ID)
+	}
+	unparked, err := store.UnparkOrgDirectivesForRole(context.Background(), "worker", now.Add(time.Minute))
+	if err != nil || unparked != 0 {
+		t.Fatalf("direct role unpark = %d, %v; want malformed park retained", unparked, err)
+	}
+	if err := store.UpsertOrgRoleArchived(context.Background(), db.OrgRoleArchived{
+		Role: "worker", ArchivedAt: now.Format(time.RFC3339Nano), ArchivedBy: "test", ObservedAt: now.Format(time.RFC3339Nano),
+	}); err != nil {
+		t.Fatal(err)
+	}
+	unparked, err = store.UnarchiveOrgSeatTransition(context.Background(), "worker", now.Add(2*time.Minute))
+	if err != nil || unparked != 0 {
+		t.Fatalf("atomic role unarchive = %d, %v; want malformed park retained", unparked, err)
+	}
+	if err := evaluateOrgDirectiveTTLs(context.Background(), store, &recordingSink{}, cfg, &output, now.Add(3*time.Minute), directiveTTLDependencies{}); err != nil {
+		t.Fatal(err)
+	}
+	if got := strings.Count(output.String(), "parked: malformed directive marker"); got != 1 {
+		t.Fatalf("park log count after role unarchive = %d, want 1; output=%q", got, output.String())
 	}
 }
 

--- a/internal/cli/org_directive_ttl_test.go
+++ b/internal/cli/org_directive_ttl_test.go
@@ -102,6 +102,48 @@ func readDirectiveTTLObligation(t *testing.T, store *db.Store, id int64) db.OrgD
 	return db.OrgDirectiveObligation{}
 }
 
+func TestEvaluateOrgDirectiveTTLsParksMalformedDirectiveOnce(t *testing.T) {
+	home := t.TempDir()
+	cfg := writeDirectiveTTLConfig(t, home, "supervisor", 10*time.Minute, 0, 3)
+	store := openDirectiveTTLStore(t, home)
+	defer store.Close()
+	malformed, err := store.InsertWorkflowNote(context.Background(), db.WorkflowNote{
+		WorkflowID: "release/ttl",
+		Author:     "sender",
+		Body:       "[org:directive malformed]",
+		Repo:       "gitmoot/gitmoot",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	valid := seedDirectiveTTLNote(t, store, "positive control", 0, false)
+	now := time.Now().UTC().Add(20 * time.Minute)
+	var output bytes.Buffer
+
+	for range 2 {
+		if err := evaluateOrgDirectiveTTLs(context.Background(), store, &recordingSink{}, cfg, &output, now, directiveTTLDependencies{}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if got := strings.Count(output.String(), "parked: malformed directive marker"); got != 1 {
+		t.Fatalf("park log count = %d, want 1; output=%q", got, output.String())
+	}
+	open, err := store.ListOpenOrgDirectiveObligations(context.Background(), 200)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(open) != 1 || open[0].ID != valid.ID {
+		t.Fatalf("open directives = %+v, want only positive-control directive %d", open, valid.ID)
+	}
+	parked, err := store.ListParkedOrgDirectives(context.Background(), "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(parked) != 1 || parked[0].ID != malformed.ID || parked[0].ParkedAt == "" || parked[0].ParkedReason != "malformed directive marker" {
+		t.Fatalf("parked directives = %+v, want malformed directive %d with durable reason", parked, malformed.ID)
+	}
+}
+
 func TestDirectiveTTLNudgesOncePerInterval(t *testing.T) {
 	home := t.TempDir()
 	cfg := writeDirectiveTTLConfig(t, home, "supervisor", 10*time.Minute, 0, 3)

--- a/internal/db/org_directive_park.go
+++ b/internal/db/org_directive_park.go
@@ -18,6 +18,8 @@ import (
 // a done/cancel-style marker note, because it records LADDER state rather than
 // obligation completion.
 
+const malformedOrgDirectiveParkReason = "malformed directive marker"
+
 // ParkOpenOrgDirectivesForRole parks every OPEN directive obligation addressed
 // to targetRole that is not already parked. Done and cancelled directives are
 // untouched (they carry no ladder to suspend). Returns how many rows parked.
@@ -60,7 +62,7 @@ WHERE substr(body, 1, length('[org:directive to=' || ? || ' ')) = '[org:directiv
 
 // ParkMalformedOrgDirective removes a syntactically invalid directive from the
 // live TTL sweep without claiming that its obligation completed.
-func (s *Store) ParkMalformedOrgDirective(ctx context.Context, id int64, at time.Time, reason string) (bool, error) {
+func (s *Store) ParkMalformedOrgDirective(ctx context.Context, id int64, at time.Time) (bool, error) {
 	result, err := s.db.ExecContext(ctx, `
 UPDATE workflow_notes
 SET directive_parked_at = ?, directive_parked_reason = ?
@@ -74,7 +76,7 @@ WHERE id = ?
 			OR substr(r.body, 1, length('[org:directive-done id=' || workflow_notes.id || ' ')) = '[org:directive-done id=' || workflow_notes.id || ' '
 		)
 	)`,
-		at.UTC().Format(time.RFC3339Nano), strings.TrimSpace(reason), id)
+		at.UTC().Format(time.RFC3339Nano), malformedOrgDirectiveParkReason, id)
 	if err != nil {
 		return false, err
 	}
@@ -99,8 +101,9 @@ func (s *Store) UnparkOrgDirectivesForRole(ctx context.Context, targetRole strin
 UPDATE workflow_notes
 SET directive_parked_at = '', directive_parked_reason = '', directive_last_nudged_at = ?
 WHERE substr(body, 1, length('[org:directive to=' || ? || ' ')) = '[org:directive to=' || ? || ' '
-	AND TRIM(directive_parked_at) <> ''`,
-		stamp, targetRole, targetRole)
+	AND TRIM(directive_parked_at) <> ''
+	AND directive_parked_reason <> ?`,
+		stamp, targetRole, targetRole, malformedOrgDirectiveParkReason)
 	if err != nil {
 		return 0, err
 	}
@@ -137,8 +140,9 @@ func (s *Store) UnarchiveOrgSeatTransition(ctx context.Context, targetRole strin
 UPDATE workflow_notes
 SET directive_parked_at = '', directive_parked_reason = '', directive_last_nudged_at = ?
 WHERE substr(body, 1, length('[org:directive to=' || ? || ' ')) = '[org:directive to=' || ? || ' '
-	AND TRIM(directive_parked_at) <> ''`,
-		stamp, targetRole, targetRole)
+	AND TRIM(directive_parked_at) <> ''
+	AND directive_parked_reason <> ?`,
+		stamp, targetRole, targetRole, malformedOrgDirectiveParkReason)
 	if err != nil {
 		return 0, err
 	}

--- a/internal/db/org_directive_park.go
+++ b/internal/db/org_directive_park.go
@@ -58,6 +58,33 @@ WHERE substr(body, 1, length('[org:directive to=' || ? || ' ')) = '[org:directiv
 	return result.RowsAffected()
 }
 
+// ParkMalformedOrgDirective removes a syntactically invalid directive from the
+// live TTL sweep without claiming that its obligation completed.
+func (s *Store) ParkMalformedOrgDirective(ctx context.Context, id int64, at time.Time, reason string) (bool, error) {
+	result, err := s.db.ExecContext(ctx, `
+UPDATE workflow_notes
+SET directive_parked_at = ?, directive_parked_reason = ?
+WHERE id = ?
+	AND TRIM(directive_parked_at) = ''
+	AND substr(body, 1, length('[org:directive ')) = '[org:directive '
+	AND NOT EXISTS (
+		SELECT 1 FROM workflow_notes r
+		WHERE r.workflow_id = workflow_notes.workflow_id AND (
+			substr(r.body, 1, length('[org:directive-cancel id=' || workflow_notes.id || ' ')) = '[org:directive-cancel id=' || workflow_notes.id || ' '
+			OR substr(r.body, 1, length('[org:directive-done id=' || workflow_notes.id || ' ')) = '[org:directive-done id=' || workflow_notes.id || ' '
+		)
+	)`,
+		at.UTC().Format(time.RFC3339Nano), strings.TrimSpace(reason), id)
+	if err != nil {
+		return false, err
+	}
+	affected, err := result.RowsAffected()
+	if err != nil {
+		return false, err
+	}
+	return affected == 1, nil
+}
+
 // UnparkOrgDirectivesForRole returns targetRole's parked directives to the live
 // sweep. The nudge anchor (directive_last_nudged_at) is reset to the unpark
 // time: a directive whose TTL elapsed while its seat was archived must get a


### PR DESCRIPTION
Fixes #1750

## What changed
- park malformed org-directive rows when the TTL sweep cannot parse their marker
- persist `directive_parked_at` and `directive_parked_reason` atomically by directive ID
- keep completed or cancelled directives protected from a racing park
- cover the production evaluator path and prove the malformed row logs once, leaves the open sweep, and remains queryable as parked

## Operations
Removed 10 enabled repo registrations whose configured checkout paths no longer exist. The supported deployed command is `gitmoot repo remove`; re-adding restores polling. A controlled 20-minute journal window contained 5 normal gitmoot polls and 0 missing-checkout `chdir` failures.

## Verification
- `go generate ./...` left the diff byte-identical
- `go build ./...`
- `go vet ./...`
- `go test -count=1 -timeout 30m ./...` (43 packages pass, 4 have no tests)
- `go test -race -count=1 ./internal/db` passed
- focused production-path CLI and DB race tests passed

The unsharded full CLI race command exceeded its 30-minute package timeout and reported unrelated pre-existing E2E and memory-cluster failures. Main's exact baseline has all 26 sharded CI checks green; this PR's sharded CI is the full-package race gate.