### PR TITLE
perf(daemon): stop the hot-path re-logging, re-reading and re-querying (#1758)

### DIFF
--- a/internal/cli/agent_dispatch.go
+++ b/internal/cli/agent_dispatch.go
@@ -669,7 +669,7 @@ func dispatchLocalAgentJob(ctx context.Context, store *db.Store, request localAg
 		if paths, err := pathsFromFlag(request.Home); err == nil {
 			workflowHome = paths.Home
 		}
-		engine := daemonWorkflowEngineForRunner(store, newAgentDispatchGitHubClient(checkoutPath), checkoutPath, workflowHome, localDispatchJobRunner(request))
+		engine := daemonWorkflowEngineForRunner(store, newAgentDispatchGitHubClient(checkoutPath), checkoutPath, workflowHome, localDispatchJobRunner(request), nil)
 		if _, err := engine.RunJob(runCtx, job.ID, effectiveAgent, adapter); err != nil {
 			if out, ok, _ := recoverAdvanceErrorOutput(ctx, store, job.ID, request, err); ok {
 				recordRuntimeOutcome(nil)

--- a/internal/cli/blocked_since.go
+++ b/internal/cli/blocked_since.go
@@ -162,8 +162,11 @@ func enabledBlockedSinceEventSink(ctx context.Context, store *db.Store, home str
 
 // sweepBlockedTaskWakeEvents is the per-repo tick entrypoint. Every failure is
 // returned only for logging by the caller; it must never fail the daemon tick.
-func sweepBlockedTaskWakeEvents(ctx context.Context, store *db.Store, home, repo string, stdout io.Writer, now time.Time) error {
-	wakeAfter := resolveBlockedRoleWakeAfter(home)
+//
+// wakeAfter arrives already resolved: it is a config.toml read, and resolving it
+// here made the daemon re-read and re-parse that file once per enabled repo per
+// tick (#1758). The tick now resolves it once and passes it down.
+func sweepBlockedTaskWakeEvents(ctx context.Context, store *db.Store, home, repo string, wakeAfter time.Duration, stdout io.Writer, now time.Time) error {
 	if wakeAfter <= 0 {
 		return nil
 	}

--- a/internal/cli/daemon_dispatch_tracked.go
+++ b/internal/cli/daemon_dispatch_tracked.go
@@ -85,6 +85,9 @@ type inflightJobTracker struct {
 	foreignBootRecoveryAt      time.Time
 	worktreeReclaimAttemptedAt time.Time
 	staleTaskLaneLockReapAt    time.Time
+	wakeOutboxHealthLast       replyWakeOutboxHealth
+	wakeOutboxHealthLogged     bool
+	jobEvents                  jobEventCandidateCache
 	liveness                   *daemonLivenessSweep
 }
 
@@ -369,6 +372,54 @@ func (t *inflightJobTracker) markStaleTaskLaneLockReclaimSuccessful(now time.Tim
 	t.mu.Lock()
 	defer t.mu.Unlock()
 	t.staleTaskLaneLockReapAt = now
+}
+
+// replyWakeOutboxHealthChanged reports whether health differs from the last
+// wake-outbox health line this supervisor logged, and remembers it when it
+// does. An `inert` obligation — a pending row with no matching wake rule — is a
+// PERMANENT state until an operator adds a rule, so re-logging the identical
+// line every tick produced ~12.8k identical lines/day carrying no new
+// information (#1758). A nil tracker (the untracked/legacy path) always reports
+// changed, so its logging stays exactly as it was.
+func (t *inflightJobTracker) replyWakeOutboxHealthChanged(health replyWakeOutboxHealth) bool {
+	if t == nil {
+		return true
+	}
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if t.wakeOutboxHealthLogged && t.wakeOutboxHealthLast == health {
+		return false
+	}
+	t.wakeOutboxHealthLast = health
+	t.wakeOutboxHealthLogged = true
+	return true
+}
+
+// forgetReplyWakeOutboxHealth drops the remembered line so the next health line
+// logs even when it repeats the last one. Every tick that does NOT print a
+// health line calls it — a drain error, or a clean drain with nothing inert — so
+// leaving the inert state and returning to it is always visible in the journal.
+func (t *inflightJobTracker) forgetReplyWakeOutboxHealth() {
+	if t == nil {
+		return
+	}
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.wakeOutboxHealthLast = replyWakeOutboxHealth{}
+	t.wakeOutboxHealthLogged = false
+}
+
+// jobEventCandidateCache returns the supervisor's cross-tick job_events cursor
+// cache (#1758). Its lifetime is the supervisor's, not the tick's, which is the
+// whole point: the per-tick candidate carrier consults it to skip a candidate
+// query whose inputs have not changed since the previous tick. A nil tracker
+// returns nil, which disables the gating and runs every query, so untracked and
+// legacy paths keep today's behavior.
+func (t *inflightJobTracker) jobEventCandidateCache() *jobEventCandidateCache {
+	if t == nil {
+		return nil
+	}
+	return &t.jobEvents
 }
 
 // holderOf returns the job ID currently holding checkoutKey, if any.

--- a/internal/cli/daemon_scheduler.go
+++ b/internal/cli/daemon_scheduler.go
@@ -904,6 +904,7 @@ type tickCandidateStore interface {
 	JobIDsWithAgedTerminalDelegationWorktree(ctx context.Context, cutoff time.Time) ([]string, error)
 	TaskIDsWithTerminalWorktree(ctx context.Context) ([]string, error)
 	FirstMalformedNonFinalJob(ctx context.Context) (string, error)
+	MaxJobEventID(ctx context.Context) (int64, error)
 }
 
 // candidateMemo lazily runs one per-tick candidate query and shares its RESULT
@@ -933,7 +934,12 @@ func (m *candidateMemo) get(fetch func() ([]string, error)) ([]string, error) {
 }
 
 type tickCandidates struct {
-	store              tickCandidateStore
+	store tickCandidateStore
+	// config carries the tick's config.toml memo (#1758). It rides the candidate
+	// carrier for the same reason the candidate sets do: the carrier is created
+	// once per tick and consumed by every repo in the sweep, so a value resolved
+	// here is resolved exactly once per tick instead of once per repo.
+	config             tickConfigCache
 	advance            candidateMemo
 	comment            candidateMemo
 	reclaim            candidateMemo
@@ -942,6 +948,11 @@ type tickCandidates struct {
 	malformedOwnerDone bool
 	malformedOwnerID   string
 	skipAgedReclaim    bool
+	// events is the supervisor's CROSS-tick job_events cursor cache (#1758). It
+	// outlives the carrier (it hangs off the tracker), which is exactly why it is
+	// a pointer while config is a value: the config memo must die with the tick,
+	// the cursor must survive it. nil disables cursor gating entirely.
+	events *jobEventCandidateCache
 }
 
 // newTickCandidates is a package var (not a plain func) only so the once-per-tick
@@ -951,15 +962,107 @@ var newTickCandidates = func(store tickCandidateStore) *tickCandidates {
 	return &tickCandidates{store: store}
 }
 
+// jobEventCandidateKind indexes the candidate sets whose value is a pure function
+// of job_events and can therefore be gated on that table's change cursor.
+type jobEventCandidateKind int
+
+const (
+	jobEventCandidateAdvance jobEventCandidateKind = iota
+	jobEventCandidateComment
+	jobEventCandidateKindCount
+)
+
+// jobEventCandidateCache carries the advance- and comment-retry candidate sets
+// ACROSS ticks, keyed by db.MaxJobEventID. Both queries GROUP BY job_id over the
+// whole of job_events (92K rows on the affected host and growing without bound)
+// and ran every ~2.5s whether or not a single event had been written (#1758).
+//
+// The cursor is only ever a permission to SKIP a query whose answer provably
+// cannot have changed — never a substitute for one. Two properties make that
+// safe, and the second is the one worth guarding:
+//
+//  1. Soundness of the key: see db.MaxJobEventID. Both gated queries read only
+//     (id, kind, job_id), which no production write mutates in place, and rows are
+//     otherwise append-only — so an unmoved maximum means an unchanged result.
+//  2. Ordering: the cursor is read BEFORE the query it guards. An event written
+//     between the two is then either seen by the query (fine) or not — but either
+//     way the RECORDED cursor pre-dates it, so the next tick sees a moved cursor
+//     and re-runs. Recording the cursor after the query would let exactly that
+//     event be skipped forever. The worst case is therefore a candidate deferred
+//     by one tick, never dropped.
+//
+// It is guarded by a mutex rather than relying on the tick goroutine: the carrier
+// is per-tick and single-threaded, but this cache is shared by every carrier the
+// supervisor makes, and the single-repo and fleet loops both reach it.
+type jobEventCandidateCache struct {
+	mu      sync.Mutex
+	entries [jobEventCandidateKindCount]jobEventCandidateEntry
+}
+
+type jobEventCandidateEntry struct {
+	cursor int64
+	valid  bool
+	ids    []string
+}
+
+func (c *jobEventCandidateCache) lookup(kind jobEventCandidateKind, cursor int64) ([]string, bool) {
+	if c == nil {
+		return nil, false
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	entry := c.entries[kind]
+	if !entry.valid || entry.cursor != cursor {
+		return nil, false
+	}
+	return entry.ids, true
+}
+
+func (c *jobEventCandidateCache) remember(kind jobEventCandidateKind, cursor int64, ids []string) {
+	if c == nil {
+		return
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.entries[kind] = jobEventCandidateEntry{cursor: cursor, valid: true, ids: ids}
+}
+
+// jobEventCandidates runs one job_events-derived candidate query, skipping it when
+// the change cursor has not moved since the last tick that ran it. Any cursor read
+// failure falls through to the query: the cache may only ever remove redundant
+// work, so a broken cursor must degrade to today's behavior, not to a skip.
+func (c *tickCandidates) jobEventCandidates(ctx context.Context, kind jobEventCandidateKind, fetch func() ([]string, error)) ([]string, error) {
+	if c.events == nil {
+		return fetch()
+	}
+	cursor, err := c.store.MaxJobEventID(ctx)
+	if err != nil {
+		return fetch()
+	}
+	if ids, ok := c.events.lookup(kind, cursor); ok {
+		return ids, nil
+	}
+	ids, err := fetch()
+	if err != nil {
+		return nil, err
+	}
+	c.events.remember(kind, cursor, ids)
+	return ids, nil
+}
+
 func (c *tickCandidates) advanceRetryCandidates(ctx context.Context) ([]string, error) {
 	return c.advance.get(func() ([]string, error) {
-		return c.store.JobIDsWithPendingAdvanceRetry(ctx)
+		return c.jobEventCandidates(ctx, jobEventCandidateAdvance, func() ([]string, error) {
+			return c.store.JobIDsWithPendingAdvanceRetry(ctx)
+		})
 	})
 }
 
 func (c *tickCandidates) commentRetryCandidates(ctx context.Context) ([]string, error) {
 	return c.comment.get(func() ([]string, error) {
-		return c.store.JobIDsWithPendingCommentRetry(ctx)
+		return c.jobEventCandidates(ctx, jobEventCandidateComment, func() ([]string, error) {
+			return c.store.JobIDsWithPendingCommentRetry(ctx)
+		})
 	})
 }
 
@@ -1437,6 +1540,7 @@ func runDaemonWorkerTickTracked(ctx context.Context, store *db.Store, worker job
 	// five global candidate queries run once rather than once per enabled repo.
 	if cand == nil {
 		cand = newTickCandidates(worker.Store)
+		cand.events = tracker.jobEventCandidateCache()
 		runWorktreeReclaim := tracker.worktreeReclaimDue(now)
 		cand.skipAgedReclaim = !runWorktreeReclaim
 		if runWorktreeReclaim {
@@ -1478,14 +1582,15 @@ func runDaemonWorkerTickTracked(ctx context.Context, store *db.Store, worker job
 	// tick's dispatch or escalate the daemon the way the store-fault recovery scans
 	// above (deliberately) do. Resolved per tick, so the TTL is live-tunable like the
 	// per-repo scheduler override below.
-	if err := sweepExpiredBlockedJobs(ctx, store, resolveBlockedTTL(worker.workflowHome()), stdout, now); err != nil {
+	workflowHome := worker.workflowHome()
+	if err := sweepExpiredBlockedJobs(ctx, store, cand.config.blockedJobTTL(workflowHome), stdout, now); err != nil {
 		writeLine(stdout, "blocked_ttl sweep failed: %v", err)
 	}
 	// Opt-in blocked-since source (#1060): stale BLOCKED tasks synthesize one
 	// blocked event per continuous episode for the existing event-rule engine.
 	// Like blocked_ttl, every failure is logged and swallowed so this optional
 	// evaluator can never fail the repo tick.
-	if err := sweepBlockedTaskWakeEvents(ctx, store, worker.workflowHome(), repoFilter, stdout, now); err != nil {
+	if err := sweepBlockedTaskWakeEvents(ctx, store, workflowHome, repoFilter, cand.config.blockedRoleWakeAfter(workflowHome), stdout, now); err != nil {
 		writeLine(stdout, "blocked_since task sweep failed: %v", err)
 	}
 	// Checkout-mutating maintenance (advancement/merge retries, delegation
@@ -1517,7 +1622,7 @@ func runDaemonWorkerTickTracked(ctx context.Context, store *db.Store, worker job
 		// The store path is already the resolved Gitmoot root. Using it keeps this
 		// hot-read on the daemon's actual home and prevents the raw/resolved
 		// double-resolution bug class.
-		if ttl, err := resolveDelegationWorktreeTTL(filepath.Dir(store.DatabasePath())); err != nil {
+		if ttl, err := cand.config.delegationWorktreeTTL(filepath.Dir(store.DatabasePath())); err != nil {
 			writeLine(stdout, "delegation_worktree_ttl reclaim skipped: %v", err)
 		} else if err := reclaimAgedTerminalDelegationWorktrees(ctx, worker, repoFilter, rootFilter, tracker.checkoutHeld, cand, now, ttl); err != nil {
 			writeLine(stdout, "delegation_worktree_ttl reclaim failed: %v", err)
@@ -1561,10 +1666,18 @@ func runEnabledRepoWorkerTicksTracked(ctx context.Context, store *db.Store, work
 	// any repository. Drain before listing repos so zero enabled repos cannot
 	// suppress delivery or hide an unreadable outbox behind a healthy fleet tick.
 	health, err := drainFleetReplyWakeOutbox(ctx, store, worker, now)
-	if err != nil {
+	switch {
+	case err != nil:
 		writeLine(stdout, "reply wake outbox drain unhealthy: %v", err)
-	} else if health.inert > 0 {
-		writeLine(stdout, "reply wake outbox drain health: %s", health)
+		tracker.forgetReplyWakeOutboxHealth()
+	case health.inert > 0:
+		// Log on CHANGE only (#1758): inert obligations persist until an
+		// operator adds a matching rule, so the unchanged line is pure noise.
+		if tracker.replyWakeOutboxHealthChanged(health) {
+			writeLine(stdout, "reply wake outbox drain health: %s", health)
+		}
+	default:
+		tracker.forgetReplyWakeOutboxHealth()
 	}
 	if tracker.staleTaskLaneLockReclaimDue(now) {
 		if err := reclaimStaleTaskLaneLocks(ctx, store, "", stdout, now); err != nil {
@@ -1583,6 +1696,9 @@ func runEnabledRepoWorkerTicksTracked(ctx context.Context, store *db.Store, work
 	// hoisting them here collapses 18 calls per query to one on the affected
 	// multi-repo daemon. Fresh each sweep; never retained.
 	cand := newTickCandidates(worker.Store)
+	// The cursor cache is the one piece of candidate state that DOES span ticks:
+	// it hangs off the tracker, and the fresh carrier borrows it for this sweep.
+	cand.events = tracker.jobEventCandidateCache()
 	runAgedReclaim := tracker.worktreeReclaimDue(now)
 	cand.skipAgedReclaim = !runAgedReclaim
 	// Scope tick faults per repo (#555 follow-up): the recovering supervisor

--- a/internal/cli/daemon_scheduler_test.go
+++ b/internal/cli/daemon_scheduler_test.go
@@ -5382,3 +5382,176 @@ func TestTickCandidatesRetriesOnError(t *testing.T) {
 		t.Fatalf("malformed owner query ran %d times, want 2", got)
 	}
 }
+
+// scriptedCursorStore drives the job_events cursor cache (#1758) directly: it
+// reports a cursor the test controls and can mutate its own candidate set from
+// INSIDE the guarded query, which is how the hazard the cache must survive is
+// reproduced deterministically — an event landing after the cursor was read but
+// after the query already took its snapshot.
+type scriptedCursorStore struct {
+	cursor      int64
+	ids         []string
+	queries     int
+	cursorReads int
+	cursorErr   error
+	duringQuery func(*scriptedCursorStore)
+}
+
+func (s *scriptedCursorStore) MaxJobEventID(context.Context) (int64, error) {
+	s.cursorReads++
+	if s.cursorErr != nil {
+		return 0, s.cursorErr
+	}
+	return s.cursor, nil
+}
+
+func (s *scriptedCursorStore) JobIDsWithPendingAdvanceRetry(context.Context) ([]string, error) {
+	s.queries++
+	snapshot := append([]string(nil), s.ids...)
+	if s.duringQuery != nil {
+		s.duringQuery(s)
+	}
+	return snapshot, nil
+}
+
+func (s *scriptedCursorStore) JobIDsWithPendingCommentRetry(context.Context) ([]string, error) {
+	return nil, nil
+}
+
+func (s *scriptedCursorStore) JobIDsWithPendingDelegationWorktreeReclaim(context.Context) ([]string, error) {
+	return nil, nil
+}
+
+func (s *scriptedCursorStore) JobIDsWithAgedTerminalDelegationWorktree(context.Context, time.Time) ([]string, error) {
+	return nil, nil
+}
+
+func (s *scriptedCursorStore) TaskIDsWithTerminalWorktree(context.Context) ([]string, error) {
+	return nil, nil
+}
+
+func (s *scriptedCursorStore) FirstMalformedNonFinalJob(context.Context) (string, error) {
+	return "", nil
+}
+
+// The cursor cache may DEFER an advancement by at most one tick; it must never
+// DROP one. The mutant this kills is recording the cursor AFTER the query instead
+// of before: an event written while the query is in flight would then be covered
+// by a cursor the query never saw, and the candidate would be skipped forever.
+func TestJobEventCursorCacheDefersButNeverDropsAnAdvancement(t *testing.T) {
+	ctx := context.Background()
+	cache := &jobEventCandidateCache{}
+	store := &scriptedCursorStore{cursor: 10, ids: []string{"job-a"}}
+	tick := func() []string {
+		cand := newTickCandidates(store)
+		cand.events = cache
+		ids, err := cand.advanceRetryCandidates(ctx)
+		if err != nil {
+			t.Fatalf("advanceRetryCandidates: %v", err)
+		}
+		return ids
+	}
+
+	if got := tick(); !reflect.DeepEqual(got, []string{"job-a"}) {
+		t.Fatalf("cold tick candidates = %v, want [job-a]", got)
+	}
+	if store.queries != 1 {
+		t.Fatalf("cold tick ran %d queries, want 1", store.queries)
+	}
+
+	// Unmoved cursor: the candidate query is SKIPPED and the memo is served.
+	if got := tick(); !reflect.DeepEqual(got, []string{"job-a"}) {
+		t.Fatalf("cached tick candidates = %v, want [job-a]", got)
+	}
+	if store.queries != 1 {
+		t.Fatalf("candidate query re-ran with an unmoved cursor (%d runs)", store.queries)
+	}
+	// Deliberately NO assertion on cursor-read counts here: this test must fail on
+	// the DROP, not on an incidental extra query. The read cadence is pinned
+	// separately by TestJobEventCursorCacheReadsCursorOncePerTick.
+
+	// An unrelated event moves the cursor, forcing a query — and a SECOND event
+	// making job-b a candidate lands while that query is in flight.
+	store.cursor = 11
+	store.duringQuery = func(s *scriptedCursorStore) {
+		s.cursor = 12
+		s.ids = []string{"job-a", "job-b"}
+	}
+	if got := tick(); !reflect.DeepEqual(got, []string{"job-a"}) {
+		t.Fatalf("in-flight tick candidates = %v, want the pre-insert snapshot [job-a]", got)
+	}
+	store.duringQuery = nil
+
+	// The cursor now sits past the one that tick recorded, so the next tick must
+	// re-run and surface job-b: deferred by exactly one tick, not dropped.
+	if got := tick(); !reflect.DeepEqual(got, []string{"job-a", "job-b"}) {
+		t.Fatalf("job-b was DROPPED by the cursor cache: candidates = %v", got)
+	}
+	if store.queries != 3 {
+		t.Fatalf("queries = %d, want 3 (cold, cursor-moved, deferred pickup)", store.queries)
+	}
+}
+
+// A cursor read that fails must fall through to the query. The cache may only
+// ever remove redundant work, so a broken cursor degrades to the un-gated
+// behavior rather than to a skip.
+func TestJobEventCursorCacheFallsBackWhenCursorUnavailable(t *testing.T) {
+	ctx := context.Background()
+	cache := &jobEventCandidateCache{}
+	store := &scriptedCursorStore{cursor: 7, ids: []string{"job-a"}}
+	tick := func() []string {
+		cand := newTickCandidates(store)
+		cand.events = cache
+		ids, err := cand.advanceRetryCandidates(ctx)
+		if err != nil {
+			t.Fatalf("advanceRetryCandidates: %v", err)
+		}
+		return ids
+	}
+
+	tick()
+	store.cursorErr = errors.New("cursor unavailable")
+	if got := tick(); !reflect.DeepEqual(got, []string{"job-a"}) {
+		t.Fatalf("candidates with a broken cursor = %v, want [job-a]", got)
+	}
+	if store.queries != 2 {
+		t.Fatalf("queries = %d, want 2: a failed cursor read must never skip the query", store.queries)
+	}
+}
+
+// With no cache attached — every non-supervisor caller — the gating is inert and
+// the cursor is never even read.
+func TestJobEventCursorCacheAbsentRunsEveryQuery(t *testing.T) {
+	ctx := context.Background()
+	store := &scriptedCursorStore{cursor: 3, ids: []string{"job-a"}}
+	for range 3 {
+		cand := newTickCandidates(store)
+		if _, err := cand.advanceRetryCandidates(ctx); err != nil {
+			t.Fatalf("advanceRetryCandidates: %v", err)
+		}
+	}
+	if store.queries != 3 || store.cursorReads != 0 {
+		t.Fatalf("queries=%d cursorReads=%d, want 3 and 0 with no cache attached", store.queries, store.cursorReads)
+	}
+}
+
+// One cheap cursor read replaces the heavy GROUP BY on an idle tick; two reads
+// would mean the gate costs more than it saves on the common path.
+func TestJobEventCursorCacheReadsCursorOncePerTick(t *testing.T) {
+	ctx := context.Background()
+	cache := &jobEventCandidateCache{}
+	store := &scriptedCursorStore{cursor: 5, ids: []string{"job-a"}}
+	for range 4 {
+		cand := newTickCandidates(store)
+		cand.events = cache
+		if _, err := cand.advanceRetryCandidates(ctx); err != nil {
+			t.Fatalf("advanceRetryCandidates: %v", err)
+		}
+	}
+	if store.cursorReads != 4 {
+		t.Fatalf("cursor reads = %d over 4 ticks, want exactly 4", store.cursorReads)
+	}
+	if store.queries != 1 {
+		t.Fatalf("candidate queries = %d over 4 idle ticks, want 1", store.queries)
+	}
+}

--- a/internal/cli/daemon_scheduler_test.go
+++ b/internal/cli/daemon_scheduler_test.go
@@ -5558,30 +5558,55 @@ func TestJobEventCursorCacheReadsCursorOncePerTick(t *testing.T) {
 
 // The tests above hand-attach cand.events and drive only the advancement path,
 // which pins the helper rather than the path: production reaches the cache by a
-// route they never take (the two `cand.events = tracker.jobEventCandidateCache()`
-// attachments), and it serves TWO kinds, not one. Two mutants survive them —
-// swapping commentRetryCandidates' kind to jobEventCandidateAdvance, and deleting
-// both attachments — and the first is a silent stall in production: an empty
-// cached ADVANCEMENT set at cursor N would be served to comment retries at the
-// same cursor, suppressing a real comment_post_failed candidate until some later
-// event moves MAX(id).
+// route they never take, and it serves TWO kinds, not one. Three mutants survive
+// them — swapping commentRetryCandidates' kind to jobEventCandidateAdvance, and
+// deleting either of the two `cand.events = tracker.jobEventCandidateCache()`
+// attachments. The kind swap is a silent stall in production: an empty cached
+// ADVANCEMENT set at cursor N would be served to comment retries at the same
+// cursor, suppressing a real comment_post_failed candidate until some later event
+// moves MAX(id).
 //
-// So drive the REAL fleet tick over two ticks with a shared tracker and DISTINCT
-// advancement and comment candidate sets, and assert both kinds are cached
-// independently, under the cache the production wiring supplied.
+// The two attachments sit on DIFFERENT production entry paths and each needs its
+// own case:
+//   - daemon_scheduler.go:1701 in runEnabledRepoWorkerTicksTracked — the
+//     multi-repo sweep, which builds one carrier for the whole tick.
+//   - daemon_scheduler.go:1543 in runDaemonWorkerTickTracked, reached ONLY on the
+//     cand == nil branch — the single-repo supervisor and direct callers, which
+//     let the tick build its own carrier.
 //
-// Every seeded candidate is state-rejected by its pass's Go predicate (#602
-// deferred-to-queued), so the ticks write no job_events and the cursor is
-// genuinely unmoved between them — otherwise the second tick would re-query for
-// an honest reason and the skip assertion would prove nothing.
+// Both are driven through their real entry point below. Hand-attaching
+// cand.events is what made the round-1 tests blind to the wiring, so neither case
+// touches the field.
 func TestJobEventCursorCacheProductionWiringCachesBothKinds(t *testing.T) {
+	t.Run("fleet sweep", func(t *testing.T) {
+		assertCursorCacheWiredForBothKinds(t, func(ctx context.Context, store *db.Store, worker jobWorker, tracker *inflightJobTracker, at time.Time) error {
+			return runEnabledRepoWorkerTicksTracked(ctx, store, worker, 1, "", io.Discard, at, nil, tracker)
+		})
+	})
+	t.Run("standalone tick with no carrier", func(t *testing.T) {
+		assertCursorCacheWiredForBothKinds(t, func(ctx context.Context, store *db.Store, worker jobWorker, tracker *inflightJobTracker, at time.Time) error {
+			// nil carrier: the single-repo supervisor's shape, where the tick
+			// itself builds the carrier and must attach the tracker's cache.
+			return runDaemonWorkerTickTracked(ctx, store, worker, 1, false, "owner/repo", "", io.Discard, at, tracker, nil)
+		})
+	})
+}
+
+// assertCursorCacheWiredForBothKinds runs `drive` for two ticks against a shared
+// tracker and proves the tracker-supplied cursor cache is in force for BOTH
+// candidate kinds, each holding its own set.
+//
+// Every seeded candidate is a pruned-orphan marker — a job_events row with no
+// surviving jobs row — so each pass drops it on the GetJob and the ticks write no
+// job_events. That is what leaves the cursor genuinely unmoved between the two
+// ticks; otherwise the second tick would re-query for an honest reason and the
+// skip assertion would prove nothing. The precondition is asserted, not assumed.
+func assertCursorCacheWiredForBothKinds(t *testing.T, drive func(context.Context, *db.Store, jobWorker, *inflightJobTracker, time.Time) error) {
+	t.Helper()
 	ctx := context.Background()
 	store := daemonWorkerStore(t)
 	seedDaemonWorkerRepo(t, store, "owner/repo", t.TempDir())
 
-	// Pruned-orphan markers: candidate rows in job_events with no surviving jobs
-	// row. Each pass's Go re-verification drops them on the GetJob, so the ticks
-	// dispatch nothing and write nothing, which is what leaves the cursor still.
 	const advanceID = "adv-pruned-orphan"
 	const commentID = "cmt-pruned-orphan"
 	if err := store.AddJobEvent(ctx, db.JobEvent{JobID: advanceID, Kind: "advance_started", Message: "orphan"}); err != nil {
@@ -5592,7 +5617,7 @@ func TestJobEventCursorCacheProductionWiringCachesBothKinds(t *testing.T) {
 	}
 
 	// The two candidate sets must DIFFER, or a kind-swapped cache would serve the
-	// right answer by accident and the test would pin nothing.
+	// right answer by accident and this would pin nothing.
 	wantAdvance, err := store.JobIDsWithPendingAdvanceRetry(ctx)
 	if err != nil {
 		t.Fatal(err)
@@ -5623,8 +5648,8 @@ func TestJobEventCursorCacheProductionWiringCachesBothKinds(t *testing.T) {
 
 	now := time.Now().UTC()
 	for i, at := range []time.Time{now, now.Add(time.Second)} {
-		if err := runEnabledRepoWorkerTicksTracked(ctx, store, worker, 1, "", io.Discard, at, nil, tracker); err != nil {
-			t.Fatalf("fleet tick %d returned error: %v", i+1, err)
+		if err := drive(ctx, store, worker, tracker, at); err != nil {
+			t.Fatalf("tick %d returned error: %v", i+1, err)
 		}
 	}
 

--- a/internal/cli/daemon_scheduler_test.go
+++ b/internal/cli/daemon_scheduler_test.go
@@ -5555,3 +5555,111 @@ func TestJobEventCursorCacheReadsCursorOncePerTick(t *testing.T) {
 		t.Fatalf("candidate queries = %d over 4 idle ticks, want 1", store.queries)
 	}
 }
+
+// The tests above hand-attach cand.events and drive only the advancement path,
+// which pins the helper rather than the path: production reaches the cache by a
+// route they never take (the two `cand.events = tracker.jobEventCandidateCache()`
+// attachments), and it serves TWO kinds, not one. Two mutants survive them —
+// swapping commentRetryCandidates' kind to jobEventCandidateAdvance, and deleting
+// both attachments — and the first is a silent stall in production: an empty
+// cached ADVANCEMENT set at cursor N would be served to comment retries at the
+// same cursor, suppressing a real comment_post_failed candidate until some later
+// event moves MAX(id).
+//
+// So drive the REAL fleet tick over two ticks with a shared tracker and DISTINCT
+// advancement and comment candidate sets, and assert both kinds are cached
+// independently, under the cache the production wiring supplied.
+//
+// Every seeded candidate is state-rejected by its pass's Go predicate (#602
+// deferred-to-queued), so the ticks write no job_events and the cursor is
+// genuinely unmoved between them — otherwise the second tick would re-query for
+// an honest reason and the skip assertion would prove nothing.
+func TestJobEventCursorCacheProductionWiringCachesBothKinds(t *testing.T) {
+	ctx := context.Background()
+	store := daemonWorkerStore(t)
+	seedDaemonWorkerRepo(t, store, "owner/repo", t.TempDir())
+
+	// Pruned-orphan markers: candidate rows in job_events with no surviving jobs
+	// row. Each pass's Go re-verification drops them on the GetJob, so the ticks
+	// dispatch nothing and write nothing, which is what leaves the cursor still.
+	const advanceID = "adv-pruned-orphan"
+	const commentID = "cmt-pruned-orphan"
+	if err := store.AddJobEvent(ctx, db.JobEvent{JobID: advanceID, Kind: "advance_started", Message: "orphan"}); err != nil {
+		t.Fatalf("AddJobEvent(advance_started) returned error: %v", err)
+	}
+	if err := store.AddJobEvent(ctx, db.JobEvent{JobID: commentID, Kind: "comment_post_failed", Message: "orphan"}); err != nil {
+		t.Fatalf("AddJobEvent(comment_post_failed) returned error: %v", err)
+	}
+
+	// The two candidate sets must DIFFER, or a kind-swapped cache would serve the
+	// right answer by accident and the test would pin nothing.
+	wantAdvance, err := store.JobIDsWithPendingAdvanceRetry(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	wantComment, err := store.JobIDsWithPendingCommentRetry(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if reflect.DeepEqual(wantAdvance, wantComment) ||
+		!reflect.DeepEqual(wantAdvance, []string{advanceID}) ||
+		!reflect.DeepEqual(wantComment, []string{commentID}) {
+		t.Fatalf("fixture is not discriminating: advance=%v comment=%v", wantAdvance, wantComment)
+	}
+	cursorBefore, err := store.MaxJobEventID(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	worker := defaultJobWorker(store, io.Discard)
+	tracker := newInflightJobTracker(ctx)
+	defer tracker.drain(io.Discard, time.Second)
+	counter := &countingCandidateStore{inner: store}
+	realNewTickCandidates := newTickCandidates
+	newTickCandidates = func(tickCandidateStore) *tickCandidates {
+		return realNewTickCandidates(counter)
+	}
+	defer func() { newTickCandidates = realNewTickCandidates }()
+
+	now := time.Now().UTC()
+	for i, at := range []time.Time{now, now.Add(time.Second)} {
+		if err := runEnabledRepoWorkerTicksTracked(ctx, store, worker, 1, "", io.Discard, at, nil, tracker); err != nil {
+			t.Fatalf("fleet tick %d returned error: %v", i+1, err)
+		}
+	}
+
+	cursorAfter, err := store.MaxJobEventID(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cursorAfter != cursorBefore {
+		t.Fatalf("the ticks wrote job_events (cursor %d -> %d); the skip below would be untestable", cursorBefore, cursorAfter)
+	}
+
+	// The cache the PRODUCTION wiring attached, not one this test supplied.
+	cache := tracker.jobEventCandidateCache()
+	advanceIDs, advanceCached := cache.lookup(jobEventCandidateAdvance, cursorBefore)
+	commentIDs, commentCached := cache.lookup(jobEventCandidateComment, cursorBefore)
+	if !advanceCached || !commentCached {
+		t.Fatalf("production wiring did not populate the cache: advance cached=%v comment cached=%v", advanceCached, commentCached)
+	}
+	if !reflect.DeepEqual(advanceIDs, wantAdvance) {
+		t.Fatalf("cached advancement candidates = %v, want %v", advanceIDs, wantAdvance)
+	}
+	if !reflect.DeepEqual(commentIDs, wantComment) {
+		t.Fatalf("cached comment candidates = %v, want %v (a kind collision serves one pass the other's set)", commentIDs, wantComment)
+	}
+
+	// Two ticks, one query each: the second tick's cursor was unmoved, so both
+	// gated queries were skipped. Without the production attachment the carrier
+	// gates nothing and each count is 2.
+	if got := atomic.LoadInt32(&counter.advance); got != 1 {
+		t.Fatalf("advancement candidate query ran %d times over two unchanged ticks, want 1", got)
+	}
+	if got := atomic.LoadInt32(&counter.comment); got != 1 {
+		t.Fatalf("comment candidate query ran %d times over two unchanged ticks, want 1", got)
+	}
+	if got := atomic.LoadInt32(&counter.jobEventCursor); got < 2 {
+		t.Fatalf("cursor reads = %d, want at least one per gated query per tick", got)
+	}
+}

--- a/internal/cli/daemon_supervision.go
+++ b/internal/cli/daemon_supervision.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"math/rand"
+	"os"
 	"strings"
 	"sync"
 	"time"
@@ -720,10 +721,17 @@ func startSingleRepoWorkerLoop(ctx context.Context, interval time.Duration, stor
 		// the supervisor boundary, outside the repository tick, matching the
 		// multi-repo fleet loop.
 		health, err := drainFleetReplyWakeOutbox(ctx, store, worker, now)
-		if err != nil {
+		switch {
+		case err != nil:
 			writeLine(stdout, "reply wake outbox drain unhealthy: %v", err)
-		} else if health.inert > 0 {
-			writeLine(stdout, "reply wake outbox drain health: %s", health)
+			tracker.forgetReplyWakeOutboxHealth()
+		case health.inert > 0:
+			// Log on CHANGE only (#1758); see the fleet loop for the rationale.
+			if tracker.replyWakeOutboxHealthChanged(health) {
+				writeLine(stdout, "reply wake outbox drain health: %s", health)
+			}
+		default:
+			tracker.forgetReplyWakeOutboxHealth()
 		}
 		// The checkout lock now guards the TICK (maintenance + claim/dispatch),
 		// not whole job runs: dispatched jobs execute on their own goroutines
@@ -956,6 +964,10 @@ type registeredRepoPoller struct {
 	GitHubClient       func(checkout string) github.Client
 	WorkflowFactory    func(store *db.Store, gh github.Client, checkout string) *workflow.Engine
 	JobWorkflowFactory func(context.Context, *db.Store, github.Client, string, db.Job) (*workflow.Engine, error)
+	// ConfigCache is the per-poll-pass config.toml memo (#1758). The
+	// WorkflowFactory closure below captures the same pointer; the pass resets it
+	// so the reads stay per-tick. nil (legacy/test callers) resolves directly.
+	ConfigCache *tickConfigCache
 }
 
 // defaultRegisteredRepoPoller wires the registered-repo supervisor's per-tick
@@ -988,7 +1000,9 @@ func defaultRegisteredRepoPoller(store *db.Store, workers int, dryRun bool, stdo
 		}
 		return &engine
 	}
+	configCache := &tickConfigCache{}
 	return registeredRepoPoller{
+		ConfigCache:             configCache,
 		Store:                   store,
 		Workers:                 workers,
 		DryRun:                  dryRun,
@@ -1000,14 +1014,14 @@ func defaultRegisteredRepoPoller(store *db.Store, workers int, dryRun bool, stdo
 		IdleMaxMultiplier:       config.DefaultDaemonIdleMaxMultiplier,
 		GitHubClient:            func(checkout string) github.Client { return github.NewClient(checkout) },
 		WorkflowFactory: func(store *db.Store, gh github.Client, checkout string) *workflow.Engine {
-			return configureWorkflow(daemonWorkflowEngine(store, gh, checkout, resolvedRoot), store)
+			return configureWorkflow(daemonWorkflowEngineCached(store, gh, checkout, resolvedRoot, configCache), store)
 		},
 		JobWorkflowFactory: func(_ context.Context, store *db.Store, gh github.Client, checkout string, job db.Job) (*workflow.Engine, error) {
 			runner, err := defaultJobWorker(store, stdout, rawHome).subprocessRunnerForJob(job)
 			if err != nil {
 				return nil, err
 			}
-			return configureWorkflow(daemonWorkflowEngineForRunner(store, gh, checkout, resolvedRoot, runner), store), nil
+			return configureWorkflow(daemonWorkflowEngineForRunner(store, gh, checkout, resolvedRoot, runner, nil), store), nil
 		},
 	}
 }
@@ -1095,8 +1109,109 @@ func resolveDelegationWorktreeTTL(home string) (time.Duration, error) {
 	return config.LoadDelegationWorktreeTTL(config.Paths{ConfigFile: resolveConfigFile(home)})
 }
 
+// tickConfigCache memoizes the daemon's hot config.toml reads for the span of
+// ONE tick (a worker sweep or a poll pass). resolveBlockedTTL,
+// resolveBlockedRoleWakeAfter, resolveDelegationWorktreeTTL and
+// daemonMemoryController are each a pure function of <home>/config.toml, and each
+// was re-read AND re-parsed once per ENABLED REPO per tick: at 45 repos that is
+// 135 opens/tick for the three durations plus ~90 more for a memory controller
+// that returns nil every time (#1758).
+//
+// It is created FRESH each tick and never retained, so config.toml keeps exactly
+// the live tunability it had — one re-read per tick — and only the per-REPO
+// repetition disappears. Entries are keyed by their home (and store, for the
+// memory controller) so a caller passing a different one always re-resolves
+// rather than silently reading another home's policy. Only SUCCESSES are
+// memoized, matching candidateMemo: a transient read failure is retried by the
+// next repo in the sweep instead of being replayed to all of them.
+//
+// Like candidateMemo it carries no mutex because it is consumed only on the
+// synchronous tick goroutine — the worker sweep's per-repo loop and the poll
+// pass's per-repo loop are both sequential, and neither dispatched jobs nor the
+// per-job engine factory touch it. A nil receiver resolves directly, so every
+// non-daemon caller and every existing test path stays byte-identical.
+type tickConfigCache struct {
+	blocked     durationMemo
+	delegation  durationMemo
+	wake        durationMemo
+	memoryHome  string
+	memoryStore *db.Store
+	memoryDone  bool
+	memory      *workflow.MemoryController
+}
+
+type durationMemo struct {
+	home  string
+	value time.Duration
+	done  bool
+}
+
+func (m *durationMemo) get(home string, resolve func(string) (time.Duration, error)) (time.Duration, error) {
+	if m.done && m.home == home {
+		return m.value, nil
+	}
+	value, err := resolve(home)
+	if err != nil {
+		return 0, err
+	}
+	m.home, m.value, m.done = home, value, true
+	return value, nil
+}
+
+// reset drops every memoized value so the next tick re-reads config.toml. The
+// poll pass reuses one cache across passes (the factory closure captures it), so
+// this is what keeps its reads per-TICK rather than per-process.
+func (c *tickConfigCache) reset() {
+	if c == nil {
+		return
+	}
+	*c = tickConfigCache{}
+}
+
+func (c *tickConfigCache) blockedJobTTL(home string) time.Duration {
+	if c == nil {
+		return resolveBlockedTTL(home)
+	}
+	ttl, _ := c.blocked.get(home, func(h string) (time.Duration, error) { return resolveBlockedTTL(h), nil })
+	return ttl
+}
+
+func (c *tickConfigCache) blockedRoleWakeAfter(home string) time.Duration {
+	if c == nil {
+		return resolveBlockedRoleWakeAfter(home)
+	}
+	wakeAfter, _ := c.wake.get(home, func(h string) (time.Duration, error) { return resolveBlockedRoleWakeAfter(h), nil })
+	return wakeAfter
+}
+
+func (c *tickConfigCache) delegationWorktreeTTL(home string) (time.Duration, error) {
+	if c == nil {
+		return resolveDelegationWorktreeTTL(home)
+	}
+	return c.delegation.get(home, resolveDelegationWorktreeTTL)
+}
+
+// memoryController memoizes the nil-or-controller resolution, including the nil
+// result — returning nil is the default outcome and it costs two full config
+// loads (LoadMemorySettings + LoadAgentTypes) to reach.
+func (c *tickConfigCache) memoryController(store *db.Store, home string) *workflow.MemoryController {
+	if c == nil {
+		return daemonMemoryController(store, home)
+	}
+	if c.memoryDone && c.memoryHome == home && c.memoryStore == store {
+		return c.memory
+	}
+	controller := daemonMemoryController(store, home)
+	c.memoryHome, c.memoryStore, c.memory, c.memoryDone = home, store, controller, true
+	return controller
+}
+
 func pollRegisteredReposWithPoller(ctx context.Context, poller registeredRepoPoller, schedule registeredRepoSchedule, now time.Time, fallbackPoll time.Duration) (time.Duration, error) {
 	schedule = schedule.ensure()
+	// Fresh config reads for THIS pass: the factory closure holds the same cache
+	// across passes, so resetting here is what keeps the poller's config.toml
+	// reads per-tick instead of per-process (#1758).
+	poller.ConfigCache.reset()
 	repos, err := poller.Store.ListRepos(ctx)
 	if err != nil {
 		return fallbackPoll, err
@@ -1203,7 +1318,20 @@ func (p registeredRepoPoller) pollRepo(ctx context.Context, repoRecord db.Repo, 
 		writeLine(p.Stdout, "%s: %s", repoRecord.FullName(), message)
 		return registeredRepoPollResult{LastError: message}, store.UpdateRepoPollResult(ctx, repoRecord.FullName(), lastPollAt, message)
 	}
-	writeLine(p.Stdout, "polling %s with %d workers dry_run=%t", repoRecord.FullName(), p.Workers, p.DryRun)
+	// A registered repo whose checkout directory is gone (moved, unmounted, or
+	// deleted out from under the daemon) cannot be polled, but without this
+	// guard it still paid for engine construction, two DB passes, a config
+	// parse and a `gh` exec that fails on chdir — every tick, forever (#1758).
+	// Same early return as the empty-path case above so the operator-visible
+	// signal (log line + repos.last_error) keeps its existing shape.
+	if info, err := os.Stat(repoRecord.CheckoutPath); err != nil || !info.IsDir() {
+		message := fmt.Sprintf("registered repo checkout path is unavailable: %s", repoRecord.CheckoutPath)
+		writeLine(p.Stdout, "%s: %s", repoRecord.FullName(), message)
+		return registeredRepoPollResult{LastError: message}, store.UpdateRepoPollResult(ctx, repoRecord.FullName(), lastPollAt, message)
+	}
+	// `Workers` is a fleet-wide flag echoed here, not a per-repo pool: no such
+	// pool exists, so printing it as one only misleads (#1758).
+	writeLine(p.Stdout, "polling %s dry_run=%t", repoRecord.FullName(), p.DryRun)
 	if p.DryRun {
 		return registeredRepoPollResult{}, store.UpdateRepoPollResult(ctx, repoRecord.FullName(), lastPollAt, "")
 	}

--- a/internal/cli/daemon_supervision_test.go
+++ b/internal/cli/daemon_supervision_test.go
@@ -6,6 +6,8 @@ import (
 	"encoding/json"
 	"errors"
 	"io"
+	"os"
+	"path/filepath"
 	"strings"
 	"sync"
 	"testing"
@@ -127,9 +129,10 @@ func TestPollRegisteredReposHonorsPerRepoIntervals(t *testing.T) {
 	defer store.Close()
 
 	ctx := context.Background()
+	slowCheckout, fastCheckout := t.TempDir(), t.TempDir()
 	repos := []db.Repo{
-		{Owner: "owner", Name: "slow", CheckoutPath: "/tmp/slow", PollInterval: "1h"},
-		{Owner: "owner", Name: "fast", CheckoutPath: "/tmp/fast", PollInterval: "30s"},
+		{Owner: "owner", Name: "slow", CheckoutPath: slowCheckout, PollInterval: "1h"},
+		{Owner: "owner", Name: "fast", CheckoutPath: fastCheckout, PollInterval: "30s"},
 	}
 	for _, repo := range repos {
 		if err := store.UpsertRepo(ctx, repo); err != nil {
@@ -188,9 +191,10 @@ func TestPollRegisteredReposRoutesEachRepoWithOwnGitHubClient(t *testing.T) {
 	ctx := context.Background()
 	repoA := github.Repository{Owner: "owner", Name: "repo-a"}
 	repoB := github.Repository{Owner: "owner", Name: "repo-b"}
+	checkoutA, checkoutB := t.TempDir(), t.TempDir()
 	for _, repo := range []db.Repo{
-		{Owner: repoA.Owner, Name: repoA.Name, CheckoutPath: "/tmp/repo-a", PollInterval: "30s"},
-		{Owner: repoB.Owner, Name: repoB.Name, CheckoutPath: "/tmp/repo-b", PollInterval: "30s"},
+		{Owner: repoA.Owner, Name: repoA.Name, CheckoutPath: checkoutA, PollInterval: "30s"},
+		{Owner: repoB.Owner, Name: repoB.Name, CheckoutPath: checkoutB, PollInterval: "30s"},
 	} {
 		if err := store.UpsertRepo(ctx, repo); err != nil {
 			t.Fatalf("UpsertRepo(%s) returned error: %v", repo.FullName(), err)
@@ -213,13 +217,13 @@ func TestPollRegisteredReposRoutesEachRepoWithOwnGitHubClient(t *testing.T) {
 	}
 
 	clients := map[string]*cliPollFakeGitHub{
-		"/tmp/repo-a": {
+		checkoutA: {
 			pulls: []github.PullRequest{{Number: 1, Title: "A", State: "open", HeadRef: "task-a", BaseRef: "main", HeadSHA: "sha-a"}},
 			comments: map[int64][]github.IssueComment{
 				1: {{ID: 77, Body: "/gitmoot audit review check repo a", Author: "alice"}},
 			},
 		},
-		"/tmp/repo-b": {
+		checkoutB: {
 			pulls: []github.PullRequest{{Number: 1, Title: "B", State: "open", HeadRef: "task-b", BaseRef: "main", HeadSHA: "sha-b"}},
 			comments: map[int64][]github.IssueComment{
 				1: {{ID: 77, Body: "/gitmoot audit review check repo b", Author: "alice"}},
@@ -286,9 +290,10 @@ func TestPollRegisteredReposBacksOffFailedRepoWithoutStoppingOthers(t *testing.T
 	defer store.Close()
 
 	ctx := context.Background()
+	failingCheckout, healthyCheckout := t.TempDir(), t.TempDir()
 	for _, repo := range []db.Repo{
-		{Owner: "owner", Name: "failing", CheckoutPath: "/tmp/failing", PollInterval: "30s"},
-		{Owner: "owner", Name: "healthy", CheckoutPath: "/tmp/healthy", PollInterval: "30s"},
+		{Owner: "owner", Name: "failing", CheckoutPath: failingCheckout, PollInterval: "30s"},
+		{Owner: "owner", Name: "healthy", CheckoutPath: healthyCheckout, PollInterval: "30s"},
 	} {
 		if err := store.UpsertRepo(ctx, repo); err != nil {
 			t.Fatalf("UpsertRepo(%s) returned error: %v", repo.FullName(), err)
@@ -298,7 +303,7 @@ func TestPollRegisteredReposBacksOffFailedRepoWithoutStoppingOthers(t *testing.T
 	healthy := &cliPollFakeGitHub{}
 	poller := defaultRegisteredRepoPoller(store, 1, false, io.Discard, "", "")
 	poller.GitHubClient = func(checkout string) github.Client {
-		if checkout == "/tmp/failing" {
+		if checkout == failingCheckout {
 			return failing
 		}
 		return healthy
@@ -360,7 +365,7 @@ func TestPollRegisteredReposAdaptiveIdleCadence(t *testing.T) {
 	}
 	defer store.Close()
 	ctx := context.Background()
-	if err := store.UpsertRepo(ctx, db.Repo{Owner: "owner", Name: "idle", CheckoutPath: "/tmp/idle", PollInterval: "1s"}); err != nil {
+	if err := store.UpsertRepo(ctx, db.Repo{Owner: "owner", Name: "idle", CheckoutPath: t.TempDir(), PollInterval: "1s"}); err != nil {
 		t.Fatal(err)
 	}
 	stats := []github.ConditionalRequestStats{
@@ -420,7 +425,7 @@ func TestPollRegisteredReposIdleErrorBackoffTakesPrecedence(t *testing.T) {
 	}
 	defer store.Close()
 	ctx := context.Background()
-	if err := store.UpsertRepo(ctx, db.Repo{Owner: "owner", Name: "repo", CheckoutPath: "/tmp/repo", PollInterval: "1s"}); err != nil {
+	if err := store.UpsertRepo(ctx, db.Repo{Owner: "owner", Name: "repo", CheckoutPath: t.TempDir(), PollInterval: "1s"}); err != nil {
 		t.Fatal(err)
 	}
 	poller := defaultRegisteredRepoPoller(store, 1, false, io.Discard, "", "")
@@ -456,7 +461,7 @@ func TestPollRegisteredReposQueuedJobPromotesImmediately(t *testing.T) {
 	}
 	defer store.Close()
 	ctx := context.Background()
-	if err := store.UpsertRepo(ctx, db.Repo{Owner: "owner", Name: "repo", CheckoutPath: "/tmp/repo", PollInterval: "1s"}); err != nil {
+	if err := store.UpsertRepo(ctx, db.Repo{Owner: "owner", Name: "repo", CheckoutPath: t.TempDir(), PollInterval: "1s"}); err != nil {
 		t.Fatal(err)
 	}
 	if err := store.CreateJob(ctx, db.Job{ID: "queued", Agent: "agent", Type: "ask", State: string(workflow.JobQueued), Payload: `{"repo":"owner/repo"}`}); err != nil {
@@ -501,7 +506,7 @@ func TestPollRegisteredReposQueuedJobDoesNotOverrideErrorBackoff(t *testing.T) {
 	}
 	defer store.Close()
 	ctx := context.Background()
-	if err := store.UpsertRepo(ctx, db.Repo{Owner: "owner", Name: "repo", CheckoutPath: "/tmp/repo", PollInterval: "1s"}); err != nil {
+	if err := store.UpsertRepo(ctx, db.Repo{Owner: "owner", Name: "repo", CheckoutPath: t.TempDir(), PollInterval: "1s"}); err != nil {
 		t.Fatal(err)
 	}
 	if err := store.CreateJob(ctx, db.Job{ID: "queued", Agent: "agent", Type: "ask", State: string(workflow.JobQueued), Payload: `{"repo":"owner/repo"}`}); err != nil {
@@ -544,7 +549,7 @@ func TestPollRegisteredReposBusyRepoAtBaseCadenceKeepsInterval(t *testing.T) {
 	}
 	defer store.Close()
 	ctx := context.Background()
-	if err := store.UpsertRepo(ctx, db.Repo{Owner: "owner", Name: "repo", CheckoutPath: "/tmp/repo", PollInterval: "1s"}); err != nil {
+	if err := store.UpsertRepo(ctx, db.Repo{Owner: "owner", Name: "repo", CheckoutPath: t.TempDir(), PollInterval: "1s"}); err != nil {
 		t.Fatal(err)
 	}
 	if err := store.CreateJob(ctx, db.Job{ID: "queued", Agent: "agent", Type: "ask", State: string(workflow.JobQueued), Payload: `{"repo":"owner/repo"}`}); err != nil {
@@ -585,7 +590,7 @@ func TestPollRegisteredReposTreats304AsSuccess(t *testing.T) {
 	}
 	defer store.Close()
 	ctx := context.Background()
-	if err := store.UpsertRepo(ctx, db.Repo{Owner: "etag304", Name: "repo", CheckoutPath: "/tmp/etag304", PollInterval: "1s"}); err != nil {
+	if err := store.UpsertRepo(ctx, db.Repo{Owner: "etag304", Name: "repo", CheckoutPath: t.TempDir(), PollInterval: "1s"}); err != nil {
 		t.Fatal(err)
 	}
 	runner := &cliETagRunner{}
@@ -658,5 +663,234 @@ func TestStartSupervisorWorkerLoopRecoveringRetriesAfterRunError(t *testing.T) {
 	defer mu.Unlock()
 	if calls < 2 {
 		t.Fatalf("recovering worker loop calls = %d, want at least 2", calls)
+	}
+}
+
+// A registered repo whose checkout directory has vanished must be reported and
+// SKIPPED (#1758): before the guard it still paid for engine construction, DB
+// passes, a config parse and a `gh` exec that could only fail on chdir, on every
+// tick forever. The factory counter is the load-bearing assertion — a version
+// that logs the problem and then polls anyway would pass a log-only check.
+func TestPollRepoSkipsRepoWhoseCheckoutIsMissing(t *testing.T) {
+	paths := config.PathsForHome(t.TempDir())
+	if err := config.Initialize(paths); err != nil {
+		t.Fatal(err)
+	}
+	store, err := dbtest.Open(t, paths.Database)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+	ctx := context.Background()
+	missing := filepath.Join(t.TempDir(), "went-away")
+	if err := store.UpsertRepo(ctx, db.Repo{Owner: "owner", Name: "gone", CheckoutPath: missing, PollInterval: "1s"}); err != nil {
+		t.Fatal(err)
+	}
+	var stdout bytes.Buffer
+	engines, clients := 0, 0
+	poller := defaultRegisteredRepoPoller(store, 1, false, &stdout, "", "")
+	poller.GitHubClient = func(string) github.Client { clients++; return &cliPollFakeGitHub{} }
+	poller.WorkflowFactory = func(*db.Store, github.Client, string) *workflow.Engine {
+		engines++
+		return nil
+	}
+	schedule := registeredRepoSchedule{NextPoll: map[string]time.Time{}, ErrorStreak: map[string]int{}, IdleStreak: map[string]int{}}
+	if _, err := pollRegisteredReposWithPoller(ctx, poller, schedule, time.Now().UTC(), time.Second); err != nil {
+		t.Fatalf("poll pass: %v", err)
+	}
+	if engines != 0 || clients != 0 {
+		t.Fatalf("missing checkout still built %d engines and %d github clients, want 0 and 0", engines, clients)
+	}
+	if !strings.Contains(stdout.String(), "owner/gone: registered repo checkout path is unavailable") {
+		t.Fatalf("poll log = %q, want the unavailable-checkout report", stdout.String())
+	}
+	if strings.Contains(stdout.String(), "polling owner/gone") {
+		t.Fatalf("missing checkout was polled anyway: %q", stdout.String())
+	}
+	repos, err := store.ListRepos(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(repos) != 1 || !strings.Contains(repos[0].LastError, "checkout path is unavailable") {
+		t.Fatalf("repos = %+v, want last_error naming the unavailable checkout", repos)
+	}
+}
+
+// The poll line echoed a fleet-wide --workers flag as if it were a per-repo pool
+// (#1758). No such pool exists, so the number is removed rather than corrected.
+func TestPollRepoLogDoesNotClaimAPerRepoWorkerPool(t *testing.T) {
+	paths := config.PathsForHome(t.TempDir())
+	if err := config.Initialize(paths); err != nil {
+		t.Fatal(err)
+	}
+	store, err := dbtest.Open(t, paths.Database)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+	ctx := context.Background()
+	if err := store.UpsertRepo(ctx, db.Repo{Owner: "owner", Name: "live", CheckoutPath: t.TempDir(), PollInterval: "1s"}); err != nil {
+		t.Fatal(err)
+	}
+	var stdout bytes.Buffer
+	poller := defaultRegisteredRepoPoller(store, 32, false, &stdout, "", "")
+	poller.GitHubClient = func(string) github.Client { return &cliPollFakeGitHub{} }
+	poller.WorkflowFactory = func(*db.Store, github.Client, string) *workflow.Engine { return nil }
+	schedule := registeredRepoSchedule{NextPoll: map[string]time.Time{}, ErrorStreak: map[string]int{}, IdleStreak: map[string]int{}}
+	if _, err := pollRegisteredReposWithPoller(ctx, poller, schedule, time.Now().UTC(), time.Second); err != nil {
+		t.Fatalf("poll pass: %v", err)
+	}
+	if !strings.Contains(stdout.String(), "polling owner/live dry_run=false") {
+		t.Fatalf("poll log = %q, want the worker-free poll line", stdout.String())
+	}
+	if strings.Contains(stdout.String(), "workers") {
+		t.Fatalf("poll log still advertises a per-repo worker pool: %q", stdout.String())
+	}
+}
+
+// The per-tick config memo must read config.toml ONCE per tick and re-read it on
+// the next one: rewriting the file between two calls on the same cache must be
+// invisible, and visible immediately after reset(). That is the same measurement
+// as counting opens, without depending on strace.
+func TestTickConfigCacheReadsConfigOncePerTick(t *testing.T) {
+	home := t.TempDir()
+	paths := config.PathsForHome(home)
+	if err := config.Initialize(paths); err != nil {
+		t.Fatal(err)
+	}
+	write := func(ttl string) {
+		if err := os.WriteFile(paths.ConfigFile, []byte("[orchestrate]\nblocked_ttl = \""+ttl+"\"\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	write("48h")
+	cache := &tickConfigCache{}
+	if got := cache.blockedJobTTL(paths.Home); got != 48*time.Hour {
+		t.Fatalf("blockedJobTTL = %s, want 48h", got)
+	}
+	write("1h")
+	if got := cache.blockedJobTTL(paths.Home); got != 48*time.Hour {
+		t.Fatalf("blockedJobTTL re-read config.toml mid-tick: got %s, want the memoized 48h", got)
+	}
+	// A different home must never be served another home's policy.
+	other := t.TempDir()
+	otherPaths := config.PathsForHome(other)
+	if err := config.Initialize(otherPaths); err != nil {
+		t.Fatal(err)
+	}
+	if got := cache.blockedJobTTL(otherPaths.Home); got != 0 {
+		t.Fatalf("a second home got %s, want its own (unset ⇒ 0) policy", got)
+	}
+	cache.reset()
+	if got := cache.blockedJobTTL(paths.Home); got != time.Hour {
+		t.Fatalf("blockedJobTTL after reset = %s, want the re-read 1h", got)
+	}
+
+	// A nil cache is the un-memoized path and must see every write immediately.
+	var uncached *tickConfigCache
+	write("2h")
+	if got := uncached.blockedJobTTL(paths.Home); got != 2*time.Hour {
+		t.Fatalf("nil cache blockedJobTTL = %s, want 2h", got)
+	}
+
+	// Every other memoized resolver must behave the same way, or the hoist only
+	// covers whichever one the test happened to exercise.
+	writePolicy := func(wake, retention string) {
+		body := "[orchestrate]\nblocked_role_wake_after = \"" + wake + "\"\n[workflow]\ndelegation_worktree_ttl = \"" + retention + "\"\n"
+		if err := os.WriteFile(paths.ConfigFile, []byte(body), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	writePolicy("3h", "24h")
+	fresh := &tickConfigCache{}
+	if got := fresh.blockedRoleWakeAfter(paths.Home); got != 3*time.Hour {
+		t.Fatalf("blockedRoleWakeAfter = %s, want 3h", got)
+	}
+	retention, err := fresh.delegationWorktreeTTL(paths.Home)
+	if err != nil || retention != 24*time.Hour {
+		t.Fatalf("delegationWorktreeTTL = %s err=%v, want 24h", retention, err)
+	}
+	writePolicy("9h", "72h")
+	if got := fresh.blockedRoleWakeAfter(paths.Home); got != 3*time.Hour {
+		t.Fatalf("blockedRoleWakeAfter re-read config.toml mid-tick: got %s, want 3h", got)
+	}
+	if got, err := fresh.delegationWorktreeTTL(paths.Home); err != nil || got != 24*time.Hour {
+		t.Fatalf("delegationWorktreeTTL re-read config.toml mid-tick: got %s err=%v, want 24h", got, err)
+	}
+	fresh.reset()
+	if got := fresh.blockedRoleWakeAfter(paths.Home); got != 9*time.Hour {
+		t.Fatalf("blockedRoleWakeAfter after reset = %s, want 9h", got)
+	}
+	if got, err := fresh.delegationWorktreeTTL(paths.Home); err != nil || got != 72*time.Hour {
+		t.Fatalf("delegationWorktreeTTL after reset = %s err=%v, want 72h", got, err)
+	}
+}
+
+// The memory controller is the loader that cost the most for the least: two full
+// config loads per repo per tick to return nil. Memoize the RESULT, nil included,
+// and still re-resolve on the next tick.
+func TestTickConfigCacheMemoizesMemoryController(t *testing.T) {
+	paths := config.PathsForHome(t.TempDir())
+	if err := config.Initialize(paths); err != nil {
+		t.Fatal(err)
+	}
+	store, err := dbtest.Open(t, paths.Database)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+	write := func(body string) {
+		if err := os.WriteFile(paths.ConfigFile, []byte(body), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	write("[agents.solo]\nmemory = true\n")
+	cache := &tickConfigCache{}
+	if cache.memoryController(store, paths.Home) == nil {
+		t.Fatal("an enrolled agent must produce a controller")
+	}
+	write("[memory]\ndisabled = true\n")
+	if cache.memoryController(store, paths.Home) == nil {
+		t.Fatal("the controller was re-resolved mid-tick; the memo did not hold")
+	}
+	cache.reset()
+	if cache.memoryController(store, paths.Home) != nil {
+		t.Fatal("after reset the kill switch must take effect")
+	}
+	// The nil result is memoized too — reaching it costs the same two loads.
+	write("[agents.solo]\nmemory = true\n")
+	if cache.memoryController(store, paths.Home) != nil {
+		t.Fatal("the nil result was not memoized")
+	}
+}
+
+// Every poll pass must start from a cold config memo, otherwise the poller would
+// read config.toml once per PROCESS rather than once per tick and stop being
+// live-tunable.
+func TestPollPassResetsConfigCache(t *testing.T) {
+	paths := config.PathsForHome(t.TempDir())
+	if err := config.Initialize(paths); err != nil {
+		t.Fatal(err)
+	}
+	store, err := dbtest.Open(t, paths.Database)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+	poller := defaultRegisteredRepoPoller(store, 1, false, io.Discard, "", "")
+	if poller.ConfigCache == nil {
+		t.Fatal("the default poller must carry a config cache")
+	}
+	poller.ConfigCache.memoryDone = true
+	poller.ConfigCache.memoryHome = "stale"
+	// No enabled repos: the pass does nothing except its own setup, so a cleared
+	// cache can only have come from the reset.
+	if _, err := pollRegisteredReposWithPoller(context.Background(), poller, registeredRepoSchedule{}, time.Now().UTC(), time.Second); err != nil {
+		t.Fatalf("poll pass: %v", err)
+	}
+	if poller.ConfigCache.memoryDone || poller.ConfigCache.memoryHome != "" {
+		t.Fatalf("config cache survived a poll pass: %+v", poller.ConfigCache)
 	}
 }

--- a/internal/cli/daemon_test.go
+++ b/internal/cli/daemon_test.go
@@ -855,6 +855,7 @@ type countingCandidateStore struct {
 	agedReclaim    int32
 	taskReclaim    int32
 	malformedOwner int32
+	jobEventCursor int32
 }
 
 func (c *countingCandidateStore) JobIDsWithPendingAdvanceRetry(ctx context.Context) ([]string, error) {
@@ -885,6 +886,11 @@ func (c *countingCandidateStore) TaskIDsWithTerminalWorktree(ctx context.Context
 func (c *countingCandidateStore) FirstMalformedNonFinalJob(ctx context.Context) (string, error) {
 	atomic.AddInt32(&c.malformedOwner, 1)
 	return c.inner.FirstMalformedNonFinalJob(ctx)
+}
+
+func (c *countingCandidateStore) MaxJobEventID(ctx context.Context) (int64, error) {
+	atomic.AddInt32(&c.jobEventCursor, 1)
+	return c.inner.MaxJobEventID(ctx)
 }
 
 // flakyCandidateStore returns an error on the first call to each candidate query and
@@ -943,4 +949,11 @@ func (s *flakyCandidateStore) FirstMalformedNonFinalJob(context.Context) (string
 		return "", errCandidateTransient
 	}
 	return "malformed-job", nil
+}
+
+// MaxJobEventID is deliberately non-flaky and unused by these carriers (they set
+// no cursor cache), so the retry-on-error proof keeps measuring only the
+// candidate queries themselves.
+func (s *flakyCandidateStore) MaxJobEventID(context.Context) (int64, error) {
+	return 0, nil
 }

--- a/internal/cli/daemon_worker.go
+++ b/internal/cli/daemon_worker.go
@@ -3782,7 +3782,7 @@ func (w jobWorker) workflowForHost(checkout string) workflow.Engine {
 }
 
 func (w jobWorker) defaultWorkflowForRunner(checkout string, runner subprocess.Runner) workflow.Engine {
-	engine := daemonWorkflowEngineForRunner(w.Store, github.NewClient(checkout), checkout, w.workflowHome(), runner)
+	engine := daemonWorkflowEngineForRunner(w.Store, github.NewClient(checkout), checkout, w.workflowHome(), runner, nil)
 	w.applyOrchestratePolicy(&engine)
 	return engine
 }

--- a/internal/cli/daemon_workflow.go
+++ b/internal/cli/daemon_workflow.go
@@ -36,10 +36,18 @@ var (
 // of which re-resolve — so handing it the raw --home would misplace delegation
 // artifacts and the event-sink config probe.
 func daemonWorkflowEngine(store *db.Store, gh github.Client, checkout string, home string) workflow.Engine {
-	return daemonWorkflowEngineForRunner(store, gh, checkout, home, subprocess.ExecRunner{})
+	return daemonWorkflowEngineForRunner(store, gh, checkout, home, subprocess.ExecRunner{}, nil)
 }
 
-func daemonWorkflowEngineForRunner(store *db.Store, gh github.Client, checkout string, home string, runner subprocess.Runner) workflow.Engine {
+// daemonWorkflowEngineCached is daemonWorkflowEngine for a caller that already
+// holds a per-tick config memo (#1758) — today only the sequential registered-repo
+// poll pass, whose 45 per-repo engine rebuilds otherwise re-read and re-parsed
+// config.toml twice each just to resolve a memory controller that is nil.
+func daemonWorkflowEngineCached(store *db.Store, gh github.Client, checkout string, home string, cfg *tickConfigCache) workflow.Engine {
+	return daemonWorkflowEngineForRunner(store, gh, checkout, home, subprocess.ExecRunner{}, cfg)
+}
+
+func daemonWorkflowEngineForRunner(store *db.Store, gh github.Client, checkout string, home string, runner subprocess.Runner, cfg *tickConfigCache) workflow.Engine {
 	gh = jobGitHubClient(checkout, gh, runner)
 	engine := workflow.Engine{
 		Store:                   store,
@@ -70,7 +78,7 @@ func daemonWorkflowEngineForRunner(store *db.Store, gh github.Client, checkout s
 		// error), so with no config NO memory hook is wired and prompt assembly +
 		// the terminal path are byte-identical. Non-enrolled agents are never touched
 		// even when the controller is present.
-		Memory: daemonMemoryController(store, home),
+		Memory: cfg.memoryController(store, home),
 		// Registry default model/effort fallbacks: when a delivered job pins no
 		// agent/job override, fall back to the HOME-AWARE resolved runtime registry
 		// (built-in defaults overlaid with [runtimes.<name>] config). Fail-open and

--- a/internal/cli/execbackend_e2e_test.go
+++ b/internal/cli/execbackend_e2e_test.go
@@ -647,7 +647,7 @@ func TestDaemonWorkflowGitHubRoutesConsumeResolvedSubprocessRunner(t *testing.T)
 		Limiter:    github.NewRateLimiter(github.RateLimiterConfig{}),
 	}
 	checkout := t.TempDir()
-	engine := daemonWorkflowEngineForRunner(nil, source, checkout, "", runner)
+	engine := daemonWorkflowEngineForRunner(nil, source, checkout, "", runner, nil)
 	finalizer, ok := engine.ImplementationFinalizer.(daemonImplementationFinalizer)
 	if !ok {
 		t.Fatalf("implementation finalizer = %T, want daemonImplementationFinalizer", engine.ImplementationFinalizer)

--- a/internal/cli/host_runner_guard_test.go
+++ b/internal/cli/host_runner_guard_test.go
@@ -87,6 +87,10 @@ var hostRunnerAllowlist = map[string]hostRunnerAllowance{
 		execRunners: 1,
 		reason:      "legacy host-mode engine wrapper; backend jobs call daemonWorkflowEngineForRunner",
 	},
+	"internal/cli/daemon_workflow.go:daemonWorkflowEngineCached": {
+		execRunners: 1,
+		reason:      "same host-mode engine wrapper as daemonWorkflowEngine, taking the poll pass's config memo (#1758); backend jobs call daemonWorkflowEngineForRunner",
+	},
 	"internal/cli/daemon_workflow.go:implementationFinalizationTargetFor": {
 		execRunners: 1,
 		reason:      "host-mode finalization wrapper delegates checkout inspection to implementationFinalizationTargetForRunner",

--- a/internal/cli/reply_wake_outbox.go
+++ b/internal/cli/reply_wake_outbox.go
@@ -52,15 +52,27 @@ func (h replyWakeOutboxHealth) String() string {
 	)
 }
 
+// wakeOutboxStore is the narrow store dependency the reply-wake drain uses. It
+// exists for the same reason tickCandidateStore does: production always threads
+// the real *db.Store, and a counting fake can then pin how many times the drain
+// projects the outbox — the property #1758 changed and would otherwise be
+// unmeasurable from outside.
+type wakeOutboxStore interface {
+	ListWakeOutboxObligations(ctx context.Context, attemptedBefore time.Time) (db.WakeOutboxObligationProjection, error)
+	ExpireAgedWakeOutbox(ctx context.Context, attemptedBefore time.Time, now time.Time) ([]db.WakeOutboxEntry, error)
+	ClaimWakeOutbox(ctx context.Context, ids []int64, now time.Time) (bool, error)
+	ListDeletedEventRulesForRoutes(ctx context.Context, routes []db.EventRuleRoute) ([]db.DeletedEventRule, error)
+}
+
 // drainReplyWakeOutbox is a store-global daemon operation. It deliberately
 // reads durable work before resolving delivery: unreadable outbox state and an
 // empty outbox therefore cannot collapse into the same result.
-func drainReplyWakeOutbox(ctx context.Context, store *db.Store, now time.Time, resolve replyWakeDeliveryResolver) error {
+func drainReplyWakeOutbox(ctx context.Context, store wakeOutboxStore, now time.Time, resolve replyWakeDeliveryResolver) error {
 	_, err := drainReplyWakeOutboxWithHealth(ctx, store, now, resolve)
 	return err
 }
 
-func drainReplyWakeOutboxWithHealth(ctx context.Context, store *db.Store, now time.Time, resolve replyWakeDeliveryResolver) (replyWakeOutboxHealth, error) {
+func drainReplyWakeOutboxWithHealth(ctx context.Context, store wakeOutboxStore, now time.Time, resolve replyWakeDeliveryResolver) (replyWakeOutboxHealth, error) {
 	if store == nil {
 		return replyWakeOutboxHealth{}, errors.New("wake outbox store is required")
 	}
@@ -69,6 +81,12 @@ func drainReplyWakeOutboxWithHealth(ctx context.Context, store *db.Store, now ti
 	if err != nil || obligations.Len() == 0 {
 		return replyWakeOutboxHealth{}, err
 	}
+	// Tracks whether this drain changed any outbox row. Only a successful claim
+	// does: ExpireAgedWakeOutbox returns above whenever it expired anything, and
+	// every other branch is a read. When nothing was claimed the projection read
+	// at line 68 still describes the store exactly, so the closing health pass
+	// can reuse it instead of issuing the same query a second time (#1758).
+	mutated := false
 
 	agedAttempted := len(obligations.AgedAttempted)
 	if agedAttempted > 0 {
@@ -160,6 +178,7 @@ func drainReplyWakeOutboxWithHealth(ctx context.Context, store *db.Store, now ti
 				return replyWakeOutboxHealth{}, err
 			}
 			if claimed {
+				mutated = true
 				event.WakeOutboxIDs = ids
 				if err := emitReplyWakeOutboxEvent(ctx, delivery.sink, event, matchingRules); err != nil {
 					return replyWakeOutboxHealth{}, fmt.Errorf("emit claimed %s wake: %w", event.WakeKind, err)
@@ -168,12 +187,19 @@ func drainReplyWakeOutboxWithHealth(ctx context.Context, store *db.Store, now ti
 			start = end
 		}
 	}
-	return wakeOutboxObligationHealth(ctx, store, attemptedBefore, resolve)
+	if mutated {
+		return wakeOutboxObligationHealth(ctx, store, attemptedBefore, resolve)
+	}
+	// The #1200/#1201 contract is untouched by the reuse: an unreadable outbox
+	// already returned its error at line 68, so only a SUCCESSFUL read can reach
+	// here, and an empty one returned early. Reuse therefore never turns "could
+	// not read" into "nothing to do".
+	return classifyWakeOutboxObligations(ctx, store, obligations, attemptedBefore, resolve)
 }
 
 func wakeOutboxObligationHealth(
 	ctx context.Context,
-	store *db.Store,
+	store wakeOutboxStore,
 	attemptedBefore time.Time,
 	resolve replyWakeDeliveryResolver,
 ) (replyWakeOutboxHealth, error) {
@@ -181,6 +207,20 @@ func wakeOutboxObligationHealth(
 	if err != nil {
 		return replyWakeOutboxHealth{}, fmt.Errorf("read wake outbox obligations: %w", err)
 	}
+	return classifyWakeOutboxObligations(ctx, store, obligations, attemptedBefore, resolve)
+}
+
+// classifyWakeOutboxObligations grades an ALREADY-READ obligation projection.
+// Splitting it out lets the drain reuse its own opening read when it claimed
+// nothing; the read itself stays in wakeOutboxObligationHealth for callers that
+// need a fresh projection.
+func classifyWakeOutboxObligations(
+	ctx context.Context,
+	store wakeOutboxStore,
+	obligations db.WakeOutboxObligationProjection,
+	attemptedBefore time.Time,
+	resolve replyWakeDeliveryResolver,
+) (replyWakeOutboxHealth, error) {
 	health := replyWakeOutboxHealth{agedAttempted: len(obligations.AgedAttempted)}
 	if len(obligations.Pending) == 0 {
 		if health.agedAttempted == 0 {

--- a/internal/cli/reply_wake_outbox_test.go
+++ b/internal/cli/reply_wake_outbox_test.go
@@ -12,6 +12,7 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -409,6 +410,14 @@ func TestReplyWakeOutboxDrainFailureDoesNotAbortRepoWork(t *testing.T) {
 	}
 }
 
+// A persistently inert wake outbox must (a) never escalate the supervisor and
+// (b) since #1758, print its health line exactly ONCE however long it persists —
+// inert is a permanent state, so the repeat carries no information and used to
+// cost ~12.8k journal lines/day.
+//
+// Ticks are counted through the newTickCandidates seam rather than through the
+// health line itself: with log-on-change the line no longer marks a tick, so
+// counting it would silently stop measuring what the test claims to measure.
 func TestReplyWakeOutboxInertHealthDoesNotEscalateSingleRepoLoop(t *testing.T) {
 	store := daemonWorkerStore(t)
 	seedDaemonWorkerRepo(t, store, "owner/repo", t.TempDir())
@@ -425,10 +434,22 @@ func TestReplyWakeOutboxInertHealthDoesNotEscalateSingleRepoLoop(t *testing.T) {
 	live := newDaemonReloadableConfig(30*time.Second, 1, false)
 	tracker := newInflightJobTracker(ctx)
 	var checkoutLock sync.Mutex
-	stdout := &cancelAfterWakeHealthWriter{
-		cancel:    cancel,
-		threshold: maxConsecutiveWorkerTickFailures + 1,
+	stdout := &syncBuffer{}
+
+	// Cancel only once the loop has run strictly more ticks than the escalation
+	// ladder tolerates, so surviving the ladder is what ends the test.
+	wantTicks := maxConsecutiveWorkerTickFailures + 2
+	var ticks atomic.Int32
+	var cancelOnce sync.Once
+	realNewTickCandidates := newTickCandidates
+	newTickCandidates = func(store tickCandidateStore) *tickCandidates {
+		if ticks.Add(1) >= int32(wantTicks) {
+			cancelOnce.Do(cancel)
+		}
+		return realNewTickCandidates(store)
 	}
+	defer func() { newTickCandidates = realNewTickCandidates }()
+
 	errCh := startSingleRepoWorkerLoop(
 		ctx, 100*time.Microsecond, store, worker, live, &checkoutLock, tracker,
 		"owner/repo", "", stdout,
@@ -440,10 +461,13 @@ func TestReplyWakeOutboxInertHealthDoesNotEscalateSingleRepoLoop(t *testing.T) {
 			t.Fatalf("single-repo loop escalated persistent inert wake health: %v", err)
 		}
 	case <-time.After(5 * time.Second):
-		t.Fatalf("single-repo loop did not report inert health beyond %d ticks; log=%q", maxConsecutiveWorkerTickFailures, stdout.String())
+		t.Fatalf("single-repo loop ran %d ticks in 5s, want %d; log=%q", ticks.Load(), wantTicks, stdout.String())
 	}
-	if got := strings.Count(stdout.String(), "reply wake outbox drain health:"); got <= maxConsecutiveWorkerTickFailures {
-		t.Fatalf("inert health lines = %d, want more than escalation threshold %d; log=%q", got, maxConsecutiveWorkerTickFailures, stdout.String())
+	if got := ticks.Load(); got < int32(wantTicks) {
+		t.Fatalf("ticks = %d, want at least %d (the escalation ladder must be outlived)", got, wantTicks)
+	}
+	if got := strings.Count(stdout.String(), "reply wake outbox drain health:"); got != 1 {
+		t.Fatalf("inert health lines = %d over %d ticks, want exactly 1; log=%q", got, ticks.Load(), stdout.String())
 	}
 	if strings.Contains(stdout.String(), "consecutive failures, escalating") {
 		t.Fatalf("inert reply wake health reached escalation ladder: %q", stdout.String())
@@ -454,26 +478,32 @@ func TestReplyWakeOutboxInertHealthDoesNotEscalateSingleRepoLoop(t *testing.T) {
 	}
 }
 
-// cancelAfterWakeHealthWriter makes shutdown deterministic: cancellation is
-// triggered only after the threshold-crossing health line has been committed,
-// so it cannot land inside the drain that produced the observed line.
-type cancelAfterWakeHealthWriter struct {
-	output    syncBuffer
-	cancel    context.CancelFunc
-	threshold int
-	once      sync.Once
-}
+// Leaving the inert state and returning to it must re-log: log-on-change may
+// suppress a repeat, never a transition.
+func TestReplyWakeOutboxHealthRelogsAfterTransition(t *testing.T) {
+	tracker := newInflightJobTracker(context.Background())
+	inert := replyWakeOutboxHealth{inert: 1}
 
-func (w *cancelAfterWakeHealthWriter) Write(p []byte) (int, error) {
-	n, err := w.output.Write(p)
-	if err == nil && strings.Count(w.output.String(), "reply wake outbox drain health:") >= w.threshold {
-		w.once.Do(w.cancel)
+	if !tracker.replyWakeOutboxHealthChanged(inert) {
+		t.Fatal("first inert health must log")
 	}
-	return n, err
-}
-
-func (w *cancelAfterWakeHealthWriter) String() string {
-	return w.output.String()
+	if tracker.replyWakeOutboxHealthChanged(inert) {
+		t.Fatal("an identical repeat must be suppressed")
+	}
+	if !tracker.replyWakeOutboxHealthChanged(replyWakeOutboxHealth{inert: 2}) {
+		t.Fatal("a changed count must log")
+	}
+	// A clean tick (nothing inert) prints nothing but must clear the memory, so
+	// the same line reappearing afterwards is visible.
+	tracker.forgetReplyWakeOutboxHealth()
+	if !tracker.replyWakeOutboxHealthChanged(replyWakeOutboxHealth{inert: 2}) {
+		t.Fatal("returning to a previously-logged state must log again")
+	}
+	// A nil tracker is the untracked path and must keep logging every tick.
+	var untracked *inflightJobTracker
+	if !untracked.replyWakeOutboxHealthChanged(inert) || !untracked.replyWakeOutboxHealthChanged(inert) {
+		t.Fatal("a nil tracker must never suppress a health line")
+	}
 }
 
 func TestReplyWakeOutboxBurstCoalescesToExactlyOneWake(t *testing.T) {
@@ -1291,5 +1321,123 @@ func setWakeOutboxCreatedAt(t *testing.T, databasePath, sourceID string, at time
 	if _, err := raw.Exec(`UPDATE wake_outbox SET created_at = ?, updated_at = ? WHERE source_kind = ? AND source_id = ?`,
 		stamp, stamp, db.WakeOutboxSourceWorkflowNote, sourceID); err != nil {
 		t.Fatal(err)
+	}
+}
+
+// countingWakeOutboxStore delegates every drain operation to a real store while
+// counting the obligation projections, which is the only way to observe #1758's
+// second half from outside: the drain used to run the identical
+// ListWakeOutboxObligations query TWICE on every tick.
+type countingWakeOutboxStore struct {
+	inner       *db.Store
+	projections int
+	claims      int
+}
+
+func (s *countingWakeOutboxStore) ListWakeOutboxObligations(ctx context.Context, attemptedBefore time.Time) (db.WakeOutboxObligationProjection, error) {
+	s.projections++
+	return s.inner.ListWakeOutboxObligations(ctx, attemptedBefore)
+}
+
+func (s *countingWakeOutboxStore) ExpireAgedWakeOutbox(ctx context.Context, attemptedBefore, now time.Time) ([]db.WakeOutboxEntry, error) {
+	return s.inner.ExpireAgedWakeOutbox(ctx, attemptedBefore, now)
+}
+
+func (s *countingWakeOutboxStore) ClaimWakeOutbox(ctx context.Context, ids []int64, now time.Time) (bool, error) {
+	claimed, err := s.inner.ClaimWakeOutbox(ctx, ids, now)
+	if claimed {
+		s.claims++
+	}
+	return claimed, err
+}
+
+func (s *countingWakeOutboxStore) ListDeletedEventRulesForRoutes(ctx context.Context, routes []db.EventRuleRoute) ([]db.DeletedEventRule, error) {
+	return s.inner.ListDeletedEventRulesForRoutes(ctx, routes)
+}
+
+// A tick that claims nothing changes no row, so its closing health pass reuses
+// the projection it already read instead of issuing the identical query again.
+// A tick that DOES claim must re-read: the rows it just moved are exactly what
+// the health grade is about.
+func TestReplyWakeOutboxDrainProjectsOnceWhenNothingIsClaimed(t *testing.T) {
+	store, sink, _, _ := replyWakeTestHarness(t, []replyWakeTestRole{{"owner", "w1:p1"}})
+	ctx := context.Background()
+	if _, err := store.InsertWorkflowNote(ctx, db.WorkflowNote{
+		WorkflowID: "release/projection-count", Author: "worker", Body: "deliverable",
+		AddressedTarget: "owner",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	pending, err := store.ListWakeOutbox(ctx, db.WakeOutboxStatePending)
+	if err != nil || len(pending) == 0 {
+		t.Fatalf("pending rows = %+v, err=%v", pending, err)
+	}
+	createdAt, err := time.Parse(time.RFC3339Nano, pending[0].CreatedAt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	due := createdAt.Add(replyWakeCoalescingWindow + time.Second)
+
+	// This row is deliverable, so the drain claims it and must re-read.
+	claiming := &countingWakeOutboxStore{inner: store}
+	if err := drainReplyWakeOutbox(ctx, claiming, due, replyWakeTestDeliveryResolver(sink)); err != nil {
+		t.Fatalf("claiming drain: %v", err)
+	}
+	if claiming.claims == 0 {
+		t.Fatalf("the fixture claimed nothing; the counting test would be vacuous")
+	}
+	if claiming.projections != 2 {
+		t.Fatalf("claiming drain projected %d times, want 2 (post-claim state must be re-read)", claiming.projections)
+	}
+
+	// Nothing left to claim: one projection for the whole drain.
+	idle := &countingWakeOutboxStore{inner: store}
+	if err := drainReplyWakeOutbox(ctx, idle, due, replyWakeTestDeliveryResolver(sink)); err != nil {
+		t.Fatalf("idle drain: %v", err)
+	}
+	if idle.claims != 0 {
+		t.Fatalf("second drain claimed %d rows, want 0", idle.claims)
+	}
+	if idle.projections > 1 {
+		t.Fatalf("idle drain projected %d times, want at most 1", idle.projections)
+	}
+}
+
+// The reuse must not change the verdict: an inert row grades identically whether
+// the projection was re-read or reused.
+func TestReplyWakeOutboxReusedProjectionGradesIdentically(t *testing.T) {
+	store, sink, _, _ := replyWakeTestHarness(t, []replyWakeTestRole{{"owner", "w1:p1"}})
+	ctx := context.Background()
+	if _, err := store.InsertWorkflowNote(ctx, db.WorkflowNote{
+		WorkflowID: "release/reuse-grade", Author: "worker", Body: "unroutable",
+		AddressedTarget: "nobody",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	pending, err := store.ListWakeOutbox(ctx, db.WakeOutboxStatePending)
+	if err != nil || len(pending) == 0 {
+		t.Fatalf("pending rows = %+v, err=%v", pending, err)
+	}
+	createdAt, err := time.Parse(time.RFC3339Nano, pending[0].CreatedAt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	due := createdAt.Add(replyWakeCoalescingWindow + time.Second)
+	attemptedBefore := due.UTC().Add(-replyWakeAttemptedUnknownAfter)
+
+	counted := &countingWakeOutboxStore{inner: store}
+	reused, reusedErr := drainReplyWakeOutboxWithHealth(ctx, counted, due, replyWakeTestDeliveryResolver(sink))
+	if counted.claims != 0 || counted.projections != 1 {
+		t.Fatalf("claims=%d projections=%d, want the reuse path (0 and 1)", counted.claims, counted.projections)
+	}
+	fresh, freshErr := wakeOutboxObligationHealth(ctx, store, attemptedBefore, replyWakeTestDeliveryResolver(sink))
+	if reused != fresh {
+		t.Fatalf("reused health %s != freshly read health %s", reused, fresh)
+	}
+	if (reusedErr == nil) != (freshErr == nil) {
+		t.Fatalf("reused err=%v, fresh err=%v", reusedErr, freshErr)
+	}
+	if reused.inert != 1 {
+		t.Fatalf("health = %s, want the unroutable row graded inert", reused)
 	}
 }

--- a/internal/cli/review_risk_test.go
+++ b/internal/cli/review_risk_test.go
@@ -289,7 +289,7 @@ func TestDaemonWorkflowEngineScopesReviewFromTheDaemonCheckout(t *testing.T) {
 	}
 	client := &reviewCompareClient{result: github.CompareResult{Status: "ahead", Files: capped, Truncated: true}}
 
-	engine := daemonWorkflowEngineForRunner(daemonWorkerStore(t), client, checkout, home, subprocess.ExecRunner{})
+	engine := daemonWorkflowEngineForRunner(daemonWorkerStore(t), client, checkout, home, subprocess.ExecRunner{}, nil)
 	if engine.ReviewChangedFiles == nil {
 		t.Fatal("the daemon engine did not wire ReviewChangedFiles")
 	}

--- a/internal/db/store_jobs.go
+++ b/internal/db/store_jobs.go
@@ -1845,6 +1845,34 @@ func (s *Store) JobIDsWithPendingAdvanceRetry(ctx context.Context) ([]string, er
 	return s.jobIDsByQuery(ctx, jobIDsWithPendingAdvanceRetrySQL)
 }
 
+// maxJobEventIDSQL is the change cursor for the candidate queries whose result is
+// a pure function of job_events. It is the same monotonic maximum the dashboard
+// already polls (dashboardChangeCursorSQL) and SQLite answers it with a single
+// descent of the integer primary key, so it costs the same whether the table
+// holds a hundred rows or a hundred thousand.
+const maxJobEventIDSQL = `SELECT COALESCE(MAX(id), 0) FROM job_events`
+
+// MaxJobEventID returns the highest job_events row id, or 0 when the table is
+// empty.
+//
+// It is a sound change cursor for JobIDsWithPendingAdvanceRetry and
+// JobIDsWithPendingCommentRetry specifically, because those two queries read only
+// the (id, kind, job_id) columns of job_events and NOTHING else — no other table,
+// no clock. Production only ever APPENDS to job_events (the sole DELETE is a
+// one-time migration that runs before any tick) and its in-place updates —
+// RefreshLatestAdvanceRetry, the running-job progress refresh, and the claimed
+// permission-policy warning — all SET message/created_at only, never id, kind or
+// job_id. So an unmoved maximum id proves those two result sets are unchanged.
+//
+// It is NOT a sound cursor for the delegation/aged/task reclaim candidates: those
+// join jobs and cleanup_obligations and compare against unixepoch('now'), so their
+// results change with the clock alone.
+func (s *Store) MaxJobEventID(ctx context.Context) (int64, error) {
+	var id int64
+	err := s.db.QueryRowContext(ctx, maxJobEventIDSQL).Scan(&id)
+	return id, err
+}
+
 // JobIDsWithPendingCommentRetry returns the IDs of jobs whose LATEST comment event
 // (by id) is comment_post_failed with no subsequent comment_posted or retry_queued
 // — exactly jobWorker.jobNeedsCommentRetry's last-one-wins rule (daemon.go),


### PR DESCRIPTION
Closes part of #1758 (Wave 1 Lane C, directive 105455). Five of the six items; **item 2 is not here** — the malformed-directive parking in `internal/cli/blocked_since.go:471-476` is gm-omp-impl's under #1750, confirmed in workflow note 105486. That file is otherwise untouched by this PR except lines 165-169, for which gm-omp-impl gave an explicit narrow grant (note 105512).

## What changed

**1. `reply wake outbox drain health` logs on CHANGE only** (12,783 lines/day). `inert > 0` is permanent until an operator adds a wake rule, so the identical line was re-emitted every tick. The last-logged health lives on the supervisor's `inflightJobTracker`; a **nil** tracker still logs every tick, and any tick that does not print a health line (drain error, or nothing inert) clears the memory so a return to the state is visible.

Same item, second half: `drainReplyWakeOutboxWithHealth` ran the identical `ListWakeOutboxObligations` query twice per tick. When the drain claims nothing it changes no row, so the closing health pass now grades the projection it already read. **The #1200/#1201 contract is preserved**: only a successful read can reach the reuse (an unreadable outbox already returned its error, an empty one returned early), so "could not read" can never collapse into "nothing to do".

**3. `pollRepo` guards on `os.Stat(CheckoutPath)`** with the same early return as the empty-path case. A repo whose checkout has vanished was still paying for engine construction, two DB passes, a config parse and a `gh` exec that could only fail on chdir — every tick, forever.

**4. Per-tick config parsing hoisted out of the per-repo loop.** `resolveBlockedTTL`, `resolveBlockedRoleWakeAfter`, `resolveDelegationWorktreeTTL` and `daemonMemoryController` each read+parsed `config.toml` once per enabled repo per tick (135 opens/tick for the durations at 45 repos, plus ~90 for a memory controller that returns nil every time). A `tickConfigCache` rides the #619 candidate carrier for the worker sweep and the poller struct for the poll pass. It is created fresh each tick, keyed by home, and memoizes successes only — so `config.toml` keeps **exactly** the live tunability it had (one re-read per tick) and only the per-repo repetition disappears.

**5. `job_events` change cursor gates the two candidate queries that are pure functions of that table** (`JobIDsWithPendingAdvanceRetry`, `JobIDsWithPendingCommentRetry`). They ran a global `GROUP BY` over all 92K events every ~2.5s even when nothing had changed.

Two things make it safe, and the second is the one to attack in review:
- **Key soundness.** Both queries read only `(id, kind, job_id)`. Production only appends to `job_events` (the sole `DELETE` is a one-time migration), and its in-place updates — `RefreshLatestAdvanceRetry`, the running-job progress refresh, the claimed permission-policy warning — all `SET message/created_at` only. So an unmoved `MAX(id)` proves an unchanged result.
- **Ordering.** The cursor is read **before** the query it guards. An event written between the two leaves a recorded cursor that pre-dates it, so the next tick re-runs. Recording it after would let that event be skipped forever. Worst case is a candidate **deferred by one tick, never dropped** — pinned by `TestJobEventCursorCacheDefersButNeverDropsAnAdvancement`, which was mutation-checked: moving the cursor read after the query makes it fail with `job-b was DROPPED by the cursor cache`.

**Deliberately NOT gated**: the delegation / aged-worktree / task-worktree / malformed-owner candidates. They join `jobs` and `cleanup_obligations` and compare against `unixepoch('now')`, so their results change with the clock alone and a `job_events` cursor would genuinely drop work.

**6.** `polling <repo> with %d workers` → `polling <repo>`. The number echoed a fleet-wide flag as if it were a per-repo pool; no such pool exists.

## Tests

New, all failing before the change:
- `TestReplyWakeOutboxInertHealthDoesNotEscalateSingleRepoLoop` — rewritten. It used to count health lines to count ticks, which log-on-change breaks; it now counts ticks through the `newTickCandidates` seam and asserts the line appears **exactly once** while the loop outlives the escalation ladder.
- `TestReplyWakeOutboxHealthRelogsAfterTransition` — a repeat is suppressed, a transition is not, and a nil tracker never suppresses.
- `TestReplyWakeOutboxDrainProjectsOnceWhenNothingIsClaimed` / `...ReusedProjectionGradesIdentically` — via a counting store fake; the claiming leg asserts `claims != 0` first so a fixture that stopped claiming cannot make the count vacuous.
- `TestJobEventCursorCacheDefersButNeverDropsAnAdvancement`, `...FallsBackWhenCursorUnavailable`, `...AbsentRunsEveryQuery`, `...ReadsCursorOncePerTick`.
- `TestPollRepoSkipsRepoWhoseCheckoutIsMissing` — asserts **zero** engines and zero GitHub clients built, not just that the log line appears.
- `TestPollRepoLogDoesNotClaimAPerRepoWorkerPool`.
- `TestTickConfigCacheReadsConfigOncePerTick`, `TestTickConfigCacheMemoizesMemoryController`, `TestPollPassResetsConfigCache` — the file is rewritten between two calls, so "did not re-read" is measured directly rather than inferred.

Six existing poller tests registered repos at `/tmp/repo-a`-style paths that do not exist. Five failed against the new stat guard; the sixth passed while silently measuring a repo that was never polled. All now use `t.TempDir()`.

## Gate

`gofmt` (my files), `go build ./...`, `go generate ./...` with a clean diff, `go vet ./...`, `go test ./...`, and `go test -race ./internal/db ./internal/cli` — all green.

Two caveats, stated rather than hidden:
- **`gofmt -l internal/` is already dirty at `origin/main` dc10bab3** in two files no lane touches (`internal/workflow/org_directive.go`, `internal/workflow/merge_reason_test.go`). Reported as a baseline defect in workflow note 105575, not fixed here.
- This box is shared with other seats and sat at load ~10/12 cores throughout. A *parallel* `go test ./internal/cli/` produced 106 failures at pristine dc10bab3 and 160 on this branch — pure CPU-starvation noise on tests with real sleeps. Every one of them passes in isolation, and the **serialized** run (`-p 1 -parallel 1`) is 0 failures on this branch, as is the serialized full suite and the race run. CI at the exact head is the authoritative signal.