### PR TITLE
docs(agents): merge authority is the org config's merge_rule, not the owner

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -319,10 +319,18 @@ changed (e.g. `curl -s http://172.17.0.1:8790/api/workflows`).
 ## Work strategy (lead-engineer)
 
 Issue-first → isolated worktrees off `main` → implement → adversarial-review →
-fix → verify on the integrated tree → owner-gated PR → deploy affected-only →
-live-probe before close. The **OWNER holds merge authority**. Under ultracode,
-orchestrate via the Workflow tool with opus sub-agents (protect the scarcer fable
-quota).
+fix → verify on the integrated tree → reviewed PR → deploy affected-only →
+live-probe before close. **Merge authority is whatever the org config records
+for your role**: `merge_rule = "self"` means the coordinator merges its own
+lane's PRs once one independent review is clean at the exact head and the PR is
+mergeable with CI green; `merge_rule = "owner"` means the owner merges. The
+`[org.roles."<role>"]` block in the gitmoot config is the authority of record
+and this file only describes it, so settle any future disagreement with a
+config read (`gitmoot org status`, `[org.roles]` in `config.toml`), not another
+doc edit. **Public releases are unchanged and still need explicit OWNER
+sign-off** — merge authority moved on 2026-08-31, release authority did not.
+Under ultracode, orchestrate via the Workflow tool with opus sub-agents
+(protect the scarcer fable quota).
 
 ## Workload mode
 
@@ -348,7 +356,8 @@ running then. `accepted_at` is the timestamp of the Herdr pane's first
 `working` status event after the issue-backed assignment prompt; `created_at` is
 the job-store timestamp. The merged PR always exists, so this record does not
 depend on a pre-existing workflow. The mode changes how much work may start; it
-never relaxes correctness, exact-head review, CI, or owner merge authority.
+never relaxes correctness, exact-head review, CI, or the merge authority
+recorded in the org config.
 
 Across both modes, use exactly one independent reviewer per corrected head.
 Parallel review lanes mean different PRs, not multiple reviewers on one head.
@@ -432,8 +441,11 @@ pinging X is the action.
   `perf:`, optional scope (e.g. `feat(workflow): …`). Reference issues with
   `(#NNN)`.
 - **Branches / PRs**: do **not** push directly to `main`. Branch, open a PR, let
-  CI (`build / vet / test`) pass, then the owner **squash-merges**. One PR per
-  issue, with deploy notes in the body.
+  CI (`build / vet / test`) pass, get one clean independent review at the exact
+  head, then whoever holds merge authority for that role in the org config
+  **squash-merges** — the coordinator itself under `merge_rule = "self"`, the
+  owner under `merge_rule = "owner"`. One PR per issue, with deploy notes in the
+  body. Cutting a public release stays an OWNER decision either way.
 - **Scope**: preserve existing behavior unless the change requires otherwise.
 - For machine-local agent notes, use a gitignored `CLAUDE.local.md` rather than
   editing this shared file. Gitignored (local-only, not in the repo): `/GOALS/`,

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -324,11 +324,18 @@ live-probe before close. **Merge authority is whatever the org config records
 for your role**: `merge_rule = "self"` means the coordinator merges its own
 lane's PRs once one independent review is clean at the exact head and the PR is
 mergeable with CI green; `merge_rule = "owner"` means the owner merges. The
-`[org.roles."<role>"]` block in the gitmoot config is the authority of record
-and this file only describes it, so settle any future disagreement with a
-config read (`gitmoot org status`, `[org.roles]` in `config.toml`), not another
-doc edit. **Public releases are unchanged and still need explicit OWNER
-sign-off** — merge authority moved on 2026-08-31, release authority did not.
+field is **advisory** — `merge_gate.go` never reads it (`internal/config/org.go`
+calls it "deliberately advisory in phase 1a"), so nothing mechanically stops a
+merge you are not entitled to make; the gate enforces exact-head review, CI and
+attribution, never role authority. The `[org.roles."<role>"]` block in the
+gitmoot config is the authority of record and this file only describes it, so
+settle any future disagreement with a config read — `gitmoot org chart` prints
+`merge=<rule>` per role, `gitmoot org brief --role <role>` prints
+`merge_rule: <rule>`, `gitmoot org status --json` carries the field, and
+`[org.roles]` in `config.toml` is the source. Plain `gitmoot org status` has no
+merge column, so it cannot answer this. **Public releases are unchanged and
+still need explicit OWNER sign-off** — merge authority moved on 2026-08-31,
+release authority did not.
 Under ultracode, orchestrate via the Workflow tool with opus sub-agents
 (protect the scarcer fable quota).
 


### PR DESCRIPTION
Authorized by jarvis directive **107061**, which reported that AGENTS.md's stale merge-authority sentences had misled jarvis itself more than once. That file is auto-loaded as repo context in every session on this box, so the stale sentence kept overriding the live org config for readers who never opened the config.

## What changed

Four places, all in `AGENTS.md`, all describing who merges:

| line (pre-change) | was | now |
|---|---|---|
| 322 | `owner-gated PR` | `reviewed PR` |
| 323 | `The **OWNER holds merge authority**` | merge authority is whatever the org config records for the role |
| 351 | `or owner merge authority` | `or the merge authority recorded in the org config` |
| 435 | `then the owner **squash-merges**` | whoever holds merge authority for that role squash-merges |

## Evidence, verified independently rather than taken from the directive

Live config `[org.roles."gitmoot"]` carries `merge_rule = "self"`, annotated *"set 2026-08-31 by jarvis on the OWNER's direct instruction"*. The same annotation and value appear on `apps-coc`, `joltra` and `herdr-app` (the last dated 2026-09-01). `gitmoot org status --json` reports `merge_rule: "self"` for this role.

Worth reading in the config's own words, because it bounds what this doc change can claim: `merge_gate.go` **never reads** `MergeRule`, so the field does not gate a merge in code — it governs what a coordinator may GRANT to seats it creates (`orgSeatMergeRuleAllows`, `internal/cli/org.go`). The operative change is the CONVENTION. The doc text therefore names the config as the authority of record without implying the engine enforces it.

## Preserved deliberately

- **Public releases still need explicit OWNER sign-off.** Merge authority moved on 2026-08-31; release authority did not. The deploy recipe's step 6 is untouched, and the new text repeats the distinction so a reader of the strategy section alone cannot miss it.
- **`merge_rule` is named as the authority OF RECORD**, with this file merely describing it, so the next drift is settled by a config read (`gitmoot org status`, `[org.roles]`) rather than another doc edit. This is the part that stops the correction from decaying the same way the original did.

## Sweep, not a per-line patch

`git grep -i` for `owner holds merge`, `owner merge authority`, `owner-gated PR` and `the owner **squash` across the whole tree returns **zero** remaining hits after this change. The other `merge authority` matches in the repo are unrelated and correctly left alone: `docs/pipelines.md` (pipeline `merge: auto` gate authority), `internal/pipeline/run.go`, `internal/workflow/engine_types.go`, `internal/workflow/merge_gate*_test.go`, `internal/cli/org.go` (`--merge-rule` flag help), and the dashboard's org-root string `human-owned merge authority` — which is accurate, since the org root IS the owner.

## Verification

Docs-only, one file, no Go or website source touched, so `build / vet / test` is the gate and no behavioral test applies. `git diff --stat` = `AGENTS.md | 26 +++++----`, 19 insertions / 7 deletions.

## Deploy notes

None. No binary, service or config change; nothing to restart, nothing to live-probe.