### PR TITLE
test(lifecycle): make the pre-claim refusal and the not-found filter testable (#1673)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -327,7 +327,15 @@ mergeable with CI green; `merge_rule = "owner"` means the owner merges. The
 field is **advisory** — `merge_gate.go` never reads it (`internal/config/org.go`
 calls it "deliberately advisory in phase 1a"), so nothing mechanically stops a
 merge you are not entitled to make; the gate enforces exact-head review, CI and
-attribution, never role authority. The `[org.roles."<role>"]` block in the
+attribution, never role authority. Advisory cuts the other way too: **an armed
+engine merge gate may merge on its own approval-plus-green conditions, with no
+`merge_rule` holder acting at all**, so a holder MUST NOT rely on parking a local
+commit to protect a merge window. #1731 merged itself at 2026-09-02T11:23:26Z as
+squash `250b3fad` ("Gitmoot merge review-pr-1731-3f3a1026", committer GitHub);
+`merge_gates` row 963 flipped to `state=merged` four seconds later and six
+seconds *before* the approving verdict comment posted, and four fixes held back
+to protect the holder's window were excluded by that merge. Land work or record
+it durably; a window you do not control is not a queue. The
 gitmoot config is the authority of record and this file only describes it, so
 settle any future disagreement with a config read — `gitmoot org chart` prints
 `merge=<rule>` per role, `gitmoot org brief --role <role>` prints

--- a/internal/daemon/forge_classification_test.go
+++ b/internal/daemon/forge_classification_test.go
@@ -36,6 +36,13 @@ func TestPollOnceClassifiesForgeFailuresByAnswerNotByTransience(t *testing.T) {
 		{name: "cancellation is not an answer", err: context.Canceled, wantPollErr: true, wantRecord: 0},
 		{name: "parse failure is not an answer", err: errors.New("parse gh output: invalid character 'x'"), wantPollErr: true, wantRecord: 0},
 		{name: "transient stays transient", err: errors.New("dial tcp: connection refused"), wantPollErr: true, wantRecord: 0},
+		// THESE TWO REACH THE COMPETING-STATUS FILTER, which every row above returns
+		// before: they carry the words "not found" AND a competing status. Review measured
+		// that deleting the filter entirely left this package green, because no existing
+		// row got past the earlier `not found` guard - a live production loop with zero
+		// coverage, and it is the exact heuristic I flagged as my risky over-correction.
+		{name: "429 body mentioning not found is not an answer", err: errors.New("gh: API rate limit exceeded, pull request not found (HTTP 429)"), wantPollErr: true, wantRecord: 0},
+		{name: "403 body mentioning not found is not an answer", err: errors.New("gh: Resource not accessible, not found (HTTP 403)"), wantPollErr: true, wantRecord: 0},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			ctx := context.Background()

--- a/internal/workflow/job_recovery.go
+++ b/internal/workflow/job_recovery.go
@@ -1226,13 +1226,20 @@ func (e Engine) advanceSupersededChildAtGeneration(ctx context.Context, jobID st
 	}
 	// REFUSE BEFORE CLAIMING ANYTHING. A coordinator whose escalation round is parked in
 	// needs_repair cannot be advanced, so this pass must not take the ownership lease or
-	// write the claim bracket for work it cannot do (#1673). Read-only on purpose: the
-	// parked round already emitted its one repair signal and whichever advance path hits
-	// the full guard blocks the task, so refusing here writes nothing and simply leaves
-	// the debt outstanding for the poll after the repair.
+	// write the claim bracket for work it cannot do (#1673).
 	//
-	// The typed check after the advance stays as defence in depth: this one is an
-	// optimisation and a hygiene fix, that one is the correctness barrier.
+	// WRITES NOTHING, INCLUDING NO TASK BLOCK, and that is a real behavioural difference
+	// rather than a detail: because this pre-flight always short-circuits when the round
+	// is parked, escalationRepairBlock's blockTask is now UNREACHABLE from this route, so
+	// the coordinator's task keeps whatever state the escalation left it in
+	// (awaiting_human) instead of moving to blocked. That matches the round's own design
+	// - engine_escalation_resume.go states a parked round deliberately does not set a task
+	// state - and the operator signal is the round's needs-repair event plus the repair
+	// command, not this path. An earlier version of this comment claimed the guard still
+	// blocked the task; review measured that false once the pre-flight was in front of it.
+	//
+	// The typed check after the advance stays as defence in depth: this one is a hygiene
+	// fix, that one is the correctness barrier.
 	if parked, err := e.coordinatorRoundNeedsRepair(ctx, jobID); err != nil {
 		return false, err
 	} else if parked {

--- a/internal/workflow/supersede_parked_round_test.go
+++ b/internal/workflow/supersede_parked_round_test.go
@@ -147,13 +147,11 @@ func TestSupersedeRecoveryRefusesAParkedRepairRound(t *testing.T) {
 	sibling := seedRoundWithSupersededSibling(t, store, engine, true)
 
 	before := countJobs(t, store, "")
-	observed := mustJob(t, store, sibling)
 	// Enter through the DEBT SWEEP, the production caller, so the assertion below covers
 	// the bookkeeping too: a refusal that still records the debt paid loses the work for
 	// good, because after the repair nothing re-drives it.
 	advanced, err := engine.CompletePendingSupersedeFinalization(ctx, sibling)
 	after := countJobs(t, store, "")
-	_ = observed
 
 	if after != before {
 		t.Fatalf("job count %d -> %d: the supersede recovery advanced the coordinator's DAG past a needs_repair round (advanced=%v err=%v)",
@@ -340,4 +338,40 @@ func TestSupersedeRecoveryAdvancesAfterTheRoundIsRepaired(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestSupersedeRecoveryRefusesBeforeClaimingOwnership distinguishes the PRE-CLAIM
+// refusal from the downstream typed guard, which the other arms cannot.
+//
+// Review measured the gap and it was mine: discarding coordinatorRoundNeedsRepair's bool
+// leaves the ENTIRE workflow package green, because the advance then takes the lease,
+// writes the claim bracket, reaches escalationRepairBlock and returns the typed refusal
+// that maps to the same (false, nil). Every quantity the other tests assert - job count,
+// retry child, advance_confirmed, finalize_completed - is identical either way. That is
+// the fifth vacuous instrument found in this campaign and the first one in code I added
+// in response to a review.
+//
+// The observable that DOES separate them is the claim bracket: a pass that refuses before
+// claiming writes no JobEventSupersedeAdvanceClaimed at all. That also states the point
+// of the pre-flight in the assertion itself - do not take a lease or stamp a claim for
+// work this pass cannot perform.
+func TestSupersedeRecoveryRefusesBeforeClaimingOwnership(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	engine := testEngine(store)
+	engine.EscalationNotifier = &recordingNotifier{}
+	sibling := seedRoundWithSupersededSibling(t, store, engine, true)
+
+	if _, err := engine.CompletePendingSupersedeFinalization(ctx, sibling); err != nil && !isDelegationPolicyOutcome(err) {
+		t.Fatalf("sweep: %v", err)
+	}
+
+	if got := countWorkflowJobEvents(t, store, sibling, JobEventSupersedeAdvanceClaimed); got != 0 {
+		t.Fatalf("%s events = %d, want 0: the pass claimed the advance bracket for work a parked round makes impossible, "+
+			"so the refusal happened after the lease and the claim rather than before them", JobEventSupersedeAdvanceClaimed, got)
+	}
+	// THE LEASE IS DELIBERATELY NOT ASSERTED. advanceSupersededChildAtGeneration releases
+	// it on every exit via defer, so it is absent after the pass either way and cannot
+	// discriminate - asserting it would be a sixth vacuous line inside the test written to
+	// fix the fifth. The claim bracket is the one durable trace that differs.
 }


### PR DESCRIPTION
Drain follow-up to #1731 (merged as `250b3fad`). Scope is strictly the four P3s from the approved review at `535370a4` plus one AGENTS.md sentence. No adjacent cleanup, no refactors, no new behaviour.

Authority: admission row 107251, jarvis directive 107252, relayed as 107255.

## Boundary

Reconstituted from parked commit `0fd4fc64` (parent `b3029258`) by cherry-pick onto `250b3fad`. It applied with **no conflict** and the resulting diff is byte-identical to the parked commit — same 3 files, same 56 insertions / 8 deletions. The parked commit is still alive on the seat. The AGENTS.md sentence is a separate commit on top and touches no other file.

## The load-bearing fix

`TestSupersedeRecoveryRefusesBeforeClaimingOwnership` did not exist, and its absence was the fifth vacuous instrument of the campaign — in code written to satisfy a previous review round. The pre-claim refusal had **no test that distinguished it**: the downstream typed guard produces identical observables, so every quantity the existing arms assert (job count, retry child, `advance_confirmed`, `finalize_completed`) is the same with or without it.

Three results, in the required order:

1. **Test GREEN on unpatched production** — 1 test matched, passing.
2. **Compile-valid semantic revert** — the guard still runs and its value is consumed (`parked, err := e.coordinatorRoundNeedsRepair(...)` then `_ = parked`); the call site is not deleted, so the mutant tests the guard rather than the compiler. It compiles.
3. **Test RED** — `supersede_advance_claimed events = 1, want 0`.

Routing check, which is the question that matters: under that same mutant `TestSupersedeRecoveryRefusesAParkedRepairRound` stays **GREEN**. So the older arm is exactly the routing mutant that leaves the real failure on the other path and still passes — and the new test is the one that does not. The discriminator is the claim bracket: a pass that refuses before claiming writes no `JobEventSupersedeAdvanceClaimed`.

The lease is deliberately **not** asserted: `advanceSupersededChildAtGeneration` releases it on every exit via `defer`, so it is absent either way and asserting it would be a sixth vacuous line inside the test written to fix the fifth.

## The other three

- **Zero-coverage production loop.** The competing-status filter in `isPullRequestNotFound` was never executed by any test: every existing row lacks a `not found` substring, so all of them returned at the earlier guard. Deleting the whole loop left `internal/daemon` green. Two rows now carry **both** a not-found phrase and a competing status (429, 403); with them, deleting the loop goes RED. This is the heuristic I flagged as my own risky over-correction, which is why it stung that nothing reached it.
- **A comment of mine that had become false.** It claimed "whichever advance path hits the full guard blocks the task". With the pre-flight in front, `escalationRepairBlock`'s `blockTask` is unreachable from this route and the coordinator's task stays `awaiting_human`. The comment now states that, notes it matches the round's own design (a parked round deliberately sets no task state), and names the operator signal that does exist.
- **Dead read.** `observed := mustJob(...)` kept alive by `_ = observed` after the test switched entry points.

## The AGENTS.md sentence

One clause added to the advisory paragraph, in its own voice: an armed engine merge gate may merge on its own approval-plus-green conditions **with no `merge_rule` holder acting**, so a holder must not rely on parking a local commit to protect a merge window.

This corrects a live *operational* statement; it does not touch #1780's policy claim, which was right. Preserved verbatim: the advisory framing and the `internal/config/org.go` quote, the config-read remedy including the plain-`gitmoot org status` caveat, and the public-release sign-off clause.

The evidence is this PR's own reason for existing: #1731 merged at 2026-09-02T11:23:26Z as squash `250b3fad`, merge commit subject "Gitmoot merge review-pr-1731-3f3a1026", committer GitHub. `merge_gates` row 963 (armed 2026-08-31 15:37:30) flipped to `state=merged` with `reason=250b3fad` at 11:23:30 — four seconds **after** the merge and six seconds **before** the approving verdict comment posted at 11:23:36. The four fixes in this PR were excluded by that gate precisely because they were parked to protect a merge window that no holder controlled.

## Gates

Under `TMPDIR=/tmp/gmtest` (the host default breaks `internal/db`'s fts5 migration): `gofmt` clean, `go build ./...` clean, `go vet ./internal/...` clean, `go generate ./...` exit 0 with true drift **0** measured after committing, `go test -count=1` green on `internal/{db,workflow,daemon,cli,prompts}`, and `go test -race` green on the supersede/parent-only/escalation selection.

## Judgement on severity

None of the four exceeds P3 in my judgement, and the reason is specific rather than reassuring: the **correctness** barrier for this path is the typed `EscalationRepairRequiredError` check, and that one *is* test-covered — reverting it turns both refusal arms red. What lacked coverage was the redundant pre-flight in front of it and a defensive filter that is present and correct on main. So main today behaves correctly; the exposure is that a future edit to either could pass CI unnoticed. That is test integrity, not a live defect — which is why I reported it as P3 and did not ask for an incident.

Signed-off-by: GM-OMP-FANOUT