### PR TITLE
docs(agents): define steady mode and the exact-head cases for a moved head

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -526,6 +526,17 @@ missing or ambiguous fails closed. `PipelineAutoMerger.Merge` re-reads the PR
 and both note streams at the final merge boundary; an older reconciled PR that
 merges after a newer owner decision cannot override the newer decision.
 
+Four properties of that enforcement are worth knowing before you write a row.
+Enforcement is keyed on the repository OWNER, so every `gitmoot/*` repo is held
+until a row exists, human-requested merges included. Repository names are
+compared case-insensitively on every stream, so a note recorded as
+`Gitmoot/gitmoot` still counts. A newest operating-mode note that cannot be
+read — a malformed field list, or a `mode` that is not a workload mode — HOLDS
+the PR and names that note, because an unreadable decision is not the absence of
+one; correct the note rather than adding a row. And a reconciliation hold at the
+merge boundary is retryable, not terminal: the pipeline gate keeps waiting until
+the row lands or the gate times out.
+
 Resolve the active decision from both durable sources: read the marker from
 `origin/main:AGENTS.md`, never a seat worktree, and read the newest typed
 operating-mode/reconciliation note. Decisions are ordered by `decided_at`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -607,9 +607,9 @@ Record every activation with:
 `mode: <THROUGHPUT|STEADY|DRAIN>`,
 `decision_ref: workflow-note:<id>`,
 `change_ref: none|pr:<owner/repo>#<number>@<40-character-reviewed-head>`,
-`activation_ref: none|workflow-note:<id>|commit:<40-character merge SHA>`,
+`activation_ref: none|workflow-note:<id>|commit:<40-character-merge-sha>`,
 `decided_at: <RFC3339>`,
-`effective_at: <RFC3339>`,
+`effective_at: none|<RFC3339>`,
 `observed_at: <RFC3339>`, zero or more
 `implementer: <seat> issue=<number> pr=<number|none> accepted_at=<RFC3339>`
 lines, zero or more `review: <job-id> pr=<number> created_at=<RFC3339>` lines,
@@ -617,7 +617,7 @@ then `[/workload-mode-transition]`.
 
 RESOLVED IN ONE DIRECTION, because this document said both and a reader could
 pick either (#1783 round-8 review, F-3): ONLY A MERGED COMMIT ACTIVATES A MODE.
-`commit:<40-character merge SHA>` is therefore the ONLY ACTIVATING form. The
+`commit:<40-character-merge-sha>` is therefore the ONLY ACTIVATING form. The
 other two record a mode that is not active yet: `workflow-note:<id>` for a
 decision not yet materialised by a merged marker PR, and `none` for a record
 posted before any marker PR exists - never for claiming a mode is active. That
@@ -625,7 +625,8 @@ matches point 1 of "DERIVE, never trust a marker id" above: the active mode is
 the marker line in `origin/main:AGENTS.md`, changed by a merged PR, and a
 decision note is not itself the marker. `decision_ref` carries the note,
 `change_ref` the PR and its reviewed head, `decided_at` the note's timestamp,
-and `effective_at` the merge commit's `mergedAt`.
+and `effective_at` the merge commit's `mergedAt` - or `none` on both while no
+marker PR has merged, which the grammar line above now admits.
 
 A note-sourced DRAIN therefore does not become active on its note alone: it is
 decided at the note, freezes admissions from `decided_at` as below, and

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -412,6 +412,53 @@ self-merge conditional on all six checks below:
 The delegation does **not** authorize releases, `gh release create`, deploys,
 service restarts, force-pushes to `main`, or merging work outside the PR's
 issue. Those actions remain owner-gated.
+**A clean, mergeable PR whose head is no longer the reviewed head is NOT ready.**
+`mergeable: MERGEABLE` / `mergeStateStatus: CLEAN` is a claim about *git* — that
+the branch applies with no textual conflict. It says nothing about whether
+anyone reviewed the tree that will land, and CI here is keyed to `head_sha`
+(`.github/workflows/ci.yml` runs on `pull_request`, and every check-run reports
+the branch head), so green CI tested the *branch*, not the branch merged into
+current `main`. Two cases, and they need different actions:
+
+- **Case A — new commits were pushed to the branch.** The verdict is void: it
+  described a tree that no longer exists. Re-review at the new head, scoped to
+  the delta since the approved head — not the whole PR again.
+- **Case B — the branch head is unchanged and `main` moved underneath it.** The
+  verdict still names a commit that still exists and git still reports CLEAN,
+  yet nobody has reviewed `main` + branch, which is what actually lands. **Check
+  the BRANCH, not the base**: `git diff origin/main..HEAD` must contain only the
+  change you intended, and a tree read must confirm no file you never touched
+  reappears or vanishes. Only then compare the base delta: if `main`'s new
+  commits touch no file and no package the PR touches, the merge result is
+  semantically the reviewed tree — merge; if they overlap, re-review the delta.
+  A clean textual merge silently produces wrong code exactly where two changes
+  touch one region: two migrations appended to the same slice merge without
+  conflict and can still renumber; two edits to one test file merge and can drop
+  an assertion.
+
+  The branch check comes first because the base check alone is **not
+  sufficient**, measured on the first push of this very PR. It was stacked on a
+  PR whose own base predated a large deletion; that parent was **squash**-merged,
+  which makes the reviewed branch commits non-ancestors of `main`, so the stack
+  silently kept the parent's stale base. The branch then reported
+  `mergeable: MERGEABLE`, no conflict and green CI while its diff against the
+  moved `main` re-added ~10,200 deleted lines — a mass revert of a merge from
+  half an hour earlier. The base-delta predicate PASSED that case: the base delta
+  touched the deleted files, the PR touched only this file, no overlap. Stacking
+  on a PR that will be squash-merged always requires a rebuild on `main`, never a
+  base-delta comparison.
+
+Prove Case B with **trees, not diff output**, and put a positive control on
+every instrument. #1731 was waived on "only `AGENTS.md` changed" by the role
+that benefited from the waiver; reversing that bought a content-addressed proof
+instead — `git ls-tree -r` over all 1173 tracked files, pairwise-equal subtree
+hashes, identical blob hashes for all 57 PR-changed files, each instrument
+shown to report differences on a known-different pair. That cost one review
+round and is the standard.
+
+And **`CLEAN` beside an empty check rollup is not green** — a head whose checks
+have not registered yet reports zero check-runs and still reads CLEAN. Read the
+count, not the label.
 
 Under ultracode, orchestrate via the Workflow tool with opus sub-agents
 (protect the scarcer fable quota).
@@ -420,13 +467,18 @@ Under ultracode, orchestrate via the Workflow tool with opus sub-agents
 
 **Current mode: THROUGHPUT.**
 
-A mode switch is a merged PR that changes the line above. It takes effect at
-that PR's `mergedAt` time. At the next check-in, the coordinator must:
+A mode switch is either a merged PR that changes the line above, or a durable
+`[operating-mode ...]` workflow note from the owner (or a coordinator acting on a
+recorded owner instruction) — whichever is later. A note takes effect at its own
+timestamp and this line is then corrected in the next PR that touches this file;
+the note path's precedent is STEADY, set by owner instruction in note 107313 on
+2026-09-02 and since superseded. A merged PR takes effect at that PR's
+`mergedAt` time. At the next check-in, the coordinator must:
 
 1. fetch `origin/main`, read the marker from `origin/main:AGENTS.md` rather than
    the seat's worktree, and steer every active seat to the merged mode;
 2. comment on the merged mode-switch PR with this exact transition record:
-   `[workload-mode-transition]`, `mode: <THROUGHPUT|DRAIN>`,
+   `[workload-mode-transition]`, `mode: <THROUGHPUT|STEADY|DRAIN>`,
    `effective_commit: <40-character SHA>`, `observed_at: <RFC3339>`, zero or more
    `implementer: <seat> issue=<number> pr=<number|none> accepted_at=<RFC3339>`
    lines, zero or more `review: <job-id> pr=<number> created_at=<RFC3339>`
@@ -447,6 +499,25 @@ Across both modes, use exactly one independent reviewer per corrected head.
 Parallel review lanes mean different PRs, not multiple reviewers on one head.
 Review panels and fanout require explicit, durable owner authorization for that
 specific incident; an incident does not override this rule by itself.
+
+### Steady mode
+
+Between throughput and drain: the **cap stays, the admission gate goes**. Set by
+the owner on 2026-09-02, because drain's cost was never its concurrency limit but
+its permission step — a seat sat on four ready, gated fixes through two
+escalations, and an armed merge gate then merged the PR without them.
+
+- At most **four implementation seats and two independent reviewers** at once.
+- **No admission gate.** A seat that finishes takes the next item itself: no
+  escalation for permission, no waiting for an authorization row.
+- Work comes off an **ordered list**, not a free choice — for a reduction epic,
+  that epic's own dependency-sorted sub-issue order.
+- **One in, one out**: no second PR from a seat while its first is unmerged.
+  This is what keeps the queue from growing, without anyone deciding.
+- Escalate only for a **P2-or-worse finding**, a **scope boundary wider than the
+  assigned item**, or **live-service impact**. Everything else is the seat's call.
+- Steady mode names its own **exit condition**: when the scoped list is merged,
+  the coordinator posts the next mode marker itself rather than waiting to be told.
 
 ### Throughput mode
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -499,11 +499,19 @@ Under ultracode, orchestrate via the Workflow tool with opus sub-agents
 
 A mode switch is either a merged PR that changes the line above, or a durable
 `[operating-mode ...]` workflow note from the owner (or a coordinator acting on a
-recorded owner instruction) — whichever is later. A note takes effect at its own
-timestamp and this line is then corrected in the next PR that touches this file;
-the note path's precedent is STEADY, set by owner instruction in note 107313 on
-2026-09-02 and since superseded. A merged PR takes effect at that PR's
-`mergedAt` time. At the next check-in, the coordinator must:
+recorded owner instruction). A note takes effect at its own timestamp and this
+line is then corrected in the next PR that touches this file; the note path's
+precedent is STEADY, set by owner instruction in note 107313 on 2026-09-02 and
+since superseded by a merged PR. A merged PR takes effect at that PR's
+`mergedAt` time only after the pre-merge reconciliation below. The later valid
+source wins.
+
+Immediately before merging a mode-switch PR, re-read the newest
+`[operating-mode ...]` note and record its id (or `none`) on the PR. The PR's
+reviewed head must implement that note's mode, unless a later durable owner
+instruction explicitly chooses another mode. Otherwise update the PR and
+re-review it, or do not merge it. An unreconciled stale PR is not a valid switch,
+and its later `mergedAt` timestamp cannot override a newer owner instruction.
 
 1. resolve the mode from BOTH sources and steer to the LATER one: fetch
    `origin/main` and read the marker from `origin/main:AGENTS.md` rather than the
@@ -520,14 +528,16 @@ the note path's precedent is STEADY, set by owner instruction in note 107313 on
    `[/workload-mode-transition]`.
 
 For DRAIN, the listed transition wave is derived from durable timestamps:
-implementation assignments accepted before `mergedAt` that have not reached a
-terminal handoff, plus review jobs created before `mergedAt` that were queued or
-running then. `accepted_at` is the timestamp of the Herdr pane's first
-`working` status event after the issue-backed assignment prompt; `created_at` is
-the job-store timestamp. A merged PR always exists for a PR-sourced switch, so that record does not
-depend on a pre-existing workflow. For a NOTE-sourced switch the note id IS the
-record and the transition record is posted as a workflow note, because the
-correcting PR may not exist yet. The mode changes how much work may start; it
+implementation assignments accepted before the switch's effective time that
+have not reached a terminal handoff, plus review jobs created before that time
+that were queued or running then. The effective time is `mergedAt` for a
+PR-sourced switch and the note's `created_at` for a note-sourced switch.
+`accepted_at` is the timestamp of the Herdr pane's first `working` status event
+after the issue-backed assignment prompt; `created_at` is the job-store
+timestamp. A merged PR always exists for a PR-sourced switch, so that record
+does not depend on a pre-existing workflow. For a NOTE-sourced switch the note
+id IS the record and the transition record is posted as a workflow note, because
+the correcting PR may not exist yet. The mode changes how much work may start;
 never relaxes correctness, exact-head review, CI, or the merge authority
 recorded in the org config.
 
@@ -575,10 +585,10 @@ escalations, and an armed merge gate then merged the PR without them.
 - Escalate only for a **P2-or-worse finding**, a **scope boundary wider than the
   assigned item**, or **live-service impact**. Everything else is the seat's call.
 - Steady mode names its own **exit condition and its destination**: when the
-  scoped list is merged, `gitmoot/*` returns to **DRAIN**, and the coordinator
-  posts that drain marker itself rather than waiting to be told (owner
-  instruction, note 107313: "we need to stop and go back to DRAIN mode once
-  those are merged").
+  scoped list is merged, `gitmoot/*` returns to **DRAIN**. The coordinator first
+  completes every DRAIN activation precondition below and only then posts the
+  drain marker itself rather than waiting to be told (owner instruction, note
+  107313: "we need to stop and go back to DRAIN mode once those are merged").
 
 ### Drain mode
 
@@ -594,17 +604,19 @@ escalations, and an armed merge gate then merged the PR without them.
 - After activation, cap the `gitmoot/*` scope at **two active implementers and
   one running reviewer**. An active implementer is a persistent seat currently
   changing code or a running engine implementation job.
-- A DRAIN mode-switch PR is not merge-ready until the coordinator configures
-  the shared daemon with `[daemon] workers = 1`; every active
+- A DRAIN switch is not effective until the coordinator configures the shared
+  daemon with `[daemon] workers = 1`; every active
   `[repos."gitmoot/*"].max_parallel` override must be absent, zero, or one.
   Apply the warm reload and verify both the effective global worker count and
   every effective per-repository limit. This is the atomic runtime gate shared
-  by native PR fanout, heartbeats, and manual background reviews.
-- Before that PR merges, every foreground or persistent-seat review already in
+  by native PR fanout, heartbeats, and manual background reviews. For a
+  PR-sourced switch, complete this before merge; for a note-sourced switch,
+  complete it before posting the marker.
+- Before DRAIN activates, every foreground or persistent-seat review already in
   progress must reach a terminal handoff; those reviews cannot be grandfathered.
   All DRAIN reviews then run as background engine jobs. Never bypass the shared
   gate with a foreground or persistent-seat reviewer.
-- Before that PR merges, disable every `action=review` heartbeat and allow
+- Before DRAIN activates, disable every `action=review` heartbeat and allow
   exactly one review-capable agent on each active `gitmoot/*` repository. For a
   PR with a branch lock, the native PR watcher is the sole producer; do not also
   dispatch a manual review. For a PR without a branch lock, native fanout cannot

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -106,14 +106,15 @@ go test -timeout 25m -skip 'TestClaudeProduceHookAutoReadLandlockE2E' ./...
 `-buildvcs=false` is required, not optional, inside a gitmoot worktree (#1209):
 Go's VCS auto-stamp only recognizes a `.git` **directory** as a repo root
 (`cmd/go/internal/vcs.vcsGit.RootNames`), but a linked worktree's `.git` is a
-**file** (a `gitdir:` pointer), so the root-detection walk-up skips the
-worktree's real root and keeps going up. What happens next depends on what the
-walk finds, and it is stated once in the deploy recipe below rather than twice
-here: see "Deploy recipe (this host)", step 1. The short version is that the
-quiet outcome is the dangerous one, not the `exit status 128` failure. This is a
-Go toolchain behavior with linked worktrees, not something gitmoot's code or
-config can fix.
-
+**file** (a `gitdir:` pointer). Go's root-detection walk-up skips past the
+worktree's real root looking for any ancestor with a `.git`-shaped directory,
+and can land on an unrelated one — hard-failing with `error obtaining VCS
+status: exit status 128` even though `git status` itself works fine from the
+same directory. This is a genuine Go toolchain limitation with linked
+worktrees (confirmed by reading `cmd/go/internal/vcs/vcs.go`'s `FromDir` /
+`isVCSRoot`), not something gitmoot's code or config can fix, and even the
+non-failing cases can silently stamp the wrong VCS metadata (wrong commit,
+wrong dirty bit) from whatever directory the walk-up happened to land on.
 Disabling it here costs nothing real: release binaries get their version
 info from the explicit `-ldflags -X ...Commit=$(git rev-parse HEAD)` recipe
 in the deploy section below, never from Go's auto-stamp.
@@ -260,53 +261,17 @@ detection.
 
 ## Deploy recipe (this host)
 
-1. On `main` after merge, build with the pinned toolchain (above), from a clean
-   detached worktree at the exact tip rather than the shared `/root/gitmoot`
-   checkout, which usually carries uncommitted work. Stamp the version the way
-   `release.yml` does, or `gitmoot version` reports `commit: unknown`.
-   `-buildvcs=false` is required for the same reason as the test gate above: in
-   a linked worktree `.git` is a **file**, which the pinned toolchain does not
-   treat as a repository root, so it walks up to the parent directories. What
-   that walk finds decides the outcome. Measured with a throwaway module on
-   go1.26.4:
-
-   - **no repository anywhere above it**: the build succeeds and simply omits
-     the stamp. This case is tolerated, not an error;
-   - **a `.git` DIRECTORY above it that git rejects as a repository**: the build
-     **fails** with `error obtaining VCS status: exit status 128`. A `.git`
-     **file** never produces this: it is skipped, and the walk continues past
-     it. This is not hypothetical here: `/tmp/.git` exists on this host as a
-     directory (`ls -A` returns nothing, and `git -C /tmp status` fails), so a
-     deploy worktree anywhere under `/tmp` hits it, and it will not be the only
-     such directory on any given host;
-   - **a working unrelated repository above it**: the build **succeeds** and
-     stamps that repository's metadata. A binary built from commit `1f76f143`
-     embedded the ancestor's `vcs.revision 60f8282c` and `vcs.modified true`.
-
-   The third case is the one to design against, because it is silent. The
-   `-ldflags` below override `Commit`, so `gitmoot version` still prints the
-   right value and the wrong stamp stays hidden in the embedded build info.
-   Drop the ldflags and `buildinfo.Current` falls back to that VCS revision
-   (`internal/buildinfo/buildinfo.go`), so an unstamped binary reports an
-   ancestor's commit as its own and the daemon build-skew check compares a
-   false identity rather than an unknown one.
-
-   Treat the `.git`-file behavior as version-specific rather than permanent:
-   Go's handling of it is being changed upstream, and `-buildvcs=false` is what
-   makes all three outcomes moot.
+1. On `main` after merge, build with the pinned toolchain (above). Stamp the
+   version the way `release.yml` does, or `gitmoot version` reports
+   `commit: unknown`:
 
    ```sh
-   git worktree add --detach /root/gitmoot-deploy "$(git rev-parse HEAD)"
-   cd /root/gitmoot-deploy
    PKG=github.com/gitmoot/gitmoot/internal/buildinfo
-   CGO_ENABLED=0 go build -trimpath -buildvcs=false -ldflags \
+   CGO_ENABLED=0 go build -trimpath -ldflags \
      "-s -w -X $PKG.Version=dev-$(git rev-parse --short HEAD) \
       -X $PKG.Commit=$(git rev-parse HEAD) -X $PKG.Date=$(date -Iseconds)" \
      -o /root/.local/bin/gitmoot.new ./cmd/gitmoot
    ```
-
-   Remove the deploy worktree when the deploy is done:
-   `git worktree remove /root/gitmoot-deploy`.
 
 2. `mv`-rename the new binary into `/root/.local/bin/gitmoot` (same filesystem;
    the rename avoids `ETXTBSY`).
@@ -497,18 +462,16 @@ Under ultracode, orchestrate via the Workflow tool with opus sub-agents
 
 ## Workload mode
 
-**Current mode: THROUGHPUT.**
+**Current mode: STEADY.**
 
 A mode decision is an append-only
 `[operating-mode repo=<owner/repo> mode=<THROUGHPUT|STEADY|DRAIN>]` workflow
 note from the owner (or a coordinator acting on a recorded owner instruction).
 A PR that changes the marker above is a second materialization path, but it
-cannot invent a later decision merely by merging later. A merged marker PR takes
-effect at its `mergedAt` only after the pre-merge reconciliation below, and the
-later valid source wins. The note path's precedent is STEADY, decided by owner
-instruction in note 107313 on 2026-09-02 and since superseded; the marker above
-is whatever `origin/main:AGENTS.md` currently says, which is the only line a
-seat should trust.
+cannot invent a later decision merely by merging later. STEADY was decided by
+owner instruction in note 107313 on 2026-09-02: that is the decision's dated
+provenance, not a claim about today. Derive the ACTIVE mode as described below,
+because an id repeated in prose freezes while the ledger moves.
 
 Before a mode-marker PR is marked ready, post
 `[workload-mode-reconciliation repo=<owner/repo> pr=<number> head=<40-character-reviewed-head> mode=<mode> decision_note=<id|none>]`.
@@ -538,18 +501,53 @@ file a new exact-head row. It is a recency boundary, not a veto, so a fresh row
 that agrees with the PR's own marker still merges, and correcting the note is
 optional rather than the only exit. The gate only refuses outright when nothing
 readable remains, meaning the note is unreadable AND the PR's marker patch is
-missing or ambiguous. A reconciliation hold at the merge boundary is retryable:
-the pipeline gate RELEASES its at-most-once merge claim, records the cause as a
+missing or ambiguous, and the hold then names both steps of the exit: append a
+fresh readable operating-mode note AND file an exact-head row citing it. A
+reconciliation hold at the merge boundary is retryable: the pipeline gate
+RELEASES its at-most-once merge claim, records the cause as a
 `pipeline_auto_merge_held` job event, and re-attempts on a later scan, so the
-row landing merges. If the gate stage sets a `timeout` the park summary carries
-that cause; a stage with no timeout waits indefinitely, which is documented
-pipeline policy and is only safe because the hold retries and is recorded.
+row landing merges. It is also BOUNDED, and the bound applies on both the
+ordinary Evaluate path and the merge boundary: with a gate `timeout` the stage
+parks at that timeout carrying the cause, and with no `timeout` it parks 6h
+after the hold episode began. A hold whose cause or head changes starts a new
+episode with a fresh budget, so a later hold is never charged for an earlier
+one.
 
 Resolve the active decision from both durable sources: read the marker from
 `origin/main:AGENTS.md`, never a seat worktree, and read the newest typed
 operating-mode/reconciliation note. Decisions are ordered by `decided_at`
 (the decision row's `created_at`), not by when their materialization later
 activates. Name both sources in the handoff.
+
+DERIVE, never trust a marker id quoted in a rules file — including any id quoted
+in THIS file. Two things are separate and were conflated on 2026-09-03, at the
+cost of two coordinators reporting the wrong mode:
+
+1. THE ACTIVE MODE IS THE MARKER LINE, `**Current mode: <MODE>.**`, in
+   `origin/main:AGENTS.md`. A switch is a MERGED PR that changes that line and
+   takes effect at its `mergedAt`. Fetch `origin/main` and read it there, never
+   from a seat worktree — a seat tree can be weeks stale, and a local grep miss
+   in one is an instrument failure, not evidence the marker moved.
+2. `[operating-mode ...]` workflow notes are DECISION rows: they record who
+   decided what and when, and the reconciliation gate above uses them to bind a
+   marker-changing PR to a decision. A decision note is not itself the marker,
+   and a note cannot switch the mode without the merged line.
+
+When you do need the newest decision note, anchor on the LITERAL PREFIX and read
+that note's own body for what it supersedes and at what scope:
+
+```sql
+select id, created_at, substr(body,1,80) from workflow_notes
+where body like '[operating-mode%' order by id desc limit 5;
+```
+
+The prefix is load-bearing: `body like '%operating-mode%'` also matches every
+note that merely DISCUSSES a marker — directives, reviews, this rule's own
+commit — so it returns a confident, current-looking row that is not a decision
+at all. A ledger whose notes debate markers cannot be counted by matching marker
+text, and a heading or phrase copied from the artifact you are trying to
+discredit makes the search self-confirming: list the headings and read the
+section instead.
 
 Record every activation with:
 `[workload-mode-transition]`,

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -433,24 +433,37 @@ exactly what makes a stale green look current. (Whether a manual "Re-run all
 jobs" re-resolves the merge ref against the new base or replays the original
 merge SHA is **unmeasured** — do not rely on either.)
 
-The two axes, and both can be true at once:
+The two axes — the head axis has two shapes — and both axes can be true at once:
 
 - **The head moved — new commits were pushed.** The verdict is void: it
   described a tree that no longer exists. Re-review at the new head, scoped to
   the delta since the approved head, not the whole PR again. Verify the branch
   carries only what you intended: `git diff origin/<baseRefName>..HEAD` and a
   tree read confirming no file you never touched reappears or vanishes.
-- **The head moved BACK — a force-push restored an earlier approved SHA.** An
-  exact-head gate keyed to `head_sha` cannot see this: the tree exists and the
-  SHA matches a prior approval. But that approval was made against a different
-  base and against intermediate history the force-push discarded. Treat it as
-  unreviewed.
+  - **Sub-case of the head axis: the head moved BACK** — a force-push restored
+    an earlier approved SHA. An exact-head gate keyed to `head_sha` cannot see
+    this: the tree exists and the SHA matches a prior approval. But that
+    approval was made against a different base and against intermediate history
+    the force-push discarded. Treat it as unreviewed.
 - **The base moved.** The verdict still names a commit that still exists and git
   still reports CLEAN, yet nobody reviewed `base` + branch, which is what lands.
   **The sound instrument is to build and test the merge result** — re-trigger CI
-  at the current base and read that run. File/package overlap between the base
-  delta and the PR is useful only to scope how much of the diff a human
-  re-reads; it is **not** a merge predicate. It has no direction and no
+  at the current base and read that run. To re-trigger it, **push to the
+  branch** (rebase onto the base, or merge the base in): that fires
+  `pull_request: synchronize`, which produces a fresh merge ref AND a fresh run.
+  Do not rely on the GitHub UI's "Re-run all jobs" — whether it re-resolves the
+  merge ref against the new base or replays the original merge SHA is unmeasured
+  here, so it may report green for the tree you were trying to leave behind.
+
+  **A green merge build is necessary, not sufficient.** It proves the merged tree
+  compiles and its tests pass; it cannot notice an assertion that stopped
+  existing. Where the base delta and the PR touch the same region, a clean
+  textual merge silently produces wrong code: two migrations appended to the same
+  slice merge without conflict and can still renumber, and two edits to one test
+  function merge with one assertion dropped — after which the merged tree builds
+  and every remaining test passes, so CI is green and reports nothing. That is
+  what file/package overlap is for: it is useful only to scope how much of the
+  diff a human re-reads, and it is **not** a merge predicate. It has no direction and no
   transitivity, while "depends on" has both: a PR changing a signature in
   `internal/workflow` and a base commit adding a call site in `internal/daemon`
   share zero files and zero packages, pass any overlap test, and produce a tree
@@ -492,8 +505,12 @@ the note path's precedent is STEADY, set by owner instruction in note 107313 on
 2026-09-02 and since superseded. A merged PR takes effect at that PR's
 `mergedAt` time. At the next check-in, the coordinator must:
 
-1. fetch `origin/main`, read the marker from `origin/main:AGENTS.md` rather than
-   the seat's worktree, and steer every active seat to the merged mode;
+1. resolve the mode from BOTH sources and steer to the LATER one: fetch
+   `origin/main` and read the marker from `origin/main:AGENTS.md` rather than the
+   seat's worktree, AND read the newest `[operating-mode ...]` workflow note.
+   Between a note and the PR that corrects the file, `AGENTS.md` is stale BY
+   CONSTRUCTION, so a coordinator reading only the file in that window steers
+   every seat to the superseded mode. Name which source you read;
 2. comment on the merged mode-switch PR with this exact transition record:
    `[workload-mode-transition]`, `mode: <THROUGHPUT|STEADY|DRAIN>`,
    `effective_commit: <40-character SHA>`, `observed_at: <RFC3339>`, zero or more
@@ -507,12 +524,14 @@ implementation assignments accepted before `mergedAt` that have not reached a
 terminal handoff, plus review jobs created before `mergedAt` that were queued or
 running then. `accepted_at` is the timestamp of the Herdr pane's first
 `working` status event after the issue-backed assignment prompt; `created_at` is
-the job-store timestamp. The merged PR always exists, so this record does not
-depend on a pre-existing workflow. The mode changes how much work may start; it
+the job-store timestamp. A merged PR always exists for a PR-sourced switch, so that record does not
+depend on a pre-existing workflow. For a NOTE-sourced switch the note id IS the
+record and the transition record is posted as a workflow note, because the
+correcting PR may not exist yet. The mode changes how much work may start; it
 never relaxes correctness, exact-head review, CI, or the merge authority
 recorded in the org config.
 
-Across both modes, use exactly one independent reviewer per corrected head.
+Across ALL THREE modes, use exactly one independent reviewer per corrected head.
 Parallel review lanes mean different PRs, not multiple reviewers on one head.
 Review panels and fanout require explicit, durable owner authorization for that
 specific incident; an incident does not override this rule by itself.
@@ -540,7 +559,17 @@ escalations, and an armed merge gate then merged the PR without them.
 - **No admission gate.** A seat that finishes takes the next item itself: no
   escalation for permission, no waiting for an authorization row.
 - Work comes off an **ordered list**, not a free choice — for a reduction epic,
-  that epic's own dependency-sorted sub-issue order.
+  that epic's own dependency-sorted sub-issue order. **Nothing outside the
+  scoped list is in scope**: with no admission gate, exclusivity is the only
+  clause that bounds what a finishing seat may pick up (owner instruction, note
+  107313: "Nothing outside #1762 is in scope").
+- **Claim before editing.** A seat posts a one-line claim note naming issue,
+  seat and branch BEFORE its first edit. No permission, no wait, no reply — it
+  is a record other seats can read. Removing the admission gate removed the
+  permission step, not the coordination signal: on 2026-09-02 two seats built
+  incompatible answers to one issue (#1757, PRs #1786 and #1789 sharing 18 files
+  and treating `NoopClient` two ways) because the second seat checked for a
+  claim, correctly found none, and started.
 - **One in, one out**: no second PR from a seat while its first is unmerged.
   This is what keeps the queue from growing, without anyone deciding.
 - Escalate only for a **P2-or-worse finding**, a **scope boundary wider than the

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -606,8 +606,8 @@ Record every activation with:
 `[workload-mode-transition]`,
 `mode: <THROUGHPUT|STEADY|DRAIN>`,
 `decision_ref: workflow-note:<id>`,
-`change_ref: none|pr:<owner/repo>#<number>@<reviewed-head>`,
-`activation_ref: workflow-note:<id>|commit:<merge-sha>`,
+`change_ref: none|pr:<owner/repo>#<number>@<40-character-reviewed-head>`,
+`activation_ref: none|workflow-note:<id>|commit:<40-character merge SHA>`,
 `decided_at: <RFC3339>`,
 `effective_at: <RFC3339>`,
 `observed_at: <RFC3339>`, zero or more
@@ -617,9 +617,10 @@ then `[/workload-mode-transition]`.
 
 RESOLVED IN ONE DIRECTION, because this document said both and a reader could
 pick either (#1783 round-8 review, F-3): ONLY A MERGED COMMIT ACTIVATES A MODE.
-`activation_ref` is therefore always `commit:<40-character merge SHA>`, and its
-`workflow-note:<id>` form is for RECORDING a decision that has not yet been
-materialised by a merged marker PR - never for claiming a mode is active. That
+`commit:<40-character merge SHA>` is therefore the ONLY ACTIVATING form. The
+other two record a mode that is not active yet: `workflow-note:<id>` for a
+decision not yet materialised by a merged marker PR, and `none` for a record
+posted before any marker PR exists - never for claiming a mode is active. That
 matches point 1 of "DERIVE, never trust a marker id" above: the active mode is
 the marker line in `origin/main:AGENTS.md`, changed by a merged PR, and a
 decision note is not itself the marker. `decision_ref` carries the note,
@@ -649,8 +650,9 @@ wave is the non-terminal implementation assignments accepted before
 `decided_at` plus review jobs created before it that were queued or running
 then. DRAIN becomes active only at `effective_at`, which is the `mergedAt` of the
 reconciled marker PR after its prerequisites are installed - not a note's
-`created_at`, per the resolution above. The remaining note-sourced case for a
-note source. A later owner decision cancels an unactivated DRAIN.
+`created_at`, per the resolution above. The remaining note-sourced case is the
+DRAIN decision itself, which freezes admissions at `decided_at` without
+activating. A later owner decision cancels an unactivated DRAIN.
 `accepted_at` is the Herdr pane's first `working` event after the issue-backed
 assignment prompt; review `created_at` is the job-store timestamp. Mode changes
 never relax correctness, exact-head review, CI, or org merge authority.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -538,9 +538,12 @@ file a new exact-head row. It is a recency boundary, not a veto, so a fresh row
 that agrees with the PR's own marker still merges, and correcting the note is
 optional rather than the only exit. The gate only refuses outright when nothing
 readable remains, meaning the note is unreadable AND the PR's marker patch is
-missing or ambiguous. And a reconciliation hold at the merge boundary is
-retryable, not terminal: the pipeline gate keeps waiting until the row lands or
-the gate times out.
+missing or ambiguous. A reconciliation hold at the merge boundary is retryable:
+the pipeline gate RELEASES its at-most-once merge claim, records the cause as a
+`pipeline_auto_merge_held` job event, and re-attempts on a later scan, so the
+row landing merges. If the gate stage sets a `timeout` the park summary carries
+that cause; a stage with no timeout waits indefinitely, which is documented
+pipeline policy and is only safe because the hold retries and is recorded.
 
 Resolve the active decision from both durable sources: read the marker from
 `origin/main:AGENTS.md`, never a seat worktree, and read the newest typed

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -106,15 +106,14 @@ go test -timeout 25m -skip 'TestClaudeProduceHookAutoReadLandlockE2E' ./...
 `-buildvcs=false` is required, not optional, inside a gitmoot worktree (#1209):
 Go's VCS auto-stamp only recognizes a `.git` **directory** as a repo root
 (`cmd/go/internal/vcs.vcsGit.RootNames`), but a linked worktree's `.git` is a
-**file** (a `gitdir:` pointer). Go's root-detection walk-up skips past the
-worktree's real root looking for any ancestor with a `.git`-shaped directory,
-and can land on an unrelated one — hard-failing with `error obtaining VCS
-status: exit status 128` even though `git status` itself works fine from the
-same directory. This is a genuine Go toolchain limitation with linked
-worktrees (confirmed by reading `cmd/go/internal/vcs/vcs.go`'s `FromDir` /
-`isVCSRoot`), not something gitmoot's code or config can fix, and even the
-non-failing cases can silently stamp the wrong VCS metadata (wrong commit,
-wrong dirty bit) from whatever directory the walk-up happened to land on.
+**file** (a `gitdir:` pointer), so the root-detection walk-up skips the
+worktree's real root and keeps going up. What happens next depends on what the
+walk finds, and it is stated once in the deploy recipe below rather than twice
+here: see "Deploy recipe (this host)", step 1. The short version is that the
+quiet outcome is the dangerous one, not the `exit status 128` failure. This is a
+Go toolchain behavior with linked worktrees, not something gitmoot's code or
+config can fix.
+
 Disabling it here costs nothing real: release binaries get their version
 info from the explicit `-ldflags -X ...Commit=$(git rev-parse HEAD)` recipe
 in the deploy section below, never from Go's auto-stamp.
@@ -261,17 +260,53 @@ detection.
 
 ## Deploy recipe (this host)
 
-1. On `main` after merge, build with the pinned toolchain (above). Stamp the
-   version the way `release.yml` does, or `gitmoot version` reports
-   `commit: unknown`:
+1. On `main` after merge, build with the pinned toolchain (above), from a clean
+   detached worktree at the exact tip rather than the shared `/root/gitmoot`
+   checkout, which usually carries uncommitted work. Stamp the version the way
+   `release.yml` does, or `gitmoot version` reports `commit: unknown`.
+   `-buildvcs=false` is required for the same reason as the test gate above: in
+   a linked worktree `.git` is a **file**, which the pinned toolchain does not
+   treat as a repository root, so it walks up to the parent directories. What
+   that walk finds decides the outcome. Measured with a throwaway module on
+   go1.26.4:
+
+   - **no repository anywhere above it**: the build succeeds and simply omits
+     the stamp. This case is tolerated, not an error;
+   - **a `.git` DIRECTORY above it that git rejects as a repository**: the build
+     **fails** with `error obtaining VCS status: exit status 128`. A `.git`
+     **file** never produces this: it is skipped, and the walk continues past
+     it. This is not hypothetical here: `/tmp/.git` exists on this host as a
+     directory (`ls -A` returns nothing, and `git -C /tmp status` fails), so a
+     deploy worktree anywhere under `/tmp` hits it, and it will not be the only
+     such directory on any given host;
+   - **a working unrelated repository above it**: the build **succeeds** and
+     stamps that repository's metadata. A binary built from commit `1f76f143`
+     embedded the ancestor's `vcs.revision 60f8282c` and `vcs.modified true`.
+
+   The third case is the one to design against, because it is silent. The
+   `-ldflags` below override `Commit`, so `gitmoot version` still prints the
+   right value and the wrong stamp stays hidden in the embedded build info.
+   Drop the ldflags and `buildinfo.Current` falls back to that VCS revision
+   (`internal/buildinfo/buildinfo.go`), so an unstamped binary reports an
+   ancestor's commit as its own and the daemon build-skew check compares a
+   false identity rather than an unknown one.
+
+   Treat the `.git`-file behavior as version-specific rather than permanent:
+   Go's handling of it is being changed upstream, and `-buildvcs=false` is what
+   makes all three outcomes moot.
 
    ```sh
+   git worktree add --detach /root/gitmoot-deploy "$(git rev-parse HEAD)"
+   cd /root/gitmoot-deploy
    PKG=github.com/gitmoot/gitmoot/internal/buildinfo
-   CGO_ENABLED=0 go build -trimpath -ldflags \
+   CGO_ENABLED=0 go build -trimpath -buildvcs=false -ldflags \
      "-s -w -X $PKG.Version=dev-$(git rev-parse --short HEAD) \
       -X $PKG.Commit=$(git rev-parse HEAD) -X $PKG.Date=$(date -Iseconds)" \
      -o /root/.local/bin/gitmoot.new ./cmd/gitmoot
    ```
+
+   Remove the deploy worktree when the deploy is done:
+   `git worktree remove /root/gitmoot-deploy`.
 
 2. `mv`-rename the new binary into `/root/.local/bin/gitmoot` (same filesystem;
    the rename avoids `ETXTBSY`).
@@ -462,7 +497,7 @@ Under ultracode, orchestrate via the Workflow tool with opus sub-agents
 
 ## Workload mode
 
-**Current mode: STEADY.**
+**Current mode: THROUGHPUT.**
 
 A mode decision is an append-only
 `[operating-mode repo=<owner/repo> mode=<THROUGHPUT|STEADY|DRAIN>]` workflow
@@ -517,13 +552,16 @@ detail and keying on it let unrelated churn defer the bound indefinitely.
 A scan that LOSES the at-most-once claim is a separate case and never parks the
 run: it cannot see whether the winner is alive, and a hold record has no expiry,
 so believing one killed runs whose reconciliation had already succeeded. It ages
-the wait from the GATE STAGE'S OWN `StartedAt` - one clock, one write, no second
-row to fall out of step with the claim - and records
-`pipeline_auto_merge_claim_orphaned` once the wait passes 15m, with
-`cause=held_past_bound`. A gate row with no recorded start time cannot be aged
-at all, and a wait that cannot be aged is recorded immediately with
-`cause=gate_start_unrecorded` rather than left silent. Either way it keeps
-waiting, and a stage `timeout` is what turns that into a park.
+the wait from THE CLAIM ROW'S OWN `created_at` - one write, no second row to fall
+out of step with the claim, and a value resume does not reset - and records
+`pipeline_auto_merge_claim_orphaned` once the claim has been held 15m, with
+`cause=held_past_bound`. If a genuinely orphaned claim is the cause, THIS run
+cannot merge: nothing in the pipeline releases that claim, its key is fixed for
+the run, and a stage `timeout` on the gate parks the run rather than recovering
+it - re-running the pipeline takes a fresh claim. A claim whose `created_at`
+will not parse cannot be aged at all; that is recorded immediately with
+`cause=claim_timestamp_unreadable`, and a stage `timeout` CANNOT park that wait,
+because `pipelineGateTimedOut` needs a start stamp it does not have.
 
 Resolve the active decision from both durable sources: read the marker from
 `origin/main:AGENTS.md`, never a seat worktree, and read the newest typed

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -516,9 +516,14 @@ changed CAUSE alone does not, because the cause carries volatile near-miss
 detail and keying on it let unrelated churn defer the bound indefinitely.
 A scan that LOSES the at-most-once claim is a separate case and never parks the
 run: it cannot see whether the winner is alive, and a hold record has no expiry,
-so believing one killed runs whose reconciliation had already succeeded. Past
-15m of a held claim it records `pipeline_auto_merge_claim_orphaned` and keeps
-waiting; a stage `timeout` is what turns that into a park.
+so believing one killed runs whose reconciliation had already succeeded. It ages
+the wait from the GATE STAGE'S OWN `StartedAt` - one clock, one write, no second
+row to fall out of step with the claim - and records
+`pipeline_auto_merge_claim_orphaned` once the wait passes 15m, with
+`cause=held_past_bound`. A gate row with no recorded start time cannot be aged
+at all, and a wait that cannot be aged is recorded immediately with
+`cause=gate_start_unrecorded` rather than left silent. Either way it keeps
+waiting, and a stage `timeout` is what turns that into a park.
 
 Resolve the active decision from both durable sources: read the marker from
 `origin/main:AGENTS.md`, never a seat worktree, and read the newest typed

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -412,53 +412,70 @@ self-merge conditional on all six checks below:
 The delegation does **not** authorize releases, `gh release create`, deploys,
 service restarts, force-pushes to `main`, or merging work outside the PR's
 issue. Those actions remain owner-gated.
-**A clean, mergeable PR whose head is no longer the reviewed head is NOT ready.**
+
+**A green, mergeable PR is not necessarily a REVIEWED one — check two axes
+independently: did the head move, and did the base move?**
 `mergeable: MERGEABLE` / `mergeStateStatus: CLEAN` is a claim about *git* — that
 the branch applies with no textual conflict. It says nothing about whether
-anyone reviewed the tree that will land, and CI here is keyed to `head_sha`
-(`.github/workflows/ci.yml` runs on `pull_request`, and every check-run reports
-the branch head), so green CI tested the *branch*, not the branch merged into
-current `main`. Two cases, and they need different actions:
+anyone reviewed the tree that will land.
 
-- **Case A — new commits were pushed to the branch.** The verdict is void: it
+CI is a **stronger** instrument than a file-level argument, but it has a
+staleness hazard. `.github/workflows/ci.yml` runs on `pull_request` with no
+`ref:` override, so each `actions/checkout` resolves `github.ref` =
+`refs/pull/N/merge` and GitHub **does** build the branch merged into the base —
+measured on this file's own PR, whose run log reads
+`git checkout --force refs/remotes/pull/1783/merge` /
+`HEAD is now at 7057f594 Merge 4b245ac5… into c3785d6d…`. But GitHub recomputes
+that merge ref when the base moves and **does not re-run CI**, and the
+check-runs are reported against the *branch head*. So a green check is a claim
+about `merge(head, base AS OF THAT RUN)` displayed against the head — which is
+exactly what makes a stale green look current. (Whether a manual "Re-run all
+jobs" re-resolves the merge ref against the new base or replays the original
+merge SHA is **unmeasured** — do not rely on either.)
+
+The two axes, and both can be true at once:
+
+- **The head moved — new commits were pushed.** The verdict is void: it
   described a tree that no longer exists. Re-review at the new head, scoped to
-  the delta since the approved head — not the whole PR again.
-- **Case B — the branch head is unchanged and `main` moved underneath it.** The
-  verdict still names a commit that still exists and git still reports CLEAN,
-  yet nobody has reviewed `main` + branch, which is what actually lands. **Check
-  the BRANCH, not the base**: `git diff origin/main..HEAD` must contain only the
-  change you intended, and a tree read must confirm no file you never touched
-  reappears or vanishes. Only then compare the base delta: if `main`'s new
-  commits touch no file and no package the PR touches, the merge result is
-  semantically the reviewed tree — merge; if they overlap, re-review the delta.
-  A clean textual merge silently produces wrong code exactly where two changes
-  touch one region: two migrations appended to the same slice merge without
-  conflict and can still renumber; two edits to one test file merge and can drop
-  an assertion.
+  the delta since the approved head, not the whole PR again. Verify the branch
+  carries only what you intended: `git diff origin/<baseRefName>..HEAD` and a
+  tree read confirming no file you never touched reappears or vanishes.
+- **The head moved BACK — a force-push restored an earlier approved SHA.** An
+  exact-head gate keyed to `head_sha` cannot see this: the tree exists and the
+  SHA matches a prior approval. But that approval was made against a different
+  base and against intermediate history the force-push discarded. Treat it as
+  unreviewed.
+- **The base moved.** The verdict still names a commit that still exists and git
+  still reports CLEAN, yet nobody reviewed `base` + branch, which is what lands.
+  **The sound instrument is to build and test the merge result** — re-trigger CI
+  at the current base and read that run. File/package overlap between the base
+  delta and the PR is useful only to scope how much of the diff a human
+  re-reads; it is **not** a merge predicate. It has no direction and no
+  transitivity, while "depends on" has both: a PR changing a signature in
+  `internal/workflow` and a base commit adding a call site in `internal/daemon`
+  share zero files and zero packages, pass any overlap test, and produce a tree
+  that does not compile. Same shape when a PR deletes a symbol the base has just
+  begun to reference — live risk during a reduction epic.
 
-  The branch check comes first because the base check alone is **not
-  sufficient**, measured on the first push of this very PR. It was stacked on a
-  PR whose own base predated a large deletion; that parent was **squash**-merged,
-  which makes the reviewed branch commits non-ancestors of `main`, so the stack
-  silently kept the parent's stale base. The branch then reported
-  `mergeable: MERGEABLE`, no conflict and green CI while its diff against the
-  moved `main` re-added ~10,200 deleted lines — a mass revert of a merge from
-  half an hour earlier. The base-delta predicate PASSED that case: the base delta
-  touched the deleted files, the PR touched only this file, no overlap. Stacking
-  on a PR that will be squash-merged always requires a rebuild on `main`, never a
-  base-delta comparison.
+Measured on the first push of this very PR: it was stacked on a PR whose own
+base predated a large deletion; that parent was **squash**-merged, which makes
+the reviewed branch commits non-ancestors of the base, so the stack silently
+kept the parent's stale base. The branch reported MERGEABLE, no conflict, green
+CI — while its diff against the moved base re-added ~10,200 deleted lines, a
+mass revert of a merge from half an hour earlier. Stacking on a PR that will be
+squash-merged always requires a rebuild on the base once the parent lands.
 
-Prove Case B with **trees, not diff output**, and put a positive control on
-every instrument. #1731 was waived on "only `AGENTS.md` changed" by the role
-that benefited from the waiver; reversing that bought a content-addressed proof
-instead — `git ls-tree -r` over all 1173 tracked files, pairwise-equal subtree
-hashes, identical blob hashes for all 57 PR-changed files, each instrument
-shown to report differences on a known-different pair. That cost one review
-round and is the standard.
+Where a tree comparison is the right tool, use **trees, not diff output**, with a
+positive control on every instrument. #1731 was waived on "only `AGENTS.md`
+changed" by the role that benefited from the waiver; reversing that bought a
+content-addressed proof instead — `git ls-tree -r` over all 1173 tracked files,
+pairwise-equal subtree hashes, identical blob hashes for all 57 PR-changed
+files, each instrument shown to report differences on a known-different pair.
 
 And **`CLEAN` beside an empty check rollup is not green** — a head whose checks
-have not registered yet reports zero check-runs and still reads CLEAN. Read the
-count, not the label.
+have not registered yet reports zero check-runs and still reads CLEAN. An empty
+check list right after a push means "not started", never "not required". Read
+the count, not the label.
 
 Under ultracode, orchestrate via the Workflow tool with opus sub-agents
 (protect the scarcer fable quota).
@@ -500,25 +517,6 @@ Parallel review lanes mean different PRs, not multiple reviewers on one head.
 Review panels and fanout require explicit, durable owner authorization for that
 specific incident; an incident does not override this rule by itself.
 
-### Steady mode
-
-Between throughput and drain: the **cap stays, the admission gate goes**. Set by
-the owner on 2026-09-02, because drain's cost was never its concurrency limit but
-its permission step — a seat sat on four ready, gated fixes through two
-escalations, and an armed merge gate then merged the PR without them.
-
-- At most **four implementation seats and two independent reviewers** at once.
-- **No admission gate.** A seat that finishes takes the next item itself: no
-  escalation for permission, no waiting for an authorization row.
-- Work comes off an **ordered list**, not a free choice — for a reduction epic,
-  that epic's own dependency-sorted sub-issue order.
-- **One in, one out**: no second PR from a seat while its first is unmerged.
-  This is what keeps the queue from growing, without anyone deciding.
-- Escalate only for a **P2-or-worse finding**, a **scope boundary wider than the
-  assigned item**, or **live-service impact**. Everything else is the seat's call.
-- Steady mode names its own **exit condition**: when the scoped list is merged,
-  the coordinator posts the next mode marker itself rather than waiting to be told.
-
 ### Throughput mode
 
 - Start independent, issue-backed work when ownership and integration order are
@@ -527,6 +525,31 @@ escalations, and an armed merge gate then merged the PR without them.
   different PRs under the repository's normal safety rules.
 - Stop opening new lanes when work queues behind shared files, unresolved
   integration order, or repeated review findings.
+
+### Steady mode
+
+Between throughput and drain: the **cap stays, the admission gate goes**. Set by
+the owner on 2026-09-02, because drain's cost was never its concurrency limit but
+its permission step — a seat sat on four ready, gated fixes through two
+escalations, and an armed merge gate then merged the PR without them.
+
+- At most **four implementation seats and two independent reviewers** at once.
+  The owner gave those numbers illustratively ("4 implementations and 2 reviews
+  for example"); note 107313 hardened them, and a rules file needs a definite
+  cap rather than an example.
+- **No admission gate.** A seat that finishes takes the next item itself: no
+  escalation for permission, no waiting for an authorization row.
+- Work comes off an **ordered list**, not a free choice — for a reduction epic,
+  that epic's own dependency-sorted sub-issue order.
+- **One in, one out**: no second PR from a seat while its first is unmerged.
+  This is what keeps the queue from growing, without anyone deciding.
+- Escalate only for a **P2-or-worse finding**, a **scope boundary wider than the
+  assigned item**, or **live-service impact**. Everything else is the seat's call.
+- Steady mode names its own **exit condition and its destination**: when the
+  scoped list is merged, `gitmoot/*` returns to **DRAIN**, and the coordinator
+  posts that drain marker itself rather than waiting to be told (owner
+  instruction, note 107313: "we need to stop and go back to DRAIN mode once
+  those are merged").
 
 ### Drain mode
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -560,8 +560,11 @@ cannot merge: nothing in the pipeline releases that claim, its key is fixed for
 the run, and a stage `timeout` on the gate parks the run rather than recovering
 it - re-running the pipeline takes a fresh claim. A claim whose `created_at`
 will not parse cannot be aged at all; that is recorded immediately with
-`cause=claim_timestamp_unreadable`, and a stage `timeout` CANNOT park that wait,
-because `pipelineGateTimedOut` needs a start stamp it does not have.
+`cause=claim_timestamp_unreadable`, and a stage `timeout` still parks that wait
+like any other - the gate row carries its ordinary start stamp, and only the
+claim's timestamp is unreadable. A claim released between a losing scan's failed
+claim attempt and its read is neither case: that is the ordinary hold cycle, so
+the loser waits quietly and the next scan takes the claim.
 
 Resolve the active decision from both durable sources: read the marker from
 `origin/main:AGENTS.md`, never a seat worktree, and read the newest typed
@@ -610,17 +613,43 @@ Record every activation with:
 `observed_at: <RFC3339>`, zero or more
 `implementer: <seat> issue=<number> pr=<number|none> accepted_at=<RFC3339>`
 lines, zero or more `review: <job-id> pr=<number> created_at=<RFC3339>` lines,
-then `[/workload-mode-transition]`. A direct STEADY/THROUGHPUT note may be both
-the decision and activation reference. A PR activates at its merge commit. A
-note-sourced DRAIN uses a later activation-marker note, so no field claims a
-commit that does not exist.
+then `[/workload-mode-transition]`.
+
+RESOLVED IN ONE DIRECTION, because this document said both and a reader could
+pick either (#1783 round-8 review, F-3): ONLY A MERGED COMMIT ACTIVATES A MODE.
+`activation_ref` is therefore always `commit:<40-character merge SHA>`, and its
+`workflow-note:<id>` form is for RECORDING a decision that has not yet been
+materialised by a merged marker PR - never for claiming a mode is active. That
+matches point 1 of "DERIVE, never trust a marker id" above: the active mode is
+the marker line in `origin/main:AGENTS.md`, changed by a merged PR, and a
+decision note is not itself the marker. `decision_ref` carries the note,
+`change_ref` the PR and its reviewed head, `decided_at` the note's timestamp,
+and `effective_at` the merge commit's `mergedAt`.
+
+A note-sourced DRAIN therefore does not become active on its note alone: it is
+decided at the note, freezes admissions from `decided_at` as below, and
+activates when its marker PR merges. If no marker PR has merged yet, post the
+record with `activation_ref: none` and `effective_at: none`, and re-post with
+both filled once it does.
+
+`activation_ref` and `change_ref` SHAs are 40 characters, matching
+`head=<40-character-reviewed-head>` in the reconciliation grammar above; an
+abbreviation grows ambiguous as the repository grows (F-6).
+
+RECORDS POSTED UNDER THE PRIOR GRAMMAR ARE GRANDFATHERED, stated rather than
+left undefined: a `[workload-mode-transition]` record carrying
+`effective_commit: <40-character SHA>` instead of `activation_ref`/`effective_at`
+remains valid and needs no re-post - the #1840 DRAIN-to-THROUGHPUT record at
+639fd973d83aa513575201e132587ab1313e6ca5 is one, and `effective_commit` maps to
+`activation_ref: commit:<same SHA>`. New records use the grammar above.
 
 A DRAIN decision freezes new admissions at `decided_at`; the previously active
 mode remains active while DRAIN prerequisites are installed. The transition
 wave is the non-terminal implementation assignments accepted before
 `decided_at` plus review jobs created before it that were queued or running
-then. DRAIN becomes active only at `effective_at`: `mergedAt` for a reconciled
-PR after its prerequisites, or the activation-marker note's `created_at` for a
+then. DRAIN becomes active only at `effective_at`, which is the `mergedAt` of the
+reconciled marker PR after its prerequisites are installed - not a note's
+`created_at`, per the resolution above. The remaining note-sourced case for a
 note source. A later owner decision cancels an unactivated DRAIN.
 `accepted_at` is the Herdr pane's first `working` event after the issue-backed
 assignment prompt; review `created_at` is the job-store timestamp. Mode changes

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -531,11 +531,16 @@ Enforcement is keyed on the repository OWNER, so every `gitmoot/*` repo is held
 until a row exists, human-requested merges included. Repository names are
 compared case-insensitively on every stream, so a note recorded as
 `Gitmoot/gitmoot` still counts. A newest operating-mode note that cannot be
-read — a malformed field list, or a `mode` that is not a workload mode — HOLDS
-the PR and names that note, because an unreadable decision is not the absence of
-one; correct the note rather than adding a row. And a reconciliation hold at the
-merge boundary is retryable, not terminal: the pipeline gate keeps waiting until
-the row lands or the gate times out.
+read — a malformed field list, or a `mode` that is not a workload mode —
+SUPERSEDES like any other decision instead of reading as no decision: a row
+filed before it no longer reconciles, and the hold names the note and says to
+file a new exact-head row. It is a recency boundary, not a veto, so a fresh row
+that agrees with the PR's own marker still merges, and correcting the note is
+optional rather than the only exit. The gate only refuses outright when nothing
+readable remains, meaning the note is unreadable AND the PR's marker patch is
+missing or ambiguous. And a reconciliation hold at the merge boundary is
+retryable, not terminal: the pipeline gate keeps waiting until the row lands or
+the gate times out.
 
 Resolve the active decision from both durable sources: read the marker from
 `origin/main:AGENTS.md`, never a seat worktree, and read the newest typed

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -508,10 +508,17 @@ RELEASES its at-most-once merge claim, records the cause as a
 `pipeline_auto_merge_held` job event, and re-attempts on a later scan, so the
 row landing merges. It is also BOUNDED, and the bound applies on both the
 ordinary Evaluate path and the merge boundary: with a gate `timeout` the stage
-parks at that timeout carrying the cause, and with no `timeout` it parks 6h
-after the hold episode began. A hold whose cause or head changes starts a new
-episode with a fresh budget, so a later hold is never charged for an earlier
-one.
+parks at that timeout carrying the cause, and with no `timeout` it parks 24h
+after the hold episode began, with the park summary naming the `timeout` as the
+lever. A hold against a new head or a new DECISION starts a new episode with a
+fresh budget, so a later hold is never charged for an earlier one - but a
+changed CAUSE alone does not, because the cause carries volatile near-miss
+detail and keying on it let unrelated churn defer the bound indefinitely.
+A scan that LOSES the at-most-once claim is a separate case and never parks the
+run: it cannot see whether the winner is alive, and a hold record has no expiry,
+so believing one killed runs whose reconciliation had already succeeded. Past
+15m of a held claim it records `pipeline_auto_merge_claim_orphaned` and keeps
+waiting; a stage `timeout` is what turns that into a park.
 
 Resolve the active decision from both durable sources: read the marker from
 `origin/main:AGENTS.md`, never a seat worktree, and read the newest typed

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -441,10 +441,12 @@ The two axes — the head axis has two shapes — and both axes can be true at o
   carries only what you intended: `git diff origin/<baseRefName>..HEAD` and a
   tree read confirming no file you never touched reappears or vanishes.
   - **Sub-case of the head axis: the head moved BACK** — a force-push restored
-    an earlier approved SHA. An exact-head gate keyed to `head_sha` cannot see
-    this: the tree exists and the SHA matches a prior approval. But that
-    approval was made against a different base and against intermediate history
-    the force-push discarded. Treat it as unreviewed.
+    an earlier approved SHA. `ensureFinalReviewCaptured` binds approval to
+    `head_sha`; it does not persist the reviewed base SHA. If the base stayed
+    unchanged, the restored head and merge tree are identical and discarded
+    intermediate commits are irrelevant. The current gate cannot prove that
+    invariant, so treat the restored head as unreviewed as a conservative
+    fail-closed policy, not because the base necessarily changed.
 - **The base moved.** The verdict still names a commit that still exists and git
   still reports CLEAN, yet nobody reviewed `base` + branch, which is what lands.
   **The sound instrument is to build and test the merge result** — re-trigger CI
@@ -497,49 +499,65 @@ Under ultracode, orchestrate via the Workflow tool with opus sub-agents
 
 **Current mode: THROUGHPUT.**
 
-A mode switch is either a merged PR that changes the line above, or a durable
-`[operating-mode ...]` workflow note from the owner (or a coordinator acting on a
-recorded owner instruction). A note takes effect at its own timestamp and this
-line is then corrected in the next PR that touches this file; the note path's
-precedent is STEADY, set by owner instruction in note 107313 on 2026-09-02 and
-since superseded by a merged PR. A merged PR takes effect at that PR's
-`mergedAt` time only after the pre-merge reconciliation below. The later valid
-source wins.
+A mode decision is an append-only
+`[operating-mode repo=<owner/repo> mode=<THROUGHPUT|STEADY|DRAIN>]` workflow
+note from the owner (or a coordinator acting on a recorded owner instruction).
+A PR that changes the marker above is a second materialization path, but it
+cannot invent a later decision merely by merging later. A merged marker PR takes
+effect at its `mergedAt` only after the pre-merge reconciliation below, and the
+later valid source wins. The note path's precedent is STEADY, decided by owner
+instruction in note 107313 on 2026-09-02 and since superseded; the marker above
+is whatever `origin/main:AGENTS.md` currently says, which is the only line a
+seat should trust.
 
-Immediately before merging a mode-switch PR, re-read the newest
-`[operating-mode ...]` note and record its id (or `none`) on the PR. The PR's
-reviewed head must implement that note's mode, unless a later durable owner
-instruction explicitly chooses another mode. Otherwise update the PR and
-re-review it, or do not merge it. An unreconciled stale PR is not a valid switch,
-and its later `mergedAt` timestamp cannot override a newer owner instruction.
+Before a mode-marker PR is marked ready, post
+`[workload-mode-reconciliation repo=<owner/repo> pr=<number> head=<40-character-reviewed-head> mode=<mode> decision_note=<id|none>]`.
+For a PR-sourced decision, use `decision_note=none`; the reconciliation row's
+`created_at` is then `decided_at`. Otherwise `decision_note` names the newest
+operating-mode note the exact head implements, and that note's `created_at` is
+`decided_at`. A later operating-mode note supersedes the reconciliation and
+requires a new exact-head row.
 
-1. resolve the mode from BOTH sources and steer to the LATER one: fetch
-   `origin/main` and read the marker from `origin/main:AGENTS.md` rather than the
-   seat's worktree, AND read the newest `[operating-mode ...]` workflow note.
-   Between a note and the PR that corrects the file, `AGENTS.md` is stale BY
-   CONSTRUCTION, so a coordinator reading only the file in that window steers
-   every seat to the superseded mode. Name which source you read;
-2. comment on the merged mode-switch PR with this exact transition record:
-   `[workload-mode-transition]`, `mode: <THROUGHPUT|STEADY|DRAIN>`,
-   `effective_commit: <40-character SHA>`, `observed_at: <RFC3339>`, zero or more
-   `implementer: <seat> issue=<number> pr=<number|none> accepted_at=<RFC3339>`
-   lines, zero or more `review: <job-id> pr=<number> created_at=<RFC3339>`
-   lines, then
-   `[/workload-mode-transition]`.
+This is mechanically enforced, not a pre-merge memory check. Both the native
+`PolicyMergeGate` and the separate `PipelineAutoMerger` read the paginated PR
+file list. A changed `+`/`-` line containing the exact `**Current mode:` marker
+requires a matching reconciliation row. An `AGENTS.md` entry whose patch is
+missing or ambiguous fails closed. `PipelineAutoMerger.Merge` re-reads the PR
+and both note streams at the final merge boundary; an older reconciled PR that
+merges after a newer owner decision cannot override the newer decision.
 
-For DRAIN, the listed transition wave is derived from durable timestamps:
-implementation assignments accepted before the switch's effective time that
-have not reached a terminal handoff, plus review jobs created before that time
-that were queued or running then. The effective time is `mergedAt` for a
-PR-sourced switch and the note's `created_at` for a note-sourced switch.
-`accepted_at` is the timestamp of the Herdr pane's first `working` status event
-after the issue-backed assignment prompt; `created_at` is the job-store
-timestamp. A merged PR always exists for a PR-sourced switch, so that record
-does not depend on a pre-existing workflow. For a NOTE-sourced switch the note
-id IS the record and the transition record is posted as a workflow note, because
-the correcting PR may not exist yet. The mode changes how much work may start;
-never relaxes correctness, exact-head review, CI, or the merge authority
-recorded in the org config.
+Resolve the active decision from both durable sources: read the marker from
+`origin/main:AGENTS.md`, never a seat worktree, and read the newest typed
+operating-mode/reconciliation note. Decisions are ordered by `decided_at`
+(the decision row's `created_at`), not by when their materialization later
+activates. Name both sources in the handoff.
+
+Record every activation with:
+`[workload-mode-transition]`,
+`mode: <THROUGHPUT|STEADY|DRAIN>`,
+`decision_ref: workflow-note:<id>`,
+`change_ref: none|pr:<owner/repo>#<number>@<reviewed-head>`,
+`activation_ref: workflow-note:<id>|commit:<merge-sha>`,
+`decided_at: <RFC3339>`,
+`effective_at: <RFC3339>`,
+`observed_at: <RFC3339>`, zero or more
+`implementer: <seat> issue=<number> pr=<number|none> accepted_at=<RFC3339>`
+lines, zero or more `review: <job-id> pr=<number> created_at=<RFC3339>` lines,
+then `[/workload-mode-transition]`. A direct STEADY/THROUGHPUT note may be both
+the decision and activation reference. A PR activates at its merge commit. A
+note-sourced DRAIN uses a later activation-marker note, so no field claims a
+commit that does not exist.
+
+A DRAIN decision freezes new admissions at `decided_at`; the previously active
+mode remains active while DRAIN prerequisites are installed. The transition
+wave is the non-terminal implementation assignments accepted before
+`decided_at` plus review jobs created before it that were queued or running
+then. DRAIN becomes active only at `effective_at`: `mergedAt` for a reconciled
+PR after its prerequisites, or the activation-marker note's `created_at` for a
+note source. A later owner decision cancels an unactivated DRAIN.
+`accepted_at` is the Herdr pane's first `working` event after the issue-backed
+assignment prompt; review `created_at` is the job-store timestamp. Mode changes
+never relax correctness, exact-head review, CI, or org merge authority.
 
 Across ALL THREE modes, use exactly one independent reviewer per corrected head.
 Parallel review lanes mean different PRs, not multiple reviewers on one head.
@@ -604,14 +622,14 @@ escalations, and an armed merge gate then merged the PR without them.
 - After activation, cap the `gitmoot/*` scope at **two active implementers and
   one running reviewer**. An active implementer is a persistent seat currently
   changing code or a running engine implementation job.
-- A DRAIN switch is not effective until the coordinator configures the shared
-  daemon with `[daemon] workers = 1`; every active
-  `[repos."gitmoot/*"].max_parallel` override must be absent, zero, or one.
-  Apply the warm reload and verify both the effective global worker count and
-  every effective per-repository limit. This is the atomic runtime gate shared
-  by native PR fanout, heartbeats, and manual background reviews. For a
-  PR-sourced switch, complete this before merge; for a note-sourced switch,
-  complete it before posting the marker.
+- A DRAIN decision freezes admission immediately, but DRAIN is not active until
+  the coordinator configures the shared daemon with `[daemon] workers = 1`;
+  every active `[repos."gitmoot/*"].max_parallel` override must be absent, zero,
+  or one. Apply the warm reload and verify the live worker setting plus every
+  effective per-repository limit; plain `gitmoot daemon status` renders process
+  arguments and is not proof of a warm-reloaded value. For a PR source, finish
+  these prerequisites before marking the reconciled PR ready and merging it.
+  For a note source, finish them before posting the separate activation marker.
 - Before DRAIN activates, every foreground or persistent-seat review already in
   progress must reach a terminal handoff; those reviews cannot be grandfathered.
   All DRAIN reviews then run as background engine jobs. Never bypass the shared

--- a/docs/pipelines.md
+++ b/docs/pipelines.md
@@ -624,7 +624,9 @@ stages:
   `created_at` will not parse is recorded immediately with
   `cause=claim_timestamp_unreadable`, which a stage `timeout` parks like any
   other wait. A claim RELEASED in the window between a losing scan's failed
-  claim and its read is reported as nothing at all: that is the ordinary hold
+  claim and its read is reported as nothing while the gate keeps waiting - the
+  reason reaches the terminal parked summary once the stage `timeout` elapses -
+  and that is the ordinary hold
   cycle and the next scan takes the claim.
 - A workload-mode reconciliation hold is a THIRD event,
   `pipeline_auto_merge_held`, carrying the cause plus the head and the time the

--- a/docs/pipelines.md
+++ b/docs/pipelines.md
@@ -616,11 +616,14 @@ stages:
   the write and `pipeline_auto_merge_confirmed` afterward, carrying pipeline/run,
   stage, PR, and head SHA. Racing scans that lose the claim never call merge, and
   never park the run either: a loser cannot see whether the winner is alive, so
-  it ages its wait from the gate stage's own `StartedAt` and records
-  `pipeline_auto_merge_claim_orphaned` with `cause=held_past_bound` once that
-  wait passes 15m. A gate row carrying no start time cannot be aged, and that
-  case is recorded immediately with `cause=gate_start_unrecorded` instead of
-  waiting silently. A stage `timeout` is what converts either wait into a park.
+  it ages its wait from the CLAIM ROW's own `created_at` - which resume does not
+  reset - and records `pipeline_auto_merge_claim_orphaned` with
+  `cause=held_past_bound` once the claim has been held 15m. A stage `timeout`
+  converts that wait into a terminal park rather than a recovery, because nothing
+  releases an orphaned claim; a NEW RUN takes a fresh claim. A claim whose
+  `created_at` will not parse is recorded immediately with
+  `cause=claim_timestamp_unreadable`, and a stage `timeout` cannot park that one
+  at all.
 - A workload-mode reconciliation hold is a THIRD event,
   `pipeline_auto_merge_held`, carrying the cause plus the head and the time the
   hold began. The hold is retryable, not terminal: the gate releases its

--- a/docs/pipelines.md
+++ b/docs/pipelines.md
@@ -622,8 +622,10 @@ stages:
   converts that wait into a terminal park rather than a recovery, because nothing
   releases an orphaned claim; a NEW RUN takes a fresh claim. A claim whose
   `created_at` will not parse is recorded immediately with
-  `cause=claim_timestamp_unreadable`, and a stage `timeout` cannot park that one
-  at all.
+  `cause=claim_timestamp_unreadable`, which a stage `timeout` parks like any
+  other wait. A claim RELEASED in the window between a losing scan's failed
+  claim and its read is reported as nothing at all: that is the ordinary hold
+  cycle and the next scan takes the claim.
 - A workload-mode reconciliation hold is a THIRD event,
   `pipeline_auto_merge_held`, carrying the cause plus the head and the time the
   hold began. The hold is retryable, not terminal: the gate releases its

--- a/docs/pipelines.md
+++ b/docs/pipelines.md
@@ -614,13 +614,13 @@ stages:
   a merge API failure is tried once and never retry-spammed.
 - The source job timeline atomically records `pipeline_auto_merge_claim` before
   the write and `pipeline_auto_merge_confirmed` afterward, carrying pipeline/run,
-  stage, PR, and head SHA, plus `pipeline_auto_merge_claim_at` carrying when the
-  claim was taken. The age row is released WITH the claim, so it measures only a
-  claim that still exists. Racing scans that lose the claim never call merge, and
+  stage, PR, and head SHA. Racing scans that lose the claim never call merge, and
   never park the run either: a loser cannot see whether the winner is alive, so
-  once the claim has been held past 15m it records
-  `pipeline_auto_merge_claim_orphaned` and keeps waiting. A stage `timeout` is
-  what converts that wait into a park.
+  it ages its wait from the gate stage's own `StartedAt` and records
+  `pipeline_auto_merge_claim_orphaned` with `cause=held_past_bound` once that
+  wait passes 15m. A gate row carrying no start time cannot be aged, and that
+  case is recorded immediately with `cause=gate_start_unrecorded` instead of
+  waiting silently. A stage `timeout` is what converts either wait into a park.
 - A workload-mode reconciliation hold is a THIRD event,
   `pipeline_auto_merge_held`, carrying the cause plus the head and the time the
   hold began. The hold is retryable, not terminal: the gate releases its

--- a/docs/pipelines.md
+++ b/docs/pipelines.md
@@ -614,16 +614,26 @@ stages:
   a merge API failure is tried once and never retry-spammed.
 - The source job timeline atomically records `pipeline_auto_merge_claim` before
   the write and `pipeline_auto_merge_confirmed` afterward, carrying pipeline/run,
-  stage, PR, and head SHA. Racing scans that lose the claim never call merge.
+  stage, PR, and head SHA, plus `pipeline_auto_merge_claim_at` carrying when the
+  claim was taken. The age row is released WITH the claim, so it measures only a
+  claim that still exists. Racing scans that lose the claim never call merge, and
+  never park the run either: a loser cannot see whether the winner is alive, so
+  once the claim has been held past 15m it records
+  `pipeline_auto_merge_claim_orphaned` and keeps waiting. A stage `timeout` is
+  what converts that wait into a park.
 - A workload-mode reconciliation hold is a THIRD event,
   `pipeline_auto_merge_held`, carrying the cause plus the head and the time the
   hold began. The hold is retryable, not terminal: the gate releases its
   at-most-once claim (safe because that refusal is returned before any GitHub
   mutation) and re-attempts on later scans, so the reconciliation row landing
   merges. It is also bounded — with a gate `timeout` the stage parks at that
-  timeout carrying the cause; with no `timeout` the hold parks 6h after the
-  episode began. A hold whose cause or head changes starts a new episode with a
-  fresh 6h budget.
+  timeout carrying the cause; with no `timeout` the hold parks 24h after the
+  episode began, and the park summary names the `timeout` as the way to change
+  that. An episode is keyed on the head and the DECISION the row must reconcile
+  against, not on the cause text: the cause deliberately carries volatile
+  near-miss detail, and keying on it let unrelated note churn hand every hold a
+  fresh budget. A hold against a new head or a new decision starts a new episode
+  with a fresh 24h budget.
 
 ### Orchestrate stages
 

--- a/docs/pipelines.md
+++ b/docs/pipelines.md
@@ -615,6 +615,15 @@ stages:
 - The source job timeline atomically records `pipeline_auto_merge_claim` before
   the write and `pipeline_auto_merge_confirmed` afterward, carrying pipeline/run,
   stage, PR, and head SHA. Racing scans that lose the claim never call merge.
+- A workload-mode reconciliation hold is a THIRD event,
+  `pipeline_auto_merge_held`, carrying the cause plus the head and the time the
+  hold began. The hold is retryable, not terminal: the gate releases its
+  at-most-once claim (safe because that refusal is returned before any GitHub
+  mutation) and re-attempts on later scans, so the reconciliation row landing
+  merges. It is also bounded — with a gate `timeout` the stage parks at that
+  timeout carrying the cause; with no `timeout` the hold parks 6h after the
+  episode began. A hold whose cause or head changes starts a new episode with a
+  fresh 6h budget.
 
 ### Orchestrate stages
 

--- a/internal/cli/daemon_merge_gate_active_job_test.go
+++ b/internal/cli/daemon_merge_gate_active_job_test.go
@@ -24,12 +24,17 @@ import (
 type activeJobMergeGateGitHub struct {
 	githubtest.NoopClient
 	pr          github.PullRequest
+	files       []github.PullRequestFile
 	mergeInputs []github.MergePullRequestInput
 	statuses    []github.CommitStatusInput
 }
 
 func (f *activeJobMergeGateGitHub) GetPullRequest(context.Context, github.Repository, int64) (github.PullRequest, error) {
 	return f.pr, nil
+}
+
+func (f *activeJobMergeGateGitHub) ListPullRequestFiles(context.Context, github.Repository, int64) ([]github.PullRequestFile, error) {
+	return append([]github.PullRequestFile(nil), f.files...), nil
 }
 
 func (f *activeJobMergeGateGitHub) GetCombinedStatus(context.Context, github.Repository, string) (github.CombinedStatus, error) {
@@ -118,6 +123,88 @@ func TestDaemonMergeGateDefaultPreservesMergePathWhenMandatoryGatePasses(t *test
 	if len(gh.mergeInputs) != 1 || gh.mergeInputs[0].Method != "squash" || gh.mergeInputs[0].Number != 17 ||
 		!gh.mergeInputs[0].DeleteBranch || gh.mergeInputs[0].MatchHeadCommit != "head123" {
 		t.Fatalf("merge inputs = %+v, want one unchanged squash/delete request", gh.mergeInputs)
+	}
+}
+
+func TestDaemonMergeGateRequiresModeReconciliationBeforeNativeMerge(t *testing.T) {
+	ctx := context.Background()
+	store := daemonWorkerStore(t)
+	checkout := createDaemonWorkerGitCheckout(t, "main")
+	const repo = "gitmoot/gitmoot"
+	seedDaemonWorkerRepo(t, store, repo, checkout)
+	if err := store.UpsertTask(ctx, db.Task{
+		ID: "task-mode", RepoFullName: repo, GoalID: "goal-mode", Title: "Switch mode",
+		State: string(workflow.TaskReadyToMerge), Branch: "mode-switch",
+	}); err != nil {
+		t.Fatalf("UpsertTask: %v", err)
+	}
+	if err := store.UpsertPullRequest(ctx, db.PullRequest{
+		RepoFullName: repo, Number: 17, URL: "https://github.com/gitmoot/gitmoot/pull/17",
+		HeadBranch: "mode-switch", BaseBranch: "main", HeadSHA: "head123", State: "open",
+	}); err != nil {
+		t.Fatalf("UpsertPullRequest: %v", err)
+	}
+	seedDaemonMergeGateJob(t, store, db.Job{
+		ID: "mode-implement", Agent: "implementer", Type: "implement", State: string(workflow.JobSucceeded),
+	}, workflow.JobPayload{
+		Repo: repo, Branch: "mode-switch", PullRequest: 17, HeadSHA: "head123", TaskID: "task-mode",
+		Result: &workflow.AgentResult{Decision: "implemented", Summary: "implemented"},
+	})
+	seedDaemonMergeGateJob(t, store, db.Job{
+		ID: "mode-review", Agent: "reviewer", Type: "review", State: string(workflow.JobSucceeded),
+	}, workflow.JobPayload{
+		Repo: repo, Branch: "mode-switch", PullRequest: 17, HeadSHA: "head123", TaskID: "task-mode",
+		ReviewRound: "review-1", Result: &workflow.AgentResult{Decision: "approved", Summary: "ready"},
+	})
+	mode, err := store.InsertWorkflowNote(ctx, db.WorkflowNote{
+		WorkflowID: "gitmoot/worktree-lifecycle", Author: "owner", Repo: repo,
+		Body: "[operating-mode repo=gitmoot/gitmoot mode=STEADY]",
+	})
+	if err != nil {
+		t.Fatalf("InsertWorkflowNote mode: %v", err)
+	}
+	mergeable := true
+	gh := &activeJobMergeGateGitHub{
+		pr: github.PullRequest{
+			Number: 17, Title: "Switch mode", State: "open", URL: "https://github.com/gitmoot/gitmoot/pull/17",
+			HeadRef: "mode-switch", BaseSHA: "base123", HeadSHA: "head123", Mergeable: &mergeable,
+		},
+		files: []github.PullRequestFile{{
+			Filename: "AGENTS.md",
+			Patch:    "@@ -1 +1 @@\n-**Current mode: DRAIN.**\n+**Current mode: STEADY.**",
+		}},
+	}
+	request := workflow.MergeRequest{
+		Repo: repo, Branch: "mode-switch", PullRequest: 17, HeadSHA: "head123",
+		TaskID: "task-mode", Reviewer: "reviewer",
+	}
+	home := t.TempDir()
+	paths := config.PathsForHome(home)
+	if err := config.Initialize(paths); err != nil {
+		t.Fatalf("Initialize config: %v", err)
+	}
+	gate := newDaemonMergeGate(store, gh, checkout, paths.Home, subprocess.ExecRunner{})
+
+	decision, err := gate.Evaluate(ctx, request)
+	if err != nil {
+		t.Fatalf("Evaluate without reconciliation: %v", err)
+	}
+	if !decision.Ready || decision.Merged || len(gh.mergeInputs) != 0 {
+		t.Fatalf("decision=%+v merges=%d, want ready-to-merge hold before merge", decision, len(gh.mergeInputs))
+	}
+	if _, err := store.InsertWorkflowNote(ctx, db.WorkflowNote{
+		WorkflowID: "gitmoot/worktree-lifecycle", Author: "coordinator", Repo: repo,
+		Body: fmt.Sprintf("[workload-mode-reconciliation repo=gitmoot/gitmoot pr=17 head=head123 mode=STEADY decision_note=%d]", mode.ID),
+	}); err != nil {
+		t.Fatalf("InsertWorkflowNote reconciliation: %v", err)
+	}
+
+	decision, err = gate.Evaluate(ctx, request)
+	if err != nil {
+		t.Fatalf("Evaluate with reconciliation: %v", err)
+	}
+	if !decision.Merged || len(gh.mergeInputs) != 1 {
+		t.Fatalf("decision=%+v merges=%d, want one native merge", decision, len(gh.mergeInputs))
 	}
 }
 

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -3484,6 +3484,7 @@ type fakeGitHub struct {
 	pulls                  []github.PullRequest
 	pullsByState           map[string][]github.PullRequest
 	pullsByNumber          map[int64]github.PullRequest
+	pullRequestFiles       []github.PullRequestFile
 	issues                 []github.Issue
 	comments               map[int64][]github.IssueComment
 	repoComments           []github.IssueComment
@@ -3706,7 +3707,7 @@ func (f *fakeGitHub) CreateCommitStatus(context.Context, github.CommitStatusInpu
 }
 
 func (f *fakeGitHub) ListPullRequestFiles(context.Context, github.Repository, int64) ([]github.PullRequestFile, error) {
-	return nil, errors.New("not implemented")
+	return append([]github.PullRequestFile(nil), f.pullRequestFiles...), nil
 }
 
 func (f *fakeGitHub) ListPullRequestCommits(context.Context, github.Repository, int64) ([]github.PullRequestCommit, error) {

--- a/internal/db/advance_retry_test.go
+++ b/internal/db/advance_retry_test.go
@@ -7,6 +7,77 @@ import (
 	"testing"
 )
 
+// ReleaseJobEventClaim must delete EXACTLY the claim it is handed. The pipeline
+// auto-merge gate releases a claim whose write provably did not happen, and a
+// predicate that ignored the message would release a DIFFERENT run's or head's
+// claim as collateral - which the #1783 round-4 review measured as unpinned by
+// the whole internal/db and internal/pipeline suites.
+func TestReleaseJobEventClaimDeletesOnlyThatClaim(t *testing.T) {
+	store := openWorkflowTestStore(t)
+	ctx := context.Background()
+	if err := store.CreateJob(ctx, Job{ID: "src", Agent: "w", Type: "implement", State: "succeeded", Payload: "{}"}); err != nil {
+		t.Fatal(err)
+	}
+	mine := JobEvent{JobID: "src", Kind: "pipeline_auto_merge_claim", Message: `{"head_sha":"aaa"}`}
+	theirs := JobEvent{JobID: "src", Kind: "pipeline_auto_merge_claim", Message: `{"head_sha":"bbb"}`}
+	for _, event := range []JobEvent{mine, theirs} {
+		if claimed, err := store.ClaimJobEvent(ctx, event); err != nil || !claimed {
+			t.Fatalf("seed claim %q: claimed=%v err=%v", event.Message, claimed, err)
+		}
+	}
+
+	released, err := store.ReleaseJobEventClaim(ctx, mine)
+	if err != nil || !released {
+		t.Fatalf("release = %v, err=%v", released, err)
+	}
+
+	events, err := store.ListJobEvents(ctx, "src")
+	if err != nil {
+		t.Fatal(err)
+	}
+	surviving := []string{}
+	for _, event := range events {
+		if event.Kind == "pipeline_auto_merge_claim" {
+			surviving = append(surviving, event.Message)
+		}
+	}
+	if len(surviving) != 1 || surviving[0] != theirs.Message {
+		t.Fatalf("surviving claims = %v, want only the other head's claim", surviving)
+	}
+
+	// Releasing again is a no-op rather than an error, and re-claiming works.
+	if released, err := store.ReleaseJobEventClaim(ctx, mine); err != nil || released {
+		t.Fatalf("second release = %v, err=%v; want no row removed", released, err)
+	}
+	if claimed, err := store.ClaimJobEvent(ctx, mine); err != nil || !claimed {
+		t.Fatalf("re-claim after release: claimed=%v err=%v", claimed, err)
+	}
+
+	// The KIND is part of the identity too: a same-message event of a different
+	// kind must survive a release, or releasing a claim would delete the hold
+	// record that bounds it.
+	sameMessageOtherKind := JobEvent{JobID: "src", Kind: "pipeline_auto_merge_held", Message: mine.Message}
+	if err := store.AddJobEvent(ctx, sameMessageOtherKind); err != nil {
+		t.Fatal(err)
+	}
+	if released, err := store.ReleaseJobEventClaim(ctx, mine); err != nil || !released {
+		t.Fatalf("release of the re-claimed row = %v, err=%v", released, err)
+	}
+	after, err := store.ListJobEvents(ctx, "src")
+	if err != nil {
+		t.Fatal(err)
+	}
+	heldRows := 0
+	for _, event := range after {
+		if event.Kind == "pipeline_auto_merge_held" {
+			heldRows++
+		}
+	}
+	if heldRows != 1 {
+		t.Fatalf("held rows after releasing a claim = %d, want the hold record untouched", heldRows)
+	}
+}
+
 func TestLatestAdvancementMarker(t *testing.T) {
 	store := openWorkflowTestStore(t)
 	ctx := context.Background()

--- a/internal/db/store_jobs.go
+++ b/internal/db/store_jobs.go
@@ -1527,6 +1527,27 @@ func (s *Store) ClaimJobEvent(ctx context.Context, event JobEvent) (bool, error)
 	return affected == 1, nil
 }
 
+// ReleaseJobEventClaim deletes an exact job/kind/message claim so a later
+// caller can win it again. It is for a claim whose external write PROVABLY did
+// not happen: the pipeline auto-merge gate claims before calling Merge, and a
+// reconciliation hold is returned before any GitHub mutation, which left the
+// claim consumed and the merge unrepeatable for the life of the run.
+//
+// It reports whether a row was removed, so a caller that loses the race with a
+// concurrent scan can tell it did not release someone else's claim.
+func (s *Store) ReleaseJobEventClaim(ctx context.Context, event JobEvent) (bool, error) {
+	result, err := s.db.ExecContext(ctx, `DELETE FROM job_events
+		WHERE job_id = ? AND kind = ? AND message = ?`, event.JobID, event.Kind, event.Message)
+	if err != nil {
+		return false, err
+	}
+	affected, err := result.RowsAffected()
+	if err != nil {
+		return false, err
+	}
+	return affected > 0, nil
+}
+
 // UpsertLatestJobEvent keeps one mutable latest-only row for a job/event kind.
 // The write is guarded by jobs.state='running' in the same transaction, so a
 // delayed best-effort progress tick that races terminalization becomes a no-op.

--- a/internal/db/workflow_store.go
+++ b/internal/db/workflow_store.go
@@ -9,6 +9,7 @@ import (
 	mrand "math/rand/v2"
 	"regexp"
 	"slices"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -1000,12 +1001,50 @@ func (s *Store) ListRepoWorkflowNotesByBodyPrefix(ctx context.Context, prefix st
 	if limit <= 0 || limit > 200 {
 		limit = 200
 	}
+	// TWO BOUNDED QUERIES, NOT ONE. A single `repo = ? OR repo = ''` window
+	// ordered by recency and truncated to LIMIT still let repo-less notes from
+	// OTHER repositories consume the whole window: the #1783 review inserted a
+	// valid DRAIN decision followed by 201 newer repo-less notes for other repos,
+	// the target decision fell out of the window, and a stale PR-sourced
+	// reconciliation merged (fail-open). The mirror case hides a valid
+	// reconciliation and falsely holds.
+	//
+	// The body-repo test is NOT replicated in SQL on purpose. The marker grammar
+	// the gate accepts tolerates `repo=x`, `repo = x` and case differences
+	// (leadingRepoValue), so an instr() predicate would silently EXCLUDE forms Go
+	// accepts - trading a fail-open for a wrong answer. Instead each scope gets
+	// its own bounded window and the caller still decides, on the same grammar,
+	// which note answers for this repository.
+	scoped, err := s.workflowNotesByBodyPrefixWhere(ctx,
+		`repo = ? COLLATE NOCASE`, []any{prefix, prefix, repo, limit}, prefix)
+	if err != nil {
+		return nil, err
+	}
+	repoless, err := s.workflowNotesByBodyPrefixWhere(ctx,
+		`repo = ''`, []any{prefix, prefix, limit}, prefix)
+	if err != nil {
+		return nil, err
+	}
+	notes := append(scoped, repoless...)
+	// Newest first across the union. The union is at most 2*limit rows and is
+	// deliberately NOT truncated back to limit: truncating the merged list would
+	// reintroduce exactly the crowd-out this split exists to remove.
+	sort.SliceStable(notes, func(i, j int) bool {
+		if notes[i].CreatedAt != notes[j].CreatedAt {
+			return notes[i].CreatedAt > notes[j].CreatedAt
+		}
+		return notes[i].ID > notes[j].ID
+	})
+	return notes, nil
+}
+
+func (s *Store) workflowNotesByBodyPrefixWhere(ctx context.Context, scope string, args []any, prefix string) ([]WorkflowNote, error) {
 	rows, err := s.db.QueryContext(ctx, `SELECT id, workflow_id, author, body, repo, memory_observation_id, created_at
 FROM workflow_notes
 WHERE substr(body, 1, length(?)) = ?
-  AND (repo = ? COLLATE NOCASE OR repo = '')
+  AND `+scope+`
 ORDER BY created_at DESC, id DESC
-LIMIT ?`, prefix, prefix, repo, limit)
+LIMIT ?`, args...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/db/workflow_store.go
+++ b/internal/db/workflow_store.go
@@ -983,6 +983,41 @@ LIMIT ?`, prefix, prefix, limit)
 	return notes, rows.Err()
 }
 
+// ListRepoWorkflowNotesByBodyPrefix is ListWorkflowNotesByBodyPrefix scoped to
+// one repository IN SQL rather than filtered in Go afterwards.
+//
+// The unscoped form orders across every repo and truncates, so a busy fleet can
+// crowd one repository's notes out of the window entirely. For the workload-mode
+// gate that was a fail-OPEN corner: losing the decision note made the gate read
+// "no decision exists", which both dropped the recency check and let a stale
+// PR-sourced reconciliation satisfy it (#1783 review, P3). A note whose repo
+// column is empty still matches, because the gate also accepts a repo named
+// inside the note body.
+func (s *Store) ListRepoWorkflowNotesByBodyPrefix(ctx context.Context, prefix string, repo string, limit int) ([]WorkflowNote, error) {
+	if limit <= 0 || limit > 200 {
+		limit = 200
+	}
+	rows, err := s.db.QueryContext(ctx, `SELECT id, workflow_id, author, body, repo, memory_observation_id, created_at
+FROM workflow_notes
+WHERE substr(body, 1, length(?)) = ?
+  AND (repo = ? OR repo = '')
+ORDER BY created_at DESC, id DESC
+LIMIT ?`, prefix, prefix, repo, limit)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	notes := []WorkflowNote{}
+	for rows.Next() {
+		var note WorkflowNote
+		if err := rows.Scan(&note.ID, &note.WorkflowID, &note.Author, &note.Body, &note.Repo, &note.MemoryObservationID, &note.CreatedAt); err != nil {
+			return nil, err
+		}
+		notes = append(notes, note)
+	}
+	return notes, rows.Err()
+}
+
 // ListUnacknowledgedOrgDirectives returns the oldest outstanding directives.
 // It is intentionally ASC and unbounded: a newer directive must never push the
 // oldest unacknowledged obligation out of a DESC+LIMIT window.

--- a/internal/db/workflow_store.go
+++ b/internal/db/workflow_store.go
@@ -992,7 +992,10 @@ LIMIT ?`, prefix, prefix, limit)
 // "no decision exists", which both dropped the recency check and let a stale
 // PR-sourced reconciliation satisfy it (#1783 review, P3). A note whose repo
 // column is empty still matches, because the gate also accepts a repo named
-// inside the note body.
+// inside the note body. The repo comparison is COLLATE NOCASE: GitHub treats
+// owner/repo case insensitively, so a note recorded as "Gitmoot/gitmoot" was
+// invisible to a byte-equal filter and took the fail-open path with it (#1783
+// review, F3).
 func (s *Store) ListRepoWorkflowNotesByBodyPrefix(ctx context.Context, prefix string, repo string, limit int) ([]WorkflowNote, error) {
 	if limit <= 0 || limit > 200 {
 		limit = 200
@@ -1000,7 +1003,7 @@ func (s *Store) ListRepoWorkflowNotesByBodyPrefix(ctx context.Context, prefix st
 	rows, err := s.db.QueryContext(ctx, `SELECT id, workflow_id, author, body, repo, memory_observation_id, created_at
 FROM workflow_notes
 WHERE substr(body, 1, length(?)) = ?
-  AND (repo = ? OR repo = '')
+  AND (repo = ? COLLATE NOCASE OR repo = '')
 ORDER BY created_at DESC, id DESC
 LIMIT ?`, prefix, prefix, repo, limit)
 	if err != nil {

--- a/internal/pipeline/auto_merge_test.go
+++ b/internal/pipeline/auto_merge_test.go
@@ -198,6 +198,55 @@ func TestPipelineAutoMergeGateExecutesAfterApprovedReviewAndGreenChecks(t *testi
 	}
 }
 
+// A TRANSIENT merge-boundary refusal must keep the gate waiting. The fold turned
+// any !Merged into "retry stopped", so a workload-mode reconciliation hold that
+// Evaluate reports as Waiting terminally blocked the run once it appeared in the
+// Evaluate->Merge window, and the at-most-once claim was already consumed
+// (#1783 review, F4). The claim is why the retry is safe: the next scan cannot
+// call Merge again.
+func TestPipelineAutoMergeWaitingResultKeepsTheGateRetryable(t *testing.T) {
+	store, enqueue, rec, spec, run, sourceJobID, now := prepareAutoMergeGate(t)
+	settleBoundReviewJob(t, store, stageRow(t, store, run.ID, "review").JobID, "approved", "0123456789abcdef")
+	executor := &stubPipelineAutoMerger{
+		readiness: workflow.PipelineAutoMergeReadiness{Ready: true, CurrentHeadSHA: "0123456789abcdef"},
+		mergeResult: workflow.PipelineAutoMergeResult{
+			Waiting: true,
+			Reason:  "workload-mode change requires reconciliation at head 0123456 against operating-mode note 41",
+		},
+	}
+	run = advanceWithAutoMerge(t, store, enqueue, rec, spec, run, now.Add(2*time.Second), executor)
+
+	if len(executor.mergeReqs) != 1 {
+		t.Fatalf("merge calls = %d, want exactly one attempt", len(executor.mergeReqs))
+	}
+	gate := stageRow(t, store, run.ID, "merge")
+	if gate.State == StageBlocked || gate.State == StageFailed {
+		t.Fatalf("a transient hold ended the run: gate=%+v run=%+v", gate, run)
+	}
+	if run.State == RunBlocked || run.State == RunFailed {
+		t.Fatalf("run = %q, want it still open after a transient hold", run.State)
+	}
+
+	// The consumed claim keeps the retry at-most-once: a later scan must not
+	// call Merge again, and the gate must still not be terminal.
+	run = advanceWithAutoMerge(t, store, enqueue, rec, spec, run, now.Add(3*time.Second), executor)
+	if len(executor.mergeReqs) != 1 {
+		t.Fatalf("rescan merge calls = %d, want the claim to hold at one", len(executor.mergeReqs))
+	}
+	if gate := stageRow(t, store, run.ID, "merge"); gate.State == StageBlocked || gate.State == StageFailed {
+		t.Fatalf("rescan ended the run: gate=%+v", gate)
+	}
+	events, err := store.ListJobEvents(context.Background(), sourceJobID)
+	if err != nil {
+		t.Fatalf("ListJobEvents(source): %v", err)
+	}
+	for _, event := range events {
+		if event.Kind == "pipeline_auto_merge_confirmed" {
+			t.Fatalf("a held merge recorded a confirmation: %+v", event)
+		}
+	}
+}
+
 // #1685. A review fan-out is refused at STAGE SETTLEMENT, before anything
 // depends on it. That is the load-bearing layer: a succeeded stage satisfies
 // pipelineStageDepsSucceeded and authorizes every dependent stage, so folding an

--- a/internal/pipeline/auto_merge_test.go
+++ b/internal/pipeline/auto_merge_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"github.com/gitmoot/gitmoot/internal/db"
 	"github.com/gitmoot/gitmoot/internal/workflow"
+	"slices"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -637,6 +638,100 @@ func TestPipelineAutoMergeLostClaimTreatsAReleasedClaimAsANormalRace(t *testing.
 	}
 }
 
+// ROUND-10 F-6: the released-claim reason - this round's new operator-facing
+// output - was asserted by nothing, and corrupting its text survived the test
+// above. That reason is the branch's whole product: autoMergeGateWaitingWithReason
+// exists (see its doc comment) so the human who finds a parked run reads WHY it
+// waited.
+//
+// THE REVIEWER'S SUGGESTED SITE CANNOT OBSERVE IT, which is why it needs its own
+// test rather than one more assertion above. On the ordinary waiting path
+// autoMergeGateWaitingWithReason DROPS the reason and falls through to
+// autoMergeGateWaiting; the text only reaches a caller when a stage
+// `timeout` parks the wait. So this arm gives the gate a timeout and ages it past
+// it - which also pins the round-8 F-2 correction, that this wait parks like any
+// other, and that claim was itself only prose until now.
+func TestPipelineAutoMergeLostClaimReleasedReasonReachesAParkedSummary(t *testing.T) {
+	ctx := context.Background()
+	timedSpec := strings.Replace(pipelineAutoMergeSpec, "    merge: auto\n", "    merge: auto\n    timeout: 1m\n", 1)
+	store := pipelineAdvanceStore(t)
+	rec, spec := newTestPipeline(t, store, "auto-merge", timedSpec)
+	enqueue := testStageEnqueuer(store)
+	now := time.Date(2026, 7, 11, 8, 0, 0, 0, time.UTC)
+	run := startTestRun(t, store, rec, spec, enqueue, now)
+	impl := stageRow(t, store, run.ID, "impl")
+	sourceJobID := impl.JobID
+	settleBoundImplementStageJob(t, store, impl.JobID, "implemented",
+		PipelineStagePRBinding{PullRequest: 813, HeadSHA: "0123456789abcdef", Branch: "feat/813", TaskID: "task-813", LeadAgent: "coder"})
+	run = advanceWithAutoMerge(t, store, enqueue, rec, spec, run, now.Add(time.Second), &stubPipelineAutoMerger{})
+	settleBoundReviewJob(t, store, stageRow(t, store, run.ID, "review").JobID, "approved", "0123456789abcdef")
+	run = advanceWithAutoMerge(t, store, enqueue, rec, spec, run, now.Add(2*time.Second),
+		&stubPipelineAutoMerger{readiness: workflow.PipelineAutoMergeReadiness{Waiting: true, CurrentHeadSHA: "0123456789abcdef"}})
+
+	claim, err := json.Marshal(map[string]any{
+		"phase": "claim", "pipeline": rec.Name, "run_id": run.ID,
+		"stage_id": "merge", "pull_request": 813, "head_sha": "0123456789abcdef",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	seedConsumedAutoMergeClaim(t, store, rec, run, sourceJobID)
+
+	var gateStage Stage
+	for _, candidate := range spec.Stages {
+		if candidate.ID == "merge" {
+			gateStage = candidate
+			break
+		}
+	}
+	if strings.TrimSpace(gateStage.Timeout) == "" {
+		t.Fatal("this fixture must carry a gate timeout, or the reason can never reach a summary")
+	}
+	released := false
+	deps := pipelineStageSettleDeps{
+		store: store, rec: rec, run: run,
+		// Past the gate's 1m timeout, so the park path runs and carries the cause.
+		now: now.Add(2 * time.Hour),
+		autoMerge: &stubPipelineAutoMerger{
+			readiness:   workflow.PipelineAutoMergeReadiness{Ready: true, CurrentHeadSHA: "0123456789abcdef"},
+			mergeResult: workflow.PipelineAutoMergeResult{Merged: true, MergeCommitSHA: "merge-sha"},
+		},
+		afterLostClaim: func() {
+			ok, relErr := store.ReleaseJobEventClaim(ctx, db.JobEvent{
+				JobID: sourceJobID, Kind: autoMergeClaimEventKind, Message: string(claim),
+			})
+			if relErr != nil || !ok {
+				t.Fatalf("releasing in the window: ok=%v err=%v", ok, relErr)
+			}
+			released = true
+		},
+	}
+	settled, state, summary, needs, _, err := gateStageSettleOutcome(ctx, deps, spec, gateStage, stageRow(t, store, run.ID, "merge"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !released {
+		t.Fatal("the seam never fired, so this scan did not lose the claim and the test proves nothing")
+	}
+	if !settled || state != StageBlocked {
+		t.Fatalf("a gate past its timeout must park: settled=%v state=%q", settled, state)
+	}
+	// The exact operator-facing sentence, not a paraphrase: this is the string a
+	// human reads off a parked run, and mutating it must fail a test.
+	const want = "was released while this scan was reading it, so the next scan takes it"
+	if !strings.Contains(summary, want) {
+		t.Fatalf("park summary must carry the released-claim cause %q: %q", want, summary)
+	}
+	if !slices.ContainsFunc(needs, func(need string) bool { return strings.Contains(need, want) }) {
+		t.Fatalf("park needs must carry the cause so it survives into the run's needs: %v", needs)
+	}
+	// Still not a fault: parking on a timeout is the operator's choice, and the
+	// released claim itself is a normal race that must record nothing.
+	if rows := autoMergeEventCount(t, store, sourceJobID, autoMergeClaimOrphanEventKind); rows != 0 {
+		t.Fatalf("orphan reports for a RELEASED claim = %d, want 0", rows)
+	}
+}
+
 // F-6's calibration, pinned directly. The gate's StartedAt is stamped when the
 // gate goes in-flight, typically long before readiness, so aging the wait from
 // the GATE made a healthy two-second race on a gate that had waited past the
@@ -672,6 +767,62 @@ func TestPipelineAutoMergeLostClaimIgnoresGateAgeWhenTheClaimIsYoung(t *testing.
 	}
 }
 
+// ROUND-10 F-1: the branch the previous head called unconstructible. Its comment
+// justified leaving the unreadable case unpinned on "no store API can construct
+// it", and the review disproved that by experiment rather than by argument -
+// db.Store.ExecForTest is exported, is already used cross-package, and its own
+// doc comment says it exists "so a test can put the database into a state no
+// production code path creates". So the branch was unpinned by CHOICE reported
+// as an inability, which also left round-9's claim_raw_stamp discriminator
+// verified by nothing.
+//
+// The corruption is applied to the STORE COLUMN, then the branch is reached
+// through the production advancer, so nothing here manufactures the report
+// itself - which is the objection round 7 raised against row surgery (F-3) and
+// the reason this drives AdvancePipelineRunWithAutoMerge rather than asserting
+// on a helper.
+func TestPipelineAutoMergeLostClaimReportsAnUnreadableClaimTimestamp(t *testing.T) {
+	ctx := context.Background()
+	store, enqueue, rec, spec, run, sourceJobID, now := prepareAutoMergeGate(t)
+	settleBoundReviewJob(t, store, stageRow(t, store, run.ID, "review").JobID, "approved", "0123456789abcdef")
+	executor := &stubPipelineAutoMerger{
+		readiness:   workflow.PipelineAutoMergeReadiness{Ready: true, CurrentHeadSHA: "0123456789abcdef"},
+		mergeResult: workflow.PipelineAutoMergeResult{Merged: true, MergeCommitSHA: "merge-sha"},
+	}
+	run = advanceWithAutoMerge(t, store, enqueue, rec, spec, run, now.Add(time.Second),
+		&stubPipelineAutoMerger{readiness: workflow.PipelineAutoMergeReadiness{Waiting: true, CurrentHeadSHA: "0123456789abcdef"}})
+	// The claim is held, so the scan below LOSES it.
+	seedConsumedAutoMergeClaim(t, store, rec, run, sourceJobID)
+
+	// A value the store itself would never write. Production can still hold one:
+	// a legacy row, a restore, a manual edit, or a kind-parameterised upsert
+	// reaching this kind (see autoMergeClaimUnreadable's branch in run.go).
+	if err := store.ExecForTest(ctx, `UPDATE job_events SET created_at = ? WHERE job_id = ? AND kind = ?`,
+		"not-a-timestamp", sourceJobID, autoMergeClaimEventKind); err != nil {
+		t.Fatalf("corrupting the claim row's created_at: %v", err)
+	}
+	// CONTROL, because a missing row would drive the GONE branch and this test
+	// would pass while proving something else entirely.
+	if body := autoMergeEventBody(t, store, sourceJobID, autoMergeClaimEventKind); body == "" {
+		t.Fatal("the claim row is absent, so this scan would take the Gone branch, not the unreadable one")
+	}
+
+	run = advanceWithAutoMerge(t, store, enqueue, rec, spec, run, time.Now().UTC().Add(16*time.Minute), executor)
+	if gate := stageRow(t, store, run.ID, "merge"); gate.State == StageBlocked {
+		t.Fatalf("an unreadable claim timestamp is not a condition this scan observed, so it must not park: %q", gate.Summary)
+	}
+	if rows := autoMergeEventCount(t, store, sourceJobID, autoMergeClaimOrphanEventKind); rows != 1 {
+		t.Fatalf("suspicion rows for an unreadable claim timestamp = %d, want exactly 1", rows)
+	}
+	// The cause is a DIFFERENT fact from held_past_bound, and it carries the raw
+	// stamp as its per-episode key - round-9's F-5 fix, unverified until now.
+	for _, want := range []string{`"cause":"claim_timestamp_unreadable"`, `"claim_raw_stamp":"not-a-timestamp"`} {
+		if body := autoMergeEventBody(t, store, sourceJobID, autoMergeClaimOrphanEventKind); !strings.Contains(body, want) {
+			t.Fatalf("suspicion row must contain %s: %s", want, body)
+		}
+	}
+}
+
 // THE SUCCESS-PATH CONTROL for the claim clock, and it guards a real hazard.
 // autoMergeClaimTakenAt reads the claim row's created_at and falls back to a
 // "cannot age this" branch when it will not parse. If the store's timestamp
@@ -679,14 +830,14 @@ func TestPipelineAutoMergeLostClaimIgnoresGateAgeWhenTheClaimIsYoung(t *testing.
 // scan would report an unreadable timestamp. This pins that the format the store
 // actually writes does parse.
 //
-// The failure side is deliberately NOT tested here and that is stated rather
-// than hidden: no store API can write created_at - every INSERT INTO job_events
-// names only (job_id, kind, message), so the column is always its
-// CURRENT_TIMESTAMP default. A malformed value comes from a corrupted or legacy
-// row, which this package cannot construct. Round 6 manufactured an equivalent
-// state by row surgery and the review called that out (#1783 round-7 F-3); the
-// honest answer is a control on the reachable side plus this note, not a fixture
-// that pins a state the system does not produce.
+// The failure side is pinned by
+// TestPipelineAutoMergeLostClaimReportsAnUnreadableClaimTimestamp above, so this
+// stays a pure success-path control. The claim this comment used to carry - "no
+// store API can write created_at" - was FALSE and is now stated once, correctly,
+// in autoMergeClaimUnreadable's branch in run.go; two copies of a reason are how
+// the round-8 F-2 defect
+// happened, so this one points at the authoritative statement instead of
+// restating it (#1783 round-10 F-2).
 func TestPipelineAutoMergeClaimTimestampParsesTheStoreFormat(t *testing.T) {
 	store, _, rec, _, run, sourceJobID, _ := prepareAutoMergeGate(t)
 	claim, err := json.Marshal(map[string]any{

--- a/internal/pipeline/auto_merge_test.go
+++ b/internal/pipeline/auto_merge_test.go
@@ -666,11 +666,15 @@ func prepareTimedAutoMergeGate(t *testing.T) (*db.Store, PipelineStageEnqueuer, 
 			break
 		}
 	}
-	// The guard that makes every test below able to fail for the right reason:
-	// without the timeout the reason can never reach a caller, so a passing
-	// assertion would be proving nothing.
+	// A TRIPWIRE, AND ONLY A TRIPWIRE - stated correctly this time. An earlier
+	// version of this comment claimed that without the timeout "a passing
+	// assertion would be proving nothing"; the round-12 review disproved that by
+	// compound mutation: with the injection removed AND this guard deleted, all
+	// four tests still fail at the park check, which runs first. So the guard
+	// buys a precise failure message, never the protection itself. Its own
+	// deletion is correctly a worthless mutant (#1783 round-12).
 	if strings.TrimSpace(gateStage.Timeout) == "" {
-		t.Fatal("this fixture must carry a gate timeout, or no reason can ever reach a summary")
+		t.Fatal("this fixture must carry a gate timeout; without it these tests fail at the park check with a less obvious message")
 	}
 	return store, enqueue, rec, spec, run, impl.JobID, now, gateStage
 }
@@ -738,11 +742,49 @@ func TestPipelineAutoMergeLostClaimReleasedReasonReachesAParkedSummary(t *testin
 	if !slices.ContainsFunc(needs, func(need string) bool { return strings.Contains(need, want) }) {
 		t.Fatalf("park needs must carry the cause so it survives into the run's needs: %v", needs)
 	}
+	// The HEAD RENDERING, the fourth of the six interpolated values in these four
+	// reasons, bound by the words after it because sha[:7] is a prefix of the raw
+	// head (#1783 round-12 F-1, survivor 3).
+	if head := "claim for head " + shortPipelineSHA(autoMergeProbeHead) + " was released"; !strings.Contains(summary, head) {
+		t.Fatalf("park summary must render the head SHORT, as %q: %q", head, summary)
+	}
 	// Still not a fault: parking on a timeout is the operator's choice, and the
 	// released claim itself is a normal race that must record nothing.
 	if rows := autoMergeEventCount(t, store, sourceJobID, autoMergeClaimOrphanEventKind); rows != 0 {
 		t.Fatalf("orphan reports for a RELEASED claim = %d, want 0", rows)
 	}
+}
+
+// autoMergeProbeHead is the head every auto-merge fixture binds to. Named rather
+// than repeated as a literal so an assertion about its RENDERING cannot drift
+// from the value the fixture injects (#1783 round-12 F-1, survivor 3).
+const autoMergeProbeHead = "0123456789abcdef"
+
+// parseParkedClaimAge pulls the rendered duration out of a parked summary and
+// FAILS if it is not there or does not parse. It exists so the age can be
+// BOUNDED rather than asserted by the punctuation around it (#1783 round-12
+// F-1): `(taken -1s ago)` satisfies a `(taken `/` ago)` check and is nonsense.
+//
+// It is deliberately strict about the delimiters, because a mutant that changed
+// the surrounding words while leaving a plausible number would otherwise make
+// this helper return an age from text no operator would recognise.
+func parseParkedClaimAge(t *testing.T, summary, prefix, suffix string) time.Duration {
+	t.Helper()
+	start := strings.Index(summary, prefix)
+	if start < 0 {
+		t.Fatalf("summary does not contain %q, so it states no claim age: %q", prefix, summary)
+	}
+	rest := summary[start+len(prefix):]
+	end := strings.Index(rest, suffix)
+	if end < 0 {
+		t.Fatalf("summary does not close the age with %q: %q", suffix, summary)
+	}
+	raw := strings.TrimSpace(rest[:end])
+	age, err := time.ParseDuration(raw)
+	if err != nil {
+		t.Fatalf("claim age %q in the park summary does not parse as a duration: %v (%q)", raw, err, summary)
+	}
+	return age
 }
 
 // ROUND-11 F-1, AND IT IS THE CLASS ROUND-10 F-6 OPENED WITHOUT CLOSING.
@@ -799,30 +841,41 @@ func TestPipelineAutoMergeLostClaimReasonsAllReachAParkedSummary(t *testing.T) {
 				t.Fatalf("park needs must carry %q: %v", want, needs)
 			}
 		}
+		// THE HEAD RENDERING, bound by the word that follows it (round-12 F-1,
+		// survivor 3). shortPipelineSHA returns sha[:7], a PREFIX of the raw head,
+		// so `for head 0123456` is satisfied by the full SHA too - a bare short-SHA
+		// substring cannot detect the substitution. Including the next literal word
+		// closes that.
+		if want := "claim for head " + shortPipelineSHA(autoMergeProbeHead) + " and the claim carries"; !strings.Contains(summary, want) {
+			t.Fatalf("park summary must render the head SHORT, as %q: %q", want, summary)
+		}
 	})
 
 	// The INSIDE-THE-WINDOW reason. Not mutated by any review; found by
 	// enumerating the function instead of the findings.
 	t.Run("held_inside_the_window", func(t *testing.T) {
-		store, _, rec, spec, run, sourceJobID, _, gateStage := prepareTimedAutoMergeGate(t)
-		// The gate has been in flight for hours on real time, so it is past its
-		// 1m timeout...
-		gate := stageRow(t, store, run.ID, "merge")
-		realNow := time.Now().UTC()
-		gate.StartedAt = realNow.Add(-2 * time.Hour)
-		if err := store.UpdatePipelineRunStage(ctx, gate); err != nil {
-			t.Fatal(err)
-		}
-		// ...while the claim was taken just now, so it is INSIDE the 15m window.
+		store, _, rec, spec, run, sourceJobID, now, gateStage := prepareTimedAutoMergeGate(t)
 		seedConsumedAutoMergeClaim(t, store, rec, run, sourceJobID)
 		if autoMergeClaimOrphanAfter != 15*time.Minute {
 			t.Fatalf("autoMergeClaimOrphanAfter = %s, want 15m0s; this test's clock is written in literals", autoMergeClaimOrphanAfter)
 		}
+		// THE AGE IS INJECTED, so the rendering is EXACT rather than bounded.
+		// Round-12 F-1 killed the range version: with a real elapsed age of a few
+		// milliseconds, `0 <= age < 1m` admits a Truncate(time.Minute) mutant that
+		// renders "0s", and admitted a precision-widening mutant too. Pinning
+		// created_at against a fixed deps.now makes held exactly 90s, so the
+		// rendered string is deterministic and every corruption of the value -
+		// negation, truncation granularity, added words - changes it.
+		settleAt := now.Add(2 * time.Hour)
+		if err := store.ExecForTest(ctx, `UPDATE job_events SET created_at = ? WHERE job_id = ? AND kind = ?`,
+			settleAt.Add(-90*time.Second).Format(time.DateTime), sourceJobID, autoMergeClaimEventKind); err != nil {
+			t.Fatalf("injecting a known claim age: %v", err)
+		}
 		deps := pipelineStageSettleDeps{
 			store: store, rec: rec, run: run,
-			now: realNow.Add(time.Second),
+			now: settleAt,
 			autoMerge: &stubPipelineAutoMerger{
-				readiness:   workflow.PipelineAutoMergeReadiness{Ready: true, CurrentHeadSHA: "0123456789abcdef"},
+				readiness:   workflow.PipelineAutoMergeReadiness{Ready: true, CurrentHeadSHA: autoMergeProbeHead},
 				mergeResult: workflow.PipelineAutoMergeResult{Merged: true, MergeCommitSHA: "merge-sha"},
 			},
 		}
@@ -833,13 +886,16 @@ func TestPipelineAutoMergeLostClaimReasonsAllReachAParkedSummary(t *testing.T) {
 		if !settled || state != StageBlocked {
 			t.Fatalf("a gate past its timeout must park: settled=%v state=%q", settled, state)
 		}
-		if want := "another scan holds the auto-merge claim for head"; !strings.Contains(summary, want) {
-			t.Fatalf("park summary must carry %q: %q", want, summary)
+		// One assertion covering BOTH interpolated values of this reason: the head
+		// rendered SHORT (bound by the following punctuation, since sha[:7] is a
+		// prefix of the raw head and a bare substring cannot tell them apart) and
+		// the age rendered from the injected 90 seconds.
+		if want := "another scan holds the auto-merge claim for head " + shortPipelineSHA(autoMergeProbeHead) + " (taken 1m30s ago)"; !strings.Contains(summary, want) {
+			t.Fatalf("park summary must render exactly %q: %q", want, summary)
 		}
-		// The AGE is the whole content of this branch's message - it is what tells
-		// an operator the claim is young rather than orphaned.
-		if !strings.Contains(summary, "(taken ") || !strings.Contains(summary, " ago)") {
-			t.Fatalf("park summary must state how long ago the claim was taken: %q", summary)
+		// And the parsed value must still sit inside the window this branch is for.
+		if age := parseParkedClaimAge(t, summary, "(taken ", " ago)"); age != 90*time.Second || age >= autoMergeClaimOrphanAfter {
+			t.Fatalf("rendered age %s, want exactly 1m30s and below the %s bound: %q", age, autoMergeClaimOrphanAfter, summary)
 		}
 		// And it must NOT report a fault: inside the window there is nothing wrong.
 		if rows := autoMergeEventCount(t, store, sourceJobID, autoMergeClaimOrphanEventKind); rows != 0 {
@@ -851,20 +907,26 @@ func TestPipelineAutoMergeLostClaimReasonsAllReachAParkedSummary(t *testing.T) {
 	// review used here reinstated exactly the falsehood round 7 removed ("just
 	// wait, it will resolve itself"), so the assertion names the true remedy.
 	t.Run("held_past_the_bound", func(t *testing.T) {
-		store, _, rec, spec, run, sourceJobID, _, gateStage := prepareTimedAutoMergeGate(t)
+		store, _, rec, spec, run, sourceJobID, now, gateStage := prepareTimedAutoMergeGate(t)
 		seedConsumedAutoMergeClaim(t, store, rec, run, sourceJobID)
-		// Anchored to REAL time, because the claim's created_at is the store's own
-		// CURRENT_TIMESTAMP and a fixture clock in the past yields a NEGATIVE age
-		// that can never cross the bound (#1783 round-7).
-		realNow := time.Now().UTC()
 		if autoMergeClaimOrphanAfter != 15*time.Minute {
 			t.Fatalf("autoMergeClaimOrphanAfter = %s, want 15m0s; this test's clock is written in literals", autoMergeClaimOrphanAfter)
 		}
+		// Age INJECTED against a fixed settle clock, exactly as in the sibling
+		// subtest. Round 7 rejected a fixture clock here because the store wrote
+		// created_at itself and a past clock yielded a NEGATIVE age; pinning the
+		// column removes that obstacle rather than working around it, and makes
+		// the rendered duration deterministic (#1783 round-12 F-1).
+		settleAt := now.Add(2 * time.Hour)
+		if err := store.ExecForTest(ctx, `UPDATE job_events SET created_at = ? WHERE job_id = ? AND kind = ?`,
+			settleAt.Add(-(16*time.Minute + 30*time.Second)).Format(time.DateTime), sourceJobID, autoMergeClaimEventKind); err != nil {
+			t.Fatalf("injecting a known claim age: %v", err)
+		}
 		deps := pipelineStageSettleDeps{
 			store: store, rec: rec, run: run,
-			now: realNow.Add(16 * time.Minute),
+			now: settleAt,
 			autoMerge: &stubPipelineAutoMerger{
-				readiness:   workflow.PipelineAutoMergeReadiness{Ready: true, CurrentHeadSHA: "0123456789abcdef"},
+				readiness:   workflow.PipelineAutoMergeReadiness{Ready: true, CurrentHeadSHA: autoMergeProbeHead},
 				mergeResult: workflow.PipelineAutoMergeResult{Merged: true, MergeCommitSHA: "merge-sha"},
 			},
 		}
@@ -894,6 +956,18 @@ func TestPipelineAutoMergeLostClaimReasonsAllReachAParkedSummary(t *testing.T) {
 		// Past the bound this branch DOES record, once.
 		if rows := autoMergeEventCount(t, store, sourceJobID, autoMergeClaimOrphanEventKind); rows != 1 {
 			t.Fatalf("suspicion rows past the bound = %d, want exactly 1", rows)
+		}
+		// BOTH interpolated values of this reason, in one exact assertion: the
+		// head rendered SHORT and bound by the words that follow it, and the age
+		// rendered from the injected 16m30s. The mutant that widened
+		// Truncate(time.Second) to time.Hour rendered "taken 0s ago" here - an
+		// orphan declared at zero seconds by a bound whose whole premise is
+		// fifteen minutes - and satisfied every phrase assertion above.
+		if want := "claim for head " + shortPipelineSHA(autoMergeProbeHead) + " was taken 16m30s ago and is still held"; !strings.Contains(summary, want) {
+			t.Fatalf("park summary must render exactly %q: %q", want, summary)
+		}
+		if age := parseParkedClaimAge(t, summary, "was taken ", " ago and"); age != 16*time.Minute+30*time.Second || age < autoMergeClaimOrphanAfter {
+			t.Fatalf("rendered age %s, want exactly 16m30s and at or past the %s bound: %q", age, autoMergeClaimOrphanAfter, summary)
 		}
 	})
 }

--- a/internal/pipeline/auto_merge_test.go
+++ b/internal/pipeline/auto_merge_test.go
@@ -556,6 +556,57 @@ func TestPipelineAutoMergeHoldAnchorsOnTheEarliestDuplicate(t *testing.T) {
 	}
 }
 
+// F-3's ordering, pinned by INJECTING the failure it exists for. A lost release
+// must leave the hold RECORDED, because the !claimed branch bounds the run from
+// that record; recording after the release left one transient DELETE error with
+// a consumed claim and no record, which is the unbounded silent wait the review
+// measured at now+72h. Nothing else distinguishes the two orderings, so without
+// this the correct order survives its own mutant.
+func TestPipelineAutoMergeHoldIsRecordedEvenWhenTheReleaseFails(t *testing.T) {
+	store, enqueue, rec, spec, run, sourceJobID, now := prepareAutoMergeGate(t)
+	settleBoundReviewJob(t, store, stageRow(t, store, run.ID, "review").JobID, "approved", "0123456789abcdef")
+	const holdReason = "workload-mode change requires reconciliation at head 0123456 against operating-mode note 41"
+	// One advance moves the gate row from queued to running; the settle path
+	// promotes a queued row and returns before it can claim.
+	waiting := &stubPipelineAutoMerger{readiness: workflow.PipelineAutoMergeReadiness{Waiting: true, CurrentHeadSHA: "0123456789abcdef"}}
+	run = advanceWithAutoMerge(t, store, enqueue, rec, spec, run, now.Add(time.Second), waiting)
+
+	executor := &stubPipelineAutoMerger{
+		readiness:   workflow.PipelineAutoMergeReadiness{Ready: true, CurrentHeadSHA: "0123456789abcdef"},
+		mergeResult: workflow.PipelineAutoMergeResult{Waiting: true, Reason: holdReason},
+	}
+	var gateStage Stage
+	for _, candidate := range spec.Stages {
+		if candidate.ID == "merge" {
+			gateStage = candidate
+		}
+	}
+	deps := pipelineStageSettleDeps{
+		store: store, rec: rec, run: run, now: now.Add(2 * time.Second), autoMerge: executor,
+		releaseClaim: func(context.Context, db.JobEvent) (bool, error) {
+			return false, errors.New("injected release failure")
+		},
+	}
+
+	_, _, _, _, _, err := gateStageSettleOutcome(context.Background(), deps, spec, gateStage, stageRow(t, store, run.ID, "merge"))
+	if err == nil {
+		t.Fatal("a failing release must surface its error")
+	}
+	if len(executor.mergeReqs) != 1 {
+		t.Fatalf("merge attempts = %d, want the hold path to have run", len(executor.mergeReqs))
+	}
+
+	// The hold survived the failed release, so the next scan is bounded rather
+	// than silent - which is the whole point of the ordering.
+	held, holdErr := latestAutoMergeHold(context.Background(), store, sourceJobID, "0123456789abcdef")
+	if holdErr != nil {
+		t.Fatal(holdErr)
+	}
+	if held.at.IsZero() || held.reason != holdReason {
+		t.Fatalf("hold record after a failed release = %+v, want the cause recorded", held)
+	}
+}
+
 // #1685. A review fan-out is refused at STAGE SETTLEMENT, before anything
 // depends on it. That is the load-bearing layer: a succeeded stage satisfies
 // pipelineStageDepsSucceeded and authorizes every dependent stage, so folding an

--- a/internal/pipeline/auto_merge_test.go
+++ b/internal/pipeline/auto_merge_test.go
@@ -321,16 +321,16 @@ func TestPipelineAutoMergeHoldIsBoundedWithoutAGateTimeout(t *testing.T) {
 	if gate := stageRow(t, store, run.ID, "merge"); gate.State == StageBlocked {
 		t.Fatalf("the first hold must wait, not park: %+v", gate)
 	}
-	held, err := latestAutoMergeHold(context.Background(), store, sourceJobID, "0123456789abcdef")
-	if err != nil || held.at.IsZero() {
-		t.Fatalf("hold episode = %+v err=%v, want a recorded hold", held, err)
+	held := newestRecordedHold(t, store, sourceJobID, "0123456789abcdef")
+	if held.at.IsZero() {
+		t.Fatalf("hold episode = %+v, want a recorded hold", held)
 	}
 	if held.reason != holdReason {
 		t.Fatalf("episode reason = %q, want the hold's cause", held.reason)
 	}
 
 	// Just INSIDE six hours: still waiting, and still retrying.
-	run = advanceWithAutoMerge(t, store, enqueue, rec, spec, run, held.at.Add(6*time.Hour-time.Minute), executor)
+	run = advanceWithAutoMerge(t, store, enqueue, rec, spec, run, held.at.Add(24*time.Hour-time.Minute), executor)
 	if len(executor.mergeReqs) != 2 {
 		t.Fatalf("merge attempts inside the bound = %d, want 2", len(executor.mergeReqs))
 	}
@@ -340,12 +340,12 @@ func TestPipelineAutoMergeHoldIsBoundedWithoutAGateTimeout(t *testing.T) {
 
 	// AT six hours exactly the bound applies: the comparison is >=, so the
 	// boundary itself parks.
-	run = advanceWithAutoMerge(t, store, enqueue, rec, spec, run, held.at.Add(6*time.Hour), executor)
+	run = advanceWithAutoMerge(t, store, enqueue, rec, spec, run, held.at.Add(24*time.Hour), executor)
 	gate := stageRow(t, store, run.ID, "merge")
 	if gate.State != StageBlocked {
 		t.Fatalf("gate = %q at exactly six hours, want blocked", gate.State)
 	}
-	for _, want := range []string{holdReason, "no gate timeout is set", "6h0m0s"} {
+	for _, want := range []string{holdReason, "no gate timeout is set", "24h0m0s"} {
 		if !strings.Contains(gate.Summary, want) {
 			t.Fatalf("park summary must contain %q: %q", want, gate.Summary)
 		}
@@ -364,24 +364,26 @@ func TestPipelineAutoMergeHoldBudgetResetsForANewEpisode(t *testing.T) {
 		mergeResult: workflow.PipelineAutoMergeResult{Waiting: true, Reason: first},
 	}
 	run = advanceWithAutoMerge(t, store, enqueue, rec, spec, run, now.Add(2*time.Second), executor)
-	episode, err := latestAutoMergeHold(context.Background(), store, sourceJobID, "0123456789abcdef")
-	if err != nil || episode.at.IsZero() {
-		t.Fatalf("first episode = %+v err=%v", episode, err)
+	episode := newestRecordedHold(t, store, sourceJobID, "0123456789abcdef")
+	if episode.at.IsZero() {
+		t.Fatalf("first episode = %+v", episode)
 	}
 
-	// Seven hours later a DIFFERENT cause holds. That is a new episode and must
-	// get its own budget rather than parking instantly on the old anchor.
+	// A day later a different DECISION holds. That is a new episode - a new
+	// stable key, not merely new prose - and it must get its own budget rather
+	// than parking instantly on the old anchor.
 	second := "workload-mode change requires reconciliation at head 0123456 against operating-mode note 77"
-	executor.mergeResult = workflow.PipelineAutoMergeResult{Waiting: true, Reason: second}
-	run = advanceWithAutoMerge(t, store, enqueue, rec, spec, run, episode.at.Add(7*time.Hour), executor)
+	executor.mergeResult = workflow.PipelineAutoMergeResult{
+		Waiting:           true,
+		ReconciliationKey: "head=0123456789abcdef decision-note=77 mode=STEADY",
+		Reason:            second,
+	}
+	run = advanceWithAutoMerge(t, store, enqueue, rec, spec, run, episode.at.Add(25*time.Hour), executor)
 	gate := stageRow(t, store, run.ID, "merge")
 	if gate.State == StageBlocked {
 		t.Fatalf("a new hold cause must start a new budget, not park instantly: %q", gate.Summary)
 	}
-	fresh, err := latestAutoMergeHold(context.Background(), store, sourceJobID, "0123456789abcdef")
-	if err != nil {
-		t.Fatal(err)
-	}
+	fresh := newestRecordedHold(t, store, sourceJobID, "0123456789abcdef")
 	if fresh.reason != second {
 		t.Fatalf("recorded cause = %q, want the CURRENT cause, not the frozen first one", fresh.reason)
 	}
@@ -389,10 +391,10 @@ func TestPipelineAutoMergeHoldBudgetResetsForANewEpisode(t *testing.T) {
 		t.Fatalf("new episode anchor %v must be later than the first %v", fresh.at, episode.at)
 	}
 
-	// And the new episode's own bound still applies six hours after IT started.
-	run = advanceWithAutoMerge(t, store, enqueue, rec, spec, run, fresh.at.Add(6*time.Hour), executor)
+	// And the new episode's own bound still applies a day after IT started.
+	run = advanceWithAutoMerge(t, store, enqueue, rec, spec, run, fresh.at.Add(24*time.Hour), executor)
 	if gate := stageRow(t, store, run.ID, "merge"); gate.State != StageBlocked {
-		t.Fatalf("gate = %q six hours into the new episode, want blocked", gate.State)
+		t.Fatalf("gate = %q a day into the new episode, want blocked", gate.State)
 	} else if !strings.Contains(gate.Summary, second) {
 		t.Fatalf("park summary must carry the CURRENT cause: %q", gate.Summary)
 	}
@@ -419,16 +421,13 @@ func TestPipelineAutoMergeEvaluateSideHoldIsRecordedAndBounded(t *testing.T) {
 	if len(executor.mergeReqs) != 0 {
 		t.Fatalf("a not-ready readiness must not attempt a merge: %d", len(executor.mergeReqs))
 	}
-	held, err := latestAutoMergeHold(context.Background(), store, sourceJobID, "0123456789abcdef")
-	if err != nil {
-		t.Fatal(err)
-	}
+	held := newestRecordedHold(t, store, sourceJobID, "0123456789abcdef")
 	if held.at.IsZero() || held.reason != holdReason {
 		t.Fatalf("the Evaluate-side hold was not recorded: %+v", held)
 	}
 
 	// Bounded on the same path: at six hours it parks WITH the cause.
-	run = advanceWithAutoMerge(t, store, enqueue, rec, spec, run, held.at.Add(6*time.Hour), executor)
+	run = advanceWithAutoMerge(t, store, enqueue, rec, spec, run, held.at.Add(24*time.Hour), executor)
 	gate := stageRow(t, store, run.ID, "merge")
 	if gate.State != StageBlocked {
 		t.Fatalf("gate = %q six hours into an Evaluate-side hold, want blocked", gate.State)
@@ -448,22 +447,22 @@ func TestPipelineAutoMergeEvaluateSideHoldIsRecordedAndBounded(t *testing.T) {
 		},
 	}
 	run2 = advanceWithAutoMerge(t, store2, enqueue2, rec2, spec2, run2, now2.Add(2*time.Second), ciWait)
-	run2 = advanceWithAutoMerge(t, store2, enqueue2, rec2, spec2, run2, now2.Add(72*time.Hour), ciWait)
+	run2 = advanceWithAutoMerge(t, store2, enqueue2, rec2, spec2, run2, now2.Add(96*time.Hour), ciWait)
 	if gate := stageRow(t, store2, run2.ID, "merge"); gate.State == StageBlocked {
 		t.Fatalf("a CI wait must not be parked by the reconciliation bound: %q", gate.Summary)
 	}
-	if held, err := latestAutoMergeHold(context.Background(), store2, sourceJobID2, "0123456789abcdef"); err != nil {
-		t.Fatal(err)
-	} else if !held.at.IsZero() {
+	if held := newestRecordedHold(t, store2, sourceJobID2, "0123456789abcdef"); !held.at.IsZero() {
 		t.Fatalf("a CI wait must not record a reconciliation hold: %+v", held)
 	}
 }
 
-// F-3: the release runs AFTER the hold is recorded, so a lost release cannot
-// strand the run. Seeded by consuming the claim and leaving it consumed: the
-// !claimed branch must find the recorded hold and keep its bound instead of
-// waiting silently forever.
-func TestPipelineAutoMergeClaimedBranchKeepsTheRecordedBound(t *testing.T) {
+// F-10, the round-5 blocking finding, entered through the production advancer.
+// A hold record plus a lost claim used to be enough to KILL a run whose
+// reconciliation had already succeeded: the !claimed branch consulted a record
+// that is never cleared, and parked terminally on it. Reaching that branch means
+// Evaluate reported Ready IN THIS PASS, so the record has already been
+// contradicted by a live measurement.
+func TestPipelineAutoMergeLostClaimNeverParksAResolvedHold(t *testing.T) {
 	store, enqueue, rec, spec, run, sourceJobID, now := prepareAutoMergeGate(t)
 	settleBoundReviewJob(t, store, stageRow(t, store, run.ID, "review").JobID, "approved", "0123456789abcdef")
 	const holdReason = "workload-mode change requires reconciliation at head 0123456 against operating-mode note 41"
@@ -472,35 +471,273 @@ func TestPipelineAutoMergeClaimedBranchKeepsTheRecordedBound(t *testing.T) {
 		mergeResult: workflow.PipelineAutoMergeResult{Waiting: true, Reason: holdReason},
 	}
 	run = advanceWithAutoMerge(t, store, enqueue, rec, spec, run, now.Add(2*time.Second), executor)
-	held, err := latestAutoMergeHold(context.Background(), store, sourceJobID, "0123456789abcdef")
-	if err != nil || held.at.IsZero() {
-		t.Fatalf("hold episode = %+v err=%v", held, err)
+	held := newestRecordedHold(t, store, sourceJobID, "0123456789abcdef")
+	if held.at.IsZero() {
+		t.Fatalf("hold episode = %+v, want a recorded hold to go stale", held)
 	}
 
-	// Simulate the lost release: re-consume the claim by hand, exactly as a
-	// failed DELETE would leave it.
-	claim, marshalErr := json.Marshal(map[string]any{
+	// The reconciliation LANDS: readiness is Ready and the merge would succeed.
+	executor.mergeResult = workflow.PipelineAutoMergeResult{Merged: true, MergeCommitSHA: "merge-sha"}
+
+	// And this scan loses the race - seeded exactly as a failed release leaves
+	// it, by re-consuming the claim by hand. The claim's age is seeded too, and
+	// deliberately older than every bound in this file: without it the branch
+	// takes the no-age fail-open path and the test would pass while parking on a
+	// known-age claim.
+	seedConsumedAutoMergeClaim(t, store, rec, run, sourceJobID)
+	seedAutoMergeClaimAt(t, store, rec, run, sourceJobID, held.at)
+
+	// Well past the hold's bound. The run must NOT be dead: the winner merges,
+	// or the claim is released and the next scan merges.
+	run = advanceWithAutoMerge(t, store, enqueue, rec, spec, run, held.at.Add(autoMergeHoldMaxWait+time.Hour), executor)
+	gate := stageRow(t, store, run.ID, "merge")
+	if gate.State == StageBlocked {
+		t.Fatalf("a lost claim must not park a run whose reconciliation resolved: %q", gate.Summary)
+	}
+	if strings.Contains(gate.Summary, holdReason) {
+		t.Fatalf("summary must not blame a reconciliation that already succeeded: %q", gate.Summary)
+	}
+	if run.State == RunBlocked {
+		t.Fatalf("run = %q, want a live run", run.State)
+	}
+}
+
+// The other half of F-10: not parking must not mean going silent again, which
+// was round-4's F-3. Past the bound the wait NAMES the orphaned claim and
+// records it, and stays non-terminal.
+func TestPipelineAutoMergeLostClaimReportsAnOrphanedClaim(t *testing.T) {
+	store, enqueue, rec, spec, run, sourceJobID, now := prepareAutoMergeGate(t)
+	settleBoundReviewJob(t, store, stageRow(t, store, run.ID, "review").JobID, "approved", "0123456789abcdef")
+	executor := &stubPipelineAutoMerger{
+		readiness:   workflow.PipelineAutoMergeReadiness{Ready: true, CurrentHeadSHA: "0123456789abcdef"},
+		mergeResult: workflow.PipelineAutoMergeResult{Merged: true, MergeCommitSHA: "merge-sha"},
+	}
+	// One advance promotes the queued gate row without claiming.
+	run = advanceWithAutoMerge(t, store, enqueue, rec, spec, run, now.Add(time.Second),
+		&stubPipelineAutoMerger{readiness: workflow.PipelineAutoMergeReadiness{Waiting: true, CurrentHeadSHA: "0123456789abcdef"}})
+	seedConsumedAutoMergeClaim(t, store, rec, run, sourceJobID)
+	claimedAt := now.Add(time.Second)
+	seedAutoMergeClaimAt(t, store, rec, run, sourceJobID, claimedAt)
+
+	// LITERALS, not autoMergeClaimOrphanAfter arithmetic. Deriving this clock
+	// from the constant it pins made widening the bound to 720h invisible -
+	// round-4's F-5, re-created here and caught by mutating my own guard.
+	if autoMergeClaimOrphanAfter != 15*time.Minute {
+		t.Fatalf("autoMergeClaimOrphanAfter = %s, want 15m0s; this test's clock is written in literals", autoMergeClaimOrphanAfter)
+	}
+
+	// Inside the window: waiting, and honest that another scan holds the claim.
+	run = advanceWithAutoMerge(t, store, enqueue, rec, spec, run, claimedAt.Add(14*time.Minute), executor)
+	if gate := stageRow(t, store, run.ID, "merge"); gate.State == StageBlocked {
+		t.Fatalf("a claim held inside the window must not park: %q", gate.Summary)
+	}
+	if events := autoMergeEventCount(t, store, sourceJobID, autoMergeClaimOrphanEventKind); events != 0 {
+		t.Fatalf("suspicion rows inside the window = %d, want 0", events)
+	}
+
+	// Past it: still not parked, but the cause is recorded and stated.
+	run = advanceWithAutoMerge(t, store, enqueue, rec, spec, run, claimedAt.Add(16*time.Minute), executor)
+	gate := stageRow(t, store, run.ID, "merge")
+	if gate.State == StageBlocked {
+		t.Fatalf("an orphaned claim is not a condition this scan observed, so it must not park: %q", gate.Summary)
+	}
+	if events := autoMergeEventCount(t, store, sourceJobID, autoMergeClaimOrphanEventKind); events != 1 {
+		t.Fatalf("suspicion rows past the window = %d, want exactly 1", events)
+	}
+	// The EVENT is the durable record on this path, not the summary: a waiting
+	// stage's summary is written only when it settles, so an operator with no
+	// stage `timeout` has the event and nothing else. It has to name the claim.
+	for _, want := range []string{`"head_sha":"0123456789abcdef"`, `"claimed_at":"` + claimedAt.UTC().Format(time.RFC3339Nano), `"after":"15m0s"`} {
+		if !strings.Contains(autoMergeEventBody(t, store, sourceJobID, autoMergeClaimOrphanEventKind), want) {
+			t.Fatalf("suspicion row must contain %s: %s", want, autoMergeEventBody(t, store, sourceJobID, autoMergeClaimOrphanEventKind))
+		}
+	}
+	// Recorded ONCE per claim, however many scans lose the race.
+	run = advanceWithAutoMerge(t, store, enqueue, rec, spec, run, claimedAt.Add(17*time.Minute), executor)
+	if events := autoMergeEventCount(t, store, sourceJobID, autoMergeClaimOrphanEventKind); events != 1 {
+		t.Fatalf("suspicion rows after a second losing scan = %d, want the same 1", events)
+	}
+}
+
+// The claim-age row is only trustworthy because it dies WITH the claim. If a
+// release left it behind, a later losing scan would measure a claim that no
+// longer exists and report an orphan for a healthy race - which is F-10's defect
+// re-created by F-10's own fix, so it is pinned rather than argued.
+func TestPipelineAutoMergeClaimAgeIsReleasedWithTheClaim(t *testing.T) {
+	store, enqueue, rec, spec, run, sourceJobID, now := prepareAutoMergeGate(t)
+	settleBoundReviewJob(t, store, stageRow(t, store, run.ID, "review").JobID, "approved", "0123456789abcdef")
+	const holdReason = "workload-mode change requires reconciliation at head 0123456 against operating-mode note 41"
+	executor := &stubPipelineAutoMerger{
+		readiness:   workflow.PipelineAutoMergeReadiness{Ready: true, CurrentHeadSHA: "0123456789abcdef"},
+		mergeResult: workflow.PipelineAutoMergeResult{Waiting: true, Reason: holdReason},
+	}
+	// A full winning pass: claim, record the age, hold, release both.
+	run = advanceWithAutoMerge(t, store, enqueue, rec, spec, run, now.Add(2*time.Second), executor)
+	if claimAtRows := autoMergeEventCount(t, store, sourceJobID, autoMergeClaimAtEventKind); claimAtRows != 0 {
+		t.Fatalf("claim-age rows after the claim was released = %d, want 0", claimAtRows)
+	}
+	if claimedAt, err := latestAutoMergeClaimAt(context.Background(), store, sourceJobID, "0123456789abcdef"); err != nil {
+		t.Fatal(err)
+	} else if !claimedAt.IsZero() {
+		t.Fatalf("a released claim must leave no age to measure, got %v", claimedAt)
+	}
+
+	// So a scan that loses a LATER race reports no orphan on the strength of the
+	// released claim.
+	seedConsumedAutoMergeClaim(t, store, rec, run, sourceJobID)
+	run = advanceWithAutoMerge(t, store, enqueue, rec, spec, run, now.Add(2*autoMergeHoldMaxWait), executor)
+	if gate := stageRow(t, store, run.ID, "merge"); gate.State == StageBlocked {
+		t.Fatalf("gate parked on a released claim: %q", gate.Summary)
+	}
+	if rows := autoMergeEventCount(t, store, sourceJobID, autoMergeClaimOrphanEventKind); rows != 0 {
+		t.Fatalf("orphan suspicions from a released claim = %d, want 0", rows)
+	}
+}
+
+// The age reader takes the NEWEST row, and that direction is load-bearing: a
+// leftover row from an earlier episode is always older, so taking the earliest
+// would report an orphan for a claim taken seconds ago. Needs two rows to be a
+// choice at all, which is why the single-row tests above cannot pin it.
+func TestPipelineAutoMergeClaimAgeTakesTheNewestRow(t *testing.T) {
+	store, enqueue, rec, spec, run, sourceJobID, now := prepareAutoMergeGate(t)
+	settleBoundReviewJob(t, store, stageRow(t, store, run.ID, "review").JobID, "approved", "0123456789abcdef")
+	run = advanceWithAutoMerge(t, store, enqueue, rec, spec, run, now.Add(time.Second),
+		&stubPipelineAutoMerger{readiness: workflow.PipelineAutoMergeReadiness{Waiting: true, CurrentHeadSHA: "0123456789abcdef"}})
+	seedConsumedAutoMergeClaim(t, store, rec, run, sourceJobID)
+
+	stale := now.Add(-48 * time.Hour)
+	current := now.Add(time.Second)
+	seedAutoMergeClaimAt(t, store, rec, run, sourceJobID, stale)
+	seedAutoMergeClaimAt(t, store, rec, run, sourceJobID, current)
+
+	claimedAt, err := latestAutoMergeClaimAt(context.Background(), store, sourceJobID, "0123456789abcdef")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !claimedAt.Equal(current.UTC()) {
+		t.Fatalf("claim age = %v, want the NEWEST row %v", claimedAt, current.UTC())
+	}
+
+	// So the young claim reports no orphan, however old the leftover row is.
+	executor := &stubPipelineAutoMerger{
+		readiness:   workflow.PipelineAutoMergeReadiness{Ready: true, CurrentHeadSHA: "0123456789abcdef"},
+		mergeResult: workflow.PipelineAutoMergeResult{Merged: true, MergeCommitSHA: "merge-sha"},
+	}
+	run = advanceWithAutoMerge(t, store, enqueue, rec, spec, run, current.Add(time.Minute), executor)
+	if rows := autoMergeEventCount(t, store, sourceJobID, autoMergeClaimOrphanEventKind); rows != 0 {
+		t.Fatalf("orphan suspicions for a one-minute-old claim = %d, want 0", rows)
+	}
+}
+
+// F-11: the hold's budget is keyed on a STABLE discriminator, so churn in the
+// volatile half of the cause cannot reset it. The near-miss text names whichever
+// row the scan saw last, and one new reconciliation row anywhere in the repo
+// changes it - which, keyed on the cause, opened a fresh episode with a full
+// budget and deferred the bound indefinitely.
+func TestPipelineAutoMergeHoldBudgetSurvivesVolatileCauseText(t *testing.T) {
+	store, enqueue, rec, spec, run, sourceJobID, now := prepareAutoMergeGate(t)
+	settleBoundReviewJob(t, store, stageRow(t, store, run.ID, "review").JobID, "approved", "0123456789abcdef")
+	const stableKey = "head=0123456789abcdef decision-note=41 mode=STEADY"
+	base := "workload-mode change requires reconciliation at head 0123456 against operating-mode note 41"
+	executor := &stubPipelineAutoMerger{
+		readiness: workflow.PipelineAutoMergeReadiness{Ready: true, CurrentHeadSHA: "0123456789abcdef"},
+		mergeResult: workflow.PipelineAutoMergeResult{
+			Waiting: true, ReconciliationKey: stableKey, Reason: base,
+		},
+	}
+	run = advanceWithAutoMerge(t, store, enqueue, rec, spec, run, now.Add(2*time.Second), executor)
+	first := newestRecordedHold(t, store, sourceJobID, "0123456789abcdef")
+	if first.at.IsZero() {
+		t.Fatalf("first episode = %+v", first)
+	}
+
+	// The same hold, one scan later, with a DIFFERENT near-miss appended - the
+	// exact churn F-11 describes.
+	executor.mergeResult.Reason = base + "; row 99 reconciles head abcdef1, but the current head is 0123456"
+	run = advanceWithAutoMerge(t, store, enqueue, rec, spec, run, first.at.Add(autoMergeHoldMaxWait-time.Minute), executor)
+	if gate := stageRow(t, store, run.ID, "merge"); gate.State == StageBlocked {
+		t.Fatalf("gate parked one minute early: %q", gate.Summary)
+	}
+
+	// Past the bound measured from the FIRST hold, the budget must be spent -
+	// the churn must not have bought another full window.
+	run = advanceWithAutoMerge(t, store, enqueue, rec, spec, run, first.at.Add(autoMergeHoldMaxWait+time.Minute), executor)
+	gate := stageRow(t, store, run.ID, "merge")
+	if gate.State != StageBlocked {
+		t.Fatalf("gate = %q past the bound, want blocked: churn in the cause must not reset the budget", gate.State)
+	}
+	// F-12: the park tells the operator what to DO about it, not only what fired.
+	for _, want := range []string{"set a `timeout` on this gate stage", autoMergeHoldMaxWait.String()} {
+		if !strings.Contains(gate.Summary, want) {
+			t.Fatalf("park summary must contain %q: %q", want, gate.Summary)
+		}
+	}
+}
+
+// seedConsumedAutoMergeClaim leaves the at-most-once claim consumed, exactly as
+// a winner that died mid-write or a failed release DELETE leaves it.
+func seedConsumedAutoMergeClaim(t *testing.T, store *db.Store, rec db.Pipeline, run db.PipelineRun, sourceJobID string) {
+	t.Helper()
+	claim, err := json.Marshal(map[string]any{
 		"phase": "claim", "pipeline": rec.Name, "run_id": run.ID,
 		"stage_id": "merge", "pull_request": 813, "head_sha": "0123456789abcdef",
 	})
-	if marshalErr != nil {
-		t.Fatal(marshalErr)
+	if err != nil {
+		t.Fatal(err)
 	}
 	if claimed, err := store.ClaimJobEvent(context.Background(), db.JobEvent{
-		JobID: sourceJobID, Kind: "pipeline_auto_merge_claim", Message: string(claim),
+		JobID: sourceJobID, Kind: autoMergeClaimEventKind, Message: string(claim),
 	}); err != nil || !claimed {
 		t.Fatalf("seeding the consumed claim: claimed=%v err=%v", claimed, err)
 	}
+}
 
-	// The !claimed branch now owns the outcome, and it must still be bounded.
-	run = advanceWithAutoMerge(t, store, enqueue, rec, spec, run, held.at.Add(6*time.Hour), executor)
-	gate := stageRow(t, store, run.ID, "merge")
-	if gate.State != StageBlocked {
-		t.Fatalf("gate = %q with a consumed claim past the bound, want blocked rather than a silent wait", gate.State)
+// seedAutoMergeClaimAt records when that claim was taken, on the pipeline's own
+// clock, which is what the losing scan measures its age against.
+func seedAutoMergeClaimAt(t *testing.T, store *db.Store, rec db.Pipeline, run db.PipelineRun, sourceJobID string, at time.Time) {
+	t.Helper()
+	message, err := json.Marshal(map[string]any{
+		"phase": "claim_at", "pipeline": rec.Name, "run_id": run.ID,
+		"stage_id": "merge", "pull_request": 813, "head_sha": "0123456789abcdef",
+		"claimed_at": at.UTC().Format(time.RFC3339Nano),
+	})
+	if err != nil {
+		t.Fatal(err)
 	}
-	if !strings.Contains(gate.Summary, holdReason) {
-		t.Fatalf("park summary must carry the cause: %q", gate.Summary)
+	if err := store.AddJobEvent(context.Background(), db.JobEvent{
+		JobID: sourceJobID, Kind: autoMergeClaimAtEventKind, Message: string(message),
+	}); err != nil {
+		t.Fatal(err)
 	}
+}
+
+func autoMergeEventBody(t *testing.T, store *db.Store, sourceJobID, kind string) string {
+	t.Helper()
+	events, err := store.ListJobEvents(context.Background(), sourceJobID)
+	if err != nil {
+		t.Fatalf("ListJobEvents: %v", err)
+	}
+	for _, event := range events {
+		if event.Kind == kind {
+			return event.Message
+		}
+	}
+	return ""
+}
+
+func autoMergeEventCount(t *testing.T, store *db.Store, sourceJobID, kind string) int {
+	t.Helper()
+	events, err := store.ListJobEvents(context.Background(), sourceJobID)
+	if err != nil {
+		t.Fatalf("ListJobEvents: %v", err)
+	}
+	count := 0
+	for _, event := range events {
+		if event.Kind == kind {
+			count++
+		}
+	}
+	return count
 }
 
 // Two scans racing the same NEW episode each write a held row, which is
@@ -520,16 +757,17 @@ func TestPipelineAutoMergeHoldAnchorsOnTheEarliestDuplicate(t *testing.T) {
 		},
 	}
 	run = advanceWithAutoMerge(t, store, enqueue, rec, spec, run, now.Add(2*time.Second), executor)
-	first, err := latestAutoMergeHold(context.Background(), store, sourceJobID, "0123456789abcdef")
-	if err != nil || first.at.IsZero() {
-		t.Fatalf("first episode = %+v err=%v", first, err)
+	first := newestRecordedHold(t, store, sourceJobID, "0123456789abcdef")
+	if first.at.IsZero() {
+		t.Fatalf("first episode = %+v", first)
 	}
 
 	// The racing scan's row: same head and cause, a LATER held_at.
 	duplicate, marshalErr := json.Marshal(map[string]any{
 		"phase": "held", "pipeline": rec.Name, "run_id": run.ID,
 		"stage_id": "merge", "pull_request": 813, "head_sha": "0123456789abcdef",
-		"reason": holdReason, "held_at": first.at.Add(5 * time.Hour).Format(time.RFC3339Nano),
+		"reason": holdReason, "episode_key": "head=0123456789abcdef",
+		"held_at": first.at.Add(23 * time.Hour).Format(time.RFC3339Nano),
 	})
 	if marshalErr != nil {
 		t.Fatal(marshalErr)
@@ -540,7 +778,10 @@ func TestPipelineAutoMergeHoldAnchorsOnTheEarliestDuplicate(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	anchored, err := latestAutoMergeHold(context.Background(), store, sourceJobID, "0123456789abcdef")
+	// Asserted through the EPISODE resolver, which is what production reads.
+	// newestRecordedHold deliberately reports the newest row, so it would report
+	// the duplicate and prove nothing about the anchor.
+	anchored, err := autoMergeHoldEpisode(context.Background(), store, sourceJobID, "0123456789abcdef", "head=0123456789abcdef")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -548,11 +789,11 @@ func TestPipelineAutoMergeHoldAnchorsOnTheEarliestDuplicate(t *testing.T) {
 		t.Fatalf("anchor = %v, want the EARLIEST duplicate %v", anchored.at, first.at)
 	}
 
-	// And the bound still fires six hours after the TRUE start, not after the
+	// And the bound still fires a day after the TRUE start, not after the
 	// duplicate: anchoring late would leave this waiting.
-	run = advanceWithAutoMerge(t, store, enqueue, rec, spec, run, first.at.Add(6*time.Hour), executor)
+	run = advanceWithAutoMerge(t, store, enqueue, rec, spec, run, first.at.Add(24*time.Hour), executor)
 	if gate := stageRow(t, store, run.ID, "merge"); gate.State != StageBlocked {
-		t.Fatalf("gate = %q six hours after the episode began, want blocked", gate.State)
+		t.Fatalf("gate = %q a day after the episode began, want blocked", gate.State)
 	}
 }
 
@@ -598,10 +839,7 @@ func TestPipelineAutoMergeHoldIsRecordedEvenWhenTheReleaseFails(t *testing.T) {
 
 	// The hold survived the failed release, so the next scan is bounded rather
 	// than silent - which is the whole point of the ordering.
-	held, holdErr := latestAutoMergeHold(context.Background(), store, sourceJobID, "0123456789abcdef")
-	if holdErr != nil {
-		t.Fatal(holdErr)
-	}
+	held := newestRecordedHold(t, store, sourceJobID, "0123456789abcdef")
 	if held.at.IsZero() || held.reason != holdReason {
 		t.Fatalf("hold record after a failed release = %+v, want the cause recorded", held)
 	}
@@ -882,4 +1120,42 @@ stages:
 	if run.State != RunSucceeded || len(executor.evaluateReqs) != 0 || len(executor.mergeReqs) != 0 {
 		t.Fatalf("human gate run=%+v evaluate=%d merge=%d", run, len(executor.evaluateReqs), len(executor.mergeReqs))
 	}
+}
+
+// newestRecordedHold is the TESTS' inspection reader: the newest hold row for a
+// head, whatever its episode key. Production has no such reader by design - a
+// scan reads a hold only for a cause it observed in the same pass - and this
+// parses the row independently rather than reusing autoMergeHoldEpisode, so a
+// bug in that lookup cannot hide behind a test that shares it.
+func newestRecordedHold(t *testing.T, store *db.Store, sourceJobID, head string) autoMergeHold {
+	t.Helper()
+	events, err := store.ListJobEvents(context.Background(), sourceJobID)
+	if err != nil {
+		t.Fatalf("ListJobEvents: %v", err)
+	}
+	var newest autoMergeHold
+	for _, event := range events {
+		if event.Kind != autoMergeHeldEventKind {
+			continue
+		}
+		var body struct {
+			HeadSHA string `json:"head_sha"`
+			Reason  string `json:"reason"`
+			HeldAt  string `json:"held_at"`
+		}
+		if json.Unmarshal([]byte(event.Message), &body) != nil {
+			continue
+		}
+		if strings.TrimSpace(body.HeadSHA) != head {
+			continue
+		}
+		at, parseErr := time.Parse(time.RFC3339Nano, strings.TrimSpace(body.HeldAt))
+		if parseErr != nil {
+			continue
+		}
+		if newest.at.IsZero() || at.After(newest.at) {
+			newest = autoMergeHold{at: at.UTC(), reason: strings.TrimSpace(body.Reason)}
+		}
+	}
+	return newest
 }

--- a/internal/pipeline/auto_merge_test.go
+++ b/internal/pipeline/auto_merge_test.go
@@ -297,9 +297,12 @@ func TestPipelineAutoMergeHoldTimeoutCarriesTheReason(t *testing.T) {
 }
 
 // With NO gate timeout the reviewer measured this parked silently at now+72h.
-// The hold now carries its own bound, measured from the first recorded hold, and
-// parks WITH the cause. A test that only exercises the happy reconcile is not a
-// test of this (#1783 round-3 review, F-A).
+// The hold carries its own bound and parks WITH the cause.
+//
+// The MAGNITUDE is pinned with LITERALS. The first version derived its clock
+// from autoMergeHoldMaxWait, so a mutant widening 6h to 720h - restoring exactly
+// the unbounded wait this exists to remove - survived: a self-referential test
+// cannot fail on the value it is meant to pin (#1783 round-4 review, F-5).
 func TestPipelineAutoMergeHoldIsBoundedWithoutAGateTimeout(t *testing.T) {
 	store, enqueue, rec, spec, run, sourceJobID, now := prepareAutoMergeGate(t)
 	settleBoundReviewJob(t, store, stageRow(t, store, run.ID, "review").JobID, "approved", "0123456789abcdef")
@@ -308,7 +311,6 @@ func TestPipelineAutoMergeHoldIsBoundedWithoutAGateTimeout(t *testing.T) {
 		readiness:   workflow.PipelineAutoMergeReadiness{Ready: true, CurrentHeadSHA: "0123456789abcdef"},
 		mergeResult: workflow.PipelineAutoMergeResult{Waiting: true, Reason: holdReason},
 	}
-	// The spec's merge stage sets no timeout, so only the hold's own bound applies.
 	for _, stage := range spec.Stages {
 		if stage.ID == "merge" && strings.TrimSpace(stage.Timeout) != "" {
 			t.Fatalf("fixture must have no gate timeout, got %q", stage.Timeout)
@@ -319,29 +321,238 @@ func TestPipelineAutoMergeHoldIsBoundedWithoutAGateTimeout(t *testing.T) {
 	if gate := stageRow(t, store, run.ID, "merge"); gate.State == StageBlocked {
 		t.Fatalf("the first hold must wait, not park: %+v", gate)
 	}
-	// Retries keep happening inside the bound.
-	run = advanceWithAutoMerge(t, store, enqueue, rec, spec, run, now.Add(time.Hour), executor)
+	held, err := latestAutoMergeHold(context.Background(), store, sourceJobID, "0123456789abcdef")
+	if err != nil || held.at.IsZero() {
+		t.Fatalf("hold episode = %+v err=%v, want a recorded hold", held, err)
+	}
+	if held.reason != holdReason {
+		t.Fatalf("episode reason = %q, want the hold's cause", held.reason)
+	}
+
+	// Just INSIDE six hours: still waiting, and still retrying.
+	run = advanceWithAutoMerge(t, store, enqueue, rec, spec, run, held.at.Add(6*time.Hour-time.Minute), executor)
 	if len(executor.mergeReqs) != 2 {
 		t.Fatalf("merge attempts inside the bound = %d, want 2", len(executor.mergeReqs))
 	}
 	if gate := stageRow(t, store, run.ID, "merge"); gate.State == StageBlocked {
-		t.Fatalf("a hold inside its bound must not park: %+v", gate)
+		t.Fatalf("a hold 5h59m old must not park: %+v", gate)
 	}
 
-	// Past the bound it parks, carrying the cause.
-	held, err := firstAutoMergeHoldAt(context.Background(), store, sourceJobID)
-	if err != nil || held.IsZero() {
-		t.Fatalf("first hold time = %v err=%v, want a recorded hold", held, err)
-	}
-	run = advanceWithAutoMerge(t, store, enqueue, rec, spec, run, held.Add(autoMergeHoldMaxWait+time.Minute), executor)
+	// AT six hours exactly the bound applies: the comparison is >=, so the
+	// boundary itself parks.
+	run = advanceWithAutoMerge(t, store, enqueue, rec, spec, run, held.at.Add(6*time.Hour), executor)
 	gate := stageRow(t, store, run.ID, "merge")
 	if gate.State != StageBlocked {
-		t.Fatalf("gate = %q past the hold bound, want blocked", gate.State)
+		t.Fatalf("gate = %q at exactly six hours, want blocked", gate.State)
 	}
-	for _, want := range []string{holdReason, "no gate timeout is set", autoMergeHoldMaxWait.String()} {
+	for _, want := range []string{holdReason, "no gate timeout is set", "6h0m0s"} {
 		if !strings.Contains(gate.Summary, want) {
 			t.Fatalf("park summary must contain %q: %q", want, gate.Summary)
 		}
+	}
+}
+
+// The bound is per HOLD EPISODE, not per job. One row per job meant the anchor
+// never reset: a brand-new hold hours later parked instantly and the recorded
+// cause froze at the first reason (#1783 round-4 review, F-2).
+func TestPipelineAutoMergeHoldBudgetResetsForANewEpisode(t *testing.T) {
+	store, enqueue, rec, spec, run, sourceJobID, now := prepareAutoMergeGate(t)
+	settleBoundReviewJob(t, store, stageRow(t, store, run.ID, "review").JobID, "approved", "0123456789abcdef")
+	first := "workload-mode change requires reconciliation at head 0123456 against operating-mode note 41"
+	executor := &stubPipelineAutoMerger{
+		readiness:   workflow.PipelineAutoMergeReadiness{Ready: true, CurrentHeadSHA: "0123456789abcdef"},
+		mergeResult: workflow.PipelineAutoMergeResult{Waiting: true, Reason: first},
+	}
+	run = advanceWithAutoMerge(t, store, enqueue, rec, spec, run, now.Add(2*time.Second), executor)
+	episode, err := latestAutoMergeHold(context.Background(), store, sourceJobID, "0123456789abcdef")
+	if err != nil || episode.at.IsZero() {
+		t.Fatalf("first episode = %+v err=%v", episode, err)
+	}
+
+	// Seven hours later a DIFFERENT cause holds. That is a new episode and must
+	// get its own budget rather than parking instantly on the old anchor.
+	second := "workload-mode change requires reconciliation at head 0123456 against operating-mode note 77"
+	executor.mergeResult = workflow.PipelineAutoMergeResult{Waiting: true, Reason: second}
+	run = advanceWithAutoMerge(t, store, enqueue, rec, spec, run, episode.at.Add(7*time.Hour), executor)
+	gate := stageRow(t, store, run.ID, "merge")
+	if gate.State == StageBlocked {
+		t.Fatalf("a new hold cause must start a new budget, not park instantly: %q", gate.Summary)
+	}
+	fresh, err := latestAutoMergeHold(context.Background(), store, sourceJobID, "0123456789abcdef")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if fresh.reason != second {
+		t.Fatalf("recorded cause = %q, want the CURRENT cause, not the frozen first one", fresh.reason)
+	}
+	if !fresh.at.After(episode.at) {
+		t.Fatalf("new episode anchor %v must be later than the first %v", fresh.at, episode.at)
+	}
+
+	// And the new episode's own bound still applies six hours after IT started.
+	run = advanceWithAutoMerge(t, store, enqueue, rec, spec, run, fresh.at.Add(6*time.Hour), executor)
+	if gate := stageRow(t, store, run.ID, "merge"); gate.State != StageBlocked {
+		t.Fatalf("gate = %q six hours into the new episode, want blocked", gate.State)
+	} else if !strings.Contains(gate.Summary, second) {
+		t.Fatalf("park summary must carry the CURRENT cause: %q", gate.Summary)
+	}
+}
+
+// THE ORDINARY PATH. ensureWorkloadModeReconciled runs in Evaluate BEFORE Merge
+// with the same inputs, so a reconciliation hold normally surfaces as
+// readiness.Waiting and never reaches the Merge-side instrumentation at all. The
+// round-4 review measured that path recording no held event, carrying no reason
+// and consulting no bound - running at now+72h with zero merge attempts, the
+// round-3 defect verbatim on the common path (F-1).
+func TestPipelineAutoMergeEvaluateSideHoldIsRecordedAndBounded(t *testing.T) {
+	store, enqueue, rec, spec, run, sourceJobID, now := prepareAutoMergeGate(t)
+	settleBoundReviewJob(t, store, stageRow(t, store, run.ID, "review").JobID, "approved", "0123456789abcdef")
+	const holdReason = "workload-mode change requires reconciliation at head 0123456 against operating-mode note 41"
+	executor := &stubPipelineAutoMerger{
+		readiness: workflow.PipelineAutoMergeReadiness{
+			Waiting: true, ReconciliationHold: true,
+			CurrentHeadSHA: "0123456789abcdef", Reason: holdReason,
+		},
+	}
+
+	run = advanceWithAutoMerge(t, store, enqueue, rec, spec, run, now.Add(2*time.Second), executor)
+	if len(executor.mergeReqs) != 0 {
+		t.Fatalf("a not-ready readiness must not attempt a merge: %d", len(executor.mergeReqs))
+	}
+	held, err := latestAutoMergeHold(context.Background(), store, sourceJobID, "0123456789abcdef")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if held.at.IsZero() || held.reason != holdReason {
+		t.Fatalf("the Evaluate-side hold was not recorded: %+v", held)
+	}
+
+	// Bounded on the same path: at six hours it parks WITH the cause.
+	run = advanceWithAutoMerge(t, store, enqueue, rec, spec, run, held.at.Add(6*time.Hour), executor)
+	gate := stageRow(t, store, run.ID, "merge")
+	if gate.State != StageBlocked {
+		t.Fatalf("gate = %q six hours into an Evaluate-side hold, want blocked", gate.State)
+	}
+	if !strings.Contains(gate.Summary, holdReason) {
+		t.Fatalf("park summary must carry the cause: %q", gate.Summary)
+	}
+
+	// A NON-reconciliation wait (CI pending) keeps the old cheap behaviour: no
+	// hold row, no bound, so this fix cannot park a run waiting on checks.
+	store2, enqueue2, rec2, spec2, run2, sourceJobID2, now2 := prepareAutoMergeGate(t)
+	settleBoundReviewJob(t, store2, stageRow(t, store2, run2.ID, "review").JobID, "approved", "0123456789abcdef")
+	ciWait := &stubPipelineAutoMerger{
+		readiness: workflow.PipelineAutoMergeReadiness{
+			Waiting: true, CurrentHeadSHA: "0123456789abcdef",
+			Reason: "GitHub has not determined pull request mergeability yet",
+		},
+	}
+	run2 = advanceWithAutoMerge(t, store2, enqueue2, rec2, spec2, run2, now2.Add(2*time.Second), ciWait)
+	run2 = advanceWithAutoMerge(t, store2, enqueue2, rec2, spec2, run2, now2.Add(72*time.Hour), ciWait)
+	if gate := stageRow(t, store2, run2.ID, "merge"); gate.State == StageBlocked {
+		t.Fatalf("a CI wait must not be parked by the reconciliation bound: %q", gate.Summary)
+	}
+	if held, err := latestAutoMergeHold(context.Background(), store2, sourceJobID2, "0123456789abcdef"); err != nil {
+		t.Fatal(err)
+	} else if !held.at.IsZero() {
+		t.Fatalf("a CI wait must not record a reconciliation hold: %+v", held)
+	}
+}
+
+// F-3: the release runs AFTER the hold is recorded, so a lost release cannot
+// strand the run. Seeded by consuming the claim and leaving it consumed: the
+// !claimed branch must find the recorded hold and keep its bound instead of
+// waiting silently forever.
+func TestPipelineAutoMergeClaimedBranchKeepsTheRecordedBound(t *testing.T) {
+	store, enqueue, rec, spec, run, sourceJobID, now := prepareAutoMergeGate(t)
+	settleBoundReviewJob(t, store, stageRow(t, store, run.ID, "review").JobID, "approved", "0123456789abcdef")
+	const holdReason = "workload-mode change requires reconciliation at head 0123456 against operating-mode note 41"
+	executor := &stubPipelineAutoMerger{
+		readiness:   workflow.PipelineAutoMergeReadiness{Ready: true, CurrentHeadSHA: "0123456789abcdef"},
+		mergeResult: workflow.PipelineAutoMergeResult{Waiting: true, Reason: holdReason},
+	}
+	run = advanceWithAutoMerge(t, store, enqueue, rec, spec, run, now.Add(2*time.Second), executor)
+	held, err := latestAutoMergeHold(context.Background(), store, sourceJobID, "0123456789abcdef")
+	if err != nil || held.at.IsZero() {
+		t.Fatalf("hold episode = %+v err=%v", held, err)
+	}
+
+	// Simulate the lost release: re-consume the claim by hand, exactly as a
+	// failed DELETE would leave it.
+	claim, marshalErr := json.Marshal(map[string]any{
+		"phase": "claim", "pipeline": rec.Name, "run_id": run.ID,
+		"stage_id": "merge", "pull_request": 813, "head_sha": "0123456789abcdef",
+	})
+	if marshalErr != nil {
+		t.Fatal(marshalErr)
+	}
+	if claimed, err := store.ClaimJobEvent(context.Background(), db.JobEvent{
+		JobID: sourceJobID, Kind: "pipeline_auto_merge_claim", Message: string(claim),
+	}); err != nil || !claimed {
+		t.Fatalf("seeding the consumed claim: claimed=%v err=%v", claimed, err)
+	}
+
+	// The !claimed branch now owns the outcome, and it must still be bounded.
+	run = advanceWithAutoMerge(t, store, enqueue, rec, spec, run, held.at.Add(6*time.Hour), executor)
+	gate := stageRow(t, store, run.ID, "merge")
+	if gate.State != StageBlocked {
+		t.Fatalf("gate = %q with a consumed claim past the bound, want blocked rather than a silent wait", gate.State)
+	}
+	if !strings.Contains(gate.Summary, holdReason) {
+		t.Fatalf("park summary must carry the cause: %q", gate.Summary)
+	}
+}
+
+// Two scans racing the same NEW episode each write a held row, which is
+// deliberate and harmless only because the anchor takes the EARLIEST held_at:
+// anchoring on the latest would restart the budget on every duplicate and the
+// bound would never be reached (#1783 round-4 review, F-5 listed this guard as
+// unkillable - it is killable once a duplicate exists, which is the state the
+// check-then-insert race actually produces).
+func TestPipelineAutoMergeHoldAnchorsOnTheEarliestDuplicate(t *testing.T) {
+	store, enqueue, rec, spec, run, sourceJobID, now := prepareAutoMergeGate(t)
+	settleBoundReviewJob(t, store, stageRow(t, store, run.ID, "review").JobID, "approved", "0123456789abcdef")
+	const holdReason = "workload-mode change requires reconciliation at head 0123456 against operating-mode note 41"
+	executor := &stubPipelineAutoMerger{
+		readiness: workflow.PipelineAutoMergeReadiness{
+			Waiting: true, ReconciliationHold: true,
+			CurrentHeadSHA: "0123456789abcdef", Reason: holdReason,
+		},
+	}
+	run = advanceWithAutoMerge(t, store, enqueue, rec, spec, run, now.Add(2*time.Second), executor)
+	first, err := latestAutoMergeHold(context.Background(), store, sourceJobID, "0123456789abcdef")
+	if err != nil || first.at.IsZero() {
+		t.Fatalf("first episode = %+v err=%v", first, err)
+	}
+
+	// The racing scan's row: same head and cause, a LATER held_at.
+	duplicate, marshalErr := json.Marshal(map[string]any{
+		"phase": "held", "pipeline": rec.Name, "run_id": run.ID,
+		"stage_id": "merge", "pull_request": 813, "head_sha": "0123456789abcdef",
+		"reason": holdReason, "held_at": first.at.Add(5 * time.Hour).Format(time.RFC3339Nano),
+	})
+	if marshalErr != nil {
+		t.Fatal(marshalErr)
+	}
+	if err := store.AddJobEvent(context.Background(), db.JobEvent{
+		JobID: sourceJobID, Kind: "pipeline_auto_merge_held", Message: string(duplicate),
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	anchored, err := latestAutoMergeHold(context.Background(), store, sourceJobID, "0123456789abcdef")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !anchored.at.Equal(first.at) {
+		t.Fatalf("anchor = %v, want the EARLIEST duplicate %v", anchored.at, first.at)
+	}
+
+	// And the bound still fires six hours after the TRUE start, not after the
+	// duplicate: anchoring late would leave this waiting.
+	run = advanceWithAutoMerge(t, store, enqueue, rec, spec, run, first.at.Add(6*time.Hour), executor)
+	if gate := stageRow(t, store, run.ID, "merge"); gate.State != StageBlocked {
+		t.Fatalf("gate = %q six hours after the episode began, want blocked", gate.State)
 	}
 }
 

--- a/internal/pipeline/auto_merge_test.go
+++ b/internal/pipeline/auto_merge_test.go
@@ -563,6 +563,80 @@ func TestPipelineAutoMergeLostClaimReportsAnOrphanedClaim(t *testing.T) {
 	}
 }
 
+// ROUND-8 F-1, and it is the reachable interleaving I asserted could not happen.
+// A losing scan's failed ClaimJobEvent and its read are two un-transacted
+// round-trips. Between them the winner can reach the Merge-side Waiting branch,
+// record its hold and RELEASE the claim - the ordinary hold cycle, and now once
+// per hold for every mode-marker PR because the mode gate runs at the merge
+// boundary. The loser then finds no claim row, and collapsing that into
+// "unreadable timestamp" wrote a durable, deduped, never-retracted orphan event
+// on a healthy run.
+//
+// MY FIRST VERSION OF THIS TEST WAS VACUOUS and the mutants said so: it released
+// the claim before advancing, so the next scan WON the claim and never entered
+// the loser branch at all - it passed while testing nothing, and three mutants
+// survived. The window only exists INSIDE a pass, so it is driven with the
+// afterLostClaim seam, which deletes the row exactly where the winner's release
+// would.
+func TestPipelineAutoMergeLostClaimTreatsAReleasedClaimAsANormalRace(t *testing.T) {
+	ctx := context.Background()
+	store, enqueue, rec, spec, run, sourceJobID, now := prepareAutoMergeGate(t)
+	settleBoundReviewJob(t, store, stageRow(t, store, run.ID, "review").JobID, "approved", "0123456789abcdef")
+	run = advanceWithAutoMerge(t, store, enqueue, rec, spec, run, now.Add(time.Second),
+		&stubPipelineAutoMerger{readiness: workflow.PipelineAutoMergeReadiness{Waiting: true, CurrentHeadSHA: "0123456789abcdef"}})
+
+	claim, err := json.Marshal(map[string]any{
+		"phase": "claim", "pipeline": rec.Name, "run_id": run.ID,
+		"stage_id": "merge", "pull_request": 813, "head_sha": "0123456789abcdef",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	// The claim is held, so this scan LOSES it...
+	seedConsumedAutoMergeClaim(t, store, rec, run, sourceJobID)
+
+	var gateStage Stage
+	for _, candidate := range spec.Stages {
+		if candidate.ID == "merge" {
+			gateStage = candidate
+			break
+		}
+	}
+	released := false
+	deps := pipelineStageSettleDeps{
+		store: store, rec: rec, run: run,
+		// Far past every bound, so a false report cannot hide behind a young claim.
+		now: time.Now().UTC().Add(48 * time.Hour),
+		autoMerge: &stubPipelineAutoMerger{
+			readiness:   workflow.PipelineAutoMergeReadiness{Ready: true, CurrentHeadSHA: "0123456789abcdef"},
+			mergeResult: workflow.PipelineAutoMergeResult{Merged: true, MergeCommitSHA: "merge-sha"},
+		},
+		// ...and the winner releases it in the window before this scan reads it.
+		afterLostClaim: func() {
+			ok, relErr := store.ReleaseJobEventClaim(ctx, db.JobEvent{
+				JobID: sourceJobID, Kind: autoMergeClaimEventKind, Message: string(claim),
+			})
+			if relErr != nil || !ok {
+				t.Fatalf("releasing in the window: ok=%v err=%v", ok, relErr)
+			}
+			released = true
+		},
+	}
+	settled, state, summary, _, _, err := gateStageSettleOutcome(ctx, deps, spec, gateStage, stageRow(t, store, run.ID, "merge"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !released {
+		t.Fatal("the seam never fired, so this scan did not lose the claim and the test proves nothing")
+	}
+	if settled && state == StageBlocked {
+		t.Fatalf("a released claim must not park: %q", summary)
+	}
+	if rows := autoMergeEventCount(t, store, sourceJobID, autoMergeClaimOrphanEventKind); rows != 0 {
+		t.Fatalf("orphan reports for a RELEASED claim = %d, want 0 - a normal hold cycle must not look like a fault", rows)
+	}
+}
+
 // F-6's calibration, pinned directly. The gate's StartedAt is stamped when the
 // gate goes in-flight, typically long before readiness, so aging the wait from
 // the GATE made a healthy two-second race on a gate that had waited past the
@@ -629,21 +703,21 @@ func TestPipelineAutoMergeClaimTimestampParsesTheStoreFormat(t *testing.T) {
 		t.Fatalf("seeding the claim: claimed=%v err=%v", claimed, err)
 	}
 
-	at, knowable, err := autoMergeClaimTakenAt(context.Background(), store, sourceJobID, string(claim))
+	at, lookup, _, err := autoMergeClaimTakenAt(context.Background(), store, sourceJobID, string(claim))
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !knowable {
+	if lookup != autoMergeClaimFound {
 		t.Fatal("the store's own created_at format must parse, or every losing scan reports an unreadable timestamp")
 	}
 	if at.Before(before) || at.After(time.Now().UTC().Add(2*time.Minute)) {
 		t.Fatalf("claim taken at %v, want a value near now - the parse succeeded but the value is wrong", at)
 	}
 	// And a message that is not this claim must not be mistaken for it.
-	if _, found, err := autoMergeClaimTakenAt(context.Background(), store, sourceJobID, `{"phase":"claim","other":true}`); err != nil {
+	if _, lookup, _, err := autoMergeClaimTakenAt(context.Background(), store, sourceJobID, `{"phase":"claim","other":true}`); err != nil {
 		t.Fatal(err)
-	} else if found {
-		t.Fatal("a different claim message must not match this claim's row")
+	} else if lookup != autoMergeClaimGone {
+		t.Fatalf("a different claim message must report Gone, got %v", lookup)
 	}
 }
 

--- a/internal/pipeline/auto_merge_test.go
+++ b/internal/pipeline/auto_merge_test.go
@@ -480,12 +480,11 @@ func TestPipelineAutoMergeLostClaimNeverParksAResolvedHold(t *testing.T) {
 	executor.mergeResult = workflow.PipelineAutoMergeResult{Merged: true, MergeCommitSHA: "merge-sha"}
 
 	// And this scan loses the race - seeded exactly as a failed release leaves
-	// it, by re-consuming the claim by hand. The claim's age is seeded too, and
-	// deliberately older than every bound in this file: without it the branch
-	// takes the no-age fail-open path and the test would pass while parking on a
-	// known-age claim.
+	// it, by re-consuming the claim by hand. No age row is seeded because none
+	// exists any more: the loser ages the wait from the gate stage's own
+	// StartedAt, so there is no state in which the claim is consumed and the age
+	// is missing (#1783 round-6 review, N-1).
 	seedConsumedAutoMergeClaim(t, store, rec, run, sourceJobID)
-	seedAutoMergeClaimAt(t, store, rec, run, sourceJobID, held.at)
 
 	// Well past the hold's bound. The run must NOT be dead: the winner merges,
 	// or the claim is released and the next scan merges.
@@ -516,8 +515,10 @@ func TestPipelineAutoMergeLostClaimReportsAnOrphanedClaim(t *testing.T) {
 	run = advanceWithAutoMerge(t, store, enqueue, rec, spec, run, now.Add(time.Second),
 		&stubPipelineAutoMerger{readiness: workflow.PipelineAutoMergeReadiness{Waiting: true, CurrentHeadSHA: "0123456789abcdef"}})
 	seedConsumedAutoMergeClaim(t, store, rec, run, sourceJobID)
-	claimedAt := now.Add(time.Second)
-	seedAutoMergeClaimAt(t, store, rec, run, sourceJobID, claimedAt)
+	gateStartedAt := stageRow(t, store, run.ID, "merge").StartedAt
+	if gateStartedAt.IsZero() {
+		t.Fatal("premise broken: the gate stage must carry a StartedAt for the wait to be ageable")
+	}
 
 	// LITERALS, not autoMergeClaimOrphanAfter arithmetic. Deriving this clock
 	// from the constant it pins made widening the bound to 720h invisible -
@@ -527,7 +528,7 @@ func TestPipelineAutoMergeLostClaimReportsAnOrphanedClaim(t *testing.T) {
 	}
 
 	// Inside the window: waiting, and honest that another scan holds the claim.
-	run = advanceWithAutoMerge(t, store, enqueue, rec, spec, run, claimedAt.Add(14*time.Minute), executor)
+	run = advanceWithAutoMerge(t, store, enqueue, rec, spec, run, gateStartedAt.Add(14*time.Minute), executor)
 	if gate := stageRow(t, store, run.ID, "merge"); gate.State == StageBlocked {
 		t.Fatalf("a claim held inside the window must not park: %q", gate.Summary)
 	}
@@ -536,7 +537,7 @@ func TestPipelineAutoMergeLostClaimReportsAnOrphanedClaim(t *testing.T) {
 	}
 
 	// Past it: still not parked, but the cause is recorded and stated.
-	run = advanceWithAutoMerge(t, store, enqueue, rec, spec, run, claimedAt.Add(16*time.Minute), executor)
+	run = advanceWithAutoMerge(t, store, enqueue, rec, spec, run, gateStartedAt.Add(16*time.Minute), executor)
 	gate := stageRow(t, store, run.ID, "merge")
 	if gate.State == StageBlocked {
 		t.Fatalf("an orphaned claim is not a condition this scan observed, so it must not park: %q", gate.Summary)
@@ -547,85 +548,53 @@ func TestPipelineAutoMergeLostClaimReportsAnOrphanedClaim(t *testing.T) {
 	// The EVENT is the durable record on this path, not the summary: a waiting
 	// stage's summary is written only when it settles, so an operator with no
 	// stage `timeout` has the event and nothing else. It has to name the claim.
-	for _, want := range []string{`"head_sha":"0123456789abcdef"`, `"claimed_at":"` + claimedAt.UTC().Format(time.RFC3339Nano), `"after":"15m0s"`} {
+	for _, want := range []string{`"head_sha":"0123456789abcdef"`, `"after":"15m0s"`, `"cause":"held_past_bound"`} {
 		if !strings.Contains(autoMergeEventBody(t, store, sourceJobID, autoMergeClaimOrphanEventKind), want) {
 			t.Fatalf("suspicion row must contain %s: %s", want, autoMergeEventBody(t, store, sourceJobID, autoMergeClaimOrphanEventKind))
 		}
 	}
 	// Recorded ONCE per claim, however many scans lose the race.
-	run = advanceWithAutoMerge(t, store, enqueue, rec, spec, run, claimedAt.Add(17*time.Minute), executor)
+	run = advanceWithAutoMerge(t, store, enqueue, rec, spec, run, gateStartedAt.Add(17*time.Minute), executor)
 	if events := autoMergeEventCount(t, store, sourceJobID, autoMergeClaimOrphanEventKind); events != 1 {
 		t.Fatalf("suspicion rows after a second losing scan = %d, want the same 1", events)
 	}
 }
 
-// The claim-age row is only trustworthy because it dies WITH the claim. If a
-// release left it behind, a later losing scan would measure a claim that no
-// longer exists and report an orphan for a healthy race - which is F-10's defect
-// re-created by F-10's own fix, so it is pinned rather than argued.
-func TestPipelineAutoMergeClaimAgeIsReleasedWithTheClaim(t *testing.T) {
-	store, enqueue, rec, spec, run, sourceJobID, now := prepareAutoMergeGate(t)
-	settleBoundReviewJob(t, store, stageRow(t, store, run.ID, "review").JobID, "approved", "0123456789abcdef")
-	const holdReason = "workload-mode change requires reconciliation at head 0123456 against operating-mode note 41"
-	executor := &stubPipelineAutoMerger{
-		readiness:   workflow.PipelineAutoMergeReadiness{Ready: true, CurrentHeadSHA: "0123456789abcdef"},
-		mergeResult: workflow.PipelineAutoMergeResult{Waiting: true, Reason: holdReason},
-	}
-	// A full winning pass: claim, record the age, hold, release both.
-	run = advanceWithAutoMerge(t, store, enqueue, rec, spec, run, now.Add(2*time.Second), executor)
-	if claimAtRows := autoMergeEventCount(t, store, sourceJobID, autoMergeClaimAtEventKind); claimAtRows != 0 {
-		t.Fatalf("claim-age rows after the claim was released = %d, want 0", claimAtRows)
-	}
-	if claimedAt, err := latestAutoMergeClaimAt(context.Background(), store, sourceJobID, "0123456789abcdef"); err != nil {
-		t.Fatal(err)
-	} else if !claimedAt.IsZero() {
-		t.Fatalf("a released claim must leave no age to measure, got %v", claimedAt)
-	}
-
-	// So a scan that loses a LATER race reports no orphan on the strength of the
-	// released claim.
-	seedConsumedAutoMergeClaim(t, store, rec, run, sourceJobID)
-	run = advanceWithAutoMerge(t, store, enqueue, rec, spec, run, now.Add(2*autoMergeHoldMaxWait), executor)
-	if gate := stageRow(t, store, run.ID, "merge"); gate.State == StageBlocked {
-		t.Fatalf("gate parked on a released claim: %q", gate.Summary)
-	}
-	if rows := autoMergeEventCount(t, store, sourceJobID, autoMergeClaimOrphanEventKind); rows != 0 {
-		t.Fatalf("orphan suspicions from a released claim = %d, want 0", rows)
-	}
-}
-
-// The age reader takes the NEWEST row, and that direction is load-bearing: a
-// leftover row from an earlier episode is always older, so taking the earliest
-// would report an orphan for a claim taken seconds ago. Needs two rows to be a
-// choice at all, which is why the single-row tests above cannot pin it.
-func TestPipelineAutoMergeClaimAgeTakesTheNewestRow(t *testing.T) {
+// N-1's second half: a gate row with NO recorded start time. A resumed run
+// zeroes StartedAt, so the loser cannot age its wait AND pipelineGateTimedOut
+// cannot fire, which means a reason string alone reaches nothing an operator can
+// read. It therefore has to RECORD. Measured: a mutant that dropped the reason
+// here changed nothing observable until the record was added.
+func TestPipelineAutoMergeLostClaimReportsAnUnageableWait(t *testing.T) {
 	store, enqueue, rec, spec, run, sourceJobID, now := prepareAutoMergeGate(t)
 	settleBoundReviewJob(t, store, stageRow(t, store, run.ID, "review").JobID, "approved", "0123456789abcdef")
 	run = advanceWithAutoMerge(t, store, enqueue, rec, spec, run, now.Add(time.Second),
 		&stubPipelineAutoMerger{readiness: workflow.PipelineAutoMergeReadiness{Waiting: true, CurrentHeadSHA: "0123456789abcdef"}})
 	seedConsumedAutoMergeClaim(t, store, rec, run, sourceJobID)
 
-	stale := now.Add(-48 * time.Hour)
-	current := now.Add(time.Second)
-	seedAutoMergeClaimAt(t, store, rec, run, sourceJobID, stale)
-	seedAutoMergeClaimAt(t, store, rec, run, sourceJobID, current)
-
-	claimedAt, err := latestAutoMergeClaimAt(context.Background(), store, sourceJobID, "0123456789abcdef")
-	if err != nil {
+	// Zero the gate row's start stamp, exactly as a resume does.
+	gate := stageRow(t, store, run.ID, "merge")
+	gate.StartedAt = time.Time{}
+	if err := store.UpdatePipelineRunStage(context.Background(), gate); err != nil {
 		t.Fatal(err)
 	}
-	if !claimedAt.Equal(current.UTC()) {
-		t.Fatalf("claim age = %v, want the NEWEST row %v", claimedAt, current.UTC())
+	if got := stageRow(t, store, run.ID, "merge"); !got.StartedAt.IsZero() {
+		t.Fatalf("premise broken: StartedAt = %v, want zero", got.StartedAt)
 	}
 
-	// So the young claim reports no orphan, however old the leftover row is.
 	executor := &stubPipelineAutoMerger{
 		readiness:   workflow.PipelineAutoMergeReadiness{Ready: true, CurrentHeadSHA: "0123456789abcdef"},
 		mergeResult: workflow.PipelineAutoMergeResult{Merged: true, MergeCommitSHA: "merge-sha"},
 	}
-	run = advanceWithAutoMerge(t, store, enqueue, rec, spec, run, current.Add(time.Minute), executor)
-	if rows := autoMergeEventCount(t, store, sourceJobID, autoMergeClaimOrphanEventKind); rows != 0 {
-		t.Fatalf("orphan suspicions for a one-minute-old claim = %d, want 0", rows)
+	run = advanceWithAutoMerge(t, store, enqueue, rec, spec, run, now.Add(time.Hour), executor)
+	if gate := stageRow(t, store, run.ID, "merge"); gate.State == StageBlocked {
+		t.Fatalf("an unageable wait must not park: %q", gate.Summary)
+	}
+	if rows := autoMergeEventCount(t, store, sourceJobID, autoMergeClaimOrphanEventKind); rows != 1 {
+		t.Fatalf("suspicion rows for an unageable wait = %d, want exactly 1", rows)
+	}
+	if body := autoMergeEventBody(t, store, sourceJobID, autoMergeClaimOrphanEventKind); !strings.Contains(body, `"cause":"gate_start_unrecorded"`) {
+		t.Fatalf("suspicion row must name the cause: %s", body)
 	}
 }
 
@@ -689,25 +658,6 @@ func seedConsumedAutoMergeClaim(t *testing.T, store *db.Store, rec db.Pipeline, 
 		JobID: sourceJobID, Kind: autoMergeClaimEventKind, Message: string(claim),
 	}); err != nil || !claimed {
 		t.Fatalf("seeding the consumed claim: claimed=%v err=%v", claimed, err)
-	}
-}
-
-// seedAutoMergeClaimAt records when that claim was taken, on the pipeline's own
-// clock, which is what the losing scan measures its age against.
-func seedAutoMergeClaimAt(t *testing.T, store *db.Store, rec db.Pipeline, run db.PipelineRun, sourceJobID string, at time.Time) {
-	t.Helper()
-	message, err := json.Marshal(map[string]any{
-		"phase": "claim_at", "pipeline": rec.Name, "run_id": run.ID,
-		"stage_id": "merge", "pull_request": 813, "head_sha": "0123456789abcdef",
-		"claimed_at": at.UTC().Format(time.RFC3339Nano),
-	})
-	if err != nil {
-		t.Fatal(err)
-	}
-	if err := store.AddJobEvent(context.Background(), db.JobEvent{
-		JobID: sourceJobID, Kind: autoMergeClaimAtEventKind, Message: string(message),
-	}); err != nil {
-		t.Fatal(err)
 	}
 }
 

--- a/internal/pipeline/auto_merge_test.go
+++ b/internal/pipeline/auto_merge_test.go
@@ -638,6 +638,43 @@ func TestPipelineAutoMergeLostClaimTreatsAReleasedClaimAsANormalRace(t *testing.
 	}
 }
 
+// prepareTimedAutoMergeGate is prepareAutoMergeGate with a stage `timeout` on the
+// gate. Every reason autoMergeLostClaimOutcome emits is observable ONLY through a
+// timeout park - autoMergeGateWaitingWithReason drops the reason on the ordinary
+// waiting path - so each of the four texts needs this fixture to be asserted at
+// all (#1783 round-11 F-1).
+func prepareTimedAutoMergeGate(t *testing.T) (*db.Store, PipelineStageEnqueuer, db.Pipeline, Spec, db.PipelineRun, string, time.Time, Stage) {
+	t.Helper()
+	timedSpec := strings.Replace(pipelineAutoMergeSpec, "    merge: auto\n", "    merge: auto\n    timeout: 1m\n", 1)
+	store := pipelineAdvanceStore(t)
+	rec, spec := newTestPipeline(t, store, "auto-merge", timedSpec)
+	enqueue := testStageEnqueuer(store)
+	now := time.Date(2026, 7, 11, 8, 0, 0, 0, time.UTC)
+	run := startTestRun(t, store, rec, spec, enqueue, now)
+	impl := stageRow(t, store, run.ID, "impl")
+	settleBoundImplementStageJob(t, store, impl.JobID, "implemented",
+		PipelineStagePRBinding{PullRequest: 813, HeadSHA: "0123456789abcdef", Branch: "feat/813", TaskID: "task-813", LeadAgent: "coder"})
+	run = advanceWithAutoMerge(t, store, enqueue, rec, spec, run, now.Add(time.Second), &stubPipelineAutoMerger{})
+	settleBoundReviewJob(t, store, stageRow(t, store, run.ID, "review").JobID, "approved", "0123456789abcdef")
+	run = advanceWithAutoMerge(t, store, enqueue, rec, spec, run, now.Add(2*time.Second),
+		&stubPipelineAutoMerger{readiness: workflow.PipelineAutoMergeReadiness{Waiting: true, CurrentHeadSHA: "0123456789abcdef"}})
+
+	var gateStage Stage
+	for _, candidate := range spec.Stages {
+		if candidate.ID == "merge" {
+			gateStage = candidate
+			break
+		}
+	}
+	// The guard that makes every test below able to fail for the right reason:
+	// without the timeout the reason can never reach a caller, so a passing
+	// assertion would be proving nothing.
+	if strings.TrimSpace(gateStage.Timeout) == "" {
+		t.Fatal("this fixture must carry a gate timeout, or no reason can ever reach a summary")
+	}
+	return store, enqueue, rec, spec, run, impl.JobID, now, gateStage
+}
+
 // ROUND-10 F-6: the released-claim reason - this round's new operator-facing
 // output - was asserted by nothing, and corrupting its text survived the test
 // above. That reason is the branch's whole product: autoMergeGateWaitingWithReason
@@ -653,20 +690,7 @@ func TestPipelineAutoMergeLostClaimTreatsAReleasedClaimAsANormalRace(t *testing.
 // other, and that claim was itself only prose until now.
 func TestPipelineAutoMergeLostClaimReleasedReasonReachesAParkedSummary(t *testing.T) {
 	ctx := context.Background()
-	timedSpec := strings.Replace(pipelineAutoMergeSpec, "    merge: auto\n", "    merge: auto\n    timeout: 1m\n", 1)
-	store := pipelineAdvanceStore(t)
-	rec, spec := newTestPipeline(t, store, "auto-merge", timedSpec)
-	enqueue := testStageEnqueuer(store)
-	now := time.Date(2026, 7, 11, 8, 0, 0, 0, time.UTC)
-	run := startTestRun(t, store, rec, spec, enqueue, now)
-	impl := stageRow(t, store, run.ID, "impl")
-	sourceJobID := impl.JobID
-	settleBoundImplementStageJob(t, store, impl.JobID, "implemented",
-		PipelineStagePRBinding{PullRequest: 813, HeadSHA: "0123456789abcdef", Branch: "feat/813", TaskID: "task-813", LeadAgent: "coder"})
-	run = advanceWithAutoMerge(t, store, enqueue, rec, spec, run, now.Add(time.Second), &stubPipelineAutoMerger{})
-	settleBoundReviewJob(t, store, stageRow(t, store, run.ID, "review").JobID, "approved", "0123456789abcdef")
-	run = advanceWithAutoMerge(t, store, enqueue, rec, spec, run, now.Add(2*time.Second),
-		&stubPipelineAutoMerger{readiness: workflow.PipelineAutoMergeReadiness{Waiting: true, CurrentHeadSHA: "0123456789abcdef"}})
+	store, _, rec, spec, run, sourceJobID, now, gateStage := prepareTimedAutoMergeGate(t)
 
 	claim, err := json.Marshal(map[string]any{
 		"phase": "claim", "pipeline": rec.Name, "run_id": run.ID,
@@ -676,17 +700,6 @@ func TestPipelineAutoMergeLostClaimReleasedReasonReachesAParkedSummary(t *testin
 		t.Fatal(err)
 	}
 	seedConsumedAutoMergeClaim(t, store, rec, run, sourceJobID)
-
-	var gateStage Stage
-	for _, candidate := range spec.Stages {
-		if candidate.ID == "merge" {
-			gateStage = candidate
-			break
-		}
-	}
-	if strings.TrimSpace(gateStage.Timeout) == "" {
-		t.Fatal("this fixture must carry a gate timeout, or the reason can never reach a summary")
-	}
 	released := false
 	deps := pipelineStageSettleDeps{
 		store: store, rec: rec, run: run,
@@ -730,6 +743,159 @@ func TestPipelineAutoMergeLostClaimReleasedReasonReachesAParkedSummary(t *testin
 	if rows := autoMergeEventCount(t, store, sourceJobID, autoMergeClaimOrphanEventKind); rows != 0 {
 		t.Fatalf("orphan reports for a RELEASED claim = %d, want 0", rows)
 	}
+}
+
+// ROUND-11 F-1, AND IT IS THE CLASS ROUND-10 F-6 OPENED WITHOUT CLOSING.
+// F-6 established the standard - an operator-facing reason asserted by nothing is
+// not pinned - and the previous head applied it to ONE of the four reasons
+// autoMergeLostClaimOutcome emits. The review mutated two of the remaining three
+// and both survived; enumerating the function rather than the two it named finds
+// a THIRD, the inside-the-window text at the `held < autoMergeClaimOrphanAfter`
+// branch, which nobody had mutated either. All four are pinned here.
+//
+// The two the review named are not strawmen, which is why they are pinned to the
+// exact sentence: the unreadable text is the round-8 F-2 CORRECTION (this wait
+// DOES park under a stage timeout, replacing wording that said it could not), and
+// the held-past-bound text is the round-7 F-1 CORRECTION (re-run the pipeline;
+// nothing releases that claim). Left unasserted, either can silently regress to
+// the falsified wording that review already removed.
+func TestPipelineAutoMergeLostClaimReasonsAllReachAParkedSummary(t *testing.T) {
+	ctx := context.Background()
+
+	// The UNREADABLE branch's reason - round-8 F-2's correction.
+	t.Run("unreadable_timestamp", func(t *testing.T) {
+		store, _, rec, spec, run, sourceJobID, now, gateStage := prepareTimedAutoMergeGate(t)
+		seedConsumedAutoMergeClaim(t, store, rec, run, sourceJobID)
+		if err := store.ExecForTest(ctx, `UPDATE job_events SET created_at = ? WHERE job_id = ? AND kind = ?`,
+			"not-a-timestamp", sourceJobID, autoMergeClaimEventKind); err != nil {
+			t.Fatalf("corrupting the claim row's created_at: %v", err)
+		}
+		deps := pipelineStageSettleDeps{
+			store: store, rec: rec, run: run,
+			now: now.Add(2 * time.Hour),
+			autoMerge: &stubPipelineAutoMerger{
+				readiness:   workflow.PipelineAutoMergeReadiness{Ready: true, CurrentHeadSHA: "0123456789abcdef"},
+				mergeResult: workflow.PipelineAutoMergeResult{Merged: true, MergeCommitSHA: "merge-sha"},
+			},
+		}
+		settled, state, summary, needs, _, err := gateStageSettleOutcome(ctx, deps, spec, gateStage, stageRow(t, store, run.ID, "merge"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !settled || state != StageBlocked {
+			t.Fatalf("a gate past its timeout must park: settled=%v state=%q", settled, state)
+		}
+		// BOTH remedies, because carrying both is what round-8 F-2 corrected: the
+		// wait parks under a timeout, and a re-run takes a fresh claim.
+		for _, want := range []string{
+			"carries no readable timestamp",
+			"a stage `timeout` on this gate still parks the wait",
+			"re-running the pipeline takes a fresh claim",
+		} {
+			if !strings.Contains(summary, want) {
+				t.Fatalf("park summary must carry %q: %q", want, summary)
+			}
+			if !slices.ContainsFunc(needs, func(need string) bool { return strings.Contains(need, want) }) {
+				t.Fatalf("park needs must carry %q: %v", want, needs)
+			}
+		}
+	})
+
+	// The INSIDE-THE-WINDOW reason. Not mutated by any review; found by
+	// enumerating the function instead of the findings.
+	t.Run("held_inside_the_window", func(t *testing.T) {
+		store, _, rec, spec, run, sourceJobID, _, gateStage := prepareTimedAutoMergeGate(t)
+		// The gate has been in flight for hours on real time, so it is past its
+		// 1m timeout...
+		gate := stageRow(t, store, run.ID, "merge")
+		realNow := time.Now().UTC()
+		gate.StartedAt = realNow.Add(-2 * time.Hour)
+		if err := store.UpdatePipelineRunStage(ctx, gate); err != nil {
+			t.Fatal(err)
+		}
+		// ...while the claim was taken just now, so it is INSIDE the 15m window.
+		seedConsumedAutoMergeClaim(t, store, rec, run, sourceJobID)
+		if autoMergeClaimOrphanAfter != 15*time.Minute {
+			t.Fatalf("autoMergeClaimOrphanAfter = %s, want 15m0s; this test's clock is written in literals", autoMergeClaimOrphanAfter)
+		}
+		deps := pipelineStageSettleDeps{
+			store: store, rec: rec, run: run,
+			now: realNow.Add(time.Second),
+			autoMerge: &stubPipelineAutoMerger{
+				readiness:   workflow.PipelineAutoMergeReadiness{Ready: true, CurrentHeadSHA: "0123456789abcdef"},
+				mergeResult: workflow.PipelineAutoMergeResult{Merged: true, MergeCommitSHA: "merge-sha"},
+			},
+		}
+		settled, state, summary, _, _, err := gateStageSettleOutcome(ctx, deps, spec, gateStage, stageRow(t, store, run.ID, "merge"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !settled || state != StageBlocked {
+			t.Fatalf("a gate past its timeout must park: settled=%v state=%q", settled, state)
+		}
+		if want := "another scan holds the auto-merge claim for head"; !strings.Contains(summary, want) {
+			t.Fatalf("park summary must carry %q: %q", want, summary)
+		}
+		// The AGE is the whole content of this branch's message - it is what tells
+		// an operator the claim is young rather than orphaned.
+		if !strings.Contains(summary, "(taken ") || !strings.Contains(summary, " ago)") {
+			t.Fatalf("park summary must state how long ago the claim was taken: %q", summary)
+		}
+		// And it must NOT report a fault: inside the window there is nothing wrong.
+		if rows := autoMergeEventCount(t, store, sourceJobID, autoMergeClaimOrphanEventKind); rows != 0 {
+			t.Fatalf("orphan reports inside the window = %d, want 0", rows)
+		}
+	})
+
+	// The HELD-PAST-BOUND reason - round-7 F-1's correction. The mutant the
+	// review used here reinstated exactly the falsehood round 7 removed ("just
+	// wait, it will resolve itself"), so the assertion names the true remedy.
+	t.Run("held_past_the_bound", func(t *testing.T) {
+		store, _, rec, spec, run, sourceJobID, _, gateStage := prepareTimedAutoMergeGate(t)
+		seedConsumedAutoMergeClaim(t, store, rec, run, sourceJobID)
+		// Anchored to REAL time, because the claim's created_at is the store's own
+		// CURRENT_TIMESTAMP and a fixture clock in the past yields a NEGATIVE age
+		// that can never cross the bound (#1783 round-7).
+		realNow := time.Now().UTC()
+		if autoMergeClaimOrphanAfter != 15*time.Minute {
+			t.Fatalf("autoMergeClaimOrphanAfter = %s, want 15m0s; this test's clock is written in literals", autoMergeClaimOrphanAfter)
+		}
+		deps := pipelineStageSettleDeps{
+			store: store, rec: rec, run: run,
+			now: realNow.Add(16 * time.Minute),
+			autoMerge: &stubPipelineAutoMerger{
+				readiness:   workflow.PipelineAutoMergeReadiness{Ready: true, CurrentHeadSHA: "0123456789abcdef"},
+				mergeResult: workflow.PipelineAutoMergeResult{Merged: true, MergeCommitSHA: "merge-sha"},
+			},
+		}
+		settled, state, summary, needs, _, err := gateStageSettleOutcome(ctx, deps, spec, gateStage, stageRow(t, store, run.ID, "merge"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !settled || state != StageBlocked {
+			t.Fatalf("a gate past its timeout must park: settled=%v state=%q", settled, state)
+		}
+		for _, want := range []string{
+			"is still held with no merge and no release",
+			"nothing in the pipeline releases that claim",
+			"re-running the pipeline takes a fresh claim",
+		} {
+			if !strings.Contains(summary, want) {
+				t.Fatalf("park summary must carry %q: %q", want, summary)
+			}
+			if !slices.ContainsFunc(needs, func(need string) bool { return strings.Contains(need, want) }) {
+				t.Fatalf("park needs must carry %q: %v", want, needs)
+			}
+		}
+		// The text must NOT promise the recovery round 7 removed.
+		if strings.Contains(summary, "merges as soon as the claim is released") {
+			t.Fatalf("park summary promises a release nothing performs: %q", summary)
+		}
+		// Past the bound this branch DOES record, once.
+		if rows := autoMergeEventCount(t, store, sourceJobID, autoMergeClaimOrphanEventKind); rows != 1 {
+			t.Fatalf("suspicion rows past the bound = %d, want exactly 1", rows)
+		}
+	})
 }
 
 // F-6's calibration, pinned directly. The gate's StartedAt is stamped when the

--- a/internal/pipeline/auto_merge_test.go
+++ b/internal/pipeline/auto_merge_test.go
@@ -515,10 +515,13 @@ func TestPipelineAutoMergeLostClaimReportsAnOrphanedClaim(t *testing.T) {
 	run = advanceWithAutoMerge(t, store, enqueue, rec, spec, run, now.Add(time.Second),
 		&stubPipelineAutoMerger{readiness: workflow.PipelineAutoMergeReadiness{Waiting: true, CurrentHeadSHA: "0123456789abcdef"}})
 	seedConsumedAutoMergeClaim(t, store, rec, run, sourceJobID)
-	gateStartedAt := stageRow(t, store, run.ID, "merge").StartedAt
-	if gateStartedAt.IsZero() {
-		t.Fatal("premise broken: the gate stage must carry a StartedAt for the wait to be ageable")
-	}
+	// THE CLOCK HERE IS ANCHORED TO REAL TIME, deliberately. The bound compares
+	// deps.now against the claim row's created_at, which the store writes from its
+	// own CURRENT_TIMESTAMP, so a fixture clock set in the past yields a NEGATIVE
+	// age and can never cross the bound. Round 6 rejected this whole design as
+	// "unpinnable because a test cannot backdate created_at" - the obstacle was
+	// the fixture's fixed 2026-07-11 clock, not the design (#1783 round-7).
+	realNow := time.Now().UTC()
 
 	// LITERALS, not autoMergeClaimOrphanAfter arithmetic. Deriving this clock
 	// from the constant it pins made widening the bound to 720h invisible -
@@ -528,7 +531,7 @@ func TestPipelineAutoMergeLostClaimReportsAnOrphanedClaim(t *testing.T) {
 	}
 
 	// Inside the window: waiting, and honest that another scan holds the claim.
-	run = advanceWithAutoMerge(t, store, enqueue, rec, spec, run, gateStartedAt.Add(14*time.Minute), executor)
+	run = advanceWithAutoMerge(t, store, enqueue, rec, spec, run, realNow.Add(14*time.Minute), executor)
 	if gate := stageRow(t, store, run.ID, "merge"); gate.State == StageBlocked {
 		t.Fatalf("a claim held inside the window must not park: %q", gate.Summary)
 	}
@@ -537,7 +540,7 @@ func TestPipelineAutoMergeLostClaimReportsAnOrphanedClaim(t *testing.T) {
 	}
 
 	// Past it: still not parked, but the cause is recorded and stated.
-	run = advanceWithAutoMerge(t, store, enqueue, rec, spec, run, gateStartedAt.Add(16*time.Minute), executor)
+	run = advanceWithAutoMerge(t, store, enqueue, rec, spec, run, realNow.Add(16*time.Minute), executor)
 	gate := stageRow(t, store, run.ID, "merge")
 	if gate.State == StageBlocked {
 		t.Fatalf("an orphaned claim is not a condition this scan observed, so it must not park: %q", gate.Summary)
@@ -548,53 +551,99 @@ func TestPipelineAutoMergeLostClaimReportsAnOrphanedClaim(t *testing.T) {
 	// The EVENT is the durable record on this path, not the summary: a waiting
 	// stage's summary is written only when it settles, so an operator with no
 	// stage `timeout` has the event and nothing else. It has to name the claim.
-	for _, want := range []string{`"head_sha":"0123456789abcdef"`, `"after":"15m0s"`, `"cause":"held_past_bound"`} {
+	for _, want := range []string{`"head_sha":"0123456789abcdef"`, `"after":"15m0s"`, `"cause":"held_past_bound"`, `"claim_taken_at":"`} {
 		if !strings.Contains(autoMergeEventBody(t, store, sourceJobID, autoMergeClaimOrphanEventKind), want) {
 			t.Fatalf("suspicion row must contain %s: %s", want, autoMergeEventBody(t, store, sourceJobID, autoMergeClaimOrphanEventKind))
 		}
 	}
 	// Recorded ONCE per claim, however many scans lose the race.
-	run = advanceWithAutoMerge(t, store, enqueue, rec, spec, run, gateStartedAt.Add(17*time.Minute), executor)
+	run = advanceWithAutoMerge(t, store, enqueue, rec, spec, run, realNow.Add(17*time.Minute), executor)
 	if events := autoMergeEventCount(t, store, sourceJobID, autoMergeClaimOrphanEventKind); events != 1 {
 		t.Fatalf("suspicion rows after a second losing scan = %d, want the same 1", events)
 	}
 }
 
-// N-1's second half: a gate row with NO recorded start time. A resumed run
-// zeroes StartedAt, so the loser cannot age its wait AND pipelineGateTimedOut
-// cannot fire, which means a reason string alone reaches nothing an operator can
-// read. It therefore has to RECORD. Measured: a mutant that dropped the reason
-// here changed nothing observable until the record was added.
-func TestPipelineAutoMergeLostClaimReportsAnUnageableWait(t *testing.T) {
+// F-6's calibration, pinned directly. The gate's StartedAt is stamped when the
+// gate goes in-flight, typically long before readiness, so aging the wait from
+// the GATE made a healthy two-second race on a gate that had waited past the
+// bound write a durable "orphaned" event. Aging from the CLAIM makes a young
+// claim young however old the gate is, and this drives exactly that shape: an
+// hour-old gate, a claim taken seconds ago, no orphan report.
+func TestPipelineAutoMergeLostClaimIgnoresGateAgeWhenTheClaimIsYoung(t *testing.T) {
 	store, enqueue, rec, spec, run, sourceJobID, now := prepareAutoMergeGate(t)
 	settleBoundReviewJob(t, store, stageRow(t, store, run.ID, "review").JobID, "approved", "0123456789abcdef")
 	run = advanceWithAutoMerge(t, store, enqueue, rec, spec, run, now.Add(time.Second),
 		&stubPipelineAutoMerger{readiness: workflow.PipelineAutoMergeReadiness{Waiting: true, CurrentHeadSHA: "0123456789abcdef"}})
-	seedConsumedAutoMergeClaim(t, store, rec, run, sourceJobID)
 
-	// Zero the gate row's start stamp, exactly as a resume does.
+	// The gate has been waiting for hours on the pipeline's clock.
 	gate := stageRow(t, store, run.ID, "merge")
-	gate.StartedAt = time.Time{}
+	realNow := time.Now().UTC()
+	gate.StartedAt = realNow.Add(-6 * time.Hour)
 	if err := store.UpdatePipelineRunStage(context.Background(), gate); err != nil {
 		t.Fatal(err)
 	}
-	if got := stageRow(t, store, run.ID, "merge"); !got.StartedAt.IsZero() {
-		t.Fatalf("premise broken: StartedAt = %v, want zero", got.StartedAt)
-	}
+	// The claim, by contrast, was taken just now.
+	seedConsumedAutoMergeClaim(t, store, rec, run, sourceJobID)
 
 	executor := &stubPipelineAutoMerger{
 		readiness:   workflow.PipelineAutoMergeReadiness{Ready: true, CurrentHeadSHA: "0123456789abcdef"},
 		mergeResult: workflow.PipelineAutoMergeResult{Merged: true, MergeCommitSHA: "merge-sha"},
 	}
-	run = advanceWithAutoMerge(t, store, enqueue, rec, spec, run, now.Add(time.Hour), executor)
+	run = advanceWithAutoMerge(t, store, enqueue, rec, spec, run, realNow.Add(time.Minute), executor)
 	if gate := stageRow(t, store, run.ID, "merge"); gate.State == StageBlocked {
-		t.Fatalf("an unageable wait must not park: %q", gate.Summary)
+		t.Fatalf("a young claim must not park: %q", gate.Summary)
 	}
-	if rows := autoMergeEventCount(t, store, sourceJobID, autoMergeClaimOrphanEventKind); rows != 1 {
-		t.Fatalf("suspicion rows for an unageable wait = %d, want exactly 1", rows)
+	if rows := autoMergeEventCount(t, store, sourceJobID, autoMergeClaimOrphanEventKind); rows != 0 {
+		t.Fatalf("orphan reports for a one-minute-old claim on a six-hour-old gate = %d, want 0", rows)
 	}
-	if body := autoMergeEventBody(t, store, sourceJobID, autoMergeClaimOrphanEventKind); !strings.Contains(body, `"cause":"gate_start_unrecorded"`) {
-		t.Fatalf("suspicion row must name the cause: %s", body)
+}
+
+// THE SUCCESS-PATH CONTROL for the claim clock, and it guards a real hazard.
+// autoMergeClaimTakenAt reads the claim row's created_at and falls back to a
+// "cannot age this" branch when it will not parse. If the store's timestamp
+// format ever changed, that fallback would swallow EVERY claim and every losing
+// scan would report an unreadable timestamp. This pins that the format the store
+// actually writes does parse.
+//
+// The failure side is deliberately NOT tested here and that is stated rather
+// than hidden: no store API can write created_at - every INSERT INTO job_events
+// names only (job_id, kind, message), so the column is always its
+// CURRENT_TIMESTAMP default. A malformed value comes from a corrupted or legacy
+// row, which this package cannot construct. Round 6 manufactured an equivalent
+// state by row surgery and the review called that out (#1783 round-7 F-3); the
+// honest answer is a control on the reachable side plus this note, not a fixture
+// that pins a state the system does not produce.
+func TestPipelineAutoMergeClaimTimestampParsesTheStoreFormat(t *testing.T) {
+	store, _, rec, _, run, sourceJobID, _ := prepareAutoMergeGate(t)
+	claim, err := json.Marshal(map[string]any{
+		"phase": "claim", "pipeline": rec.Name, "run_id": run.ID,
+		"stage_id": "merge", "pull_request": 813, "head_sha": "0123456789abcdef",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	before := time.Now().UTC().Add(-2 * time.Minute)
+	if claimed, err := store.ClaimJobEvent(context.Background(), db.JobEvent{
+		JobID: sourceJobID, Kind: autoMergeClaimEventKind, Message: string(claim),
+	}); err != nil || !claimed {
+		t.Fatalf("seeding the claim: claimed=%v err=%v", claimed, err)
+	}
+
+	at, knowable, err := autoMergeClaimTakenAt(context.Background(), store, sourceJobID, string(claim))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !knowable {
+		t.Fatal("the store's own created_at format must parse, or every losing scan reports an unreadable timestamp")
+	}
+	if at.Before(before) || at.After(time.Now().UTC().Add(2*time.Minute)) {
+		t.Fatalf("claim taken at %v, want a value near now - the parse succeeded but the value is wrong", at)
+	}
+	// And a message that is not this claim must not be mistaken for it.
+	if _, found, err := autoMergeClaimTakenAt(context.Background(), store, sourceJobID, `{"phase":"claim","other":true}`); err != nil {
+		t.Fatal(err)
+	} else if found {
+		t.Fatal("a different claim message must not match this claim's row")
 	}
 }
 

--- a/internal/pipeline/auto_merge_test.go
+++ b/internal/pipeline/auto_merge_test.go
@@ -149,7 +149,7 @@ func prepareAutoMergeGate(t *testing.T) (*db.Store, PipelineStageEnqueuer, db.Pi
 	now := time.Date(2026, 7, 11, 8, 0, 0, 0, time.UTC)
 	run := startTestRun(t, store, rec, spec, enqueue, now)
 	impl := stageRow(t, store, run.ID, "impl")
-	setttle := PipelineStagePRBinding{PullRequest: 813, HeadSHA: "0123456789abcdef", Branch: "feat/813", TaskID: "task-813", LeadAgent: "coder"}
+	setttle := PipelineStagePRBinding{PullRequest: 813, HeadSHA: autoMergeProbeHead, Branch: "feat/813", TaskID: "task-813", LeadAgent: "coder"}
 	settleBoundImplementStageJob(t, store, impl.JobID, "implemented", setttle)
 	run = advanceWithAutoMerge(t, store, enqueue, rec, spec, run, now.Add(time.Second), &stubPipelineAutoMerger{})
 	return store, enqueue, rec, spec, run, impl.JobID, now
@@ -160,7 +160,7 @@ func TestPipelineAutoMergeGateExecutesAfterApprovedReviewAndGreenChecks(t *testi
 	review := stageRow(t, store, run.ID, "review")
 	settleBoundReviewJob(t, store, review.JobID, "approved", "0123456789abcdef")
 	executor := &stubPipelineAutoMerger{
-		readiness:   workflow.PipelineAutoMergeReadiness{Ready: true, CurrentHeadSHA: "0123456789abcdef"},
+		readiness:   workflow.PipelineAutoMergeReadiness{Ready: true, CurrentHeadSHA: autoMergeProbeHead},
 		mergeResult: workflow.PipelineAutoMergeResult{Merged: true, MergeCommitSHA: "merge-sha"},
 	}
 	run = advanceWithAutoMerge(t, store, enqueue, rec, spec, run, now.Add(2*time.Second), executor)
@@ -210,10 +210,10 @@ func TestPipelineAutoMergeGateExecutesAfterApprovedReviewAndGreenChecks(t *testi
 // mutation.
 func TestPipelineAutoMergeWaitingHoldClearsWhenTheConditionClears(t *testing.T) {
 	store, enqueue, rec, spec, run, sourceJobID, now := prepareAutoMergeGate(t)
-	settleBoundReviewJob(t, store, stageRow(t, store, run.ID, "review").JobID, "approved", "0123456789abcdef")
+	settleBoundReviewJob(t, store, stageRow(t, store, run.ID, "review").JobID, "approved", autoMergeProbeHead)
 	const holdReason = "workload-mode change requires reconciliation at head 0123456 against operating-mode note 41"
 	executor := &stubPipelineAutoMerger{
-		readiness:   workflow.PipelineAutoMergeReadiness{Ready: true, CurrentHeadSHA: "0123456789abcdef"},
+		readiness:   workflow.PipelineAutoMergeReadiness{Ready: true, CurrentHeadSHA: autoMergeProbeHead},
 		mergeResult: workflow.PipelineAutoMergeResult{Waiting: true, Reason: holdReason},
 	}
 	run = advanceWithAutoMerge(t, store, enqueue, rec, spec, run, now.Add(2*time.Second), executor)
@@ -278,11 +278,11 @@ func TestPipelineAutoMergeHoldTimeoutCarriesTheReason(t *testing.T) {
 	settleBoundImplementStageJob(t, store, impl.JobID, "implemented",
 		PipelineStagePRBinding{PullRequest: 813, HeadSHA: "0123456789abcdef", Branch: "feat/813", TaskID: "task-813", LeadAgent: "coder"})
 	run = advanceWithAutoMerge(t, store, enqueue, rec, spec, run, now.Add(time.Second), &stubPipelineAutoMerger{})
-	settleBoundReviewJob(t, store, stageRow(t, store, run.ID, "review").JobID, "approved", "0123456789abcdef")
+	settleBoundReviewJob(t, store, stageRow(t, store, run.ID, "review").JobID, "approved", autoMergeProbeHead)
 
 	const holdReason = "workload-mode change requires reconciliation at head 0123456 against operating-mode note 41"
 	executor := &stubPipelineAutoMerger{
-		readiness:   workflow.PipelineAutoMergeReadiness{Ready: true, CurrentHeadSHA: "0123456789abcdef"},
+		readiness:   workflow.PipelineAutoMergeReadiness{Ready: true, CurrentHeadSHA: autoMergeProbeHead},
 		mergeResult: workflow.PipelineAutoMergeResult{Waiting: true, Reason: holdReason},
 	}
 	run = advanceWithAutoMerge(t, store, enqueue, rec, spec, run, now.Add(2*time.Second), executor)
@@ -306,10 +306,10 @@ func TestPipelineAutoMergeHoldTimeoutCarriesTheReason(t *testing.T) {
 // cannot fail on the value it is meant to pin (#1783 round-4 review, F-5).
 func TestPipelineAutoMergeHoldIsBoundedWithoutAGateTimeout(t *testing.T) {
 	store, enqueue, rec, spec, run, sourceJobID, now := prepareAutoMergeGate(t)
-	settleBoundReviewJob(t, store, stageRow(t, store, run.ID, "review").JobID, "approved", "0123456789abcdef")
+	settleBoundReviewJob(t, store, stageRow(t, store, run.ID, "review").JobID, "approved", autoMergeProbeHead)
 	const holdReason = "workload-mode change requires reconciliation at head 0123456 against operating-mode note 41"
 	executor := &stubPipelineAutoMerger{
-		readiness:   workflow.PipelineAutoMergeReadiness{Ready: true, CurrentHeadSHA: "0123456789abcdef"},
+		readiness:   workflow.PipelineAutoMergeReadiness{Ready: true, CurrentHeadSHA: autoMergeProbeHead},
 		mergeResult: workflow.PipelineAutoMergeResult{Waiting: true, Reason: holdReason},
 	}
 	for _, stage := range spec.Stages {
@@ -358,10 +358,10 @@ func TestPipelineAutoMergeHoldIsBoundedWithoutAGateTimeout(t *testing.T) {
 // cause froze at the first reason (#1783 round-4 review, F-2).
 func TestPipelineAutoMergeHoldBudgetResetsForANewEpisode(t *testing.T) {
 	store, enqueue, rec, spec, run, sourceJobID, now := prepareAutoMergeGate(t)
-	settleBoundReviewJob(t, store, stageRow(t, store, run.ID, "review").JobID, "approved", "0123456789abcdef")
+	settleBoundReviewJob(t, store, stageRow(t, store, run.ID, "review").JobID, "approved", autoMergeProbeHead)
 	first := "workload-mode change requires reconciliation at head 0123456 against operating-mode note 41"
 	executor := &stubPipelineAutoMerger{
-		readiness:   workflow.PipelineAutoMergeReadiness{Ready: true, CurrentHeadSHA: "0123456789abcdef"},
+		readiness:   workflow.PipelineAutoMergeReadiness{Ready: true, CurrentHeadSHA: autoMergeProbeHead},
 		mergeResult: workflow.PipelineAutoMergeResult{Waiting: true, Reason: first},
 	}
 	run = advanceWithAutoMerge(t, store, enqueue, rec, spec, run, now.Add(2*time.Second), executor)
@@ -409,7 +409,7 @@ func TestPipelineAutoMergeHoldBudgetResetsForANewEpisode(t *testing.T) {
 // round-3 defect verbatim on the common path (F-1).
 func TestPipelineAutoMergeEvaluateSideHoldIsRecordedAndBounded(t *testing.T) {
 	store, enqueue, rec, spec, run, sourceJobID, now := prepareAutoMergeGate(t)
-	settleBoundReviewJob(t, store, stageRow(t, store, run.ID, "review").JobID, "approved", "0123456789abcdef")
+	settleBoundReviewJob(t, store, stageRow(t, store, run.ID, "review").JobID, "approved", autoMergeProbeHead)
 	const holdReason = "workload-mode change requires reconciliation at head 0123456 against operating-mode note 41"
 	executor := &stubPipelineAutoMerger{
 		readiness: workflow.PipelineAutoMergeReadiness{
@@ -465,10 +465,10 @@ func TestPipelineAutoMergeEvaluateSideHoldIsRecordedAndBounded(t *testing.T) {
 // contradicted by a live measurement.
 func TestPipelineAutoMergeLostClaimNeverParksAResolvedHold(t *testing.T) {
 	store, enqueue, rec, spec, run, sourceJobID, now := prepareAutoMergeGate(t)
-	settleBoundReviewJob(t, store, stageRow(t, store, run.ID, "review").JobID, "approved", "0123456789abcdef")
+	settleBoundReviewJob(t, store, stageRow(t, store, run.ID, "review").JobID, "approved", autoMergeProbeHead)
 	const holdReason = "workload-mode change requires reconciliation at head 0123456 against operating-mode note 41"
 	executor := &stubPipelineAutoMerger{
-		readiness:   workflow.PipelineAutoMergeReadiness{Ready: true, CurrentHeadSHA: "0123456789abcdef"},
+		readiness:   workflow.PipelineAutoMergeReadiness{Ready: true, CurrentHeadSHA: autoMergeProbeHead},
 		mergeResult: workflow.PipelineAutoMergeResult{Waiting: true, Reason: holdReason},
 	}
 	run = advanceWithAutoMerge(t, store, enqueue, rec, spec, run, now.Add(2*time.Second), executor)
@@ -507,14 +507,14 @@ func TestPipelineAutoMergeLostClaimNeverParksAResolvedHold(t *testing.T) {
 // records it, and stays non-terminal.
 func TestPipelineAutoMergeLostClaimReportsAnOrphanedClaim(t *testing.T) {
 	store, enqueue, rec, spec, run, sourceJobID, now := prepareAutoMergeGate(t)
-	settleBoundReviewJob(t, store, stageRow(t, store, run.ID, "review").JobID, "approved", "0123456789abcdef")
+	settleBoundReviewJob(t, store, stageRow(t, store, run.ID, "review").JobID, "approved", autoMergeProbeHead)
 	executor := &stubPipelineAutoMerger{
-		readiness:   workflow.PipelineAutoMergeReadiness{Ready: true, CurrentHeadSHA: "0123456789abcdef"},
+		readiness:   workflow.PipelineAutoMergeReadiness{Ready: true, CurrentHeadSHA: autoMergeProbeHead},
 		mergeResult: workflow.PipelineAutoMergeResult{Merged: true, MergeCommitSHA: "merge-sha"},
 	}
 	// One advance promotes the queued gate row without claiming.
 	run = advanceWithAutoMerge(t, store, enqueue, rec, spec, run, now.Add(time.Second),
-		&stubPipelineAutoMerger{readiness: workflow.PipelineAutoMergeReadiness{Waiting: true, CurrentHeadSHA: "0123456789abcdef"}})
+		&stubPipelineAutoMerger{readiness: workflow.PipelineAutoMergeReadiness{Waiting: true, CurrentHeadSHA: autoMergeProbeHead}})
 	seedConsumedAutoMergeClaim(t, store, rec, run, sourceJobID)
 	// THE CLOCK HERE IS ANCHORED TO REAL TIME, deliberately. The bound compares
 	// deps.now against the claim row's created_at, which the store writes from its
@@ -582,13 +582,13 @@ func TestPipelineAutoMergeLostClaimReportsAnOrphanedClaim(t *testing.T) {
 func TestPipelineAutoMergeLostClaimTreatsAReleasedClaimAsANormalRace(t *testing.T) {
 	ctx := context.Background()
 	store, enqueue, rec, spec, run, sourceJobID, now := prepareAutoMergeGate(t)
-	settleBoundReviewJob(t, store, stageRow(t, store, run.ID, "review").JobID, "approved", "0123456789abcdef")
+	settleBoundReviewJob(t, store, stageRow(t, store, run.ID, "review").JobID, "approved", autoMergeProbeHead)
 	run = advanceWithAutoMerge(t, store, enqueue, rec, spec, run, now.Add(time.Second),
-		&stubPipelineAutoMerger{readiness: workflow.PipelineAutoMergeReadiness{Waiting: true, CurrentHeadSHA: "0123456789abcdef"}})
+		&stubPipelineAutoMerger{readiness: workflow.PipelineAutoMergeReadiness{Waiting: true, CurrentHeadSHA: autoMergeProbeHead}})
 
 	claim, err := json.Marshal(map[string]any{
 		"phase": "claim", "pipeline": rec.Name, "run_id": run.ID,
-		"stage_id": "merge", "pull_request": 813, "head_sha": "0123456789abcdef",
+		"stage_id": "merge", "pull_request": 813, "head_sha": autoMergeProbeHead,
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -609,7 +609,7 @@ func TestPipelineAutoMergeLostClaimTreatsAReleasedClaimAsANormalRace(t *testing.
 		// Far past every bound, so a false report cannot hide behind a young claim.
 		now: time.Now().UTC().Add(48 * time.Hour),
 		autoMerge: &stubPipelineAutoMerger{
-			readiness:   workflow.PipelineAutoMergeReadiness{Ready: true, CurrentHeadSHA: "0123456789abcdef"},
+			readiness:   workflow.PipelineAutoMergeReadiness{Ready: true, CurrentHeadSHA: autoMergeProbeHead},
 			mergeResult: workflow.PipelineAutoMergeResult{Merged: true, MergeCommitSHA: "merge-sha"},
 		},
 		// ...and the winner releases it in the window before this scan reads it.
@@ -653,11 +653,11 @@ func prepareTimedAutoMergeGate(t *testing.T) (*db.Store, PipelineStageEnqueuer, 
 	run := startTestRun(t, store, rec, spec, enqueue, now)
 	impl := stageRow(t, store, run.ID, "impl")
 	settleBoundImplementStageJob(t, store, impl.JobID, "implemented",
-		PipelineStagePRBinding{PullRequest: 813, HeadSHA: "0123456789abcdef", Branch: "feat/813", TaskID: "task-813", LeadAgent: "coder"})
+		PipelineStagePRBinding{PullRequest: 813, HeadSHA: autoMergeProbeHead, Branch: "feat/813", TaskID: "task-813", LeadAgent: "coder"})
 	run = advanceWithAutoMerge(t, store, enqueue, rec, spec, run, now.Add(time.Second), &stubPipelineAutoMerger{})
-	settleBoundReviewJob(t, store, stageRow(t, store, run.ID, "review").JobID, "approved", "0123456789abcdef")
+	settleBoundReviewJob(t, store, stageRow(t, store, run.ID, "review").JobID, "approved", autoMergeProbeHead)
 	run = advanceWithAutoMerge(t, store, enqueue, rec, spec, run, now.Add(2*time.Second),
-		&stubPipelineAutoMerger{readiness: workflow.PipelineAutoMergeReadiness{Waiting: true, CurrentHeadSHA: "0123456789abcdef"}})
+		&stubPipelineAutoMerger{readiness: workflow.PipelineAutoMergeReadiness{Waiting: true, CurrentHeadSHA: autoMergeProbeHead}})
 
 	var gateStage Stage
 	for _, candidate := range spec.Stages {
@@ -698,7 +698,7 @@ func TestPipelineAutoMergeLostClaimReleasedReasonReachesAParkedSummary(t *testin
 
 	claim, err := json.Marshal(map[string]any{
 		"phase": "claim", "pipeline": rec.Name, "run_id": run.ID,
-		"stage_id": "merge", "pull_request": 813, "head_sha": "0123456789abcdef",
+		"stage_id": "merge", "pull_request": 813, "head_sha": autoMergeProbeHead,
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -710,7 +710,7 @@ func TestPipelineAutoMergeLostClaimReleasedReasonReachesAParkedSummary(t *testin
 		// Past the gate's 1m timeout, so the park path runs and carries the cause.
 		now: now.Add(2 * time.Hour),
 		autoMerge: &stubPipelineAutoMerger{
-			readiness:   workflow.PipelineAutoMergeReadiness{Ready: true, CurrentHeadSHA: "0123456789abcdef"},
+			readiness:   workflow.PipelineAutoMergeReadiness{Ready: true, CurrentHeadSHA: autoMergeProbeHead},
 			mergeResult: workflow.PipelineAutoMergeResult{Merged: true, MergeCommitSHA: "merge-sha"},
 		},
 		afterLostClaim: func() {
@@ -735,6 +735,7 @@ func TestPipelineAutoMergeLostClaimReleasedReasonReachesAParkedSummary(t *testin
 	}
 	// The exact operator-facing sentence, not a paraphrase: this is the string a
 	// human reads off a parked run, and mutating it must fail a test.
+	assertParkWrapper(t, summary, "1h59m59s")
 	const want = "was released while this scan was reading it, so the next scan takes it"
 	if !strings.Contains(summary, want) {
 		t.Fatalf("park summary must carry the released-claim cause %q: %q", want, summary)
@@ -755,10 +756,38 @@ func TestPipelineAutoMergeLostClaimReleasedReasonReachesAParkedSummary(t *testin
 	}
 }
 
-// autoMergeProbeHead is the head every auto-merge fixture binds to. Named rather
-// than repeated as a literal so an assertion about its RENDERING cannot drift
-// from the value the fixture injects (#1783 round-12 F-1, survivor 3).
+// autoMergeProbeHead is the head the auto-merge FIXTURE PATH binds to:
+// prepareAutoMergeGate, prepareTimedAutoMergeGate, seedConsumedAutoMergeClaim and
+// the four reason tests all read this one constant, so an assertion about the
+// head's RENDERING moves with the value being injected instead of merely
+// matching a second copy of it (#1783 round-12 F-1, survivor 3).
+//
+// THE SCOPE IS EXACTLY THAT, and the first version of this comment overclaimed
+// it. It said no assertion could drift from the fixture while three injection
+// sites in prepareTimedAutoMergeGate were still literals - the assertion and the
+// injection were two independent strings that happened to be equal. DEMONSTRATED
+// rather than asserted this time: changing this constant leaves the four reason
+// tests GREEN, because everything they touch moves together. 33 literal heads
+// remain in this file, in older tests with their own fixtures and their own
+// assertions, and changing this constant DOES fail those - they are outside this
+// constant's reach and this comment does not claim otherwise.
 const autoMergeProbeHead = "0123456789abcdef"
+
+// assertParkWrapper pins the THREE values autoMergeGateWaitingWithReason
+// interpolates around every reason: the gate name, the rendered wait, and the
+// wait description. Round-13 F-2: this PR introduced that wrapper and nothing in
+// the package asserted any of them - `grep "timed out after"` across the test
+// files returned nothing - so the same operator-facing string these tests check
+// carried three unpinned values. `waited` is a rendered duration in a park
+// summary, which is exactly the category round-10 F-6 and round-12 F-1 put in
+// scope, and the fixed fixture clock makes all three deterministic.
+func assertParkWrapper(t *testing.T, summary, waited string) {
+	t.Helper()
+	want := "gate pr_merged timed out after " + waited + " waiting for auto-merge readiness for PR #813 merged: "
+	if !strings.HasPrefix(summary, want) {
+		t.Fatalf("park summary must open with the wrapper %q: %q", want, summary)
+	}
+}
 
 // parseParkedClaimAge pulls the rendered duration out of a parked summary and
 // FAILS if it is not there or does not parse. It exists so the age can be
@@ -816,7 +845,7 @@ func TestPipelineAutoMergeLostClaimReasonsAllReachAParkedSummary(t *testing.T) {
 			store: store, rec: rec, run: run,
 			now: now.Add(2 * time.Hour),
 			autoMerge: &stubPipelineAutoMerger{
-				readiness:   workflow.PipelineAutoMergeReadiness{Ready: true, CurrentHeadSHA: "0123456789abcdef"},
+				readiness:   workflow.PipelineAutoMergeReadiness{Ready: true, CurrentHeadSHA: autoMergeProbeHead},
 				mergeResult: workflow.PipelineAutoMergeResult{Merged: true, MergeCommitSHA: "merge-sha"},
 			},
 		}
@@ -829,6 +858,7 @@ func TestPipelineAutoMergeLostClaimReasonsAllReachAParkedSummary(t *testing.T) {
 		}
 		// BOTH remedies, because carrying both is what round-8 F-2 corrected: the
 		// wait parks under a timeout, and a re-run takes a fresh claim.
+		assertParkWrapper(t, summary, "1h59m59s")
 		for _, want := range []string{
 			"carries no readable timestamp",
 			"a stage `timeout` on this gate still parks the wait",
@@ -866,7 +896,7 @@ func TestPipelineAutoMergeLostClaimReasonsAllReachAParkedSummary(t *testing.T) {
 		// created_at against a fixed deps.now makes held exactly 90s, so the
 		// rendered string is deterministic and every corruption of the value -
 		// negation, truncation granularity, added words - changes it.
-		settleAt := now.Add(2 * time.Hour)
+		settleAt := now.Add(2*time.Hour + 750*time.Millisecond)
 		if err := store.ExecForTest(ctx, `UPDATE job_events SET created_at = ? WHERE job_id = ? AND kind = ?`,
 			settleAt.Add(-90*time.Second).Format(time.DateTime), sourceJobID, autoMergeClaimEventKind); err != nil {
 			t.Fatalf("injecting a known claim age: %v", err)
@@ -890,6 +920,7 @@ func TestPipelineAutoMergeLostClaimReasonsAllReachAParkedSummary(t *testing.T) {
 		// rendered SHORT (bound by the following punctuation, since sha[:7] is a
 		// prefix of the raw head and a bare substring cannot tell them apart) and
 		// the age rendered from the injected 90 seconds.
+		assertParkWrapper(t, summary, "1h59m59.75s")
 		if want := "another scan holds the auto-merge claim for head " + shortPipelineSHA(autoMergeProbeHead) + " (taken 1m30s ago)"; !strings.Contains(summary, want) {
 			t.Fatalf("park summary must render exactly %q: %q", want, summary)
 		}
@@ -917,7 +948,7 @@ func TestPipelineAutoMergeLostClaimReasonsAllReachAParkedSummary(t *testing.T) {
 		// created_at itself and a past clock yielded a NEGATIVE age; pinning the
 		// column removes that obstacle rather than working around it, and makes
 		// the rendered duration deterministic (#1783 round-12 F-1).
-		settleAt := now.Add(2 * time.Hour)
+		settleAt := now.Add(2*time.Hour + 750*time.Millisecond)
 		if err := store.ExecForTest(ctx, `UPDATE job_events SET created_at = ? WHERE job_id = ? AND kind = ?`,
 			settleAt.Add(-(16*time.Minute + 30*time.Second)).Format(time.DateTime), sourceJobID, autoMergeClaimEventKind); err != nil {
 			t.Fatalf("injecting a known claim age: %v", err)
@@ -937,6 +968,7 @@ func TestPipelineAutoMergeLostClaimReasonsAllReachAParkedSummary(t *testing.T) {
 		if !settled || state != StageBlocked {
 			t.Fatalf("a gate past its timeout must park: settled=%v state=%q", settled, state)
 		}
+		assertParkWrapper(t, summary, "1h59m59.75s")
 		for _, want := range []string{
 			"is still held with no merge and no release",
 			"nothing in the pipeline releases that claim",
@@ -980,9 +1012,9 @@ func TestPipelineAutoMergeLostClaimReasonsAllReachAParkedSummary(t *testing.T) {
 // hour-old gate, a claim taken seconds ago, no orphan report.
 func TestPipelineAutoMergeLostClaimIgnoresGateAgeWhenTheClaimIsYoung(t *testing.T) {
 	store, enqueue, rec, spec, run, sourceJobID, now := prepareAutoMergeGate(t)
-	settleBoundReviewJob(t, store, stageRow(t, store, run.ID, "review").JobID, "approved", "0123456789abcdef")
+	settleBoundReviewJob(t, store, stageRow(t, store, run.ID, "review").JobID, "approved", autoMergeProbeHead)
 	run = advanceWithAutoMerge(t, store, enqueue, rec, spec, run, now.Add(time.Second),
-		&stubPipelineAutoMerger{readiness: workflow.PipelineAutoMergeReadiness{Waiting: true, CurrentHeadSHA: "0123456789abcdef"}})
+		&stubPipelineAutoMerger{readiness: workflow.PipelineAutoMergeReadiness{Waiting: true, CurrentHeadSHA: autoMergeProbeHead}})
 
 	// The gate has been waiting for hours on the pipeline's clock.
 	gate := stageRow(t, store, run.ID, "merge")
@@ -995,7 +1027,7 @@ func TestPipelineAutoMergeLostClaimIgnoresGateAgeWhenTheClaimIsYoung(t *testing.
 	seedConsumedAutoMergeClaim(t, store, rec, run, sourceJobID)
 
 	executor := &stubPipelineAutoMerger{
-		readiness:   workflow.PipelineAutoMergeReadiness{Ready: true, CurrentHeadSHA: "0123456789abcdef"},
+		readiness:   workflow.PipelineAutoMergeReadiness{Ready: true, CurrentHeadSHA: autoMergeProbeHead},
 		mergeResult: workflow.PipelineAutoMergeResult{Merged: true, MergeCommitSHA: "merge-sha"},
 	}
 	run = advanceWithAutoMerge(t, store, enqueue, rec, spec, run, realNow.Add(time.Minute), executor)
@@ -1024,13 +1056,13 @@ func TestPipelineAutoMergeLostClaimIgnoresGateAgeWhenTheClaimIsYoung(t *testing.
 func TestPipelineAutoMergeLostClaimReportsAnUnreadableClaimTimestamp(t *testing.T) {
 	ctx := context.Background()
 	store, enqueue, rec, spec, run, sourceJobID, now := prepareAutoMergeGate(t)
-	settleBoundReviewJob(t, store, stageRow(t, store, run.ID, "review").JobID, "approved", "0123456789abcdef")
+	settleBoundReviewJob(t, store, stageRow(t, store, run.ID, "review").JobID, "approved", autoMergeProbeHead)
 	executor := &stubPipelineAutoMerger{
-		readiness:   workflow.PipelineAutoMergeReadiness{Ready: true, CurrentHeadSHA: "0123456789abcdef"},
+		readiness:   workflow.PipelineAutoMergeReadiness{Ready: true, CurrentHeadSHA: autoMergeProbeHead},
 		mergeResult: workflow.PipelineAutoMergeResult{Merged: true, MergeCommitSHA: "merge-sha"},
 	}
 	run = advanceWithAutoMerge(t, store, enqueue, rec, spec, run, now.Add(time.Second),
-		&stubPipelineAutoMerger{readiness: workflow.PipelineAutoMergeReadiness{Waiting: true, CurrentHeadSHA: "0123456789abcdef"}})
+		&stubPipelineAutoMerger{readiness: workflow.PipelineAutoMergeReadiness{Waiting: true, CurrentHeadSHA: autoMergeProbeHead}})
 	// The claim is held, so the scan below LOSES it.
 	seedConsumedAutoMergeClaim(t, store, rec, run, sourceJobID)
 
@@ -1082,7 +1114,7 @@ func TestPipelineAutoMergeClaimTimestampParsesTheStoreFormat(t *testing.T) {
 	store, _, rec, _, run, sourceJobID, _ := prepareAutoMergeGate(t)
 	claim, err := json.Marshal(map[string]any{
 		"phase": "claim", "pipeline": rec.Name, "run_id": run.ID,
-		"stage_id": "merge", "pull_request": 813, "head_sha": "0123456789abcdef",
+		"stage_id": "merge", "pull_request": 813, "head_sha": autoMergeProbeHead,
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -1119,7 +1151,7 @@ func TestPipelineAutoMergeClaimTimestampParsesTheStoreFormat(t *testing.T) {
 // budget and deferred the bound indefinitely.
 func TestPipelineAutoMergeHoldBudgetSurvivesVolatileCauseText(t *testing.T) {
 	store, enqueue, rec, spec, run, sourceJobID, now := prepareAutoMergeGate(t)
-	settleBoundReviewJob(t, store, stageRow(t, store, run.ID, "review").JobID, "approved", "0123456789abcdef")
+	settleBoundReviewJob(t, store, stageRow(t, store, run.ID, "review").JobID, "approved", autoMergeProbeHead)
 	const stableKey = "head=0123456789abcdef decision-note=41 mode=STEADY"
 	base := "workload-mode change requires reconciliation at head 0123456 against operating-mode note 41"
 	executor := &stubPipelineAutoMerger{
@@ -1163,7 +1195,7 @@ func seedConsumedAutoMergeClaim(t *testing.T, store *db.Store, rec db.Pipeline, 
 	t.Helper()
 	claim, err := json.Marshal(map[string]any{
 		"phase": "claim", "pipeline": rec.Name, "run_id": run.ID,
-		"stage_id": "merge", "pull_request": 813, "head_sha": "0123456789abcdef",
+		"stage_id": "merge", "pull_request": 813, "head_sha": autoMergeProbeHead,
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -1212,7 +1244,7 @@ func autoMergeEventCount(t *testing.T, store *db.Store, sourceJobID, kind string
 // check-then-insert race actually produces).
 func TestPipelineAutoMergeHoldAnchorsOnTheEarliestDuplicate(t *testing.T) {
 	store, enqueue, rec, spec, run, sourceJobID, now := prepareAutoMergeGate(t)
-	settleBoundReviewJob(t, store, stageRow(t, store, run.ID, "review").JobID, "approved", "0123456789abcdef")
+	settleBoundReviewJob(t, store, stageRow(t, store, run.ID, "review").JobID, "approved", autoMergeProbeHead)
 	const holdReason = "workload-mode change requires reconciliation at head 0123456 against operating-mode note 41"
 	executor := &stubPipelineAutoMerger{
 		readiness: workflow.PipelineAutoMergeReadiness{
@@ -1229,7 +1261,7 @@ func TestPipelineAutoMergeHoldAnchorsOnTheEarliestDuplicate(t *testing.T) {
 	// The racing scan's row: same head and cause, a LATER held_at.
 	duplicate, marshalErr := json.Marshal(map[string]any{
 		"phase": "held", "pipeline": rec.Name, "run_id": run.ID,
-		"stage_id": "merge", "pull_request": 813, "head_sha": "0123456789abcdef",
+		"stage_id": "merge", "pull_request": 813, "head_sha": autoMergeProbeHead,
 		"reason": holdReason, "episode_key": "head=0123456789abcdef",
 		"held_at": first.at.Add(23 * time.Hour).Format(time.RFC3339Nano),
 	})
@@ -1269,15 +1301,15 @@ func TestPipelineAutoMergeHoldAnchorsOnTheEarliestDuplicate(t *testing.T) {
 // this the correct order survives its own mutant.
 func TestPipelineAutoMergeHoldIsRecordedEvenWhenTheReleaseFails(t *testing.T) {
 	store, enqueue, rec, spec, run, sourceJobID, now := prepareAutoMergeGate(t)
-	settleBoundReviewJob(t, store, stageRow(t, store, run.ID, "review").JobID, "approved", "0123456789abcdef")
+	settleBoundReviewJob(t, store, stageRow(t, store, run.ID, "review").JobID, "approved", autoMergeProbeHead)
 	const holdReason = "workload-mode change requires reconciliation at head 0123456 against operating-mode note 41"
 	// One advance moves the gate row from queued to running; the settle path
 	// promotes a queued row and returns before it can claim.
-	waiting := &stubPipelineAutoMerger{readiness: workflow.PipelineAutoMergeReadiness{Waiting: true, CurrentHeadSHA: "0123456789abcdef"}}
+	waiting := &stubPipelineAutoMerger{readiness: workflow.PipelineAutoMergeReadiness{Waiting: true, CurrentHeadSHA: autoMergeProbeHead}}
 	run = advanceWithAutoMerge(t, store, enqueue, rec, spec, run, now.Add(time.Second), waiting)
 
 	executor := &stubPipelineAutoMerger{
-		readiness:   workflow.PipelineAutoMergeReadiness{Ready: true, CurrentHeadSHA: "0123456789abcdef"},
+		readiness:   workflow.PipelineAutoMergeReadiness{Ready: true, CurrentHeadSHA: autoMergeProbeHead},
 		mergeResult: workflow.PipelineAutoMergeResult{Waiting: true, Reason: holdReason},
 	}
 	var gateStage Stage
@@ -1320,7 +1352,7 @@ func TestPipelineFanOutReviewNeverSettlesAsStageSuccess(t *testing.T) {
 	settleBoundReviewJob(t, store, review.JobID, "approved", "0123456789abcdef")
 	declareBoundReviewDelegations(t, store, review.JobID)
 	executor := &stubPipelineAutoMerger{
-		readiness:   workflow.PipelineAutoMergeReadiness{Ready: true, CurrentHeadSHA: "0123456789abcdef"},
+		readiness:   workflow.PipelineAutoMergeReadiness{Ready: true, CurrentHeadSHA: autoMergeProbeHead},
 		mergeResult: workflow.PipelineAutoMergeResult{Merged: true, MergeCommitSHA: "merge-sha"},
 	}
 	run = advanceWithAutoMerge(t, store, enqueue, rec, spec, run, now.Add(2*time.Second), executor)
@@ -1360,7 +1392,7 @@ func TestPipelineAutoMergeGateRefusesFanOutReview(t *testing.T) {
 	declareBoundReviewDelegations(t, store, review.JobID)
 
 	executor := &stubPipelineAutoMerger{
-		readiness:   workflow.PipelineAutoMergeReadiness{Ready: true, CurrentHeadSHA: "0123456789abcdef"},
+		readiness:   workflow.PipelineAutoMergeReadiness{Ready: true, CurrentHeadSHA: autoMergeProbeHead},
 		mergeResult: workflow.PipelineAutoMergeResult{Merged: true, MergeCommitSHA: "merge-sha"},
 	}
 	run = advanceWithAutoMerge(t, store, enqueue, rec, spec, run, now.Add(2*time.Second), executor)
@@ -1444,8 +1476,8 @@ func TestPipelineAutoMergeGateRequiresEverySourceBoundReview(t *testing.T) {
 
 func TestPipelineAutoMergeClaimAllowsExactlyOneRacingMerge(t *testing.T) {
 	store, enqueue, rec, spec, run, sourceJobID, now := prepareAutoMergeGate(t)
-	settleBoundReviewJob(t, store, stageRow(t, store, run.ID, "review").JobID, "approved", "0123456789abcdef")
-	waiting := &stubPipelineAutoMerger{readiness: workflow.PipelineAutoMergeReadiness{Waiting: true, CurrentHeadSHA: "0123456789abcdef"}}
+	settleBoundReviewJob(t, store, stageRow(t, store, run.ID, "review").JobID, "approved", autoMergeProbeHead)
+	waiting := &stubPipelineAutoMerger{readiness: workflow.PipelineAutoMergeReadiness{Waiting: true, CurrentHeadSHA: autoMergeProbeHead}}
 	run = advanceWithAutoMerge(t, store, enqueue, rec, spec, run, now.Add(2*time.Second), waiting)
 	gateRow := stageRow(t, store, run.ID, "merge")
 	var gateStage Stage

--- a/internal/pipeline/auto_merge_test.go
+++ b/internal/pipeline/auto_merge_test.go
@@ -198,51 +198,149 @@ func TestPipelineAutoMergeGateExecutesAfterApprovedReviewAndGreenChecks(t *testi
 	}
 }
 
-// A TRANSIENT merge-boundary refusal must keep the gate waiting. The fold turned
-// any !Merged into "retry stopped", so a workload-mode reconciliation hold that
-// Evaluate reports as Waiting terminally blocked the run once it appeared in the
-// Evaluate->Merge window, and the at-most-once claim was already consumed
-// (#1783 review, F4). The claim is why the retry is safe: the next scan cannot
-// call Merge again.
-func TestPipelineAutoMergeWaitingResultKeepsTheGateRetryable(t *testing.T) {
+// A TRANSIENT merge-boundary refusal must keep the gate waiting AND stay
+// mergeable once the condition clears. My first version of this test asserted
+// the opposite and called it safety: it required mergeReqs to stay at 1 on
+// rescan, which is exactly the defect the round-3 review measured - the
+// at-most-once claim is keyed on run/stage/PR/head, so a consumed claim meant
+// Merge was NEVER re-attempted and the reconciliation row landing merged
+// nothing, forever, with the reason discarded. The claim is now RELEASED on a
+// Waiting return, which is sound because that return happens before any GitHub
+// mutation.
+func TestPipelineAutoMergeWaitingHoldClearsWhenTheConditionClears(t *testing.T) {
 	store, enqueue, rec, spec, run, sourceJobID, now := prepareAutoMergeGate(t)
 	settleBoundReviewJob(t, store, stageRow(t, store, run.ID, "review").JobID, "approved", "0123456789abcdef")
+	const holdReason = "workload-mode change requires reconciliation at head 0123456 against operating-mode note 41"
 	executor := &stubPipelineAutoMerger{
-		readiness: workflow.PipelineAutoMergeReadiness{Ready: true, CurrentHeadSHA: "0123456789abcdef"},
-		mergeResult: workflow.PipelineAutoMergeResult{
-			Waiting: true,
-			Reason:  "workload-mode change requires reconciliation at head 0123456 against operating-mode note 41",
-		},
+		readiness:   workflow.PipelineAutoMergeReadiness{Ready: true, CurrentHeadSHA: "0123456789abcdef"},
+		mergeResult: workflow.PipelineAutoMergeResult{Waiting: true, Reason: holdReason},
 	}
 	run = advanceWithAutoMerge(t, store, enqueue, rec, spec, run, now.Add(2*time.Second), executor)
 
 	if len(executor.mergeReqs) != 1 {
-		t.Fatalf("merge calls = %d, want exactly one attempt", len(executor.mergeReqs))
-	}
-	gate := stageRow(t, store, run.ID, "merge")
-	if gate.State == StageBlocked || gate.State == StageFailed {
-		t.Fatalf("a transient hold ended the run: gate=%+v run=%+v", gate, run)
-	}
-	if run.State == RunBlocked || run.State == RunFailed {
-		t.Fatalf("run = %q, want it still open after a transient hold", run.State)
-	}
-
-	// The consumed claim keeps the retry at-most-once: a later scan must not
-	// call Merge again, and the gate must still not be terminal.
-	run = advanceWithAutoMerge(t, store, enqueue, rec, spec, run, now.Add(3*time.Second), executor)
-	if len(executor.mergeReqs) != 1 {
-		t.Fatalf("rescan merge calls = %d, want the claim to hold at one", len(executor.mergeReqs))
+		t.Fatalf("merge calls = %d, want one attempt", len(executor.mergeReqs))
 	}
 	if gate := stageRow(t, store, run.ID, "merge"); gate.State == StageBlocked || gate.State == StageFailed {
-		t.Fatalf("rescan ended the run: gate=%+v", gate)
+		t.Fatalf("a transient hold ended the run: gate=%+v run=%+v", gate, run)
 	}
+	// The hold is RECORDED, not silent: the pre-change terminal block carried the
+	// reason and a bare wait threw it away.
 	events, err := store.ListJobEvents(context.Background(), sourceJobID)
 	if err != nil {
 		t.Fatalf("ListJobEvents(source): %v", err)
 	}
+	held := ""
 	for _, event := range events {
-		if event.Kind == "pipeline_auto_merge_confirmed" {
+		switch event.Kind {
+		case "pipeline_auto_merge_held":
+			held = event.Message
+		case "pipeline_auto_merge_confirmed":
 			t.Fatalf("a held merge recorded a confirmation: %+v", event)
+		}
+	}
+	if !strings.Contains(held, holdReason) {
+		t.Fatalf("the hold reason was not recorded: %q", held)
+	}
+
+	// The condition clears. THIS is the property that matters: the next scan must
+	// re-attempt and merge.
+	executor.mergeResult = workflow.PipelineAutoMergeResult{Merged: true, MergeCommitSHA: "merge-after-hold"}
+	run = advanceWithAutoMerge(t, store, enqueue, rec, spec, run, now.Add(3*time.Second), executor)
+	if len(executor.mergeReqs) != 2 {
+		t.Fatalf("merge calls = %d after the hold cleared, want a second attempt", len(executor.mergeReqs))
+	}
+	if run.State != RunSucceeded || stageRow(t, store, run.ID, "merge").State != StageSucceeded {
+		t.Fatalf("run/gate = %+v / %+v, want succeeded once the hold cleared", run, stageRow(t, store, run.ID, "merge"))
+	}
+
+	// At-most-once still holds AFTER a real merge: the confirmed claim is not
+	// released, so a later scan must not merge again.
+	run = advanceWithAutoMerge(t, store, enqueue, rec, spec, run, now.Add(4*time.Second), executor)
+	if len(executor.mergeReqs) != 2 {
+		t.Fatalf("post-merge rescan merge calls = %d, want the claim to hold at two", len(executor.mergeReqs))
+	}
+}
+
+// A hold that outlives the gate's timeout must park with its CAUSE, not only
+// with what it was waiting for. The round-3 review measured an empty summary
+// here, and a spec that sets no timeout waits forever - documented pipeline
+// policy for gate stages, but only defensible while the hold is retryable and
+// recorded, which the test above pins.
+func TestPipelineAutoMergeHoldTimeoutCarriesTheReason(t *testing.T) {
+	timedSpec := strings.Replace(pipelineAutoMergeSpec, "    merge: auto\n", "    merge: auto\n    timeout: 1m\n", 1)
+	store := pipelineAdvanceStore(t)
+	rec, spec := newTestPipeline(t, store, "auto-merge", timedSpec)
+	enqueue := testStageEnqueuer(store)
+	now := time.Date(2026, 7, 11, 8, 0, 0, 0, time.UTC)
+	run := startTestRun(t, store, rec, spec, enqueue, now)
+	impl := stageRow(t, store, run.ID, "impl")
+	settleBoundImplementStageJob(t, store, impl.JobID, "implemented",
+		PipelineStagePRBinding{PullRequest: 813, HeadSHA: "0123456789abcdef", Branch: "feat/813", TaskID: "task-813", LeadAgent: "coder"})
+	run = advanceWithAutoMerge(t, store, enqueue, rec, spec, run, now.Add(time.Second), &stubPipelineAutoMerger{})
+	settleBoundReviewJob(t, store, stageRow(t, store, run.ID, "review").JobID, "approved", "0123456789abcdef")
+
+	const holdReason = "workload-mode change requires reconciliation at head 0123456 against operating-mode note 41"
+	executor := &stubPipelineAutoMerger{
+		readiness:   workflow.PipelineAutoMergeReadiness{Ready: true, CurrentHeadSHA: "0123456789abcdef"},
+		mergeResult: workflow.PipelineAutoMergeResult{Waiting: true, Reason: holdReason},
+	}
+	run = advanceWithAutoMerge(t, store, enqueue, rec, spec, run, now.Add(2*time.Second), executor)
+	run = advanceWithAutoMerge(t, store, enqueue, rec, spec, run, now.Add(2*time.Hour), executor)
+
+	gate := stageRow(t, store, run.ID, "merge")
+	if gate.State != StageBlocked {
+		t.Fatalf("gate = %q after the timeout, want blocked", gate.State)
+	}
+	if !strings.Contains(gate.Summary, holdReason) {
+		t.Fatalf("park summary must carry the cause: %q", gate.Summary)
+	}
+}
+
+// With NO gate timeout the reviewer measured this parked silently at now+72h.
+// The hold now carries its own bound, measured from the first recorded hold, and
+// parks WITH the cause. A test that only exercises the happy reconcile is not a
+// test of this (#1783 round-3 review, F-A).
+func TestPipelineAutoMergeHoldIsBoundedWithoutAGateTimeout(t *testing.T) {
+	store, enqueue, rec, spec, run, sourceJobID, now := prepareAutoMergeGate(t)
+	settleBoundReviewJob(t, store, stageRow(t, store, run.ID, "review").JobID, "approved", "0123456789abcdef")
+	const holdReason = "workload-mode change requires reconciliation at head 0123456 against operating-mode note 41"
+	executor := &stubPipelineAutoMerger{
+		readiness:   workflow.PipelineAutoMergeReadiness{Ready: true, CurrentHeadSHA: "0123456789abcdef"},
+		mergeResult: workflow.PipelineAutoMergeResult{Waiting: true, Reason: holdReason},
+	}
+	// The spec's merge stage sets no timeout, so only the hold's own bound applies.
+	for _, stage := range spec.Stages {
+		if stage.ID == "merge" && strings.TrimSpace(stage.Timeout) != "" {
+			t.Fatalf("fixture must have no gate timeout, got %q", stage.Timeout)
+		}
+	}
+
+	run = advanceWithAutoMerge(t, store, enqueue, rec, spec, run, now.Add(2*time.Second), executor)
+	if gate := stageRow(t, store, run.ID, "merge"); gate.State == StageBlocked {
+		t.Fatalf("the first hold must wait, not park: %+v", gate)
+	}
+	// Retries keep happening inside the bound.
+	run = advanceWithAutoMerge(t, store, enqueue, rec, spec, run, now.Add(time.Hour), executor)
+	if len(executor.mergeReqs) != 2 {
+		t.Fatalf("merge attempts inside the bound = %d, want 2", len(executor.mergeReqs))
+	}
+	if gate := stageRow(t, store, run.ID, "merge"); gate.State == StageBlocked {
+		t.Fatalf("a hold inside its bound must not park: %+v", gate)
+	}
+
+	// Past the bound it parks, carrying the cause.
+	held, err := firstAutoMergeHoldAt(context.Background(), store, sourceJobID)
+	if err != nil || held.IsZero() {
+		t.Fatalf("first hold time = %v err=%v, want a recorded hold", held, err)
+	}
+	run = advanceWithAutoMerge(t, store, enqueue, rec, spec, run, held.Add(autoMergeHoldMaxWait+time.Minute), executor)
+	gate := stageRow(t, store, run.ID, "merge")
+	if gate.State != StageBlocked {
+		t.Fatalf("gate = %q past the hold bound, want blocked", gate.State)
+	}
+	for _, want := range []string{holdReason, "no gate timeout is set", autoMergeHoldMaxWait.String()} {
+		if !strings.Contains(gate.Summary, want) {
+			t.Fatalf("park summary must contain %q: %q", want, gate.Summary)
 		}
 	}
 }

--- a/internal/pipeline/run.go
+++ b/internal/pipeline/run.go
@@ -1941,6 +1941,13 @@ func autoMergeGateStageSettleOutcome(ctx context.Context, deps pipelineStageSett
 		return block(readiness.Reason)
 	}
 	if !readiness.Ready {
+		if readiness.ReconciliationHold {
+			// The ORDINARY path. Evaluate runs the same reconciliation check before
+			// Merge, so this is where a workload-mode hold actually surfaces;
+			// instrumenting only the Merge-side window left this branch silent,
+			// unrecorded and unbounded (#1783 round-4 review, F-1).
+			return autoMergeHoldOutcome(ctx, deps, stage, stageRow, sourceJobID, payload.PullRequest, reviewedHead, readiness.Reason)
+		}
 		return autoMergeGateWaiting(stage, stageRow, deps.now, payload.PullRequest)
 	}
 
@@ -1957,8 +1964,16 @@ func autoMergeGateStageSettleOutcome(ctx context.Context, deps pipelineStageSett
 	}
 	if !claimed {
 		// Another scan owns this exact run/stage/PR/head write. Do not call Merge;
-		// the next scan observes either the merged PR or the winner's blocked fold.
-		return autoMergeGateWaiting(stage, stageRow, deps.now, payload.PullRequest)
+		// the next scan observes either the merged PR or the winner's fold. A hold
+		// already recorded for this head keeps its bound here too, so a lost
+		// release cannot park the run in an unbounded silent wait (F-3).
+		if held, holdErr := latestAutoMergeHold(ctx, deps.store, sourceJobID, reviewedHead); holdErr != nil {
+			return false, "", "", nil, nil, holdErr
+		} else if held.at.IsZero() {
+			return autoMergeGateWaiting(stage, stageRow, deps.now, payload.PullRequest)
+		} else {
+			return autoMergeHoldDisposition(stage, stageRow, deps.now, payload.PullRequest, held)
+		}
 	}
 
 	result, mergeErr := deps.autoMerge.Merge(ctx, request)
@@ -1971,50 +1986,30 @@ func autoMergeGateStageSettleOutcome(ctx context.Context, deps pipelineStageSett
 			reason = "GitHub did not confirm the merge"
 		}
 		if result.Waiting {
-			// A TRANSIENT refusal keeps the stage waiting instead of ending the run.
-			// It must also RELEASE the claim: the claim is keyed on
-			// run/stage/PR/head, so leaving it consumed meant Merge was never
-			// re-attempted for the life of the run and the row landing merged
-			// nothing (#1783 round-3 review, F-A, measured). Releasing is safe
-			// because a Waiting return happens in PipelineAutoMerger.Merge BEFORE
-			// executePullRequestMerge, so no GitHub mutation occurred; the claim
-			// guards a write that provably did not happen.
+			// A TRANSIENT refusal keeps the stage waiting instead of ending the run,
+			// and RELEASES the claim so Merge can be re-attempted: the claim is keyed
+			// on run/stage/PR/head, so leaving it consumed meant the row landing
+			// merged nothing for the life of the run (#1783 round-3 review, F-A).
+			//
+			// Releasing is safe because PipelineAutoMergeResult.Waiting is a contract
+			// that NO GitHub mutation was attempted; the claim guards a write that
+			// provably did not happen.
+			//
+			// The hold is RECORDED BEFORE the release. Recording second left one
+			// transient DELETE failure - or a crash in between - with a consumed
+			// claim and no held event, after which every scan took the unbounded
+			// silent !claimed branch (#1783 round-4 review, F-3). Recording first
+			// means that branch finds the hold and keeps its bound.
+			held, holdErr := recordAutoMergeHold(ctx, deps, stage, sourceJobID, payload.PullRequest, reviewedHead, reason)
+			if holdErr != nil {
+				return false, "", "", nil, nil, holdErr
+			}
 			if _, releaseErr := deps.store.ReleaseJobEventClaim(ctx, db.JobEvent{
 				JobID: sourceJobID, Kind: "pipeline_auto_merge_claim", Message: string(claim),
 			}); releaseErr != nil {
 				return false, "", "", nil, nil, releaseErr
 			}
-			// Record WHY the run is parked. The pre-change terminal block carried
-			// the reason; a silent wait reintroduced exactly the unexplained hold
-			// the native lane's F2 work removed.
-			held, marshalErr := json.Marshal(map[string]any{
-				"phase": "held", "pipeline": deps.rec.Name, "run_id": deps.run.ID,
-				"stage_id": stage.ID, "pull_request": payload.PullRequest,
-				"head_sha": reviewedHead, "reason": reason,
-			})
-			if marshalErr != nil {
-				return false, "", "", nil, nil, marshalErr
-			}
-			if eventErr := deps.store.AddJobEventIfAbsent(ctx, db.JobEvent{
-				JobID: sourceJobID, Kind: "pipeline_auto_merge_held", Message: string(held),
-			}); eventErr != nil {
-				return false, "", "", nil, nil, eventErr
-			}
-			// BOUND the wait. A gate stage's `timeout` is optional, so without one
-			// the reviewer measured this parked silently at now+72h. When the spec
-			// sets no timeout, the hold itself is bounded from the FIRST recorded
-			// hold event and parks with its cause; a spec timeout still wins.
-			if strings.TrimSpace(stage.Timeout) == "" {
-				heldSince, holdErr := firstAutoMergeHoldAt(ctx, deps.store, sourceJobID)
-				if holdErr != nil {
-					return false, "", "", nil, nil, holdErr
-				}
-				if !heldSince.IsZero() && deps.now.Sub(heldSince) >= autoMergeHoldMaxWait {
-					return block(fmt.Sprintf("auto-merge held %s without reconciliation (no gate timeout is set, so the hold's own bound of %s applied): %s",
-						deps.now.Sub(heldSince).Truncate(time.Second), autoMergeHoldMaxWait, reason))
-				}
-			}
-			return autoMergeGateWaitingWithReason(stage, stageRow, deps.now, payload.PullRequest, reason)
+			return autoMergeHoldDisposition(stage, stageRow, deps.now, payload.PullRequest, held)
 		}
 		return block(reason + "; retry stopped")
 	}
@@ -2047,37 +2042,165 @@ func autoMergeGateWaitingWithReason(stage Stage, stageRow db.PipelineRunStage, n
 	return autoMergeGateWaiting(stage, stageRow, now, pr)
 }
 
-// autoMergeHoldMaxWait bounds a merge-boundary reconciliation hold when the gate
-// stage sets no `timeout`. A gate with no timeout otherwise waits forever, which
-// the #1783 round-3 review measured as a silent park at now+72h. The hold is
-// retryable, so this bound only decides when to stop retrying and park WITH the
-// cause; a spec timeout takes precedence.
+// autoMergeHoldMaxWait bounds a reconciliation hold when the gate stage sets no
+// `timeout`. A gate with no timeout otherwise waits forever, which the #1783
+// round-3 review measured as a silent park at now+72h. The hold is retryable, so
+// this bound only decides when to stop retrying and park WITH the cause; a spec
+// timeout takes precedence. Tests pin the MAGNITUDE with a literal: deriving the
+// clock from this constant made a mutant that restores an unbounded wait
+// invisible (#1783 round-4 review, F-5).
 const autoMergeHoldMaxWait = 6 * time.Hour
 
-// firstAutoMergeHoldAt returns when this source job's merge-boundary hold was
-// first recorded, or the zero time when no hold has been recorded yet. Parse
-// failures return zero rather than an error: an unbounded wait is better than a
-// park on an unreadable timestamp.
-func firstAutoMergeHoldAt(ctx context.Context, store *db.Store, sourceJobID string) (time.Time, error) {
+// autoMergeHold is one hold EPISODE: the cause, and when that cause was first
+// recorded for the current head. The bound is measured from the episode, not
+// from the job's first-ever hold - a single row per job meant a brand-new hold
+// hours later parked instantly and the recorded cause froze at the first reason
+// (#1783 round-4 review, F-2).
+type autoMergeHold struct {
+	at     time.Time
+	reason string
+}
+
+// recordAutoMergeHold records the hold and returns its episode.
+//
+// The anchor is `held_at`, written from the PIPELINE's clock (deps.now), not the
+// row's created_at. The bound compares against deps.now, so anchoring on a
+// database timestamp measured elapsed time across two clocks - and made the
+// bound untestable except by deriving the test clock from the constant it was
+// meant to pin, which is how the round-4 mutant survived.
+//
+// A hold whose head or cause differs opens a new EPISODE with its own budget; a
+// repeated identical hold appends nothing. The existence check is check-then-
+// insert rather than atomic, and that is deliberate: two scans racing the same
+// new episode write two rows with near-identical held_at values, and the episode
+// anchor takes the EARLIEST, so the duplicate is harmless.
+func recordAutoMergeHold(ctx context.Context, deps pipelineStageSettleDeps, stage Stage, sourceJobID string, pr int, head, reason string) (autoMergeHold, error) {
+	existing, err := autoMergeHoldEpisode(ctx, deps.store, sourceJobID, head, reason)
+	if err != nil {
+		return autoMergeHold{}, err
+	}
+	if !existing.at.IsZero() {
+		return existing, nil
+	}
+	held := autoMergeHold{at: deps.now.UTC(), reason: reason}
+	message, marshalErr := json.Marshal(map[string]any{
+		"phase": "held", "pipeline": deps.rec.Name, "run_id": deps.run.ID,
+		"stage_id": stage.ID, "pull_request": pr,
+		"head_sha": head, "reason": reason,
+		"held_at": held.at.Format(time.RFC3339Nano),
+	})
+	if marshalErr != nil {
+		return autoMergeHold{}, marshalErr
+	}
+	if _, err := deps.store.ClaimJobEvent(ctx, db.JobEvent{
+		JobID: sourceJobID, Kind: autoMergeHeldEventKind, Message: string(message),
+	}); err != nil {
+		return autoMergeHold{}, err
+	}
+	return held, nil
+}
+
+const autoMergeHeldEventKind = "pipeline_auto_merge_held"
+
+// autoMergeHoldEpisode returns the earliest recorded hold for this head whose
+// cause matches `reason`, i.e. the start of the current episode. An empty
+// `reason` matches the newest recorded cause for that head, which is what the
+// !claimed branch needs when it has no reason of its own.
+func autoMergeHoldEpisode(ctx context.Context, store *db.Store, sourceJobID, head, reason string) (autoMergeHold, error) {
 	events, err := store.ListJobEvents(ctx, sourceJobID)
 	if err != nil {
-		return time.Time{}, err
+		return autoMergeHold{}, err
 	}
-	first := time.Time{}
+	type row struct {
+		at     time.Time
+		reason string
+	}
+	var rows []row
 	for _, event := range events {
-		if event.Kind != "pipeline_auto_merge_held" {
+		if event.Kind != autoMergeHeldEventKind {
 			continue
 		}
-		at, parseErr := time.Parse(time.DateTime, strings.TrimSpace(event.CreatedAt))
+		var body struct {
+			HeadSHA string `json:"head_sha"`
+			Reason  string `json:"reason"`
+			HeldAt  string `json:"held_at"`
+		}
+		if json.Unmarshal([]byte(event.Message), &body) != nil {
+			continue
+		}
+		if strings.TrimSpace(body.HeadSHA) != strings.TrimSpace(head) {
+			continue
+		}
+		at, parseErr := time.Parse(time.RFC3339Nano, strings.TrimSpace(body.HeldAt))
 		if parseErr != nil {
+			// A row written before held_at existed, or an unreadable value: fall
+			// back to the database timestamp rather than dropping the episode.
+			at, parseErr = time.Parse(time.DateTime, strings.TrimSpace(event.CreatedAt))
+			if parseErr != nil {
+				continue
+			}
+		}
+		rows = append(rows, row{at: at.UTC(), reason: strings.TrimSpace(body.Reason)})
+	}
+	if len(rows) == 0 {
+		return autoMergeHold{}, nil
+	}
+	want := strings.TrimSpace(reason)
+	if want == "" {
+		newest := rows[0]
+		for _, candidate := range rows[1:] {
+			if candidate.at.After(newest.at) {
+				newest = candidate
+			}
+		}
+		want = newest.reason
+	}
+	episode := autoMergeHold{reason: want}
+	for _, candidate := range rows {
+		if candidate.reason != want {
 			continue
 		}
-		at = at.UTC()
-		if first.IsZero() || at.Before(first) {
-			first = at
+		if episode.at.IsZero() || candidate.at.Before(episode.at) {
+			episode.at = candidate.at
 		}
 	}
-	return first, nil
+	return episode, nil
+}
+
+// latestAutoMergeHold reports the current episode for a head with no reason in
+// hand, for the !claimed branch: a hold recorded by the scan that lost its
+// release must still bound this one (#1783 round-4 review, F-3).
+func latestAutoMergeHold(ctx context.Context, store *db.Store, sourceJobID, head string) (autoMergeHold, error) {
+	return autoMergeHoldEpisode(ctx, store, sourceJobID, head, "")
+}
+
+// autoMergeHoldOutcome records a hold and returns its disposition. Both paths a
+// reconciliation hold can take - Evaluate-side readiness and the Merge-side
+// Waiting return - go through here, because instrumenting only one left the
+// other silent, unrecorded and unbounded (#1783 round-4 review, F-1).
+func autoMergeHoldOutcome(ctx context.Context, deps pipelineStageSettleDeps, stage Stage, stageRow db.PipelineRunStage, sourceJobID string, pr int, head, reason string) (bool, string, string, []string, *db.PipelineRunStage, error) {
+	reason = strings.TrimSpace(reason)
+	if reason == "" {
+		reason = "auto-merge is waiting on workload-mode reconciliation"
+	}
+	held, err := recordAutoMergeHold(ctx, deps, stage, sourceJobID, pr, head, reason)
+	if err != nil {
+		return false, "", "", nil, nil, err
+	}
+	return autoMergeHoldDisposition(stage, stageRow, deps.now, pr, held)
+}
+
+// autoMergeHoldDisposition parks a hold that outlived its bound, carrying the
+// cause, and otherwise keeps the stage waiting with the cause attached.
+func autoMergeHoldDisposition(stage Stage, stageRow db.PipelineRunStage, now time.Time, pr int, held autoMergeHold) (bool, string, string, []string, *db.PipelineRunStage, error) {
+	if strings.TrimSpace(stage.Timeout) == "" && !held.at.IsZero() {
+		if waited := now.Sub(held.at); waited >= autoMergeHoldMaxWait {
+			summary := fmt.Sprintf("gate auto-merge blocked: auto-merge held %s without reconciliation (no gate timeout is set, so the hold's own bound of %s applied): %s",
+				waited.Truncate(time.Second), autoMergeHoldMaxWait, held.reason)
+			return true, StageBlocked, summary, []string{held.reason}, nil, nil
+		}
+	}
+	return autoMergeGateWaitingWithReason(stage, stageRow, now, pr, held.reason)
 }
 
 func autoMergeGateWaiting(stage Stage, stageRow db.PipelineRunStage, now time.Time, pr int) (bool, string, string, []string, *db.PipelineRunStage, error) {

--- a/internal/pipeline/run.go
+++ b/internal/pipeline/run.go
@@ -2219,18 +2219,33 @@ func autoMergeLostClaimOutcome(ctx context.Context, deps pipelineStageSettleDeps
 		// configured stage `timeout` parks this wait exactly as it parks any other
 		// (#1783 round-8 review, F-2).
 		//
-		// THIS BRANCH IS DEFENSIVE AND UNPINNED, stated rather than pretended. No
-		// INSERT INTO job_events accepts created_at - all 30-odd sites name only
-		// (job_id, kind, message) - so no test in this package can produce a
-		// malformed value through an insert. The precise claim matters, because a
-		// store-wide "nothing can write it" is FALSE: UpsertLatestJobEvent and
-		// RefreshLatestAdvanceRetry both set created_at = CURRENT_TIMESTAMP. Neither
-		// can touch a claim row, because each is pinned to a different event kind in
-		// its own SQL, so the age cannot be refreshed - but the safety rests on that
-		// kind discipline, not on impossibility, and a kind-parameterised upsert
-		// would silently reset the bound (#1783 round-8 review, F-4).
+		// THIS BRANCH IS PINNED, and the previous head's reason for leaving it
+		// unpinned was FALSE. It said the state "cannot be constructed by any
+		// store API"; the round-10 review disproved that by experiment.
+		// db.Store.ExecForTest (internal/db/store_escalation_rounds.go) is exported,
+		// already used cross-package, and its own doc comment says it exists "so a
+		// test can put the database into a state no production code path creates" -
+		// verbatim the situation that claim called impossible. It is now driven by
+		// TestPipelineAutoMergeLostClaimReportsAnUnreadableClaimTimestamp, which
+		// also pins the claim_raw_stamp discriminator below (#1783 round-10 F-1).
 		//
-		// The reachable side IS pinned, by
+		// No INSERT INTO job_events accepts created_at - all 30-odd sites name only
+		// (job_id, kind, message) - so PRODUCTION cannot write this value on an
+		// insert. Two functions do write it, and the reason each is safe DIFFERS:
+		// RefreshLatestAdvanceRetry carries the literal kind = 'advance_retry' in its
+		// SQL and so cannot reach a claim row at all, while UpsertLatestJobEvent pins
+		// NO kind - it binds `kind = ?` from event.Kind. That one is safe only by
+		// CALL-SITE discipline: its single caller, the progress writer in
+		// progress.go, passes the literal Kind: "progress" (both in internal/db's
+		// store_jobs.go; NAMED, not line-cited, because #1841 moved both bodies
+		// while this PR was in review and a line number would already be stale).
+		// The blast radius if that ever slipped is worth naming, because its UPDATE
+		// has no message predicate: it would rewrite every row of the given kind for
+		// the job and reset created_at, resetting the 15-minute bound exactly as
+		// feared (#1783 round-10 F-3, correcting the round-8 F-4 fix, which
+		// attributed SQL kind-pinning to both).
+		//
+		// The reachable side is pinned separately by
 		// TestPipelineAutoMergeClaimTimestampParsesTheStoreFormat, which guards the
 		// hazard that matters - if the store's timestamp format changed, every
 		// claim would fall down here and every losing scan would report an

--- a/internal/pipeline/run.go
+++ b/internal/pipeline/run.go
@@ -1959,7 +1959,7 @@ func autoMergeGateStageSettleOutcome(ctx context.Context, deps pipelineStageSett
 			// Merge, so this is where a workload-mode hold actually surfaces;
 			// instrumenting only the Merge-side window left this branch silent,
 			// unrecorded and unbounded (#1783 round-4 review, F-1).
-			return autoMergeHoldOutcome(ctx, deps, stage, stageRow, sourceJobID, payload.PullRequest, reviewedHead, readiness.Reason)
+			return autoMergeHoldOutcome(ctx, deps, stage, stageRow, sourceJobID, payload.PullRequest, reviewedHead, readiness.ReconciliationKey, readiness.Reason)
 		}
 		return autoMergeGateWaiting(stage, stageRow, deps.now, payload.PullRequest)
 	}
@@ -1971,22 +1971,41 @@ func autoMergeGateStageSettleOutcome(ctx context.Context, deps pipelineStageSett
 	if marshalErr != nil {
 		return false, "", "", nil, nil, marshalErr
 	}
-	claimed, claimErr := deps.store.ClaimJobEvent(ctx, db.JobEvent{JobID: sourceJobID, Kind: "pipeline_auto_merge_claim", Message: string(claim)})
+	claimed, claimErr := deps.store.ClaimJobEvent(ctx, db.JobEvent{JobID: sourceJobID, Kind: autoMergeClaimEventKind, Message: string(claim)})
 	if claimErr != nil {
 		return false, "", "", nil, nil, claimErr
 	}
 	if !claimed {
 		// Another scan owns this exact run/stage/PR/head write. Do not call Merge;
-		// the next scan observes either the merged PR or the winner's fold. A hold
-		// already recorded for this head keeps its bound here too, so a lost
-		// release cannot park the run in an unbounded silent wait (F-3).
-		if held, holdErr := latestAutoMergeHold(ctx, deps.store, sourceJobID, reviewedHead); holdErr != nil {
-			return false, "", "", nil, nil, holdErr
-		} else if held.at.IsZero() {
-			return autoMergeGateWaiting(stage, stageRow, deps.now, payload.PullRequest)
-		} else {
-			return autoMergeHoldDisposition(stage, stageRow, deps.now, payload.PullRequest, held)
-		}
+		// the next scan observes either the merged PR or the winner's fold.
+		//
+		// This branch does NOT consult the reconciliation hold record, and must
+		// not. Reaching it means Evaluate reported Ready for this head IN THIS
+		// PASS, so any recorded hold has already been contradicted by a live
+		// measurement - and hold records are never cleared, so believing one
+		// terminally parked runs whose reconciliation had finished hours earlier,
+		// with a summary telling the operator to go fix it (#1783 round-5 review,
+		// F-10). The rule that settles: a scan may park a run terminally only on a
+		// condition it observed ITSELF in the same pass. A lost race is not that
+		// condition - the loser cannot see whether the winner is alive.
+		//
+		// It can still stop being SILENT, which was F-3's real complaint. The
+		// defect F-3 found is an ORPHANED claim: a winner that died between
+		// claiming and writing, or whose release failed, leaves the claim consumed
+		// and Merge never re-attempted. So a losing scan RECORDS the suspicion as
+		// a job event once the claim's own age passes the bound, and stays
+		// non-terminal and self-healing (#1783 round-4 review, F-3).
+		//
+		// Measured, because the obvious assumption is wrong: a waiting stage's
+		// summary is written only when it SETTLES, so the cause reaches a summary
+		// only if the stage has a `timeout` for pipelineGateTimedOut to fire. The
+		// durable record on the unbounded path is therefore the job event, not the
+		// summary - a probe through the advancer showed state="running" with an
+		// empty summary and the event present.
+		return autoMergeLostClaimOutcome(ctx, deps, stage, stageRow, sourceJobID, payload.PullRequest, reviewedHead)
+	}
+	if err := recordAutoMergeClaimAt(ctx, deps, stage, sourceJobID, payload.PullRequest, reviewedHead); err != nil {
+		return false, "", "", nil, nil, err
 	}
 
 	result, mergeErr := deps.autoMerge.Merge(ctx, request)
@@ -2013,13 +2032,20 @@ func autoMergeGateStageSettleOutcome(ctx context.Context, deps pipelineStageSett
 			// claim and no held event, after which every scan took the unbounded
 			// silent !claimed branch (#1783 round-4 review, F-3). Recording first
 			// means that branch finds the hold and keeps its bound.
-			held, holdErr := recordAutoMergeHold(ctx, deps, stage, sourceJobID, payload.PullRequest, reviewedHead, reason)
+			held, holdErr := recordAutoMergeHold(ctx, deps, stage, sourceJobID, payload.PullRequest, reviewedHead, autoMergeEpisodeKey(result.ReconciliationKey, reviewedHead), reason)
 			if holdErr != nil {
 				return false, "", "", nil, nil, holdErr
 			}
 			if _, releaseErr := deps.releaseAutoMergeClaim(ctx, db.JobEvent{
-				JobID: sourceJobID, Kind: "pipeline_auto_merge_claim", Message: string(claim),
+				JobID: sourceJobID, Kind: autoMergeClaimEventKind, Message: string(claim),
 			}); releaseErr != nil {
+				return false, "", "", nil, nil, releaseErr
+			}
+			// The claim's age row is released WITH the claim. That pairing is the
+			// whole reason the loser branch may trust it: the row exists exactly
+			// while the claim it measures does, so it cannot become the kind of
+			// never-cleared record that F-10 is about.
+			if releaseErr := releaseAutoMergeClaimAt(ctx, deps, stage, sourceJobID, payload.PullRequest, reviewedHead); releaseErr != nil {
 				return false, "", "", nil, nil, releaseErr
 			}
 			return autoMergeHoldDisposition(stage, stageRow, deps.now, payload.PullRequest, held)
@@ -2062,7 +2088,171 @@ func autoMergeGateWaitingWithReason(stage Stage, stageRow db.PipelineRunStage, n
 // timeout takes precedence. Tests pin the MAGNITUDE with a literal: deriving the
 // clock from this constant made a mutant that restores an unbounded wait
 // invisible (#1783 round-4 review, F-5).
-const autoMergeHoldMaxWait = 6 * time.Hour
+//
+// 24h, not the 6h this shipped with. The satisfying event is a HUMAN writing an
+// operating-mode note or a reconciliation row, and the park is terminal - a run
+// that needs an owner overnight, over a timezone, or across a weekend morning
+// exceeded 6h routinely and died on a hold that was progressing normally
+// (#1783 round-5 review, F-12). A repo that wants a shorter leash sets a stage
+// `timeout`, which still takes precedence in both directions.
+const autoMergeHoldMaxWait = 24 * time.Hour
+
+// autoMergeEpisodeKey is the episode discriminator, with the head as the floor.
+// Falling back to the CAUSE when a caller has no key would restore exactly the
+// volatile keying that let external churn reset the bound (#1783 round-5
+// review, F-11).
+func autoMergeEpisodeKey(key, head string) string {
+	if key = strings.TrimSpace(key); key != "" {
+		return key
+	}
+	return "head=" + strings.TrimSpace(head)
+}
+
+// autoMergeClaimOrphanAfter is how long the at-most-once merge claim may be held
+// by another scan before a losing scan says so out loud.
+//
+// It is not a park: the loser never learns whether the winner is alive, so it
+// may not end the run (#1783 round-5 review, F-10). A live winner holds the
+// claim for one Merge API call, so anything past this is either a winner that
+// died between claiming and writing or a release that failed - F-3's defect,
+// which used to be an unbounded SILENT wait. Tests pin the magnitude with a
+// literal, as with autoMergeHoldMaxWait.
+const autoMergeClaimOrphanAfter = 15 * time.Minute
+
+const (
+	autoMergeClaimEventKind       = "pipeline_auto_merge_claim"
+	autoMergeClaimAtEventKind     = "pipeline_auto_merge_claim_at"
+	autoMergeClaimOrphanEventKind = "pipeline_auto_merge_claim_orphaned"
+)
+
+// autoMergeClaimAtMessage is the companion row's exact content. The CLAIM row
+// itself cannot carry a timestamp: its message is the identity that makes
+// ClaimJobEvent's insert-if-absent at-most-once, so varying it would let every
+// scan win. The companion carries the pipeline's clock instead, and is released
+// with the claim, so its lifetime is exactly the claim's.
+func autoMergeClaimAtMessage(deps pipelineStageSettleDeps, stage Stage, pr int, head string) (string, error) {
+	message, err := json.Marshal(map[string]any{
+		"phase": "claim_at", "pipeline": deps.rec.Name, "run_id": deps.run.ID,
+		"stage_id": stage.ID, "pull_request": pr, "head_sha": head,
+		"claimed_at": deps.now.UTC().Format(time.RFC3339Nano),
+	})
+	if err != nil {
+		return "", err
+	}
+	return string(message), nil
+}
+
+func recordAutoMergeClaimAt(ctx context.Context, deps pipelineStageSettleDeps, stage Stage, sourceJobID string, pr int, head string) error {
+	message, err := autoMergeClaimAtMessage(deps, stage, pr, head)
+	if err != nil {
+		return err
+	}
+	_, err = deps.store.ClaimJobEvent(ctx, db.JobEvent{JobID: sourceJobID, Kind: autoMergeClaimAtEventKind, Message: message})
+	return err
+}
+
+// releaseAutoMergeClaimAt drops the companion when the claim is released. A
+// leftover row - this delete failing after the claim's succeeded - can only be
+// OLDER than the next winner's, and the reader takes the newest, so the worst
+// case is that a suspicion is reported late rather than early.
+func releaseAutoMergeClaimAt(ctx context.Context, deps pipelineStageSettleDeps, stage Stage, sourceJobID string, pr int, head string) error {
+	message, err := autoMergeClaimAtMessage(deps, stage, pr, head)
+	if err != nil {
+		return err
+	}
+	_, err = deps.store.ReleaseJobEventClaim(ctx, db.JobEvent{JobID: sourceJobID, Kind: autoMergeClaimAtEventKind, Message: message})
+	return err
+}
+
+// latestAutoMergeClaimAt reports when the CURRENT claim for this head was taken,
+// or the zero time when nothing recorded it. Newest wins: see
+// releaseAutoMergeClaimAt for why that is the safe direction.
+func latestAutoMergeClaimAt(ctx context.Context, store *db.Store, sourceJobID, head string) (time.Time, error) {
+	events, err := store.ListJobEvents(ctx, sourceJobID)
+	if err != nil {
+		return time.Time{}, err
+	}
+	var newest time.Time
+	for _, event := range events {
+		if event.Kind != autoMergeClaimAtEventKind {
+			continue
+		}
+		var body struct {
+			HeadSHA   string `json:"head_sha"`
+			ClaimedAt string `json:"claimed_at"`
+		}
+		if json.Unmarshal([]byte(event.Message), &body) != nil {
+			continue
+		}
+		if strings.TrimSpace(body.HeadSHA) != strings.TrimSpace(head) {
+			continue
+		}
+		at, parseErr := time.Parse(time.RFC3339Nano, strings.TrimSpace(body.ClaimedAt))
+		if parseErr != nil {
+			continue
+		}
+		if at = at.UTC(); newest.IsZero() || at.After(newest) {
+			newest = at
+		}
+	}
+	return newest, nil
+}
+
+// autoMergeLostClaimOutcome is the losing scan's disposition. It is ALWAYS
+// non-terminal on its own account: the only terminal exit is the operator's own
+// stage `timeout`, applied by autoMergeGateWaitingWithReason.
+//
+// The trade this makes, stated rather than hidden: with no stage `timeout`, a
+// genuinely orphaned claim waits indefinitely. That is deliberate. The loser
+// cannot tell an orphan from a live winner, and round 5 measured what happens
+// when it guesses - a terminal park on a run that was merging fine. So the cause
+// becomes a durable job event an operator can query, and the operator's own
+// `timeout` remains the lever that converts it into a park.
+func autoMergeLostClaimOutcome(ctx context.Context, deps pipelineStageSettleDeps, stage Stage, stageRow db.PipelineRunStage, sourceJobID string, pr int, head string) (bool, string, string, []string, *db.PipelineRunStage, error) {
+	claimedAt, err := latestAutoMergeClaimAt(ctx, deps.store, sourceJobID, head)
+	if err != nil {
+		return false, "", "", nil, nil, err
+	}
+	if claimedAt.IsZero() {
+		// Nothing recorded the claim, so nothing is known about its age. Waiting
+		// with no cause is the honest report.
+		return autoMergeGateWaiting(stage, stageRow, deps.now, pr)
+	}
+	held := deps.now.Sub(claimedAt)
+	if held < autoMergeClaimOrphanAfter {
+		return autoMergeGateWaitingWithReason(stage, stageRow, deps.now, pr,
+			fmt.Sprintf("another scan holds the auto-merge claim for head %s (%s)", shortPipelineSHA(head), held.Truncate(time.Second)))
+	}
+	reason := fmt.Sprintf("the auto-merge claim for head %s has been held for %s with no merge and no release, which is the signature of a claim orphaned by a scan that stopped between claiming and writing; the run keeps re-observing and merges as soon as the claim is released, and setting a `timeout` on this gate stage is what turns this wait into a park",
+		shortPipelineSHA(head), held.Truncate(time.Second))
+	if err := recordAutoMergeClaimOrphanSuspicion(ctx, deps, stage, sourceJobID, pr, head, claimedAt); err != nil {
+		return false, "", "", nil, nil, err
+	}
+	return autoMergeGateWaitingWithReason(stage, stageRow, deps.now, pr, reason)
+}
+
+// recordAutoMergeClaimOrphanSuspicion writes the suspicion once per claim, so a
+// scan loop cannot append a row a minute. The claim's own timestamp is part of
+// the content, so a NEW claim gets a new row.
+//
+// The content carries NOTHING that changes between scans. The first version
+// embedded the rendered cause, which states the elapsed time, so every scan
+// wrote a different message and the dedup never matched - measured as 2 rows
+// from 2 losing scans. The elapsed time belongs in the stage summary, which is
+// regenerated per scan by design.
+func recordAutoMergeClaimOrphanSuspicion(ctx context.Context, deps pipelineStageSettleDeps, stage Stage, sourceJobID string, pr int, head string, claimedAt time.Time) error {
+	message, err := json.Marshal(map[string]any{
+		"phase": "claim_orphan_suspected", "pipeline": deps.rec.Name, "run_id": deps.run.ID,
+		"stage_id": stage.ID, "pull_request": pr, "head_sha": head,
+		"claimed_at": claimedAt.UTC().Format(time.RFC3339Nano),
+		"after":      autoMergeClaimOrphanAfter.String(),
+	})
+	if err != nil {
+		return err
+	}
+	_, err = deps.store.ClaimJobEvent(ctx, db.JobEvent{JobID: sourceJobID, Kind: autoMergeClaimOrphanEventKind, Message: string(message)})
+	return err
+}
 
 // autoMergeHold is one hold EPISODE: the cause, and when that cause was first
 // recorded for the current head. The bound is measured from the episode, not
@@ -2087,8 +2277,8 @@ type autoMergeHold struct {
 // insert rather than atomic, and that is deliberate: two scans racing the same
 // new episode write two rows with near-identical held_at values, and the episode
 // anchor takes the EARLIEST, so the duplicate is harmless.
-func recordAutoMergeHold(ctx context.Context, deps pipelineStageSettleDeps, stage Stage, sourceJobID string, pr int, head, reason string) (autoMergeHold, error) {
-	existing, err := autoMergeHoldEpisode(ctx, deps.store, sourceJobID, head, reason)
+func recordAutoMergeHold(ctx context.Context, deps pipelineStageSettleDeps, stage Stage, sourceJobID string, pr int, head, episodeKey, reason string) (autoMergeHold, error) {
+	existing, err := autoMergeHoldEpisode(ctx, deps.store, sourceJobID, head, episodeKey)
 	if err != nil {
 		return autoMergeHold{}, err
 	}
@@ -2100,7 +2290,8 @@ func recordAutoMergeHold(ctx context.Context, deps pipelineStageSettleDeps, stag
 		"phase": "held", "pipeline": deps.rec.Name, "run_id": deps.run.ID,
 		"stage_id": stage.ID, "pull_request": pr,
 		"head_sha": head, "reason": reason,
-		"held_at": held.at.Format(time.RFC3339Nano),
+		"episode_key": episodeKey,
+		"held_at":     held.at.Format(time.RFC3339Nano),
 	})
 	if marshalErr != nil {
 		return autoMergeHold{}, marshalErr
@@ -2116,16 +2307,22 @@ func recordAutoMergeHold(ctx context.Context, deps pipelineStageSettleDeps, stag
 const autoMergeHeldEventKind = "pipeline_auto_merge_held"
 
 // autoMergeHoldEpisode returns the earliest recorded hold for this head whose
-// cause matches `reason`, i.e. the start of the current episode. An empty
-// `reason` matches the newest recorded cause for that head, which is what the
-// !claimed branch needs when it has no reason of its own.
-func autoMergeHoldEpisode(ctx context.Context, store *db.Store, sourceJobID, head, reason string) (autoMergeHold, error) {
+// EPISODE KEY matches, i.e. the start of the current episode.
+//
+// It is called only by recordAutoMergeHold, i.e. only by a scan that has just
+// observed this hold for itself. There is deliberately NO "match whatever was
+// recorded last" mode: that mode existed for the !claimed branch, which had no
+// cause of its own, and it is what let a never-cleared record park a healthy run
+// (#1783 round-5 review, F-10). A caller with no observed cause has no business
+// reading a hold.
+func autoMergeHoldEpisode(ctx context.Context, store *db.Store, sourceJobID, head, episodeKey string) (autoMergeHold, error) {
 	events, err := store.ListJobEvents(ctx, sourceJobID)
 	if err != nil {
 		return autoMergeHold{}, err
 	}
 	type row struct {
 		at     time.Time
+		key    string
 		reason string
 	}
 	var rows []row
@@ -2134,9 +2331,10 @@ func autoMergeHoldEpisode(ctx context.Context, store *db.Store, sourceJobID, hea
 			continue
 		}
 		var body struct {
-			HeadSHA string `json:"head_sha"`
-			Reason  string `json:"reason"`
-			HeldAt  string `json:"held_at"`
+			HeadSHA    string `json:"head_sha"`
+			EpisodeKey string `json:"episode_key"`
+			Reason     string `json:"reason"`
+			HeldAt     string `json:"held_at"`
 		}
 		if json.Unmarshal([]byte(event.Message), &body) != nil {
 			continue
@@ -2153,50 +2351,36 @@ func autoMergeHoldEpisode(ctx context.Context, store *db.Store, sourceJobID, hea
 				continue
 			}
 		}
-		rows = append(rows, row{at: at.UTC(), reason: strings.TrimSpace(body.Reason)})
+		rows = append(rows, row{
+			at:     at.UTC(),
+			key:    strings.TrimSpace(body.EpisodeKey),
+			reason: strings.TrimSpace(body.Reason),
+		})
 	}
-	if len(rows) == 0 {
-		return autoMergeHold{}, nil
-	}
-	want := strings.TrimSpace(reason)
-	if want == "" {
-		newest := rows[0]
-		for _, candidate := range rows[1:] {
-			if candidate.at.After(newest.at) {
-				newest = candidate
-			}
-		}
-		want = newest.reason
-	}
-	episode := autoMergeHold{reason: want}
+	want := strings.TrimSpace(episodeKey)
+	var episode autoMergeHold
 	for _, candidate := range rows {
-		if candidate.reason != want {
+		if candidate.key != want {
 			continue
 		}
 		if episode.at.IsZero() || candidate.at.Before(episode.at) {
 			episode.at = candidate.at
+			episode.reason = candidate.reason
 		}
 	}
 	return episode, nil
-}
-
-// latestAutoMergeHold reports the current episode for a head with no reason in
-// hand, for the !claimed branch: a hold recorded by the scan that lost its
-// release must still bound this one (#1783 round-4 review, F-3).
-func latestAutoMergeHold(ctx context.Context, store *db.Store, sourceJobID, head string) (autoMergeHold, error) {
-	return autoMergeHoldEpisode(ctx, store, sourceJobID, head, "")
 }
 
 // autoMergeHoldOutcome records a hold and returns its disposition. Both paths a
 // reconciliation hold can take - Evaluate-side readiness and the Merge-side
 // Waiting return - go through here, because instrumenting only one left the
 // other silent, unrecorded and unbounded (#1783 round-4 review, F-1).
-func autoMergeHoldOutcome(ctx context.Context, deps pipelineStageSettleDeps, stage Stage, stageRow db.PipelineRunStage, sourceJobID string, pr int, head, reason string) (bool, string, string, []string, *db.PipelineRunStage, error) {
+func autoMergeHoldOutcome(ctx context.Context, deps pipelineStageSettleDeps, stage Stage, stageRow db.PipelineRunStage, sourceJobID string, pr int, head, episodeKey, reason string) (bool, string, string, []string, *db.PipelineRunStage, error) {
 	reason = strings.TrimSpace(reason)
 	if reason == "" {
 		reason = "auto-merge is waiting on workload-mode reconciliation"
 	}
-	held, err := recordAutoMergeHold(ctx, deps, stage, sourceJobID, pr, head, reason)
+	held, err := recordAutoMergeHold(ctx, deps, stage, sourceJobID, pr, head, autoMergeEpisodeKey(episodeKey, head), reason)
 	if err != nil {
 		return false, "", "", nil, nil, err
 	}
@@ -2208,7 +2392,12 @@ func autoMergeHoldOutcome(ctx context.Context, deps pipelineStageSettleDeps, sta
 func autoMergeHoldDisposition(stage Stage, stageRow db.PipelineRunStage, now time.Time, pr int, held autoMergeHold) (bool, string, string, []string, *db.PipelineRunStage, error) {
 	if strings.TrimSpace(stage.Timeout) == "" && !held.at.IsZero() {
 		if waited := now.Sub(held.at); waited >= autoMergeHoldMaxWait {
-			summary := fmt.Sprintf("gate auto-merge blocked: auto-merge held %s without reconciliation (no gate timeout is set, so the hold's own bound of %s applied): %s",
+			// The summary states the ESCAPE HATCH, not just the bound that fired.
+			// "no gate timeout is set, so the bound applied" was true and left the
+			// operator with nothing to do about it; the actionable half is that a
+			// stage `timeout` overrides this bound in both directions (#1783
+			// round-5 review, F-12).
+			summary := fmt.Sprintf("gate auto-merge blocked: auto-merge held %s without reconciliation (no gate timeout is set, so the hold's own bound of %s applied - set a `timeout` on this gate stage if reconciliations here legitimately take longer): %s",
 				waited.Truncate(time.Second), autoMergeHoldMaxWait, held.reason)
 			return true, StageBlocked, summary, []string{held.reason}, nil, nil
 		}

--- a/internal/pipeline/run.go
+++ b/internal/pipeline/run.go
@@ -1329,6 +1329,14 @@ type pipelineStageSettleDeps struct {
 	autoMerge        PipelineAutoMergeExecutor
 	events           *pipelineJobEventSnapshot
 	terminalJobState *string
+	// afterLostClaim runs immediately after a FAILED claim attempt and before the
+	// claim row is read. Production leaves it nil. It exists because the round-8
+	// F-1 interleaving - the winner releasing the claim in the window between a
+	// loser's failed ClaimJobEvent and its read - cannot be driven deterministically
+	// from outside: both calls are sequential in one goroutine, so only something
+	// inside that window can delete the row. Same seam pattern as releaseClaim
+	// below, which pinned round-4's F-3 for the same reason.
+	afterLostClaim func()
 	// releaseClaim overrides the auto-merge claim release. Production leaves it
 	// nil and uses the store; a test injects a FAILING release, which is the only
 	// way to observe that the hold is recorded BEFORE the release - the ordering
@@ -2002,6 +2010,9 @@ func autoMergeGateStageSettleOutcome(ctx context.Context, deps pipelineStageSett
 		// durable record on the unbounded path is therefore the job event, not the
 		// summary - a probe through the advancer showed state="running" with an
 		// empty summary and the event present.
+		if deps.afterLostClaim != nil {
+			deps.afterLostClaim()
+		}
 		return autoMergeLostClaimOutcome(ctx, deps, stage, stageRow, sourceJobID, payload.PullRequest, reviewedHead, string(claim))
 	}
 
@@ -2174,11 +2185,23 @@ const (
 // this gate parks the run rather than recovering it, and the reason text says
 // so instead of promising recovery.
 func autoMergeLostClaimOutcome(ctx context.Context, deps pipelineStageSettleDeps, stage Stage, stageRow db.PipelineRunStage, sourceJobID string, pr int, head string, claim string) (bool, string, string, []string, *db.PipelineRunStage, error) {
-	claimedAt, knowable, err := autoMergeClaimTakenAt(ctx, deps.store, sourceJobID, claim)
+	claimedAt, lookup, rawClaimStamp, err := autoMergeClaimTakenAt(ctx, deps.store, sourceJobID, claim)
 	if err != nil {
 		return false, "", "", nil, nil, err
 	}
-	if !knowable {
+	if lookup == autoMergeClaimGone {
+		// The claim was RELEASED between this scan's failed claim and this read.
+		// That is the ordinary hold cycle, not a fault, and it is now the common
+		// case rather than a rarity: the mode gate calls ensureWorkloadModeReconciled
+		// at the merge boundary, so hold -> record -> release runs once per hold for
+		// every mode-marker PR. The next scan takes the claim. Reporting anything
+		// here would put a permanent orphan event on a healthy run, which is exactly
+		// what collapsing this case into "unreadable" did (#1783 round-8 review,
+		// F-1).
+		return autoMergeGateWaitingWithReason(stage, stageRow, deps.now, pr,
+			fmt.Sprintf("the auto-merge claim for head %s was released while this scan was reading it, so the next scan takes it", shortPipelineSHA(head)))
+	}
+	if lookup == autoMergeClaimUnreadable {
 		// The claim row is present - it is why this branch runs - but its
 		// created_at is empty or unparseable, so the age cannot be read. That is a
 		// DATA cause, not a lifecycle one: a legacy row written before this column
@@ -2188,23 +2211,35 @@ func autoMergeLostClaimOutcome(ctx context.Context, deps pipelineStageSettleDeps
 		// skips any row that is not queued or running, and the same advance
 		// re-stamps it before a settle pass can look (#1783 round-7 review, F-3).
 		//
-		// It records rather than only carrying a reason, because a wait that cannot
-		// be aged also cannot be parked by a stage `timeout` - so the reason alone
-		// would reach nothing an operator can read.
+		// It records rather than only carrying a reason so the condition is durable
+		// even when no timeout is configured. It does NOT claim the wait is
+		// unparkable: that reasoning was inherited from round 6, where the unageable
+		// case was a zero StartedAt on the GATE row. Here the gate row carries its
+		// ordinary stamp and only the CLAIM row's timestamp is unreadable, so a
+		// configured stage `timeout` parks this wait exactly as it parks any other
+		// (#1783 round-8 review, F-2).
 		//
-		// THIS BRANCH IS DEFENSIVE AND UNPINNED, stated rather than pretended: no
-		// store API can write created_at (every INSERT INTO job_events names only
-		// job_id, kind and message), so no test in this package can produce a
-		// malformed value. The reachable side IS pinned, by
+		// THIS BRANCH IS DEFENSIVE AND UNPINNED, stated rather than pretended. No
+		// INSERT INTO job_events accepts created_at - all 30-odd sites name only
+		// (job_id, kind, message) - so no test in this package can produce a
+		// malformed value through an insert. The precise claim matters, because a
+		// store-wide "nothing can write it" is FALSE: UpsertLatestJobEvent and
+		// RefreshLatestAdvanceRetry both set created_at = CURRENT_TIMESTAMP. Neither
+		// can touch a claim row, because each is pinned to a different event kind in
+		// its own SQL, so the age cannot be refreshed - but the safety rests on that
+		// kind discipline, not on impossibility, and a kind-parameterised upsert
+		// would silently reset the bound (#1783 round-8 review, F-4).
+		//
+		// The reachable side IS pinned, by
 		// TestPipelineAutoMergeClaimTimestampParsesTheStoreFormat, which guards the
 		// hazard that matters - if the store's timestamp format changed, every
 		// claim would fall down here and every losing scan would report an
 		// unreadable timestamp.
-		if err := recordAutoMergeClaimOrphanSuspicion(ctx, deps, stage, sourceJobID, pr, head, autoMergeClaimAgeUnknown, time.Time{}); err != nil {
+		if err := recordAutoMergeClaimOrphanSuspicion(ctx, deps, stage, sourceJobID, pr, head, autoMergeClaimAgeUnknown, time.Time{}, rawClaimStamp); err != nil {
 			return false, "", "", nil, nil, err
 		}
 		return autoMergeGateWaitingWithReason(stage, stageRow, deps.now, pr,
-			fmt.Sprintf("another scan holds the auto-merge claim for head %s and the claim carries no readable timestamp, so its age cannot be measured and a stage `timeout` cannot park this wait", shortPipelineSHA(head)))
+			fmt.Sprintf("another scan holds the auto-merge claim for head %s and the claim carries no readable timestamp, so its age cannot be measured; a stage `timeout` on this gate still parks the wait, and re-running the pipeline takes a fresh claim", shortPipelineSHA(head)))
 	}
 	held := deps.now.Sub(claimedAt)
 	if held < autoMergeClaimOrphanAfter {
@@ -2222,36 +2257,65 @@ func autoMergeLostClaimOutcome(ctx context.Context, deps pipelineStageSettleDeps
 	// id, so a re-run takes a fresh claim (#1783 round-7 review, F-1).
 	reason := fmt.Sprintf("the auto-merge claim for head %s was taken %s ago and is still held with no merge and no release; if the scan that took it is gone, nothing in the pipeline releases that claim - the key is fixed for this run, so THIS run cannot merge and a stage `timeout` would park it rather than recover it, while re-running the pipeline takes a fresh claim",
 		shortPipelineSHA(head), held.Truncate(time.Second))
-	if err := recordAutoMergeClaimOrphanSuspicion(ctx, deps, stage, sourceJobID, pr, head, autoMergeClaimHeldPastBound, claimedAt); err != nil {
+	if err := recordAutoMergeClaimOrphanSuspicion(ctx, deps, stage, sourceJobID, pr, head, autoMergeClaimHeldPastBound, claimedAt, ""); err != nil {
 		return false, "", "", nil, nil, err
 	}
 	return autoMergeGateWaitingWithReason(stage, stageRow, deps.now, pr, reason)
 }
 
+// autoMergeClaimLookup is what a losing scan learned about the claim it lost.
+// THREE outcomes, not two, and collapsing the last two was a real defect: a
+// released claim and an unreadable timestamp are different facts with different
+// dispositions (#1783 round-8 review, F-1).
+type autoMergeClaimLookup int
+
+const (
+	// autoMergeClaimFound: the row is there and its created_at parsed.
+	autoMergeClaimFound autoMergeClaimLookup = iota
+	// autoMergeClaimGone: no row matches. The claim was RELEASED between this
+	// scan's failed ClaimJobEvent and its read - two un-transacted round-trips -
+	// which is the ordinary hold cycle, not a fault: the winner records its hold
+	// and releases the claim on the Merge-side Waiting path, and with the mode
+	// gate calling ensureWorkloadModeReconciled at the merge boundary that cycle
+	// runs once per hold for every mode-marker PR. The next scan simply claims it.
+	autoMergeClaimGone
+	// autoMergeClaimUnreadable: the row is there and its created_at will not
+	// parse. Defensive; see the caller.
+	autoMergeClaimUnreadable
+)
+
 // autoMergeClaimTakenAt reads when THIS claim was inserted, from the claim row's
 // own created_at. `claim` is the exact message the caller built, so the lookup is
 // by identity rather than by scanning for the newest anything.
-func autoMergeClaimTakenAt(ctx context.Context, store *db.Store, sourceJobID, claim string) (time.Time, bool, error) {
+//
+// It previously returned a bare (zero, false) for BOTH "no row matches" and
+// "timestamp unparseable", and the caller's comment asserted "the claim row is
+// present - it is why this branch runs". That premise was false: the claim can
+// be released between the failed claim attempt and this read, so a healthy run
+// wrote a durable, deduped, never-retracted "unreadable timestamp" event on the
+// ordinary hold path (#1783 round-8 review, F-1).
+func autoMergeClaimTakenAt(ctx context.Context, store *db.Store, sourceJobID, claim string) (time.Time, autoMergeClaimLookup, string, error) {
 	events, err := store.ListJobEvents(ctx, sourceJobID)
 	if err != nil {
-		return time.Time{}, false, err
+		return time.Time{}, autoMergeClaimGone, "", err
 	}
 	for _, event := range events {
 		if event.Kind != autoMergeClaimEventKind || event.Message != claim {
 			continue
 		}
-		at, parseErr := time.Parse(time.DateTime, strings.TrimSpace(event.CreatedAt))
+		raw := strings.TrimSpace(event.CreatedAt)
+		at, parseErr := time.Parse(time.DateTime, raw)
 		if parseErr != nil {
 			// Also accept an RFC3339 store, so this does not depend on one backend's
 			// timestamp spelling.
-			at, parseErr = time.Parse(time.RFC3339Nano, strings.TrimSpace(event.CreatedAt))
+			at, parseErr = time.Parse(time.RFC3339Nano, raw)
 			if parseErr != nil {
-				return time.Time{}, false, nil
+				return time.Time{}, autoMergeClaimUnreadable, raw, nil
 			}
 		}
-		return at.UTC(), true, nil
+		return at.UTC(), autoMergeClaimFound, raw, nil
 	}
-	return time.Time{}, false, nil
+	return time.Time{}, autoMergeClaimGone, "", nil
 }
 
 // autoMergeClaimSuspicionCause names WHY a losing scan reported the claim, so
@@ -2280,7 +2344,7 @@ const (
 // time, so every scan wrote a different message and the dedup never matched -
 // measured as 2 rows from 2 losing scans. Elapsed time belongs in the stage
 // summary, which is regenerated per scan by design.
-func recordAutoMergeClaimOrphanSuspicion(ctx context.Context, deps pipelineStageSettleDeps, stage Stage, sourceJobID string, pr int, head string, cause autoMergeClaimSuspicionCause, claimedAt time.Time) error {
+func recordAutoMergeClaimOrphanSuspicion(ctx context.Context, deps pipelineStageSettleDeps, stage Stage, sourceJobID string, pr int, head string, cause autoMergeClaimSuspicionCause, claimedAt time.Time, rawStamp string) error {
 	body := map[string]any{
 		"phase": "claim_orphan_suspected", "pipeline": deps.rec.Name, "run_id": deps.run.ID,
 		"stage_id": stage.ID, "pull_request": pr, "head_sha": head,
@@ -2289,6 +2353,14 @@ func recordAutoMergeClaimOrphanSuspicion(ctx context.Context, deps pipelineStage
 	if cause == autoMergeClaimHeldPastBound {
 		body["after"] = autoMergeClaimOrphanAfter.String()
 		body["claim_taken_at"] = claimedAt.UTC().Format(time.RFC3339Nano)
+	} else {
+		// PER-EPISODE for this cause too. Round 7 earned "once per claim" by
+		// carrying the claim's timestamp, and this cause has no parseable one - so
+		// it carries the RAW value instead, which is stable for a row and differs
+		// between rows. Without it the body fell back to the once-per-RUN key that
+		// round-7 F-5 rejected, on the one branch that keeps it (#1783 round-8
+		// review, F-5).
+		body["claim_raw_stamp"] = rawStamp
 	}
 	message, err := json.Marshal(body)
 	if err != nil {

--- a/internal/pipeline/run.go
+++ b/internal/pipeline/run.go
@@ -1970,12 +1970,51 @@ func autoMergeGateStageSettleOutcome(ctx context.Context, deps pipelineStageSett
 		if reason == "" {
 			reason = "GitHub did not confirm the merge"
 		}
-		// A TRANSIENT refusal keeps the stage waiting, bounded by the gate's own
-		// timeout, instead of ending the run. The at-most-once claim is already
-		// consumed, so the next scan takes the !claimed path and waits there too
-		// until the PR merges or the gate times out (#1783 review, F4).
 		if result.Waiting {
-			return autoMergeGateWaiting(stage, stageRow, deps.now, payload.PullRequest)
+			// A TRANSIENT refusal keeps the stage waiting instead of ending the run.
+			// It must also RELEASE the claim: the claim is keyed on
+			// run/stage/PR/head, so leaving it consumed meant Merge was never
+			// re-attempted for the life of the run and the row landing merged
+			// nothing (#1783 round-3 review, F-A, measured). Releasing is safe
+			// because a Waiting return happens in PipelineAutoMerger.Merge BEFORE
+			// executePullRequestMerge, so no GitHub mutation occurred; the claim
+			// guards a write that provably did not happen.
+			if _, releaseErr := deps.store.ReleaseJobEventClaim(ctx, db.JobEvent{
+				JobID: sourceJobID, Kind: "pipeline_auto_merge_claim", Message: string(claim),
+			}); releaseErr != nil {
+				return false, "", "", nil, nil, releaseErr
+			}
+			// Record WHY the run is parked. The pre-change terminal block carried
+			// the reason; a silent wait reintroduced exactly the unexplained hold
+			// the native lane's F2 work removed.
+			held, marshalErr := json.Marshal(map[string]any{
+				"phase": "held", "pipeline": deps.rec.Name, "run_id": deps.run.ID,
+				"stage_id": stage.ID, "pull_request": payload.PullRequest,
+				"head_sha": reviewedHead, "reason": reason,
+			})
+			if marshalErr != nil {
+				return false, "", "", nil, nil, marshalErr
+			}
+			if eventErr := deps.store.AddJobEventIfAbsent(ctx, db.JobEvent{
+				JobID: sourceJobID, Kind: "pipeline_auto_merge_held", Message: string(held),
+			}); eventErr != nil {
+				return false, "", "", nil, nil, eventErr
+			}
+			// BOUND the wait. A gate stage's `timeout` is optional, so without one
+			// the reviewer measured this parked silently at now+72h. When the spec
+			// sets no timeout, the hold itself is bounded from the FIRST recorded
+			// hold event and parks with its cause; a spec timeout still wins.
+			if strings.TrimSpace(stage.Timeout) == "" {
+				heldSince, holdErr := firstAutoMergeHoldAt(ctx, deps.store, sourceJobID)
+				if holdErr != nil {
+					return false, "", "", nil, nil, holdErr
+				}
+				if !heldSince.IsZero() && deps.now.Sub(heldSince) >= autoMergeHoldMaxWait {
+					return block(fmt.Sprintf("auto-merge held %s without reconciliation (no gate timeout is set, so the hold's own bound of %s applied): %s",
+						deps.now.Sub(heldSince).Truncate(time.Second), autoMergeHoldMaxWait, reason))
+				}
+			}
+			return autoMergeGateWaitingWithReason(stage, stageRow, deps.now, payload.PullRequest, reason)
 		}
 		return block(reason + "; retry stopped")
 	}
@@ -1991,6 +2030,54 @@ func autoMergeGateStageSettleOutcome(ctx context.Context, deps pipelineStageSett
 		return false, "", "", nil, nil, eventErr
 	}
 	return true, StageSucceeded, fmt.Sprintf("gate %s auto-merged PR #%d at %s", stage.Gate, payload.PullRequest, shortPipelineSHA(reviewedHead)), nil, nil, nil
+}
+
+// autoMergeGateWaitingWithReason is autoMergeGateWaiting for a hold that HAS a
+// stated cause. On timeout the cause travels into the park summary and needs, so
+// the human who finds the parked run reads why it waited rather than only what
+// it waited for (#1783 round-3 review, F-A).
+func autoMergeGateWaitingWithReason(stage Stage, stageRow db.PipelineRunStage, now time.Time, pr int, reason string) (bool, string, string, []string, *db.PipelineRunStage, error) {
+	reason = strings.TrimSpace(reason)
+	if timedOut, waited := pipelineGateTimedOut(stage, stageRow, now); timedOut && reason != "" {
+		want := pipelineGateWaitDescription(stage.Gate, pr)
+		return true, StageBlocked,
+			fmt.Sprintf("gate %s timed out after %s waiting for auto-merge readiness for %s: %s", stage.Gate, waited, want, reason),
+			[]string{want, reason}, nil, nil
+	}
+	return autoMergeGateWaiting(stage, stageRow, now, pr)
+}
+
+// autoMergeHoldMaxWait bounds a merge-boundary reconciliation hold when the gate
+// stage sets no `timeout`. A gate with no timeout otherwise waits forever, which
+// the #1783 round-3 review measured as a silent park at now+72h. The hold is
+// retryable, so this bound only decides when to stop retrying and park WITH the
+// cause; a spec timeout takes precedence.
+const autoMergeHoldMaxWait = 6 * time.Hour
+
+// firstAutoMergeHoldAt returns when this source job's merge-boundary hold was
+// first recorded, or the zero time when no hold has been recorded yet. Parse
+// failures return zero rather than an error: an unbounded wait is better than a
+// park on an unreadable timestamp.
+func firstAutoMergeHoldAt(ctx context.Context, store *db.Store, sourceJobID string) (time.Time, error) {
+	events, err := store.ListJobEvents(ctx, sourceJobID)
+	if err != nil {
+		return time.Time{}, err
+	}
+	first := time.Time{}
+	for _, event := range events {
+		if event.Kind != "pipeline_auto_merge_held" {
+			continue
+		}
+		at, parseErr := time.Parse(time.DateTime, strings.TrimSpace(event.CreatedAt))
+		if parseErr != nil {
+			continue
+		}
+		at = at.UTC()
+		if first.IsZero() || at.Before(first) {
+			first = at
+		}
+	}
+	return first, nil
 }
 
 func autoMergeGateWaiting(stage Stage, stageRow db.PipelineRunStage, now time.Time, pr int) (bool, string, string, []string, *db.PipelineRunStage, error) {

--- a/internal/pipeline/run.go
+++ b/internal/pipeline/run.go
@@ -1329,6 +1329,19 @@ type pipelineStageSettleDeps struct {
 	autoMerge        PipelineAutoMergeExecutor
 	events           *pipelineJobEventSnapshot
 	terminalJobState *string
+	// releaseClaim overrides the auto-merge claim release. Production leaves it
+	// nil and uses the store; a test injects a FAILING release, which is the only
+	// way to observe that the hold is recorded BEFORE the release - the ordering
+	// that keeps a lost release bounded instead of silently stranding the run
+	// (#1783 round-4 review, F-3).
+	releaseClaim func(context.Context, db.JobEvent) (bool, error)
+}
+
+func (d pipelineStageSettleDeps) releaseAutoMergeClaim(ctx context.Context, event db.JobEvent) (bool, error) {
+	if d.releaseClaim != nil {
+		return d.releaseClaim(ctx, event)
+	}
+	return d.store.ReleaseJobEventClaim(ctx, event)
 }
 
 // stageSettleOutcome is the per-stage-kind SETTLE PREDICATE seam. Given an in-flight
@@ -2004,7 +2017,7 @@ func autoMergeGateStageSettleOutcome(ctx context.Context, deps pipelineStageSett
 			if holdErr != nil {
 				return false, "", "", nil, nil, holdErr
 			}
-			if _, releaseErr := deps.store.ReleaseJobEventClaim(ctx, db.JobEvent{
+			if _, releaseErr := deps.releaseAutoMergeClaim(ctx, db.JobEvent{
 				JobID: sourceJobID, Kind: "pipeline_auto_merge_claim", Message: string(claim),
 			}); releaseErr != nil {
 				return false, "", "", nil, nil, releaseErr

--- a/internal/pipeline/run.go
+++ b/internal/pipeline/run.go
@@ -2002,7 +2002,7 @@ func autoMergeGateStageSettleOutcome(ctx context.Context, deps pipelineStageSett
 		// durable record on the unbounded path is therefore the job event, not the
 		// summary - a probe through the advancer showed state="running" with an
 		// empty summary and the event present.
-		return autoMergeLostClaimOutcome(ctx, deps, stage, stageRow, sourceJobID, payload.PullRequest, reviewedHead)
+		return autoMergeLostClaimOutcome(ctx, deps, stage, stageRow, sourceJobID, payload.PullRequest, reviewedHead, string(claim))
 	}
 
 	result, mergeErr := deps.autoMerge.Merge(ctx, request)
@@ -2118,81 +2118,142 @@ const (
 // non-terminal on its own account: the only terminal exit is the operator's own
 // stage `timeout`, applied by autoMergeGateWaitingWithReason.
 //
-// The clock is the GATE STAGE'S OWN StartedAt, and that choice is the round-6
-// fix rather than a detail. The previous shape recorded a companion
-// `pipeline_auto_merge_claim_at` row after taking the claim, so the claim and
-// its age were TWO writes: a crash or a transient error between them left a
-// consumed claim with no age, and because F-10 had just deleted every hold read
-// from this branch there was nothing left to bound it - a permanent, silent,
-// unbounded wait, which is round-4 F-3's class re-created on the path F-10 made
-// load-bearing (#1783 round-6 review, N-1).
+// THE CLOCK IS THE CLAIM EVENT'S OWN created_at, and getting here took three
+// rounds of being wrong in different directions.
 //
-// The fix DELETES the compensation instead of hardening it. Reordering was not
-// available: writing the age first would let every LOSER refresh it each scan
-// and suppress the report forever, and putting the timestamp inside the claim
-// message would make each scan's content unique and break the insert-if-absent
-// that IS at-most-once. Falling back to the claim row's database created_at
-// would compare the pipeline clock against the store clock - the two-clock
-// mistake round 4 already paid for at the hold anchor - and a test cannot
-// backdate created_at, so that bound would be unpinnable.
+// Round 5 recorded a companion `pipeline_auto_merge_claim_at` row on the
+// pipeline clock. The claim was taken first and the companion written second, so
+// a crash between them left a consumed claim with no age and nothing to bound it
+// - round-4 F-3's silent unbounded wait, re-created (round-6 N-1).
 //
-// stageRow.StartedAt needs none of it: it is written from the pipeline's own
-// clock (run.go, the gate arm sets `row.StartedAt = now`), it is the same clock
-// deps.now comes from, it is atomic with the stage row's existence, and
-// pipelineGateTimedOut already trusts it for the operator's timeout. One write,
-// one clock, no window.
+// Round 6 deleted the companion and aged the wait from the GATE STAGE'S
+// StartedAt. That closed the window and introduced three defects, because the
+// gate's start is not the claim's age: resume zeroes StartedAt and the next
+// enqueue re-stamps it, so every resume restarted the bound on a claim that was
+// still held (round-7 F-2); the gate is stamped when it goes in-flight, long
+// before readiness, so a healthy two-second race on a gate that had waited past
+// the bound wrote a durable "orphaned" event (F-6); and the suspicion body lost
+// every claim-specific field, so a second episode at the same head became
+// unreportable (F-5).
 //
-// What that trades, stated: the bound now measures how long this GATE has been
-// waiting, not how long the claim has been held, so a claim taken late in a long
-// gate wait can be reported early. The report is non-terminal, so the cost of
-// being early is one job event, never a run - and "this gate has waited past the
-// bound and the claim is still held" is the condition an operator can act on
-// anyway.
-func autoMergeLostClaimOutcome(ctx context.Context, deps pipelineStageSettleDeps, stage Stage, stageRow db.PipelineRunStage, sourceJobID string, pr int, head string) (bool, string, string, []string, *db.PipelineRunStage, error) {
-	held, knowable := autoMergeGateWaitFor(stageRow, deps.now)
+// I REJECTED THIS CLOCK IN ROUND 6 AND THE REJECTION WAS WRONG, which the
+// round-7 directive asks be stated rather than quietly reversed. The round-6
+// reviewer proposed exactly this fallback; I refused it as "unpinnable, because
+// a test cannot backdate created_at". A test does not need to: it needs deps.now
+// LATER than created_at, which it gets by anchoring its clock to time.Now()
+// instead of the fixture's fixed 2026-07-11 date. The obstacle was my fixture,
+// not the design.
+//
+// Why the two-clock objection does not transfer: it correctly rules a database
+// timestamp out of the HOLD anchor, which drives a TERMINAL park at 24h and must
+// be exact on one clock. This is a coarse 15-minute SUSPICION on a path that
+// never parks by itself, so store-vs-advancer skew cannot change an outcome. The
+// hold keeps its pipeline-clock `held_at`; only this bound reads created_at.
+//
+// What it buys: the claim row EXISTS whenever this branch is reached - that is
+// the branch's own precondition - so there is no window and no second write; the
+// age is the CLAIM's age, so a fast race is young however long the gate waited;
+// it survives resume, because resume rewrites pipeline_run_stages and never
+// touches job_events; and a new claim has a new created_at, which restores
+// per-episode reporting.
+//
+// RESUME DOES NOT RELEASE THE CLAIM, and that is a decision rather than an
+// omission. Round 7 asked whether ResumePipelineRun should release the
+// auto-merge claim for reset gate stages. It must not: the claim is the only
+// thing standing between two concurrent scans and two merge attempts, resume
+// cannot tell a dead winner from one that is mid-Merge against GitHub, and
+// releasing it on a live winner converts at-most-once into at-least-once - the
+// exact property round 4's F-9 and the Waiting contract exist to protect. The
+// bound no longer depends on resume either way: the age lives on the claim row,
+// which resume leaves alone, so a resumed run reports the orphan on its first
+// losing scan instead of restarting a 15-minute silence (#1783 round-7 F-2).
+//
+// WHAT IS STILL TRADED, stated: a genuinely orphaned claim keeps THIS run from
+// merging, and no code path clears it - the honest remedy is a new run, which
+// takes a fresh claim because the key carries the run id. A stage `timeout` on
+// this gate parks the run rather than recovering it, and the reason text says
+// so instead of promising recovery.
+func autoMergeLostClaimOutcome(ctx context.Context, deps pipelineStageSettleDeps, stage Stage, stageRow db.PipelineRunStage, sourceJobID string, pr int, head string, claim string) (bool, string, string, []string, *db.PipelineRunStage, error) {
+	claimedAt, knowable, err := autoMergeClaimTakenAt(ctx, deps.store, sourceJobID, claim)
+	if err != nil {
+		return false, "", "", nil, nil, err
+	}
 	if !knowable {
-		// No start stamp on the stage row - reachable, because a resumed run zeroes
-		// it (resume.go) - so no age is knowable and pipelineGateTimedOut will not
-		// fire either. An unmeasurable wait is at least as suspicious as a long
-		// one, so it RECORDS rather than merely carrying a reason: with no timeout
-		// possible, the reason would never reach a summary and a mutant that
-		// dropped it changed nothing observable. Measured: it survived until the
-		// record was added (#1783 round-6 review, N-1).
-		if err := recordAutoMergeClaimOrphanSuspicion(ctx, deps, stage, sourceJobID, pr, head, autoMergeClaimAgeUnknown); err != nil {
+		// The claim row is present - it is why this branch runs - but its
+		// created_at is empty or unparseable, so the age cannot be read. That is a
+		// DATA cause, not a lifecycle one: a legacy row written before this column
+		// was populated, or a corrupted value. An earlier version of this comment
+		// claimed a resumed run reached here, and it cannot: resume sets
+		// StagePending in the same write that zeroes StartedAt, the settle loop
+		// skips any row that is not queued or running, and the same advance
+		// re-stamps it before a settle pass can look (#1783 round-7 review, F-3).
+		//
+		// It records rather than only carrying a reason, because a wait that cannot
+		// be aged also cannot be parked by a stage `timeout` - so the reason alone
+		// would reach nothing an operator can read.
+		//
+		// THIS BRANCH IS DEFENSIVE AND UNPINNED, stated rather than pretended: no
+		// store API can write created_at (every INSERT INTO job_events names only
+		// job_id, kind and message), so no test in this package can produce a
+		// malformed value. The reachable side IS pinned, by
+		// TestPipelineAutoMergeClaimTimestampParsesTheStoreFormat, which guards the
+		// hazard that matters - if the store's timestamp format changed, every
+		// claim would fall down here and every losing scan would report an
+		// unreadable timestamp.
+		if err := recordAutoMergeClaimOrphanSuspicion(ctx, deps, stage, sourceJobID, pr, head, autoMergeClaimAgeUnknown, time.Time{}); err != nil {
 			return false, "", "", nil, nil, err
 		}
 		return autoMergeGateWaitingWithReason(stage, stageRow, deps.now, pr,
-			fmt.Sprintf("another scan holds the auto-merge claim for head %s and this gate has no recorded start time, so the wait cannot be aged", shortPipelineSHA(head)))
+			fmt.Sprintf("another scan holds the auto-merge claim for head %s and the claim carries no readable timestamp, so its age cannot be measured and a stage `timeout` cannot park this wait", shortPipelineSHA(head)))
 	}
+	held := deps.now.Sub(claimedAt)
 	if held < autoMergeClaimOrphanAfter {
 		return autoMergeGateWaitingWithReason(stage, stageRow, deps.now, pr,
-			fmt.Sprintf("another scan holds the auto-merge claim for head %s (%s into this gate)", shortPipelineSHA(head), held.Truncate(time.Second)))
+			fmt.Sprintf("another scan holds the auto-merge claim for head %s (taken %s ago)", shortPipelineSHA(head), held.Truncate(time.Second)))
 	}
-	reason := fmt.Sprintf("the auto-merge claim for head %s is still held %s into this gate with no merge and no release, which is the signature of a claim orphaned by a scan that stopped after taking it; the run keeps re-observing and merges as soon as the claim is released, and setting a `timeout` on this gate stage is what turns this wait into a park",
+	// THE REMEDY IN THIS TEXT IS THE ONE THAT EXISTS. The previous wording said
+	// the run "merges as soon as the claim is released" and that a stage `timeout`
+	// turns the wait into a park. For the case this branch diagnoses both were
+	// false: the claim is keyed on (pipeline, run id, stage id, PR, head), every
+	// part fixed for the run's life; the only release site is the Merge-side
+	// Waiting branch, which the scan that died will never reach; resume does not
+	// touch job_events; and a stage `timeout` here produces a TERMINAL park rather
+	// than a recovery. What does work is a NEW RUN: the claim key carries the run
+	// id, so a re-run takes a fresh claim (#1783 round-7 review, F-1).
+	reason := fmt.Sprintf("the auto-merge claim for head %s was taken %s ago and is still held with no merge and no release; if the scan that took it is gone, nothing in the pipeline releases that claim - the key is fixed for this run, so THIS run cannot merge and a stage `timeout` would park it rather than recover it, while re-running the pipeline takes a fresh claim",
 		shortPipelineSHA(head), held.Truncate(time.Second))
-	if err := recordAutoMergeClaimOrphanSuspicion(ctx, deps, stage, sourceJobID, pr, head, autoMergeClaimHeldPastBound); err != nil {
+	if err := recordAutoMergeClaimOrphanSuspicion(ctx, deps, stage, sourceJobID, pr, head, autoMergeClaimHeldPastBound, claimedAt); err != nil {
 		return false, "", "", nil, nil, err
 	}
 	return autoMergeGateWaitingWithReason(stage, stageRow, deps.now, pr, reason)
 }
 
-// autoMergeGateWaitFor reports how long this gate stage has been waiting, on the
-// pipeline's clock, and whether that is knowable at all.
-func autoMergeGateWaitFor(stageRow db.PipelineRunStage, now time.Time) (time.Duration, bool) {
-	if stageRow.StartedAt.IsZero() {
-		return 0, false
+// autoMergeClaimTakenAt reads when THIS claim was inserted, from the claim row's
+// own created_at. `claim` is the exact message the caller built, so the lookup is
+// by identity rather than by scanning for the newest anything.
+func autoMergeClaimTakenAt(ctx context.Context, store *db.Store, sourceJobID, claim string) (time.Time, bool, error) {
+	events, err := store.ListJobEvents(ctx, sourceJobID)
+	if err != nil {
+		return time.Time{}, false, err
 	}
-	return now.Sub(stageRow.StartedAt), true
+	for _, event := range events {
+		if event.Kind != autoMergeClaimEventKind || event.Message != claim {
+			continue
+		}
+		at, parseErr := time.Parse(time.DateTime, strings.TrimSpace(event.CreatedAt))
+		if parseErr != nil {
+			// Also accept an RFC3339 store, so this does not depend on one backend's
+			// timestamp spelling.
+			at, parseErr = time.Parse(time.RFC3339Nano, strings.TrimSpace(event.CreatedAt))
+			if parseErr != nil {
+				return time.Time{}, false, nil
+			}
+		}
+		return at.UTC(), true, nil
+	}
+	return time.Time{}, false, nil
 }
 
-// recordAutoMergeClaimOrphanSuspicion writes the suspicion once per claim, so a
-// scan loop cannot append a row a minute.
-//
-// The content carries NOTHING that changes between scans. An earlier version
-// embedded the rendered cause, which states the elapsed time, so every scan
-// wrote a different message and the dedup never matched - measured as 2 rows
-// from 2 losing scans. The elapsed time belongs in the stage summary, which is
-// regenerated per scan by design.
 // autoMergeClaimSuspicionCause names WHY a losing scan reported the claim, so
 // the two shapes are distinguishable in the record: a claim still held past the
 // bound, and a wait that cannot be aged at all.
@@ -2200,10 +2261,26 @@ type autoMergeClaimSuspicionCause string
 
 const (
 	autoMergeClaimHeldPastBound autoMergeClaimSuspicionCause = "held_past_bound"
-	autoMergeClaimAgeUnknown    autoMergeClaimSuspicionCause = "gate_start_unrecorded"
+	autoMergeClaimAgeUnknown    autoMergeClaimSuspicionCause = "claim_timestamp_unreadable"
 )
 
-func recordAutoMergeClaimOrphanSuspicion(ctx context.Context, deps pipelineStageSettleDeps, stage Stage, sourceJobID string, pr int, head string, cause autoMergeClaimSuspicionCause) error {
+// recordAutoMergeClaimOrphanSuspicion writes the suspicion ONCE PER CLAIM
+// EPISODE, and that property is earned by carrying the claim's own timestamp:
+// a new claim has a new created_at, so it gets its own row, while every scan
+// that loses the SAME claim writes the identical message and ClaimJobEvent
+// dedups it.
+//
+// Round 6 dropped that field and the comment kept promising "once per claim",
+// which the code no longer delivered - the body became (run, stage, PR, head,
+// cause) and one row then covered the whole life of the run, so a second orphan
+// episode at the same head was unreportable (#1783 round-7 review, F-5).
+//
+// What must NOT go in the body is anything that varies between scans of the same
+// claim: an earlier version embedded the rendered cause, which states elapsed
+// time, so every scan wrote a different message and the dedup never matched -
+// measured as 2 rows from 2 losing scans. Elapsed time belongs in the stage
+// summary, which is regenerated per scan by design.
+func recordAutoMergeClaimOrphanSuspicion(ctx context.Context, deps pipelineStageSettleDeps, stage Stage, sourceJobID string, pr int, head string, cause autoMergeClaimSuspicionCause, claimedAt time.Time) error {
 	body := map[string]any{
 		"phase": "claim_orphan_suspected", "pipeline": deps.rec.Name, "run_id": deps.run.ID,
 		"stage_id": stage.ID, "pull_request": pr, "head_sha": head,
@@ -2211,6 +2288,7 @@ func recordAutoMergeClaimOrphanSuspicion(ctx context.Context, deps pipelineStage
 	}
 	if cause == autoMergeClaimHeldPastBound {
 		body["after"] = autoMergeClaimOrphanAfter.String()
+		body["claim_taken_at"] = claimedAt.UTC().Format(time.RFC3339Nano)
 	}
 	message, err := json.Marshal(body)
 	if err != nil {

--- a/internal/pipeline/run.go
+++ b/internal/pipeline/run.go
@@ -1970,6 +1970,13 @@ func autoMergeGateStageSettleOutcome(ctx context.Context, deps pipelineStageSett
 		if reason == "" {
 			reason = "GitHub did not confirm the merge"
 		}
+		// A TRANSIENT refusal keeps the stage waiting, bounded by the gate's own
+		// timeout, instead of ending the run. The at-most-once claim is already
+		// consumed, so the next scan takes the !claimed path and waits there too
+		// until the PR merges or the gate times out (#1783 review, F4).
+		if result.Waiting {
+			return autoMergeGateWaiting(stage, stageRow, deps.now, payload.PullRequest)
+		}
 		return block(reason + "; retry stopped")
 	}
 	confirmation, marshalErr := json.Marshal(map[string]any{

--- a/internal/pipeline/run.go
+++ b/internal/pipeline/run.go
@@ -2004,9 +2004,6 @@ func autoMergeGateStageSettleOutcome(ctx context.Context, deps pipelineStageSett
 		// empty summary and the event present.
 		return autoMergeLostClaimOutcome(ctx, deps, stage, stageRow, sourceJobID, payload.PullRequest, reviewedHead)
 	}
-	if err := recordAutoMergeClaimAt(ctx, deps, stage, sourceJobID, payload.PullRequest, reviewedHead); err != nil {
-		return false, "", "", nil, nil, err
-	}
 
 	result, mergeErr := deps.autoMerge.Merge(ctx, request)
 	if mergeErr != nil {
@@ -2039,13 +2036,6 @@ func autoMergeGateStageSettleOutcome(ctx context.Context, deps pipelineStageSett
 			if _, releaseErr := deps.releaseAutoMergeClaim(ctx, db.JobEvent{
 				JobID: sourceJobID, Kind: autoMergeClaimEventKind, Message: string(claim),
 			}); releaseErr != nil {
-				return false, "", "", nil, nil, releaseErr
-			}
-			// The claim's age row is released WITH the claim. That pairing is the
-			// whole reason the loser branch may trust it: the row exists exactly
-			// while the claim it measures does, so it cannot become the kind of
-			// never-cleared record that F-10 is about.
-			if releaseErr := releaseAutoMergeClaimAt(ctx, deps, stage, sourceJobID, payload.PullRequest, reviewedHead); releaseErr != nil {
 				return false, "", "", nil, nil, releaseErr
 			}
 			return autoMergeHoldDisposition(stage, stageRow, deps.now, payload.PullRequest, held)
@@ -2121,132 +2111,108 @@ const autoMergeClaimOrphanAfter = 15 * time.Minute
 
 const (
 	autoMergeClaimEventKind       = "pipeline_auto_merge_claim"
-	autoMergeClaimAtEventKind     = "pipeline_auto_merge_claim_at"
 	autoMergeClaimOrphanEventKind = "pipeline_auto_merge_claim_orphaned"
 )
-
-// autoMergeClaimAtMessage is the companion row's exact content. The CLAIM row
-// itself cannot carry a timestamp: its message is the identity that makes
-// ClaimJobEvent's insert-if-absent at-most-once, so varying it would let every
-// scan win. The companion carries the pipeline's clock instead, and is released
-// with the claim, so its lifetime is exactly the claim's.
-func autoMergeClaimAtMessage(deps pipelineStageSettleDeps, stage Stage, pr int, head string) (string, error) {
-	message, err := json.Marshal(map[string]any{
-		"phase": "claim_at", "pipeline": deps.rec.Name, "run_id": deps.run.ID,
-		"stage_id": stage.ID, "pull_request": pr, "head_sha": head,
-		"claimed_at": deps.now.UTC().Format(time.RFC3339Nano),
-	})
-	if err != nil {
-		return "", err
-	}
-	return string(message), nil
-}
-
-func recordAutoMergeClaimAt(ctx context.Context, deps pipelineStageSettleDeps, stage Stage, sourceJobID string, pr int, head string) error {
-	message, err := autoMergeClaimAtMessage(deps, stage, pr, head)
-	if err != nil {
-		return err
-	}
-	_, err = deps.store.ClaimJobEvent(ctx, db.JobEvent{JobID: sourceJobID, Kind: autoMergeClaimAtEventKind, Message: message})
-	return err
-}
-
-// releaseAutoMergeClaimAt drops the companion when the claim is released. A
-// leftover row - this delete failing after the claim's succeeded - can only be
-// OLDER than the next winner's, and the reader takes the newest, so the worst
-// case is that a suspicion is reported late rather than early.
-func releaseAutoMergeClaimAt(ctx context.Context, deps pipelineStageSettleDeps, stage Stage, sourceJobID string, pr int, head string) error {
-	message, err := autoMergeClaimAtMessage(deps, stage, pr, head)
-	if err != nil {
-		return err
-	}
-	_, err = deps.store.ReleaseJobEventClaim(ctx, db.JobEvent{JobID: sourceJobID, Kind: autoMergeClaimAtEventKind, Message: message})
-	return err
-}
-
-// latestAutoMergeClaimAt reports when the CURRENT claim for this head was taken,
-// or the zero time when nothing recorded it. Newest wins: see
-// releaseAutoMergeClaimAt for why that is the safe direction.
-func latestAutoMergeClaimAt(ctx context.Context, store *db.Store, sourceJobID, head string) (time.Time, error) {
-	events, err := store.ListJobEvents(ctx, sourceJobID)
-	if err != nil {
-		return time.Time{}, err
-	}
-	var newest time.Time
-	for _, event := range events {
-		if event.Kind != autoMergeClaimAtEventKind {
-			continue
-		}
-		var body struct {
-			HeadSHA   string `json:"head_sha"`
-			ClaimedAt string `json:"claimed_at"`
-		}
-		if json.Unmarshal([]byte(event.Message), &body) != nil {
-			continue
-		}
-		if strings.TrimSpace(body.HeadSHA) != strings.TrimSpace(head) {
-			continue
-		}
-		at, parseErr := time.Parse(time.RFC3339Nano, strings.TrimSpace(body.ClaimedAt))
-		if parseErr != nil {
-			continue
-		}
-		if at = at.UTC(); newest.IsZero() || at.After(newest) {
-			newest = at
-		}
-	}
-	return newest, nil
-}
 
 // autoMergeLostClaimOutcome is the losing scan's disposition. It is ALWAYS
 // non-terminal on its own account: the only terminal exit is the operator's own
 // stage `timeout`, applied by autoMergeGateWaitingWithReason.
 //
-// The trade this makes, stated rather than hidden: with no stage `timeout`, a
-// genuinely orphaned claim waits indefinitely. That is deliberate. The loser
-// cannot tell an orphan from a live winner, and round 5 measured what happens
-// when it guesses - a terminal park on a run that was merging fine. So the cause
-// becomes a durable job event an operator can query, and the operator's own
-// `timeout` remains the lever that converts it into a park.
+// The clock is the GATE STAGE'S OWN StartedAt, and that choice is the round-6
+// fix rather than a detail. The previous shape recorded a companion
+// `pipeline_auto_merge_claim_at` row after taking the claim, so the claim and
+// its age were TWO writes: a crash or a transient error between them left a
+// consumed claim with no age, and because F-10 had just deleted every hold read
+// from this branch there was nothing left to bound it - a permanent, silent,
+// unbounded wait, which is round-4 F-3's class re-created on the path F-10 made
+// load-bearing (#1783 round-6 review, N-1).
+//
+// The fix DELETES the compensation instead of hardening it. Reordering was not
+// available: writing the age first would let every LOSER refresh it each scan
+// and suppress the report forever, and putting the timestamp inside the claim
+// message would make each scan's content unique and break the insert-if-absent
+// that IS at-most-once. Falling back to the claim row's database created_at
+// would compare the pipeline clock against the store clock - the two-clock
+// mistake round 4 already paid for at the hold anchor - and a test cannot
+// backdate created_at, so that bound would be unpinnable.
+//
+// stageRow.StartedAt needs none of it: it is written from the pipeline's own
+// clock (run.go, the gate arm sets `row.StartedAt = now`), it is the same clock
+// deps.now comes from, it is atomic with the stage row's existence, and
+// pipelineGateTimedOut already trusts it for the operator's timeout. One write,
+// one clock, no window.
+//
+// What that trades, stated: the bound now measures how long this GATE has been
+// waiting, not how long the claim has been held, so a claim taken late in a long
+// gate wait can be reported early. The report is non-terminal, so the cost of
+// being early is one job event, never a run - and "this gate has waited past the
+// bound and the claim is still held" is the condition an operator can act on
+// anyway.
 func autoMergeLostClaimOutcome(ctx context.Context, deps pipelineStageSettleDeps, stage Stage, stageRow db.PipelineRunStage, sourceJobID string, pr int, head string) (bool, string, string, []string, *db.PipelineRunStage, error) {
-	claimedAt, err := latestAutoMergeClaimAt(ctx, deps.store, sourceJobID, head)
-	if err != nil {
-		return false, "", "", nil, nil, err
+	held, knowable := autoMergeGateWaitFor(stageRow, deps.now)
+	if !knowable {
+		// No start stamp on the stage row - reachable, because a resumed run zeroes
+		// it (resume.go) - so no age is knowable and pipelineGateTimedOut will not
+		// fire either. An unmeasurable wait is at least as suspicious as a long
+		// one, so it RECORDS rather than merely carrying a reason: with no timeout
+		// possible, the reason would never reach a summary and a mutant that
+		// dropped it changed nothing observable. Measured: it survived until the
+		// record was added (#1783 round-6 review, N-1).
+		if err := recordAutoMergeClaimOrphanSuspicion(ctx, deps, stage, sourceJobID, pr, head, autoMergeClaimAgeUnknown); err != nil {
+			return false, "", "", nil, nil, err
+		}
+		return autoMergeGateWaitingWithReason(stage, stageRow, deps.now, pr,
+			fmt.Sprintf("another scan holds the auto-merge claim for head %s and this gate has no recorded start time, so the wait cannot be aged", shortPipelineSHA(head)))
 	}
-	if claimedAt.IsZero() {
-		// Nothing recorded the claim, so nothing is known about its age. Waiting
-		// with no cause is the honest report.
-		return autoMergeGateWaiting(stage, stageRow, deps.now, pr)
-	}
-	held := deps.now.Sub(claimedAt)
 	if held < autoMergeClaimOrphanAfter {
 		return autoMergeGateWaitingWithReason(stage, stageRow, deps.now, pr,
-			fmt.Sprintf("another scan holds the auto-merge claim for head %s (%s)", shortPipelineSHA(head), held.Truncate(time.Second)))
+			fmt.Sprintf("another scan holds the auto-merge claim for head %s (%s into this gate)", shortPipelineSHA(head), held.Truncate(time.Second)))
 	}
-	reason := fmt.Sprintf("the auto-merge claim for head %s has been held for %s with no merge and no release, which is the signature of a claim orphaned by a scan that stopped between claiming and writing; the run keeps re-observing and merges as soon as the claim is released, and setting a `timeout` on this gate stage is what turns this wait into a park",
+	reason := fmt.Sprintf("the auto-merge claim for head %s is still held %s into this gate with no merge and no release, which is the signature of a claim orphaned by a scan that stopped after taking it; the run keeps re-observing and merges as soon as the claim is released, and setting a `timeout` on this gate stage is what turns this wait into a park",
 		shortPipelineSHA(head), held.Truncate(time.Second))
-	if err := recordAutoMergeClaimOrphanSuspicion(ctx, deps, stage, sourceJobID, pr, head, claimedAt); err != nil {
+	if err := recordAutoMergeClaimOrphanSuspicion(ctx, deps, stage, sourceJobID, pr, head, autoMergeClaimHeldPastBound); err != nil {
 		return false, "", "", nil, nil, err
 	}
 	return autoMergeGateWaitingWithReason(stage, stageRow, deps.now, pr, reason)
 }
 
+// autoMergeGateWaitFor reports how long this gate stage has been waiting, on the
+// pipeline's clock, and whether that is knowable at all.
+func autoMergeGateWaitFor(stageRow db.PipelineRunStage, now time.Time) (time.Duration, bool) {
+	if stageRow.StartedAt.IsZero() {
+		return 0, false
+	}
+	return now.Sub(stageRow.StartedAt), true
+}
+
 // recordAutoMergeClaimOrphanSuspicion writes the suspicion once per claim, so a
-// scan loop cannot append a row a minute. The claim's own timestamp is part of
-// the content, so a NEW claim gets a new row.
+// scan loop cannot append a row a minute.
 //
-// The content carries NOTHING that changes between scans. The first version
+// The content carries NOTHING that changes between scans. An earlier version
 // embedded the rendered cause, which states the elapsed time, so every scan
 // wrote a different message and the dedup never matched - measured as 2 rows
 // from 2 losing scans. The elapsed time belongs in the stage summary, which is
 // regenerated per scan by design.
-func recordAutoMergeClaimOrphanSuspicion(ctx context.Context, deps pipelineStageSettleDeps, stage Stage, sourceJobID string, pr int, head string, claimedAt time.Time) error {
-	message, err := json.Marshal(map[string]any{
+// autoMergeClaimSuspicionCause names WHY a losing scan reported the claim, so
+// the two shapes are distinguishable in the record: a claim still held past the
+// bound, and a wait that cannot be aged at all.
+type autoMergeClaimSuspicionCause string
+
+const (
+	autoMergeClaimHeldPastBound autoMergeClaimSuspicionCause = "held_past_bound"
+	autoMergeClaimAgeUnknown    autoMergeClaimSuspicionCause = "gate_start_unrecorded"
+)
+
+func recordAutoMergeClaimOrphanSuspicion(ctx context.Context, deps pipelineStageSettleDeps, stage Stage, sourceJobID string, pr int, head string, cause autoMergeClaimSuspicionCause) error {
+	body := map[string]any{
 		"phase": "claim_orphan_suspected", "pipeline": deps.rec.Name, "run_id": deps.run.ID,
 		"stage_id": stage.ID, "pull_request": pr, "head_sha": head,
-		"claimed_at": claimedAt.UTC().Format(time.RFC3339Nano),
-		"after":      autoMergeClaimOrphanAfter.String(),
-	})
+		"cause": string(cause),
+	}
+	if cause == autoMergeClaimHeldPastBound {
+		body["after"] = autoMergeClaimOrphanAfter.String()
+	}
+	message, err := json.Marshal(body)
 	if err != nil {
 		return err
 	}

--- a/internal/workflow/merge_gate.go
+++ b/internal/workflow/merge_gate.go
@@ -386,10 +386,10 @@ func (g PolicyMergeGate) Evaluate(ctx context.Context, request MergeRequest) (Me
 	if pr.Mergeable != nil && !*pr.Mergeable {
 		return g.block(ctx, request, headSHA, "pull request is not mergeable; rebase or update the branch", MergeBlockTransient)
 	}
-	if required, reconciled, reason, err := ensureWorkloadModeReconciled(ctx, g.Store, g.GitHub, repo, int64(request.PullRequest), headSHA); err != nil {
+	if required, reconciled, hold, err := ensureWorkloadModeReconciled(ctx, g.Store, g.GitHub, repo, int64(request.PullRequest), headSHA); err != nil {
 		return MergeDecision{}, err
 	} else if required && !reconciled {
-		return g.pending(ctx, request, headSHA, reason)
+		return g.pending(ctx, request, headSHA, hold.detail)
 	}
 	result, err := g.executePullRequestMergeFenced(ctx, request, github.MergePullRequestInput{
 		Repo:            repo,

--- a/internal/workflow/merge_gate.go
+++ b/internal/workflow/merge_gate.go
@@ -54,6 +54,7 @@ type MergeGateGitHub interface {
 	GetPullRequest(ctx context.Context, repo github.Repository, number int64) (github.PullRequest, error)
 	GetCombinedStatus(ctx context.Context, repo github.Repository, ref string) (github.CombinedStatus, error)
 	ListCheckRunsForRef(ctx context.Context, repo github.Repository, ref string) ([]github.PullRequestCheck, error)
+	ListPullRequestFiles(ctx context.Context, repo github.Repository, number int64) ([]github.PullRequestFile, error)
 	CompareCommits(ctx context.Context, repo github.Repository, base string, head string) (github.CompareResult, error)
 	ListPullRequestChecks(ctx context.Context, repo github.Repository, number int64) ([]github.PullRequestCheck, error)
 	CreateCommitStatus(ctx context.Context, input github.CommitStatusInput) (github.CommitStatus, error)
@@ -384,6 +385,11 @@ func (g PolicyMergeGate) Evaluate(ctx context.Context, request MergeRequest) (Me
 	}
 	if pr.Mergeable != nil && !*pr.Mergeable {
 		return g.block(ctx, request, headSHA, "pull request is not mergeable; rebase or update the branch", MergeBlockTransient)
+	}
+	if required, reconciled, reason, err := ensureWorkloadModeReconciled(ctx, g.Store, g.GitHub, repo, int64(request.PullRequest), headSHA); err != nil {
+		return MergeDecision{}, err
+	} else if required && !reconciled {
+		return g.pending(ctx, request, headSHA, reason)
 	}
 	result, err := g.executePullRequestMergeFenced(ctx, request, github.MergePullRequestInput{
 		Repo:            repo,

--- a/internal/workflow/merge_gate_test.go
+++ b/internal/workflow/merge_gate_test.go
@@ -5151,6 +5151,7 @@ type fakeMergeGateGitHub struct {
 	status         github.CombinedStatus
 	compare        github.CompareResult
 	checks         []github.PullRequestCheck
+	files          []github.PullRequestFile
 	mergeResult    github.MergeResult
 	getPullRequest func(int) (github.PullRequest, error)
 	mergeErr       error
@@ -5182,6 +5183,10 @@ func (f *fakeMergeGateGitHub) GetPullRequest(context.Context, github.Repository,
 		return f.getPullRequest(f.getCalls)
 	}
 	return f.pr, nil
+}
+
+func (f *fakeMergeGateGitHub) ListPullRequestFiles(context.Context, github.Repository, int64) ([]github.PullRequestFile, error) {
+	return append([]github.PullRequestFile(nil), f.files...), nil
 }
 
 func (f *fakeMergeGateGitHub) GetCombinedStatus(context.Context, github.Repository, string) (github.CombinedStatus, error) {

--- a/internal/workflow/pipeline_auto_merge.go
+++ b/internal/workflow/pipeline_auto_merge.go
@@ -106,6 +106,13 @@ func (m PipelineAutoMerger) Evaluate(ctx context.Context, request PipelineAutoMe
 		readiness.Reason = "pull request is not mergeable; rebase or update the branch"
 		return readiness, nil
 	}
+	if required, reconciled, reason, err := ensureWorkloadModeReconciled(ctx, m.Store, m.GitHub, repo, int64(request.PullRequest), head); err != nil {
+		return PipelineAutoMergeReadiness{}, err
+	} else if required && !reconciled {
+		readiness.Waiting = true
+		readiness.Reason = reason
+		return readiness, nil
+	}
 	gate := PolicyMergeGate{
 		Store:             m.Store,
 		GitHub:            m.GitHub,
@@ -146,6 +153,22 @@ func (m PipelineAutoMerger) Merge(ctx context.Context, request PipelineAutoMerge
 	repo, err := parseRepoFullName(request.Repo)
 	if err != nil {
 		return PipelineAutoMergeResult{}, err
+	}
+	if m.Store == nil || m.GitHub == nil {
+		return PipelineAutoMergeResult{}, fmt.Errorf("pipeline auto-merge executor is not configured")
+	}
+	pr, err := m.GitHub.GetPullRequest(ctx, repo, int64(request.PullRequest))
+	if err != nil {
+		return PipelineAutoMergeResult{}, err
+	}
+	head := strings.TrimSpace(pr.HeadSHA)
+	if head != strings.TrimSpace(request.HeadSHA) {
+		return PipelineAutoMergeResult{Reason: fmt.Sprintf("pull request head drifted after review: reviewed %s, current %s", shortSHA(request.HeadSHA), shortSHA(head))}, nil
+	}
+	if required, reconciled, reason, err := ensureWorkloadModeReconciled(ctx, m.Store, m.GitHub, repo, int64(request.PullRequest), head); err != nil {
+		return PipelineAutoMergeResult{}, err
+	} else if required && !reconciled {
+		return PipelineAutoMergeResult{Reason: reason}, nil
 	}
 	result, err := executePullRequestMerge(ctx, m.GitHub, github.MergePullRequestInput{
 		Repo:            repo,

--- a/internal/workflow/pipeline_auto_merge.go
+++ b/internal/workflow/pipeline_auto_merge.go
@@ -26,22 +26,30 @@ type PipelineAutoMergeRequest struct {
 // mergeability and checks are green; Waiting is a transient not-yet-green state;
 // Blocked is terminal for this pipeline run. Merged is idempotent success.
 type PipelineAutoMergeReadiness struct {
-	Ready          bool
-	Waiting        bool
-	Blocked        bool
-	Merged         bool
-	CurrentHeadSHA string
-	MergeCommitSHA string
-	Reason         string
+	Ready   bool
+	Waiting bool
+	// ReconciliationHold marks the Waiting state as a workload-mode
+	// reconciliation hold specifically, rather than a not-yet-green CI or
+	// mergeability wait. The pipeline records and bounds this class; instrumenting
+	// only the Merge-side hold left the ORDINARY path - Evaluate, which runs the
+	// same check first - silent, unbounded and unrecorded (#1783 round-4 review,
+	// F-1, measured at now+72h).
+	ReconciliationHold bool
+	Blocked            bool
+	Merged             bool
+	CurrentHeadSHA     string
+	MergeCommitSHA     string
+	Reason             string
 }
 
 // PipelineAutoMergeResult is the result of the single audited merge attempt.
 //
-// Waiting separates a TRANSIENT refusal from a terminal one. The pipeline folds
-// any !Merged into a blocked stage with "retry stopped", so a reconciliation
-// hold that Evaluate reports as Waiting became a terminal block when it landed
-// in the Evaluate->Merge window - the same condition, two dispositions, and the
-// worse one needed a human (#1783 review, F4).
+// Waiting separates a TRANSIENT refusal from a terminal one, and carries a
+// SAFETY PRECONDITION the pipeline relies on: Waiting means NO GitHub mutation
+// was attempted. The pipeline releases its at-most-once merge claim on a Waiting
+// return, so mapping a merge-API timeout or any post-request failure to Waiting
+// would silently convert at-most-once into at-least-once (#1783 round-4 review,
+// F-9). A refusal that may have reached GitHub must NOT set Waiting.
 type PipelineAutoMergeResult struct {
 	Merged         bool
 	Waiting        bool
@@ -117,6 +125,7 @@ func (m PipelineAutoMerger) Evaluate(ctx context.Context, request PipelineAutoMe
 		return PipelineAutoMergeReadiness{}, err
 	} else if required && !reconciled {
 		readiness.Waiting = true
+		readiness.ReconciliationHold = true
 		readiness.Reason = reason
 		return readiness, nil
 	}

--- a/internal/workflow/pipeline_auto_merge.go
+++ b/internal/workflow/pipeline_auto_merge.go
@@ -36,8 +36,15 @@ type PipelineAutoMergeReadiness struct {
 }
 
 // PipelineAutoMergeResult is the result of the single audited merge attempt.
+//
+// Waiting separates a TRANSIENT refusal from a terminal one. The pipeline folds
+// any !Merged into a blocked stage with "retry stopped", so a reconciliation
+// hold that Evaluate reports as Waiting became a terminal block when it landed
+// in the Evaluate->Merge window - the same condition, two dispositions, and the
+// worse one needed a human (#1783 review, F4).
 type PipelineAutoMergeResult struct {
 	Merged         bool
+	Waiting        bool
 	MergeCommitSHA string
 	Reason         string
 }
@@ -168,7 +175,9 @@ func (m PipelineAutoMerger) Merge(ctx context.Context, request PipelineAutoMerge
 	if required, reconciled, reason, err := ensureWorkloadModeReconciled(ctx, m.Store, m.GitHub, repo, int64(request.PullRequest), head); err != nil {
 		return PipelineAutoMergeResult{}, err
 	} else if required && !reconciled {
-		return PipelineAutoMergeResult{Reason: reason}, nil
+		// Waiting, matching Evaluate: a reconciliation row or an owner note can
+		// land at any moment, so the run must re-observe rather than end.
+		return PipelineAutoMergeResult{Waiting: true, Reason: reason}, nil
 	}
 	result, err := executePullRequestMerge(ctx, m.GitHub, github.MergePullRequestInput{
 		Repo:            repo,

--- a/internal/workflow/pipeline_auto_merge.go
+++ b/internal/workflow/pipeline_auto_merge.go
@@ -35,11 +35,15 @@ type PipelineAutoMergeReadiness struct {
 	// same check first - silent, unbounded and unrecorded (#1783 round-4 review,
 	// F-1, measured at now+72h).
 	ReconciliationHold bool
-	Blocked            bool
-	Merged             bool
-	CurrentHeadSHA     string
-	MergeCommitSHA     string
-	Reason             string
+	// ReconciliationKey is the STABLE episode discriminator for that hold. Reason
+	// carries volatile near-miss text for the operator, so the pipeline keys the
+	// hold's budget on this instead (#1783 round-5 review, F-11).
+	ReconciliationKey string
+	Blocked           bool
+	Merged            bool
+	CurrentHeadSHA    string
+	MergeCommitSHA    string
+	Reason            string
 }
 
 // PipelineAutoMergeResult is the result of the single audited merge attempt.
@@ -51,10 +55,13 @@ type PipelineAutoMergeReadiness struct {
 // would silently convert at-most-once into at-least-once (#1783 round-4 review,
 // F-9). A refusal that may have reached GitHub must NOT set Waiting.
 type PipelineAutoMergeResult struct {
-	Merged         bool
-	Waiting        bool
-	MergeCommitSHA string
-	Reason         string
+	Merged  bool
+	Waiting bool
+	// ReconciliationKey is set only for a workload-mode reconciliation Waiting,
+	// and is the stable episode key for it (#1783 round-5 review, F-11).
+	ReconciliationKey string
+	MergeCommitSHA    string
+	Reason            string
 }
 
 // PipelineAutoMerger adapts the existing policy merge-gate checks and the shared
@@ -121,12 +128,13 @@ func (m PipelineAutoMerger) Evaluate(ctx context.Context, request PipelineAutoMe
 		readiness.Reason = "pull request is not mergeable; rebase or update the branch"
 		return readiness, nil
 	}
-	if required, reconciled, reason, err := ensureWorkloadModeReconciled(ctx, m.Store, m.GitHub, repo, int64(request.PullRequest), head); err != nil {
+	if required, reconciled, hold, err := ensureWorkloadModeReconciled(ctx, m.Store, m.GitHub, repo, int64(request.PullRequest), head); err != nil {
 		return PipelineAutoMergeReadiness{}, err
 	} else if required && !reconciled {
 		readiness.Waiting = true
 		readiness.ReconciliationHold = true
-		readiness.Reason = reason
+		readiness.ReconciliationKey = hold.key
+		readiness.Reason = hold.detail
 		return readiness, nil
 	}
 	gate := PolicyMergeGate{
@@ -181,12 +189,12 @@ func (m PipelineAutoMerger) Merge(ctx context.Context, request PipelineAutoMerge
 	if head != strings.TrimSpace(request.HeadSHA) {
 		return PipelineAutoMergeResult{Reason: fmt.Sprintf("pull request head drifted after review: reviewed %s, current %s", shortSHA(request.HeadSHA), shortSHA(head))}, nil
 	}
-	if required, reconciled, reason, err := ensureWorkloadModeReconciled(ctx, m.Store, m.GitHub, repo, int64(request.PullRequest), head); err != nil {
+	if required, reconciled, hold, err := ensureWorkloadModeReconciled(ctx, m.Store, m.GitHub, repo, int64(request.PullRequest), head); err != nil {
 		return PipelineAutoMergeResult{}, err
 	} else if required && !reconciled {
 		// Waiting, matching Evaluate: a reconciliation row or an owner note can
 		// land at any moment, so the run must re-observe rather than end.
-		return PipelineAutoMergeResult{Waiting: true, Reason: reason}, nil
+		return PipelineAutoMergeResult{Waiting: true, ReconciliationKey: hold.key, Reason: hold.detail}, nil
 	}
 	result, err := executePullRequestMerge(ctx, m.GitHub, github.MergePullRequestInput{
 		Repo:            repo,

--- a/internal/workflow/workload_mode_gate.go
+++ b/internal/workflow/workload_mode_gate.go
@@ -21,6 +21,29 @@ type modeSensitivePullRequest struct {
 	required  bool
 	mode      string
 	ambiguous bool
+	// patchUnavailable records that GitHub omitted the AGENTS.md patch, which is
+	// an API limit on large files rather than an author mistake.
+	patchUnavailable bool
+}
+
+// noteConcernsRepo decides whether an UNPARSEABLE note belongs to this repo:
+// its repo column when set, else a lenient `repo=<value>` scan of the body. A
+// note that names neither is another lane's and is skipped.
+func noteConcernsRepo(note db.WorkflowNote, repo string) bool {
+	repo = strings.TrimSpace(repo)
+	if repo == "" {
+		return false
+	}
+	if column := strings.TrimSpace(note.Repo); column != "" {
+		return strings.EqualFold(column, repo)
+	}
+	for _, field := range strings.Fields(note.Body) {
+		field = strings.TrimRight(field, "]")
+		if value, ok := strings.CutPrefix(field, "repo="); ok {
+			return strings.EqualFold(strings.TrimSpace(value), repo)
+		}
+	}
+	return false
 }
 
 // workloadModeEnforcedOwner is the repository OWNER whose mode-marker changes
@@ -58,7 +81,12 @@ func inspectModeSensitivePullRequest(ctx context.Context, gh MergeGateGitHub, re
 		}
 		patch := strings.TrimSpace(file.Patch)
 		if patch == "" {
-			return modeSensitivePullRequest{required: true, ambiguous: true}, nil
+			// GitHub OMITS `patch` for large files, and AGENTS.md is large, so this
+			// is routinely an API limit rather than anything the author did. It
+			// still requires reconciliation - the marker may have moved and we
+			// cannot see it - but the hold must not tell the author to fix a
+			// marker that is not the problem (#1783 round-3 review, F-B).
+			return modeSensitivePullRequest{required: true, ambiguous: true, patchUnavailable: true}, nil
 		}
 		var addedMode string
 		changed := false
@@ -154,9 +182,13 @@ func ensureWorkloadModeReconciled(ctx context.Context, store *db.Store, gh Merge
 	// unreadable note, or a PR whose own marker is unreadable too, where nothing
 	// remains to check the row against.
 	if decision.unreadableID > 0 && strings.TrimSpace(observed.mode) == "" {
+		remedy := "correct that note, or append a fresh readable operating-mode note"
+		if observed.patchUnavailable {
+			remedy = "GitHub omitted this PR's AGENTS.md patch, so the marker cannot be read here and is not the author's to fix; " + remedy
+		}
 		return true, false, fmt.Sprintf(
-			"workload-mode change cannot be reconciled: operating-mode note %d %s and this PR's own mode marker is missing or ambiguous, so no readable decision remains; correct that note or the marker",
-			decision.unreadableID, decision.unreadableWhy,
+			"workload-mode change cannot be reconciled: operating-mode note %d %s and this PR's own mode marker is missing or ambiguous, so no readable decision remains; %s",
+			decision.unreadableID, decision.unreadableWhy, remedy,
 		), nil
 	}
 	expectedMode := strings.ToUpper(strings.TrimSpace(observed.mode))
@@ -255,7 +287,19 @@ func ensureWorkloadModeReconciled(ctx context.Context, store *db.Store, gh Merge
 	}
 	detail := fmt.Sprintf("workload-mode change requires reconciliation at head %s against operating-mode note %s", shortSHA(headSHA), decisionID)
 	if observed.ambiguous {
-		detail += "; AGENTS.md mode-marker patch is missing or ambiguous"
+		if observed.patchUnavailable {
+			detail += "; GitHub omitted this PR's AGENTS.md patch, so the mode marker could not be read"
+		} else {
+			detail += "; AGENTS.md mode-marker patch is missing or ambiguous"
+		}
+	}
+	if len(notes) >= workloadModeReconciliationScan {
+		// The window is FULL, so a valid row for this head may have been pushed
+		// out of it by newer rows from the same repo. Without this line the hold
+		// names whichever near-miss the loop happened to see and reads as a
+		// verdict on the operator's own row (#1783 round-3 review, F-C). Refiling
+		// the row recovers it, which is why this is a message fix.
+		detail += fmt.Sprintf("; the newest %d reconciliation rows for this repository were scanned and a valid row for this head may have aged out - refile it if you already wrote one", workloadModeReconciliationScan)
 	}
 	if nearMiss == "" {
 		// The repo-scoped SQL drops a row whose repo COLUMN names another
@@ -313,11 +357,17 @@ func latestOperatingModeDecision(ctx context.Context, store *db.Store, repo stri
 			}, nil
 		}
 		// An unparseable body cannot answer "is this note for this repo?" through
-		// its repo FIELD, so fall back to the note's repo COLUMN. A note that is
-		// demonstrably this repo's and unreadable HOLDS; one that names neither
+		// its repo FIELD, so fall back to the note's repo COLUMN, and when that is
+		// empty to a lenient scan of the body for `repo=<this repo>`. A note that
+		// is demonstrably this repo's and unreadable HOLDS; one that names neither
 		// this repo nor nothing is another lane's problem and is skipped, so a
 		// typo in an unrelated note cannot freeze every gitmoot repository.
-		if !parsed && strings.EqualFold(strings.TrimSpace(note.Repo), strings.TrimSpace(repo)) {
+		//
+		// The lenient body scan closes the residual fail-open the round-3 review
+		// measured (F-D): `workflow note` is written by hand, so an omitted --repo
+		// left a malformed note invisible and a stale PR-sourced row still
+		// reconciled.
+		if !parsed && noteConcernsRepo(note, repo) {
 			return operatingModeDecision{
 				unreadableID:  note.ID,
 				unreadableWhy: "has a malformed field list, so its mode cannot be read",

--- a/internal/workflow/workload_mode_gate.go
+++ b/internal/workflow/workload_mode_gate.go
@@ -26,9 +26,14 @@ type modeSensitivePullRequest struct {
 	patchUnavailable bool
 }
 
-// noteConcernsRepo decides whether an UNPARSEABLE note belongs to this repo:
-// its repo column when set, else a lenient `repo=<value>` scan of the body. A
-// note that names neither is another lane's and is skipped.
+// noteConcernsRepo decides whether an UNPARSEABLE note belongs to this repo: its
+// repo column when set, else a lenient scan of the body for a repo value.
+//
+// The scan tolerates the shapes a hand-written note actually takes. The first
+// version matched only a bare `repo=<value>` token, so `repo=owner/name,` and
+// `repo = owner/name` still slipped through and a stale row merged (#1783
+// round-4 review, F-6). A note that names neither this repo nor nothing is
+// another lane's and is skipped, which is the anti-wedge narrowing.
 func noteConcernsRepo(note db.WorkflowNote, repo string) bool {
 	repo = strings.TrimSpace(repo)
 	if repo == "" {
@@ -37,13 +42,41 @@ func noteConcernsRepo(note db.WorkflowNote, repo string) bool {
 	if column := strings.TrimSpace(note.Repo); column != "" {
 		return strings.EqualFold(column, repo)
 	}
-	for _, field := range strings.Fields(note.Body) {
-		field = strings.TrimRight(field, "]")
-		if value, ok := strings.CutPrefix(field, "repo="); ok {
-			return strings.EqualFold(strings.TrimSpace(value), repo)
-		}
+	if value, ok := leadingRepoValue(note.Body); ok {
+		return strings.EqualFold(value, repo)
 	}
 	return false
+}
+
+// leadingRepoValue extracts the first repo value from a note body, tolerating
+// `repo=x`, `repo = x`, and trailing punctuation such as `,`, `;` or `]`.
+func leadingRepoValue(body string) (string, bool) {
+	fields := strings.Fields(body)
+	for i, field := range fields {
+		key, value, split := strings.Cut(field, "=")
+		if !strings.EqualFold(strings.TrimSpace(key), "repo") {
+			continue
+		}
+		if !split || strings.TrimSpace(value) == "" {
+			// `repo = x` or `repo =x`: the value is in a later field.
+			for _, next := range fields[i+1:] {
+				next = strings.TrimPrefix(strings.TrimSpace(next), "=")
+				if trimmed := trimNoteFieldValue(next); trimmed != "" {
+					return trimmed, true
+				}
+			}
+			return "", false
+		}
+		if trimmed := trimNoteFieldValue(value); trimmed != "" {
+			return trimmed, true
+		}
+		return "", false
+	}
+	return "", false
+}
+
+func trimNoteFieldValue(value string) string {
+	return strings.Trim(strings.TrimSpace(value), "],;\"'")
 }
 
 // workloadModeEnforcedOwner is the repository OWNER whose mode-marker changes
@@ -182,7 +215,11 @@ func ensureWorkloadModeReconciled(ctx context.Context, store *db.Store, gh Merge
 	// unreadable note, or a PR whose own marker is unreadable too, where nothing
 	// remains to check the row against.
 	if decision.unreadableID > 0 && strings.TrimSpace(observed.mode) == "" {
-		remedy := "correct that note, or append a fresh readable operating-mode note"
+		// The remedy must be COMPLETE. Naming only the note left an exit that does
+		// not by itself clear the hold: a fresh readable note restores a decision,
+		// and the PR still needs an exact-head reconciliation row against it
+		// (#1783 round-4 review, F-7).
+		remedy := "append a fresh readable operating-mode note AND file an exact-head reconciliation row citing it, or correct the malformed note"
 		if observed.patchUnavailable {
 			remedy = "GitHub omitted this PR's AGENTS.md patch, so the marker cannot be read here and is not the author's to fix; " + remedy
 		}

--- a/internal/workflow/workload_mode_gate.go
+++ b/internal/workflow/workload_mode_gate.go
@@ -1,0 +1,192 @@
+package workflow
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/gitmoot/gitmoot/internal/db"
+	"github.com/gitmoot/gitmoot/internal/github"
+)
+
+const (
+	operatingModeNotePrefix        = "[operating-mode "
+	modeReconciliationNotePrefix   = "[workload-mode-reconciliation "
+	workloadModeMarker             = "**Current mode:"
+	workloadModeReconciliationScan = 200
+)
+
+type modeSensitivePullRequest struct {
+	required  bool
+	mode      string
+	ambiguous bool
+}
+
+func inspectModeSensitivePullRequest(ctx context.Context, gh MergeGateGitHub, repo github.Repository, number int64) (modeSensitivePullRequest, error) {
+	if repo.FullName() != "gitmoot/gitmoot" {
+		return modeSensitivePullRequest{}, nil
+	}
+	files, err := gh.ListPullRequestFiles(ctx, repo, number)
+	if err != nil {
+		return modeSensitivePullRequest{}, fmt.Errorf("list pull request files for workload-mode reconciliation: %w", err)
+	}
+	for _, file := range files {
+		if strings.TrimSpace(file.Filename) != "AGENTS.md" {
+			continue
+		}
+		patch := strings.TrimSpace(file.Patch)
+		if patch == "" {
+			return modeSensitivePullRequest{required: true, ambiguous: true}, nil
+		}
+		var addedMode string
+		changed := false
+		ambiguous := false
+		for _, line := range strings.Split(patch, "\n") {
+			if len(line) < 2 || (line[0] != '+' && line[0] != '-') {
+				continue
+			}
+			text := strings.TrimSpace(line[1:])
+			if !strings.HasPrefix(text, workloadModeMarker) {
+				continue
+			}
+			changed = true
+			if line[0] != '+' {
+				continue
+			}
+			mode, ok := parseWorkloadModeMarker(text)
+			if !ok || (addedMode != "" && addedMode != mode) {
+				ambiguous = true
+				continue
+			}
+			addedMode = mode
+		}
+		if !changed {
+			return modeSensitivePullRequest{}, nil
+		}
+		if addedMode == "" {
+			ambiguous = true
+		}
+		return modeSensitivePullRequest{required: true, mode: addedMode, ambiguous: ambiguous}, nil
+	}
+	return modeSensitivePullRequest{}, nil
+}
+
+func parseWorkloadModeMarker(line string) (string, bool) {
+	line = strings.TrimSpace(line)
+	if !strings.HasPrefix(line, workloadModeMarker) || !strings.HasSuffix(line, ".**") {
+		return "", false
+	}
+	mode := strings.TrimSpace(strings.TrimSuffix(strings.TrimPrefix(line, workloadModeMarker), ".**"))
+	return mode, validWorkloadMode(mode)
+}
+
+func validWorkloadMode(mode string) bool {
+	switch strings.ToUpper(strings.TrimSpace(mode)) {
+	case "THROUGHPUT", "STEADY", "DRAIN":
+		return true
+	default:
+		return false
+	}
+}
+
+type operatingModeDecision struct {
+	id   int64
+	mode string
+}
+
+func ensureWorkloadModeReconciled(ctx context.Context, store *db.Store, gh MergeGateGitHub, repo github.Repository, number int64, headSHA string) (required, reconciled bool, reason string, err error) {
+	observed, err := inspectModeSensitivePullRequest(ctx, gh, repo, number)
+	if err != nil {
+		return false, false, "", err
+	}
+	if !observed.required {
+		return false, true, "", nil
+	}
+	if store == nil {
+		return true, false, "", fmt.Errorf("workload-mode reconciliation requires a store")
+	}
+	decision, err := latestOperatingModeDecision(ctx, store, repo.FullName())
+	if err != nil {
+		return true, false, "", err
+	}
+	expectedMode := strings.ToUpper(strings.TrimSpace(observed.mode))
+	if expectedMode == "" && decision.id > 0 {
+		expectedMode = decision.mode
+	}
+	decisionID := "none"
+	if decision.id > 0 {
+		decisionID = strconv.FormatInt(decision.id, 10)
+	}
+	notes, err := store.ListWorkflowNotesByBodyPrefix(ctx, modeReconciliationNotePrefix, workloadModeReconciliationScan)
+	if err != nil {
+		return true, false, "", fmt.Errorf("list workload-mode reconciliation notes: %w", err)
+	}
+	for _, note := range notes {
+		fields, ok := parseModeNoteFields(note.Body, modeReconciliationNotePrefix)
+		if !ok || !workflowNoteMatchesRepo(note, fields, repo.FullName()) {
+			continue
+		}
+		if fields["pr"] != strconv.FormatInt(number, 10) || fields["head"] != strings.TrimSpace(headSHA) || fields["decision_note"] != decisionID {
+			continue
+		}
+		mode := strings.ToUpper(strings.TrimSpace(fields["mode"]))
+		if !validWorkloadMode(mode) || (expectedMode != "" && mode != expectedMode) {
+			continue
+		}
+		if decision.id > 0 && note.ID <= decision.id {
+			continue
+		}
+		return true, true, "", nil
+	}
+	detail := fmt.Sprintf("workload-mode change requires reconciliation at head %s against operating-mode note %s", shortSHA(headSHA), decisionID)
+	if observed.ambiguous {
+		detail += "; AGENTS.md mode-marker patch is missing or ambiguous"
+	}
+	return true, false, detail, nil
+}
+
+func latestOperatingModeDecision(ctx context.Context, store *db.Store, repo string) (operatingModeDecision, error) {
+	notes, err := store.ListWorkflowNotesByBodyPrefix(ctx, operatingModeNotePrefix, workloadModeReconciliationScan)
+	if err != nil {
+		return operatingModeDecision{}, fmt.Errorf("list operating-mode notes: %w", err)
+	}
+	for _, note := range notes {
+		fields, ok := parseModeNoteFields(note.Body, operatingModeNotePrefix)
+		if !ok || !workflowNoteMatchesRepo(note, fields, repo) {
+			continue
+		}
+		mode := strings.ToUpper(strings.TrimSpace(fields["mode"]))
+		if validWorkloadMode(mode) {
+			return operatingModeDecision{id: note.ID, mode: mode}, nil
+		}
+	}
+	return operatingModeDecision{}, nil
+}
+
+func parseModeNoteFields(body, prefix string) (map[string]string, bool) {
+	if !strings.HasPrefix(body, prefix) {
+		return nil, false
+	}
+	end := strings.IndexByte(body, ']')
+	if end < len(prefix) {
+		return nil, false
+	}
+	fields := make(map[string]string)
+	for _, field := range strings.Fields(body[len(prefix):end]) {
+		key, value, ok := strings.Cut(field, "=")
+		if !ok || strings.TrimSpace(key) == "" || strings.TrimSpace(value) == "" {
+			return nil, false
+		}
+		fields[strings.TrimSpace(key)] = strings.TrimSpace(value)
+	}
+	return fields, true
+}
+
+func workflowNoteMatchesRepo(note db.WorkflowNote, fields map[string]string, repo string) bool {
+	repo = strings.TrimSpace(repo)
+	if noteRepo := strings.TrimSpace(note.Repo); noteRepo != "" && noteRepo != repo {
+		return false
+	}
+	return strings.TrimSpace(fields["repo"]) == repo
+}

--- a/internal/workflow/workload_mode_gate.go
+++ b/internal/workflow/workload_mode_gate.go
@@ -184,20 +184,41 @@ type operatingModeDecision struct {
 	unreadableWhy string
 }
 
-func ensureWorkloadModeReconciled(ctx context.Context, store *db.Store, gh MergeGateGitHub, repo github.Repository, number int64, headSHA string) (required, reconciled bool, reason string, err error) {
+// workloadModeHold is one reconciliation hold, split into the two things a
+// caller needs for different reasons.
+//
+// `detail` is the operator-facing cause and deliberately carries VOLATILE
+// context: whichever near-miss row the scan saw last, note ids, row heads, and
+// a scan-window notice that appears once the window fills. `key` is the STABLE
+// discriminator for the hold's EPISODE - the head and the decision it must
+// reconcile against - and nothing else.
+//
+// They are separate because the pipeline keys a hold episode's budget on the
+// cause. Keying it on `detail` let external churn reset the bound: one new
+// reconciliation row anywhere in the repo changes the appended near-miss, which
+// opened a fresh episode with a full budget and appended another held row, so a
+// repo whose notes churn could defer the bound indefinitely - the unbounded
+// silent wait this campaign exists to remove, reachable with no code defect at
+// all (#1783 round-5 review, F-11).
+type workloadModeHold struct {
+	key    string
+	detail string
+}
+
+func ensureWorkloadModeReconciled(ctx context.Context, store *db.Store, gh MergeGateGitHub, repo github.Repository, number int64, headSHA string) (required, reconciled bool, hold workloadModeHold, err error) {
 	observed, err := inspectModeSensitivePullRequest(ctx, gh, repo, number)
 	if err != nil {
-		return false, false, "", err
+		return false, false, workloadModeHold{}, err
 	}
 	if !observed.required {
-		return false, true, "", nil
+		return false, true, workloadModeHold{}, nil
 	}
 	if store == nil {
-		return true, false, "", fmt.Errorf("workload-mode reconciliation requires a store")
+		return true, false, workloadModeHold{}, fmt.Errorf("workload-mode reconciliation requires a store")
 	}
 	decision, err := latestOperatingModeDecision(ctx, store, repo.FullName())
 	if err != nil {
-		return true, false, "", err
+		return true, false, workloadModeHold{}, err
 	}
 	// An UNREADABLE newest decision is not "no decision". Skipping it returned
 	// id==0, which dropped the supersession check AND made decision_note=none
@@ -223,10 +244,13 @@ func ensureWorkloadModeReconciled(ctx context.Context, store *db.Store, gh Merge
 		if observed.patchUnavailable {
 			remedy = "GitHub omitted this PR's AGENTS.md patch, so the marker cannot be read here and is not the author's to fix; " + remedy
 		}
-		return true, false, fmt.Sprintf(
-			"workload-mode change cannot be reconciled: operating-mode note %d %s and this PR's own mode marker is missing or ambiguous, so no readable decision remains; %s",
-			decision.unreadableID, decision.unreadableWhy, remedy,
-		), nil
+		return true, false, workloadModeHold{
+			key: fmt.Sprintf("head=%s unreadable-note=%d", strings.TrimSpace(headSHA), decision.unreadableID),
+			detail: fmt.Sprintf(
+				"workload-mode change cannot be reconciled: operating-mode note %d %s and this PR's own mode marker is missing or ambiguous, so no readable decision remains; %s",
+				decision.unreadableID, decision.unreadableWhy, remedy,
+			),
+		}, nil
 	}
 	expectedMode := strings.ToUpper(strings.TrimSpace(observed.mode))
 	if expectedMode == "" && decision.id > 0 {
@@ -244,7 +268,7 @@ func ensureWorkloadModeReconciled(ctx context.Context, store *db.Store, gh Merge
 	}
 	notes, err := store.ListRepoWorkflowNotesByBodyPrefix(ctx, modeReconciliationNotePrefix, repo.FullName(), workloadModeReconciliationScan)
 	if err != nil {
-		return true, false, "", fmt.Errorf("list workload-mode reconciliation notes: %w", err)
+		return true, false, workloadModeHold{}, fmt.Errorf("list workload-mode reconciliation notes: %w", err)
 	}
 	// Two rejections used to be silent, and the #1783 review found both.
 	//
@@ -305,12 +329,12 @@ func ensureWorkloadModeReconciled(ctx context.Context, store *db.Store, gh Merge
 		cited := strings.TrimSpace(fields["decision_note"])
 		if cited == "none" {
 			// PR-sourced: this PR is the decision, so no earlier note must agree.
-			return true, true, "", nil
+			return true, true, workloadModeHold{}, nil
 		}
 		// A row may cite the unreadable note itself: it names what the coordinator
 		// saw, and the mode check above already bound it to the PR's marker.
 		if decision.unreadableID > 0 && cited == strconv.FormatInt(decision.unreadableID, 10) {
-			return true, true, "", nil
+			return true, true, workloadModeHold{}, nil
 		}
 		if cited != decisionID {
 			nearMiss = fmt.Sprintf("; row %d cites decision_note=%s but the newest operating-mode note is %s", note.ID, cited, decisionID)
@@ -320,7 +344,7 @@ func ensureWorkloadModeReconciled(ctx context.Context, store *db.Store, gh Merge
 			nearMiss = fmt.Sprintf("; row %d cites operating-mode note %d, which decided %s, so it cannot ratify %s", note.ID, decision.id, decision.mode, mode)
 			continue
 		}
-		return true, true, "", nil
+		return true, true, workloadModeHold{}, nil
 	}
 	detail := fmt.Sprintf("workload-mode change requires reconciliation at head %s against operating-mode note %s", shortSHA(headSHA), decisionID)
 	if observed.ambiguous {
@@ -347,7 +371,13 @@ func ensureWorkloadModeReconciled(ctx context.Context, store *db.Store, gh Merge
 		nearMiss = misfiledReconciliationRow(ctx, store, repo.FullName(), number, headSHA)
 	}
 	detail += nearMiss
-	return true, false, detail, nil
+	// The key names the head and the decision the row must reconcile against,
+	// and stops there. Every string appended above is volatile by design, and an
+	// episode keyed on volatile text has no bound (#1783 round-5 review, F-11).
+	return true, false, workloadModeHold{
+		key:    fmt.Sprintf("head=%s decision-note=%s mode=%s", strings.TrimSpace(headSHA), decisionID, expectedMode),
+		detail: detail,
+	}, nil
 }
 
 // misfiledReconciliationRow finds a row that names THIS repo in its body but was

--- a/internal/workflow/workload_mode_gate.go
+++ b/internal/workflow/workload_mode_gate.go
@@ -262,9 +262,27 @@ func ensureWorkloadModeReconciled(ctx context.Context, store *db.Store, gh Merge
 	if decision.unreadableID > supersededBy {
 		supersededBy = decision.unreadableID
 	}
+	// The episode key must change when the DECISION changes, including when the
+	// new decision is unreadable. Leaving decisionID at "none" for every
+	// unreadable note gave two different malformed notes at one head the SAME
+	// key, and run.go reuses the earliest matching hold timestamp - so a fresh
+	// unreadable decision inherited the previous one's 24h budget and could park
+	// immediately (#1783 review, P2c). An unreadable decision is still a
+	// decision: it gets its own identity, distinguishable from a readable one so
+	// the two can never collide on the same id.
+	// decisionID is the EPISODE IDENTITY; decisionLabel is what an operator reads.
+	// They differ only for an unreadable decision, where the key needs a value
+	// that cannot collide with a readable note's id and the message needs a
+	// sentence.
 	decisionID := "none"
-	if decision.id > 0 {
+	decisionLabel := "none"
+	switch {
+	case decision.id > 0:
 		decisionID = strconv.FormatInt(decision.id, 10)
+		decisionLabel = decisionID
+	case decision.unreadableID > 0:
+		decisionID = "unreadable-" + strconv.FormatInt(decision.unreadableID, 10)
+		decisionLabel = fmt.Sprintf("%d (unreadable: it %s)", decision.unreadableID, decision.unreadableWhy)
 	}
 	notes, err := store.ListRepoWorkflowNotesByBodyPrefix(ctx, modeReconciliationNotePrefix, repo.FullName(), workloadModeReconciliationScan)
 	if err != nil {
@@ -337,7 +355,7 @@ func ensureWorkloadModeReconciled(ctx context.Context, store *db.Store, gh Merge
 			return true, true, workloadModeHold{}, nil
 		}
 		if cited != decisionID {
-			nearMiss = fmt.Sprintf("; row %d cites decision_note=%s but the newest operating-mode note is %s", note.ID, cited, decisionID)
+			nearMiss = fmt.Sprintf("; row %d cites decision_note=%s but the newest operating-mode note is %s", note.ID, cited, decisionLabel)
 			continue
 		}
 		if decision.id > 0 && mode != decision.mode {
@@ -346,7 +364,7 @@ func ensureWorkloadModeReconciled(ctx context.Context, store *db.Store, gh Merge
 		}
 		return true, true, workloadModeHold{}, nil
 	}
-	detail := fmt.Sprintf("workload-mode change requires reconciliation at head %s against operating-mode note %s", shortSHA(headSHA), decisionID)
+	detail := fmt.Sprintf("workload-mode change requires reconciliation at head %s against operating-mode note %s", shortSHA(headSHA), decisionLabel)
 	if observed.ambiguous {
 		if observed.patchUnavailable {
 			detail += "; GitHub omitted this PR's AGENTS.md patch, so the mode marker could not be read"
@@ -421,6 +439,23 @@ func latestOperatingModeDecision(ctx context.Context, store *db.Store, repo stri
 			return operatingModeDecision{
 				unreadableID:  note.ID,
 				unreadableWhy: fmt.Sprintf("declares mode=%q, which is not a workload mode", fields["mode"]),
+			}, nil
+		}
+		// A note whose body PARSED but whose repo FIELD does not confirm this
+		// repository is NOT automatically another lane's problem. If the note is
+		// demonstrably this repository's - its repo COLUMN says so - then its body
+		// omits or contradicts repo=, and that is an unreadable decision for THIS
+		// repo, so it must HOLD. Skipping it let the next-oldest row answer and a
+		// stale PR-sourced reconciliation merge; the #1783 review reproduced
+		// Merged=true through PolicyMergeGate.Evaluate with exactly that shape.
+		// Only a note that neither parses for this repo nor belongs to it by column
+		// is skipped, so one lane's typo still cannot freeze every repository.
+		if parsed && noteConcernsRepo(note, repo) {
+			return operatingModeDecision{
+				unreadableID: note.ID,
+				unreadableWhy: fmt.Sprintf(
+					"was recorded for this repository but its body declares repo=%q, so it cannot be read as this repository's decision",
+					strings.TrimSpace(fields["repo"])),
 			}, nil
 		}
 		// An unparseable body cannot answer "is this note for this repo?" through

--- a/internal/workflow/workload_mode_gate.go
+++ b/internal/workflow/workload_mode_gate.go
@@ -142,16 +142,32 @@ func ensureWorkloadModeReconciled(ctx context.Context, store *db.Store, gh Merge
 	// id==0, which dropped the supersession check AND made decision_note=none
 	// satisfiable by a row written before the owner decided — the same fail-open
 	// corner the repo-scoped SQL closed, reachable through a typo instead of a
-	// truncated window (#1783 review, F1). Hold and name the note to fix.
-	if decision.unreadableID > 0 {
+	// truncated window (#1783 review, F1).
+	//
+	// It must not WEDGE a PR either, which is what directive 110704 asked me to
+	// check. Holding unconditionally meant one malformed note froze every
+	// mode-marker PR in the repo until someone edited an append-only journal, and
+	// the coordinator's remedy — write a fresh exact-head row — did nothing. So an
+	// unreadable note is a RECENCY BOUNDARY, not a veto: a row filed AFTER it,
+	// which is a coordinator asserting the current head against a decision they
+	// can see, still reconciles. Only two states hold: no row newer than the
+	// unreadable note, or a PR whose own marker is unreadable too, where nothing
+	// remains to check the row against.
+	if decision.unreadableID > 0 && strings.TrimSpace(observed.mode) == "" {
 		return true, false, fmt.Sprintf(
-			"workload-mode change cannot be reconciled: operating-mode note %d %s, so the current decision is unknown; correct that note",
+			"workload-mode change cannot be reconciled: operating-mode note %d %s and this PR's own mode marker is missing or ambiguous, so no readable decision remains; correct that note or the marker",
 			decision.unreadableID, decision.unreadableWhy,
 		), nil
 	}
 	expectedMode := strings.ToUpper(strings.TrimSpace(observed.mode))
 	if expectedMode == "" && decision.id > 0 {
 		expectedMode = decision.mode
+	}
+	// supersededBy is the note a row must be newer than: the newest readable
+	// decision, or an unreadable one, whichever is later.
+	supersededBy := decision.id
+	if decision.unreadableID > supersededBy {
+		supersededBy = decision.unreadableID
 	}
 	decisionID := "none"
 	if decision.id > 0 {
@@ -202,17 +218,29 @@ func ensureWorkloadModeReconciled(ctx context.Context, store *db.Store, gh Merge
 			nearMiss = fmt.Sprintf("; row %d declares mode=%q, which is not a workload mode", note.ID, fields["mode"])
 			continue
 		}
+		// The row must reconcile the mode the PR ADDS. On the decision_note=none
+		// path this is the only binding constraint, so without it a PR-sourced row
+		// could ratify a marker change it disagreed with (#1783 review, F5a).
 		if expectedMode != "" && mode != expectedMode {
 			nearMiss = fmt.Sprintf("; row %d reconciles mode=%s but the PR changes the marker to %s", note.ID, mode, expectedMode)
 			continue
 		}
-		if decision.id > 0 && note.ID <= decision.id {
-			nearMiss = fmt.Sprintf("; row %d predates operating-mode note %d, so it reconciles a superseded decision", note.ID, decision.id)
+		if supersededBy > 0 && note.ID <= supersededBy {
+			if decision.unreadableID == supersededBy {
+				nearMiss = fmt.Sprintf("; row %d predates operating-mode note %d, which %s, so file a new exact-head row acknowledging it", note.ID, supersededBy, decision.unreadableWhy)
+			} else {
+				nearMiss = fmt.Sprintf("; row %d predates operating-mode note %d, so it reconciles a superseded decision", note.ID, supersededBy)
+			}
 			continue
 		}
 		cited := strings.TrimSpace(fields["decision_note"])
 		if cited == "none" {
 			// PR-sourced: this PR is the decision, so no earlier note must agree.
+			return true, true, "", nil
+		}
+		// A row may cite the unreadable note itself: it names what the coordinator
+		// saw, and the mode check above already bound it to the PR's marker.
+		if decision.unreadableID > 0 && cited == strconv.FormatInt(decision.unreadableID, 10) {
 			return true, true, "", nil
 		}
 		if cited != decisionID {

--- a/internal/workflow/workload_mode_gate.go
+++ b/internal/workflow/workload_mode_gate.go
@@ -30,10 +30,22 @@ type modeSensitivePullRequest struct {
 // merged with no reconciliation at all (#1783 review, P3). The note grammar is
 // already repo-parameterized, so widening to the owner matches the policy the
 // gate implements without inventing a config knob.
+//
+// Two deliberate consequences, both raised by the round-2 review and both kept:
+// every gitmoot-owned repository is held until a reconciliation row exists, even
+// one where no coordinator writes notes today, and a human-requested merge is
+// held too. A mode marker is a fleet-wide instruction, so the hold is the point;
+// the escape hatch is the documented PR-sourced row (decision_note=none), not a
+// per-repo opt-out. If a sibling repo ever needs exemption that is a config
+// knob and an AGENTS.md change, not a silent scope narrowing here.
+//
+// The comparison is case-INSENSITIVE. GitHub treats owner/repo case
+// insensitively, so a repo recorded as "Gitmoot/gitmoot" disabled the entire
+// gate under a byte comparison — fail-open, and invisible.
 const workloadModeEnforcedOwner = "gitmoot"
 
 func inspectModeSensitivePullRequest(ctx context.Context, gh MergeGateGitHub, repo github.Repository, number int64) (modeSensitivePullRequest, error) {
-	if strings.TrimSpace(repo.Owner) != workloadModeEnforcedOwner {
+	if !strings.EqualFold(strings.TrimSpace(repo.Owner), workloadModeEnforcedOwner) {
 		return modeSensitivePullRequest{}, nil
 	}
 	files, err := gh.ListPullRequestFiles(ctx, repo, number)
@@ -99,9 +111,16 @@ func validWorkloadMode(mode string) bool {
 	}
 }
 
+// operatingModeDecision is the newest READABLE owner decision for a repo, or a
+// record of why the newest decision-shaped note could not be read.
 type operatingModeDecision struct {
 	id   int64
 	mode string
+	// unreadableID names a note that IS an operating-mode note for this repo but
+	// whose fields or mode cannot be read. It is not "no decision": the owner
+	// decided something the gate cannot determine, so the gate must hold.
+	unreadableID  int64
+	unreadableWhy string
 }
 
 func ensureWorkloadModeReconciled(ctx context.Context, store *db.Store, gh MergeGateGitHub, repo github.Repository, number int64, headSHA string) (required, reconciled bool, reason string, err error) {
@@ -118,6 +137,17 @@ func ensureWorkloadModeReconciled(ctx context.Context, store *db.Store, gh Merge
 	decision, err := latestOperatingModeDecision(ctx, store, repo.FullName())
 	if err != nil {
 		return true, false, "", err
+	}
+	// An UNREADABLE newest decision is not "no decision". Skipping it returned
+	// id==0, which dropped the supersession check AND made decision_note=none
+	// satisfiable by a row written before the owner decided — the same fail-open
+	// corner the repo-scoped SQL closed, reachable through a typo instead of a
+	// truncated window (#1783 review, F1). Hold and name the note to fix.
+	if decision.unreadableID > 0 {
+		return true, false, fmt.Sprintf(
+			"workload-mode change cannot be reconciled: operating-mode note %d %s, so the current decision is unknown; correct that note",
+			decision.unreadableID, decision.unreadableWhy,
+		), nil
 	}
 	expectedMode := strings.ToUpper(strings.TrimSpace(observed.mode))
 	if expectedMode == "" && decision.id > 0 {
@@ -155,7 +185,16 @@ func ensureWorkloadModeReconciled(ctx context.Context, store *db.Store, gh Merge
 		if !ok || !workflowNoteMatchesRepo(note, fields, repo.FullName()) {
 			continue
 		}
-		if fields["pr"] != strconv.FormatInt(number, 10) || fields["head"] != strings.TrimSpace(headSHA) {
+		// The two most likely coordinator mistakes used to `continue` silently, so
+		// the hold said only "requires reconciliation": a row written at the
+		// PREVIOUS head after a fix-up push, and a row naming another PR (#1783
+		// review, F2). Name the row and both values instead.
+		if rowPR := strings.TrimSpace(fields["pr"]); rowPR != strconv.FormatInt(number, 10) {
+			nearMiss = fmt.Sprintf("; row %d reconciles pr=%s, not this pull request", note.ID, rowPR)
+			continue
+		}
+		if rowHead := strings.TrimSpace(fields["head"]); rowHead != strings.TrimSpace(headSHA) {
+			nearMiss = fmt.Sprintf("; row %d reconciles head %s, but the current head is %s", note.ID, shortSHA(rowHead), shortSHA(headSHA))
 			continue
 		}
 		mode := strings.ToUpper(strings.TrimSpace(fields["mode"]))
@@ -190,8 +229,42 @@ func ensureWorkloadModeReconciled(ctx context.Context, store *db.Store, gh Merge
 	if observed.ambiguous {
 		detail += "; AGENTS.md mode-marker patch is missing or ambiguous"
 	}
+	if nearMiss == "" {
+		// The repo-scoped SQL drops a row whose repo COLUMN names another
+		// repository before this loop ever sees it, so a coordinator who filed the
+		// row against the wrong workflow saw only the generic hold (#1783 review,
+		// F2). One unscoped scan, only when nothing else explained the hold, finds
+		// it and names both repositories.
+		nearMiss = misfiledReconciliationRow(ctx, store, repo.FullName(), number, headSHA)
+	}
 	detail += nearMiss
 	return true, false, detail, nil
+}
+
+// misfiledReconciliationRow finds a row that names THIS repo in its body but was
+// recorded under a different repo column, which makes it invisible to the
+// repo-scoped lookup. It returns "" when there is nothing to report.
+func misfiledReconciliationRow(ctx context.Context, store *db.Store, repo string, number int64, headSHA string) string {
+	notes, err := store.ListWorkflowNotesByBodyPrefix(ctx, modeReconciliationNotePrefix, workloadModeReconciliationScan)
+	if err != nil {
+		return ""
+	}
+	for _, note := range notes {
+		fields, ok := parseModeNoteFields(note.Body, modeReconciliationNotePrefix)
+		if !ok || !strings.EqualFold(strings.TrimSpace(fields["repo"]), strings.TrimSpace(repo)) {
+			continue
+		}
+		noteRepo := strings.TrimSpace(note.Repo)
+		if noteRepo == "" || strings.EqualFold(noteRepo, strings.TrimSpace(repo)) {
+			continue
+		}
+		if strings.TrimSpace(fields["pr"]) != strconv.FormatInt(number, 10) ||
+			strings.TrimSpace(fields["head"]) != strings.TrimSpace(headSHA) {
+			continue
+		}
+		return fmt.Sprintf("; row %d names this repository in its body but was recorded under %s, so the repo-scoped lookup cannot see it", note.ID, noteRepo)
+	}
+	return ""
 }
 
 func latestOperatingModeDecision(ctx context.Context, store *db.Store, repo string) (operatingModeDecision, error) {
@@ -200,13 +273,27 @@ func latestOperatingModeDecision(ctx context.Context, store *db.Store, repo stri
 		return operatingModeDecision{}, fmt.Errorf("list operating-mode notes: %w", err)
 	}
 	for _, note := range notes {
-		fields, ok := parseModeNoteFields(note.Body, operatingModeNotePrefix)
-		if !ok || !workflowNoteMatchesRepo(note, fields, repo) {
-			continue
+		fields, parsed := parseModeNoteFields(note.Body, operatingModeNotePrefix)
+		if parsed && workflowNoteMatchesRepo(note, fields, repo) {
+			mode := strings.ToUpper(strings.TrimSpace(fields["mode"]))
+			if validWorkloadMode(mode) {
+				return operatingModeDecision{id: note.ID, mode: mode}, nil
+			}
+			return operatingModeDecision{
+				unreadableID:  note.ID,
+				unreadableWhy: fmt.Sprintf("declares mode=%q, which is not a workload mode", fields["mode"]),
+			}, nil
 		}
-		mode := strings.ToUpper(strings.TrimSpace(fields["mode"]))
-		if validWorkloadMode(mode) {
-			return operatingModeDecision{id: note.ID, mode: mode}, nil
+		// An unparseable body cannot answer "is this note for this repo?" through
+		// its repo FIELD, so fall back to the note's repo COLUMN. A note that is
+		// demonstrably this repo's and unreadable HOLDS; one that names neither
+		// this repo nor nothing is another lane's problem and is skipped, so a
+		// typo in an unrelated note cannot freeze every gitmoot repository.
+		if !parsed && strings.EqualFold(strings.TrimSpace(note.Repo), strings.TrimSpace(repo)) {
+			return operatingModeDecision{
+				unreadableID:  note.ID,
+				unreadableWhy: "has a malformed field list, so its mode cannot be read",
+			}, nil
 		}
 	}
 	return operatingModeDecision{}, nil
@@ -231,10 +318,14 @@ func parseModeNoteFields(body, prefix string) (map[string]string, bool) {
 	return fields, true
 }
 
+// workflowNoteMatchesRepo compares repositories CASE-INSENSITIVELY. GitHub
+// treats owner/repo case insensitively, so a byte comparison made a note
+// written as "Gitmoot/gitmoot" invisible on both note streams (#1783 review,
+// F3).
 func workflowNoteMatchesRepo(note db.WorkflowNote, fields map[string]string, repo string) bool {
 	repo = strings.TrimSpace(repo)
-	if noteRepo := strings.TrimSpace(note.Repo); noteRepo != "" && noteRepo != repo {
+	if noteRepo := strings.TrimSpace(note.Repo); noteRepo != "" && !strings.EqualFold(noteRepo, repo) {
 		return false
 	}
-	return strings.TrimSpace(fields["repo"]) == repo
+	return strings.EqualFold(strings.TrimSpace(fields["repo"]), repo)
 }

--- a/internal/workflow/workload_mode_gate.go
+++ b/internal/workflow/workload_mode_gate.go
@@ -23,8 +23,17 @@ type modeSensitivePullRequest struct {
 	ambiguous bool
 }
 
+// workloadModeEnforcedOwner is the repository OWNER whose mode-marker changes
+// this gate enforces. AGENTS.md writes its workload-mode rules against the
+// gitmoot/* scope, but the gate compared FullName to the literal
+// "gitmoot/gitmoot", so a mode-marker change in any other gitmoot repository
+// merged with no reconciliation at all (#1783 review, P3). The note grammar is
+// already repo-parameterized, so widening to the owner matches the policy the
+// gate implements without inventing a config knob.
+const workloadModeEnforcedOwner = "gitmoot"
+
 func inspectModeSensitivePullRequest(ctx context.Context, gh MergeGateGitHub, repo github.Repository, number int64) (modeSensitivePullRequest, error) {
-	if repo.FullName() != "gitmoot/gitmoot" {
+	if strings.TrimSpace(repo.Owner) != workloadModeEnforcedOwner {
 		return modeSensitivePullRequest{}, nil
 	}
 	files, err := gh.ListPullRequestFiles(ctx, repo, number)
@@ -118,23 +127,61 @@ func ensureWorkloadModeReconciled(ctx context.Context, store *db.Store, gh Merge
 	if decision.id > 0 {
 		decisionID = strconv.FormatInt(decision.id, 10)
 	}
-	notes, err := store.ListWorkflowNotesByBodyPrefix(ctx, modeReconciliationNotePrefix, workloadModeReconciliationScan)
+	notes, err := store.ListRepoWorkflowNotesByBodyPrefix(ctx, modeReconciliationNotePrefix, repo.FullName(), workloadModeReconciliationScan)
 	if err != nil {
 		return true, false, "", fmt.Errorf("list workload-mode reconciliation notes: %w", err)
 	}
+	// Two rejections used to be silent, and the #1783 review found both.
+	//
+	// P2a: the documented `decision_note=none` was unmatchable. decisionID is
+	// "none" only while the repo has ZERO operating-mode notes, so the moment the
+	// first typed note exists, every row written per the documented PR-sourced
+	// instruction was skipped and the PR held forever. `none` is now accepted as
+	// what it claims to be: a PR-SOURCED decision, where the PR itself decides
+	// and no earlier note has to agree. The row must still be newer than the
+	// newest note, so a superseded PR-sourced row cannot ratify anything.
+	//
+	// P2b: a row citing a note id proved only that someone READ that note, never
+	// that the PR agreed with it. With the newest note deciding STEADY, a PR
+	// flipping the marker to THROUGHPUT merged cleanly by citing the STEADY note.
+	// A row that names a decision must now match that decision's mode.
+	//
+	// Every rejection reason is recorded and appended to the hold, because the
+	// native path holds through g.pending, which retries silently: a coordinator
+	// who HAD written a row saw an indefinitely pending PR and no cause.
+	nearMiss := ""
 	for _, note := range notes {
 		fields, ok := parseModeNoteFields(note.Body, modeReconciliationNotePrefix)
 		if !ok || !workflowNoteMatchesRepo(note, fields, repo.FullName()) {
 			continue
 		}
-		if fields["pr"] != strconv.FormatInt(number, 10) || fields["head"] != strings.TrimSpace(headSHA) || fields["decision_note"] != decisionID {
+		if fields["pr"] != strconv.FormatInt(number, 10) || fields["head"] != strings.TrimSpace(headSHA) {
 			continue
 		}
 		mode := strings.ToUpper(strings.TrimSpace(fields["mode"]))
-		if !validWorkloadMode(mode) || (expectedMode != "" && mode != expectedMode) {
+		if !validWorkloadMode(mode) {
+			nearMiss = fmt.Sprintf("; row %d declares mode=%q, which is not a workload mode", note.ID, fields["mode"])
+			continue
+		}
+		if expectedMode != "" && mode != expectedMode {
+			nearMiss = fmt.Sprintf("; row %d reconciles mode=%s but the PR changes the marker to %s", note.ID, mode, expectedMode)
 			continue
 		}
 		if decision.id > 0 && note.ID <= decision.id {
+			nearMiss = fmt.Sprintf("; row %d predates operating-mode note %d, so it reconciles a superseded decision", note.ID, decision.id)
+			continue
+		}
+		cited := strings.TrimSpace(fields["decision_note"])
+		if cited == "none" {
+			// PR-sourced: this PR is the decision, so no earlier note must agree.
+			return true, true, "", nil
+		}
+		if cited != decisionID {
+			nearMiss = fmt.Sprintf("; row %d cites decision_note=%s but the newest operating-mode note is %s", note.ID, cited, decisionID)
+			continue
+		}
+		if decision.id > 0 && mode != decision.mode {
+			nearMiss = fmt.Sprintf("; row %d cites operating-mode note %d, which decided %s, so it cannot ratify %s", note.ID, decision.id, decision.mode, mode)
 			continue
 		}
 		return true, true, "", nil
@@ -143,11 +190,12 @@ func ensureWorkloadModeReconciled(ctx context.Context, store *db.Store, gh Merge
 	if observed.ambiguous {
 		detail += "; AGENTS.md mode-marker patch is missing or ambiguous"
 	}
+	detail += nearMiss
 	return true, false, detail, nil
 }
 
 func latestOperatingModeDecision(ctx context.Context, store *db.Store, repo string) (operatingModeDecision, error) {
-	notes, err := store.ListWorkflowNotesByBodyPrefix(ctx, operatingModeNotePrefix, workloadModeReconciliationScan)
+	notes, err := store.ListRepoWorkflowNotesByBodyPrefix(ctx, operatingModeNotePrefix, repo, workloadModeReconciliationScan)
 	if err != nil {
 		return operatingModeDecision{}, fmt.Errorf("list operating-mode notes: %w", err)
 	}

--- a/internal/workflow/workload_mode_gate_test.go
+++ b/internal/workflow/workload_mode_gate_test.go
@@ -991,3 +991,107 @@ func TestPipelineAutoMergerEvaluateMarksTheReconciliationHold(t *testing.T) {
 		t.Fatalf("a mergeability wait must not be a reconciliation hold: %+v", pendingReadiness)
 	}
 }
+
+// #1783 round-6 review, P2a. A note whose body PARSES but whose repo= field does
+// not confirm this repository, while its repo COLUMN says it IS this
+// repository's, used to satisfy neither arm of latestOperatingModeDecision and
+// was skipped entirely. A stale `decision_note=none` row then answered and the
+// reviewer's probe reproduced Merged=true. Mode-resolution failure must fail
+// CLOSED here, like every other unreadable decision.
+func TestWorkloadModeGateHoldsWhenThisReposNoteNamesAnotherRepo(t *testing.T) {
+	for name, body := range map[string]string{
+		"repo field omitted":  "[operating-mode mode=DRAIN]",
+		"repo field conflict": "[operating-mode repo=other/repo mode=DRAIN]",
+	} {
+		t.Run(name, func(t *testing.T) {
+			store, gh, gate, request := newWorkloadModeGateScenario(t)
+			// The row that would satisfy the gate if the newest decision vanished.
+			insertRawModeReconciliation(t, store, "STEADY", "head123", "none")
+			note := insertRawOperatingMode(t, store, "gitmoot/gitmoot", body)
+
+			decision, err := gate.Evaluate(context.Background(), request)
+			if err != nil {
+				t.Fatalf("Evaluate: %v", err)
+			}
+			if decision.Merged || len(gh.merges) != 0 {
+				t.Fatalf("a note recorded for this repo whose body does not name it must HOLD, not be skipped: decision=%+v merges=%d reason=%q",
+					decision, len(gh.merges), decision.Reason.Render())
+			}
+			if rendered := decision.Reason.Render(); !strings.Contains(rendered, strconv.FormatInt(note.ID, 10)) {
+				t.Fatalf("hold must name note %d: %q", note.ID, rendered)
+			}
+		})
+	}
+}
+
+// #1783 round-6 review, P2b. The decision window admitted every repo-less note
+// and truncated at the scan limit BEFORE the body-repo filter ran, so unrelated
+// repo-less traffic could push this repository's decision out of the window. The
+// reviewer's probe buried a valid DRAIN decision under 201 newer repo-less notes
+// and a stale PR-sourced reconciliation merged.
+func TestWorkloadModeGateFindsTheDecisionBehindRepolessNotes(t *testing.T) {
+	store, gh, gate, request := newWorkloadModeGateScenario(t)
+	decisionNote := insertOperatingModeDecision(t, store, "STEADY")
+	for i := 0; i < workloadModeReconciliationScan+10; i++ {
+		// repo COLUMN empty - the shape that used to consume the window - and a
+		// body naming a DIFFERENT repository, so it can never answer for this one.
+		insertRawOperatingMode(t, store, "",
+			fmt.Sprintf("[operating-mode repo=other/repo-%d mode=DRAIN]", i))
+	}
+	insertRawModeReconciliation(t, store, "STEADY", "head123", strconv.FormatInt(decisionNote.ID, 10))
+
+	decision, err := gate.Evaluate(context.Background(), request)
+	if err != nil {
+		t.Fatalf("Evaluate: %v", err)
+	}
+	if !decision.Merged || len(gh.merges) != 1 {
+		t.Fatalf("this repository's decision must survive unrelated repo-less traffic: decision=%+v merges=%d reason=%q",
+			decision, len(gh.merges), decision.Reason.Render())
+	}
+}
+
+// #1783 round-6 review, P2c. Every unreadable decision reported decisionID
+// "none", so two DIFFERENT malformed notes at one head produced the same hold
+// key. run.go reuses the earliest matching hold timestamp, so the second
+// decision inherited the first one's elapsed budget. A new decision - readable
+// or not - starts a new episode, and the key is what carries that.
+func TestWorkloadModeGateGivesEachUnreadableDecisionItsOwnEpisode(t *testing.T) {
+	// ONE store, two successive unreadable decisions - the real scenario. A fresh
+	// store per arm would hand both notes the same rowid and prove nothing about
+	// the key; the first version of this test did exactly that and failed for that
+	// reason rather than for the defect.
+	//
+	// ensureWorkloadModeReconciled is the function the merge gate calls and the
+	// one that MINTS the episode key; the key is not carried on MergeDecision, so
+	// this reads it where production produces it.
+	store, gh, _, request := newWorkloadModeGateScenario(t)
+	insertRawModeReconciliation(t, store, "STEADY", "head123", "none")
+	repo := github.Repository{Owner: "gitmoot", Name: "gitmoot"}
+	keyNow := func(t *testing.T) string {
+		t.Helper()
+		required, reconciled, hold, err := ensureWorkloadModeReconciled(
+			context.Background(), store, gh, repo, int64(request.PullRequest), "head123")
+		if err != nil {
+			t.Fatalf("ensureWorkloadModeReconciled: %v", err)
+		}
+		if !required || reconciled {
+			t.Fatalf("an unreadable decision must be required-and-unreconciled: required=%v reconciled=%v", required, reconciled)
+		}
+		return hold.key
+	}
+	firstNote := insertRawOperatingMode(t, store, "gitmoot/gitmoot", "[operating-mode repo=gitmoot/gitmoot mode=DRAIN urgent]")
+	first := keyNow(t)
+	secondNote := insertRawOperatingMode(t, store, "gitmoot/gitmoot", "[operating-mode repo=gitmoot/gitmoot mode=PAUSED]")
+	second := keyNow(t)
+
+	if firstNote.ID == secondNote.ID {
+		t.Fatalf("fixture defect: both notes have id %d, so the key could not differ either way", firstNote.ID)
+	}
+	if first == "" || second == "" {
+		t.Fatalf("both holds must carry an episode key: %q / %q", first, second)
+	}
+	if first == second {
+		t.Fatalf("unreadable decisions %d and %d shared one episode key %q, so the second inherits the first's elapsed budget",
+			firstNote.ID, secondNote.ID, first)
+	}
+}

--- a/internal/workflow/workload_mode_gate_test.go
+++ b/internal/workflow/workload_mode_gate_test.go
@@ -744,3 +744,168 @@ func TestWorkloadModeGateBoundaryCatchesAMalformedNoteWithNoRepoColumn(t *testin
 		t.Fatalf("another repo's repo-less malformed note must not hold this one: %q", decision.Reason.Render())
 	}
 }
+
+// The remedy must be COMPLETE, and this test applies it in the two documented
+// steps SEPARATELY. The round-4 review measured that the note alone leaves
+// merged=false, and that the earlier test masked it by filing a row at the same
+// time (F-7). It also pins patchUnavailable in BOTH directions: a hold for a
+// patch GitHub DID return must not claim the API omitted it (F-5).
+func TestWorkloadModeGateStatesTheWholeRemedyAndOnlyBlamesTheAPIWhenItIsAtFault(t *testing.T) {
+	store, gh, gate, request := newWorkloadModeGateScenario(t)
+	gh.files = []github.PullRequestFile{{Filename: "AGENTS.md"}} // patch omitted
+	insertRawOperatingMode(t, store, "gitmoot/gitmoot", "[operating-mode repo=gitmoot/gitmoot mode=PAUSED]")
+
+	first, err := gate.Evaluate(context.Background(), request)
+	if err != nil {
+		t.Fatalf("Evaluate: %v", err)
+	}
+	if !strings.Contains(first.Reason.Render(), "AND file an exact-head reconciliation row") {
+		t.Fatalf("the hold must name BOTH steps: %q", first.Reason.Render())
+	}
+
+	// STEP ONE ONLY: a fresh readable note. This must NOT merge by itself - that
+	// is what the incomplete remedy text implied.
+	insertOperatingModeDecision(t, store, "STEADY")
+	step1, err := gate.Evaluate(context.Background(), request)
+	if err != nil {
+		t.Fatalf("Evaluate after step one: %v", err)
+	}
+	if step1.Merged || len(gh.merges) != 0 {
+		t.Fatalf("the note alone must not clear the hold: decision=%+v merges=%d", step1, len(gh.merges))
+	}
+
+	// STEP TWO: the exact-head row. Now it merges.
+	insertRawModeReconciliation(t, store, "STEADY", "head123", "none")
+	step2, err := gate.Evaluate(context.Background(), request)
+	if err != nil {
+		t.Fatalf("Evaluate after step two: %v", err)
+	}
+	if !step2.Merged || len(gh.merges) != 1 {
+		t.Fatalf("both steps together must clear the hold: decision=%+v merges=%d reason=%q",
+			step2, len(gh.merges), step2.Reason.Render())
+	}
+
+	// A hold for a patch GitHub DID return must not blame the API.
+	other, otherGH, otherGate, otherRequest := newWorkloadModeGateScenario(t)
+	insertRawOperatingMode(t, other, "gitmoot/gitmoot", "[operating-mode repo=gitmoot/gitmoot mode=PAUSED]")
+	otherGH.files = []github.PullRequestFile{{
+		Filename: "AGENTS.md",
+		Patch:    "@@ -1 +1 @@\n-**Current mode: DRAIN.**\n+**Current mode: SOMETHING.**",
+	}}
+	held, err := otherGate.Evaluate(context.Background(), otherRequest)
+	if err != nil {
+		t.Fatalf("Evaluate: %v", err)
+	}
+	if strings.Contains(held.Reason.Render(), "GitHub omitted") {
+		t.Fatalf("a returned patch must not be reported as omitted by GitHub: %q", held.Reason.Render())
+	}
+}
+
+// The scan-window notice must fire only when the window is actually FULL: a
+// mutant relaxing the condition to '>= 0' printed it on every hold and survived
+// (#1783 round-4 review, F-5).
+func TestWorkloadModeGateDoesNotClaimAFullWindowWhenItIsNot(t *testing.T) {
+	store, gh, gate, request := newWorkloadModeGateScenario(t)
+	insertOperatingModeDecision(t, store, "STEADY")
+
+	decision, err := gate.Evaluate(context.Background(), request)
+	if err != nil {
+		t.Fatalf("Evaluate: %v", err)
+	}
+	if decision.Merged || len(gh.merges) != 0 {
+		t.Fatalf("no row exists, so this must hold: decision=%+v merges=%d", decision, len(gh.merges))
+	}
+	if strings.Contains(decision.Reason.Render(), "may have aged out") {
+		t.Fatalf("an empty window must not be reported as full: %q", decision.Reason.Render())
+	}
+}
+
+// The lenient repo scan must cover the shapes a HAND-WRITTEN note takes. The
+// first version matched a bare `repo=x` token only, so a trailing comma or
+// spaces around `=` still let a stale row merge (#1783 round-4 review, F-6).
+func TestWorkloadModeGateBoundaryToleratesHandWrittenRepoFields(t *testing.T) {
+	for name, body := range map[string]string{
+		"trailing comma": "[operating-mode repo=gitmoot/gitmoot, mode=DRAIN urgent]",
+		"spaced equals":  "[operating-mode repo = gitmoot/gitmoot mode=DRAIN urgent]",
+		"trailing brace": "[operating-mode repo=gitmoot/gitmoot] mode=DRAIN urgent",
+	} {
+		t.Run(name, func(t *testing.T) {
+			store, gh, gate, request := newWorkloadModeGateScenario(t)
+			stale := insertRawModeReconciliation(t, store, "STEADY", "head123", "none")
+			unreadable := insertRawOperatingMode(t, store, "", body)
+
+			decision, err := gate.Evaluate(context.Background(), request)
+			if err != nil {
+				t.Fatalf("Evaluate: %v", err)
+			}
+			if decision.Merged || len(gh.merges) != 0 {
+				t.Fatalf("a repo-less malformed note must supersede the stale row: decision=%+v merges=%d reason=%q",
+					decision, len(gh.merges), decision.Reason.Render())
+			}
+			rendered := decision.Reason.Render()
+			if !strings.Contains(rendered, strconv.FormatInt(stale.ID, 10)) || !strings.Contains(rendered, strconv.FormatInt(unreadable.ID, 10)) {
+				t.Fatalf("hold must name the stale row and the note that superseded it: %q", rendered)
+			}
+		})
+	}
+
+	// Still narrow: another repo's repo-less malformed note, in the same shapes,
+	// must not hold this repository.
+	for name, body := range map[string]string{
+		"trailing comma": "[operating-mode repo=other/repo, mode=DRAIN urgent]",
+		"spaced equals":  "[operating-mode repo = other/repo mode=DRAIN urgent]",
+	} {
+		t.Run("ignores "+name, func(t *testing.T) {
+			store, gh, gate, request := newWorkloadModeGateScenario(t)
+			mode := insertOperatingModeDecision(t, store, "STEADY")
+			insertModeReconciliation(t, store, mode, "STEADY", "head123")
+			insertRawOperatingMode(t, store, "", body)
+
+			decision, err := gate.Evaluate(context.Background(), request)
+			if err != nil {
+				t.Fatalf("Evaluate: %v", err)
+			}
+			if !decision.Merged || len(gh.merges) != 1 {
+				t.Fatalf("another repo's malformed note must not hold this one: decision=%+v reason=%q",
+					decision, decision.Reason.Render())
+			}
+		})
+	}
+}
+
+// The pipeline records and bounds the RECONCILIATION class specifically, so
+// Evaluate must mark it. Without this, the class flag was set in production and
+// asserted only through a pipeline stub, so deleting the production line changed
+// no test (#1783 round-4 review, F-1's second half).
+func TestPipelineAutoMergerEvaluateMarksTheReconciliationHold(t *testing.T) {
+	store, gh, _, _ := newWorkloadModeGateScenario(t)
+	insertOperatingModeDecision(t, store, "STEADY")
+	merger := PipelineAutoMerger{Store: store, GitHub: gh}
+	request := PipelineAutoMergeRequest{Repo: "gitmoot/gitmoot", PullRequest: 9, HeadSHA: "head123", Pipeline: "release", RunID: "run-1", StageID: "merge"}
+
+	readiness, err := merger.Evaluate(context.Background(), request)
+	if err != nil {
+		t.Fatalf("Evaluate: %v", err)
+	}
+	if !readiness.Waiting || !readiness.ReconciliationHold {
+		t.Fatalf("readiness = %+v, want a marked reconciliation hold", readiness)
+	}
+	if !strings.Contains(readiness.Reason, "requires reconciliation") {
+		t.Fatalf("readiness reason = %q", readiness.Reason)
+	}
+
+	// A NON-reconciliation wait must NOT carry the class, or the pipeline would
+	// bound CI waits too.
+	pending, pendingGH, _, _ := newWorkloadModeGateScenario(t)
+	mode := insertOperatingModeDecision(t, pending, "STEADY")
+	insertModeReconciliation(t, pending, mode, "STEADY", "head123")
+	pendingGH.pr.Mergeable = nil
+	pendingMerger := PipelineAutoMerger{Store: pending, GitHub: pendingGH}
+	pendingReadiness, err := pendingMerger.Evaluate(context.Background(), request)
+	if err != nil {
+		t.Fatalf("Evaluate (mergeability unknown): %v", err)
+	}
+	if !pendingReadiness.Waiting || pendingReadiness.ReconciliationHold {
+		t.Fatalf("a mergeability wait must not be a reconciliation hold: %+v", pendingReadiness)
+	}
+}

--- a/internal/workflow/workload_mode_gate_test.go
+++ b/internal/workflow/workload_mode_gate_test.go
@@ -1,0 +1,130 @@
+package workflow
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/gitmoot/gitmoot/internal/db"
+	"github.com/gitmoot/gitmoot/internal/github"
+)
+
+func newWorkloadModeGateScenario(t *testing.T) (*db.Store, *fakeMergeGateGitHub, PolicyMergeGate, MergeRequest) {
+	t.Helper()
+	store, gh, gate, request := newMergeGateQuorumScenario(t)
+	insertMergeGateReviewFixture(t, store, mergeGateReviewFixture{
+		id: "mode-review", agent: "reviewer", headSHA: "head123", decision: "approved", hasResult: true,
+	})
+	gh.files = []github.PullRequestFile{{
+		Filename: "AGENTS.md",
+		Patch:    "@@ -1 +1 @@\n-**Current mode: DRAIN.**\n+**Current mode: STEADY.**",
+	}}
+	return store, gh, gate, request
+}
+
+func insertOperatingModeDecision(t *testing.T, store *db.Store, mode string) db.WorkflowNote {
+	t.Helper()
+	note, err := store.InsertWorkflowNote(context.Background(), db.WorkflowNote{
+		WorkflowID: "gitmoot/worktree-lifecycle",
+		Author:     "owner",
+		Repo:       "gitmoot/gitmoot",
+		Body:       fmt.Sprintf("[operating-mode repo=gitmoot/gitmoot mode=%s]", mode),
+	})
+	if err != nil {
+		t.Fatalf("InsertWorkflowNote decision: %v", err)
+	}
+	return note
+}
+
+func insertModeReconciliation(t *testing.T, store *db.Store, decision db.WorkflowNote, mode, head string) db.WorkflowNote {
+	t.Helper()
+	note, err := store.InsertWorkflowNote(context.Background(), db.WorkflowNote{
+		WorkflowID: "gitmoot/worktree-lifecycle",
+		Author:     "coordinator",
+		Repo:       "gitmoot/gitmoot",
+		Body: fmt.Sprintf("[workload-mode-reconciliation repo=gitmoot/gitmoot pr=9 head=%s mode=%s decision_note=%d]",
+			head, mode, decision.ID),
+	})
+	if err != nil {
+		t.Fatalf("InsertWorkflowNote reconciliation: %v", err)
+	}
+	return note
+}
+
+func TestPolicyMergeGateRequiresExactModeReconciliation(t *testing.T) {
+	t.Run("missing reconciliation defers before merge", func(t *testing.T) {
+		store, gh, gate, request := newWorkloadModeGateScenario(t)
+		insertOperatingModeDecision(t, store, "STEADY")
+
+		decision, err := gate.Evaluate(context.Background(), request)
+		if err != nil {
+			t.Fatalf("Evaluate: %v", err)
+		}
+		if !decision.Ready || decision.Merged || len(gh.merges) != 0 || !strings.Contains(decision.Reason.Render(), "requires reconciliation") {
+			t.Fatalf("decision=%+v merges=%d", decision, len(gh.merges))
+		}
+	})
+
+	t.Run("matching exact-head reconciliation merges", func(t *testing.T) {
+		store, gh, gate, request := newWorkloadModeGateScenario(t)
+		mode := insertOperatingModeDecision(t, store, "STEADY")
+		insertModeReconciliation(t, store, mode, "STEADY", "head123")
+
+		decision, err := gate.Evaluate(context.Background(), request)
+		if err != nil {
+			t.Fatalf("Evaluate: %v", err)
+		}
+		if !decision.Merged || len(gh.merges) != 1 {
+			t.Fatalf("decision=%+v merges=%d", decision, len(gh.merges))
+		}
+	})
+
+	t.Run("later operating-mode decision invalidates reconciliation", func(t *testing.T) {
+		store, gh, gate, request := newWorkloadModeGateScenario(t)
+		mode := insertOperatingModeDecision(t, store, "STEADY")
+		insertModeReconciliation(t, store, mode, "STEADY", "head123")
+		insertOperatingModeDecision(t, store, "DRAIN")
+
+		decision, err := gate.Evaluate(context.Background(), request)
+		if err != nil {
+			t.Fatalf("Evaluate: %v", err)
+		}
+		if !decision.Ready || decision.Merged || len(gh.merges) != 0 {
+			t.Fatalf("decision=%+v merges=%d", decision, len(gh.merges))
+		}
+	})
+}
+
+func TestPipelineAutoMergerRechecksModeReconciliationAtMergeBoundary(t *testing.T) {
+	store, gh, _, _ := newWorkloadModeGateScenario(t)
+	mode := insertOperatingModeDecision(t, store, "STEADY")
+	insertModeReconciliation(t, store, mode, "STEADY", "head123")
+	merger := PipelineAutoMerger{Store: store, GitHub: gh}
+	request := PipelineAutoMergeRequest{Repo: "gitmoot/gitmoot", PullRequest: 9, HeadSHA: "head123", Pipeline: "release", RunID: "run-1", StageID: "merge"}
+
+	readiness, err := merger.Evaluate(context.Background(), request)
+	if err != nil || !readiness.Ready {
+		t.Fatalf("Evaluate readiness=%+v err=%v", readiness, err)
+	}
+	insertOperatingModeDecision(t, store, "DRAIN")
+
+	result, err := merger.Merge(context.Background(), request)
+	if err != nil {
+		t.Fatalf("Merge: %v", err)
+	}
+	if result.Merged || len(gh.merges) != 0 || !strings.Contains(result.Reason, "requires reconciliation") {
+		t.Fatalf("result=%+v merges=%d", result, len(gh.merges))
+	}
+}
+
+func TestModeSensitivePullRequestFailsClosedOnMissingPatch(t *testing.T) {
+	gh := &fakeMergeGateGitHub{files: []github.PullRequestFile{{Filename: "AGENTS.md"}}}
+	got, err := inspectModeSensitivePullRequest(context.Background(), gh, github.Repository{Owner: "gitmoot", Name: "gitmoot"}, 9)
+	if err != nil {
+		t.Fatalf("inspectModeSensitivePullRequest: %v", err)
+	}
+	if !got.required || !got.ambiguous {
+		t.Fatalf("inspection = %+v, want required ambiguous reconciliation", got)
+	}
+}

--- a/internal/workflow/workload_mode_gate_test.go
+++ b/internal/workflow/workload_mode_gate_test.go
@@ -554,3 +554,87 @@ func TestWorkloadModeGateHoldNamesAMisfiledReconciliationRow(t *testing.T) {
 		t.Fatalf("hold must name the misfiled row and the repo it was recorded under: %q", rendered)
 	}
 }
+
+// Directive 110704 asked whether the fail-closed rule can WEDGE a legitimately
+// reconciled PR. Holding unconditionally did: one malformed note froze every
+// mode-marker PR in the repo until someone edited an append-only journal, and
+// the coordinator's own remedy - a fresh exact-head row - could not clear it.
+// An unreadable note is therefore a RECENCY BOUNDARY, not a veto.
+func TestWorkloadModeGateUnreadableDecisionIsABoundaryNotAWedge(t *testing.T) {
+	t.Run("a row filed after the unreadable note reconciles", func(t *testing.T) {
+		store, gh, gate, request := newWorkloadModeGateScenario(t)
+		insertRawOperatingMode(t, store, "gitmoot/gitmoot", "[operating-mode repo=gitmoot/gitmoot mode=DRAIN urgent]")
+		// The PR's marker adds STEADY, and the row agrees with the PR.
+		insertRawModeReconciliation(t, store, "STEADY", "head123", "none")
+
+		decision, err := gate.Evaluate(context.Background(), request)
+		if err != nil {
+			t.Fatalf("Evaluate: %v", err)
+		}
+		if !decision.Merged || len(gh.merges) != 1 {
+			t.Fatalf("a fresh row must clear an unreadable note: decision=%+v merges=%d reason=%q",
+				decision, len(gh.merges), decision.Reason.Render())
+		}
+	})
+
+	t.Run("a row citing the unreadable note reconciles", func(t *testing.T) {
+		store, gh, gate, request := newWorkloadModeGateScenario(t)
+		unreadable := insertRawOperatingMode(t, store, "gitmoot/gitmoot", "[operating-mode repo=gitmoot/gitmoot mode=PAUSED]")
+		insertRawModeReconciliation(t, store, "STEADY", "head123", strconv.FormatInt(unreadable.ID, 10))
+
+		decision, err := gate.Evaluate(context.Background(), request)
+		if err != nil {
+			t.Fatalf("Evaluate: %v", err)
+		}
+		if !decision.Merged || len(gh.merges) != 1 {
+			t.Fatalf("a row naming the unreadable note must reconcile: decision=%+v merges=%d reason=%q",
+				decision, len(gh.merges), decision.Reason.Render())
+		}
+	})
+
+	t.Run("a row that predates the unreadable note is held and told what to do", func(t *testing.T) {
+		store, gh, gate, request := newWorkloadModeGateScenario(t)
+		stale := insertRawModeReconciliation(t, store, "STEADY", "head123", "none")
+		unreadable := insertRawOperatingMode(t, store, "gitmoot/gitmoot", "[operating-mode repo=gitmoot/gitmoot mode=PAUSED]")
+
+		decision, err := gate.Evaluate(context.Background(), request)
+		if err != nil {
+			t.Fatalf("Evaluate: %v", err)
+		}
+		if decision.Merged || len(gh.merges) != 0 {
+			t.Fatalf("a row older than the unreadable note must not reconcile: decision=%+v merges=%d", decision, len(gh.merges))
+		}
+		rendered := decision.Reason.Render()
+		for _, want := range []string{
+			strconv.FormatInt(stale.ID, 10),
+			strconv.FormatInt(unreadable.ID, 10),
+			"file a new exact-head row",
+		} {
+			if !strings.Contains(rendered, want) {
+				t.Fatalf("hold must name both notes and the remedy %q: %q", want, rendered)
+			}
+		}
+	})
+
+	t.Run("an unreadable note plus an unreadable marker is genuinely unknowable", func(t *testing.T) {
+		store, gh, gate, request := newWorkloadModeGateScenario(t)
+		gh.files = []github.PullRequestFile{{
+			Filename: "AGENTS.md",
+			Patch:    "@@ -1 +1 @@\n-**Current mode: DRAIN.**\n+**Current mode: SOMETHING.**",
+		}}
+		unreadable := insertRawOperatingMode(t, store, "gitmoot/gitmoot", "[operating-mode repo=gitmoot/gitmoot mode=PAUSED]")
+		insertRawModeReconciliation(t, store, "STEADY", "head123", "none")
+
+		decision, err := gate.Evaluate(context.Background(), request)
+		if err != nil {
+			t.Fatalf("Evaluate: %v", err)
+		}
+		if decision.Merged || len(gh.merges) != 0 {
+			t.Fatalf("nothing readable remains, so the gate must hold: decision=%+v merges=%d", decision, len(gh.merges))
+		}
+		rendered := decision.Reason.Render()
+		if !strings.Contains(rendered, strconv.FormatInt(unreadable.ID, 10)) || !strings.Contains(rendered, "no readable decision remains") {
+			t.Fatalf("hold must say why nothing can be checked: %q", rendered)
+		}
+	})
+}

--- a/internal/workflow/workload_mode_gate_test.go
+++ b/internal/workflow/workload_mode_gate_test.go
@@ -2,6 +2,7 @@ package workflow
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strconv"
 	"strings"
@@ -870,6 +871,87 @@ func TestWorkloadModeGateBoundaryToleratesHandWrittenRepoFields(t *testing.T) {
 					decision, decision.Reason.Render())
 			}
 		})
+	}
+}
+
+// F-11 at the SOURCE. The pipeline keys a hold episode's budget on this key, so
+// the key must not move when the operator-facing detail does. Driven through
+// Evaluate, because a pipeline test that injects a key through a stub pins the
+// stub, not the construction.
+func TestPipelineAutoMergerReconciliationKeyIgnoresVolatileDetail(t *testing.T) {
+	store, gh, _, _ := newWorkloadModeGateScenario(t)
+	decision := insertOperatingModeDecision(t, store, "STEADY")
+	// A row for the WRONG head: reconciliation still holds, and the hold's detail
+	// names this row as the near miss.
+	insertModeReconciliation(t, store, decision, "STEADY", "otherhead1")
+	merger := PipelineAutoMerger{Store: store, GitHub: gh}
+	request := PipelineAutoMergeRequest{Repo: "gitmoot/gitmoot", PullRequest: 9, HeadSHA: "head123", Pipeline: "release", RunID: "run-1", StageID: "merge"}
+
+	first, err := merger.Evaluate(context.Background(), request)
+	if err != nil {
+		t.Fatalf("Evaluate: %v", err)
+	}
+	if !first.ReconciliationHold || strings.TrimSpace(first.ReconciliationKey) == "" {
+		t.Fatalf("readiness = %+v, want a keyed reconciliation hold", first)
+	}
+
+	// Churn in the volatile half: the same hold, same head, same decision, but
+	// the marker patch now reads as ambiguous, which appends a clause to the
+	// detail. The DETAIL must move and the KEY must not.
+	gh.files = []github.PullRequestFile{{
+		Filename: "AGENTS.md",
+		Patch:    "@@ -1 +1 @@\n-**Current mode: DRAIN.**",
+	}}
+	second, err := merger.Evaluate(context.Background(), request)
+	if err != nil {
+		t.Fatalf("Evaluate after churn: %v", err)
+	}
+	if second.Reason == first.Reason {
+		t.Fatalf("this fixture must change the detail, or it proves nothing: %q", second.Reason)
+	}
+	if second.ReconciliationKey != first.ReconciliationKey {
+		t.Fatalf("episode key moved with the detail: %q then %q - external churn would reset the hold's budget",
+			first.ReconciliationKey, second.ReconciliationKey)
+	}
+	// And the key must not simply embed the detail, which would key on churn
+	// while comparing equal in this pair by accident.
+	if strings.Contains(first.ReconciliationKey, "otherhead1") || strings.Contains(first.ReconciliationKey, "near") {
+		t.Fatalf("episode key carries near-miss text: %q", first.ReconciliationKey)
+	}
+	for _, want := range []string{"head=head123", "decision-note=" + strconv.FormatInt(decision.ID, 10)} {
+		if !strings.Contains(first.ReconciliationKey, want) {
+			t.Fatalf("episode key %q must name %q", first.ReconciliationKey, want)
+		}
+	}
+}
+
+// Waiting carries a SAFETY PRECONDITION - no GitHub mutation was attempted -
+// because the pipeline RELEASES its at-most-once merge claim on a Waiting
+// return. The type says so, and a comment is not a guard: a mutant that mapped a
+// post-request merge error onto {Waiting: true} passed internal/workflow and
+// internal/pipeline fully green, because nothing pinned the mapping (#1783
+// round-5 review, F-9). A merge API error may have reached GitHub, so it must
+// surface as an ERROR, never as a releasable wait.
+func TestPipelineAutoMergerMergeNeverMapsAMutationErrorToWaiting(t *testing.T) {
+	store, gh, _, _ := newWorkloadModeGateScenario(t)
+	mode := insertOperatingModeDecision(t, store, "STEADY")
+	// Reconciliation satisfied, so Merge reaches the mutation rather than
+	// returning the legitimate reconciliation Waiting before it.
+	insertModeReconciliation(t, store, mode, "STEADY", "head123")
+	mergeErr := errors.New("merge API timed out after the request was sent")
+	gh.mergeErr = mergeErr
+	merger := PipelineAutoMerger{Store: store, GitHub: gh}
+	request := PipelineAutoMergeRequest{Repo: "gitmoot/gitmoot", PullRequest: 9, HeadSHA: "head123", Pipeline: "release", RunID: "run-1", StageID: "merge"}
+
+	result, err := merger.Merge(context.Background(), request)
+	if !errors.Is(err, mergeErr) {
+		t.Fatalf("Merge error = %v, want the merge API error to surface", err)
+	}
+	if result.Waiting {
+		t.Fatalf("a refusal that may have reached GitHub must not set Waiting: %+v", result)
+	}
+	if result.Merged {
+		t.Fatalf("a failed merge must not report Merged: %+v", result)
 	}
 }
 

--- a/internal/workflow/workload_mode_gate_test.go
+++ b/internal/workflow/workload_mode_gate_test.go
@@ -638,3 +638,109 @@ func TestWorkloadModeGateUnreadableDecisionIsABoundaryNotAWedge(t *testing.T) {
 		}
 	})
 }
+
+// GitHub OMITS the patch for large files, and AGENTS.md is large, so the
+// refusal used to tell the author to fix a marker that was never the problem
+// and name no exit they could take (#1783 round-3 review, F-B).
+func TestWorkloadModeGateNamesAReachableRemedyWhenGitHubOmitsThePatch(t *testing.T) {
+	store, gh, gate, request := newWorkloadModeGateScenario(t)
+	gh.files = []github.PullRequestFile{{Filename: "AGENTS.md"}} // patch omitted by the API
+	unreadable := insertRawOperatingMode(t, store, "gitmoot/gitmoot", "[operating-mode repo=gitmoot/gitmoot mode=PAUSED]")
+
+	decision, err := gate.Evaluate(context.Background(), request)
+	if err != nil {
+		t.Fatalf("Evaluate: %v", err)
+	}
+	if decision.Merged || len(gh.merges) != 0 {
+		t.Fatalf("an unreadable note plus an unreadable marker must hold: decision=%+v merges=%d", decision, len(gh.merges))
+	}
+	rendered := decision.Reason.Render()
+	for _, want := range []string{
+		strconv.FormatInt(unreadable.ID, 10),
+		"GitHub omitted this PR's AGENTS.md patch",
+		"not the author's to fix",
+		"append a fresh readable operating-mode note",
+	} {
+		if !strings.Contains(rendered, want) {
+			t.Fatalf("hold must contain %q: %q", want, rendered)
+		}
+	}
+
+	// And the owner-level exit actually works: a fresh readable note clears it.
+	insertOperatingModeDecision(t, store, "STEADY")
+	insertRawModeReconciliation(t, store, "STEADY", "head123", "none")
+	cleared, err := gate.Evaluate(context.Background(), request)
+	if err != nil {
+		t.Fatalf("Evaluate after the fresh note: %v", err)
+	}
+	if !cleared.Merged || len(gh.merges) != 1 {
+		t.Fatalf("the named remedy did not work: decision=%+v merges=%d reason=%q",
+			cleared, len(gh.merges), cleared.Reason.Render())
+	}
+}
+
+// A valid row aged out of the 200-row window used to leave the hold blaming an
+// unrelated near-miss row, which reads as a verdict on the operator's own work
+// (#1783 round-3 review, F-C). The window is recoverable by refiling, so this
+// is a message fix - the hold must SAY the window was full.
+func TestWorkloadModeGateHoldNamesTheScanWindowWhenItIsFull(t *testing.T) {
+	store, gh, gate, request := newWorkloadModeGateScenario(t)
+	mode := insertOperatingModeDecision(t, store, "STEADY")
+	insertModeReconciliation(t, store, mode, "STEADY", "head123")
+	for i := range workloadModeReconciliationScan + 5 {
+		if _, err := store.InsertWorkflowNote(context.Background(), db.WorkflowNote{
+			WorkflowID: "gitmoot/worktree-lifecycle",
+			Author:     "coordinator",
+			Repo:       "gitmoot/gitmoot",
+			Body: fmt.Sprintf("[workload-mode-reconciliation repo=gitmoot/gitmoot pr=%d head=otherhead mode=STEADY decision_note=%d]",
+				1000+i, mode.ID),
+		}); err != nil {
+			t.Fatalf("InsertWorkflowNote filler %d: %v", i, err)
+		}
+	}
+
+	decision, err := gate.Evaluate(context.Background(), request)
+	if err != nil {
+		t.Fatalf("Evaluate: %v", err)
+	}
+	if decision.Merged || len(gh.merges) != 0 {
+		t.Fatalf("an aged-out row cannot reconcile: decision=%+v merges=%d", decision, len(gh.merges))
+	}
+	if rendered := decision.Reason.Render(); !strings.Contains(rendered, "may have aged out") {
+		t.Fatalf("hold must name the full scan window rather than only a near-miss row: %q", rendered)
+	}
+}
+
+// `workflow note` is written by hand, so an omitted --repo left a malformed
+// operating-mode note invisible to the boundary and a stale PR-sourced row
+// still reconciled (#1783 round-3 review, F-D).
+func TestWorkloadModeGateBoundaryCatchesAMalformedNoteWithNoRepoColumn(t *testing.T) {
+	store, gh, gate, request := newWorkloadModeGateScenario(t)
+	stale := insertRawModeReconciliation(t, store, "STEADY", "head123", "none")
+	unreadable := insertRawOperatingMode(t, store, "", "[operating-mode repo=gitmoot/gitmoot mode=DRAIN urgent]")
+
+	decision, err := gate.Evaluate(context.Background(), request)
+	if err != nil {
+		t.Fatalf("Evaluate: %v", err)
+	}
+	if decision.Merged || len(gh.merges) != 0 {
+		t.Fatalf("a repo-less malformed note must still supersede: decision=%+v merges=%d reason=%q",
+			decision, len(gh.merges), decision.Reason.Render())
+	}
+	rendered := decision.Reason.Render()
+	if !strings.Contains(rendered, strconv.FormatInt(stale.ID, 10)) || !strings.Contains(rendered, strconv.FormatInt(unreadable.ID, 10)) {
+		t.Fatalf("hold must name the stale row and the note that superseded it: %q", rendered)
+	}
+
+	// A malformed note that names ANOTHER repo, with no repo column, must still
+	// be ignored: the anti-wedge narrowing is the point.
+	other, _, otherGate, otherRequest := newWorkloadModeGateScenario(t)
+	otherMode := insertOperatingModeDecision(t, other, "STEADY")
+	insertModeReconciliation(t, other, otherMode, "STEADY", "head123")
+	insertRawOperatingMode(t, other, "", "[operating-mode repo=other/repo mode=DRAIN urgent]")
+	if decision, err := otherGate.Evaluate(context.Background(), otherRequest); err != nil {
+		t.Fatalf("Evaluate: %v", err)
+	} else if !decision.Merged {
+		t.Fatalf("another repo's repo-less malformed note must not hold this one: %q", decision.Reason.Render())
+	}
+}

--- a/internal/workflow/workload_mode_gate_test.go
+++ b/internal/workflow/workload_mode_gate_test.go
@@ -286,3 +286,271 @@ func TestWorkloadModeGateFindsTheDecisionBehindOtherReposNotes(t *testing.T) {
 			decision, len(gh.merges), decision.Reason.Render())
 	}
 }
+
+// insertRawOperatingMode writes an operating-mode note with an arbitrary field
+// list, including bodies the parser rejects.
+func insertRawOperatingMode(t *testing.T, store *db.Store, repoColumn, body string) db.WorkflowNote {
+	t.Helper()
+	note, err := store.InsertWorkflowNote(context.Background(), db.WorkflowNote{
+		WorkflowID: "gitmoot/worktree-lifecycle",
+		Author:     "owner",
+		Repo:       repoColumn,
+		Body:       body,
+	})
+	if err != nil {
+		t.Fatalf("InsertWorkflowNote raw decision: %v", err)
+	}
+	return note
+}
+
+// An UNREADABLE newest decision is not "no decision". Skipping it returned
+// id==0, which dropped the supersession check AND made decision_note=none
+// satisfiable by a row written before the owner decided, so both halves of the
+// mode guard failed together (#1783 review, F1).
+func TestWorkloadModeGateHoldsWhenTheNewestDecisionIsUnreadable(t *testing.T) {
+	for name, body := range map[string]string{
+		"malformed field list": "[operating-mode repo=gitmoot/gitmoot mode=DRAIN urgent]",
+		"unknown mode":         "[operating-mode repo=gitmoot/gitmoot mode=PAUSED]",
+	} {
+		t.Run(name, func(t *testing.T) {
+			store, gh, gate, request := newWorkloadModeGateScenario(t)
+			// A row that WOULD satisfy the gate if the newest decision were absent.
+			insertRawModeReconciliation(t, store, "STEADY", "head123", "none")
+			unreadable := insertRawOperatingMode(t, store, "gitmoot/gitmoot", body)
+
+			decision, err := gate.Evaluate(context.Background(), request)
+			if err != nil {
+				t.Fatalf("Evaluate: %v", err)
+			}
+			if decision.Merged || len(gh.merges) != 0 {
+				t.Fatalf("an unreadable decision must hold: decision=%+v merges=%d", decision, len(gh.merges))
+			}
+			rendered := decision.Reason.Render()
+			if !strings.Contains(rendered, strconv.FormatInt(unreadable.ID, 10)) {
+				t.Fatalf("hold must name the unreadable note %d: %q", unreadable.ID, rendered)
+			}
+		})
+	}
+}
+
+// The fail-closed rule must not freeze repositories it cannot prove are
+// affected: one typo in another lane's note would otherwise hold every
+// gitmoot-owned repo, and a valid reconciliation must still merge.
+func TestWorkloadModeGateIgnoresAnUnreadableNoteFromAnotherRepo(t *testing.T) {
+	store, gh, gate, request := newWorkloadModeGateScenario(t)
+	mode := insertOperatingModeDecision(t, store, "STEADY")
+	insertModeReconciliation(t, store, mode, "STEADY", "head123")
+	insertRawOperatingMode(t, store, "other/repo", "[operating-mode repo=other/repo mode=DRAIN urgent]")
+
+	decision, err := gate.Evaluate(context.Background(), request)
+	if err != nil {
+		t.Fatalf("Evaluate: %v", err)
+	}
+	if !decision.Merged || len(gh.merges) != 1 {
+		t.Fatalf("another repo's malformed note must not hold this one: decision=%+v merges=%d reason=%q",
+			decision, len(gh.merges), decision.Reason.Render())
+	}
+}
+
+// The headline invariant is EXACT-HEAD reconciliation, and no test refused a row
+// written at a stale head: every fixture used the current head, so deleting the
+// head clause changed nothing (#1783 review, F5b). Same for the pr clause (F5c).
+func TestWorkloadModeGateRefusesRowsForAnotherHeadOrPullRequest(t *testing.T) {
+	t.Run("stale head", func(t *testing.T) {
+		store, gh, gate, request := newWorkloadModeGateScenario(t)
+		mode := insertOperatingModeDecision(t, store, "STEADY")
+		stale := insertModeReconciliation(t, store, mode, "STEADY", "head000")
+
+		decision, err := gate.Evaluate(context.Background(), request)
+		if err != nil {
+			t.Fatalf("Evaluate: %v", err)
+		}
+		if decision.Merged || len(gh.merges) != 0 {
+			t.Fatalf("a row at a stale head must not reconcile: decision=%+v merges=%d", decision, len(gh.merges))
+		}
+		rendered := decision.Reason.Render()
+		if !strings.Contains(rendered, strconv.FormatInt(stale.ID, 10)) || !strings.Contains(rendered, "head") {
+			t.Fatalf("hold must name the stale row and both heads: %q", rendered)
+		}
+	})
+
+	t.Run("another pull request", func(t *testing.T) {
+		store, gh, gate, request := newWorkloadModeGateScenario(t)
+		decisionNote := insertOperatingModeDecision(t, store, "STEADY")
+		other, err := store.InsertWorkflowNote(context.Background(), db.WorkflowNote{
+			WorkflowID: "gitmoot/worktree-lifecycle",
+			Author:     "coordinator",
+			Repo:       "gitmoot/gitmoot",
+			Body: fmt.Sprintf("[workload-mode-reconciliation repo=gitmoot/gitmoot pr=77 head=head123 mode=STEADY decision_note=%d]",
+				decisionNote.ID),
+		})
+		if err != nil {
+			t.Fatalf("InsertWorkflowNote: %v", err)
+		}
+
+		decision, err := gate.Evaluate(context.Background(), request)
+		if err != nil {
+			t.Fatalf("Evaluate: %v", err)
+		}
+		if decision.Merged || len(gh.merges) != 0 {
+			t.Fatalf("another PR's row must not reconcile this one: decision=%+v merges=%d", decision, len(gh.merges))
+		}
+		if rendered := decision.Reason.Render(); !strings.Contains(rendered, strconv.FormatInt(other.ID, 10)) {
+			t.Fatalf("hold must name the row that reconciles another PR: %q", rendered)
+		}
+	})
+}
+
+// The row's mode must equal the mode the PR ADDS. On the decision_note=none
+// path that is the ONLY binding constraint, so with it deleted a PR-sourced row
+// could ratify a marker change it disagreed with (#1783 review, F5a).
+func TestWorkloadModeGateRefusesAPRSourcedRowThatDisagreesWithTheMarker(t *testing.T) {
+	store, gh, gate, request := newWorkloadModeGateScenario(t)
+	// The scenario's patch adds "**Current mode: STEADY.**"; the row says DRAIN.
+	row := insertRawModeReconciliation(t, store, "DRAIN", "head123", "none")
+
+	decision, err := gate.Evaluate(context.Background(), request)
+	if err != nil {
+		t.Fatalf("Evaluate: %v", err)
+	}
+	if decision.Merged || len(gh.merges) != 0 {
+		t.Fatalf("a PR-sourced row must still match the marker: decision=%+v merges=%d", decision, len(gh.merges))
+	}
+	rendered := decision.Reason.Render()
+	if !strings.Contains(rendered, strconv.FormatInt(row.ID, 10)) || !strings.Contains(rendered, "STEADY") {
+		t.Fatalf("hold must name the row and the mode the PR adds: %q", rendered)
+	}
+}
+
+// When the marker patch is AMBIGUOUS the expected mode falls back to the newest
+// decision, so a row must agree with that decision. Nothing exercised the
+// fallback, so deleting it changed no test (#1783 review, F5d).
+func TestWorkloadModeGateFallsBackToTheDecisionModeForAnAmbiguousPatch(t *testing.T) {
+	store, gh, gate, request := newWorkloadModeGateScenario(t)
+	// Marker lines change on BOTH sides with no readable added mode: ambiguous.
+	gh.files = []github.PullRequestFile{{
+		Filename: "AGENTS.md",
+		Patch:    "@@ -1 +1 @@\n-**Current mode: DRAIN.**\n+**Current mode: SOMETHING.**",
+	}}
+	insertOperatingModeDecision(t, store, "STEADY")
+	row := insertRawModeReconciliation(t, store, "DRAIN", "head123", "none")
+
+	decision, err := gate.Evaluate(context.Background(), request)
+	if err != nil {
+		t.Fatalf("Evaluate: %v", err)
+	}
+	if decision.Merged || len(gh.merges) != 0 {
+		t.Fatalf("an ambiguous patch must still be held against the decision mode: decision=%+v merges=%d", decision, len(gh.merges))
+	}
+	if rendered := decision.Reason.Render(); !strings.Contains(rendered, strconv.FormatInt(row.ID, 10)) {
+		t.Fatalf("hold must name the disagreeing row: %q", rendered)
+	}
+}
+
+// GitHub treats owner/repo case insensitively, so a byte comparison on the owner
+// silently disabled the whole gate for a repo recorded as "Gitmoot" (#1783
+// review, F3).
+func TestModeSensitivePullRequestIgnoresOwnerCase(t *testing.T) {
+	gh := &fakeMergeGateGitHub{files: []github.PullRequestFile{{
+		Filename: "AGENTS.md",
+		Patch:    "@@ -1 +1 @@\n-**Current mode: DRAIN.**\n+**Current mode: STEADY.**",
+	}}}
+	got, err := inspectModeSensitivePullRequest(context.Background(), gh, github.Repository{Owner: "Gitmoot", Name: "gitmoot"}, 9)
+	if err != nil {
+		t.Fatalf("inspectModeSensitivePullRequest: %v", err)
+	}
+	if !got.required || got.mode != "STEADY" {
+		t.Fatalf("inspection = %+v, want a required STEADY reconciliation for owner \"Gitmoot\"", got)
+	}
+}
+
+// A note whose repo COLUMN differs only by case must still be visible on both
+// note streams; the byte-equal SQL filter dropped it and took the fail-open
+// path with it (#1783 review, F3).
+func TestWorkloadModeGateFindsNotesRecordedWithDifferentRepoCase(t *testing.T) {
+	store, gh, gate, request := newWorkloadModeGateScenario(t)
+	decisionNote := insertRawOperatingMode(t, store, "Gitmoot/Gitmoot", "[operating-mode repo=Gitmoot/Gitmoot mode=STEADY]")
+	if _, err := store.InsertWorkflowNote(context.Background(), db.WorkflowNote{
+		WorkflowID: "gitmoot/worktree-lifecycle",
+		Author:     "coordinator",
+		Repo:       "Gitmoot/Gitmoot",
+		Body: fmt.Sprintf("[workload-mode-reconciliation repo=Gitmoot/Gitmoot pr=9 head=head123 mode=STEADY decision_note=%d]",
+			decisionNote.ID),
+	}); err != nil {
+		t.Fatalf("InsertWorkflowNote: %v", err)
+	}
+
+	decision, err := gate.Evaluate(context.Background(), request)
+	if err != nil {
+		t.Fatalf("Evaluate: %v", err)
+	}
+	if !decision.Merged || len(gh.merges) != 1 {
+		t.Fatalf("case-different notes must reconcile: decision=%+v merges=%d reason=%q",
+			decision, len(gh.merges), decision.Reason.Render())
+	}
+}
+
+// The merge-boundary recheck must produce a WAITING disposition, not a terminal
+// one: the pipeline folds any !Merged into a blocked stage with "retry
+// stopped", so an owner note landing in the Evaluate->Merge window ended the run
+// and needed a human where the pre-merge path simply waited (#1783 review, F4).
+func TestPipelineAutoMergerHoldsMergeBoundaryAsWaiting(t *testing.T) {
+	store, gh, _, _ := newWorkloadModeGateScenario(t)
+	mode := insertOperatingModeDecision(t, store, "STEADY")
+	insertModeReconciliation(t, store, mode, "STEADY", "head123")
+	merger := PipelineAutoMerger{Store: store, GitHub: gh}
+	request := PipelineAutoMergeRequest{Repo: "gitmoot/gitmoot", PullRequest: 9, HeadSHA: "head123", Pipeline: "release", RunID: "run-1", StageID: "merge"}
+	insertOperatingModeDecision(t, store, "DRAIN")
+
+	result, err := merger.Merge(context.Background(), request)
+	if err != nil {
+		t.Fatalf("Merge: %v", err)
+	}
+	if result.Merged || len(gh.merges) != 0 {
+		t.Fatalf("result=%+v merges=%d, want no merge", result, len(gh.merges))
+	}
+	if !result.Waiting {
+		t.Fatalf("a reconciliation hold must be retryable, not terminal: result=%+v", result)
+	}
+
+	// A head drift at the merge boundary stays TERMINAL: the reviewed head is
+	// gone, so no amount of waiting makes this request mergeable.
+	gh.pr.HeadSHA = "head999"
+	drift, err := merger.Merge(context.Background(), request)
+	if err != nil {
+		t.Fatalf("Merge after drift: %v", err)
+	}
+	if drift.Merged || drift.Waiting {
+		t.Fatalf("head drift must not be retryable: result=%+v", drift)
+	}
+}
+
+// A row recorded under ANOTHER repo column is invisible to the repo-scoped
+// lookup, so the coordinator who filed it against the wrong workflow saw only
+// the generic hold with no cause (#1783 review, F2).
+func TestWorkloadModeGateHoldNamesAMisfiledReconciliationRow(t *testing.T) {
+	store, gh, gate, request := newWorkloadModeGateScenario(t)
+	decisionNote := insertOperatingModeDecision(t, store, "STEADY")
+	misfiled, err := store.InsertWorkflowNote(context.Background(), db.WorkflowNote{
+		WorkflowID: "other/lane",
+		Author:     "coordinator",
+		Repo:       "other/repo",
+		Body: fmt.Sprintf("[workload-mode-reconciliation repo=gitmoot/gitmoot pr=9 head=head123 mode=STEADY decision_note=%d]",
+			decisionNote.ID),
+	})
+	if err != nil {
+		t.Fatalf("InsertWorkflowNote: %v", err)
+	}
+
+	decision, err := gate.Evaluate(context.Background(), request)
+	if err != nil {
+		t.Fatalf("Evaluate: %v", err)
+	}
+	if decision.Merged || len(gh.merges) != 0 {
+		t.Fatalf("a misfiled row must not reconcile: decision=%+v merges=%d", decision, len(gh.merges))
+	}
+	rendered := decision.Reason.Render()
+	if !strings.Contains(rendered, strconv.FormatInt(misfiled.ID, 10)) || !strings.Contains(rendered, "other/repo") {
+		t.Fatalf("hold must name the misfiled row and the repo it was recorded under: %q", rendered)
+	}
+}

--- a/internal/workflow/workload_mode_gate_test.go
+++ b/internal/workflow/workload_mode_gate_test.go
@@ -3,6 +3,7 @@ package workflow
 import (
 	"context"
 	"fmt"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -126,5 +127,162 @@ func TestModeSensitivePullRequestFailsClosedOnMissingPatch(t *testing.T) {
 	}
 	if !got.required || !got.ambiguous {
 		t.Fatalf("inspection = %+v, want required ambiguous reconciliation", got)
+	}
+}
+
+// insertRawModeReconciliation writes a reconciliation row with an arbitrary
+// decision_note value, including the documented literal "none".
+func insertRawModeReconciliation(t *testing.T, store *db.Store, mode, head, decisionNote string) db.WorkflowNote {
+	t.Helper()
+	note, err := store.InsertWorkflowNote(context.Background(), db.WorkflowNote{
+		WorkflowID: "gitmoot/worktree-lifecycle",
+		Author:     "coordinator",
+		Repo:       "gitmoot/gitmoot",
+		Body: fmt.Sprintf("[workload-mode-reconciliation repo=gitmoot/gitmoot pr=9 head=%s mode=%s decision_note=%s]",
+			head, mode, decisionNote),
+	})
+	if err != nil {
+		t.Fatalf("InsertWorkflowNote reconciliation: %v", err)
+	}
+	return note
+}
+
+// AGENTS.md documents `decision_note=none` for a PR-SOURCED decision, where the
+// PR itself is the decision. That value used to be matchable only while the repo
+// had zero operating-mode notes, so from the first typed note onward every row
+// written per the documented instruction was skipped and the PR held forever
+// with no stated cause (#1783 review, P2).
+func TestWorkloadModeGateAcceptsDocumentedPRSourcedDecisionNote(t *testing.T) {
+	store, gh, gate, request := newWorkloadModeGateScenario(t)
+	insertOperatingModeDecision(t, store, "DRAIN")
+	insertRawModeReconciliation(t, store, "STEADY", "head123", "none")
+
+	decision, err := gate.Evaluate(context.Background(), request)
+	if err != nil {
+		t.Fatalf("Evaluate: %v", err)
+	}
+	if !decision.Merged || len(gh.merges) != 1 {
+		t.Fatalf("a PR-sourced reconciliation must merge: decision=%+v merges=%d reason=%q",
+			decision, len(gh.merges), decision.Reason.Render())
+	}
+}
+
+// A PR-sourced row still cannot ratify a SUPERSEDED decision: an owner note
+// landing after the row invalidates it, exactly as for a row citing an id.
+func TestWorkloadModeGateRejectsSupersededPRSourcedRow(t *testing.T) {
+	store, gh, gate, request := newWorkloadModeGateScenario(t)
+	insertRawModeReconciliation(t, store, "STEADY", "head123", "none")
+	insertOperatingModeDecision(t, store, "DRAIN")
+
+	decision, err := gate.Evaluate(context.Background(), request)
+	if err != nil {
+		t.Fatalf("Evaluate: %v", err)
+	}
+	if decision.Merged || len(gh.merges) != 0 {
+		t.Fatalf("a superseded PR-sourced row must not merge: decision=%+v merges=%d", decision, len(gh.merges))
+	}
+	if reason := decision.Reason.Render(); !strings.Contains(reason, "predates operating-mode note") {
+		t.Fatalf("hold reason must name the supersession: %q", reason)
+	}
+}
+
+// Citing a decision note proved only that someone READ it. With the newest note
+// deciding STEADY, a PR flipping the marker to THROUGHPUT merged cleanly by
+// citing that STEADY note. A row may only ratify the mode its decision decided.
+func TestWorkloadModeGateRejectsRowCitingADisagreeingDecision(t *testing.T) {
+	store, gh, gate, request := newWorkloadModeGateScenario(t)
+	gh.files = []github.PullRequestFile{{
+		Filename: "AGENTS.md",
+		Patch:    "@@ -1 +1 @@\n-**Current mode: DRAIN.**\n+**Current mode: THROUGHPUT.**",
+	}}
+	decisionNote := insertOperatingModeDecision(t, store, "STEADY")
+	insertRawModeReconciliation(t, store, "THROUGHPUT", "head123", strconv.FormatInt(decisionNote.ID, 10))
+
+	decision, err := gate.Evaluate(context.Background(), request)
+	if err != nil {
+		t.Fatalf("Evaluate: %v", err)
+	}
+	if decision.Merged || len(gh.merges) != 0 {
+		t.Fatalf("a row citing a disagreeing decision must not merge: decision=%+v merges=%d", decision, len(gh.merges))
+	}
+	if reason := decision.Reason.Render(); !strings.Contains(reason, "cannot ratify") {
+		t.Fatalf("hold reason must say the row cannot ratify that mode: %q", reason)
+	}
+}
+
+// The hold used to say only "requires reconciliation", and the native path holds
+// through g.pending, which retries silently. A coordinator who HAD written a row
+// therefore saw an indefinitely pending PR with nothing pointing at the cause.
+func TestWorkloadModeGateHoldNamesTheMismatchedRow(t *testing.T) {
+	store, _, gate, request := newWorkloadModeGateScenario(t)
+	newest := insertOperatingModeDecision(t, store, "STEADY")
+	insertRawModeReconciliation(t, store, "STEADY", "head123", "999999")
+
+	decision, err := gate.Evaluate(context.Background(), request)
+	if err != nil {
+		t.Fatalf("Evaluate: %v", err)
+	}
+	reason := decision.Reason.Render()
+	if !strings.Contains(reason, "cites decision_note=999999") ||
+		!strings.Contains(reason, strconv.FormatInt(newest.ID, 10)) {
+		t.Fatalf("hold reason must name the row and the newest note: %q", reason)
+	}
+}
+
+// Enforcement is documented against the gitmoot/* scope, and the gate compared
+// FullName to the literal "gitmoot/gitmoot", so a mode-marker change in any
+// other gitmoot repository merged with no reconciliation at all (#1783 review,
+// P3).
+func TestModeSensitivePullRequestCoversTheDocumentedOwnerScope(t *testing.T) {
+	patch := "@@ -1 +1 @@\n-**Current mode: DRAIN.**\n+**Current mode: STEADY.**"
+	for name, test := range map[string]struct {
+		repo         github.Repository
+		wantRequired bool
+	}{
+		"flagship":        {repo: github.Repository{Owner: "gitmoot", Name: "gitmoot"}, wantRequired: true},
+		"sibling in org":  {repo: github.Repository{Owner: "gitmoot", Name: "gitmoot-dashboard"}, wantRequired: true},
+		"outside the org": {repo: github.Repository{Owner: "jerryfane", Name: "joltra"}, wantRequired: false},
+	} {
+		t.Run(name, func(t *testing.T) {
+			gh := &fakeMergeGateGitHub{files: []github.PullRequestFile{{Filename: "AGENTS.md", Patch: patch}}}
+			got, err := inspectModeSensitivePullRequest(context.Background(), gh, test.repo, 9)
+			if err != nil {
+				t.Fatalf("inspectModeSensitivePullRequest: %v", err)
+			}
+			if got.required != test.wantRequired {
+				t.Fatalf("required = %v, want %v for %s", got.required, test.wantRequired, test.repo.FullName())
+			}
+		})
+	}
+}
+
+// The decision lookup is scoped to the repository IN SQL. Ordering across every
+// repo and truncating was a fail-OPEN corner: losing this repo's decision note
+// made the gate read "no decision exists", which dropped the recency check and
+// let a stale PR-sourced row satisfy the gate (#1783 review, P3).
+func TestWorkloadModeGateFindsTheDecisionBehindOtherReposNotes(t *testing.T) {
+	store, gh, gate, request := newWorkloadModeGateScenario(t)
+	decisionNote := insertOperatingModeDecision(t, store, "STEADY")
+	// Bury it under more operating-mode notes than the scan window holds, all for
+	// other repositories.
+	for i := 0; i < workloadModeReconciliationScan+10; i++ {
+		if _, err := store.InsertWorkflowNote(context.Background(), db.WorkflowNote{
+			WorkflowID: "other/lane",
+			Author:     "owner",
+			Repo:       fmt.Sprintf("other/repo-%d", i),
+			Body:       fmt.Sprintf("[operating-mode repo=other/repo-%d mode=DRAIN]", i),
+		}); err != nil {
+			t.Fatalf("InsertWorkflowNote filler: %v", err)
+		}
+	}
+	insertRawModeReconciliation(t, store, "STEADY", "head123", strconv.FormatInt(decisionNote.ID, 10))
+
+	decision, err := gate.Evaluate(context.Background(), request)
+	if err != nil {
+		t.Fatalf("Evaluate: %v", err)
+	}
+	if !decision.Merged || len(gh.merges) != 1 {
+		t.Fatalf("the buried decision must still be found: decision=%+v merges=%d reason=%q",
+			decision, len(gh.merges), decision.Reason.Render())
 	}
 }

--- a/skills/gitmoot/references/CLI.md
+++ b/skills/gitmoot/references/CLI.md
@@ -3843,7 +3843,10 @@ the existing `allow_scheduled_writes` key. Omitting `merge` preserves human merg
 Pending checks wait; skipped/neutral check-runs pass; failures block; and zero
 external statuses/checks always block regardless of `require_external_ci`. The
 source job atomically records `pipeline_auto_merge_claim` before the write and
-`pipeline_auto_merge_confirmed` after GitHub confirms it.
+`pipeline_auto_merge_confirmed` after GitHub confirms it. A workload-mode
+reconciliation hold records `pipeline_auto_merge_held` with its cause, releases
+the claim so the merge is re-attempted when the row lands, and parks with that
+cause at the gate `timeout` or 6h after the hold began when no timeout is set.
 
 `pipeline install-defaults` installs the built-in memory pipelines
 `memory-ingest-sweep` and `memory-groom-propose`. The daemon also runs this

--- a/skills/gitmoot/references/CLI.md
+++ b/skills/gitmoot/references/CLI.md
@@ -3843,10 +3843,11 @@ the existing `allow_scheduled_writes` key. Omitting `merge` preserves human merg
 Pending checks wait; skipped/neutral check-runs pass; failures block; and zero
 external statuses/checks always block regardless of `require_external_ci`. The
 source job atomically records `pipeline_auto_merge_claim` before the write,
-`pipeline_auto_merge_claim_at` for the claim's age, and
 `pipeline_auto_merge_confirmed` after GitHub confirms it. A scan that loses the
-claim never parks the run; past 15m it records
-`pipeline_auto_merge_claim_orphaned` and keeps waiting. A workload-mode
+claim never parks the run; it ages its wait from the gate stage's own
+`StartedAt` and records `pipeline_auto_merge_claim_orphaned` past 15m, or
+immediately with `cause=gate_start_unrecorded` when that stamp is missing, and
+keeps waiting. A workload-mode
 reconciliation hold records `pipeline_auto_merge_held` with its cause, releases
 the claim so the merge is re-attempted when the row lands, and parks with that
 cause at the gate `timeout` or 24h after the hold began when no timeout is set;

--- a/skills/gitmoot/references/CLI.md
+++ b/skills/gitmoot/references/CLI.md
@@ -3847,9 +3847,10 @@ source job atomically records `pipeline_auto_merge_claim` before the write,
 claim never parks the run; it ages its wait from the claim row's own
 `created_at` and records `pipeline_auto_merge_claim_orphaned` past 15m, or
 immediately with `cause=claim_timestamp_unreadable` when that value will not
-parse, and keeps waiting. A stage `timeout` parks the aged case terminally
-rather than recovering it - nothing releases an orphaned claim, so a new run is
-the remedy - and cannot park the unreadable case at all. A workload-mode
+parse, and keeps waiting. A stage `timeout` parks either case terminally rather
+than recovering it - nothing releases an orphaned claim, so a new run is the
+remedy. A claim released in the window between a losing scan's failed claim and
+its read is the ordinary hold cycle and is reported as nothing. A workload-mode
 reconciliation hold records `pipeline_auto_merge_held` with its cause, releases
 the claim so the merge is re-attempted when the row lands, and parks with that
 cause at the gate `timeout` or 24h after the hold began when no timeout is set;

--- a/skills/gitmoot/references/CLI.md
+++ b/skills/gitmoot/references/CLI.md
@@ -3874,9 +3874,25 @@ case-insensitively on repository:
 - RECONCILIATION: `[workload-mode-reconciliation repo=<owner/repo> pr=<number> head=<40-character reviewed head> mode=<mode> decision_note=<note id|none>]`
 
 Every field is `key=value`, whitespace separated, inside the leading bracket. A
-field with an empty key or value makes the whole body unparseable, so write the
-row with `gitmoot workflow note --repo <owner/repo>` rather than by hand where a
-missing `--repo` is easy.
+field with an empty key or value makes the whole body unparseable, so the
+`repo=` field inside the body is what identifies the repository:
+
+```
+gitmoot workflow note <label> "[operating-mode repo=owner/repo mode=STEADY]"
+```
+
+`<label>` must be a workflow that already has jobs - `workflow note` refuses an
+unknown label to guard against a typo - so file the row under the lane the PR is
+already being coordinated in rather than inventing a label.
+
+The note's repo COLUMN is a separate, optional thing. A note whose column is
+empty still counts when its body names this repository, which is the ordinary
+case: `gitmoot workflow note` writes an empty column unless you pass
+`--remember --repo <owner/repo>`, and `--repo` is REJECTED without `--remember`
+(`--agent, --repo, and --remember-status require --remember`), because that flag
+set also opts the note into durable memory. Setting the column is therefore
+optional and costs a memory write; getting `repo=` right in the BODY is not
+optional.
 
 PRECEDENCE. The NEWEST decision wins, and a reconciliation row must be newer than
 it. `decision_note=none` means the PR itself is the decision, and the row's own

--- a/skills/gitmoot/references/CLI.md
+++ b/skills/gitmoot/references/CLI.md
@@ -3844,10 +3844,12 @@ Pending checks wait; skipped/neutral check-runs pass; failures block; and zero
 external statuses/checks always block regardless of `require_external_ci`. The
 source job atomically records `pipeline_auto_merge_claim` before the write,
 `pipeline_auto_merge_confirmed` after GitHub confirms it. A scan that loses the
-claim never parks the run; it ages its wait from the gate stage's own
-`StartedAt` and records `pipeline_auto_merge_claim_orphaned` past 15m, or
-immediately with `cause=gate_start_unrecorded` when that stamp is missing, and
-keeps waiting. A workload-mode
+claim never parks the run; it ages its wait from the claim row's own
+`created_at` and records `pipeline_auto_merge_claim_orphaned` past 15m, or
+immediately with `cause=claim_timestamp_unreadable` when that value will not
+parse, and keeps waiting. A stage `timeout` parks the aged case terminally
+rather than recovering it - nothing releases an orphaned claim, so a new run is
+the remedy - and cannot park the unreadable case at all. A workload-mode
 reconciliation hold records `pipeline_auto_merge_held` with its cause, releases
 the claim so the merge is re-attempted when the row lands, and parks with that
 cause at the gate `timeout` or 24h after the hold began when no timeout is set;

--- a/skills/gitmoot/references/CLI.md
+++ b/skills/gitmoot/references/CLI.md
@@ -3850,11 +3850,57 @@ immediately with `cause=claim_timestamp_unreadable` when that value will not
 parse, and keeps waiting. A stage `timeout` parks either case terminally rather
 than recovering it - nothing releases an orphaned claim, so a new run is the
 remedy. A claim released in the window between a losing scan's failed claim and
-its read is the ordinary hold cycle and is reported as nothing. A workload-mode
+its read is the ordinary hold cycle: the scan retries SILENTLY, so nothing is
+reported while the gate is still waiting. It is not discarded, though - the
+release reason travels with the wait, and if the stage `timeout` has elapsed it
+appears in the TERMINAL PARKED summary, so the human who finds a parked run reads
+why it waited. A workload-mode
 reconciliation hold records `pipeline_auto_merge_held` with its cause, releases
 the claim so the merge is re-attempted when the row lands, and parks with that
 cause at the gate `timeout` or 24h after the hold began when no timeout is set;
 the episode is keyed on the head and the decision, not on the cause text.
+
+### Satisfying the workload-mode gate
+
+A pull request whose diff changes the `**Current mode:` marker in `AGENTS.md` is
+HELD until an exact-head reconciliation row exists. The gate is keyed on the
+repository OWNER, so every `gitmoot/*` repository is held, human-requested merges
+included.
+
+Two note streams decide it, both matched by an exact body PREFIX and compared
+case-insensitively on repository:
+
+- DECISION: `[operating-mode repo=<owner/repo> mode=<THROUGHPUT|STEADY|DRAIN>]`
+- RECONCILIATION: `[workload-mode-reconciliation repo=<owner/repo> pr=<number> head=<40-character reviewed head> mode=<mode> decision_note=<note id|none>]`
+
+Every field is `key=value`, whitespace separated, inside the leading bracket. A
+field with an empty key or value makes the whole body unparseable, so write the
+row with `gitmoot workflow note --repo <owner/repo>` rather than by hand where a
+missing `--repo` is easy.
+
+PRECEDENCE. The NEWEST decision wins, and a reconciliation row must be newer than
+it. `decision_note=none` means the PR itself is the decision, and the row's own
+`created_at` is `decided_at`; otherwise `decision_note` names the newest
+operating-mode note the exact head implements. A row that cites a note the PR
+contradicts cannot ratify it.
+
+WHEN A DECISION CANNOT BE READ. An unreadable newest decision - a malformed field
+list, a `mode` that is not a workload mode, or a note recorded for this
+repository whose body omits or contradicts `repo=` - SUPERSEDES like any other
+decision rather than reading as "no decision". It is a recency boundary, not a
+veto: a fresh exact-head row that agrees with the PR's own marker still merges,
+so correcting the note is optional. The gate refuses outright only when nothing
+readable remains - the note is unreadable AND the PR's marker patch is missing or
+ambiguous - and the hold then names both exits: append a readable operating-mode
+note, and file an exact-head row citing it.
+
+CLEARING A HOLD. The hold is retryable: the pipeline gate releases its
+at-most-once merge claim, records `pipeline_auto_merge_held` with the cause, and
+merges on a later scan once the row lands. It is bounded on both the ordinary
+evaluate path and the final merge boundary - the stage parks at the gate
+`timeout`, or 24h after the episode began when no `timeout` is set. An episode is
+keyed on the head and the decision, so a new head or a new decision (including a
+new unreadable one) starts a fresh budget rather than inheriting the old one.
 
 `pipeline install-defaults` installs the built-in memory pipelines
 `memory-ingest-sweep` and `memory-groom-propose`. The daemon also runs this

--- a/skills/gitmoot/references/CLI.md
+++ b/skills/gitmoot/references/CLI.md
@@ -3842,11 +3842,15 @@ Merge errors are not retried. Scheduled pipelines need both `allow_auto_merge` a
 the existing `allow_scheduled_writes` key. Omitting `merge` preserves human merge.
 Pending checks wait; skipped/neutral check-runs pass; failures block; and zero
 external statuses/checks always block regardless of `require_external_ci`. The
-source job atomically records `pipeline_auto_merge_claim` before the write and
-`pipeline_auto_merge_confirmed` after GitHub confirms it. A workload-mode
+source job atomically records `pipeline_auto_merge_claim` before the write,
+`pipeline_auto_merge_claim_at` for the claim's age, and
+`pipeline_auto_merge_confirmed` after GitHub confirms it. A scan that loses the
+claim never parks the run; past 15m it records
+`pipeline_auto_merge_claim_orphaned` and keeps waiting. A workload-mode
 reconciliation hold records `pipeline_auto_merge_held` with its cause, releases
 the claim so the merge is re-attempted when the row lands, and parks with that
-cause at the gate `timeout` or 6h after the hold began when no timeout is set.
+cause at the gate `timeout` or 24h after the hold began when no timeout is set;
+the episode is keyed on the head and the decision, not on the cause text.
 
 `pipeline install-defaults` installs the built-in memory pipelines
 `memory-ingest-sweep` and `memory-groom-propose`. The daemon also runs this

--- a/skills/gitmoot/references/WORKFLOWS.md
+++ b/skills/gitmoot/references/WORKFLOWS.md
@@ -1070,9 +1070,25 @@ case-insensitively on repository:
 - RECONCILIATION: `[workload-mode-reconciliation repo=<owner/repo> pr=<number> head=<40-character reviewed head> mode=<mode> decision_note=<note id|none>]`
 
 Every field is `key=value`, whitespace separated, inside the leading bracket. A
-field with an empty key or value makes the whole body unparseable, so write the
-row with `gitmoot workflow note --repo <owner/repo>` rather than by hand where a
-missing `--repo` is easy.
+field with an empty key or value makes the whole body unparseable, so the
+`repo=` field inside the body is what identifies the repository:
+
+```
+gitmoot workflow note <label> "[operating-mode repo=owner/repo mode=STEADY]"
+```
+
+`<label>` must be a workflow that already has jobs - `workflow note` refuses an
+unknown label to guard against a typo - so file the row under the lane the PR is
+already being coordinated in rather than inventing a label.
+
+The note's repo COLUMN is a separate, optional thing. A note whose column is
+empty still counts when its body names this repository, which is the ordinary
+case: `gitmoot workflow note` writes an empty column unless you pass
+`--remember --repo <owner/repo>`, and `--repo` is REJECTED without `--remember`
+(`--agent, --repo, and --remember-status require --remember`), because that flag
+set also opts the note into durable memory. Setting the column is therefore
+optional and costs a memory write; getting `repo=` right in the BODY is not
+optional.
 
 PRECEDENCE. The NEWEST decision wins, and a reconciliation row must be newer than
 it. `decision_note=none` means the PR itself is the decision, and the row's own

--- a/skills/gitmoot/references/WORKFLOWS.md
+++ b/skills/gitmoot/references/WORKFLOWS.md
@@ -1043,7 +1043,10 @@ Without `merge: auto`, human merge remains unchanged.
 Pending checks wait; skipped/neutral check-runs pass; failures block; and zero
 external statuses/checks always block regardless of `require_external_ci`. The
 source job event timeline atomically records `pipeline_auto_merge_claim` before
-the write and `pipeline_auto_merge_confirmed` after GitHub confirms it.
+the write and `pipeline_auto_merge_confirmed` after GitHub confirms it, plus
+`pipeline_auto_merge_held` when a workload-mode reconciliation hold parks the
+gate: that hold releases the claim and retries, and is bounded by the gate
+`timeout` or by 6h from the start of the hold episode.
 
 `pipeline add` warns (does not block) when an agent stage names an agent that does
 not exist yet; create it before the stage runs. The

--- a/skills/gitmoot/references/WORKFLOWS.md
+++ b/skills/gitmoot/references/WORKFLOWS.md
@@ -1050,8 +1050,9 @@ gate: that hold releases the claim and retries, and is bounded by the gate
 the decision rather than the cause text. A scan that loses the claim ages its wait from the claim row's own `created_at`
 and records `pipeline_auto_merge_claim_orphaned` past 15m - or immediately, with
 `cause=claim_timestamp_unreadable`, when that value will not parse - and waits
-rather than parking. A stage `timeout` parks the aged case terminally instead of
-recovering it, and cannot park the unreadable case at all.
+rather than parking. A stage `timeout` parks either case terminally instead of
+recovering it. A claim released while a losing scan was reading it is the
+ordinary hold cycle and is reported as nothing.
 
 `pipeline add` warns (does not block) when an agent stage names an agent that does
 not exist yet; create it before the stage runs. The

--- a/skills/gitmoot/references/WORKFLOWS.md
+++ b/skills/gitmoot/references/WORKFLOWS.md
@@ -1044,12 +1044,13 @@ Pending checks wait; skipped/neutral check-runs pass; failures block; and zero
 external statuses/checks always block regardless of `require_external_ci`. The
 source job event timeline atomically records `pipeline_auto_merge_claim` before
 the write and `pipeline_auto_merge_confirmed` after GitHub confirms it, plus
-`pipeline_auto_merge_claim_at` for the claim's age and
 `pipeline_auto_merge_held` when a workload-mode reconciliation hold parks the
 gate: that hold releases the claim and retries, and is bounded by the gate
 `timeout` or by 24h from the start of the hold episode, keyed on the head and
-the decision rather than the cause text. A scan that loses the claim records
-`pipeline_auto_merge_claim_orphaned` past 15m and waits rather than parking.
+the decision rather than the cause text. A scan that loses the claim ages its wait from the gate stage's own `StartedAt`
+and records `pipeline_auto_merge_claim_orphaned` past 15m - or immediately, with
+`cause=gate_start_unrecorded`, when that stamp is missing - and waits rather
+than parking.
 
 `pipeline add` warns (does not block) when an agent stage names an agent that does
 not exist yet; create it before the stage runs. The

--- a/skills/gitmoot/references/WORKFLOWS.md
+++ b/skills/gitmoot/references/WORKFLOWS.md
@@ -1052,7 +1052,51 @@ and records `pipeline_auto_merge_claim_orphaned` past 15m - or immediately, with
 `cause=claim_timestamp_unreadable`, when that value will not parse - and waits
 rather than parking. A stage `timeout` parks either case terminally instead of
 recovering it. A claim released while a losing scan was reading it is the
-ordinary hold cycle and is reported as nothing.
+ordinary hold cycle and is reported as nothing WHILE THE GATE KEEPS WAITING - the
+scan simply retries. After the stage `timeout` elapses the release reason is
+carried into the terminal parked summary rather than dropped.
+
+### Satisfying the workload-mode gate
+
+A pull request whose diff changes the `**Current mode:` marker in `AGENTS.md` is
+HELD until an exact-head reconciliation row exists. The gate is keyed on the
+repository OWNER, so every `gitmoot/*` repository is held, human-requested merges
+included.
+
+Two note streams decide it, both matched by an exact body PREFIX and compared
+case-insensitively on repository:
+
+- DECISION: `[operating-mode repo=<owner/repo> mode=<THROUGHPUT|STEADY|DRAIN>]`
+- RECONCILIATION: `[workload-mode-reconciliation repo=<owner/repo> pr=<number> head=<40-character reviewed head> mode=<mode> decision_note=<note id|none>]`
+
+Every field is `key=value`, whitespace separated, inside the leading bracket. A
+field with an empty key or value makes the whole body unparseable, so write the
+row with `gitmoot workflow note --repo <owner/repo>` rather than by hand where a
+missing `--repo` is easy.
+
+PRECEDENCE. The NEWEST decision wins, and a reconciliation row must be newer than
+it. `decision_note=none` means the PR itself is the decision, and the row's own
+`created_at` is `decided_at`; otherwise `decision_note` names the newest
+operating-mode note the exact head implements. A row that cites a note the PR
+contradicts cannot ratify it.
+
+WHEN A DECISION CANNOT BE READ. An unreadable newest decision - a malformed field
+list, a `mode` that is not a workload mode, or a note recorded for this
+repository whose body omits or contradicts `repo=` - SUPERSEDES like any other
+decision rather than reading as "no decision". It is a recency boundary, not a
+veto: a fresh exact-head row that agrees with the PR's own marker still merges,
+so correcting the note is optional. The gate refuses outright only when nothing
+readable remains - the note is unreadable AND the PR's marker patch is missing or
+ambiguous - and the hold then names both exits: append a readable operating-mode
+note, and file an exact-head row citing it.
+
+CLEARING A HOLD. The hold is retryable: the pipeline gate releases its
+at-most-once merge claim, records `pipeline_auto_merge_held` with the cause, and
+merges on a later scan once the row lands. It is bounded on both the ordinary
+evaluate path and the final merge boundary - the stage parks at the gate
+`timeout`, or 24h after the episode began when no `timeout` is set. An episode is
+keyed on the head and the decision, so a new head or a new decision (including a
+new unreadable one) starts a fresh budget rather than inheriting the old one.
 
 `pipeline add` warns (does not block) when an agent stage names an agent that does
 not exist yet; create it before the stage runs. The

--- a/skills/gitmoot/references/WORKFLOWS.md
+++ b/skills/gitmoot/references/WORKFLOWS.md
@@ -1044,9 +1044,12 @@ Pending checks wait; skipped/neutral check-runs pass; failures block; and zero
 external statuses/checks always block regardless of `require_external_ci`. The
 source job event timeline atomically records `pipeline_auto_merge_claim` before
 the write and `pipeline_auto_merge_confirmed` after GitHub confirms it, plus
+`pipeline_auto_merge_claim_at` for the claim's age and
 `pipeline_auto_merge_held` when a workload-mode reconciliation hold parks the
 gate: that hold releases the claim and retries, and is bounded by the gate
-`timeout` or by 6h from the start of the hold episode.
+`timeout` or by 24h from the start of the hold episode, keyed on the head and
+the decision rather than the cause text. A scan that loses the claim records
+`pipeline_auto_merge_claim_orphaned` past 15m and waits rather than parking.
 
 `pipeline add` warns (does not block) when an agent stage names an agent that does
 not exist yet; create it before the stage runs. The

--- a/skills/gitmoot/references/WORKFLOWS.md
+++ b/skills/gitmoot/references/WORKFLOWS.md
@@ -1047,10 +1047,11 @@ the write and `pipeline_auto_merge_confirmed` after GitHub confirms it, plus
 `pipeline_auto_merge_held` when a workload-mode reconciliation hold parks the
 gate: that hold releases the claim and retries, and is bounded by the gate
 `timeout` or by 24h from the start of the hold episode, keyed on the head and
-the decision rather than the cause text. A scan that loses the claim ages its wait from the gate stage's own `StartedAt`
+the decision rather than the cause text. A scan that loses the claim ages its wait from the claim row's own `created_at`
 and records `pipeline_auto_merge_claim_orphaned` past 15m - or immediately, with
-`cause=gate_start_unrecorded`, when that stamp is missing - and waits rather
-than parking.
+`cause=claim_timestamp_unreadable`, when that value will not parse - and waits
+rather than parking. A stage `timeout` parks the aged case terminally instead of
+recovering it, and cannot park the unreadable case at all.
 
 `pipeline add` warns (does not block) when an agent stage names an agent that does
 not exist yet; create it before the stage runs. The

--- a/website/docs/workflows/pipelines-workflow.md
+++ b/website/docs/workflows/pipelines-workflow.md
@@ -588,11 +588,13 @@ merge API failure also folds the gate blocked; merge errors are not retried. A
 scheduled auto-merge flow requires both `allow_auto_merge: true` and the existing
 `pipeline_auto_merge_claim` before the write and `pipeline_auto_merge_confirmed`
 after GitHub confirms it. Racing scans that lose the claim do not call merge and
-do not park the run; a loser ages its wait from the gate stage's own `StartedAt`
+do not park the run; a loser ages its wait from the claim row's own `created_at`
 and records `pipeline_auto_merge_claim_orphaned` with `cause=held_past_bound`
-once that wait passes 15m, or immediately with `cause=gate_start_unrecorded`
-when the gate row carries no start time and the wait cannot be aged. Either way
-it keeps waiting, which a stage `timeout` turns into a park. A workload-mode reconciliation hold records
+once the claim has been held 15m, or immediately with
+`cause=claim_timestamp_unreadable` when that timestamp will not parse. A stage
+`timeout` turns the first into a terminal park rather than a recovery - nothing
+releases an orphaned claim, so a new run is the remedy - and cannot park the
+second at all. A workload-mode reconciliation hold records
 `pipeline_auto_merge_held` with its cause: the gate releases the claim and
 re-attempts, so the hold is retryable rather than terminal, and it parks with
 that cause at the gate `timeout` or, when no timeout is set, 24h after the hold

--- a/website/docs/workflows/pipelines-workflow.md
+++ b/website/docs/workflows/pipelines-workflow.md
@@ -592,9 +592,10 @@ do not park the run; a loser ages its wait from the claim row's own `created_at`
 and records `pipeline_auto_merge_claim_orphaned` with `cause=held_past_bound`
 once the claim has been held 15m, or immediately with
 `cause=claim_timestamp_unreadable` when that timestamp will not parse. A stage
-`timeout` turns the first into a terminal park rather than a recovery - nothing
-releases an orphaned claim, so a new run is the remedy - and cannot park the
-second at all. A workload-mode reconciliation hold records
+`timeout` turns either into a terminal park rather than a recovery - nothing
+releases an orphaned claim, so a new run is the remedy. A claim released in the
+window between a losing scan's failed claim and its read is reported as nothing:
+that is the ordinary hold cycle. A workload-mode reconciliation hold records
 `pipeline_auto_merge_held` with its cause: the gate releases the claim and
 re-attempts, so the hold is retryable rather than terminal, and it parks with
 that cause at the gate `timeout` or, when no timeout is set, 24h after the hold

--- a/website/docs/workflows/pipelines-workflow.md
+++ b/website/docs/workflows/pipelines-workflow.md
@@ -653,9 +653,25 @@ case-insensitively on repository:
 - RECONCILIATION: `[workload-mode-reconciliation repo=<owner/repo> pr=<number> head=<40-character reviewed head> mode=<mode> decision_note=<note id|none>]`
 
 Every field is `key=value`, whitespace separated, inside the leading bracket. A
-field with an empty key or value makes the whole body unparseable, so write the
-row with `gitmoot workflow note --repo <owner/repo>` rather than by hand where a
-missing `--repo` is easy.
+field with an empty key or value makes the whole body unparseable, so the
+`repo=` field inside the body is what identifies the repository:
+
+```
+gitmoot workflow note <label> "[operating-mode repo=owner/repo mode=STEADY]"
+```
+
+`<label>` must be a workflow that already has jobs - `workflow note` refuses an
+unknown label to guard against a typo - so file the row under the lane the PR is
+already being coordinated in rather than inventing a label.
+
+The note's repo COLUMN is a separate, optional thing. A note whose column is
+empty still counts when its body names this repository, which is the ordinary
+case: `gitmoot workflow note` writes an empty column unless you pass
+`--remember --repo <owner/repo>`, and `--repo` is REJECTED without `--remember`
+(`--agent, --repo, and --remember-status require --remember`), because that flag
+set also opts the note into durable memory. Setting the column is therefore
+optional and costs a memory write; getting `repo=` right in the BODY is not
+optional.
 
 PRECEDENCE. The NEWEST decision wins, and a reconciliation row must be newer than
 it. `decision_note=none` means the PR itself is the decision, and the row's own

--- a/website/docs/workflows/pipelines-workflow.md
+++ b/website/docs/workflows/pipelines-workflow.md
@@ -587,11 +587,12 @@ merge never synthesizes a no-CI success. Head drift, unmergeability/conflict, or
 merge API failure also folds the gate blocked; merge errors are not retried. A
 scheduled auto-merge flow requires both `allow_auto_merge: true` and the existing
 `pipeline_auto_merge_claim` before the write and `pipeline_auto_merge_confirmed`
-after GitHub confirms it, plus `pipeline_auto_merge_claim_at` recording when the
-claim was taken and released with it. Racing scans that lose the claim do not
-call merge and do not park the run; past 15m of a held claim a loser records
-`pipeline_auto_merge_claim_orphaned` and keeps waiting, which a stage `timeout`
-turns into a park. A workload-mode reconciliation hold records
+after GitHub confirms it. Racing scans that lose the claim do not call merge and
+do not park the run; a loser ages its wait from the gate stage's own `StartedAt`
+and records `pipeline_auto_merge_claim_orphaned` with `cause=held_past_bound`
+once that wait passes 15m, or immediately with `cause=gate_start_unrecorded`
+when the gate row carries no start time and the wait cannot be aged. Either way
+it keeps waiting, which a stage `timeout` turns into a park. A workload-mode reconciliation hold records
 `pipeline_auto_merge_held` with its cause: the gate releases the claim and
 re-attempts, so the hold is retryable rather than terminal, and it parks with
 that cause at the gate `timeout` or, when no timeout is set, 24h after the hold

--- a/website/docs/workflows/pipelines-workflow.md
+++ b/website/docs/workflows/pipelines-workflow.md
@@ -585,10 +585,12 @@ merge gate; failures block. Zero external statuses/checks always block pipeline
 auto-merge—even when `[merge_gate] require_external_ci` is false—so unattended
 merge never synthesizes a no-CI success. Head drift, unmergeability/conflict, or a
 merge API failure also folds the gate blocked; merge errors are not retried. A
-scheduled auto-merge flow requires both `allow_auto_merge: true` and the existing
-`pipeline_auto_merge_claim` before the write and `pipeline_auto_merge_confirmed`
-after GitHub confirms it. Racing scans that lose the claim do not call merge and
-do not park the run; a loser ages its wait from the claim row's own `created_at`
+scheduled auto-merge flow requires two spec keys, `allow_scheduled_writes: true`
+and `allow_auto_merge: true`, because the merge is a write on an unattended
+schedule and each gate is spelled separately. The claim itself is not a key: the
+run RECORDS the `pipeline_auto_merge_claim` event before the write and
+`pipeline_auto_merge_confirmed` after GitHub confirms it. Racing scans that lose
+the claim do not call merge and do not park the run; a loser ages its wait from the claim row's own `created_at`
 and records `pipeline_auto_merge_claim_orphaned` with `cause=held_past_bound`
 once the claim has been held 15m, or immediately with
 `cause=claim_timestamp_unreadable` when that timestamp will not parse. A stage

--- a/website/docs/workflows/pipelines-workflow.md
+++ b/website/docs/workflows/pipelines-workflow.md
@@ -587,12 +587,16 @@ merge never synthesizes a no-CI success. Head drift, unmergeability/conflict, or
 merge API failure also folds the gate blocked; merge errors are not retried. A
 scheduled auto-merge flow requires both `allow_auto_merge: true` and the existing
 `pipeline_auto_merge_claim` before the write and `pipeline_auto_merge_confirmed`
-after GitHub confirms it; racing scans that lose the claim do not call merge. A
-workload-mode reconciliation hold records a third event,
-`pipeline_auto_merge_held`, with its cause: the gate releases the claim and
+after GitHub confirms it, plus `pipeline_auto_merge_claim_at` recording when the
+claim was taken and released with it. Racing scans that lose the claim do not
+call merge and do not park the run; past 15m of a held claim a loser records
+`pipeline_auto_merge_claim_orphaned` and keeps waiting, which a stage `timeout`
+turns into a park. A workload-mode reconciliation hold records
+`pipeline_auto_merge_held` with its cause: the gate releases the claim and
 re-attempts, so the hold is retryable rather than terminal, and it parks with
-that cause at the gate `timeout` or, when no timeout is set, 6h after the hold
-episode began.
+that cause at the gate `timeout` or, when no timeout is set, 24h after the hold
+episode began. The episode is keyed on the head and the decision to reconcile
+against, never on the cause text, which carries volatile near-miss detail.
 
 An agent stage runs the named agent on **its own registered runtime** (claude /
 codex — no per-job shell override):

--- a/website/docs/workflows/pipelines-workflow.md
+++ b/website/docs/workflows/pipelines-workflow.md
@@ -586,9 +586,13 @@ auto-merge—even when `[merge_gate] require_external_ci` is false—so unattend
 merge never synthesizes a no-CI success. Head drift, unmergeability/conflict, or a
 merge API failure also folds the gate blocked; merge errors are not retried. A
 scheduled auto-merge flow requires both `allow_auto_merge: true` and the existing
-`allow_scheduled_writes: true`. The source job records an atomic
 `pipeline_auto_merge_claim` before the write and `pipeline_auto_merge_confirmed`
-after GitHub confirms it; racing scans that lose the claim do not call merge.
+after GitHub confirms it; racing scans that lose the claim do not call merge. A
+workload-mode reconciliation hold records a third event,
+`pipeline_auto_merge_held`, with its cause: the gate releases the claim and
+re-attempts, so the hold is retryable rather than terminal, and it parks with
+that cause at the gate `timeout` or, when no timeout is set, 6h after the hold
+episode began.
 
 An agent stage runs the named agent on **its own registered runtime** (claude /
 codex — no per-job shell override):

--- a/website/docs/workflows/pipelines-workflow.md
+++ b/website/docs/workflows/pipelines-workflow.md
@@ -596,7 +596,9 @@ once the claim has been held 15m, or immediately with
 `cause=claim_timestamp_unreadable` when that timestamp will not parse. A stage
 `timeout` turns either into a terminal park rather than a recovery - nothing
 releases an orphaned claim, so a new run is the remedy. A claim released in the
-window between a losing scan's failed claim and its read is reported as nothing:
+window between a losing scan's failed claim and its read is reported as nothing
+while the gate keeps waiting, and its reason reaches the terminal parked summary
+if the stage `timeout` has elapsed:
 that is the ordinary hold cycle. A workload-mode reconciliation hold records
 `pipeline_auto_merge_held` with its cause: the gate releases the claim and
 re-attempts, so the hold is retryable rather than terminal, and it parks with
@@ -636,6 +638,48 @@ codex — no per-job shell override):
 Agent stages fold by `gitmoot_result` `decision` and park/advance exactly like shell
 stages — an `approved`/`implemented` review advances dependents, a `blocked` result
 parks the run with its `needs`, `changes_requested` is a failure by default.
+
+## Satisfying the workload-mode gate
+
+A pull request whose diff changes the `**Current mode:` marker in `AGENTS.md` is
+HELD until an exact-head reconciliation row exists. The gate is keyed on the
+repository OWNER, so every `gitmoot/*` repository is held, human-requested merges
+included.
+
+Two note streams decide it, both matched by an exact body PREFIX and compared
+case-insensitively on repository:
+
+- DECISION: `[operating-mode repo=<owner/repo> mode=<THROUGHPUT|STEADY|DRAIN>]`
+- RECONCILIATION: `[workload-mode-reconciliation repo=<owner/repo> pr=<number> head=<40-character reviewed head> mode=<mode> decision_note=<note id|none>]`
+
+Every field is `key=value`, whitespace separated, inside the leading bracket. A
+field with an empty key or value makes the whole body unparseable, so write the
+row with `gitmoot workflow note --repo <owner/repo>` rather than by hand where a
+missing `--repo` is easy.
+
+PRECEDENCE. The NEWEST decision wins, and a reconciliation row must be newer than
+it. `decision_note=none` means the PR itself is the decision, and the row's own
+`created_at` is `decided_at`; otherwise `decision_note` names the newest
+operating-mode note the exact head implements. A row that cites a note the PR
+contradicts cannot ratify it.
+
+WHEN A DECISION CANNOT BE READ. An unreadable newest decision - a malformed field
+list, a `mode` that is not a workload mode, or a note recorded for this
+repository whose body omits or contradicts `repo=` - SUPERSEDES like any other
+decision rather than reading as "no decision". It is a recency boundary, not a
+veto: a fresh exact-head row that agrees with the PR's own marker still merges,
+so correcting the note is optional. The gate refuses outright only when nothing
+readable remains - the note is unreadable AND the PR's marker patch is missing or
+ambiguous - and the hold then names both exits: append a readable operating-mode
+note, and file an exact-head row citing it.
+
+CLEARING A HOLD. The hold is retryable: the pipeline gate releases its
+at-most-once merge claim, records `pipeline_auto_merge_held` with the cause, and
+merges on a later scan once the row lands. It is bounded on both the ordinary
+evaluate path and the final merge boundary - the stage parks at the gate
+`timeout`, or 24h after the episode began when no `timeout` is set. An episode is
+keyed on the head and the decision, so a new head or a new decision (including a
+new unreadable one) starts a fresh budget rather than inheriting the old one.
 
 ## Produce data without changing the repo
 

--- a/website/static/llms.txt
+++ b/website/static/llms.txt
@@ -14,6 +14,14 @@ full expanded context.
 Native review verdicts return `changes_requested` to the requester's org role
 by default. Unattended implement fix dispatch is a durable per-PR opt-in.
 
+A pull request that changes the `**Current mode:` marker in `AGENTS.md` is held
+until an exact-head reconciliation row exists:
+`[workload-mode-reconciliation repo=<owner/repo> pr=<n> head=<40-char reviewed head> mode=<THROUGHPUT|STEADY|DRAIN> decision_note=<note id|none>]`.
+The decision itself is an append-only `[operating-mode repo=<owner/repo> mode=<mode>]`
+note; `decision_note=none` means the PR is the decision. The newest decision
+wins, an unreadable one supersedes rather than reading as absent, and a hold is
+retryable and bounded by the gate `timeout` or 24h from the episode's start.
+
 ## Start Here
 
 - [Introduction](https://gitmoot.io/docs/intro): What Gitmoot is and when to use it.


### PR DESCRIPTION
Directive 107895 authorized the exact-head remediation. This PR now defines the middle workload mode, corrects the review rules, and mechanically prevents unreconciled mode-switch PRs from auto-merging.

## Changes

- Defines **STEADY**: four implementation seats, two reviewers, no admission gate, an ordered exclusive list, claim-before-editing, one-in-one-out, and an explicit exit condition.
- Separates mode-decision identity from activation: `decision_ref`, `change_ref`, `activation_ref`, `decided_at`, `effective_at`, and `observed_at` are source-neutral for note- and PR-sourced transitions.
- Makes DRAIN admission freeze at `decided_at`; the previous mode remains active until the drain gates pass and `effective_at` is recorded.
- Corrects the force-push-back rule: identical base plus identical commit means an identical tree, but mandatory re-review remains a conservative fail-closed policy because the gate is not base-bound.
- Adds one shared mode-sensitive predicate using paginated `ListPullRequestFiles`. A changed `AGENTS.md` mode marker requires exact-head reconciliation; a missing/ambiguous patch fails closed; an absent or unchanged marker follows the ordinary merge path.
- Enforces that predicate in both `PolicyMergeGate.Evaluate` and `PipelineAutoMerger`, including a final pull-request/head/reconciliation recheck immediately before pipeline merge.
- Requires the reconciliation note to name the exact repo, PR, head, effective mode, and newest operating-decision note.

## Verification

At head `710e1752160635a72cac85bbf1ae148c6bb55bc1`, rebased onto main `fa5acf4bada59826ef0cb50465903e05ed7ec839`:

- focused workflow and daemon production-path tests pass;
- full daemon package tests pass, including ordinary non-mode merge paths;
- semantic mutant (native reconciliation bypass) fails by performing the forbidden merge;
- `go generate ./...` leaves the generated contract unchanged;
- `go build ./...` passes with VCS stamping disabled for this worktree;
- `go vet ./...` passes;
- `scripts/partition-race-tests_test.sh` passes;
- full `internal/workflow` package tests pass.

The local full suite reaches all packages but fails the existing host Landlock E2E checks (`internal/cli` and `internal/sandbox`: writes outside the allowed roots succeed). Exact-head GitHub CI is the authoritative Linux sandbox check.

Do not merge from this lane. One independent report-only review is required after exact-head CI is green.
