### PR TITLE
refactor(github): move ParseRepository out of internal/daemon (step 1 of #1760)

### DIFF
--- a/internal/cli/agent.go
+++ b/internal/cli/agent.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"flag"
 	"fmt"
+	"github.com/gitmoot/gitmoot/internal/github"
 	"io"
 	"os"
 	"os/signal"
@@ -17,7 +18,6 @@ import (
 
 	"github.com/gitmoot/gitmoot/internal/agenttemplate"
 	"github.com/gitmoot/gitmoot/internal/config"
-	"github.com/gitmoot/gitmoot/internal/daemon"
 	"github.com/gitmoot/gitmoot/internal/db"
 	"github.com/gitmoot/gitmoot/internal/runtime"
 	"github.com/gitmoot/gitmoot/internal/subprocess"
@@ -1501,7 +1501,7 @@ func runAgentStart(args []string, stdout, stderr io.Writer) int {
 	if memoryExplicit {
 		memoryEnrolled = *memoryFlag
 	}
-	repo, err := daemon.ParseRepository(*repoFlag)
+	repo, err := github.ParseRepository(*repoFlag)
 	if err != nil {
 		fmt.Fprintf(stderr, "invalid repo: %v\n", err)
 		return 2
@@ -1850,7 +1850,7 @@ func registerAgentOnly(ctx context.Context, store *db.Store, name, runtimeName, 
 	}
 	repos := []string{}
 	if agent.RepoScope != "" {
-		repo, err := daemon.ParseRepository(agent.RepoScope)
+		repo, err := github.ParseRepository(agent.RepoScope)
 		if err != nil {
 			return err
 		}
@@ -2605,7 +2605,7 @@ func normalizeRepoFlags(values []string) ([]string, error) {
 }
 
 func normalizeRepoFlag(value string) (string, error) {
-	repo, err := daemon.ParseRepository(value)
+	repo, err := github.ParseRepository(value)
 	if err != nil {
 		return "", err
 	}

--- a/internal/cli/agent_dispatch.go
+++ b/internal/cli/agent_dispatch.go
@@ -12,7 +12,6 @@ import (
 	"time"
 
 	"github.com/gitmoot/gitmoot/internal/config"
-	"github.com/gitmoot/gitmoot/internal/daemon"
 	"github.com/gitmoot/gitmoot/internal/db"
 	"github.com/gitmoot/gitmoot/internal/execbackend"
 	gitutil "github.com/gitmoot/gitmoot/internal/git"
@@ -1728,7 +1727,7 @@ func resolveLocalAgentRepo(ctx context.Context, store *db.Store, repoFlag string
 
 func localAgentTargetRepo(ctx context.Context, repoFlag string) (github.Repository, error) {
 	if strings.TrimSpace(repoFlag) != "" {
-		return daemon.ParseRepository(repoFlag)
+		return github.ParseRepository(repoFlag)
 	}
 	remote, err := (gitutil.NewHostClient(".")).OriginRemote(ctx)
 	if err != nil {

--- a/internal/cli/agent_template_remote.go
+++ b/internal/cli/agent_template_remote.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/gitmoot/gitmoot/internal/agenttemplate"
 	"github.com/gitmoot/gitmoot/internal/config"
-	"github.com/gitmoot/gitmoot/internal/daemon"
 	"github.com/gitmoot/gitmoot/internal/db"
 	"github.com/gitmoot/gitmoot/internal/github"
 )
@@ -102,7 +101,7 @@ func runAgentTemplatePublish(args []string, stdout, stderr io.Writer) int {
 			fmt.Fprintln(stderr, "no custom templates to publish")
 			return nil
 		}
-		repository, err := daemon.ParseRepository(repoName)
+		repository, err := github.ParseRepository(repoName)
 		if err != nil {
 			return err
 		}

--- a/internal/cli/daemon_checkout.go
+++ b/internal/cli/daemon_checkout.go
@@ -9,7 +9,6 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/gitmoot/gitmoot/internal/daemon"
 	"github.com/gitmoot/gitmoot/internal/db"
 	gitutil "github.com/gitmoot/gitmoot/internal/git"
 	"github.com/gitmoot/gitmoot/internal/github"
@@ -214,7 +213,7 @@ func (w jobWorker) resolveJobCheckoutForRunner(ctx context.Context, job db.Job, 
 		if checkout == "" {
 			return "", errors.New("review fix job has no allocated worktree path")
 		}
-		repo, err := daemon.ParseRepository(payload.Repo)
+		repo, err := github.ParseRepository(payload.Repo)
 		if err != nil {
 			return "", err
 		}
@@ -227,7 +226,7 @@ func (w jobWorker) resolveJobCheckoutForRunner(ctx context.Context, job db.Job, 
 	if err != nil {
 		return "", err
 	}
-	repo, err := daemon.ParseRepository(payload.Repo)
+	repo, err := github.ParseRepository(payload.Repo)
 	if err != nil {
 		return "", err
 	}

--- a/internal/cli/daemon_checkout_test.go
+++ b/internal/cli/daemon_checkout_test.go
@@ -3,13 +3,13 @@ package cli
 import (
 	"bytes"
 	"context"
+	"github.com/gitmoot/gitmoot/internal/github"
 	"io"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 
-	"github.com/gitmoot/gitmoot/internal/daemon"
 	"github.com/gitmoot/gitmoot/internal/db"
 	"github.com/gitmoot/gitmoot/internal/runtime"
 	"github.com/gitmoot/gitmoot/internal/subprocess"
@@ -315,7 +315,7 @@ func TestResolveDaemonStartRepoUsesRegisteredCheckout(t *testing.T) {
 	runGit(t, otherDir, "commit", "-m", "init")
 	runGit(t, otherDir, "remote", "add", "origin", "https://github.com/owner/other.git")
 
-	repo, err := daemon.ParseRepository("owner/repo")
+	repo, err := github.ParseRepository("owner/repo")
 	if err != nil {
 		t.Fatalf("ParseRepository returned error: %v", err)
 	}
@@ -350,7 +350,7 @@ func TestResolveDaemonStartRepoBootstrapsUnregistered(t *testing.T) {
 	runGit(t, checkout, "commit", "-m", "initial")
 	runGit(t, checkout, "remote", "add", "origin", "https://github.com/owner/repo.git")
 
-	repo, err := daemon.ParseRepository("owner/repo")
+	repo, err := github.ParseRepository("owner/repo")
 	if err != nil {
 		t.Fatalf("ParseRepository returned error: %v", err)
 	}
@@ -363,7 +363,7 @@ func TestResolveDaemonStartRepoBootstrapsUnregistered(t *testing.T) {
 		t.Fatalf("bootstrapped repo = %s/%s, want owner/repo", record.Owner, record.Name)
 	}
 	// Origin protection: a non-matching cwd for an unregistered repo still fails.
-	other, err := daemon.ParseRepository("owner/elsewhere")
+	other, err := github.ParseRepository("owner/elsewhere")
 	if err != nil {
 		t.Fatalf("ParseRepository returned error: %v", err)
 	}

--- a/internal/cli/daemon_lifecycle.go
+++ b/internal/cli/daemon_lifecycle.go
@@ -323,7 +323,7 @@ func runDaemonRun(args []string, stdout, stderr io.Writer) int {
 		return 0
 	}
 
-	repo, err := daemon.ParseRepository(*repoFlag)
+	repo, err := github.ParseRepository(*repoFlag)
 	if err != nil {
 		fmt.Fprintf(stderr, "invalid repo: %v\n", err)
 		return 2
@@ -997,7 +997,7 @@ func parseDaemonStartConfig(command string, args []string, stderr io.Writer) (da
 	// --scheduler barrier still forces the old per-tick behavior.
 	cfg.Scheduler = autoSelectScheduler(cfg.Scheduler, cfg.Workers, cfg.ExplicitScheduler)
 	if cfg.RepoFlag != "" {
-		repo, err := daemon.ParseRepository(cfg.RepoFlag)
+		repo, err := github.ParseRepository(cfg.RepoFlag)
 		if err != nil {
 			fmt.Fprintf(stderr, "invalid repo: %v\n", err)
 			return daemonStartConfig{}, 2

--- a/internal/cli/daemon_result.go
+++ b/internal/cli/daemon_result.go
@@ -5,10 +5,10 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"github.com/gitmoot/gitmoot/internal/github"
 	"strings"
 	"time"
 
-	"github.com/gitmoot/gitmoot/internal/daemon"
 	"github.com/gitmoot/gitmoot/internal/db"
 	"github.com/gitmoot/gitmoot/internal/runtime"
 	"github.com/gitmoot/gitmoot/internal/workflow"
@@ -620,7 +620,7 @@ func (w jobWorker) postJobResultComment(ctx context.Context, jobID string, agent
 	if posted {
 		return nil
 	}
-	repo, err := daemon.ParseRepository(payload.Repo)
+	repo, err := github.ParseRepository(payload.Repo)
 	if err != nil {
 		return err
 	}

--- a/internal/cli/daemon_supervision.go
+++ b/internal/cli/daemon_supervision.go
@@ -670,7 +670,7 @@ type heartbeatImplementFields struct {
 // base) rather than re-deriving the base from the possibly-off-branch shared
 // checkout (#611).
 func allocateHeartbeatImplement(ctx context.Context, store *db.Store, home string, heartbeat config.Heartbeat) (heartbeatImplementFields, error) {
-	repo, err := daemon.ParseRepository(heartbeat.Repo)
+	repo, err := github.ParseRepository(heartbeat.Repo)
 	if err != nil {
 		return heartbeatImplementFields{}, err
 	}
@@ -1294,7 +1294,7 @@ type conditionalRequestStatsProvider interface {
 
 func (p registeredRepoPoller) pollRepo(ctx context.Context, repoRecord db.Repo, now time.Time) (registeredRepoPollResult, error) {
 	store := p.Store
-	repo, err := daemon.ParseRepository(repoRecord.FullName())
+	repo, err := github.ParseRepository(repoRecord.FullName())
 	if err != nil {
 		lastError := err.Error()
 		writeLine(p.Stdout, "%s: %s", repoRecord.FullName(), lastError)

--- a/internal/cli/daemon_test.go
+++ b/internal/cli/daemon_test.go
@@ -19,7 +19,6 @@ import (
 	"time"
 
 	"github.com/gitmoot/gitmoot/internal/config"
-	"github.com/gitmoot/gitmoot/internal/daemon"
 	"github.com/gitmoot/gitmoot/internal/db"
 	"github.com/gitmoot/gitmoot/internal/db/dbtest"
 	"github.com/gitmoot/gitmoot/internal/github"
@@ -586,7 +585,7 @@ func runDaemonWorkerGit(t *testing.T, dir string, args ...string) {
 
 func seedDaemonWorkerRepo(t *testing.T, store *db.Store, fullName string, checkout string) {
 	t.Helper()
-	repo, err := daemon.ParseRepository(fullName)
+	repo, err := github.ParseRepository(fullName)
 	if err != nil {
 		t.Fatalf("ParseRepository returned error: %v", err)
 	}

--- a/internal/cli/daemon_workflow.go
+++ b/internal/cli/daemon_workflow.go
@@ -8,7 +8,6 @@ import (
 	"strings"
 
 	"github.com/gitmoot/gitmoot/internal/config"
-	"github.com/gitmoot/gitmoot/internal/daemon"
 	"github.com/gitmoot/gitmoot/internal/db"
 	gitutil "github.com/gitmoot/gitmoot/internal/git"
 	"github.com/gitmoot/gitmoot/internal/github"
@@ -175,7 +174,7 @@ func (n *daemonEscalationNotifier) NotifyEscalation(ctx context.Context, request
 		// still stands. Nothing to notify.
 		return nil
 	}
-	repo, err := daemon.ParseRepository(repoFull)
+	repo, err := github.ParseRepository(repoFull)
 	if err != nil {
 		return err
 	}
@@ -484,7 +483,7 @@ func (f daemonImplementationFinalizer) FinalizeImplementation(ctx context.Contex
 	if hasValidatedPR {
 		return f.adoptValidatedImplementationPullRequest(ctx, payload, task, validatedPR, head)
 	}
-	repo, err := daemon.ParseRepository(payload.Repo)
+	repo, err := github.ParseRepository(payload.Repo)
 	if err != nil {
 		return payload, err
 	}
@@ -565,7 +564,7 @@ func (f daemonImplementationFinalizer) revalidateImplementationPullRequest(ctx c
 	if payload.PullRequest <= 0 {
 		return github.PullRequest{}, false, blockedResultDelivery("validated implementation payload has no pull request number")
 	}
-	repo, err := daemon.ParseRepository(payload.Repo)
+	repo, err := github.ParseRepository(payload.Repo)
 	if err != nil {
 		return github.PullRequest{}, false, err
 	}

--- a/internal/cli/github_remote.go
+++ b/internal/cli/github_remote.go
@@ -9,7 +9,6 @@ import (
 	"strings"
 
 	"github.com/gitmoot/gitmoot/internal/config"
-	"github.com/gitmoot/gitmoot/internal/daemon"
 	"github.com/gitmoot/gitmoot/internal/github"
 )
 
@@ -51,7 +50,7 @@ func resolveGitHubRemote(paths config.Paths, repoFlag, refFlag, pathFlag, defaul
 	if repo == "" {
 		return "", "", "", errors.New(missingMessage)
 	}
-	if _, parseErr := daemon.ParseRepository(repo); parseErr != nil {
+	if _, parseErr := github.ParseRepository(repo); parseErr != nil {
 		return "", "", "", parseErr
 	}
 	ref = strings.TrimSpace(refFlag)
@@ -112,7 +111,7 @@ func runGitHubRemoteSet(args []string, stdout, stderr io.Writer, opts githubRemo
 		fmt.Fprintf(stderr, "%s set requires exactly one <owner/repo>\n", opts.Command)
 		return 2
 	}
-	repository, err := daemon.ParseRepository(repoArg)
+	repository, err := github.ParseRepository(repoArg)
 	if err != nil {
 		fmt.Fprintf(stderr, "set %s remote: %v\n", opts.Noun, err)
 		return 2

--- a/internal/cli/job_session.go
+++ b/internal/cli/job_session.go
@@ -11,7 +11,6 @@ import (
 	"time"
 
 	"github.com/gitmoot/gitmoot/internal/config"
-	"github.com/gitmoot/gitmoot/internal/daemon"
 	"github.com/gitmoot/gitmoot/internal/db"
 	"github.com/gitmoot/gitmoot/internal/github"
 	"github.com/gitmoot/gitmoot/internal/workflow"
@@ -418,7 +417,7 @@ func validateSessionParentJob(ctx context.Context, store *db.Store, parentJobID 
 // explicitly provided repo. Requiring the repo be tracked keeps the recorded
 // session job consistent with the registered-agent path and rejects typos.
 func validateSessionRepo(ctx context.Context, store *db.Store, repoFlag string) (string, error) {
-	repo, err := daemon.ParseRepository(repoFlag)
+	repo, err := github.ParseRepository(repoFlag)
 	if err != nil {
 		return "", err
 	}

--- a/internal/cli/lock.go
+++ b/internal/cli/lock.go
@@ -6,11 +6,11 @@ import (
 	"errors"
 	"flag"
 	"fmt"
+	"github.com/gitmoot/gitmoot/internal/github"
 	"io"
 	"strings"
 	"time"
 
-	"github.com/gitmoot/gitmoot/internal/daemon"
 	"github.com/gitmoot/gitmoot/internal/db"
 )
 
@@ -236,7 +236,7 @@ func normalizeOptionalRepoFlag(value string, stderr io.Writer) (string, bool) {
 }
 
 func normalizeRepoArg(value string, stderr io.Writer) (string, bool) {
-	repo, err := daemon.ParseRepository(value)
+	repo, err := github.ParseRepository(value)
 	if err != nil {
 		fmt.Fprintf(stderr, "invalid repo: %v\n", err)
 		return "", false

--- a/internal/cli/pipeline.go
+++ b/internal/cli/pipeline.go
@@ -7,8 +7,8 @@ import (
 	"flag"
 	"fmt"
 	"github.com/gitmoot/gitmoot/internal/config"
-	"github.com/gitmoot/gitmoot/internal/daemon"
 	"github.com/gitmoot/gitmoot/internal/db"
+	"github.com/gitmoot/gitmoot/internal/github"
 	"github.com/gitmoot/gitmoot/internal/pipeline"
 	"github.com/gitmoot/gitmoot/internal/runtime"
 	"github.com/gitmoot/gitmoot/internal/workflow"
@@ -198,7 +198,7 @@ func runPipelineAdd(args []string, stdout, stderr io.Writer) int {
 	}
 	repo := ""
 	if strings.TrimSpace(spec.Repo) != "" {
-		parsed, err := daemon.ParseRepository(spec.Repo)
+		parsed, err := github.ParseRepository(spec.Repo)
 		if err != nil {
 			fmt.Fprintf(stderr, "pipeline add: invalid repo %q: %v\n", spec.Repo, err)
 			return 2

--- a/internal/cli/pipeline_bundle.go
+++ b/internal/cli/pipeline_bundle.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"flag"
 	"fmt"
+	"github.com/gitmoot/gitmoot/internal/github"
 	"io"
 	"os"
 	"os/exec"
@@ -18,7 +19,6 @@ import (
 
 	"github.com/gitmoot/gitmoot/internal/agenttemplate"
 	"github.com/gitmoot/gitmoot/internal/buildinfo"
-	"github.com/gitmoot/gitmoot/internal/daemon"
 	"github.com/gitmoot/gitmoot/internal/db"
 	"github.com/gitmoot/gitmoot/internal/pipeline"
 	"github.com/gitmoot/gitmoot/internal/runtime"
@@ -326,7 +326,7 @@ func runPipelineImport(args []string, stdout, stderr io.Writer) int {
 		fmt.Fprintln(stderr, "pipeline import accepts exactly one bundle directory")
 		return 2
 	}
-	repo, err := daemon.ParseRepository(*repoFlag)
+	repo, err := github.ParseRepository(*repoFlag)
 	if err != nil {
 		fmt.Fprintf(stderr, "pipeline import: --repo is required and must be owner/name: %v\n", err)
 		return 2
@@ -620,7 +620,7 @@ func importPipelineBundle(ctx context.Context, store *db.Store, home, bundleDir,
 	if err != nil {
 		return fmt.Errorf("validate imported spec: %w", err)
 	}
-	parsedRepo, err := daemon.ParseRepository(spec.Repo)
+	parsedRepo, err := github.ParseRepository(spec.Repo)
 	if err != nil {
 		return fmt.Errorf("invalid imported repo %q: %w", spec.Repo, err)
 	}

--- a/internal/cli/pipeline_enqueue.go
+++ b/internal/cli/pipeline_enqueue.go
@@ -6,9 +6,9 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"github.com/gitmoot/gitmoot/internal/github"
 	"strings"
 
-	"github.com/gitmoot/gitmoot/internal/daemon"
 	"github.com/gitmoot/gitmoot/internal/db"
 	"github.com/gitmoot/gitmoot/internal/pipeline"
 	"github.com/gitmoot/gitmoot/internal/runtime"
@@ -419,7 +419,7 @@ func allocatePipelineStageWritableWorktreeForRunner(ctx context.Context, store *
 	if err != nil {
 		return request, fmt.Errorf("resolve repo %q for implement stage: %w", request.Repo, err)
 	}
-	repo, err := daemon.ParseRepository(request.Repo)
+	repo, err := github.ParseRepository(request.Repo)
 	if err != nil {
 		return request, err
 	}

--- a/internal/cli/pipeline_remote.go
+++ b/internal/cli/pipeline_remote.go
@@ -14,7 +14,6 @@ import (
 
 	"github.com/gitmoot/gitmoot/internal/agenttemplate"
 	"github.com/gitmoot/gitmoot/internal/config"
-	"github.com/gitmoot/gitmoot/internal/daemon"
 	"github.com/gitmoot/gitmoot/internal/db"
 	"github.com/gitmoot/gitmoot/internal/github"
 	yaml "gopkg.in/yaml.v3"
@@ -123,7 +122,7 @@ func runPipelinePublish(args []string, stdout, stderr io.Writer) int {
 		if err != nil {
 			return err
 		}
-		repository, err := daemon.ParseRepository(repoName)
+		repository, err := github.ParseRepository(repoName)
 		if err != nil {
 			return err
 		}
@@ -324,7 +323,7 @@ func runPipelinePull(args []string, stdout, stderr io.Writer) int {
 		fmt.Fprintln(stderr, "pipeline pull requires a name-safe pipeline name or --list")
 		return 2
 	}
-	if _, err := daemon.ParseRepository(*repoFlag); err != nil {
+	if _, err := github.ParseRepository(*repoFlag); err != nil {
 		fmt.Fprintf(stderr, "pipeline pull: --repo is required and must be owner/name: %v\n", err)
 		return 2
 	}

--- a/internal/cli/pipeline_remote_test.go
+++ b/internal/cli/pipeline_remote_test.go
@@ -12,7 +12,6 @@ import (
 	"testing"
 
 	"github.com/gitmoot/gitmoot/internal/agenttemplate"
-	"github.com/gitmoot/gitmoot/internal/daemon"
 	"github.com/gitmoot/gitmoot/internal/github"
 	yaml "gopkg.in/yaml.v3"
 )
@@ -141,7 +140,7 @@ func TestPipelineRemotePathLayout(t *testing.T) {
 }
 
 func TestSyncPipelineRemoteFilesNoopAndDeletesVanishedFiles(t *testing.T) {
-	repo, err := daemon.ParseRepository("jerry/catalog")
+	repo, err := github.ParseRepository("jerry/catalog")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/cli/repo.go
+++ b/internal/cli/repo.go
@@ -13,7 +13,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/gitmoot/gitmoot/internal/daemon"
 	"github.com/gitmoot/gitmoot/internal/db"
 	gitutil "github.com/gitmoot/gitmoot/internal/git"
 	"github.com/gitmoot/gitmoot/internal/github"
@@ -117,7 +116,7 @@ func runRepoAdd(args []string, stdout, stderr io.Writer) int {
 			pollExplicit = true
 		}
 	})
-	repo, err := daemon.ParseRepository(repoArg)
+	repo, err := github.ParseRepository(repoArg)
 	if err != nil {
 		fmt.Fprintf(stderr, "invalid repo: %v\n", err)
 		return 2
@@ -284,7 +283,7 @@ func runRepoSetInterval(args []string, stdout, stderr io.Writer) int {
 			// Accept the fully-spelled form from the command synopsis; --all makes
 			// the validated owner/repo selector informational.
 			repoArg, value = fs.Arg(0), fs.Arg(1)
-			if _, err := daemon.ParseRepository(repoArg); err != nil {
+			if _, err := github.ParseRepository(repoArg); err != nil {
 				fmt.Fprintf(stderr, "invalid repo: %v\n", err)
 				return 2
 			}
@@ -298,7 +297,7 @@ func runRepoSetInterval(args []string, stdout, stderr io.Writer) int {
 			return 2
 		}
 		repoArg, value = fs.Arg(0), fs.Arg(1)
-		repo, err := daemon.ParseRepository(repoArg)
+		repo, err := github.ParseRepository(repoArg)
 		if err != nil {
 			fmt.Fprintf(stderr, "invalid repo: %v\n", err)
 			return 2
@@ -383,7 +382,7 @@ func runRepoAutoFix(args []string, stdout, stderr io.Writer) int {
 		fmt.Fprintln(stderr, "repo auto-fix requires --reason")
 		return 2
 	}
-	repo, err := daemon.ParseRepository(repoArg)
+	repo, err := github.ParseRepository(repoArg)
 	if err != nil {
 		fmt.Fprintf(stderr, "invalid repo: %v\n", err)
 		return 2
@@ -432,7 +431,7 @@ func runRepoRemove(args []string, stdout, stderr io.Writer) int {
 	if code >= 0 {
 		return code
 	}
-	repo, err := daemon.ParseRepository(repoArg)
+	repo, err := github.ParseRepository(repoArg)
 	if err != nil {
 		fmt.Fprintf(stderr, "invalid repo: %v\n", err)
 		return 2
@@ -470,7 +469,7 @@ func runRepoDoctor(args []string, stdout, stderr io.Writer) int {
 	if code >= 0 {
 		return code
 	}
-	repo, err := daemon.ParseRepository(repoArg)
+	repo, err := github.ParseRepository(repoArg)
 	if err != nil {
 		fmt.Fprintf(stderr, "invalid repo: %v\n", err)
 		return 2
@@ -519,7 +518,7 @@ func runRepoDoctor(args []string, stdout, stderr io.Writer) int {
 }
 
 func inspectRegisteredRepoCheckout(ctx context.Context, store *db.Store, record db.Repo) (db.Repo, bool, bool, error) {
-	repo, err := daemon.ParseRepository(record.FullName())
+	repo, err := github.ParseRepository(record.FullName())
 	if err != nil {
 		return db.Repo{}, false, false, err
 	}

--- a/internal/cli/repo_collisions.go
+++ b/internal/cli/repo_collisions.go
@@ -10,7 +10,6 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/gitmoot/gitmoot/internal/daemon"
 	"github.com/gitmoot/gitmoot/internal/github"
 )
 
@@ -55,7 +54,7 @@ func runRepoCollisions(args []string, stdout, stderr io.Writer) int {
 		fmt.Fprintf(stderr, "repo collisions: --limit must be between 1 and %d\n", repoCollisionMaxLimit)
 		return 2
 	}
-	repo, err := daemon.ParseRepository(repoArg)
+	repo, err := github.ParseRepository(repoArg)
 	if err != nil {
 		fmt.Fprintf(stderr, "repo collisions: invalid repo: %v\n", err)
 		return 2

--- a/internal/cli/setup.go
+++ b/internal/cli/setup.go
@@ -6,11 +6,11 @@ import (
 	"errors"
 	"flag"
 	"fmt"
+	"github.com/gitmoot/gitmoot/internal/github"
 	"io"
 	"os"
 	"strings"
 
-	"github.com/gitmoot/gitmoot/internal/daemon"
 	"github.com/gitmoot/gitmoot/internal/db"
 	"github.com/gitmoot/gitmoot/internal/runtime"
 )
@@ -43,7 +43,7 @@ func runSetup(args []string, stdout, stderr io.Writer) int {
 		fmt.Fprintln(stderr, "setup requires --repo, --agent, --runtime, and --session")
 		return 2
 	}
-	repo, err := daemon.ParseRepository(*repoFlag)
+	repo, err := github.ParseRepository(*repoFlag)
 	if err != nil {
 		fmt.Fprintf(stderr, "invalid repo: %v\n", err)
 		return 2

--- a/internal/cli/workflow.go
+++ b/internal/cli/workflow.go
@@ -21,7 +21,6 @@ import (
 	"unicode"
 
 	"github.com/gitmoot/gitmoot/internal/config"
-	"github.com/gitmoot/gitmoot/internal/daemon"
 	"github.com/gitmoot/gitmoot/internal/db"
 	"github.com/gitmoot/gitmoot/internal/github"
 	"github.com/gitmoot/gitmoot/internal/subprocess"
@@ -218,7 +217,7 @@ func runGoalImport(args []string, stdout, stderr io.Writer) int {
 	}
 	repoScope := strings.TrimSpace(*repo)
 	if repoScope != "" {
-		parsedRepo, err := daemon.ParseRepository(repoScope)
+		parsedRepo, err := github.ParseRepository(repoScope)
 		if err != nil {
 			fmt.Fprintf(stderr, "invalid repo: %v\n", err)
 			return 2
@@ -428,7 +427,7 @@ func runTaskRun(args []string, stdout, stderr io.Writer) int {
 		if strings.TrimSpace(requestRepo) == "" {
 			return errors.New("task run requires --repo when task has no repo")
 		}
-		repo, err := daemon.ParseRepository(requestRepo)
+		repo, err := github.ParseRepository(requestRepo)
 		if err != nil {
 			return fmt.Errorf("invalid repo: %w", err)
 		}
@@ -996,7 +995,7 @@ func recoverTaskImplementationForRunner(ctx context.Context, store *db.Store, ta
 	if strings.TrimSpace(requestRepo) == "" {
 		return workflow.JobPayload{}, errors.New("task recover requires --repo when task has no repo")
 	}
-	if _, err := daemon.ParseRepository(requestRepo); err != nil {
+	if _, err := github.ParseRepository(requestRepo); err != nil {
 		return workflow.JobPayload{}, fmt.Errorf("invalid repo: %w", err)
 	}
 	if _, err := store.GetRepo(ctx, requestRepo); err != nil {

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -3309,11 +3309,3 @@ func issueJobID(repo github.Repository, issueNumber, commentID int64, sequence i
 	_, _ = hash.Write([]byte(action))
 	return "issue-comment-" + strconv.FormatUint(hash.Sum64(), 36)
 }
-
-func ParseRepository(value string) (github.Repository, error) {
-	parts := strings.Split(strings.TrimSpace(value), "/")
-	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
-		return github.Repository{}, fmt.Errorf("repo must be owner/repo")
-	}
-	return github.Repository{Owner: parts[0], Name: parts[1]}, nil
-}

--- a/internal/daemon/task_disposal.go
+++ b/internal/daemon/task_disposal.go
@@ -147,7 +147,7 @@ func (d Daemon) disposeTaskCandidate(ctx context.Context, candidate db.StaleTask
 		}
 		getter, ok := d.GitHub.(issueGetter)
 		if ok {
-			subjectRepo, parseErr := ParseRepository(itemEvidence.subjectRepo)
+			subjectRepo, parseErr := github.ParseRepository(itemEvidence.subjectRepo)
 			if parseErr != nil {
 				return d.strandTask(ctx, candidate, taskDisposalReasonUnavailable, orgConfig)
 			}

--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -1877,3 +1877,19 @@ func firstNonEmpty(values ...string) string {
 	}
 	return ""
 }
+
+// ParseRepository parses an "owner/repo" argument into a Repository.
+//
+// It lives here rather than in internal/daemon because it CONSTRUCTS the Repository
+// type this package owns, and because internal/pipeline imported internal/daemon for
+// this one symbol and nothing else - the single edge that blocked moving the daemon
+// worker into internal/daemon (#1760). internal/git was the other candidate and was
+// rejected: it does not import internal/github, so putting a Repository constructor
+// there would ADD an import edge to delete none.
+func ParseRepository(value string) (Repository, error) {
+	parts := strings.Split(strings.TrimSpace(value), "/")
+	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+		return Repository{}, fmt.Errorf("repo must be owner/repo")
+	}
+	return Repository{Owner: parts[0], Name: parts[1]}, nil
+}

--- a/internal/pipeline/defaults.go
+++ b/internal/pipeline/defaults.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"fmt"
 	"github.com/gitmoot/gitmoot/internal/config"
-	"github.com/gitmoot/gitmoot/internal/daemon"
 	"github.com/gitmoot/gitmoot/internal/db"
+	"github.com/gitmoot/gitmoot/internal/github"
 	yaml "gopkg.in/yaml.v3"
 	"io"
 	"os"
@@ -99,7 +99,7 @@ func InstallDefaultMemoryPipelinesForDaemon(ctx context.Context, store *db.Store
 
 func defaultMemoryPipelineRepo(ctx context.Context, store *db.Store, settings config.MemoryPipelineSettings) (string, error) {
 	if repo := strings.TrimSpace(settings.Repo); repo != "" {
-		parsed, err := daemon.ParseRepository(repo)
+		parsed, err := github.ParseRepository(repo)
 		if err != nil {
 			return "", fmt.Errorf("memory.pipelines.repo: %w", err)
 		}
@@ -107,7 +107,7 @@ func defaultMemoryPipelineRepo(ctx context.Context, store *db.Store, settings co
 	}
 	for _, source := range settings.IngestSources {
 		if repo := strings.TrimSpace(source.Repo); repo != "" {
-			parsed, err := daemon.ParseRepository(repo)
+			parsed, err := github.ParseRepository(repo)
 			if err != nil {
 				return "", fmt.Errorf("memory.ingest repo %q: %w", repo, err)
 			}


### PR DESCRIPTION
**Step 1 of #1760 only.** `Refs #1760`, not `Closes` — steps 2–5 (compat shims, e2e tagging, the daemon-worker package move, plugin/doctor consolidation) are untouched.

## What it does

`internal/pipeline` imported `internal/daemon` for **one symbol and nothing else** — `daemon.ParseRepository`, at `defaults.go:102` and `:110`. That was the single edge the issue identifies as blocking the daemon-worker move. It is gone:

```
go list -deps ./internal/pipeline | grep -c internal/daemon   # 0
```

That is one of #1760's three named acceptance criteria, met outright.

45 call sites repointed across `internal/cli` (38 + 4 in tests), `internal/pipeline` (2) and `internal/daemon` (1, which was a bare in-package call).

## Why `internal/github` and not `internal/git`

The issue offered either. Decided on merits rather than left implicit:

- `internal/github` **already owns** the `Repository` type this function constructs, and is already a dependency of every caller — so the move adds **no new import edge**.
- `internal/git` does **not** import `internal/github`. Putting a `Repository` constructor there would *add* an edge in order to delete none, which is precisely the trade the issue's own "Not recommended" section rejects for the dispatch-package and config-rewrite ideas.

The reasoning is in the function's doc comment, so the next reader gets it without this PR.

## Recon first, per directive 107534 — three of the issue's numbers are stale

I diffed every measured claim against current `main` before writing anything (posted as workflow note 107576). Confirmed: the edge is exactly as described; all three compat shims are present; **zero** tests are build-tagged; `test_binary_test.go:32` still runs `go build ./cmd/gitmoot` inside the unit run.

Stale:

| claim | issue | current `main` | direction |
|---|---|---|---|
| `internal/cli` non-test LOC | 92,186 / 470 files | **72,799 / 166** | over by ~19K |
| e2e/integration/live files | 44 (42 in cli) | **35** (33 in cli); `_integration` = **0** | over by 9 |
| `cli/daemon_*.go` | 13 files / 14,232 LOC | **45 files / 34,135 LOC** | **under by 2.4×** |

The LOC over-count changes the acceptance arithmetic: the gap to `internal/cli` < 60K is ~12.8K, not ~32K.

The **under**-count is the one that matters, and it is the same direction `gm-omp-gate` found on #1759. An over-count makes work look big and gets it deferred; an under-count makes it look safe and gets it started at the wrong moment — and this one is attached to step 4, which the issue itself says to do at an idle window with a live probe after deploy. Whoever takes that step should size it off 45 files / 34K LOC.

## Gates

Under `TMPDIR=/tmp/gmtest`: `gofmt` clean, `go build ./...` clean, `go vet ./internal/...` clean, `go generate ./...` exit 0. `go test -count=1` green on `internal/pipeline`, `internal/daemon`, `internal/github`, `internal/cli` (470s), `internal/workflow` (127s), `internal/db` (255s).

No behaviour change: the function body is byte-identical apart from dropping the now-redundant `github.` package qualifier on its own package's type.

Signed-off-by: GM-OMP-FANOUT