### PR TITLE
fix: serialize daemon pool output

### DIFF
--- a/internal/cli/daemon_scheduler_test.go
+++ b/internal/cli/daemon_scheduler_test.go
@@ -2761,6 +2761,46 @@ func TestRunQueuedJobsPoolIsolatesContendedReadJob(t *testing.T) {
 	}
 }
 
+// concurrentOutputProbe makes overlapping writes observable instead of relying
+// on scheduler luck. The first armed write waits for a peer; a worker that owns
+// serialization keeps the peer outside Write, while an unguarded pool admits it.
+type concurrentOutputProbe struct {
+	armed       atomic.Bool
+	active      atomic.Int32
+	overlap     atomic.Bool
+	firstWrite  sync.Once
+	peerEntered sync.Once
+	peer        chan struct{}
+	buf         bytes.Buffer
+}
+
+func newConcurrentOutputProbe() *concurrentOutputProbe {
+	return &concurrentOutputProbe{peer: make(chan struct{})}
+}
+
+func (b *concurrentOutputProbe) Write(p []byte) (int, error) {
+	if !b.armed.Load() {
+		return b.buf.Write(p)
+	}
+	active := b.active.Add(1)
+	defer b.active.Add(-1)
+	if active > 1 {
+		b.overlap.Store(true)
+		b.peerEntered.Do(func() { close(b.peer) })
+	}
+	b.firstWrite.Do(func() {
+		select {
+		case <-b.peer:
+		case <-time.After(250 * time.Millisecond):
+		}
+	})
+	return b.buf.Write(p)
+}
+
+func (b *concurrentOutputProbe) String() string {
+	return b.buf.String()
+}
+
 func TestPoolIsolationAppendsCommittedTipNote(t *testing.T) {
 	// #696: three same-repo top-level read-only (ask) jobs submitted together under
 	// the pool run concurrently — one in the shared checkout, the other two
@@ -2780,8 +2820,8 @@ func TestPoolIsolationAppendsCommittedTipNote(t *testing.T) {
 	for i, id := range []string{"job-1", "job-2", "job-3"} {
 		enqueueDaemonWorkerJob(t, store, workflow.JobRequest{ID: id, Agent: "audit", Action: "ask", Repo: "owner/repo", Branch: "main", PullRequest: i + 1, Instructions: goal})
 	}
-	var workerOutput bytes.Buffer
-	worker := defaultJobWorker(store, &workerOutput, home)
+	workerOutput := newConcurrentOutputProbe()
+	worker := defaultJobWorker(store, workerOutput, home)
 	worker.UsePool = true
 	worker.CheckoutValidator = func(_ context.Context, _ db.Job, payload workflow.JobPayload, _ runtime.Agent) (string, error) {
 		if strings.TrimSpace(payload.WorktreePath) != "" {
@@ -2789,9 +2829,13 @@ func TestPoolIsolationAppendsCommittedTipNote(t *testing.T) {
 		}
 		return checkout, nil
 	}
+	workerOutput.armed.Store(true)
 
 	if err := runQueuedJobsForRepo(ctx, worker, 3, "", ""); err != nil {
 		t.Fatalf("pool run: %v", err)
+	}
+	if workerOutput.overlap.Load() {
+		t.Fatal("pool workers wrote to the shared output concurrently")
 	}
 
 	isolated, shared := 0, 0

--- a/internal/cli/daemon_worker.go
+++ b/internal/cli/daemon_worker.go
@@ -172,7 +172,7 @@ func defaultJobWorker(store *db.Store, stdout io.Writer, home ...string) jobWork
 		configHome = home[0]
 		configHomeExplicit = true
 	}
-	worker := jobWorker{Store: store, Stdout: stdout, ConfigHome: configHome, ConfigHomeExplicit: configHomeExplicit}
+	worker := jobWorker{Store: store, Stdout: serializeWrites(stdout), ConfigHome: configHome, ConfigHomeExplicit: configHomeExplicit}
 	worker.AdapterFactory = worker.defaultAdapter
 	worker.OutputAdapterFactory = worker.outputAdapter
 	worker.StartAdapterFactory = worker.defaultStartAdapter
@@ -180,8 +180,8 @@ func defaultJobWorker(store *db.Store, stdout io.Writer, home ...string) jobWork
 	worker.RuntimePreflight = runtime.DefaultRuntimeContractChecker().CheckRequest
 	worker.QuotaWake = newQuotaRoleUnavailableWakeClient()
 	recoverKillPendingAtWorkerStartup.Do(func() {
-		if err := recoverKillPendingJobs(context.Background(), store, stdout); err != nil {
-			writeLine(stdout, "job kill-pending recovery failed: %v", err)
+		if err := recoverKillPendingJobs(context.Background(), store, worker.Stdout); err != nil {
+			writeLine(worker.Stdout, "job kill-pending recovery failed: %v", err)
 		}
 	})
 	return worker

--- a/internal/cli/output.go
+++ b/internal/cli/output.go
@@ -6,7 +6,30 @@ import (
 	"io"
 	"os"
 	"strings"
+	"sync"
 )
+
+// serializedWriter protects the shared output sink used by concurrent pool jobs.
+type serializedWriter struct {
+	mu sync.Mutex
+	w  io.Writer
+}
+
+func (w *serializedWriter) Write(p []byte) (int, error) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return w.w.Write(p)
+}
+
+func serializeWrites(w io.Writer) io.Writer {
+	if w == nil {
+		return nil
+	}
+	if _, ok := w.(*serializedWriter); ok {
+		return w
+	}
+	return &serializedWriter{w: w}
+}
 
 func writeJSON(w io.Writer, value any) error {
 	encoder := json.NewEncoder(w)


### PR DESCRIPTION
Closes #1794

## Problem
Main commit `4d32d086` failed `race (internal/cli, shard 6/8)` in `TestPoolIsolationAppendsCommittedTipNote`. Concurrent pool workers wrote completion lines to the same `bytes.Buffer` through `jobWorker.Stdout`.

## Fix
Wrap the output sink once in `defaultJobWorker`, so every worker copy and runtime output path shares one serialized writer. Nil output behavior remains unchanged. The regression uses a production-path concurrency probe that deterministically records overlapping worker writes.

## Proof
Semantic reversion: replacing `serializeWrites(stdout)` with `stdout` failed in one run with a race report and `pool workers wrote to the shared output concurrently`.

Fixed head:
`TMPDIR=/tmp/gm-race-107698 /root/.local/toolchains/go1.26.4/bin/go test -race -p 1 -parallel 1 ./internal/cli -run '^TestPoolIsolationAppendsCommittedTipNote$' -count=10`

Result: PASS, 10/10.

Directives: `107698`, `107757`, `107762`, `107771`. No merge requested; coordinator retains merge authority.