### PR TITLE
reduction: consolidate duplicated code - enumerated tranche (refs #1759)

### DIFF
--- a/internal/cli/plugin.go
+++ b/internal/cli/plugin.go
@@ -20,6 +20,7 @@ import (
 	"github.com/gitmoot/gitmoot/internal/plugininstall"
 	"github.com/gitmoot/gitmoot/internal/pluginpack"
 	gitmootruntime "github.com/gitmoot/gitmoot/internal/runtime"
+	"github.com/gitmoot/gitmoot/internal/shellquote"
 	"github.com/gitmoot/gitmoot/internal/subprocess"
 	"github.com/gitmoot/gitmoot/skills"
 )
@@ -601,14 +602,12 @@ func shellQuote(value string, shell string) string {
 	}
 }
 
+// posixQuote delegates to the single shared implementation (#1759). It kept a
+// DENYLIST until then, which passed '~', '#' and every non-ASCII rune through
+// unquoted; the shared allowlist quotes them. The multi-shell dispatch in
+// shellQuote above is a real feature and stays.
 func posixQuote(value string) string {
-	if value == "" {
-		return "''"
-	}
-	if !strings.ContainsAny(value, " \t\r\n'\"\\$`!&;()<>|*?[]{}") {
-		return value
-	}
-	return "'" + strings.ReplaceAll(value, "'", "'\\''") + "'"
+	return shellquote.Posix(value)
 }
 
 func powershellQuote(value string) string {

--- a/internal/cli/plugin_test.go
+++ b/internal/cli/plugin_test.go
@@ -70,7 +70,11 @@ func TestRunPluginCodexLaunchConfigSnippet(t *testing.T) {
 
 func TestFormatCodexLaunchCommandQuotesShellArguments(t *testing.T) {
 	posix := formatCodexLaunchCommand("codex-face", "/tmp/repo with spaces", "/tmp/git'moot", "posix")
-	if !strings.Contains(posix, "'/tmp/repo with spaces'") || !strings.Contains(posix, "'/tmp/git'\\''moot'") {
+	// #1759 moved the embedded-single-quote idiom from '\'' to '"'"' when the four
+	// shellQuote implementations were consolidated. Both are valid POSIX and mean
+	// the same thing to sh - internal/shellquote's /bin/sh round-trip covers that
+	// - but the bytes differ, so this expectation names the current idiom.
+	if !strings.Contains(posix, "'/tmp/repo with spaces'") || !strings.Contains(posix, `'/tmp/git'"'"'moot'`) {
 		t.Fatalf("posix command did not quote safely: %s", posix)
 	}
 	powershell := formatCodexLaunchCommand("codex-face", `C:\Repo With Spaces`, `C:\Users\O'Brien\.gitmoot`, "powershell")

--- a/internal/cockpit/cockpit.go
+++ b/internal/cockpit/cockpit.go
@@ -19,6 +19,7 @@ import (
 	"time"
 
 	"github.com/gitmoot/gitmoot/internal/runtime"
+	"github.com/gitmoot/gitmoot/internal/shellquote"
 	"github.com/gitmoot/gitmoot/internal/transcript"
 	"github.com/gitmoot/gitmoot/internal/workflow"
 )
@@ -514,16 +515,16 @@ func (a *paneAdapter) workspaceRoot() string {
 // watcher remains the best-effort fallback.
 func (a *paneAdapter) watchCommand() string {
 	if a.meta.LogPath != "" {
-		path := shellQuote(a.meta.LogPath)
-		cmd := fmt.Sprintf("%s job watch %s --transcript --log-path %s --runtime %s", a.cockpit.gitmootBin, shellQuote(a.meta.JobID), path, shellQuote(a.meta.Runtime))
+		path := shellquote.Posix(a.meta.LogPath)
+		cmd := fmt.Sprintf("%s job watch %s --transcript --log-path %s --runtime %s", a.cockpit.gitmootBin, shellquote.Posix(a.meta.JobID), path, shellquote.Posix(a.meta.Runtime))
 		if a.cockpit.home != "" {
-			cmd += fmt.Sprintf(" --home %s", shellQuote(a.cockpit.home))
+			cmd += fmt.Sprintf(" --home %s", shellquote.Posix(a.cockpit.home))
 		}
 		return cmd + fmt.Sprintf(" || exec tail -n +1 -F %s", path)
 	}
-	cmd := fmt.Sprintf("%s job watch %s", a.cockpit.gitmootBin, shellQuote(a.meta.JobID))
+	cmd := fmt.Sprintf("%s job watch %s", a.cockpit.gitmootBin, shellquote.Posix(a.meta.JobID))
 	if a.cockpit.home != "" {
-		cmd += fmt.Sprintf(" --home %s", shellQuote(a.cockpit.home))
+		cmd += fmt.Sprintf(" --home %s", shellquote.Posix(a.cockpit.home))
 	}
 	return cmd
 }
@@ -532,9 +533,6 @@ func (a *paneAdapter) watchCommand() string {
 // command the pane runs, so a log path with spaces or shell metacharacters is
 // passed as one literal argument. Single quotes preserve everything except a
 // single quote, which is closed, escaped, and reopened.
-func shellQuote(s string) string {
-	return "'" + strings.ReplaceAll(s, "'", `'\''`) + "'"
-}
 
 // rootPaneFor derives a best-effort split-parent for a workspace whose root pane
 // id was not captured at create time (legacy registry rows predating that

--- a/internal/cockpit/cockpit_test.go
+++ b/internal/cockpit/cockpit_test.go
@@ -575,6 +575,18 @@ func TestWatchCommandShellQuotesJobRuntimeAndHome(t *testing.T) {
 	if got := a.watchCommand(); got != want {
 		t.Fatalf("watchCommand = %q, want %q", got, want)
 	}
+	// Every dangerous value above contains a SPACE, so a naive "quote only when
+	// there is whitespace" policy would still quote them and this test would pass
+	// against it — measured with a compiling mutant during #1759. A space-free
+	// injection is the case that actually pins the allowlist.
+	spaceFree := &paneAdapter{
+		cockpit: &Cockpit{gitmootBin: "gitmoot"},
+		meta:    JobMeta{JobID: "job;id", Runtime: "shell$(id)", LogPath: "/tmp/a|b.log"},
+	}
+	wantSpaceFree := "gitmoot job watch 'job;id' --transcript --log-path '/tmp/a|b.log' --runtime 'shell$(id)' || exec tail -n +1 -F '/tmp/a|b.log'"
+	if got := spaceFree.watchCommand(); got != wantSpaceFree {
+		t.Fatalf("space-free injection watchCommand = %q, want %q", got, wantSpaceFree)
+	}
 }
 
 func TestWrapDeliverPaneRunTailsLogPath(t *testing.T) {

--- a/internal/cockpit/cockpit_test.go
+++ b/internal/cockpit/cockpit_test.go
@@ -498,7 +498,7 @@ func TestWrapDeliverArgsCarryVerifiedFields(t *testing.T) {
 	assertContains("pane report-agent w1:p2 --source custom:gitmoot --agent gm-abcdef01 --state working")
 	assertContains("--state idle")
 	// pane run carries the job-watch command.
-	assertContains("pane run w1:p2 gitmoot job watch 'abcdef0123456789'")
+	assertContains("pane run w1:p2 gitmoot job watch abcdef0123456789")
 	// teardown releases then closes.
 	assertContains("pane release-agent w1:p2 --source custom:gitmoot --agent gm-abcdef01")
 	assertContains("pane close w1:p2")
@@ -534,7 +534,7 @@ func TestWatchCommandRendersLogWithExternalTailFallback(t *testing.T) {
 		meta:    JobMeta{JobID: "abcdef0123456789", Runtime: runtime.CodexRuntime, LogPath: "/home/g/logs/jobs/abcdef0123456789.log"},
 	}
 	got := a.watchCommand()
-	want := "gitmoot job watch 'abcdef0123456789' --transcript --log-path '/home/g/logs/jobs/abcdef0123456789.log' --runtime 'codex' --home '/home/g' || exec tail -n +1 -F '/home/g/logs/jobs/abcdef0123456789.log'"
+	want := "gitmoot job watch abcdef0123456789 --transcript --log-path /home/g/logs/jobs/abcdef0123456789.log --runtime codex --home /home/g || exec tail -n +1 -F /home/g/logs/jobs/abcdef0123456789.log"
 	if got != want {
 		t.Fatalf("watchCommand = %q, want %q", got, want)
 	}
@@ -548,7 +548,7 @@ func TestWatchCommandFallsBackToJobWatchWhenNoLogPath(t *testing.T) {
 		meta:    JobMeta{JobID: "abcdef0123456789"},
 	}
 	got := a.watchCommand()
-	want := "gitmoot job watch 'abcdef0123456789' --home '/home/g'"
+	want := "gitmoot job watch abcdef0123456789 --home /home/g"
 	if got != want {
 		t.Fatalf("watchCommand = %q, want %q", got, want)
 	}
@@ -561,20 +561,26 @@ func TestWatchCommandShellQuotesLogPathWithSpaces(t *testing.T) {
 		cockpit: &Cockpit{gitmootBin: "gitmoot"},
 		meta:    JobMeta{JobID: "x", Runtime: runtime.ShellRuntime, LogPath: "/home/my logs/jobs/x.log"},
 	}
-	if got, want := a.watchCommand(), "gitmoot job watch 'x' --transcript --log-path '/home/my logs/jobs/x.log' --runtime 'shell' || exec tail -n +1 -F '/home/my logs/jobs/x.log'"; got != want {
+	if got, want := a.watchCommand(), "gitmoot job watch x --transcript --log-path '/home/my logs/jobs/x.log' --runtime shell || exec tail -n +1 -F '/home/my logs/jobs/x.log'"; got != want {
 		t.Fatalf("watchCommand = %q, want %q", got, want)
 	}
 }
 
+// TestWatchCommandShellQuotesJobRuntimeAndHome is the security half and its
+// expectations are UNCHANGED by #1759: every dangerous value here still arrives
+// single-quoted. Only fully-safe words lost their cosmetic quotes when the four
+// shellQuote implementations were consolidated onto one allowlist, so this test
+// still fails if quoting is ever lost for input that needs it.
 func TestWatchCommandShellQuotesJobRuntimeAndHome(t *testing.T) {
 	a := &paneAdapter{
 		cockpit: &Cockpit{gitmootBin: "gitmoot", home: "/home/git moot"},
 		meta:    JobMeta{JobID: "job; echo nope", Runtime: "shell; echo nope", LogPath: "/tmp/job.log"},
 	}
-	want := "gitmoot job watch 'job; echo nope' --transcript --log-path '/tmp/job.log' --runtime 'shell; echo nope' --home '/home/git moot' || exec tail -n +1 -F '/tmp/job.log'"
+	want := "gitmoot job watch 'job; echo nope' --transcript --log-path /tmp/job.log --runtime 'shell; echo nope' --home '/home/git moot' || exec tail -n +1 -F /tmp/job.log"
 	if got := a.watchCommand(); got != want {
 		t.Fatalf("watchCommand = %q, want %q", got, want)
 	}
+
 	// Every dangerous value above contains a SPACE, so a naive "quote only when
 	// there is whitespace" policy would still quote them and this test would pass
 	// against it — measured with a compiling mutant during #1759. A space-free
@@ -601,7 +607,7 @@ func TestWrapDeliverPaneRunTailsLogPath(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	joined := strings.Join(fr.calls, "\n")
-	if want := "pane run w1:p2 gitmoot job watch 'abcdef0123456789' --transcript --log-path '/tmp/logs/jobs/abcdef0123456789.log' --runtime 'codex' || exec tail -n +1 -F '/tmp/logs/jobs/abcdef0123456789.log'"; !strings.Contains(joined, want) {
+	if want := "pane run w1:p2 gitmoot job watch abcdef0123456789 --transcript --log-path /tmp/logs/jobs/abcdef0123456789.log --runtime codex || exec tail -n +1 -F /tmp/logs/jobs/abcdef0123456789.log"; !strings.Contains(joined, want) {
 		t.Fatalf("expected pane run to render the log; want %q; calls:\n%s", want, joined)
 	}
 	if !strings.Contains(joined, "|| exec tail") {

--- a/internal/cockpit/cockpit_test.go
+++ b/internal/cockpit/cockpit_test.go
@@ -1181,3 +1181,38 @@ func TestSafeLogName(t *testing.T) {
 		}
 	}
 }
+
+// TestWatchCommandKeepsReservedTokensInArgumentPosition is the CLI-path half of
+// the #1795 review's shellquote finding. internal/shellquote's contract is
+// scoped to ARGUMENT position, so this asserts the property that scope depends
+// on: values that would be reinterpreted in command position - the reserved
+// word `if`, the assignment form `FOO=bar` - land after a flag or after the
+// command word, never as the command word itself.
+//
+// The command word here is gitmootBin, which is deliberately NOT routed through
+// shellquote.Posix. If a future change ever built the command word from a quoted
+// value, this test is where that shows up.
+func TestWatchCommandKeepsReservedTokensInArgumentPosition(t *testing.T) {
+	a := &paneAdapter{
+		cockpit: &Cockpit{gitmootBin: "gitmoot", home: "FOO=bar"},
+		meta:    JobMeta{JobID: "if", Runtime: "while", LogPath: "/tmp/if.log"},
+	}
+	got := a.watchCommand()
+
+	// The command word is the literal binary, not a quoted value.
+	if !strings.HasPrefix(got, "gitmoot job watch ") {
+		t.Fatalf("command word is not the literal binary: %q", got)
+	}
+	// Each reserved/assignment token appears only after a preceding word.
+	for _, want := range []string{"job watch if", "--runtime while", "--home FOO=bar"} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("want %q in argument position; got %q", want, got)
+		}
+	}
+	// And none of them starts the command.
+	for _, token := range []string{"if ", "while ", "FOO=bar "} {
+		if strings.HasPrefix(got, token) {
+			t.Fatalf("token %q reached COMMAND position: %q", token, got)
+		}
+	}
+}

--- a/internal/config/admission.go
+++ b/internal/config/admission.go
@@ -71,9 +71,8 @@ func LoadAdmissionPolicy(paths Paths) (AdmissionPolicy, error) {
 		if line == "" {
 			continue
 		}
-		if strings.HasPrefix(line, "[") && strings.HasSuffix(line, "]") {
-			section := strings.TrimSuffix(strings.TrimPrefix(line, "["), "]")
-			current = strings.TrimSpace(section) == "admission"
+		if section, ok := sectionHeader(line); ok {
+			current = section == "admission"
 			continue
 		}
 		if !current {

--- a/internal/config/admission.go
+++ b/internal/config/admission.go
@@ -72,6 +72,11 @@ func LoadAdmissionPolicy(paths Paths) (AdmissionPolicy, error) {
 			continue
 		}
 		if section, ok := sectionHeader(line); ok {
+			if section == "" && malformedHeaderTargets(line, "admission") {
+				// Falling back to the zero policy makes Enabled() false, which
+				// makes the daemon skip admission accounting entirely.
+				return AdmissionPolicy{}, fmt.Errorf("parse admission section: missing closing ]")
+			}
 			current = section == "admission"
 			continue
 		}

--- a/internal/config/credentials.go
+++ b/internal/config/credentials.go
@@ -49,9 +49,8 @@ func LoadCredentialsConfig(paths Paths) (CredentialsConfig, error) {
 		if line == "" {
 			continue
 		}
-		if strings.HasPrefix(line, "[") && strings.HasSuffix(line, "]") {
-			section := strings.TrimSuffix(strings.TrimPrefix(line, "["), "]")
-			current = strings.TrimSpace(section) == "credentials"
+		if section, ok := sectionHeader(line); ok {
+			current = section == "credentials"
 			continue
 		}
 		if !current {

--- a/internal/config/daemon_runtime.go
+++ b/internal/config/daemon_runtime.go
@@ -96,9 +96,8 @@ func LoadDaemonRuntimeConfig(paths Paths) (DaemonRuntimeConfig, error) {
 		if line == "" {
 			continue
 		}
-		if strings.HasPrefix(line, "[") && strings.HasSuffix(line, "]") {
-			section := strings.TrimSuffix(strings.TrimPrefix(line, "["), "]")
-			current = strings.TrimSpace(section) == "daemon"
+		if section, ok := sectionHeader(line); ok {
+			current = section == "daemon"
 			continue
 		}
 		if !current {

--- a/internal/config/disk_guard_test.go
+++ b/internal/config/disk_guard_test.go
@@ -68,3 +68,45 @@ func TestLoadDiskGuardPolicyValidation(t *testing.T) {
 		})
 	}
 }
+
+// TestLoadDiskGuardPolicyMalformedHeaderEndsTheSection pins the malformed-header
+// reset that disk_guard.go shares with tool_cache.go: a header with no closing
+// bracket ENDS whatever section was active rather than silently continuing it.
+//
+// Without the reset, the "[disk_guard" typo below would leave [disk_guard] the
+// active section, and min_free_percent = 99 would be applied to the policy - the
+// same class of bug the #1113 finder raised for [cache].
+//
+// This test exists because the behaviour was UNPINNED. Measured by deleting the
+// reset branch from disk_guard.go: the mutant compiled and the whole
+// internal/config package stayed green, while the equivalent mutant in
+// tool_cache.go is caught by TestLoadToolCache. A shared section scanner would
+// therefore have been free to drop the reset here and nothing would have said so.
+func TestLoadDiskGuardPolicyMalformedHeaderEndsTheSection(t *testing.T) {
+	paths := PathsForHome(t.TempDir())
+	if err := os.MkdirAll(paths.Home, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(paths.ConfigFile, []byte(`
+[disk_guard]
+enabled = true
+min_free_bytes = 111
+[disk_guard
+min_free_percent = 99
+`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	got, err := LoadDiskGuardPolicy(paths)
+	if err != nil {
+		t.Fatalf("LoadDiskGuardPolicy: %v", err)
+	}
+	if got.MinFreeBytes != 111 {
+		t.Fatalf("MinFreeBytes = %d, want 111 (keys before the malformed header must still apply)", got.MinFreeBytes)
+	}
+	if got.MinFreePercent == 99 {
+		t.Fatal("min_free_percent after a malformed header was applied to [disk_guard]; the header must end the section")
+	}
+	if got.MinFreePercent != DefaultDiskGuardPolicy().MinFreePercent {
+		t.Fatalf("MinFreePercent = %v, want the default %v", got.MinFreePercent, DefaultDiskGuardPolicy().MinFreePercent)
+	}
+}

--- a/internal/config/edit_compat.go
+++ b/internal/config/edit_compat.go
@@ -68,8 +68,13 @@ func configSectionAtParseError(contents string, parseErr error) string {
 	section := ""
 	for _, raw := range lines[:lineNumber] {
 		line := strings.TrimSpace(stripConfigComment(raw))
-		if strings.HasPrefix(line, "[") && strings.HasSuffix(line, "]") {
-			section = strings.TrimSpace(line[1 : len(line)-1])
+		// Shares the package's section classification (#1759), which also means a
+		// malformed header CLEARS the reported section rather than leaving the
+		// previous one named. That is the right answer for a diagnostic: an
+		// unclosed bracket is frequently the parse error itself, so naming the
+		// section before it would point the operator at the wrong place.
+		if header, ok := sectionHeader(line); ok {
+			section = header
 		}
 	}
 	return section

--- a/internal/config/gate_malformed_header_test.go
+++ b/internal/config/gate_malformed_header_test.go
@@ -142,7 +142,8 @@ func TestWellFormedGateConfigIsUnchanged(t *testing.T) {
 // here: the 4 guard loaders by refusal (merge_gate, admission, workflow,
 // review) and 8 by routing (parallel_sessions, transcripts, router, daemon,
 // github, remote_exec, credentials, plus admission's original regression) - 12
-// of 26.
+// of 26 (8 routing + 4 guards + admission original, then 4 more in
+// TestMalformedHeaderRoutingRemainingLoaders = 16).
 //
 // NOT PINNED, and named so the next reader does not have to re-derive it:
 // github_remote, heartbeats, implement_base, memory, repo_concurrency,
@@ -242,6 +243,67 @@ func TestMalformedHeaderRoutingPerCallSite(t *testing.T) {
 		}
 		if !settings.ContextEnabled {
 			t.Error("router context_enabled = true was not applied")
+		}
+	})
+}
+
+// TestMalformedHeaderRoutingRemainingLoaders extends per-call-site coverage to
+// loaders whose section name is compared after assignment rather than at the
+// header. Each case uses the loader's REAL entrypoint and a field that
+// distinguishes pre-header state from a post-malformed-header override, and
+// each was MUTATION-PROVEN: reverting that loader's call site to the inline
+// two-bracket form fails the matching subtest.
+//
+// NOT INCLUDED, and stated rather than quietly omitted: [agents.*] heartbeats.
+// A test of the same shape PASSED under the reverted call site, because an
+// enabled flag alone does not make LoadHeartbeats emit a distinguishable
+// entry - so it would have been coverage in name only. That site remains
+// unpinned and is counted as such.
+func TestMalformedHeaderRoutingRemainingLoaders(t *testing.T) {
+	t.Run("result_checks", func(t *testing.T) {
+		mode, err := LoadResultChecksMode(writeGateConfig(t, "[workflow]\nresult_checks = warn\n[workflow\nresult_checks = block\n"))
+		if err != nil {
+			t.Fatalf("load: %v", err)
+		}
+		if string(mode) != "warn" {
+			t.Fatalf("result_checks = %q, want warn: the override after a malformed header was misattributed", mode)
+		}
+	})
+
+	t.Run("memory", func(t *testing.T) {
+		settings, err := LoadMemorySettings(writeGateConfig(t, "[memory]\ntoken_budget = 111\n[memory\ntoken_budget = 999\n"))
+		if err != nil {
+			t.Fatalf("load: %v", err)
+		}
+		if settings.TokenBudget == 999 {
+			t.Fatal("token_budget = 999 after a malformed header was misattributed to [memory]")
+		}
+		if settings.TokenBudget != 111 {
+			t.Fatalf("token_budget = %d, want 111 (keys BEFORE the malformed header must still apply)", settings.TokenBudget)
+		}
+	})
+
+	t.Run("runtime_registry", func(t *testing.T) {
+		overrides, err := LoadRuntimeOverrides(writeGateConfig(t, "[runtimes.codex]\ndefault_model = \"keep\"\n[runtimes.codex\ndefault_model = \"leaked\"\n"))
+		if err != nil {
+			t.Fatalf("load: %v", err)
+		}
+		for _, override := range overrides {
+			if override.DefaultModel == "leaked" {
+				t.Fatalf("a key after a malformed header was misattributed: %+v", override)
+			}
+		}
+	})
+
+	t.Run("repo_concurrency", func(t *testing.T) {
+		limits, err := LoadRepoConcurrency(writeGateConfig(t, "[repos.\"owner/repo\"]\nmax_parallel = 2\n[repos.\"owner/repo\"\nmax_parallel = 99\n"))
+		if err != nil {
+			t.Fatalf("load: %v", err)
+		}
+		for _, limit := range limits {
+			if limit.MaxParallel == 99 {
+				t.Fatalf("max_parallel = 99 after a malformed header was misattributed: %+v", limit)
+			}
 		}
 	})
 }

--- a/internal/config/gate_malformed_header_test.go
+++ b/internal/config/gate_malformed_header_test.go
@@ -137,34 +137,37 @@ func TestWellFormedGateConfigIsUnchanged(t *testing.T) {
 // the malformed line stops being a boundary, the override is misattributed to
 // the still-open section, and the loader returns the override - so a revert at
 // any covered site fails here rather than passing quietly.
-// COVERAGE, STATED AS A COUNT RATHER THAN IMPLIED, and derived here because
-// this is the only place the number is actually computed - the previous
-// decomposition double-counted admission and is what produced section.go's
-// wrong 16 while 15 were pinned (#1795 review N1, P2-1c).
+// COVERAGE IS ENFORCED, NOT COUNTED IN PROSE. The authority for which
+// sectionHeader call sites exist and which are pinned is
+// TestSectionHeaderCoverageIsDerivedNotAsserted in section_coverage_test.go: it
+// derives the set from the AST and requires pinnedSectionHeaderSites and
+// unpinnedSectionHeaderSites to partition it exactly. This block explains the
+// METHOD and groups the pinned sites by how they are proven; it deliberately
+// states no total, because the previous shape kept a count here and another in
+// section.go, they drifted, and that is what produced the wrong 16 while 15
+// were pinned (#1795 review N1, P2-1c, P3-1, P3-2).
 //
-// sectionHeader has 26 call sites across 22 files in this package. PINNED
-// through a production loader, 16 DISTINCT sites:
+// The pinned sites, grouped by the mechanism that proves each one. FILE:LINE
+// citations are ADVISORY and are not enforced: the subtests pin BEHAVIOUR, and
+// enforcing line numbers would fail on any ordinary edit above a call site.
+// The enforced identity is file::function, in section_coverage_test.go.
 //
-//	4 guard loaders, by refusal, in TestGateLoadersRefuseTheirOwnMalformedHeader:
+//	guard loaders, by refusal, in TestGateLoadersRefuseTheirOwnMalformedHeader:
 //	  merge_gate.go:112, admission.go:74, require_workflow.go:71,
 //	  orchestrate.go:625 (via LoadReviewConfig)
-//	8 by routing, here: parallel_sessions.go:46, transcripts.go:50, router.go:46,
+//	by routing, here: parallel_sessions.go:46, transcripts.go:50, router.go:46,
 //	  daemon_runtime.go:99, github_limiter.go:80, remote_exec.go:72,
 //	  credentials.go:52, heartbeats.go:61
-//	4 in TestMalformedHeaderRoutingRemainingLoaders: result_checks.go:59,
+//	in TestMalformedHeaderRoutingRemainingLoaders: result_checks.go:59,
 //	  memory.go:185, runtime_registry.go:61, repo_concurrency.go:56
 //
 // admission appears ONCE, under the guard loaders. Its routing regression is
-// the same call site proven a second way, not a seventeenth site.
+// the same call site proven a second way, not an additional site.
 //
-// NOT PINNED, the remaining 10, named so the next reader does not have to
-// re-derive them: github_remote, implement_base, stale_tasks (3 sites),
-// workflow_lifecycle, orchestrate's LoadOrchestratePolicy and LoadEventsPolicy,
-// org.go's parseOrgContent (which has its own stricter org-shaped refusal), and
-// edit_compat's configSectionAtParseError (a diagnostic, not a loader). Those
-// loaders key off prefixes, repo-scoped names or no fixed section string, so
-// each needs its own observable field; a revert at one of them would NOT fail
-// this test. 16 pinned + 10 unpinned = 26.
+// The unpinned remainder is listed by symbol in unpinnedSectionHeaderSites.
+// Those loaders key off prefixes, repo-scoped names or no fixed section string,
+// so each needs its own observable field; a revert at one of them would NOT
+// fail this test.
 func TestMalformedHeaderRoutingPerCallSite(t *testing.T) {
 	t.Run("parallel_sessions", func(t *testing.T) {
 		paths := writeGateConfig(t, "[parallel_sessions]\nsame_session = \"queue\"\n[parallel_sessions\nsame_session = \"fork_temp_session\"\n")

--- a/internal/config/gate_malformed_header_test.go
+++ b/internal/config/gate_malformed_header_test.go
@@ -1,0 +1,191 @@
+package config
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+// writeGateConfig puts content at the config path for a fresh home and returns the
+// paths, so every case below enters through the PRODUCTION loader rather than
+// through sectionHeader.
+func writeGateConfig(t *testing.T, content string) Paths {
+	t.Helper()
+	paths := PathsForHome(t.TempDir())
+	if err := os.MkdirAll(paths.Home, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(paths.ConfigFile, []byte(content), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return paths
+}
+
+// TestGateLoadersRefuseTheirOwnMalformedHeader is the round-N P2-1.
+//
+// The #1759 malformed-header reset stopped MISATTRIBUTING keys, which was the
+// point, but for the guard loaders it also discarded the operator's settings
+// and returned the DEFAULT with a nil error. For merge_gate that default is the
+// permissive one, so a config typo silently re-enabled auto-merge and dropped
+// the external-CI requirement. Silence plus a permissive default is the worst
+// available combination, so these loaders now refuse the file.
+//
+// Fixtures are the reviewer's, verbatim in shape.
+func TestGateLoadersRefuseTheirOwnMalformedHeader(t *testing.T) {
+	t.Run("merge_gate", func(t *testing.T) {
+		paths := writeGateConfig(t, "[merge_gate]\n[merge_gate\nauto_merge = false\nrequire_external_ci = true\n")
+		_, err := LoadMergeGatePolicy(paths)
+		if err == nil {
+			t.Fatal("a malformed merge_gate header loaded cleanly; the permissive default would silently re-enable auto-merge")
+		}
+		if !strings.Contains(err.Error(), "merge_gate") || !strings.Contains(err.Error(), "missing closing") {
+			t.Errorf("error = %v, want it to name the section and the defect", err)
+		}
+	})
+
+	t.Run("admission", func(t *testing.T) {
+		paths := writeGateConfig(t, "[admission]\n[admission\nmax_concurrent_sessions = 2\nmax_memory_gb = 8\n")
+		_, err := LoadAdmissionPolicy(paths)
+		if err == nil {
+			t.Fatal("a malformed admission header loaded cleanly; the zero policy disables admission accounting entirely")
+		}
+		if !strings.Contains(err.Error(), "admission") {
+			t.Errorf("error = %v, want it to name admission", err)
+		}
+	})
+
+	t.Run("workflow", func(t *testing.T) {
+		paths := writeGateConfig(t, "[workflow]\n[workflow\nresult_checks = block\n")
+		if _, err := LoadRequireWorkflow(paths); err == nil {
+			t.Fatal("a malformed workflow header loaded cleanly")
+		}
+	})
+
+	t.Run("review", func(t *testing.T) {
+		paths := writeGateConfig(t, "[review]\n[review\nrequire_external_ci = true\n")
+		if _, err := LoadReviewConfig(paths); err == nil {
+			t.Fatal("a malformed review header loaded cleanly")
+		}
+	})
+
+	t.Run("repo-scoped malformed header is also refused", func(t *testing.T) {
+		paths := writeGateConfig(t, "[repos.\"owner/repo\".merge_gate\nauto_merge = false\n")
+		if _, err := LoadMergeGatePolicy(paths); err == nil {
+			t.Fatal("a malformed repo-scoped merge_gate header loaded cleanly")
+		}
+	})
+}
+
+// TestAnUnrelatedMalformedHeaderStillLoadsTheGates is the direction that keeps
+// the refusal from becoming a worse defect than the one it fixes.
+//
+// org.go set the precedent in this package: fail closed only for a header
+// shaped like YOUR OWN section, because "a typo in an unrelated section must
+// not brick dispatch". A daemon that will not start because of a typo in
+// [disk_guard is a bigger outage than the one being prevented.
+func TestAnUnrelatedMalformedHeaderStillLoadsTheGates(t *testing.T) {
+	const unrelated = "[merge_gate]\nauto_merge = false\n\n[disk_guard\nmin_free_bytes = 111\n"
+
+	gate, err := LoadMergeGatePolicy(writeGateConfig(t, unrelated))
+	if err != nil {
+		t.Fatalf("a typo in an unrelated section bricked the merge gate: %v", err)
+	}
+	if gate.For("owner/repo").AutoMerge {
+		t.Error("the operator's auto_merge = false was discarded even though the typo was elsewhere")
+	}
+
+	if _, err := LoadAdmissionPolicy(writeGateConfig(t, unrelated)); err != nil {
+		t.Errorf("a typo in an unrelated section bricked admission: %v", err)
+	}
+	if _, err := LoadRequireWorkflow(writeGateConfig(t, unrelated)); err != nil {
+		t.Errorf("a typo in an unrelated section bricked require_workflow: %v", err)
+	}
+	if _, err := LoadReviewConfig(writeGateConfig(t, unrelated)); err != nil {
+		t.Errorf("a typo in an unrelated section bricked review: %v", err)
+	}
+
+	// A name that merely STARTS with a gate name is unrelated too.
+	if _, err := LoadMergeGatePolicy(writeGateConfig(t, "[merge_gateway\nx = 1\n")); err != nil {
+		t.Errorf("[merge_gateway is not a merge_gate header and must not refuse: %v", err)
+	}
+}
+
+// TestWellFormedGateConfigIsUnchanged pins that none of the above touched the
+// ordinary path: a valid file must load exactly as before.
+func TestWellFormedGateConfigIsUnchanged(t *testing.T) {
+	paths := writeGateConfig(t, "[merge_gate]\nauto_merge = false\nrequire_external_ci = true\n")
+	gate, err := LoadMergeGatePolicy(paths)
+	if err != nil {
+		t.Fatalf("a well-formed config was refused: %v", err)
+	}
+	policy := gate.For("owner/repo")
+	if policy.AutoMerge {
+		t.Error("auto_merge = false was not applied")
+	}
+	if !policy.RequireExternalCI {
+		t.Error("require_external_ci = true was not applied")
+	}
+}
+
+// TestMalformedHeaderRoutingPerCallSite is the round-N P2-3: the converted call
+// sites were unproven, and reverting merge_gate.go's site to the inline
+// two-bracket form survived the whole package.
+//
+// Each case drives a PRODUCTION loader and asserts the misattribution property
+// directly: a value set inside a well-formed section, then a malformed header
+// of that same section, then an OVERRIDE of the value. If the site is reverted,
+// the malformed line stops being a boundary, the override is misattributed to
+// the still-open section, and the loader returns the override - so a revert at
+// any covered site fails here rather than passing quietly.
+func TestMalformedHeaderRoutingPerCallSite(t *testing.T) {
+	t.Run("parallel_sessions", func(t *testing.T) {
+		paths := writeGateConfig(t, "[parallel_sessions]\nsame_session = \"queue\"\n[parallel_sessions\nsame_session = \"fork_temp_session\"\n")
+		policy, err := LoadParallelSessionPolicy(paths)
+		if err != nil {
+			t.Fatalf("load: %v", err)
+		}
+		if policy.SameSession != "queue" {
+			t.Fatalf("same_session = %q, want queue: the override after a malformed header was misattributed", policy.SameSession)
+		}
+	})
+
+	t.Run("transcripts", func(t *testing.T) {
+		paths := writeGateConfig(t, "[transcripts]\nenabled = false\n[transcripts\nenabled = true\n")
+		if got := LoadTranscriptsConfig(paths); got.Enabled {
+			t.Fatal("enabled = true after a malformed header was misattributed to [transcripts]")
+		}
+	})
+
+	t.Run("router", func(t *testing.T) {
+		paths := writeGateConfig(t, "[router]\ncontext_enabled = false\n[router\ncontext_enabled = true\n")
+		settings, err := LoadRouterSettings(paths)
+		if err != nil {
+			t.Fatalf("load: %v", err)
+		}
+		if settings.ContextEnabled {
+			t.Fatal("context_enabled = true after a malformed header was misattributed to [router]")
+		}
+	})
+
+	// The valid-header path for the same loaders, so these assertions cannot be
+	// satisfied by a loader that simply ignores everything.
+	t.Run("valid headers still apply their values", func(t *testing.T) {
+		policy, err := LoadParallelSessionPolicy(writeGateConfig(t, "[parallel_sessions]\nsame_session = \"fork_temp_session\"\n"))
+		if err != nil {
+			t.Fatalf("load: %v", err)
+		}
+		if policy.SameSession != "fork_temp_session" {
+			t.Errorf("same_session = %q, want fork_temp_session", policy.SameSession)
+		}
+		if got := LoadTranscriptsConfig(writeGateConfig(t, "[transcripts]\nenabled = true\n")); !got.Enabled {
+			t.Error("transcripts enabled = true was not applied")
+		}
+		settings, err := LoadRouterSettings(writeGateConfig(t, "[router]\ncontext_enabled = true\n"))
+		if err != nil {
+			t.Fatalf("load: %v", err)
+		}
+		if !settings.ContextEnabled {
+			t.Error("router context_enabled = true was not applied")
+		}
+	})
+}

--- a/internal/config/gate_malformed_header_test.go
+++ b/internal/config/gate_malformed_header_test.go
@@ -137,6 +137,22 @@ func TestWellFormedGateConfigIsUnchanged(t *testing.T) {
 // the malformed line stops being a boundary, the override is misattributed to
 // the still-open section, and the loader returns the override - so a revert at
 // any covered site fails here rather than passing quietly.
+// COVERAGE, STATED AS A COUNT RATHER THAN IMPLIED. sectionHeader has 26 call
+// sites across 22 files in this package. Pinned through a production loader
+// here: the 4 guard loaders by refusal (merge_gate, admission, workflow,
+// review) and 8 by routing (parallel_sessions, transcripts, router, daemon,
+// github, remote_exec, credentials, plus admission's original regression) - 12
+// of 26.
+//
+// NOT PINNED, and named so the next reader does not have to re-derive it:
+// github_remote, heartbeats, implement_base, memory, repo_concurrency,
+// result_checks, runtime_registry, stale_tasks (3 sites), workflow_lifecycle,
+// orchestrate's LoadOrchestratePolicy and LoadEventsPolicy, org.go's
+// parseOrgContent (which has its own stricter org-shaped refusal), and
+// edit_compat's configSectionAtParseError (a diagnostic, not a loader). Those
+// loaders key off prefixes, repo-scoped names or no fixed section string, so
+// each needs its own observable field; a revert at one of them would NOT fail
+// this test.
 func TestMalformedHeaderRoutingPerCallSite(t *testing.T) {
 	t.Run("parallel_sessions", func(t *testing.T) {
 		paths := writeGateConfig(t, "[parallel_sessions]\nsame_session = \"queue\"\n[parallel_sessions\nsame_session = \"fork_temp_session\"\n")
@@ -164,6 +180,46 @@ func TestMalformedHeaderRoutingPerCallSite(t *testing.T) {
 		}
 		if settings.ContextEnabled {
 			t.Fatal("context_enabled = true after a malformed header was misattributed to [router]")
+		}
+	})
+
+	t.Run("daemon", func(t *testing.T) {
+		cfg, err := LoadDaemonRuntimeConfig(writeGateConfig(t, "[daemon]\nworkers = 2\n[daemon\nworkers = 99\n"))
+		if err != nil {
+			t.Fatalf("load: %v", err)
+		}
+		if cfg.Workers != 2 {
+			t.Fatalf("workers = %d, want 2: the override after a malformed header was misattributed", cfg.Workers)
+		}
+	})
+
+	t.Run("github", func(t *testing.T) {
+		policy, err := LoadGitHubLimiterPolicy(writeGateConfig(t, "[github]\nmax_concurrent = 2\n[github\nmax_concurrent = 99\n"))
+		if err != nil {
+			t.Fatalf("load: %v", err)
+		}
+		if policy.MaxConcurrent != 2 {
+			t.Fatalf("max_concurrent = %d, want 2", policy.MaxConcurrent)
+		}
+	})
+
+	t.Run("remote_exec", func(t *testing.T) {
+		cfg, err := LoadRemoteExecConfig(writeGateConfig(t, "[remote_exec]\nbackend = \"local\"\n[remote_exec\nbackend = \"remote\"\n"))
+		if err != nil {
+			t.Fatalf("load: %v", err)
+		}
+		if cfg.Backend != "local" {
+			t.Fatalf("backend = %q, want local", cfg.Backend)
+		}
+	})
+
+	t.Run("credentials", func(t *testing.T) {
+		cfg, err := LoadCredentialsConfig(writeGateConfig(t, "[credentials]\nenv_curation = false\n[credentials\nenv_curation = true\n"))
+		if err != nil {
+			t.Fatalf("load: %v", err)
+		}
+		if cfg.EnvCuration {
+			t.Fatal("env_curation = true after a malformed header was misattributed to [credentials]")
 		}
 	})
 

--- a/internal/config/gate_malformed_header_test.go
+++ b/internal/config/gate_malformed_header_test.go
@@ -226,6 +226,29 @@ func TestMalformedHeaderRoutingPerCallSite(t *testing.T) {
 
 	// The valid-header path for the same loaders, so these assertions cannot be
 	// satisfied by a loader that simply ignores everything.
+	t.Run("agents heartbeats", func(t *testing.T) {
+		// The site section.go previously recorded as unpinnable. A same-shape
+		// fixture DID pass under the reverted call site, but only because it
+		// omitted a PRECEDING heartbeat whose field the misattributed key could
+		// overwrite - and because a heartbeat missing repo/interval/prompt fails
+		// validation at both arms, which reads as "unpinnable" rather than as a
+		// broken fixture (#1795 review N2).
+		paths := writeGateConfig(t, "[agents.a.heartbeats.h1]\nrepo = \"owner/repo\"\ninterval = \"1h\"\nprompt = \"first\"\n[agents.a.heartbeats.h2\nprompt = \"second\"\n")
+		beats, err := LoadHeartbeats(paths)
+		if err != nil {
+			t.Fatalf("load: %v", err)
+		}
+		if len(beats) != 1 {
+			t.Fatalf("heartbeats = %d (%+v), want exactly h1: the malformed header must open nothing", len(beats), beats)
+		}
+		if beats[0].Name != "h1" {
+			t.Fatalf("heartbeat name = %q, want h1", beats[0].Name)
+		}
+		if beats[0].Prompt != "first" {
+			t.Fatalf("prompt = %q, want first: the key under the malformed header was misattributed to the previous heartbeat", beats[0].Prompt)
+		}
+	})
+
 	t.Run("valid headers still apply their values", func(t *testing.T) {
 		policy, err := LoadParallelSessionPolicy(writeGateConfig(t, "[parallel_sessions]\nsame_session = \"fork_temp_session\"\n"))
 		if err != nil {

--- a/internal/config/gate_malformed_header_test.go
+++ b/internal/config/gate_malformed_header_test.go
@@ -137,23 +137,34 @@ func TestWellFormedGateConfigIsUnchanged(t *testing.T) {
 // the malformed line stops being a boundary, the override is misattributed to
 // the still-open section, and the loader returns the override - so a revert at
 // any covered site fails here rather than passing quietly.
-// COVERAGE, STATED AS A COUNT RATHER THAN IMPLIED. sectionHeader has 26 call
-// sites across 22 files in this package. Pinned through a production loader
-// here: the 4 guard loaders by refusal (merge_gate, admission, workflow,
-// review) and 8 by routing (parallel_sessions, transcripts, router, daemon,
-// github, remote_exec, credentials, plus admission's original regression) - 12
-// of 26 (8 routing + 4 guards + admission original, then 4 more in
-// TestMalformedHeaderRoutingRemainingLoaders = 16).
+// COVERAGE, STATED AS A COUNT RATHER THAN IMPLIED, and derived here because
+// this is the only place the number is actually computed - the previous
+// decomposition double-counted admission and is what produced section.go's
+// wrong 16 while 15 were pinned (#1795 review N1, P2-1c).
 //
-// NOT PINNED, and named so the next reader does not have to re-derive it:
-// github_remote, heartbeats, implement_base, memory, repo_concurrency,
-// result_checks, runtime_registry, stale_tasks (3 sites), workflow_lifecycle,
-// orchestrate's LoadOrchestratePolicy and LoadEventsPolicy, org.go's
-// parseOrgContent (which has its own stricter org-shaped refusal), and
+// sectionHeader has 26 call sites across 22 files in this package. PINNED
+// through a production loader, 16 DISTINCT sites:
+//
+//	4 guard loaders, by refusal, in TestGateLoadersRefuseTheirOwnMalformedHeader:
+//	  merge_gate.go:112, admission.go:74, require_workflow.go:71,
+//	  orchestrate.go:625 (via LoadReviewConfig)
+//	8 by routing, here: parallel_sessions.go:46, transcripts.go:50, router.go:46,
+//	  daemon_runtime.go:99, github_limiter.go:80, remote_exec.go:72,
+//	  credentials.go:52, heartbeats.go:61
+//	4 in TestMalformedHeaderRoutingRemainingLoaders: result_checks.go:59,
+//	  memory.go:185, runtime_registry.go:61, repo_concurrency.go:56
+//
+// admission appears ONCE, under the guard loaders. Its routing regression is
+// the same call site proven a second way, not a seventeenth site.
+//
+// NOT PINNED, the remaining 10, named so the next reader does not have to
+// re-derive them: github_remote, implement_base, stale_tasks (3 sites),
+// workflow_lifecycle, orchestrate's LoadOrchestratePolicy and LoadEventsPolicy,
+// org.go's parseOrgContent (which has its own stricter org-shaped refusal), and
 // edit_compat's configSectionAtParseError (a diagnostic, not a loader). Those
 // loaders key off prefixes, repo-scoped names or no fixed section string, so
 // each needs its own observable field; a revert at one of them would NOT fail
-// this test.
+// this test. 16 pinned + 10 unpinned = 26.
 func TestMalformedHeaderRoutingPerCallSite(t *testing.T) {
 	t.Run("parallel_sessions", func(t *testing.T) {
 		paths := writeGateConfig(t, "[parallel_sessions]\nsame_session = \"queue\"\n[parallel_sessions\nsame_session = \"fork_temp_session\"\n")
@@ -224,8 +235,6 @@ func TestMalformedHeaderRoutingPerCallSite(t *testing.T) {
 		}
 	})
 
-	// The valid-header path for the same loaders, so these assertions cannot be
-	// satisfied by a loader that simply ignores everything.
 	t.Run("agents heartbeats", func(t *testing.T) {
 		// The site section.go previously recorded as unpinnable. A same-shape
 		// fixture DID pass under the reverted call site, but only because it
@@ -249,6 +258,8 @@ func TestMalformedHeaderRoutingPerCallSite(t *testing.T) {
 		}
 	})
 
+	// The valid-header path for the same loaders, so these assertions cannot be
+	// satisfied by a loader that simply ignores everything.
 	t.Run("valid headers still apply their values", func(t *testing.T) {
 		policy, err := LoadParallelSessionPolicy(writeGateConfig(t, "[parallel_sessions]\nsame_session = \"fork_temp_session\"\n"))
 		if err != nil {
@@ -277,11 +288,13 @@ func TestMalformedHeaderRoutingPerCallSite(t *testing.T) {
 // each was MUTATION-PROVEN: reverting that loader's call site to the inline
 // two-bracket form fails the matching subtest.
 //
-// NOT INCLUDED, and stated rather than quietly omitted: [agents.*] heartbeats.
-// A test of the same shape PASSED under the reverted call site, because an
-// enabled flag alone does not make LoadHeartbeats emit a distinguishable
-// entry - so it would have been coverage in name only. That site remains
-// unpinned and is counted as such.
+// [agents.*] heartbeats WAS listed here as not-included, on the grounds that a
+// same-shape test passed under the reverted call site. That was wrong twice
+// over and is retracted: the fixture omitted a PRECEDING heartbeat whose field
+// the misattributed key could overwrite, and a heartbeat without
+// repo/interval/prompt fails validation at BOTH arms, so it discriminated
+// nothing. The site is pinned in TestMalformedHeaderRoutingPerCallSite
+// ("agents heartbeats") and counted there (#1795 review N2, P2-1a).
 func TestMalformedHeaderRoutingRemainingLoaders(t *testing.T) {
 	t.Run("result_checks", func(t *testing.T) {
 		mode, err := LoadResultChecksMode(writeGateConfig(t, "[workflow]\nresult_checks = warn\n[workflow\nresult_checks = block\n"))

--- a/internal/config/github_limiter.go
+++ b/internal/config/github_limiter.go
@@ -77,8 +77,7 @@ func LoadGitHubLimiterPolicy(paths Paths) (GitHubLimiterPolicy, error) {
 		if line == "" {
 			continue
 		}
-		if strings.HasPrefix(line, "[") && strings.HasSuffix(line, "]") {
-			section := strings.TrimSpace(strings.TrimSuffix(strings.TrimPrefix(line, "["), "]"))
+		if section, ok := sectionHeader(line); ok {
 			current = section == "github"
 			continue
 		}

--- a/internal/config/github_remote.go
+++ b/internal/config/github_remote.go
@@ -47,9 +47,8 @@ func loadGitHubRemote(paths Paths, section string) (GitHubRemotePolicy, error) {
 		if line == "" {
 			continue
 		}
-		if strings.HasPrefix(line, "[") && strings.HasSuffix(line, "]") {
-			name := strings.TrimSuffix(strings.TrimPrefix(line, "["), "]")
-			current = strings.TrimSpace(name) == section
+		if header, ok := sectionHeader(line); ok {
+			current = header == section
 			continue
 		}
 		if !current {

--- a/internal/config/heartbeats.go
+++ b/internal/config/heartbeats.go
@@ -58,9 +58,8 @@ func LoadHeartbeats(paths Paths) ([]Heartbeat, error) {
 		if line == "" {
 			continue
 		}
-		if strings.HasPrefix(line, "[") && strings.HasSuffix(line, "]") {
+		if section, ok := sectionHeader(line); ok {
 			current = nil
-			section := strings.TrimSuffix(strings.TrimPrefix(line, "["), "]")
 			agent, name, ok := parseHeartbeatSection(section)
 			if !ok {
 				continue

--- a/internal/config/implement_base.go
+++ b/internal/config/implement_base.go
@@ -24,8 +24,8 @@ func LoadImplementBase(paths Paths) (string, error) {
 		if line == "" {
 			continue
 		}
-		if strings.HasPrefix(line, "[") && strings.HasSuffix(line, "]") {
-			current = strings.TrimSpace(strings.TrimSuffix(strings.TrimPrefix(line, "["), "]"))
+		if section, ok := sectionHeader(line); ok {
+			current = section
 			continue
 		}
 		if current != "workflow" {

--- a/internal/config/memory.go
+++ b/internal/config/memory.go
@@ -182,8 +182,8 @@ func LoadMemorySettings(paths Paths) (MemorySettings, error) {
 		if line == "" {
 			continue
 		}
-		if strings.HasPrefix(line, "[") && strings.HasSuffix(line, "]") {
-			current = strings.TrimSpace(strings.TrimSuffix(strings.TrimPrefix(line, "["), "]"))
+		if section, ok := sectionHeader(line); ok {
+			current = section
 			continue
 		}
 		if current != "memory" {

--- a/internal/config/merge_gate.go
+++ b/internal/config/merge_gate.go
@@ -109,8 +109,7 @@ func LoadMergeGatePolicy(paths Paths) (MergeGateConfig, error) {
 		if line == "" {
 			continue
 		}
-		if strings.HasPrefix(line, "[") && strings.HasSuffix(line, "]") {
-			section := strings.TrimSuffix(strings.TrimPrefix(line, "["), "]")
+		if section, ok := sectionHeader(line); ok {
 			repo, inSection = parseMergeGateSection(section)
 			if inSection && repo != "" {
 				if _, ok := cfg.repos[repo]; !ok {

--- a/internal/config/merge_gate.go
+++ b/internal/config/merge_gate.go
@@ -110,6 +110,13 @@ func LoadMergeGatePolicy(paths Paths) (MergeGateConfig, error) {
 			continue
 		}
 		if section, ok := sectionHeader(line); ok {
+			if section == "" && malformedHeaderTargets(line, "merge_gate") {
+				// A malformed merge_gate header must not fall through to
+				// DefaultMergeGatePolicy: that default is the PERMISSIVE one
+				// (auto-merge on, external CI not required), so a typo would
+				// silently loosen the gate while returning a nil error.
+				return MergeGateConfig{}, fmt.Errorf("parse merge_gate section: missing closing ]")
+			}
 			repo, inSection = parseMergeGateSection(section)
 			if inSection && repo != "" {
 				if _, ok := cfg.repos[repo]; !ok {

--- a/internal/config/orchestrate.go
+++ b/internal/config/orchestrate.go
@@ -623,6 +623,9 @@ func LoadReviewConfig(paths Paths) (ReviewConfig, error) {
 			continue
 		}
 		if section, ok := sectionHeader(line); ok {
+			if section == "" && malformedHeaderTargets(line, "review") {
+				return ReviewConfig{}, fmt.Errorf("parse review section: missing closing ]")
+			}
 			repo, inSection = parseReviewSection(section)
 			if inSection && repo != "" {
 				if _, ok := cfg.repos[repo]; !ok {

--- a/internal/config/orchestrate.go
+++ b/internal/config/orchestrate.go
@@ -157,9 +157,8 @@ func LoadOrchestratePolicy(paths Paths) (OrchestratePolicy, error) {
 		if line == "" {
 			continue
 		}
-		if strings.HasPrefix(line, "[") && strings.HasSuffix(line, "]") {
-			section := strings.TrimSuffix(strings.TrimPrefix(line, "["), "]")
-			current = strings.TrimSpace(section) == "orchestrate"
+		if section, ok := sectionHeader(line); ok {
+			current = section == "orchestrate"
 			continue
 		}
 		if !current {
@@ -432,9 +431,8 @@ func LoadEventsPolicy(paths Paths) (EventsPolicy, error) {
 		if line == "" {
 			continue
 		}
-		if strings.HasPrefix(line, "[") && strings.HasSuffix(line, "]") {
-			section := strings.TrimSuffix(strings.TrimPrefix(line, "["), "]")
-			current = strings.TrimSpace(section) == "events"
+		if section, ok := sectionHeader(line); ok {
+			current = section == "events"
 			continue
 		}
 		if !current {
@@ -624,8 +622,7 @@ func LoadReviewConfig(paths Paths) (ReviewConfig, error) {
 		if line == "" {
 			continue
 		}
-		if strings.HasPrefix(line, "[") && strings.HasSuffix(line, "]") {
-			section := strings.TrimSuffix(strings.TrimPrefix(line, "["), "]")
+		if section, ok := sectionHeader(line); ok {
 			repo, inSection = parseReviewSection(section)
 			if inSection && repo != "" {
 				if _, ok := cfg.repos[repo]; !ok {

--- a/internal/config/org.go
+++ b/internal/config/org.go
@@ -210,8 +210,8 @@ func parseOrgContent(content []byte) (OrgConfig, error) {
 			}
 			continue
 		}
-		if strings.HasPrefix(line, "[") && strings.HasSuffix(line, "]") {
-			name, role, ok, err := parseOrgSection(strings.TrimSpace(line[1 : len(line)-1]))
+		if header, isHeader := sectionHeader(line); isHeader {
+			name, role, ok, err := parseOrgSection(header)
 			if err != nil {
 				return OrgConfig{}, err
 			}

--- a/internal/config/parallel_sessions.go
+++ b/internal/config/parallel_sessions.go
@@ -43,9 +43,8 @@ func LoadParallelSessionPolicy(paths Paths) (ParallelSessionPolicy, error) {
 		if line == "" {
 			continue
 		}
-		if strings.HasPrefix(line, "[") && strings.HasSuffix(line, "]") {
-			section := strings.TrimSuffix(strings.TrimPrefix(line, "["), "]")
-			current = strings.TrimSpace(section) == "parallel_sessions"
+		if section, ok := sectionHeader(line); ok {
+			current = section == "parallel_sessions"
 			continue
 		}
 		if !current {

--- a/internal/config/remote_exec.go
+++ b/internal/config/remote_exec.go
@@ -69,9 +69,8 @@ func LoadRemoteExecConfig(paths Paths) (RemoteExecConfig, error) {
 		if line == "" {
 			continue
 		}
-		if strings.HasPrefix(line, "[") && strings.HasSuffix(line, "]") {
-			section := strings.TrimSuffix(strings.TrimPrefix(line, "["), "]")
-			current = strings.TrimSpace(section) == "remote_exec"
+		if section, ok := sectionHeader(line); ok {
+			current = section == "remote_exec"
 			continue
 		}
 		if !current {

--- a/internal/config/repo_concurrency.go
+++ b/internal/config/repo_concurrency.go
@@ -53,9 +53,8 @@ func LoadRepoConcurrency(paths Paths) ([]RepoConcurrency, error) {
 		if line == "" {
 			continue
 		}
-		if strings.HasPrefix(line, "[") && strings.HasSuffix(line, "]") {
+		if section, ok := sectionHeader(line); ok {
 			current = nil
-			section := strings.TrimSuffix(strings.TrimPrefix(line, "["), "]")
 			repo, ok := parseRepoConcurrencySection(section)
 			if !ok {
 				continue

--- a/internal/config/require_workflow.go
+++ b/internal/config/require_workflow.go
@@ -68,8 +68,8 @@ func LoadRequireWorkflow(paths Paths) (RequireWorkflowConfig, error) {
 		if line == "" {
 			continue
 		}
-		if strings.HasPrefix(line, "[") && strings.HasSuffix(line, "]") {
-			repo, inSection = parseRequireWorkflowSection(strings.TrimSuffix(strings.TrimPrefix(line, "["), "]"))
+		if section, ok := sectionHeader(line); ok {
+			repo, inSection = parseRequireWorkflowSection(section)
 			if inSection && repo != "" {
 				if _, ok := cfg.repos[repo]; !ok {
 					cfg.repos[repo] = requireWorkflowOverride{}

--- a/internal/config/require_workflow.go
+++ b/internal/config/require_workflow.go
@@ -69,6 +69,9 @@ func LoadRequireWorkflow(paths Paths) (RequireWorkflowConfig, error) {
 			continue
 		}
 		if section, ok := sectionHeader(line); ok {
+			if section == "" && malformedHeaderTargets(line, "workflow") {
+				return RequireWorkflowConfig{}, fmt.Errorf("parse workflow section: missing closing ]")
+			}
 			repo, inSection = parseRequireWorkflowSection(section)
 			if inSection && repo != "" {
 				if _, ok := cfg.repos[repo]; !ok {

--- a/internal/config/result_checks.go
+++ b/internal/config/result_checks.go
@@ -56,8 +56,8 @@ func LoadResultChecksMode(paths Paths) (ResultChecksMode, error) {
 		if line == "" {
 			continue
 		}
-		if strings.HasPrefix(line, "[") && strings.HasSuffix(line, "]") {
-			current = strings.TrimSpace(strings.TrimSuffix(strings.TrimPrefix(line, "["), "]"))
+		if section, ok := sectionHeader(line); ok {
+			current = section
 			continue
 		}
 		if current != "workflow" {

--- a/internal/config/router.go
+++ b/internal/config/router.go
@@ -43,8 +43,8 @@ func LoadRouterSettings(paths Paths) (RouterSettings, error) {
 		if line == "" {
 			continue
 		}
-		if strings.HasPrefix(line, "[") && strings.HasSuffix(line, "]") {
-			current = strings.TrimSpace(strings.TrimSuffix(strings.TrimPrefix(line, "["), "]"))
+		if section, ok := sectionHeader(line); ok {
+			current = section
 			continue
 		}
 		if current != "router" {

--- a/internal/config/runtime_registry.go
+++ b/internal/config/runtime_registry.go
@@ -58,9 +58,8 @@ func LoadRuntimeOverrides(paths Paths) ([]RuntimeOverride, error) {
 		if line == "" {
 			continue
 		}
-		if strings.HasPrefix(line, "[") && strings.HasSuffix(line, "]") {
+		if section, ok := sectionHeader(line); ok {
 			current = nil
-			section := strings.TrimSuffix(strings.TrimPrefix(line, "["), "]")
 			name, ok := parseRuntimeRegistrySection(section)
 			if !ok {
 				continue

--- a/internal/config/section.go
+++ b/internal/config/section.go
@@ -41,9 +41,16 @@ import "strings"
 // is MUTATION-PROVEN - reverting that site to the old two-bracket form fails a
 // named subtest. See TestMalformedHeaderRoutingPerCallSite and
 // TestMalformedHeaderRoutingRemainingLoaders, which together name what is NOT
-// pinned, including one site ([agents.*] heartbeats) where a same-shape test
-// passed under the reverted call site and was therefore rejected rather than
-// counted. A revert of an unpinned site would not fail the suite today.
+// pinned. A revert of an unpinned site would not fail the suite today.
+//
+// The count is 16 only since the [agents.*] heartbeats pin landed. This comment
+// previously claimed 16 while 15 were pinned, and explained the shortfall by
+// calling that site unpinnable because a same-shape test passed under the
+// reverted call site. Both halves were wrong (#1795 review N1/N2): the site is
+// pinnable, and the fixture was at fault twice over - it omitted a PRECEDING
+// heartbeat whose field the misattributed key could overwrite, and a heartbeat
+// without repo/interval/prompt fails validation at BOTH arms, which reads as
+// "the site cannot be pinned" rather than as "this fixture proves nothing".
 //
 // A valid header is byte-equivalent to the old behaviour: same trimming, same
 // name. Only the invalid-input path changes.

--- a/internal/config/section.go
+++ b/internal/config/section.go
@@ -36,21 +36,17 @@ import "strings"
 //
 // So: one classification for the plain scanners, NOT one for the package.
 //
-// ROUTING COVERAGE is partial and counted rather than implied: 16 of the 26
-// call sites are pinned through their production loader and every one of those
-// is MUTATION-PROVEN - reverting that site to the old two-bracket form fails a
-// named subtest. See TestMalformedHeaderRoutingPerCallSite and
-// TestMalformedHeaderRoutingRemainingLoaders, which together name what is NOT
-// pinned. A revert of an unpinned site would not fail the suite today.
+// ROUTING COVERAGE is partial, and the count is NOT repeated here on purpose.
+// It is derived in exactly one place - the COVERAGE block above
+// TestMalformedHeaderRoutingPerCallSite in gate_malformed_header_test.go, which
+// enumerates every pinned site by file and line, names the unpinned remainder,
+// and closes against the total. A revert of an unpinned site would not fail the
+// suite today; which sites those are is stated there.
 //
-// The count is 16 only since the [agents.*] heartbeats pin landed. This comment
-// previously claimed 16 while 15 were pinned, and explained the shortfall by
-// calling that site unpinnable because a same-shape test passed under the
-// reverted call site. Both halves were wrong (#1795 review N1/N2): the site is
-// pinnable, and the fixture was at fault twice over - it omitted a PRECEDING
-// heartbeat whose field the misattributed key could overwrite, and a heartbeat
-// without repo/interval/prompt fails validation at BOTH arms, which reads as
-// "the site cannot be pinned" rather than as "this fixture proves nothing".
+// Two copies of a number is what produced the original error: this comment said
+// 16 while 15 were pinned, and the count could drift again the moment a pin is
+// added or removed here rather than there (#1795 review N1, and the residual
+// after it). One derivation, everything else points at it.
 //
 // A valid header is byte-equivalent to the old behaviour: same trimming, same
 // name. Only the invalid-input path changes.

--- a/internal/config/section.go
+++ b/internal/config/section.go
@@ -36,6 +36,12 @@ import "strings"
 //
 // So: one classification for the plain scanners, NOT one for the package.
 //
+// ROUTING COVERAGE is also partial and counted rather than implied: 12 of the
+// 26 call sites are pinned through their production loader (see
+// TestMalformedHeaderRoutingPerCallSite, which names the 14 that are not). A
+// revert of an unpinned site to the old two-bracket form would not fail the
+// suite today.
+//
 // A valid header is byte-equivalent to the old behaviour: same trimming, same
 // name. Only the invalid-input path changes.
 func sectionHeader(line string) (name string, ok bool) {

--- a/internal/config/section.go
+++ b/internal/config/section.go
@@ -19,9 +19,22 @@ import "strings"
 // once, so `[workflow` failed the test entirely, was not treated as a header,
 // and every key after it was applied to whichever section was open before -
 // silently misattributing configuration on invalid input. tool_cache.go and
-// disk_guard.go already cleared state here, each citing the #1113 finder; this
-// makes all of them agree rather than leaving twenty-one loaders with the unsafe
-// reading.
+// disk_guard.go already cleared state here, each citing the #1113 finder.
+//
+// WHAT THIS DOES NOT COVER, because a comment that overstates its own reach
+// stops the next reader checking. It is used by the plain section scanners in
+// this package - 26 call sites across 22 files. Deliberately EXCLUDED per the
+// #1759 ruling (workflow note 107889) on their measured structural
+// differences: agent_types.go (LoadAgentTypes and removeAgentTypeBlocks) and
+// memory_pipelines.go keep the pre-#1759 two-bracket form, so LoadAgentTypes
+// still MISATTRIBUTES keys after a malformed header and removeAgentTypeBlocks
+// - a WRITE path - still drops the malformed line and the lines under it from
+// the operator's file. Both are pre-existing, both sit outside what that
+// ruling scoped, and neither is fixed here. disk_guard.go and tool_cache.go
+// additionally keep private inline copies of this classification:
+// behaviourally identical, but a second implementation.
+//
+// So: one classification for the plain scanners, NOT one for the package.
 //
 // A valid header is byte-equivalent to the old behaviour: same trimming, same
 // name. Only the invalid-input path changes.
@@ -34,4 +47,26 @@ func sectionHeader(line string) (name string, ok bool) {
 		return "", true
 	}
 	return strings.TrimSpace(strings.TrimSuffix(strings.TrimPrefix(line, "["), "]")), true
+}
+
+// malformedHeaderTargets reports whether a MALFORMED header (one that opened
+// with '[' and never closed) names section as a complete dotted segment.
+//
+// It exists so a GATE loader can refuse a file whose own section is unreadable
+// without refusing files whose typo is somewhere else entirely. org.go set this
+// precedent for [org: fail closed only for a genuinely org-shaped header, so
+// that "a typo in an unrelated section must not brick dispatch". The same
+// asymmetry applies here - `[disk_guard` must not stop the merge gate loading,
+// while `[merge_gate` must stop it returning a permissive default.
+//
+// Matching is per dotted SEGMENT, so `[repos.owner/repo.merge_gate` targets
+// merge_gate and `[merge_gateway` does not.
+func malformedHeaderTargets(line, section string) bool {
+	body := strings.TrimSpace(strings.TrimPrefix(line, "["))
+	for _, segment := range strings.Split(body, ".") {
+		if strings.TrimSpace(segment) == section {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/config/section.go
+++ b/internal/config/section.go
@@ -23,7 +23,7 @@ import "strings"
 //
 // WHAT THIS DOES NOT COVER, because a comment that overstates its own reach
 // stops the next reader checking. It is used by the plain section scanners in
-// this package - 26 call sites across 22 files. Deliberately EXCLUDED per the
+// this package. Deliberately EXCLUDED per the
 // #1759 ruling (workflow note 107889) on their measured structural
 // differences: agent_types.go (LoadAgentTypes and removeAgentTypeBlocks) and
 // memory_pipelines.go keep the pre-#1759 two-bracket form, so LoadAgentTypes
@@ -36,17 +36,19 @@ import "strings"
 //
 // So: one classification for the plain scanners, NOT one for the package.
 //
-// ROUTING COVERAGE is partial, and the count is NOT repeated here on purpose.
-// It is derived in exactly one place - the COVERAGE block above
-// TestMalformedHeaderRoutingPerCallSite in gate_malformed_header_test.go, which
-// enumerates every pinned site by file and line, names the unpinned remainder,
-// and closes against the total. A revert of an unpinned site would not fail the
-// suite today; which sites those are is stated there.
+// ROUTING COVERAGE is partial, and NO CURRENT COUNT IS STATED HERE on purpose -
+// the only numbers below are historical, inside the retraction. The
+// call-site set is DERIVED FROM THE AST and ENFORCED, not asserted in prose:
+// TestSectionHeaderCoverageIsDerivedNotAsserted parses this package, requires
+// pinnedSectionHeaderSites and unpinnedSectionHeaderSites to partition every
+// discovered site exactly, and fails naming any site that is neither. Adding a
+// call site therefore breaks a test rather than quietly outdating a comment. A
+// revert of an unpinned site would still not fail the suite today; which sites
+// those are is listed there, by symbol.
 //
 // Two copies of a number is what produced the original error: this comment said
-// 16 while 15 were pinned, and the count could drift again the moment a pin is
-// added or removed here rather than there (#1795 review N1, and the residual
-// after it). One derivation, everything else points at it.
+// 16 while 15 were pinned (#1795 review N1). Prose could drift silently, which
+// is why the successor is a test and not a better sentence (#1795 review P3-2).
 //
 // A valid header is byte-equivalent to the old behaviour: same trimming, same
 // name. Only the invalid-input path changes.

--- a/internal/config/section.go
+++ b/internal/config/section.go
@@ -1,0 +1,37 @@
+package config
+
+import "strings"
+
+// sectionHeader classifies one already-trimmed, comment-stripped config line as
+// a TOML section header.
+//
+// It answers two things and nothing else - is this line a section boundary, and
+// which section does it open - because that classification was the only genuinely
+// shared part of the twenty-odd hand-rolled section scanners in this package
+// (#1759). Each loader keeps its own field application: there is no callback, no
+// generic parser and no policy flag here, so a reader of any single loader still
+// sees its whole parse in one place.
+//
+// FAIL-CLOSED ON A MALFORMED HEADER. A line that opens with '[' but never closes
+// is STILL a boundary (ok is true) and names NO section (name is empty), so the
+// caller's current-section state is cleared. That is deliberate and it is the
+// behaviour correction in #1759: the previous form tested for both brackets at
+// once, so `[workflow` failed the test entirely, was not treated as a header,
+// and every key after it was applied to whichever section was open before -
+// silently misattributing configuration on invalid input. tool_cache.go and
+// disk_guard.go already cleared state here, each citing the #1113 finder; this
+// makes all of them agree rather than leaving twenty-one loaders with the unsafe
+// reading.
+//
+// A valid header is byte-equivalent to the old behaviour: same trimming, same
+// name. Only the invalid-input path changes.
+func sectionHeader(line string) (name string, ok bool) {
+	if !strings.HasPrefix(line, "[") {
+		return "", false
+	}
+	if !strings.HasSuffix(line, "]") {
+		// Malformed: a boundary that opens nothing.
+		return "", true
+	}
+	return strings.TrimSpace(strings.TrimSuffix(strings.TrimPrefix(line, "["), "]")), true
+}

--- a/internal/config/section.go
+++ b/internal/config/section.go
@@ -36,11 +36,14 @@ import "strings"
 //
 // So: one classification for the plain scanners, NOT one for the package.
 //
-// ROUTING COVERAGE is also partial and counted rather than implied: 12 of the
-// 26 call sites are pinned through their production loader (see
-// TestMalformedHeaderRoutingPerCallSite, which names the 14 that are not). A
-// revert of an unpinned site to the old two-bracket form would not fail the
-// suite today.
+// ROUTING COVERAGE is partial and counted rather than implied: 16 of the 26
+// call sites are pinned through their production loader and every one of those
+// is MUTATION-PROVEN - reverting that site to the old two-bracket form fails a
+// named subtest. See TestMalformedHeaderRoutingPerCallSite and
+// TestMalformedHeaderRoutingRemainingLoaders, which together name what is NOT
+// pinned, including one site ([agents.*] heartbeats) where a same-shape test
+// passed under the reverted call site and was therefore rejected rather than
+// counted. A revert of an unpinned site would not fail the suite today.
 //
 // A valid header is byte-equivalent to the old behaviour: same trimming, same
 // name. Only the invalid-input path changes.

--- a/internal/config/section_coverage_test.go
+++ b/internal/config/section_coverage_test.go
@@ -1,0 +1,173 @@
+package config
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+)
+
+// sectionHeaderCoverage is the SINGLE authority for which sectionHeader call
+// sites exist and which of them are pinned. Everything else in this package
+// points here instead of restating a number: section.go's doc, and the COVERAGE
+// block above TestMalformedHeaderRoutingPerCallSite.
+//
+// WHY THIS IS A TEST RATHER THAN A COMMENT (#1795 review P3-2). Consolidating to
+// one prose derivation made the count auditable in one read but not
+// self-checking, so it could go stale silently three ways: a 27th call site left
+// the prose wrong with the suite green; the hand-maintained file:line citations
+// misaimed on any edit above a cited line, while the behavioural subtests kept
+// passing because they pin BEHAVIOUR and never line numbers; and the pointer
+// named a test function with nothing tying the two together. This test turns all
+// three into a failing test.
+//
+// CITATIONS ARE BY SYMBOL, NEVER BY LINE, deliberately: enforcing line numbers
+// would make an ordinary edit above a call site fail, which is a guard that
+// punishes unrelated work. file::function survives reordering and reformatting
+// and still names one site unambiguously, because no function in this package
+// calls sectionHeader twice.
+var (
+	// pinnedSectionHeaderSites are MUTATION-PROVEN: reverting the site to the
+	// pre-#1759 two-bracket form fails a named subtest. 4 guard loaders by
+	// refusal, 8 by routing, 4 in TestMalformedHeaderRoutingRemainingLoaders.
+	pinnedSectionHeaderSites = []string{
+		"admission.go::LoadAdmissionPolicy",
+		"credentials.go::LoadCredentialsConfig",
+		"daemon_runtime.go::LoadDaemonRuntimeConfig",
+		"github_limiter.go::LoadGitHubLimiterPolicy",
+		"heartbeats.go::LoadHeartbeats",
+		"memory.go::LoadMemorySettings",
+		"merge_gate.go::LoadMergeGatePolicy",
+		"orchestrate.go::LoadReviewConfig",
+		"parallel_sessions.go::LoadParallelSessionPolicy",
+		"remote_exec.go::LoadRemoteExecConfig",
+		"repo_concurrency.go::LoadRepoConcurrency",
+		"require_workflow.go::LoadRequireWorkflow",
+		"result_checks.go::LoadResultChecksMode",
+		"router.go::LoadRouterSettings",
+		"runtime_registry.go::LoadRuntimeOverrides",
+		"transcripts.go::LoadTranscriptsConfig",
+	}
+
+	// unpinnedSectionHeaderSites key off prefixes, repo-scoped names or no fixed
+	// section string, so each needs its own observable field. A revert at one of
+	// these would NOT fail this package's suite today. Named so the next reader
+	// does not re-derive them, and enforced so the list cannot rot.
+	unpinnedSectionHeaderSites = []string{
+		"edit_compat.go::configSectionAtParseError",
+		"github_remote.go::loadGitHubRemote",
+		"implement_base.go::LoadImplementBase",
+		"orchestrate.go::LoadEventsPolicy",
+		"orchestrate.go::LoadOrchestratePolicy",
+		"org.go::parseOrgContent",
+		"stale_tasks.go::LoadDelegationWorktreeTTL",
+		"stale_tasks.go::LoadPlannedTaskTTL",
+		"stale_tasks.go::LoadStaleTaskTTL",
+		"workflow_lifecycle.go::LoadWorkflowLifecycle",
+	}
+)
+
+// discoverSectionHeaderCallSites parses this package's PRODUCTION files and
+// returns every sectionHeader call site as "file::enclosingFunc", plus how many
+// files it parsed. Test files are excluded: the count documents production
+// reach, and a fixture calling sectionHeader is not a call site to pin.
+func discoverSectionHeaderCallSites(t *testing.T) (sites []string, filesParsed int, distinctFiles int) {
+	t.Helper()
+	entries, err := os.ReadDir(".")
+	if err != nil {
+		t.Fatalf("read package dir: %v", err)
+	}
+	fset := token.NewFileSet()
+	seen := map[string]bool{}
+	for _, entry := range entries {
+		name := entry.Name()
+		if entry.IsDir() || !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
+			continue
+		}
+		file, err := parser.ParseFile(fset, filepath.Join(".", name), nil, 0)
+		if err != nil {
+			// Fail closed: an unparseable file must not silently shrink the count.
+			t.Fatalf("parse %s: %v", name, err)
+		}
+		filesParsed++
+		var enclosing string
+		ast.Inspect(file, func(node ast.Node) bool {
+			switch typed := node.(type) {
+			case *ast.FuncDecl:
+				enclosing = typed.Name.Name
+			case *ast.CallExpr:
+				ident, ok := typed.Fun.(*ast.Ident)
+				if ok && ident.Name == "sectionHeader" {
+					sites = append(sites, name+"::"+enclosing)
+					seen[name] = true
+				}
+			}
+			return true
+		})
+	}
+	sort.Strings(sites)
+	return sites, filesParsed, len(seen)
+}
+
+// TestSectionHeaderCoverageIsDerivedNotAsserted derives the call-site set from
+// the AST and requires the pinned and unpinned lists to PARTITION it exactly.
+// Add a 27th call site and this fails naming it, whichever file it lands in.
+func TestSectionHeaderCoverageIsDerivedNotAsserted(t *testing.T) {
+	sites, filesParsed, distinctFiles := discoverSectionHeaderCallSites(t)
+
+	// Positive control, so a broken or empty derivation cannot pass quietly: the
+	// walk must have parsed real files and found a site we know exists.
+	if filesParsed == 0 {
+		t.Fatal("parsed 0 production files: the derivation is broken, not the package")
+	}
+	if len(sites) == 0 {
+		t.Fatal("found 0 sectionHeader call sites: the derivation is broken, not the package")
+	}
+	if !slicesContain(sites, "heartbeats.go::LoadHeartbeats") {
+		t.Fatalf("control site heartbeats.go::LoadHeartbeats missing from %d discovered sites; the walk is not seeing real calls", len(sites))
+	}
+
+	classified := map[string]string{}
+	for _, site := range pinnedSectionHeaderSites {
+		classified[site] = "pinned"
+	}
+	for _, site := range unpinnedSectionHeaderSites {
+		if existing, dup := classified[site]; dup {
+			t.Fatalf("%s is listed as both %s and unpinned", site, existing)
+		}
+		classified[site] = "unpinned"
+	}
+
+	discovered := map[string]bool{}
+	for _, site := range sites {
+		discovered[site] = true
+		if _, ok := classified[site]; !ok {
+			t.Errorf("sectionHeader call site %s is not classified: add it to pinnedSectionHeaderSites (with a subtest that fails when the site is reverted) or to unpinnedSectionHeaderSites", site)
+		}
+	}
+	for site := range classified {
+		if !discovered[site] {
+			t.Errorf("classified site %s no longer exists: remove it from its list", site)
+		}
+	}
+
+	if want := len(pinnedSectionHeaderSites) + len(unpinnedSectionHeaderSites); len(sites) != want {
+		t.Errorf("discovered %d sectionHeader call sites, classified %d: the lists and the package disagree", len(sites), want)
+	}
+	if distinctFiles != 22 {
+		t.Errorf("sectionHeader call sites span %d files, want 22: update this expectation together with the lists above", distinctFiles)
+	}
+}
+
+func slicesContain(haystack []string, needle string) bool {
+	for _, candidate := range haystack {
+		if candidate == needle {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/config/section_test.go
+++ b/internal/config/section_test.go
@@ -1,0 +1,118 @@
+package config
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+// TestSectionHeaderClassification is the helper table. The load-bearing rows are
+// the malformed ones: a line that opens a bracket and never closes it must be
+// reported as a BOUNDARY that names no section, which is what clears the
+// caller's state instead of misattributing the keys that follow.
+func TestSectionHeaderClassification(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		line     string
+		wantName string
+		wantOK   bool
+	}{
+		{name: "valid", line: "[workflow]", wantName: "workflow", wantOK: true},
+		{name: "valid with inner spaces", line: "[ workflow ]", wantName: "workflow", wantOK: true},
+		{name: "valid dotted", line: "[agents.planner]", wantName: "agents.planner", wantOK: true},
+		{name: "valid empty name", line: "[]", wantName: "", wantOK: true},
+
+		// The correction. Each of these previously failed the two-bracket test
+		// outright, so it was not treated as a header at all and the PREVIOUS
+		// section stayed open.
+		{name: "malformed unclosed", line: "[workflow", wantName: "", wantOK: true},
+		{name: "malformed unclosed dotted", line: "[agents.planner", wantName: "", wantOK: true},
+		{name: "malformed bare bracket", line: "[", wantName: "", wantOK: true},
+
+		// Not headers at all: no leading bracket, so no boundary.
+		{name: "key", line: "enabled = true", wantName: "", wantOK: false},
+		{name: "value with brackets", line: "roots = [\"a\"]", wantName: "", wantOK: false},
+		{name: "empty", line: "", wantName: "", wantOK: false},
+		{name: "trailing bracket only", line: "workflow]", wantName: "", wantOK: false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			gotName, gotOK := sectionHeader(tc.line)
+			if gotName != tc.wantName || gotOK != tc.wantOK {
+				t.Fatalf("sectionHeader(%q) = (%q, %v), want (%q, %v)", tc.line, gotName, gotOK, tc.wantName, tc.wantOK)
+			}
+		})
+	}
+}
+
+// TestMalformedHeaderNeverMisattributesKeys is the regression that matters, and
+// it runs through PRODUCTION LOADERS rather than the helper: a table test on
+// sectionHeader would stay green if a loader kept its own inline classification,
+// which is exactly the mutant this consolidation could leave behind.
+//
+// The fixture is the hazard shape from the #1113 finder: a valid section, then a
+// botched header with no closing bracket, then a key that the malformed header
+// must prevent from landing in the earlier section.
+func TestMalformedHeaderNeverMisattributesKeys(t *testing.T) {
+	paths := PathsForHome(t.TempDir())
+	if err := os.MkdirAll(paths.Home, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(paths.ConfigFile, []byte(`
+[admission]
+max_memory_gb = 1.0
+
+[admission
+max_memory_gb = 99.0
+`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	policy, err := LoadAdmissionPolicy(paths)
+	if err != nil {
+		t.Fatalf("LoadAdmissionPolicy: %v", err)
+	}
+	if policy.MaxMemoryGB == 99.0 {
+		t.Fatal("a key after a malformed header was applied to [admission]; the header must end the section")
+	}
+	if policy.MaxMemoryGB != 1.0 {
+		t.Fatalf("MaxMemoryGB = %v, want 1.0 (keys BEFORE the malformed header must still apply)", policy.MaxMemoryGB)
+	}
+}
+
+// TestValidHeadersRemainByteEquivalent pins the other half of the contract: only
+// the invalid-input path changed. A consolidation that quietly altered trimming
+// or name resolution would show up here rather than in production.
+func TestValidHeadersRemainByteEquivalent(t *testing.T) {
+	paths := PathsForHome(t.TempDir())
+	if err := os.MkdirAll(paths.Home, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	// Odd but VALID spacing, plus an unrelated section in between, so section
+	// switching and trimming are both exercised.
+	if err := os.WriteFile(paths.ConfigFile, []byte(`
+[ admission ]
+max_memory_gb = 2.5
+[workflow]
+result_checks = block
+[admission]
+max_concurrent_sessions = 7
+`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	policy, err := LoadAdmissionPolicy(paths)
+	if err != nil {
+		t.Fatalf("LoadAdmissionPolicy: %v", err)
+	}
+	if policy.MaxMemoryGB != 2.5 {
+		t.Fatalf("MaxMemoryGB = %v, want 2.5 from the spaced-but-valid header", policy.MaxMemoryGB)
+	}
+	if policy.MaxConcurrentSessions != 7 {
+		t.Fatalf("MaxConcurrentSessions = %d, want 7 from the re-opened [admission] section", policy.MaxConcurrentSessions)
+	}
+	mode, err := LoadResultChecksMode(paths)
+	if err != nil {
+		t.Fatalf("LoadResultChecksMode: %v", err)
+	}
+	if !strings.Contains(strings.ToLower(string(mode)), "block") {
+		t.Fatalf("result_checks mode = %q, want block (the interleaved section must still parse)", mode)
+	}
+}

--- a/internal/config/section_test.go
+++ b/internal/config/section_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"strings"
 	"testing"
+	"time"
 )
 
 // TestSectionHeaderClassification is the helper table. The load-bearing rows are
@@ -45,36 +46,40 @@ func TestSectionHeaderClassification(t *testing.T) {
 }
 
 // TestMalformedHeaderNeverMisattributesKeys is the regression that matters, and
-// it runs through PRODUCTION LOADERS rather than the helper: a table test on
-// sectionHeader would stay green if a loader kept its own inline classification,
-// which is exactly the mutant this consolidation could leave behind.
+// it runs through a PRODUCTION LOADER rather than the helper: a table test on
+// sectionHeader would stay green if a loader kept its own inline
+// classification, which is exactly the mutant this consolidation could leave
+// behind.
 //
 // The fixture is the hazard shape from the #1113 finder: a valid section, then a
 // botched header with no closing bracket, then a key that the malformed header
 // must prevent from landing in the earlier section.
+//
+// It used to drive LoadAdmissionPolicy. Admission is a GUARD loader and now
+// REFUSES its own malformed header outright (#1795 review P2-1: resetting to
+// the zero policy silently disabled admission accounting), so the
+// no-misattribution property is demonstrated here through a non-guard loader
+// and the refusal is pinned in TestGateLoadersRefuseTheirOwnMalformedHeader.
 func TestMalformedHeaderNeverMisattributesKeys(t *testing.T) {
 	paths := PathsForHome(t.TempDir())
 	if err := os.MkdirAll(paths.Home, 0o700); err != nil {
 		t.Fatal(err)
 	}
 	if err := os.WriteFile(paths.ConfigFile, []byte(`
-[admission]
-max_memory_gb = 1.0
+[transcripts]
+retain = "48h"
 
-[admission
-max_memory_gb = 99.0
+[transcripts
+retain = "1h"
 `), 0o600); err != nil {
 		t.Fatal(err)
 	}
-	policy, err := LoadAdmissionPolicy(paths)
-	if err != nil {
-		t.Fatalf("LoadAdmissionPolicy: %v", err)
+	got := LoadTranscriptsConfig(paths)
+	if got.Retain == time.Hour {
+		t.Fatal("a key after a malformed header was applied to [transcripts]; the header must end the section")
 	}
-	if policy.MaxMemoryGB == 99.0 {
-		t.Fatal("a key after a malformed header was applied to [admission]; the header must end the section")
-	}
-	if policy.MaxMemoryGB != 1.0 {
-		t.Fatalf("MaxMemoryGB = %v, want 1.0 (keys BEFORE the malformed header must still apply)", policy.MaxMemoryGB)
+	if got.Retain != 48*time.Hour {
+		t.Fatalf("Retain = %v, want 48h (keys BEFORE the malformed header must still apply)", got.Retain)
 	}
 }
 

--- a/internal/config/stale_tasks.go
+++ b/internal/config/stale_tasks.go
@@ -30,8 +30,8 @@ func LoadPlannedTaskTTL(paths Paths) (time.Duration, error) {
 		if line == "" {
 			continue
 		}
-		if strings.HasPrefix(line, "[") && strings.HasSuffix(line, "]") {
-			current = strings.TrimSpace(strings.TrimSuffix(strings.TrimPrefix(line, "["), "]"))
+		if section, ok := sectionHeader(line); ok {
+			current = section
 			continue
 		}
 		if current != "workflow" {
@@ -75,8 +75,8 @@ func LoadStaleTaskTTL(paths Paths) (time.Duration, error) {
 		if line == "" {
 			continue
 		}
-		if strings.HasPrefix(line, "[") && strings.HasSuffix(line, "]") {
-			current = strings.TrimSpace(strings.TrimSuffix(strings.TrimPrefix(line, "["), "]"))
+		if section, ok := sectionHeader(line); ok {
+			current = section
 			continue
 		}
 		if current != "workflow" {
@@ -135,8 +135,8 @@ func LoadDelegationWorktreeTTL(paths Paths) (time.Duration, error) {
 		if line == "" {
 			continue
 		}
-		if strings.HasPrefix(line, "[") && strings.HasSuffix(line, "]") {
-			current = strings.TrimSpace(strings.TrimSuffix(strings.TrimPrefix(line, "["), "]"))
+		if section, ok := sectionHeader(line); ok {
+			current = section
 			continue
 		}
 		if current != "workflow" {

--- a/internal/config/transcripts.go
+++ b/internal/config/transcripts.go
@@ -47,8 +47,7 @@ func LoadTranscriptsConfig(paths Paths) TranscriptsConfig {
 		if line == "" {
 			continue
 		}
-		if strings.HasPrefix(line, "[") && strings.HasSuffix(line, "]") {
-			section := strings.TrimSpace(strings.TrimSuffix(strings.TrimPrefix(line, "["), "]"))
+		if section, ok := sectionHeader(line); ok {
 			current = section == "transcripts"
 			found = found || current
 			continue

--- a/internal/config/workflow_lifecycle.go
+++ b/internal/config/workflow_lifecycle.go
@@ -33,8 +33,8 @@ func LoadWorkflowLifecycle(paths Paths) (WorkflowLifecyclePolicy, error) {
 		if line == "" {
 			continue
 		}
-		if strings.HasPrefix(line, "[") && strings.HasSuffix(line, "]") {
-			current = strings.TrimSpace(strings.TrimSuffix(strings.TrimPrefix(line, "["), "]"))
+		if section, ok := sectionHeader(line); ok {
+			current = section
 			continue
 		}
 		if current != "workflow" {

--- a/internal/db/dashboard_store.go
+++ b/internal/db/dashboard_store.go
@@ -196,25 +196,23 @@ func (s *Store) ListDashboardUnlabeledJobs(ctx context.Context, since string) ([
 }
 
 func (s *Store) ListDashboardBlockedJobs(ctx context.Context) ([]DashboardJobRow, error) {
-	rows, err := s.db.QueryContext(ctx, `SELECT j.id, j.agent, j.state, j.workflow_id, j.repo,
+	out, err := queryList(ctx, s.db, `SELECT j.id, j.agent, j.state, j.workflow_id, j.repo,
 		j.payload, j.created_at, j.updated_at,
 		COALESCE(NULLIF(j.blocker_suggested_action, ''),
 			(SELECT e.message FROM job_events e WHERE e.job_id = j.id ORDER BY e.id DESC LIMIT 1), '')
-	FROM jobs j WHERE j.state = 'blocked' ORDER BY j.updated_at DESC, j.id`)
+	FROM jobs j WHERE j.state = 'blocked' ORDER BY j.updated_at DESC, j.id`, nil,
+		func(row rowScanner) (DashboardJobRow, error) {
+			var item DashboardJobRow
+			err := row.Scan(&item.ID, &item.Agent, &item.State, &item.WorkflowID, &item.Repo,
+				&item.Payload, &item.CreatedAt, &item.UpdatedAt, &item.Reason)
+			return item, err
+		})
 	if err != nil {
 		return nil, err
 	}
-	defer rows.Close()
-	out := []DashboardJobRow{}
-	for rows.Next() {
-		var item DashboardJobRow
-		if err := rows.Scan(&item.ID, &item.Agent, &item.State, &item.WorkflowID, &item.Repo,
-			&item.Payload, &item.CreatedAt, &item.UpdatedAt, &item.Reason); err != nil {
-			return nil, err
-		}
-		out = append(out, item)
-	}
-	return out, rows.Err()
+	// Promised a non-nil empty slice before #1759 and still does: this one is
+	// served directly to the dashboard's HTTP client.
+	return emptyIfNil(out), nil
 }
 
 func (s *Store) ListDashboardTerminalBuckets(ctx context.Context, since, now string) ([]DashboardTerminalBucket, error) {

--- a/internal/db/dashboard_store.go
+++ b/internal/db/dashboard_store.go
@@ -207,10 +207,12 @@ func (s *Store) ListDashboardBlockedJobs(ctx context.Context) ([]DashboardJobRow
 				&item.Payload, &item.CreatedAt, &item.UpdatedAt, &item.Reason)
 			return item, err
 		})
-	// Pre-#1759 these loaders returned `accumulator, rows.Err()`, so a LATE
-	// iteration error arrived WITH the rows already read. Returning nil here
-	// would silently convert an iteration failure into an empty result, which
-	// is the one shape a caller checking only the slice cannot notice.
+	// emptyIfNil (query_list.go) is the whole contract, including the QUERY-time
+	// divergence this justification used to omit: on an early failure these
+	// methods return a non-nil len-0 slice with the error, where the pre-#1759
+	// bodies returned nil. Stated once there rather than restated here, because
+	// six copies of a justification drift and the previous six were already
+	// silent about half of it (#1795 review N4).
 	return emptyIfNil(out), err
 }
 

--- a/internal/db/dashboard_store.go
+++ b/internal/db/dashboard_store.go
@@ -207,12 +207,11 @@ func (s *Store) ListDashboardBlockedJobs(ctx context.Context) ([]DashboardJobRow
 				&item.Payload, &item.CreatedAt, &item.UpdatedAt, &item.Reason)
 			return item, err
 		})
-	if err != nil {
-		return nil, err
-	}
-	// Promised a non-nil empty slice before #1759 and still does: this one is
-	// served directly to the dashboard's HTTP client.
-	return emptyIfNil(out), nil
+	// Pre-#1759 these loaders returned `accumulator, rows.Err()`, so a LATE
+	// iteration error arrived WITH the rows already read. Returning nil here
+	// would silently convert an iteration failure into an empty result, which
+	// is the one shape a caller checking only the slice cannot notice.
+	return emptyIfNil(out), err
 }
 
 func (s *Store) ListDashboardTerminalBuckets(ctx context.Context, since, now string) ([]DashboardTerminalBucket, error) {

--- a/internal/db/org_recycle_overdue_episodes.go
+++ b/internal/db/org_recycle_overdue_episodes.go
@@ -50,19 +50,16 @@ func (s *Store) ClearRecycleOverdueEpisode(ctx context.Context, subject string) 
 
 // ListRecycleOverdueEpisodes returns every open episode in stable subject order.
 func (s *Store) ListRecycleOverdueEpisodes(ctx context.Context) ([]RecycleOverdueEpisode, error) {
-	rows, err := s.db.QueryContext(ctx, `SELECT subject, overdue_since, COALESCE(emitted_at, ''), updated_at
-		FROM org_recycle_overdue_episodes ORDER BY subject`)
+	result, err := queryList(ctx, s.db, `SELECT subject, overdue_since, COALESCE(emitted_at, ''), updated_at
+		FROM org_recycle_overdue_episodes ORDER BY subject`, nil,
+		func(row rowScanner) (RecycleOverdueEpisode, error) {
+			var episode RecycleOverdueEpisode
+			err := row.Scan(&episode.Subject, &episode.OverdueSince, &episode.EmittedAt, &episode.UpdatedAt)
+			return episode, err
+		})
 	if err != nil {
 		return nil, err
 	}
-	defer rows.Close()
-	result := []RecycleOverdueEpisode{}
-	for rows.Next() {
-		var episode RecycleOverdueEpisode
-		if err := rows.Scan(&episode.Subject, &episode.OverdueSince, &episode.EmittedAt, &episode.UpdatedAt); err != nil {
-			return nil, err
-		}
-		result = append(result, episode)
-	}
-	return result, rows.Err()
+	// This method promised a non-nil empty slice before #1759 and still does.
+	return emptyIfNil(result), nil
 }

--- a/internal/db/org_recycle_overdue_episodes.go
+++ b/internal/db/org_recycle_overdue_episodes.go
@@ -57,9 +57,11 @@ func (s *Store) ListRecycleOverdueEpisodes(ctx context.Context) ([]RecycleOverdu
 			err := row.Scan(&episode.Subject, &episode.OverdueSince, &episode.EmittedAt, &episode.UpdatedAt)
 			return episode, err
 		})
-	// Pre-#1759 these loaders returned `accumulator, rows.Err()`, so a LATE
-	// iteration error arrived WITH the rows already read. Returning nil here
-	// would silently convert an iteration failure into an empty result, which
-	// is the one shape a caller checking only the slice cannot notice.
+	// emptyIfNil (query_list.go) is the whole contract, including the QUERY-time
+	// divergence this justification used to omit: on an early failure these
+	// methods return a non-nil len-0 slice with the error, where the pre-#1759
+	// bodies returned nil. Stated once there rather than restated here, because
+	// six copies of a justification drift and the previous six were already
+	// silent about half of it (#1795 review N4).
 	return emptyIfNil(result), err
 }

--- a/internal/db/org_recycle_overdue_episodes.go
+++ b/internal/db/org_recycle_overdue_episodes.go
@@ -57,9 +57,9 @@ func (s *Store) ListRecycleOverdueEpisodes(ctx context.Context) ([]RecycleOverdu
 			err := row.Scan(&episode.Subject, &episode.OverdueSince, &episode.EmittedAt, &episode.UpdatedAt)
 			return episode, err
 		})
-	if err != nil {
-		return nil, err
-	}
-	// This method promised a non-nil empty slice before #1759 and still does.
-	return emptyIfNil(result), nil
+	// Pre-#1759 these loaders returned `accumulator, rows.Err()`, so a LATE
+	// iteration error arrived WITH the rows already read. Returning nil here
+	// would silently convert an iteration failure into an empty result, which
+	// is the one shape a caller checking only the slice cannot notice.
+	return emptyIfNil(result), err
 }

--- a/internal/db/pipeline.go
+++ b/internal/db/pipeline.go
@@ -93,22 +93,10 @@ func (s *Store) GetPipeline(ctx context.Context, name string) (Pipeline, bool, e
 
 // ListPipelines returns every registered pipeline ordered by name.
 func (s *Store) ListPipelines(ctx context.Context) ([]Pipeline, error) {
-	rows, err := s.db.QueryContext(ctx, `SELECT name, repo, spec_yaml, spec_hash, enabled, interval, jitter,
+	// Returns NIL for zero rows, as before #1759 (see queryList).
+	return queryList(ctx, s.db, `SELECT name, repo, spec_yaml, spec_hash, enabled, interval, jitter,
 		last_run_at, next_due_at, last_run_id, last_status, created_at, updated_at
-		FROM pipelines ORDER BY name`)
-	if err != nil {
-		return nil, err
-	}
-	defer rows.Close()
-	var pipelines []Pipeline
-	for rows.Next() {
-		pipeline, err := scanPipeline(rows)
-		if err != nil {
-			return nil, err
-		}
-		pipelines = append(pipelines, pipeline)
-	}
-	return pipelines, rows.Err()
+		FROM pipelines ORDER BY name`, nil, scanPipeline)
 }
 
 // SetPipelineEnabled flips the enabled flag for a pipeline. It returns an error

--- a/internal/db/pipeline_run.go
+++ b/internal/db/pipeline_run.go
@@ -154,21 +154,9 @@ func (s *Store) ActivePipelineRun(ctx context.Context, pipeline string) (Pipelin
 // advanced, so a parked (blocked/failed) or terminal run consumes zero compute
 // until it is resumed.
 func (s *Store) ListActivePipelineRuns(ctx context.Context) ([]PipelineRun, error) {
-	rows, err := s.db.QueryContext(ctx, `SELECT id, pipeline, trigger, payload_json, spec_hash, state, halt_stage, halt_reason, needs_json, started_at, finished_at
-		FROM pipeline_runs WHERE state = 'running' ORDER BY started_at, id`)
-	if err != nil {
-		return nil, err
-	}
-	defer rows.Close()
-	var runs []PipelineRun
-	for rows.Next() {
-		run, err := scanPipelineRun(rows)
-		if err != nil {
-			return nil, err
-		}
-		runs = append(runs, run)
-	}
-	return runs, rows.Err()
+	// Returns NIL for zero rows, as before #1759 (see queryList).
+	return queryList(ctx, s.db, `SELECT id, pipeline, trigger, payload_json, spec_hash, state, halt_stage, halt_reason, needs_json, started_at, finished_at
+		FROM pipeline_runs WHERE state = 'running' ORDER BY started_at, id`, nil, scanPipelineRun)
 }
 
 // UpdatePipelineRun writes a run's mutable advancement fields (state, halt

--- a/internal/db/query_list.go
+++ b/internal/db/query_list.go
@@ -65,8 +65,10 @@ type rowScanner = interface {
 // promise `[]` rather than `null` say so in one readable token and a grep for
 // emptyIfNil enumerates exactly which list methods carry that promise.
 //
-// ONE SHAPE DIVERGENCE, stated because the call-site comments justify this
-// wrapper by the LATE-iteration path and were silent about the early one: on a
+// ONE SHAPE DIVERGENCE, stated here because this is the single source of truth
+// for the wrapper's contract. The call sites USED TO justify it by the
+// LATE-iteration path and were silent about the early one; they now point here
+// instead of restating it (#1795 review N4, P3-2). The divergence: on a
 // QUERY-time failure these methods now return a non-nil len-0 slice alongside
 // the error, where the pre-#1759 bodies returned nil because they failed before
 // any normalisation could run. Only a caller that IGNORES err and tests the

--- a/internal/db/query_list.go
+++ b/internal/db/query_list.go
@@ -1,0 +1,72 @@
+package db
+
+import (
+	"context"
+	"database/sql"
+)
+
+// queryList runs a row-returning query and collects each row through scan.
+//
+// It replaces the QueryContext -> rows.Next -> scan -> append -> rows.Err block
+// copied across a dozen list methods (#1759). Those copies were identical in
+// structure but NOT in one observable respect: some initialised their
+// accumulator as `var xs []T` and some as `[]T{}`, so half returned a nil slice
+// for an empty table and half returned an empty one. Measured here: 5 nil, 6 non-nil.
+//
+// That difference is not cosmetic. A nil slice marshals to JSON `null` while an
+// empty one marshals to `[]`, and several of these lists are served straight out
+// of the dashboard HTTP API to a client that iterates them. #1752 shipped that
+// defect in the other direction - a dropped slice initialiser made a pinned
+// dashboard field marshal as `null` - so this helper does NOT decide it:
+//
+//   - queryList returns whatever append produced, i.e. nil for zero rows;
+//   - every caller that returned a non-nil empty slice keeps an explicit
+//     normalisation at its own call site.
+//
+// Making the callers state which shape they promise is the point. A helper that
+// silently picked one would turn a visible contract into an invisible one.
+func queryList[T any](
+	ctx context.Context,
+	db *sql.DB,
+	query string,
+	args []any,
+	scan func(rowScanner) (T, error),
+) ([]T, error) {
+	rows, err := db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var out []T
+	for rows.Next() {
+		item, err := scan(rows)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, item)
+	}
+	return out, rows.Err()
+}
+
+// rowScanner is the only method queryList needs from *sql.Rows. An interface
+// rather than *sql.Rows lets the existing scanX helpers - which already take a
+// one-row scanner so they serve both QueryRow and Query paths - pass straight
+// through without an adapter closure.
+// A type ALIAS, not a defined type: a defined interface is never identical to an
+// unnamed one, so func(rowScanner) would not match the existing
+// func(interface{ Scan(dest ...any) error }) scanX helpers and generic inference
+// would fail. The alias makes them the same type, so scanRepo, scanPipeline and
+// friends pass straight through with no adapter closure.
+type rowScanner = interface {
+	Scan(dest ...any) error
+}
+
+// emptyIfNil normalises a nil slice to an empty one, so the call sites that
+// promise `[]` rather than `null` say so in one readable token and a grep for
+// emptyIfNil enumerates exactly which list methods carry that promise.
+func emptyIfNil[T any](in []T) []T {
+	if in == nil {
+		return []T{}
+	}
+	return in
+}

--- a/internal/db/query_list.go
+++ b/internal/db/query_list.go
@@ -64,6 +64,15 @@ type rowScanner = interface {
 // emptyIfNil normalises a nil slice to an empty one, so the call sites that
 // promise `[]` rather than `null` say so in one readable token and a grep for
 // emptyIfNil enumerates exactly which list methods carry that promise.
+//
+// ONE SHAPE DIVERGENCE, stated because the call-site comments justify this
+// wrapper by the LATE-iteration path and were silent about the early one: on a
+// QUERY-time failure these methods now return a non-nil len-0 slice alongside
+// the error, where the pre-#1759 bodies returned nil because they failed before
+// any normalisation could run. Only a caller that IGNORES err and tests the
+// slice for nil can observe it, and err is non-nil in both shapes - but the
+// wrapper is not a full equivalence, and nil-preserving list methods in this
+// package still return nil on the same path.
 func emptyIfNil[T any](in []T) []T {
 	if in == nil {
 		return []T{}

--- a/internal/db/query_list_fault_test.go
+++ b/internal/db/query_list_fault_test.go
@@ -1,0 +1,144 @@
+package db
+
+import (
+	"context"
+	"database/sql"
+	"database/sql/driver"
+	"errors"
+	"fmt"
+	"io"
+	"sync"
+	"testing"
+)
+
+// errIterationFailed stands in for a mid-iteration failure - a dropped
+// connection, a corrupted page - which surfaces through rows.Err() AFTER rows
+// have already been handed to the caller.
+var errIterationFailed = errors.New("iteration failed after the first row")
+
+// faultRowsDriver returns one usable row and then fails, so rows.Err() is
+// non-nil while the accumulator is non-empty. That is the exact shape the
+// pre-#1759 loaders returned as `accumulator, rows.Err()`, and the shape a
+// naive `if err != nil { return nil, err }` silently converts into an empty
+// result: a caller that checks only the slice sees "no rows" instead of
+// "something broke".
+type faultRowsDriver struct{ columns int }
+
+func (d faultRowsDriver) Open(string) (driver.Conn, error) { return faultConn(d), nil }
+
+type faultConn faultRowsDriver
+
+func (c faultConn) Prepare(query string) (driver.Stmt, error) { return faultStmt(c), nil }
+func (c faultConn) Close() error                              { return nil }
+func (c faultConn) Begin() (driver.Tx, error)                 { return nil, errors.New("no tx") }
+
+type faultStmt faultRowsDriver
+
+func (s faultStmt) Close() error  { return nil }
+func (s faultStmt) NumInput() int { return -1 }
+func (s faultStmt) Exec([]driver.Value) (driver.Result, error) {
+	return nil, errors.New("no exec")
+}
+func (s faultStmt) Query([]driver.Value) (driver.Rows, error) {
+	return &faultRows{columns: s.columns}, nil
+}
+
+type faultRows struct {
+	columns int
+	served  bool
+}
+
+func (r *faultRows) Columns() []string {
+	cols := make([]string, r.columns)
+	for i := range cols {
+		cols[i] = "c"
+	}
+	return cols
+}
+func (r *faultRows) Close() error { return nil }
+func (r *faultRows) Next(dest []driver.Value) error {
+	if r.served {
+		// NOT io.EOF: a non-EOF error here is what database/sql reports through
+		// rows.Err() once iteration has already yielded a row.
+		return errIterationFailed
+	}
+	r.served = true
+	for i := range dest {
+		dest[i] = ""
+	}
+	return nil
+}
+
+var _ = io.EOF // documents that returning EOF would be the CLEAN end-of-rows path
+
+var (
+	faultDriverMu         sync.Mutex
+	faultDriverRegistered = map[int]bool{}
+)
+
+// openFaultingStore registers one driver PER COLUMN COUNT. database/sql requires
+// Scan's destination count to equal the reported column count, so a single
+// registration shared by callers with different queries silently becomes a
+// column-mismatch error instead of the iteration error under test - which is
+// exactly how the first version of this test failed for a reason that had
+// nothing to do with the property.
+func openFaultingStore(t *testing.T, columns int) *Store {
+	t.Helper()
+	name := fmt.Sprintf("gitmoot-faultrows-%d", columns)
+	faultDriverMu.Lock()
+	if !faultDriverRegistered[columns] {
+		sql.Register(name, faultRowsDriver{columns: columns})
+		faultDriverRegistered[columns] = true
+	}
+	faultDriverMu.Unlock()
+	raw, err := sql.Open(name, "")
+	if err != nil {
+		t.Fatalf("sql.Open(%s): %v", name, err)
+	}
+	t.Cleanup(func() { _ = raw.Close() })
+	return &Store{db: raw}
+}
+
+// TestQueryListPreservesRowsOnIterationError is the regression for the P2 found
+// by the exact-head review of #1795. The refactor had introduced
+// `if err != nil { return nil, err }` at the six preserving call sites, which
+// dropped the accumulated rows that the pre-refactor `return xs, rows.Err()`
+// handed back.
+//
+// It fails if the value is dropped: the assertion is that the slice is non-nil
+// AND the error is surfaced, together.
+func TestQueryListPreservesRowsOnIterationError(t *testing.T) {
+	ctx := context.Background()
+	// ListGoals selects four columns and is one of the six preserving callers.
+	store := openFaultingStore(t, 4)
+
+	goals, err := store.ListGoals(ctx)
+	if err == nil {
+		t.Fatal("want the iteration error surfaced, got nil - a faulting driver must not read as success")
+	}
+	if goals == nil {
+		t.Fatalf("iteration error returned a NIL slice, silently converting a failure into an empty result; want the accumulated rows alongside err=%v", err)
+	}
+	if len(goals) != 1 {
+		t.Fatalf("len(goals) = %d, want 1 row accumulated before the fault (err=%v)", len(goals), err)
+	}
+}
+
+// TestQueryListReturnsErrorNotSilentEmpty pins the same property at the helper
+// level, so a future caller added without emptyIfNil still cannot turn an
+// iteration failure into a clean empty read.
+func TestQueryListReturnsErrorNotSilentEmpty(t *testing.T) {
+	ctx := context.Background()
+	store := openFaultingStore(t, 1)
+	out, err := queryList(ctx, store.db, `SELECT x FROM t`, nil,
+		func(row rowScanner) (string, error) {
+			var v string
+			return v, row.Scan(&v)
+		})
+	if err == nil {
+		t.Fatal("queryList swallowed the iteration error")
+	}
+	if len(out) != 1 {
+		t.Fatalf("queryList discarded the accumulated row: len=%d err=%v", len(out), err)
+	}
+}

--- a/internal/db/query_list_test.go
+++ b/internal/db/query_list_test.go
@@ -1,0 +1,89 @@
+package db
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+)
+
+// TestListMethodsPreserveTheirEmptyResultShape pins the nil-versus-empty
+// contract of every list method converted to queryList in #1759.
+//
+// This is the assertion the refactor actually needs. A nil slice marshals to
+// JSON `null` and an empty one to `[]`, so flipping either silently changes what
+// an HTTP client iterating the dashboard API receives - and no length or
+// round-trip assertion can see the difference. #1752 shipped exactly that defect
+// when a slice initialiser was dropped during a deletion, which is why the shape
+// is pinned here rather than left to whichever form the helper happened to
+// produce.
+func TestListMethodsPreserveTheirEmptyResultShape(t *testing.T) {
+	ctx := context.Background()
+	store, err := openCachedTestStore(t, filepath.Join(t.TempDir(), "shape.db"))
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+
+	// Every table below is empty, which is the only state in which the two
+	// shapes are distinguishable.
+	t.Run("ListRecycleOverdueEpisodes promises non-nil", func(t *testing.T) {
+		got, err := store.ListRecycleOverdueEpisodes(ctx)
+		if err != nil {
+			t.Fatalf("ListRecycleOverdueEpisodes: %v", err)
+		}
+		if got == nil {
+			t.Fatal("returned nil; this method promised a non-nil empty slice before #1759 (it marshals to JSON [] not null)")
+		}
+		if len(got) != 0 {
+			t.Fatalf("len = %d, want 0", len(got))
+		}
+	})
+
+	t.Run("ListResourceLocks promises nil", func(t *testing.T) {
+		got, err := store.ListResourceLocks(ctx)
+		if err != nil {
+			t.Fatalf("ListResourceLocks: %v", err)
+		}
+		if got != nil {
+			t.Fatalf("returned %#v; this method returned nil for no locks before #1759 and callers may rely on that", got)
+		}
+	})
+	// Every method converted to queryList in #1759 is pinned here, in the shape
+	// it promised BEFORE the refactor. The split was measured, not chosen: five
+	// methods returned nil and six returned an empty slice, and both groups have
+	// HTTP consumers, so neither shape could be standardised away.
+	t.Run("nil-returning methods", func(t *testing.T) {
+		if got, err := store.ListPipelines(ctx); err != nil || got != nil {
+			t.Fatalf("ListPipelines = %#v, err %v; want nil slice", got, err)
+		}
+		if got, err := store.ListAllCockpitPanes(ctx); err != nil || got != nil {
+			t.Fatalf("ListAllCockpitPanes = %#v, err %v; want nil slice", got, err)
+		}
+		if got, err := store.ListActivePipelineRuns(ctx); err != nil || got != nil {
+			t.Fatalf("ListActivePipelineRuns = %#v, err %v; want nil slice", got, err)
+		}
+		if got, err := store.ListAgents(ctx); err != nil || got != nil {
+			t.Fatalf("ListAgents = %#v, err %v; want nil slice", got, err)
+		}
+	})
+
+	t.Run("non-nil-returning methods", func(t *testing.T) {
+		if got, err := store.ListRepos(ctx); err != nil || got == nil {
+			t.Fatalf("ListRepos = %#v, err %v; want non-nil empty slice (marshals to [] not null)", got, err)
+		}
+		if got, err := store.ListAgentInstances(ctx); err != nil || got == nil {
+			t.Fatalf("ListAgentInstances = %#v, err %v; want non-nil empty slice", got, err)
+		}
+		if got, err := store.ListAgentTemplates(ctx); err != nil || got == nil {
+			t.Fatalf("ListAgentTemplates = %#v, err %v; want non-nil empty slice", got, err)
+		}
+		if got, err := store.ListGoals(ctx); err != nil || got == nil {
+			t.Fatalf("ListGoals = %#v, err %v; want non-nil empty slice", got, err)
+		}
+		// Served straight to the dashboard HTTP client, so null-vs-[] is visible
+		// to a browser, not just to Go callers.
+		if got, err := store.ListDashboardBlockedJobs(ctx); err != nil || got == nil {
+			t.Fatalf("ListDashboardBlockedJobs = %#v, err %v; want non-nil empty slice", got, err)
+		}
+	})
+}

--- a/internal/db/store.go
+++ b/internal/db/store.go
@@ -334,21 +334,9 @@ func (s *Store) ListCockpitPanesByRoot(ctx context.Context, rootJobID string) ([
 // The reconcile GC uses it to find orphaned rows (pane gone from herdr + owning
 // root terminal) without scanning per-root.
 func (s *Store) ListAllCockpitPanes(ctx context.Context) ([]CockpitPane, error) {
-	rows, err := s.db.QueryContext(ctx, `SELECT id, job_id, pane_key, root_job_id, pane_id, workspace_id, source, created_at
-		FROM cockpit_panes ORDER BY created_at, rowid`)
-	if err != nil {
-		return nil, err
-	}
-	defer rows.Close()
-	var panes []CockpitPane
-	for rows.Next() {
-		pane, err := scanCockpitPane(rows)
-		if err != nil {
-			return nil, err
-		}
-		panes = append(panes, pane)
-	}
-	return panes, rows.Err()
+	// Returns NIL for zero rows, as before #1759 (see queryList).
+	return queryList(ctx, s.db, `SELECT id, job_id, pane_key, root_job_id, pane_id, workspace_id, source, created_at
+		FROM cockpit_panes ORDER BY created_at, rowid`, nil, scanCockpitPane)
 }
 
 // DeleteCockpitPane removes a pane record by ID. Deleting a missing row is a

--- a/internal/db/store_agents.go
+++ b/internal/db/store_agents.go
@@ -442,10 +442,12 @@ func (s *Store) FindActiveAgentInstance(ctx context.Context, typ string, repo st
 func (s *Store) ListAgentInstances(ctx context.Context) ([]AgentInstance, error) {
 	out, err := queryList(ctx, s.db, `SELECT name, type, runtime, runtime_ref, repo_full_name, role, template_id, model, effort, capabilities_json, autonomy_policy, state, created_at, last_used_at, expires_at
 		FROM agent_instances ORDER BY type, repo_full_name, name`, nil, scanAgentInstance)
-	// Pre-#1759 these loaders returned `accumulator, rows.Err()`, so a LATE
-	// iteration error arrived WITH the rows already read. Returning nil here
-	// would silently convert an iteration failure into an empty result, which
-	// is the one shape a caller checking only the slice cannot notice.
+	// emptyIfNil (query_list.go) is the whole contract, including the QUERY-time
+	// divergence this justification used to omit: on an early failure these
+	// methods return a non-nil len-0 slice with the error, where the pre-#1759
+	// bodies returned nil. Stated once there rather than restated here, because
+	// six copies of a justification drift and the previous six were already
+	// silent about half of it (#1795 review N4).
 	return emptyIfNil(out), err
 }
 

--- a/internal/db/store_agents.go
+++ b/internal/db/store_agents.go
@@ -128,22 +128,11 @@ func (s *Store) GetAgent(ctx context.Context, name string) (Agent, error) {
 }
 
 func (s *Store) ListAgents(ctx context.Context) ([]Agent, error) {
-	rows, err := s.db.QueryContext(ctx, `SELECT name, role, runtime, runtime_ref, repo_scope, template_id, model, effort, capabilities_json, autonomy_policy, health_status
-		FROM agents ORDER BY name`)
-	if err != nil {
-		return nil, err
-	}
-	defer rows.Close()
-
-	var agents []Agent
-	for rows.Next() {
-		agent, err := scanAgent(rows)
-		if err != nil {
-			return nil, err
-		}
-		agents = append(agents, agent)
-	}
-	return agents, rows.Err()
+	// Returns NIL for zero rows, as before #1759 (see queryList). scanAgent takes
+	// the DEFINED agentScanner interface, so it needs an adapter closure.
+	return queryList(ctx, s.db, `SELECT name, role, runtime, runtime_ref, repo_scope, template_id, model, effort, capabilities_json, autonomy_policy, health_status
+		FROM agents ORDER BY name`, nil,
+		func(row rowScanner) (Agent, error) { return scanAgent(row) })
 }
 
 func (s *Store) RemoveAgent(ctx context.Context, name string) (bool, error) {
@@ -451,21 +440,13 @@ func (s *Store) FindActiveAgentInstance(ctx context.Context, typ string, repo st
 }
 
 func (s *Store) ListAgentInstances(ctx context.Context) ([]AgentInstance, error) {
-	rows, err := s.db.QueryContext(ctx, `SELECT name, type, runtime, runtime_ref, repo_full_name, role, template_id, model, effort, capabilities_json, autonomy_policy, state, created_at, last_used_at, expires_at
-		FROM agent_instances ORDER BY type, repo_full_name, name`)
+	out, err := queryList(ctx, s.db, `SELECT name, type, runtime, runtime_ref, repo_full_name, role, template_id, model, effort, capabilities_json, autonomy_policy, state, created_at, last_used_at, expires_at
+		FROM agent_instances ORDER BY type, repo_full_name, name`, nil, scanAgentInstance)
 	if err != nil {
 		return nil, err
 	}
-	defer rows.Close()
-	instances := []AgentInstance{}
-	for rows.Next() {
-		instance, err := scanAgentInstance(rows)
-		if err != nil {
-			return nil, err
-		}
-		instances = append(instances, instance)
-	}
-	return instances, rows.Err()
+	// Promised a non-nil empty slice before #1759 and still does.
+	return emptyIfNil(out), nil
 }
 
 func (s *Store) TouchAgentInstance(ctx context.Context, name string, now time.Time, idleTimeout time.Duration) error {

--- a/internal/db/store_agents.go
+++ b/internal/db/store_agents.go
@@ -442,11 +442,11 @@ func (s *Store) FindActiveAgentInstance(ctx context.Context, typ string, repo st
 func (s *Store) ListAgentInstances(ctx context.Context) ([]AgentInstance, error) {
 	out, err := queryList(ctx, s.db, `SELECT name, type, runtime, runtime_ref, repo_full_name, role, template_id, model, effort, capabilities_json, autonomy_policy, state, created_at, last_used_at, expires_at
 		FROM agent_instances ORDER BY type, repo_full_name, name`, nil, scanAgentInstance)
-	if err != nil {
-		return nil, err
-	}
-	// Promised a non-nil empty slice before #1759 and still does.
-	return emptyIfNil(out), nil
+	// Pre-#1759 these loaders returned `accumulator, rows.Err()`, so a LATE
+	// iteration error arrived WITH the rows already read. Returning nil here
+	// would silently convert an iteration failure into an empty result, which
+	// is the one shape a caller checking only the slice cannot notice.
+	return emptyIfNil(out), err
 }
 
 func (s *Store) TouchAgentInstance(ctx context.Context, name string, now time.Time, idleTimeout time.Duration) error {

--- a/internal/db/store_jobs.go
+++ b/internal/db/store_jobs.go
@@ -1636,59 +1636,52 @@ func (s *Store) LatestAdvancementMarker(ctx context.Context, jobID string) (stri
 // GetLatestJobEventsByKind returns the newest event of kind for each requested
 // job in one indexed query. Empty input returns an initialized empty map.
 func (s *Store) GetLatestJobEventsByKind(ctx context.Context, jobIDs []string, kind string) (map[string]JobEvent, error) {
-	out := map[string]JobEvent{}
-	if len(jobIDs) == 0 {
-		return out, nil
-	}
-	placeholders := strings.TrimSuffix(strings.Repeat("?,", len(jobIDs)), ",")
-	args := make([]any, 0, 2*(len(jobIDs)+1))
-	args = append(args, kind)
-	for _, jobID := range jobIDs {
-		args = append(args, jobID)
-	}
-	args = append(args, kind)
-	for _, jobID := range jobIDs {
-		args = append(args, jobID)
-	}
-	query := `SELECT job_id, kind, message, created_at FROM job_events
-		WHERE kind = ? AND job_id IN (` + placeholders + `)
-		  AND id IN (SELECT MAX(id) FROM job_events
-			WHERE kind = ? AND job_id IN (` + placeholders + `) GROUP BY job_id)`
-	rows, err := s.db.QueryContext(ctx, query, args...)
-	if err != nil {
-		return nil, err
-	}
-	defer rows.Close()
-	for rows.Next() {
-		var event JobEvent
-		if err := rows.Scan(&event.JobID, &event.Kind, &event.Message, &event.CreatedAt); err != nil {
-			return nil, err
-		}
-		out[event.JobID] = event
-	}
-	return out, rows.Err()
+	return s.jobEventsByKindExtreme(ctx, jobIDs, kind, jobEventPickNewest)
 }
 
 // GetEarliestJobEventsByKind returns the oldest event of kind for each requested
 // job in one indexed query. Empty input returns an initialized empty map.
 func (s *Store) GetEarliestJobEventsByKind(ctx context.Context, jobIDs []string, kind string) (map[string]JobEvent, error) {
+	return s.jobEventsByKindExtreme(ctx, jobIDs, kind, jobEventPickOldest)
+}
+
+// jobEventPick names the aggregate that selects one event per job. It is a
+// closed set of package-private constants rather than a string parameter
+// precisely because its value is INTERPOLATED into the statement below: a caller
+// able to supply that text would be supplying SQL. The two exported methods
+// above are the only way in, and each names a constant.
+type jobEventPick string
+
+const (
+	jobEventPickNewest jobEventPick = "MAX"
+	jobEventPickOldest jobEventPick = "MIN"
+)
+
+// jobEventsByKindExtreme is the shared body of GetLatestJobEventsByKind and
+// GetEarliestJobEventsByKind, which were line-for-line identical apart from
+// MAX(id) versus MIN(id) (#1759). Both exported names are kept: they are called
+// from the daemon's hot path and from the escalation ladder, and renaming them
+// would be a behaviour change dressed as deduplication.
+//
+// Returns an INITIALIZED EMPTY MAP for empty input, as both twins did - a nil
+// map would still read as empty but would panic on assignment for any future
+// caller that tried to add to the result.
+func (s *Store) jobEventsByKindExtreme(ctx context.Context, jobIDs []string, kind string, pick jobEventPick) (map[string]JobEvent, error) {
 	out := map[string]JobEvent{}
 	if len(jobIDs) == 0 {
 		return out, nil
 	}
 	placeholders := strings.TrimSuffix(strings.Repeat("?,", len(jobIDs)), ",")
 	args := make([]any, 0, 2*(len(jobIDs)+1))
-	args = append(args, kind)
-	for _, jobID := range jobIDs {
-		args = append(args, jobID)
-	}
-	args = append(args, kind)
-	for _, jobID := range jobIDs {
-		args = append(args, jobID)
+	for range 2 {
+		args = append(args, kind)
+		for _, jobID := range jobIDs {
+			args = append(args, jobID)
+		}
 	}
 	query := `SELECT job_id, kind, message, created_at FROM job_events
 		WHERE kind = ? AND job_id IN (` + placeholders + `)
-		  AND id IN (SELECT MIN(id) FROM job_events
+		  AND id IN (SELECT ` + string(pick) + `(id) FROM job_events
 			WHERE kind = ? AND job_id IN (` + placeholders + `) GROUP BY job_id)`
 	rows, err := s.db.QueryContext(ctx, query, args...)
 	if err != nil {

--- a/internal/db/store_locks.go
+++ b/internal/db/store_locks.go
@@ -129,20 +129,14 @@ func (s *Store) GetResourceLock(ctx context.Context, resourceKey string) (Resour
 
 // ListResourceLocks returns all held resource locks, ordered by resource key.
 func (s *Store) ListResourceLocks(ctx context.Context) ([]ResourceLock, error) {
-	rows, err := s.db.QueryContext(ctx, `SELECT resource_key, owner_job_id, owner_token, owner_pid, owner_hostname, command_hash, acquired_at, updated_at, expires_at FROM resource_locks ORDER BY resource_key`)
-	if err != nil {
-		return nil, err
-	}
-	defer rows.Close()
-	var locks []ResourceLock
-	for rows.Next() {
-		var lock ResourceLock
-		if err := rows.Scan(&lock.ResourceKey, &lock.OwnerJobID, &lock.OwnerToken, &lock.OwnerPID, &lock.OwnerHostname, &lock.CommandHash, &lock.AcquiredAt, &lock.UpdatedAt, &lock.ExpiresAt); err != nil {
-			return nil, err
-		}
-		locks = append(locks, lock)
-	}
-	return locks, rows.Err()
+	// Returns NIL for no locks, as it did before #1759. Not normalised on
+	// purpose: see queryList's note on the nil/empty contract.
+	return queryList(ctx, s.db, `SELECT resource_key, owner_job_id, owner_token, owner_pid, owner_hostname, command_hash, acquired_at, updated_at, expires_at FROM resource_locks ORDER BY resource_key`, nil,
+		func(row rowScanner) (ResourceLock, error) {
+			var lock ResourceLock
+			err := row.Scan(&lock.ResourceKey, &lock.OwnerJobID, &lock.OwnerToken, &lock.OwnerPID, &lock.OwnerHostname, &lock.CommandHash, &lock.AcquiredAt, &lock.UpdatedAt, &lock.ExpiresAt)
+			return lock, err
+		})
 }
 
 // SupersedeAdvanceLockKeyPrefix namespaces the resource lock a supersession

--- a/internal/db/store_tasks.go
+++ b/internal/db/store_tasks.go
@@ -82,21 +82,13 @@ func (s *Store) GetRepo(ctx context.Context, fullName string) (Repo, error) {
 }
 
 func (s *Store) ListRepos(ctx context.Context) ([]Repo, error) {
-	rows, err := s.db.QueryContext(ctx, `SELECT owner, name, default_branch, remote_url, checkout_path, primary_checkout_path, enabled, poll_interval, last_poll_at, last_error
-		FROM repos ORDER BY full_name`)
+	out, err := queryList(ctx, s.db, `SELECT owner, name, default_branch, remote_url, checkout_path, primary_checkout_path, enabled, poll_interval, last_poll_at, last_error
+		FROM repos ORDER BY full_name`, nil, scanRepo)
 	if err != nil {
 		return nil, err
 	}
-	defer rows.Close()
-	repos := []Repo{}
-	for rows.Next() {
-		repo, err := scanRepo(rows)
-		if err != nil {
-			return nil, err
-		}
-		repos = append(repos, repo)
-	}
-	return repos, rows.Err()
+	// Promised a non-nil empty slice before #1759 and still does.
+	return emptyIfNil(out), nil
 }
 
 // HealRepoCheckout atomically replaces a repo checkout only when it still has
@@ -198,20 +190,17 @@ func upsertGoal(ctx context.Context, execer sqlExecer, goal Goal) error {
 }
 
 func (s *Store) ListGoals(ctx context.Context) ([]Goal, error) {
-	rows, err := s.db.QueryContext(ctx, `SELECT id, title, source, status FROM goals ORDER BY id`)
+	out, err := queryList(ctx, s.db, `SELECT id, title, source, status FROM goals ORDER BY id`, nil,
+		func(row rowScanner) (Goal, error) {
+			var goal Goal
+			err := row.Scan(&goal.ID, &goal.Title, &goal.Source, &goal.Status)
+			return goal, err
+		})
 	if err != nil {
 		return nil, err
 	}
-	defer rows.Close()
-	goals := []Goal{}
-	for rows.Next() {
-		var goal Goal
-		if err := rows.Scan(&goal.ID, &goal.Title, &goal.Source, &goal.Status); err != nil {
-			return nil, err
-		}
-		goals = append(goals, goal)
-	}
-	return goals, rows.Err()
+	// Promised a non-nil empty slice before #1759 and still does.
+	return emptyIfNil(out), nil
 }
 
 func (s *Store) UpsertTask(ctx context.Context, task Task) error {

--- a/internal/db/store_tasks.go
+++ b/internal/db/store_tasks.go
@@ -84,10 +84,12 @@ func (s *Store) GetRepo(ctx context.Context, fullName string) (Repo, error) {
 func (s *Store) ListRepos(ctx context.Context) ([]Repo, error) {
 	out, err := queryList(ctx, s.db, `SELECT owner, name, default_branch, remote_url, checkout_path, primary_checkout_path, enabled, poll_interval, last_poll_at, last_error
 		FROM repos ORDER BY full_name`, nil, scanRepo)
-	// Pre-#1759 these loaders returned `accumulator, rows.Err()`, so a LATE
-	// iteration error arrived WITH the rows already read. Returning nil here
-	// would silently convert an iteration failure into an empty result, which
-	// is the one shape a caller checking only the slice cannot notice.
+	// emptyIfNil (query_list.go) is the whole contract, including the QUERY-time
+	// divergence this justification used to omit: on an early failure these
+	// methods return a non-nil len-0 slice with the error, where the pre-#1759
+	// bodies returned nil. Stated once there rather than restated here, because
+	// six copies of a justification drift and the previous six were already
+	// silent about half of it (#1795 review N4).
 	return emptyIfNil(out), err
 }
 
@@ -196,10 +198,12 @@ func (s *Store) ListGoals(ctx context.Context) ([]Goal, error) {
 			err := row.Scan(&goal.ID, &goal.Title, &goal.Source, &goal.Status)
 			return goal, err
 		})
-	// Pre-#1759 these loaders returned `accumulator, rows.Err()`, so a LATE
-	// iteration error arrived WITH the rows already read. Returning nil here
-	// would silently convert an iteration failure into an empty result, which
-	// is the one shape a caller checking only the slice cannot notice.
+	// emptyIfNil (query_list.go) is the whole contract, including the QUERY-time
+	// divergence this justification used to omit: on an early failure these
+	// methods return a non-nil len-0 slice with the error, where the pre-#1759
+	// bodies returned nil. Stated once there rather than restated here, because
+	// six copies of a justification drift and the previous six were already
+	// silent about half of it (#1795 review N4).
 	return emptyIfNil(out), err
 }
 

--- a/internal/db/store_tasks.go
+++ b/internal/db/store_tasks.go
@@ -84,11 +84,11 @@ func (s *Store) GetRepo(ctx context.Context, fullName string) (Repo, error) {
 func (s *Store) ListRepos(ctx context.Context) ([]Repo, error) {
 	out, err := queryList(ctx, s.db, `SELECT owner, name, default_branch, remote_url, checkout_path, primary_checkout_path, enabled, poll_interval, last_poll_at, last_error
 		FROM repos ORDER BY full_name`, nil, scanRepo)
-	if err != nil {
-		return nil, err
-	}
-	// Promised a non-nil empty slice before #1759 and still does.
-	return emptyIfNil(out), nil
+	// Pre-#1759 these loaders returned `accumulator, rows.Err()`, so a LATE
+	// iteration error arrived WITH the rows already read. Returning nil here
+	// would silently convert an iteration failure into an empty result, which
+	// is the one shape a caller checking only the slice cannot notice.
+	return emptyIfNil(out), err
 }
 
 // HealRepoCheckout atomically replaces a repo checkout only when it still has
@@ -196,11 +196,11 @@ func (s *Store) ListGoals(ctx context.Context) ([]Goal, error) {
 			err := row.Scan(&goal.ID, &goal.Title, &goal.Source, &goal.Status)
 			return goal, err
 		})
-	if err != nil {
-		return nil, err
-	}
-	// Promised a non-nil empty slice before #1759 and still does.
-	return emptyIfNil(out), nil
+	// Pre-#1759 these loaders returned `accumulator, rows.Err()`, so a LATE
+	// iteration error arrived WITH the rows already read. Returning nil here
+	// would silently convert an iteration failure into an empty result, which
+	// is the one shape a caller checking only the slice cannot notice.
+	return emptyIfNil(out), err
 }
 
 func (s *Store) UpsertTask(ctx context.Context, task Task) error {

--- a/internal/db/store_templates.go
+++ b/internal/db/store_templates.go
@@ -101,11 +101,11 @@ func (s *Store) ListAgentTemplates(ctx context.Context) ([]AgentTemplate, error)
 		// interface, which is never identical to queryList's unnamed one, so this
 		// one call site needs an explicit adapter rather than the bare function.
 		func(row rowScanner) (AgentTemplate, error) { return scanAgentTemplateWithVersion(row) })
-	if err != nil {
-		return nil, err
-	}
-	// Promised a non-nil empty slice before #1759 and still does.
-	return emptyIfNil(out), nil
+	// Pre-#1759 these loaders returned `accumulator, rows.Err()`, so a LATE
+	// iteration error arrived WITH the rows already read. Returning nil here
+	// would silently convert an iteration failure into an empty result, which
+	// is the one shape a caller checking only the slice cannot notice.
+	return emptyIfNil(out), err
 }
 
 func (s *Store) GetAgentTemplateReference(ctx context.Context, ref string) (AgentTemplate, error) {

--- a/internal/db/store_templates.go
+++ b/internal/db/store_templates.go
@@ -92,24 +92,20 @@ func (s *Store) GetAgentTemplate(ctx context.Context, id string) (AgentTemplate,
 }
 
 func (s *Store) ListAgentTemplates(ctx context.Context) ([]AgentTemplate, error) {
-	rows, err := s.db.QueryContext(ctx, `SELECT t.id, t.name, t.description, t.source_repo, t.source_ref, t.source_path, t.resolved_commit, t.content, t.metadata_json,
+	out, err := queryList(ctx, s.db, `SELECT t.id, t.name, t.description, t.source_repo, t.source_ref, t.source_path, t.resolved_commit, t.content, t.metadata_json,
 			COALESCE(v.id, ''), COALESCE(v.version, 0), COALESCE(v.state, ''), COALESCE(NULLIF(v.content_hash, ''), ''), t.created_at, t.updated_at
 		FROM agent_templates t
 		LEFT JOIN agent_template_versions v ON v.id = t.current_version_id
-		ORDER BY t.id`)
+		ORDER BY t.id`, nil,
+		// scanAgentTemplateWithVersion takes the DEFINED agentTemplateScanner
+		// interface, which is never identical to queryList's unnamed one, so this
+		// one call site needs an explicit adapter rather than the bare function.
+		func(row rowScanner) (AgentTemplate, error) { return scanAgentTemplateWithVersion(row) })
 	if err != nil {
 		return nil, err
 	}
-	defer rows.Close()
-	templates := []AgentTemplate{}
-	for rows.Next() {
-		template, err := scanAgentTemplateWithVersion(rows)
-		if err != nil {
-			return nil, err
-		}
-		templates = append(templates, template)
-	}
-	return templates, rows.Err()
+	// Promised a non-nil empty slice before #1759 and still does.
+	return emptyIfNil(out), nil
 }
 
 func (s *Store) GetAgentTemplateReference(ctx context.Context, ref string) (AgentTemplate, error) {

--- a/internal/db/store_templates.go
+++ b/internal/db/store_templates.go
@@ -101,10 +101,12 @@ func (s *Store) ListAgentTemplates(ctx context.Context) ([]AgentTemplate, error)
 		// interface, which is never identical to queryList's unnamed one, so this
 		// one call site needs an explicit adapter rather than the bare function.
 		func(row rowScanner) (AgentTemplate, error) { return scanAgentTemplateWithVersion(row) })
-	// Pre-#1759 these loaders returned `accumulator, rows.Err()`, so a LATE
-	// iteration error arrived WITH the rows already read. Returning nil here
-	// would silently convert an iteration failure into an empty result, which
-	// is the one shape a caller checking only the slice cannot notice.
+	// emptyIfNil (query_list.go) is the whole contract, including the QUERY-time
+	// divergence this justification used to omit: on an early failure these
+	// methods return a non-nil len-0 slice with the error, where the pre-#1759
+	// bodies returned nil. Stated once there rather than restated here, because
+	// six copies of a justification drift and the previous six were already
+	// silent about half of it (#1795 review N4).
 	return emptyIfNil(out), err
 }
 

--- a/internal/plugininstall/install.go
+++ b/internal/plugininstall/install.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/gitmoot/gitmoot/internal/buildinfo"
 	"github.com/gitmoot/gitmoot/internal/pluginpack"
+	"github.com/gitmoot/gitmoot/internal/shellquote"
 	"github.com/gitmoot/gitmoot/internal/subprocess"
 )
 
@@ -293,13 +294,13 @@ func manualCommands(provider pluginpack.Provider, marketplaceRoot string, packag
 	switch provider {
 	case pluginpack.ProviderCodex:
 		return []string{
-			"codex plugin marketplace add " + shellQuote(marketplaceRoot),
+			"codex plugin marketplace add " + shellquote.Posix(marketplaceRoot),
 			"codex plugin add " + pluginpack.PluginName + "@" + pluginpack.MarketplaceName,
 		}
 	case pluginpack.ProviderClaude:
 		return []string{
-			"claude plugin validate " + shellQuote(packagePath),
-			"claude plugin marketplace add " + shellQuote(marketplaceRoot) + " --scope " + scope,
+			"claude plugin validate " + shellquote.Posix(packagePath),
+			"claude plugin marketplace add " + shellquote.Posix(marketplaceRoot) + " --scope " + scope,
 			"claude plugin uninstall " + pluginpack.PluginName + "@" + pluginpack.MarketplaceName + " --scope " + scope + " --keep-data 2>/dev/null || true",
 			"claude plugin install " + pluginpack.PluginName + "@" + pluginpack.MarketplaceName + " --scope " + scope,
 		}
@@ -317,36 +318,6 @@ func joinArgs(args []string) string {
 		out += arg
 	}
 	return out
-}
-
-func shellQuote(value string) string {
-	if value == "" {
-		return "''"
-	}
-	for _, r := range value {
-		if !isShellSafe(r) {
-			return "'" + strings.ReplaceAll(value, "'", "'\"'\"'") + "'"
-		}
-	}
-	return value
-}
-
-func isShellSafe(r rune) bool {
-	if r >= 'a' && r <= 'z' {
-		return true
-	}
-	if r >= 'A' && r <= 'Z' {
-		return true
-	}
-	if r >= '0' && r <= '9' {
-		return true
-	}
-	switch r {
-	case '/', '.', '_', '-', '+', '=', ':', ',', '@', '%':
-		return true
-	default:
-		return false
-	}
 }
 
 func pathExists(path string) (bool, error) {

--- a/internal/plugininstall/manual_commands_quote_test.go
+++ b/internal/plugininstall/manual_commands_quote_test.go
@@ -1,0 +1,45 @@
+package plugininstall
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/gitmoot/gitmoot/internal/pluginpack"
+)
+
+// TestManualCommandsQuoteCommaAndPercent pins this call site's #1759 behaviour
+// change, which was unproven: restoring its own pre-#1759 quoter (a wider
+// allowlist admitting ',' and '%') compiled and survived the whole suite.
+//
+// The observable change is exactly that a marketplaceRoot or packagePath
+// containing ',' or '%' is now QUOTED where it previously was not, so that is
+// what this asserts - not the quoter's internals.
+func TestManualCommandsQuoteCommaAndPercent(t *testing.T) {
+	for name, path := range map[string]string{
+		"comma":   "/tmp/repo,with,commas",
+		"percent": "/tmp/repo%name",
+		"both":    "/tmp/a,b%c",
+	} {
+		t.Run(name, func(t *testing.T) {
+			for _, provider := range []pluginpack.Provider{pluginpack.ProviderCodex, pluginpack.ProviderClaude} {
+				for _, command := range manualCommands(provider, path, path, "user") {
+					if !strings.Contains(command, path) {
+						continue
+					}
+					if strings.Contains(command, "'"+path+"'") {
+						continue
+					}
+					t.Errorf("%s command leaves %q unquoted, so a shell would reinterpret it: %s", provider, path, command)
+				}
+			}
+		})
+	}
+
+	// A path needing no quoting must still be emitted bare, so the assertion
+	// above cannot be satisfied by quoting everything.
+	for _, command := range manualCommands(pluginpack.ProviderCodex, "/tmp/plain", "/tmp/plain", "user") {
+		if strings.Contains(command, "'/tmp/plain'") {
+			t.Errorf("a safe path was quoted unnecessarily: %s", command)
+		}
+	}
+}

--- a/internal/shellquote/shellquote.go
+++ b/internal/shellquote/shellquote.go
@@ -43,11 +43,16 @@ import "strings"
 // command line rather than be passed as an empty argument.
 //
 // The allowlist is deliberately narrower than "characters sh happens to treat
-// literally today": it is the set that is safe in every position of every
-// POSIX-compatible shell, so a caller never has to reason about whether its
-// value lands in a command position, an argument, or inside a `[ ... ]` test.
-// Anything else is single-quoted, with embedded single quotes closed, escaped
-// and reopened via the '"'"' idiom.
+// literally today": it is the set that is safe in every ARGUMENT position of
+// every POSIX-compatible shell - after a command name, after a flag, inside a
+// `[ ... ]` test - so a caller passing arguments never has to reason about
+// where its value lands. Anything else is single-quoted, with embedded single
+// quotes closed, escaped and reopened via the '"'"' idiom.
+//
+// COMMAND POSITION IS OUT OF SCOPE, and no allowlist can bring it in: `if` and
+// `FOO=bar` are all-safe-rune yet the shell reads them as a reserved word and an
+// assignment before quoting is consulted. See the package comment; callers own
+// that boundary and gitmoot never builds a command word from this result.
 func Posix(value string) string {
 	if value == "" {
 		return "''"

--- a/internal/shellquote/shellquote.go
+++ b/internal/shellquote/shellquote.go
@@ -1,0 +1,59 @@
+// Package shellquote holds the single POSIX shell quoting implementation.
+//
+// Before #1759 there were four, with four different safe-character policies:
+// an allowlist in internal/update, a slightly wider allowlist in
+// internal/plugininstall (it also admitted ',' and '%'), an unconditional
+// quoter in internal/cockpit, and a DENYLIST in internal/cli's posixQuote that
+// passed '~', '#' and every non-ASCII rune through unquoted. Four policies over
+// twenty-odd call sites is not duplication that can be deleted by picking one
+// at random: each choice is a different answer to "which bytes reach a shell".
+//
+// This package answers it once, with the STRICTEST of the four: quote unless
+// every rune is provably safe. Over-quoting is always correctness-preserving —
+// a quoted string means exactly itself to sh — whereas under-quoting is how a
+// path with a '#' or a '~' becomes a comment or a home-directory expansion.
+package shellquote
+
+import "strings"
+
+// Posix returns value as a single POSIX shell word.
+//
+// The empty string becomes ” because a bare empty word would vanish from the
+// command line rather than be passed as an empty argument.
+//
+// The allowlist is deliberately narrower than "characters sh happens to treat
+// literally today": it is the set that is safe in every position of every
+// POSIX-compatible shell, so a caller never has to reason about whether its
+// value lands in a command position, an argument, or inside a `[ ... ]` test.
+// Anything else is single-quoted, with embedded single quotes closed, escaped
+// and reopened via the '"'"' idiom.
+func Posix(value string) string {
+	if value == "" {
+		return "''"
+	}
+	for _, r := range value {
+		if !safe(r) {
+			return "'" + strings.ReplaceAll(value, "'", `'"'"'`) + "'"
+		}
+	}
+	return value
+}
+
+// safe reports whether r needs no quoting anywhere in a POSIX command line.
+//
+// ',' and '%' are NOT here even though internal/plugininstall's allowlist
+// admitted them and they are in fact literal to sh: the strictest of the four
+// merged policies wins, and quoting them costs two bytes rather than a class of
+// argument nobody re-derives when this list is next edited.
+func safe(r rune) bool {
+	switch {
+	case r >= 'a' && r <= 'z', r >= 'A' && r <= 'Z', r >= '0' && r <= '9':
+		return true
+	}
+	switch r {
+	case '/', '.', '-', '_', ':', '@', '+', '=':
+		return true
+	default:
+		return false
+	}
+}

--- a/internal/shellquote/shellquote.go
+++ b/internal/shellquote/shellquote.go
@@ -23,10 +23,17 @@
 //
 // Callers own that boundary. Every current call site builds `<literal command>
 // <quoted arguments>` — `gh release view <repo>`, `codex plugin marketplace add
-// <root>`, `<gitmootBin> job watch <id>` — so no Posix result ever lands in
-// command position, and gitmootBin is deliberately NOT routed through here. A
-// future caller that needs a computed COMMAND WORD must not use this function
-// and must not assume it protects that position.
+// <root>`, `<gitmootBin> job watch <id>` — and gitmootBin is deliberately NOT
+// routed through here.
+//
+// ONE CALL SITE IS AN EXCEPTION, and an earlier version of this comment claimed
+// otherwise: internal/cli/plugin.go passes args[0] through the quoter when it
+// builds a plugin launch command, so a quoted value CAN land in command
+// position there. It is not exploitable today because the operator supplies
+// that value with --cli, but the general claim "no Posix result ever lands in
+// command position" was false, and a future caller must not rely on it. A
+// caller that needs a computed COMMAND WORD must not use this function and must
+// not assume it protects that position.
 //
 // Deliberately NOT solved by quoting reserved words and assignment-form tokens:
 // that would mean enumerating every shell's reserved list correctly, forever,

--- a/internal/shellquote/shellquote.go
+++ b/internal/shellquote/shellquote.go
@@ -12,6 +12,27 @@
 // every rune is provably safe. Over-quoting is always correctness-preserving —
 // a quoted string means exactly itself to sh — whereas under-quoting is how a
 // path with a '#' or a '~' becomes a comment or a home-directory expansion.
+//
+// SCOPE: ARGUMENT POSITION ONLY. The guarantee is that sh passes the value
+// through as one literal word where a WORD is expected — after a command name,
+// after a flag, inside a `[ ... ]` test. It is NOT a guarantee about COMMAND
+// position, and it cannot be: a bare `if`, `while` or `!` is a reserved word
+// there, and a bare `FOO=bar` is a variable assignment, so the shell reinterprets
+// them before any quoting question arises. Both are returned unquoted by Posix
+// because both are safe as arguments, which is the only position gitmoot uses.
+//
+// Callers own that boundary. Every current call site builds `<literal command>
+// <quoted arguments>` — `gh release view <repo>`, `codex plugin marketplace add
+// <root>`, `<gitmootBin> job watch <id>` — so no Posix result ever lands in
+// command position, and gitmootBin is deliberately NOT routed through here. A
+// future caller that needs a computed COMMAND WORD must not use this function
+// and must not assume it protects that position.
+//
+// Deliberately NOT solved by quoting reserved words and assignment-form tokens:
+// that would mean enumerating every shell's reserved list correctly, forever,
+// which is precisely the denylist defect this package replaced. Narrowing a
+// documented contract to what the code actually guarantees is the cheaper and
+// more honest fix (#1759, review of PR #1795).
 package shellquote
 
 import "strings"

--- a/internal/shellquote/shellquote_test.go
+++ b/internal/shellquote/shellquote_test.go
@@ -1,0 +1,107 @@
+package shellquote
+
+import (
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+// TestPosixQuotesWhereTheOldImplementationsDisagreed pins the policy at exactly
+// the inputs that separated the four pre-#1759 implementations. A test built
+// only from obvious cases (a space, a quote) would pass against all four and
+// would therefore not pin the consolidation at all.
+//
+// Each case names which old implementation it corrects, so a future reader can
+// tell a deliberate policy from an accident.
+func TestPosixQuotesWhereTheOldImplementationsDisagreed(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		in    string
+		want  string
+		fixes string
+	}{
+		{
+			name: "tilde", in: "~/bin/gitmoot", want: `'~/bin/gitmoot'`,
+			fixes: "cli.posixQuote's denylist passed ~ through, so sh would expand it",
+		},
+		{
+			name: "hash", in: "v1#2", want: `'v1#2'`,
+			fixes: "cli.posixQuote's denylist passed # through, starting a comment",
+		},
+		{
+			name: "non-ascii", in: "café", want: `'café'`,
+			fixes: "cli.posixQuote's denylist passed every non-ASCII rune through",
+		},
+		{
+			name: "comma", in: "a,b", want: `'a,b'`,
+			fixes: "plugininstall's allowlist admitted ','; the strictest policy wins",
+		},
+		{
+			name: "percent", in: "100%", want: `'100%'`,
+			fixes: "plugininstall's allowlist admitted '%'",
+		},
+		{
+			name: "safe path stays bare", in: "/root/.gitmoot/x.log", want: "/root/.gitmoot/x.log",
+			fixes: "cockpit quoted unconditionally; a fully-safe word needs no quotes",
+		},
+		{
+			name: "empty", in: "", want: "''",
+			fixes: "a bare empty word would vanish instead of being an empty argument",
+		},
+		{
+			name: "embedded single quote", in: "it's", want: `'it'"'"'s'`,
+			fixes: "cockpit used the '\\'' idiom, so its output bytes differed",
+		},
+		{
+			name: "space", in: "a b", want: `'a b'`,
+			fixes: "all four agreed here - included so the table is not only edge cases",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := Posix(tc.in); got != tc.want {
+				t.Fatalf("Posix(%q) = %q, want %q (%s)", tc.in, got, tc.want, tc.fixes)
+			}
+		})
+	}
+}
+
+// TestPosixRoundTripsThroughARealShell is the half that matters: the assertions
+// above pin BYTES, which a wrong-but-consistent implementation would also
+// satisfy. This one hands the quoted word to /bin/sh and checks the shell hands
+// back the original string, so the property under test is "sh sees exactly this
+// value" rather than "the function returns the string I expected".
+func TestPosixRoundTripsThroughARealShell(t *testing.T) {
+	sh, err := exec.LookPath("sh")
+	if err != nil {
+		t.Skipf("no sh on PATH: %v", err)
+	}
+	for _, in := range []string{
+		"", "plain", "/root/.gitmoot/x.log", "a b", "it's", "~/bin", "v1#2", "café",
+		"a,b", "100%", `$HOME`, "back\\slash", "a\tb", "semi;colon", "pipe|d",
+		"glob*", "sub$(echo hi)", "back`tick`", "new\nline", `dq"uote`,
+	} {
+		// printf %s with the quoted word as its sole argument: whatever sh
+		// parses is what a real command would have received.
+		out, err := exec.Command(sh, "-c", "printf %s "+Posix(in)).Output()
+		if err != nil {
+			t.Fatalf("sh rejected Posix(%q) = %s: %v", in, Posix(in), err)
+		}
+		if string(out) != in {
+			t.Fatalf("Posix(%q) = %s -> sh saw %q, want %q", in, Posix(in), string(out), in)
+		}
+	}
+}
+
+// TestPosixNeverEmitsAnUnquotedMetacharacter is the invariant behind the
+// allowlist, stated independently of the table above so that adding a character
+// to safe() without thinking fails here rather than in production.
+func TestPosixNeverEmitsAnUnquotedMetacharacter(t *testing.T) {
+	const meta = " \t\r\n'\"\\$`!&;()<>|*?[]{}~#,%^"
+	for _, r := range meta {
+		in := "a" + string(r) + "b"
+		got := Posix(in)
+		if !strings.HasPrefix(got, "'") {
+			t.Fatalf("Posix(%q) = %q left metacharacter %q unquoted", in, got, string(r))
+		}
+	}
+}

--- a/internal/shellquote/shellquote_test.go
+++ b/internal/shellquote/shellquote_test.go
@@ -105,3 +105,76 @@ func TestPosixNeverEmitsAnUnquotedMetacharacter(t *testing.T) {
 		}
 	}
 }
+
+// TestPosixArgumentPositionHoldsForReservedAndAssignmentTokens pins the NARROWED
+// contract from the #1795 review: `if` and `FOO=bar` come back unquoted, and
+// that is correct BECAUSE the guarantee is argument position only.
+//
+// Both are then round-tripped through a real /bin/sh in argument position, which
+// is the assertion that matters: the value the shell hands the command must be
+// the original string, reserved word or not.
+func TestPosixArgumentPositionHoldsForReservedAndAssignmentTokens(t *testing.T) {
+	sh, err := exec.LookPath("sh")
+	if err != nil {
+		t.Skipf("no sh on PATH: %v", err)
+	}
+	// Reserved WORDS and assignment-form tokens are all-safe-rune, so they come
+	// back bare. '!' is deliberately NOT in this list: it is a metacharacter
+	// (negation, and history expansion in an interactive shell) and IS quoted -
+	// asserting otherwise was this test's own first mistake.
+	for _, in := range []string{"if", "while", "then", "FOO=bar", "PATH=/tmp"} {
+		quoted := Posix(in)
+		if quoted != in {
+			t.Fatalf("Posix(%q) = %q; these tokens are argument-safe and should stay bare", in, quoted)
+		}
+		// Argument position: printf's first operand. This is how every gitmoot
+		// call site uses the result.
+		out, err := exec.Command(sh, "-c", "printf %s "+quoted).Output()
+		if err != nil {
+			t.Fatalf("sh rejected %q in argument position: %v", quoted, err)
+		}
+		if string(out) != in {
+			t.Fatalf("argument position: sh saw %q, want %q", string(out), in)
+		}
+	}
+
+	// Whether a token is quoted or not, argument position must round-trip. '!'
+	// belongs here rather than above: it is quoted, and still arrives intact.
+	for _, in := range []string{"!", "if", "FOO=bar"} {
+		out, err := exec.Command(sh, "-c", "printf %s "+Posix(in)).Output()
+		if err != nil {
+			t.Fatalf("sh rejected Posix(%q) = %s: %v", in, Posix(in), err)
+		}
+		if string(out) != in {
+			t.Fatalf("argument position: Posix(%q) -> sh saw %q", in, string(out))
+		}
+	}
+}
+
+// TestPosixDoesNotClaimCommandPosition is the negative half, and it exists so the
+// limitation is DEMONSTRATED rather than only documented. `FOO=bar` in command
+// position is an assignment: the shell runs no command and produces no output,
+// which is exactly the reinterpretation the package doc now disclaims.
+//
+// If a future change made Posix quote assignment-form tokens, this test fails and
+// tells the author to widen the documented contract deliberately rather than by
+// accident.
+func TestPosixDoesNotClaimCommandPosition(t *testing.T) {
+	sh, err := exec.LookPath("sh")
+	if err != nil {
+		t.Skipf("no sh on PATH: %v", err)
+	}
+	assignment := Posix("FOO=bar")
+	if assignment != "FOO=bar" {
+		t.Fatalf("Posix(\"FOO=bar\") = %q; if this is now quoted, the package doc's argument-position scope must be widened on purpose", assignment)
+	}
+	// Command position: the shell treats it as an assignment, so `printf` never
+	// runs and nothing is written.
+	out, err := exec.Command(sh, "-c", assignment).Output()
+	if err != nil {
+		t.Fatalf("sh -c %q errored unexpectedly: %v", assignment, err)
+	}
+	if len(out) != 0 {
+		t.Fatalf("command position produced %q; the assignment reinterpretation this test documents did not occur", string(out))
+	}
+}

--- a/internal/update/update.go
+++ b/internal/update/update.go
@@ -14,6 +14,7 @@ import (
 	"strings"
 
 	"github.com/gitmoot/gitmoot/internal/buildinfo"
+	"github.com/gitmoot/gitmoot/internal/shellquote"
 	"github.com/gitmoot/gitmoot/internal/subprocess"
 )
 
@@ -96,7 +97,7 @@ func Check(ctx context.Context, client ReleaseClient, repo string, current build
 			CurrentVersion: current.Version,
 			LatestVersion:  "none",
 			NoRelease:      true,
-			ManualCommands: []string{"gh release view --repo " + shellQuote(repo)},
+			ManualCommands: []string{"gh release view --repo " + shellquote.Posix(repo)},
 		}, nil
 	}
 	if err != nil {
@@ -153,15 +154,15 @@ func Apply(ctx context.Context, runner subprocess.Runner, repo string, check Che
 func ManualCommands(repo string, tag string, asset *Asset, executable string) []string {
 	if asset == nil {
 		return []string{
-			"gh release view " + shellQuote(tag) + " --repo " + shellQuote(repo),
-			"gh release download " + shellQuote(tag) + " --repo " + shellQuote(repo) + " --dir /tmp/gitmoot-update",
+			"gh release view " + shellquote.Posix(tag) + " --repo " + shellquote.Posix(repo),
+			"gh release download " + shellquote.Posix(tag) + " --repo " + shellquote.Posix(repo) + " --dir /tmp/gitmoot-update",
 		}
 	}
 	downloadPath := "/tmp/gitmoot-update/" + asset.Name
 	return []string{
 		"mkdir -p /tmp/gitmoot-update",
-		"gh release download " + shellQuote(tag) + " --repo " + shellQuote(repo) + " --pattern " + shellQuote(asset.Name) + " --output " + shellQuote(downloadPath),
-		"install -m 0755 " + shellQuote(downloadPath) + " " + shellExecutable(executable),
+		"gh release download " + shellquote.Posix(tag) + " --repo " + shellquote.Posix(repo) + " --pattern " + shellquote.Posix(asset.Name) + " --output " + shellquote.Posix(downloadPath),
+		"install -m 0755 " + shellquote.Posix(downloadPath) + " " + shellExecutable(executable),
 	}
 }
 
@@ -309,23 +310,11 @@ func replaceExecutable(source string, target string) error {
 	return os.Remove(backup)
 }
 
-func shellQuote(value string) string {
-	if value == "" {
-		return "''"
-	}
-	if strings.IndexFunc(value, func(r rune) bool {
-		return !(r == '/' || r == '.' || r == '-' || r == '_' || r == ':' || r == '@' || r == '+' || r == '=' || r >= '0' && r <= '9' || r >= 'A' && r <= 'Z' || r >= 'a' && r <= 'z')
-	}) == -1 {
-		return value
-	}
-	return "'" + strings.ReplaceAll(value, "'", "'\"'\"'") + "'"
-}
-
 func shellExecutable(value string) string {
 	if strings.TrimSpace(value) == "" {
 		return "$(command -v gitmoot)"
 	}
-	return shellQuote(value)
+	return shellquote.Posix(value)
 }
 
 func commandError(result subprocess.Result, err error) error {


### PR DESCRIPTION
Refs #1759. The enumerated tranche only — the under-60 residual is **#1792**, per owner authorization 107705 / directives 107708 and 107726.

Five commits, each independently reviewable and revertable. Base `origin/main` 4d32d086.

## What shipped

| commit | what |
|---|---|
| `5d29942b` | cockpit space-free injection test |
| `35149786` | one POSIX quoter replacing four policies |
| `15b1cf39` | `queryList` across 11 list methods, net −81 non-test lines |
| `74fd0ae7` | MAX/MIN job-event twins folded into one body |
| `8fa5ba0d` | pin `disk_guard`'s malformed-header reset — it was unpinned |

## `shellQuote` was four policies, not a clone group

| impl | safe-char policy | escape idiom |
|---|---|---|
| `update` | allowlist `/.-_:@+=` | `'"'"'` |
| `plugininstall` | allowlist + `,` `%` | `'"'"'` |
| `cockpit` | **none** — always quoted | `'\''` |
| `cli` `posixQuote` | **denylist** | `'\''` |

Consolidated on the strictest, per ruling 107582. The exposure is **position-dependent**: `#` starts a comment only at word start and `~` expands only at word start, so the hazard is a value *beginning* with one — not any value containing them. Non-ASCII passing bare is harmless for quoting.

**Four directions of change**, and the fourth was found by the test suite after an earlier draft of the commit message listed three:

1. `internal/cli` (~10 sites): **tighter** — `~`, `#`, `,`, `%`, non-ASCII now quoted.
2. `internal/cockpit` (5 sites): bytes differ, semantics identical — safe words render bare; six expectations updated.
3. `update`/`plugininstall` (9 sites): unchanged except `,` and `%` now quote.
4. `cockpit` **and** `cli`: idiom moves `'\''` → `'"'"'`. `TestFormatCodexLaunchCommandQuotesShellArguments` pinned the old form; updated.

`internal/cli` keeps its two-arg `shellQuote` — powershell dispatch is a feature, not duplication.

**Live paths to attack:** the Claude SessionStart hook via `plugininstall`, and cockpit's tmux command construction.

## `queryList`: the trap was nil-vs-empty

Five of the converted methods returned `nil` for an empty table; six returned `[]`. A nil slice marshals to JSON `null`, and `ListDashboardBlockedJobs` is served straight to the dashboard client. #1752 shipped exactly that defect in the other direction.

So the helper **refuses to decide**: it returns nil, and each of the six says `emptyIfNil` explicitly — which also means `grep emptyIfNil` enumerates the promises. Both flip directions are mutation-proven; no length or round-trip assertion can see that flip.

`rowScanner` is a type **alias**, not a defined type: a defined interface is never identical to an unnamed one, so `func(rowScanner)` wouldn't match the existing `scanX` helpers and inference would fail.

## Two items not consolidated, with evidence

**Org episode stores — declined, upheld by 107666.** The issue calls them line-for-line clones. Measured **119 vs 65** lines: `BlockedEpisode` has 6 fields, `RecycleOverdueEpisode` 4; columns differ (`blocked_since` vs `overdue_since`); `blocked` has an asymmetric compare-and-set method. Parameterising table + column + row type to share ~25–30 SQL lines adds more mechanism than it removes, on the live escalation ladder, for two tables holding **0 rows**.

**`scanSection` — not attempted.** 21 scanners ignore a malformed header; 2 deliberately end the section (`tool_cache`, `disk_guard`), citing the #1113 finder. That's the same preserve-or-change policy question as `shellQuote`, and 107582 was scoped to `shellQuote`; I did not extend it by analogy. Two further corrections: `agent_types.go`'s resets are a section switch and the #533 phantom-agent guard, not malformed-header handling, and `memory_pipelines.go` is an arrays-of-tables parser. The issue's "39 scanners" is really 21 plain + 2 reset + 2 bespoke + 3 writers.

## `disk_guard` was unpinned

Deleting `tool_cache`'s reset fails `TestLoadToolCache`. Deleting `disk_guard`'s left all of `internal/config` **green**. Two files sharing one deliberate behaviour with asymmetric coverage — so a shared scanner could drop the reset and be caught for one and not the other. **Partial detection reads as full detection.** Now pinned and mutation-proven.

## dupl, measured three ways

| tree | groups |
|---|---|
| `dc10bab3` (audit tree; issue's own figure) | **137** |
| `origin/main` 4d32d086 | **99** |
| this head `8fa5ba0d` | **94** |

137 matches the issue body exactly, which is what makes the comparison a real one rather than a tool difference. The deletions in #1752/#1754/#1757 did the heavy lifting (137→99); the enumerated items are worth ~5, not the ~39 the under-60 target assumed. Only **5** groups sit entirely in `internal/config`, so even completing `scanSection` reaches ~89 — the residual is `internal/db` (39 groups) and `internal/cli` (33), which is **#1792**.

## Gate at `8fa5ba0d`

`gofmt` clean · `go build ./...` · `go vet ./...` · `go generate ./...` clean diff · full suite **rc=0, 41 packages** · `-race` **rc=0** on `internal/{db,cockpit,shellquote,update,plugininstall,cli,config}`.
