### PR TITLE
docs: make the deploy build command work in a worktree (#1800)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -265,16 +265,37 @@ detection.
    checkout, which usually carries uncommitted work. Stamp the version the way
    `release.yml` does, or `gitmoot version` reports `commit: unknown`.
    `-buildvcs=false` is required for the same reason as the test gate above: in
-   a linked worktree `.git` is a file, so Go's VCS stamp fails with
-   `error obtaining VCS status: exit status 128`.
+   a linked worktree `.git` is a **file**, which Go never accepts as a
+   repository root, so it walks up to the parent directories. Both outcomes of
+   that walk are wrong, and only one of them is loud:
+
+   - no repository above the worktree: the build **fails** with
+     `error obtaining VCS status: exit status 128`;
+   - an unrelated repository above it: the build **succeeds** and stamps that
+     repository's metadata. Measured on this host with a throwaway module: a
+     binary built from commit `03cf3963` embedded the ancestor's
+     `vcs.revision 866bf37b` and `vcs.modified true`.
+
+   The silent case is the one to design against. The `-ldflags` below override
+   `Commit`, so `gitmoot version` still prints the right value and the wrong
+   stamp stays hidden in the embedded build info. Drop the ldflags and
+   `buildinfo.Current` falls back to that VCS revision
+   (`internal/buildinfo/buildinfo.go`), so an unstamped binary reports the
+   ancestor's commit as its own and the daemon build-skew check compares a
+   false identity rather than an unknown one.
 
    ```sh
+   git worktree add --detach /root/gitmoot-deploy "$(git rev-parse HEAD)"
+   cd /root/gitmoot-deploy
    PKG=github.com/gitmoot/gitmoot/internal/buildinfo
    CGO_ENABLED=0 go build -trimpath -buildvcs=false -ldflags \
      "-s -w -X $PKG.Version=dev-$(git rev-parse --short HEAD) \
       -X $PKG.Commit=$(git rev-parse HEAD) -X $PKG.Date=$(date -Iseconds)" \
      -o /root/.local/bin/gitmoot.new ./cmd/gitmoot
    ```
+
+   Remove the deploy worktree when the deploy is done:
+   `git worktree remove /root/gitmoot-deploy`.
 
 2. `mv`-rename the new binary into `/root/.local/bin/gitmoot` (same filesystem;
    the rename avoids `ETXTBSY`).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -106,15 +106,14 @@ go test -timeout 25m -skip 'TestClaudeProduceHookAutoReadLandlockE2E' ./...
 `-buildvcs=false` is required, not optional, inside a gitmoot worktree (#1209):
 Go's VCS auto-stamp only recognizes a `.git` **directory** as a repo root
 (`cmd/go/internal/vcs.vcsGit.RootNames`), but a linked worktree's `.git` is a
-**file** (a `gitdir:` pointer). Go's root-detection walk-up skips past the
-worktree's real root looking for any ancestor with a `.git`-shaped directory,
-and can land on an unrelated one — hard-failing with `error obtaining VCS
-status: exit status 128` even though `git status` itself works fine from the
-same directory. This is a genuine Go toolchain limitation with linked
-worktrees (confirmed by reading `cmd/go/internal/vcs/vcs.go`'s `FromDir` /
-`isVCSRoot`), not something gitmoot's code or config can fix, and even the
-non-failing cases can silently stamp the wrong VCS metadata (wrong commit,
-wrong dirty bit) from whatever directory the walk-up happened to land on.
+**file** (a `gitdir:` pointer), so the root-detection walk-up skips the
+worktree's real root and keeps going up. What happens next depends on what the
+walk finds, and it is stated once in the deploy recipe below rather than twice
+here: see "Deploy recipe (this host)", step 1. The short version is that the
+quiet outcome is the dangerous one, not the `exit status 128` failure. This is a
+Go toolchain behavior with linked worktrees, not something gitmoot's code or
+config can fix.
+
 Disabling it here costs nothing real: release binaries get their version
 info from the explicit `-ldflags -X ...Commit=$(git rev-parse HEAD)` recipe
 in the deploy section below, never from Go's auto-stamp.
@@ -272,10 +271,13 @@ detection.
 
    - **no repository anywhere above it**: the build succeeds and simply omits
      the stamp. This case is tolerated, not an error;
-   - **a `.git` that is not a valid repository**: the build **fails** with
-     `error obtaining VCS status: exit status 128`. This is not hypothetical
-     here: `/tmp/.git` exists on this host as an empty directory, so a deploy
-     worktree anywhere under `/tmp` hits it;
+   - **a `.git` DIRECTORY above it that git rejects as a repository**: the build
+     **fails** with `error obtaining VCS status: exit status 128`. A `.git`
+     **file** never produces this: it is skipped, and the walk continues past
+     it. This is not hypothetical here: `/tmp/.git` exists on this host as a
+     directory (`ls -A` returns nothing, and `git -C /tmp status` fails), so a
+     deploy worktree anywhere under `/tmp` hits it, and it will not be the only
+     such directory on any given host;
    - **a working unrelated repository above it**: the build **succeeds** and
      stamps that repository's metadata. A binary built from commit `1f76f143`
      embedded the ancestor's `vcs.revision 60f8282c` and `vcs.modified true`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -265,24 +265,32 @@ detection.
    checkout, which usually carries uncommitted work. Stamp the version the way
    `release.yml` does, or `gitmoot version` reports `commit: unknown`.
    `-buildvcs=false` is required for the same reason as the test gate above: in
-   a linked worktree `.git` is a **file**, which Go never accepts as a
-   repository root, so it walks up to the parent directories. Both outcomes of
-   that walk are wrong, and only one of them is loud:
+   a linked worktree `.git` is a **file**, which the pinned toolchain does not
+   treat as a repository root, so it walks up to the parent directories. What
+   that walk finds decides the outcome. Measured with a throwaway module on
+   go1.26.4:
 
-   - no repository above the worktree: the build **fails** with
-     `error obtaining VCS status: exit status 128`;
-   - an unrelated repository above it: the build **succeeds** and stamps that
-     repository's metadata. Measured on this host with a throwaway module: a
-     binary built from commit `03cf3963` embedded the ancestor's
-     `vcs.revision 866bf37b` and `vcs.modified true`.
+   - **no repository anywhere above it**: the build succeeds and simply omits
+     the stamp. This case is tolerated, not an error;
+   - **a `.git` that is not a valid repository**: the build **fails** with
+     `error obtaining VCS status: exit status 128`. This is not hypothetical
+     here: `/tmp/.git` exists on this host as an empty directory, so a deploy
+     worktree anywhere under `/tmp` hits it;
+   - **a working unrelated repository above it**: the build **succeeds** and
+     stamps that repository's metadata. A binary built from commit `1f76f143`
+     embedded the ancestor's `vcs.revision 60f8282c` and `vcs.modified true`.
 
-   The silent case is the one to design against. The `-ldflags` below override
-   `Commit`, so `gitmoot version` still prints the right value and the wrong
-   stamp stays hidden in the embedded build info. Drop the ldflags and
-   `buildinfo.Current` falls back to that VCS revision
-   (`internal/buildinfo/buildinfo.go`), so an unstamped binary reports the
+   The third case is the one to design against, because it is silent. The
+   `-ldflags` below override `Commit`, so `gitmoot version` still prints the
+   right value and the wrong stamp stays hidden in the embedded build info.
+   Drop the ldflags and `buildinfo.Current` falls back to that VCS revision
+   (`internal/buildinfo/buildinfo.go`), so an unstamped binary reports an
    ancestor's commit as its own and the daemon build-skew check compares a
    false identity rather than an unknown one.
+
+   Treat the `.git`-file behavior as version-specific rather than permanent:
+   Go's handling of it is being changed upstream, and `-buildvcs=false` is what
+   makes all three outcomes moot.
 
    ```sh
    git worktree add --detach /root/gitmoot-deploy "$(git rev-parse HEAD)"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -260,13 +260,17 @@ detection.
 
 ## Deploy recipe (this host)
 
-1. On `main` after merge, build with the pinned toolchain (above). Stamp the
-   version the way `release.yml` does, or `gitmoot version` reports
-   `commit: unknown`:
+1. On `main` after merge, build with the pinned toolchain (above), from a clean
+   detached worktree at the exact tip rather than the shared `/root/gitmoot`
+   checkout, which usually carries uncommitted work. Stamp the version the way
+   `release.yml` does, or `gitmoot version` reports `commit: unknown`.
+   `-buildvcs=false` is required for the same reason as the test gate above: in
+   a linked worktree `.git` is a file, so Go's VCS stamp fails with
+   `error obtaining VCS status: exit status 128`.
 
    ```sh
    PKG=github.com/gitmoot/gitmoot/internal/buildinfo
-   CGO_ENABLED=0 go build -trimpath -ldflags \
+   CGO_ENABLED=0 go build -trimpath -buildvcs=false -ldflags \
      "-s -w -X $PKG.Version=dev-$(git rev-parse --short HEAD) \
       -X $PKG.Commit=$(git rev-parse HEAD) -X $PKG.Date=$(date -Iseconds)" \
      -o /root/.local/bin/gitmoot.new ./cmd/gitmoot


### PR DESCRIPTION
Closes #1800. Authorization: workflow row 108168.

The deploy recipe told you to build clean and then handed you a command that fails in a worktree. Reproduced at `fa5acf4b`:

```
error obtaining VCS status: exit status 128
	Use -buildvcs=false to disable VCS stamping.
```

The gate section already explains why (`.git` is a file in a linked worktree, #1209); only the deploy step omitted the flag. This adds `-buildvcs=false`, says to build from a clean detached worktree rather than the shared `/root/gitmoot` checkout, and cross-references the existing reason.

## Verification

- Documented command before this change, in a detached worktree: exit 1 with the VCS error.
- Corrected command run verbatim: exit 0, and the artifact reports `gitmoot dev-fa5acf4b`, `commit: fa5acf4bada59826ef0cb50465903e05ed7ec839`, `go: go1.26.4` — so the stamp still works with the flag.
- `git diff --check` clean. No website/docs copy of this recipe exists (grepped `buildinfo`, `gitmoot.new`, `dashboard-web.new`).

Docs only; no runtime change.