### PR TITLE
fix(review): declare what each runtime needs staged into a read-only seat

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -754,6 +754,35 @@ is missing - or a seat that cannot reach a provider - can find out why:
 gitmoot job events <job-id> | grep read_only_seat_config_narrowed
 ```
 
+### Two more refusals, and what gateway mode withholds
+
+Narrowing reads the file with ONE scanner shared by narrowing and provider
+selection, so escapes, comments, multi-line strings and unbalanced brackets are
+interpreted identically everywhere. Two shapes are refused rather than staged,
+because in both cases part of the file could not be classified, and staging an
+unclassified tail is the leak the narrowing exists to prevent:
+
+- `config has an array or inline table that never closes` - an unbalanced `[`
+  or `{` reached the end of the file.
+- `config has a multi-line string that never closes` - as before.
+
+A triple delimiter inside a COMMENT or inside a single-line string is not a
+multi-line string, and a backslash-escaped quote is valid TOML that stages
+unchanged.
+
+One provider shape is refused for a different reason:
+
+- `codex model_provider "<name>" authenticates only through env_key, and a
+  read-only seat's environment allowlist does not pass that variable through` -
+  set an inline `api_key` for that provider, or point `model_provider` at one
+  the seat can reach. Previously this staged cleanly and the seat failed later
+  with the runtime's own message.
+
+In GATEWAY mode the gateway supplies the credential, so a gateway seat stages
+NO credential file for any runtime - claude's `.credentials.json`, codex's
+`auth.json` and kimi's `credentials/kimi-code.json` are all withheld. Model
+settings are still staged, narrowed as above.
+
 ## Worktrees consume too much disk
 
 The daemon checks task-owned worktrees every five minutes. A task is eligible

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -718,6 +718,42 @@ Dotted and quoted forms are classified the same way, so
 `mcp_servers.github.env.TOKEN = "..."` at the top level and
 `[mcp_servers."my server".env]` are both dropped.
 
+### The staged kimi config.toml is narrowed too
+
+kimi's `config.toml` is REQUIRED, and it carries more than codex's does:
+measured on a live host, `api_key` under `[services.*]` and a key under
+`[services.*.oauth]` alongside `[providers.*]`. For kimi the staged copy lands
+directly inside the seat's writable root, so it is narrowed on the same rule:
+
+- `[services.*]` is dropped ENTIRELY. It configures optional tooling (moonshot
+  search and fetch) and carries those tools' credentials.
+- `[providers.*]` keeps its structure and keeps `api_key` and its `env`
+  sub-table ONLY for the provider `default_model` resolves to - the model's
+  segment before the first `/` matched against the provider name's segment
+  after the last `:`, so `default_model = "kimi-code/k3"` selects
+  `[providers."managed:kimi-code"]`. Dropping every provider credential is not
+  an option: kimi refuses to start when both `api_key` and the `env` sub-table
+  are absent, so the seat legitimately needs exactly one.
+- If NO provider can be resolved, or two match ambiguously, every provider
+  credential is withheld. A credential nobody can prove is needed is not
+  staged.
+
+The same rule now applies to codex: `[model_providers.*]` keeps `api_key` and
+`http_headers` for the provider `model_provider` selects and strips every
+other. Stripping the selected provider's key too left the seat unable to
+authenticate at all, because `env_key` names a variable the sandbox's
+environment allowlist does not pass through.
+
+### Finding out what was withheld
+
+Narrowing is not silent. When anything is withheld the job records a
+`read_only_seat_config_narrowed` event naming it, so a reviewer whose MCP tool
+is missing - or a seat that cannot reach a provider - can find out why:
+
+```sh
+gitmoot job events <job-id> | grep read_only_seat_config_narrowed
+```
+
 ## Worktrees consume too much disk
 
 The daemon checks task-owned worktrees every five minutes. A task is eligible

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -783,6 +783,33 @@ NO credential file for any runtime - claude's `.credentials.json`, codex's
 `auth.json` and kimi's `credentials/kimi-code.json` are all withheld. Model
 settings are still staged, narrowed as above.
 
+### Comments, and what a seat does when a config cannot be narrowed
+
+Narrowing classifies the COMMENT-FREE part of each line and stages the line
+unchanged, so an ordinary TOML comment cannot change what is withheld. Both
+directions were defects: `[services] # see [docs]` used to have the comment's
+`]` swallowed into the section name, staging that section's secrets verbatim,
+and `default_model = "kimi-code/k3" # pinned` used to make the comment part of
+the provider name, withholding the one credential the seat needs. Your comments
+survive into the staged file.
+
+A key/value pair is split on the first `=` OUTSIDE quotes, so a quoted key
+containing `=` is kept rather than dropped.
+
+**A config that cannot be narrowed is treated by whether the runtime needs it:**
+
+- codex's `config.toml` is OPTIONAL. If it cannot be narrowed - an unbalanced
+  `[` or `{` at end of file, an unreadable section header, or a selected
+  provider that can only authenticate through `env_key` - the seat starts
+  WITHOUT it and falls back to the runtime default. The file is not staged and
+  the reason is named in the `read_only_seat_config_narrowed` job event.
+- kimi's `config.toml` is REQUIRED, so the same refusal fails the seat by name.
+  kimi cannot start without it, and a silent fallback would surface later as
+  "No model configured".
+
+In GATEWAY mode no runtime stages a credential file, and the policy the seat
+computes says so rather than naming files it then withholds.
+
 ## Worktrees consume too much disk
 
 The daemon checks task-owned worktrees every five minutes. A task is eligible

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -660,6 +660,64 @@ Fixes:
   then abstains from its native merge gate — fail-closed, it never merges
   gatelessly; the external gate makes the call.
 
+## Read-Only Reviewer Seat Refuses To Start
+
+A read-only seat runs the runtime against an ISOLATED home rather than yours, so
+anything the runtime reads at startup must be staged into that home first. When
+a startup input is missing, Gitmoot now fails BY NAME instead of letting the
+runtime report something unrelated.
+
+Symptoms:
+
+- `read-only seat requires runtime input "config.toml", and <path> does not
+  exist` - the host profile has no such file. This is a HARD PREREQUISITE for
+  kimi: `~/.kimi-code/config.toml` must exist on the host, or the seat cannot
+  start. Previously this surfaced as "No model configured" behind an auth
+  message that pointed at `kimi login`, which cannot fix it.
+- `runtime input "<path>" must be a regular file` - the path is a directory,
+  socket, device or fifo. A SYMLINK is fine and is followed, so a
+  stow/chezmoi-managed profile works; a symlink whose target is missing counts
+  as missing, and a symlink to a directory is refused.
+- `read-only seat credential <path> is unusable: claudeAiOauth expired at
+  <time> and carries no refreshToken` - the profile stages and parses but cannot
+  authenticate. Re-authenticate the host claude profile. An expired token WITH a
+  refresh token is accepted, because refreshing it is the runtime's job.
+- `narrow runtime input "<path>": codex config.toml has a section header that is
+  not readable` - the file has a section header that never closes, so Gitmoot
+  cannot locate the credentials it must strip. It refuses rather than stage a
+  file it cannot classify. Fix the TOML or remove it from the host state dir.
+
+What the seat stages, per runtime:
+
+| runtime | staged from | inputs |
+| --- | --- | --- |
+| claude | `~/.claude` | `.credentials.json`, narrowed to `claudeAiOauth` and checked for usability. Nothing is staged in gateway mode, where the gateway supplies the credential. |
+| codex | `~/.codex` | `auth.json`, plus `config.toml` when present - NARROWED, see below |
+| kimi | `~/.kimi-code` | `config.toml` (REQUIRED), `credentials/kimi-code.json` |
+
+### Why the staged codex config.toml is not a copy
+
+The seat's staged state lives inside the one writable path granted to the
+sandbox, so a reviewer can read anything placed there. A codex `config.toml`
+routinely carries credentials that have nothing to do with running the model, so
+Gitmoot narrows it before staging:
+
+- `[mcp_servers.*]` is dropped ENTIRELY. Its `env` table holds tokens, `args`
+  can hold them just as easily, and a read-only reviewer seat has no business
+  spawning third-party servers. MCP servers are optional to codex, so dropping
+  them cannot stop the seat starting.
+- `[model_providers.*]` KEEPS its structure and loses only `api_key` and
+  `http_headers`. Dropping the section would look stricter and would break a
+  custom `model`, because removing `base_url` and `wire_api` makes the provider
+  unresolvable. `env_key` and `env_http_headers` name environment variables
+  rather than hold values, so they stay.
+- Everything else is kept: those are the model and sandbox settings the file is
+  staged for.
+
+Dotted and quoted forms are classified the same way, so
+`mcp_servers.github.env.TOKEN = "..."` at the top level and
+`[mcp_servers."my server".env]` are both dropped.
+
 ## Worktrees consume too much disk
 
 The daemon checks task-owned worktrees every five minutes. A task is eligible

--- a/internal/cli/agent_dispatch.go
+++ b/internal/cli/agent_dispatch.go
@@ -33,7 +33,10 @@ var localAgentDispatchRuntimeAdapterFor foregroundRuntimeAdapterFactory = func(h
 	if err != nil {
 		return nil, err
 	}
-	delivery, err := wrapReadOnlySandboxAdapter(home, agent, checkout, adapter)
+	// The withheld-config report is dropped here deliberately: foreground
+	// dispatch has no job row to attach an event to, and the same narrowing is
+	// recorded by the daemon path that runs seats unattended.
+	delivery, _, err := wrapReadOnlySandboxAdapter(home, agent, checkout, adapter)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/cli/agent_dispatch.go
+++ b/internal/cli/agent_dispatch.go
@@ -396,6 +396,10 @@ func dispatchLocalAgentJob(ctx context.Context, store *db.Store, request localAg
 		checkoutPath = readOnlyWorktreePath
 		promptHeadWarnings = dispatchPromptHeadContradictionWarnings(ctx, jobGitClient(checkoutPath, localDispatchJobRunner(request)), request.Instructions, request.HeadSHA)
 	}
+	// Locking stays on the agent's REGISTERED session (see the same split in
+	// jobWorker.run): a read-only seat isolates DELIVERY, not serialization, so
+	// #684's "busy reviewer session leaves the review queued" is unchanged.
+	sessionLockAgent := effectiveAgent
 	if readOnlyWorktreePath != "" {
 		if err := applyReadOnlySeat(true, selectedRuntimeConfigDir(effectiveAgent.Runtime), jobID, &effectiveAgent); err != nil {
 			return localAgentJobOutput{}, fmt.Errorf("isolate read-only seat session: %w", err)
@@ -528,10 +532,13 @@ func dispatchLocalAgentJob(ctx context.Context, store *db.Store, request localAg
 	if jobTimeout > 0 {
 		lockTTL = jobTimeout + runtimeLeaseTeardownGrace
 	}
-	// SESSION SAFETY (#531): the lock is taken on the EFFECTIVE agent, so an
-	// overridden job locks the OVERRIDE runtime's session key and can never
-	// collide with (or occupy) the agent's default-runtime session lock.
-	releaseLock, acquired, lockKey, ownerToken, err := acquireJobRuntimeSessionLock(ctx, store, job.ID, effectiveAgent, overrideRuntime != "", time.Now().UTC(), lockTTL)
+	// SESSION SAFETY (#531): the lock is taken on the agent an override already
+	// swapped in, so an overridden job locks the OVERRIDE runtime's session key
+	// and can never collide with (or occupy) the agent's default-runtime session
+	// lock. A read-only seat is the one case where this is NOT the delivery
+	// agent: sessionLockAgent still carries the registered session ref, because a
+	// seat isolates delivery without loosening #684 serialization.
+	releaseLock, acquired, lockKey, ownerToken, err := acquireJobRuntimeSessionLock(ctx, store, job.ID, sessionLockAgent, overrideRuntime != "", time.Now().UTC(), lockTTL)
 	if err != nil {
 		return localAgentJobOutput{}, err
 	}

--- a/internal/cli/agent_dispatch.go
+++ b/internal/cli/agent_dispatch.go
@@ -397,7 +397,9 @@ func dispatchLocalAgentJob(ctx context.Context, store *db.Store, request localAg
 		promptHeadWarnings = dispatchPromptHeadContradictionWarnings(ctx, jobGitClient(checkoutPath, localDispatchJobRunner(request)), request.Instructions, request.HeadSHA)
 	}
 	if readOnlyWorktreePath != "" {
-		applyReadOnlySeat(true, selectedRuntimeConfigDir(effectiveAgent.Runtime), &effectiveAgent)
+		if err := applyReadOnlySeat(true, selectedRuntimeConfigDir(effectiveAgent.Runtime), jobID, &effectiveAgent); err != nil {
+			return localAgentJobOutput{}, fmt.Errorf("isolate read-only seat session: %w", err)
+		}
 		if request.Action != "review" {
 			// An ask worktree is the committed tip of checkout HEAD, which may have
 			// advanced past its inherited HeadSHA. Review is different: its worktree

--- a/internal/cli/daemon_scheduler.go
+++ b/internal/cli/daemon_scheduler.go
@@ -2844,21 +2844,7 @@ func queuedJobRuntimeResourceKey(ctx context.Context, store *db.Store, job db.Jo
 	if err != nil {
 		return ""
 	}
-	effective := runtimeAgent(agent)
-	// A read-only seat runs on a job-scoped fresh ref (applyReadOnlySeat), never
-	// the agent's stored session, so gate on the SAME ref the worker acquires.
-	// Gating on the stored ref would serialize disposable review seats behind the
-	// agent's live default-runtime session AND disagree with acquisition. That is
-	// the #1034 shape, where a gate and a lock computed from different keys let a
-	// job pass the gate and then collide.
-	if payload, payloadErr := daemonJobPayload(job); payloadErr == nil && payload.ReadOnlySeat && resumableSessionRuntime(effective.Runtime) {
-		ref, refErr := readOnlySeatRuntimeRef(job.ID)
-		if refErr != nil {
-			return ""
-		}
-		effective.RuntimeRef = ref
-	}
-	key, ok := runtimeSessionResourceKey(effective)
+	key, ok := runtimeSessionResourceKey(runtimeAgent(agent))
 	if !ok {
 		return ""
 	}

--- a/internal/cli/daemon_scheduler.go
+++ b/internal/cli/daemon_scheduler.go
@@ -2844,7 +2844,21 @@ func queuedJobRuntimeResourceKey(ctx context.Context, store *db.Store, job db.Jo
 	if err != nil {
 		return ""
 	}
-	key, ok := runtimeSessionResourceKey(runtimeAgent(agent))
+	effective := runtimeAgent(agent)
+	// A read-only seat runs on a job-scoped fresh ref (applyReadOnlySeat), never
+	// the agent's stored session, so gate on the SAME ref the worker acquires.
+	// Gating on the stored ref would serialize disposable review seats behind the
+	// agent's live default-runtime session AND disagree with acquisition. That is
+	// the #1034 shape, where a gate and a lock computed from different keys let a
+	// job pass the gate and then collide.
+	if payload, payloadErr := daemonJobPayload(job); payloadErr == nil && payload.ReadOnlySeat && resumableSessionRuntime(effective.Runtime) {
+		ref, refErr := readOnlySeatRuntimeRef(job.ID)
+		if refErr != nil {
+			return ""
+		}
+		effective.RuntimeRef = ref
+	}
+	key, ok := runtimeSessionResourceKey(effective)
 	if !ok {
 		return ""
 	}

--- a/internal/cli/daemon_worker.go
+++ b/internal/cli/daemon_worker.go
@@ -347,7 +347,13 @@ func (w jobWorker) run(ctx context.Context, job db.Job) error {
 	if readOnlySeat && runtimeConfigDir == "" {
 		runtimeConfigDir = selectedRuntimeConfigDir(agent.Runtime)
 	}
-	applyReadOnlySeat(readOnlySeat, runtimeConfigDir, &agent)
+	if err := applyReadOnlySeat(readOnlySeat, runtimeConfigDir, job.ID, &agent); err != nil {
+		if finishErr := w.finishQueuedJob(ctx, job, workflow.JobFailed, err); finishErr != nil {
+			return finishErr
+		}
+		_ = w.postJobResultComment(ctx, job.ID, agent, "", err)
+		return nil
+	}
 	preflightRequest := runtime.RuntimeContractRequest{Plan: payload.Plan}
 	if result, checked, preflightErr := w.runtimeContractPreflight(ctx, execBackend, execConfig, agent, preflightRequest); preflightErr != nil {
 		if finishErr := w.finishQueuedJob(ctx, job, workflow.JobFailed, preflightErr); finishErr != nil {
@@ -1522,15 +1528,73 @@ func wrapReadOnlyAdapterRunner(runtimeName string, adapter workflow.DeliveryAdap
 	}
 }
 
-func applyReadOnlySeat(readOnlySeat bool, configDir string, agent *runtime.Agent) {
+// applyReadOnlySeat rewrites an agent for hard runtime isolation.
+//
+// SESSION SAFETY: prepareReadOnlyRuntimeState builds the seat's runtime state
+// dir EMPTY (RemoveAll, MkdirAll, then only the credential file is staged)
+// and points CLAUDE_CONFIG_DIR/CODEX_HOME at it. An isolated home therefore can
+// never contain the session history a concrete ref names, so a seat resuming
+// the agent's stored ref fails: a codex review died with "thread/resume: no
+// rollout found for thread id <uuid>" while that rollout sat in the real
+// ~/.codex/sessions tree the seat cannot see. Run the seat on a job-scoped
+// FRESH ref instead, which also stops a disposable review seat from OCCUPYING
+// the runtime-session lock key of the agent's live default-runtime session
+// (the lock is taken on this effective agent), and keeps the mailbox from
+// persisting the minted session id back onto the stored agent row
+// (runtime.IsFreshRef gates that write).
+//
+// An already-fresh ref is left alone: a per-job runtime override minted a
+// unique ref at enqueue and a registered fresh:<seat> ref was already scoped by
+// scopeRegisteredFreshRefForJob, and both are the keys the scheduler gate
+// computed, so rewriting them would desync gate from acquisition.
+//
+// ONLY RESUMABLE RUNTIMES ARE REWRITTEN. A shell ref is a COMMAND, not a
+// session: overwriting it with a fresh ref would replace the stage's work with
+// nothing. Isolated shell pipeline stages carry ReadOnlySeat=true, so this
+// guard is load-bearing rather than defensive.
+func applyReadOnlySeat(readOnlySeat bool, configDir string, jobID string, agent *runtime.Agent) error {
 	if agent == nil || !readOnlySeat {
-		return
+		return nil
 	}
 	agent.ReadOnlySeat = true
 	agent.RuntimeConfigDir = strings.TrimSpace(configDir)
 	agent.WritablePaths = nil
 	agent.ReadablePaths = nil
 	agent.ReadableFiles = nil
+	if !resumableSessionRuntime(agent.Runtime) || runtime.IsFreshRef(agent.RuntimeRef) {
+		return nil
+	}
+	ref, err := readOnlySeatRuntimeRef(jobID)
+	if err != nil {
+		return err
+	}
+	agent.RuntimeRef = ref
+	return nil
+}
+
+// resumableSessionRuntime reports whether a runtime's RuntimeRef names a
+// resumable session (rather than a shell command or nothing at all). It is the
+// same set runtimeSessionResourceKey keys locks for.
+func resumableSessionRuntime(runtimeName string) bool {
+	switch strings.TrimSpace(runtimeName) {
+	case runtime.CodexRuntime, runtime.ClaudeRuntime, runtime.KimiRuntime:
+		return true
+	default:
+		return false
+	}
+}
+
+// readOnlySeatRuntimeRef is the fresh session ref a read-only seat runs on.
+// queuedJobRuntimeResourceKey (the scheduler gate) and the worker's lock
+// acquisition both derive their key from this one function, so they cannot
+// disagree. That is the #1034 isolated-shell-stage shape. A job id is always
+// available at both call sites; the unnamed case still gets a fresh, never
+// resumed ref rather than silently falling back to a resumable session.
+func readOnlySeatRuntimeRef(jobID string) (string, error) {
+	if id := strings.TrimSpace(jobID); id != "" {
+		return runtime.FreshRefForJob(id), nil
+	}
+	return runtime.NewFreshRef()
 }
 
 func selectedRuntimeConfigDir(runtimeName string) string {

--- a/internal/cli/daemon_worker.go
+++ b/internal/cli/daemon_worker.go
@@ -347,6 +347,12 @@ func (w jobWorker) run(ctx context.Context, job db.Job) error {
 	if readOnlySeat && runtimeConfigDir == "" {
 		runtimeConfigDir = selectedRuntimeConfigDir(agent.Runtime)
 	}
+	// The runtime-session lock keeps naming the agent's REGISTERED session, so
+	// #684's serialization is unchanged: a read-only seat still queues behind a
+	// busy reviewer session, and the scheduler gate (queuedJobRuntimeResourceKey,
+	// which reads the stored agent) still computes the same key the acquisition
+	// below does. Only DELIVERY moves to the seat's isolated fresh session.
+	sessionLockAgent := agent
 	if err := applyReadOnlySeat(readOnlySeat, runtimeConfigDir, job.ID, &agent); err != nil {
 		if finishErr := w.finishQueuedJob(ctx, job, workflow.JobFailed, err); finishErr != nil {
 			return finishErr
@@ -554,7 +560,7 @@ func (w jobWorker) run(ctx context.Context, job db.Job) error {
 		// acquireJobRuntimeSessionLock itself delegates to.
 		releaseLock, acquired, lockKey, ownerToken, err = acquireRuntimeSessionLockWithKey(ctx, w.Store, job.ID, key, true, time.Now().UTC(), lockTTL)
 	} else {
-		releaseLock, acquired, lockKey, ownerToken, err = acquireJobRuntimeSessionLock(ctx, w.Store, job.ID, agent, overridden, time.Now().UTC(), lockTTL)
+		releaseLock, acquired, lockKey, ownerToken, err = acquireJobRuntimeSessionLock(ctx, w.Store, job.ID, sessionLockAgent, overridden, time.Now().UTC(), lockTTL)
 	}
 	if err != nil {
 		if finishErr := w.finishQueuedJob(ctx, job, workflow.JobFailed, err); finishErr != nil {
@@ -1667,45 +1673,102 @@ func readOnlyRuntimeSandboxGrants(home string, agent runtime.Agent, checkout str
 	return grants, nil
 }
 
+// readOnlySeatStatePolicy declares everything a runtime needs staged into its
+// wiped isolated state dir, and whether a session in that dir can be resumed.
+//
+// It is declarative because the seat has now omitted a required startup input
+// THREE times, each presenting as a different failure: `/etc/ssl/openssl.cnf`
+// (#1802, "OpenSSL configuration error"), the codex `sessions/` tree (#1804,
+// "thread/resume: no rollout found"), and the kimi `config.toml` (which reports
+// "No model configured" behind an auth message that sends the reader to
+// `kimi login`, an owner action that cannot fix it). Three sites, one class: an
+// isolated home is missing something the runtime reads at startup.
+//
+// Adding or changing a runtime means declaring its inputs HERE, and
+// TestReadOnlySeatStatePolicyCoversEveryRegisteredRuntime fails when a
+// registered runtime has no policy.
+type readOnlySeatStatePolicy struct {
+	// defaultSourceDir is the host state dir used when the agent declares none.
+	defaultSourceDir string
+	// relativeState is where the isolated copy is staged.
+	relativeState string
+	// stateAtCacheRoot stages under cacheRoot rather than cacheRoot/runtime-state,
+	// for a runtime that reads its profile from the sandbox HOME.
+	stateAtCacheRoot bool
+	// credentialFile is copied through stageReadOnlyRuntimeCredential, which
+	// validates it and can narrow it to credentialSection.
+	credentialFile    string
+	credentialSection string
+	// requiredInputs are startup inputs staged verbatim. A missing one is an
+	// error naming the file, because the runtime's own message for it does not.
+	requiredInputs []string
+	// optionalInputs are staged verbatim when present and skipped when absent.
+	optionalInputs []string
+	// stateEnv names the environment variable that points the runtime at the
+	// staged dir. Empty when the runtime finds it through HOME.
+	stateEnv string
+}
+
+// readOnlySeatStatePolicyFor returns the staging policy for a runtime. The
+// second result is false for a runtime that needs no isolated state at all.
+func readOnlySeatStatePolicyFor(runtimeName string, userHome string, gatewayMode bool) (readOnlySeatStatePolicy, bool, error) {
+	switch runtimeName {
+	case runtime.ClaudeRuntime:
+		policy := readOnlySeatStatePolicy{
+			defaultSourceDir: filepath.Join(userHome, ".claude"),
+			relativeState:    ".claude",
+			stateEnv:         "CLAUDE_CONFIG_DIR",
+		}
+		if !gatewayMode {
+			policy.credentialFile = ".credentials.json"
+			policy.credentialSection = "claudeAiOauth"
+		}
+		return policy, true, nil
+	case runtime.CodexRuntime:
+		return readOnlySeatStatePolicy{
+			defaultSourceDir: filepath.Join(userHome, ".codex"),
+			relativeState:    ".codex",
+			credentialFile:   "auth.json",
+			// config.toml carries the model and sandbox settings. A seat without
+			// it silently falls back to the runtime default (ConfiguredCodexModel
+			// reads CODEX_HOME/config.toml), so stage it when the host has one.
+			optionalInputs: []string{"config.toml"},
+			stateEnv:       "CODEX_HOME",
+		}, true, nil
+	case runtime.KimiRuntime:
+		return readOnlySeatStatePolicy{
+			defaultSourceDir: filepath.Join(userHome, ".kimi-code"),
+			// Kimi reads HOME/.kimi-code. The sandbox supplies HOME=cacheRoot/home,
+			// so stage its isolated profile at that exact path.
+			stateAtCacheRoot: true,
+			relativeState:    filepath.Join("home", ".kimi-code"),
+			credentialFile:   filepath.Join("credentials", "kimi-code.json"),
+			// config.toml holds default_model plus the provider and model blocks.
+			// Without it kimi starts, authenticates, and then refuses with
+			// "No model configured", which reads as an auth failure.
+			requiredInputs: []string{"config.toml"},
+		}, true, nil
+	case runtime.ShellRuntime:
+		return readOnlySeatStatePolicy{}, false, nil
+	case runtime.OmpRuntime:
+		return readOnlySeatStatePolicy{}, false, errors.New("read-only seats cannot use omp without an isolated credential broker")
+	default:
+		return readOnlySeatStatePolicy{}, false, fmt.Errorf("read-only seat runtime %q has no isolated state policy", runtimeName)
+	}
+}
+
 func prepareReadOnlyRuntimeState(agent runtime.Agent, cacheRoot string, gatewayMode bool) (string, []string, error) {
 	userHome, err := os.UserHomeDir()
 	if err != nil {
 		return "", nil, fmt.Errorf("resolve read-only runtime state home: %w", err)
 	}
+	policy, needsState, err := readOnlySeatStatePolicyFor(agent.Runtime, userHome, gatewayMode)
+	if err != nil || !needsState {
+		return "", nil, err
+	}
 	sourceDir := strings.TrimSpace(agent.RuntimeConfigDir)
-	var relativeState, credentialFile, credentialSection string
-	stateRoot := filepath.Join(cacheRoot, "runtime-state")
-	switch agent.Runtime {
-	case runtime.ClaudeRuntime:
-		if sourceDir == "" {
-			sourceDir = filepath.Join(userHome, ".claude")
-		}
-		relativeState = ".claude"
-		if !gatewayMode {
-			credentialFile = ".credentials.json"
-			credentialSection = "claudeAiOauth"
-		}
-	case runtime.CodexRuntime:
-		if sourceDir == "" {
-			sourceDir = filepath.Join(userHome, ".codex")
-		}
-		relativeState = ".codex"
-		credentialFile = "auth.json"
-	case runtime.KimiRuntime:
-		if sourceDir == "" {
-			sourceDir = filepath.Join(userHome, ".kimi-code")
-		}
-		// Kimi reads HOME/.kimi-code. The sandbox supplies HOME=cacheRoot/home,
-		// so stage its isolated profile at that exact path.
-		stateRoot = cacheRoot
-		relativeState = filepath.Join("home", ".kimi-code")
-		credentialFile = filepath.Join("credentials", "kimi-code.json")
-	case runtime.ShellRuntime:
-		return "", nil, nil
-	case runtime.OmpRuntime:
-		return "", nil, errors.New("read-only seats cannot use omp without an isolated credential broker")
-	default:
-		return "", nil, fmt.Errorf("read-only seat runtime %q has no isolated state policy", agent.Runtime)
+	if sourceDir == "" {
+		sourceDir = policy.defaultSourceDir
 	}
 	sourceDir, err = filepath.Abs(sourceDir)
 	if err != nil {
@@ -1714,30 +1777,77 @@ func prepareReadOnlyRuntimeState(agent runtime.Agent, cacheRoot string, gatewayM
 	if resolved, resolveErr := filepath.EvalSymlinks(sourceDir); resolveErr == nil {
 		sourceDir = resolved
 	}
-	stateDir := filepath.Join(stateRoot, relativeState)
+	stateRoot := filepath.Join(cacheRoot, "runtime-state")
+	if policy.stateAtCacheRoot {
+		stateRoot = cacheRoot
+	}
+	stateDir := filepath.Join(stateRoot, policy.relativeState)
 	if err := os.RemoveAll(stateDir); err != nil {
 		return "", nil, fmt.Errorf("reset isolated runtime state %q: %w", stateDir, err)
 	}
 	if err := os.MkdirAll(stateDir, 0o700); err != nil {
 		return "", nil, fmt.Errorf("create isolated runtime state %q: %w", stateDir, err)
 	}
-	if credentialFile != "" {
+	if policy.credentialFile != "" {
 		if err := stageReadOnlyRuntimeCredential(
-			filepath.Join(sourceDir, credentialFile),
-			filepath.Join(stateDir, credentialFile),
-			credentialSection,
+			filepath.Join(sourceDir, policy.credentialFile),
+			filepath.Join(stateDir, policy.credentialFile),
+			policy.credentialSection,
 		); err != nil {
 			return "", nil, err
 		}
 	}
+	for _, name := range policy.requiredInputs {
+		if err := stageReadOnlyRuntimeInput(sourceDir, stateDir, name, true); err != nil {
+			return "", nil, err
+		}
+	}
+	for _, name := range policy.optionalInputs {
+		if err := stageReadOnlyRuntimeInput(sourceDir, stateDir, name, false); err != nil {
+			return "", nil, err
+		}
+	}
 	var stateEnv []string
-	switch agent.Runtime {
-	case runtime.ClaudeRuntime:
-		stateEnv = append(stateEnv, "CLAUDE_CONFIG_DIR="+stateDir)
-	case runtime.CodexRuntime:
-		stateEnv = append(stateEnv, "CODEX_HOME="+stateDir)
+	if policy.stateEnv != "" {
+		stateEnv = append(stateEnv, policy.stateEnv+"="+stateDir)
 	}
 	return stateDir, stateEnv, nil
+}
+
+// stageReadOnlyRuntimeInput copies one non-credential startup input into the
+// isolated state dir. A required input that the host does not have is an error
+// that NAMES the file: the runtime's own diagnostic for a missing config is
+// what cost a day here, so gitmoot must not depend on it.
+func stageReadOnlyRuntimeInput(sourceDir, stateDir, name string, required bool) error {
+	source := filepath.Join(sourceDir, name)
+	info, err := os.Lstat(source)
+	if errors.Is(err, os.ErrNotExist) {
+		if required {
+			return fmt.Errorf("read-only seat requires runtime input %q, and %s does not exist: the runtime will start and then refuse for a reason of its own choosing", name, source)
+		}
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("inspect runtime input %q: %w", source, err)
+	}
+	if !info.Mode().IsRegular() {
+		return fmt.Errorf("runtime input %q must be a regular file", source)
+	}
+	if info.Size() > maxReadOnlyRuntimeStateFileBytes {
+		return fmt.Errorf("runtime input %q must be no larger than %d bytes", source, maxReadOnlyRuntimeStateFileBytes)
+	}
+	data, err := os.ReadFile(source)
+	if err != nil {
+		return fmt.Errorf("read runtime input %q: %w", source, err)
+	}
+	destination := filepath.Join(stateDir, name)
+	if err := os.MkdirAll(filepath.Dir(destination), 0o700); err != nil {
+		return fmt.Errorf("create runtime input directory for %q: %w", destination, err)
+	}
+	if err := os.WriteFile(destination, data, 0o600); err != nil {
+		return fmt.Errorf("stage runtime input %q: %w", destination, err)
+	}
+	return nil
 }
 
 func stageReadOnlyRuntimeCredential(source, destination, section string) error {

--- a/internal/cli/daemon_worker.go
+++ b/internal/cli/daemon_worker.go
@@ -1752,6 +1752,23 @@ type readOnlySeatStatePolicy struct {
 // readOnlySeatStatePolicyFor returns the staging policy for a runtime. The
 // second result is false for a runtime that needs no isolated state at all.
 func readOnlySeatStatePolicyFor(runtimeName string, userHome string, gatewayMode bool) (readOnlySeatStatePolicy, bool, error) {
+	policy, needsState, err := readOnlySeatStatePolicyForRuntime(runtimeName, userHome, gatewayMode)
+	if err != nil || !needsState || !gatewayMode {
+		return policy, needsState, err
+	}
+	// In gateway mode the gateway supplies the credential, so NO runtime's
+	// credential file is staged. This is applied HERE rather than at the
+	// staging call site so the policy this function returns is the policy that
+	// is actually enforced: a caller (or a test) reading it back used to see
+	// codex's auth.json and kimi's token still listed while the seat withheld
+	// them, which is a policy that disagrees with itself.
+	policy.credentialFile = ""
+	policy.credentialSection = ""
+	policy.credentialUsable = nil
+	return policy, needsState, nil
+}
+
+func readOnlySeatStatePolicyForRuntime(runtimeName string, userHome string, gatewayMode bool) (readOnlySeatStatePolicy, bool, error) {
 	switch runtimeName {
 	case runtime.ClaudeRuntime:
 		policy := readOnlySeatStatePolicy{
@@ -1817,15 +1834,6 @@ func prepareReadOnlyRuntimeState(agent runtime.Agent, cacheRoot string, gatewayM
 		return "", nil, nil, fmt.Errorf("resolve read-only runtime state home: %w", err)
 	}
 	policy, needsState, err := readOnlySeatStatePolicyFor(agent.Runtime, userHome, gatewayMode)
-	if gatewayMode {
-		// The gateway supplies the credential, as the claude branch has always
-		// said. Only claude acted on it, so a gateway seat still staged
-		// codex's auth.json and kimi's token - neither of which it needs.
-		// Model settings (the narrowed config inputs) are still staged.
-		policy.credentialFile = ""
-		policy.credentialSection = ""
-		policy.credentialUsable = nil
-	}
 	if err != nil || !needsState {
 		return "", nil, nil, err
 	}
@@ -1979,7 +1987,15 @@ func stageReadOnlyRuntimeInput(sourceDir, stateDir, name string, required bool, 
 	var dropped []string
 	if narrow != nil {
 		narrowed, narrowErr := narrow(data)
-		if narrowErr != nil {
+		switch {
+		case narrowErr != nil && !required:
+			// OPTIONAL means optional for CONTENT too, not only for absence.
+			// A file gitmoot cannot narrow is one it must not stage - but the
+			// runtime's own default is a working outcome for an optional
+			// input, so refusing the whole seat would turn "we could not read
+			// your config" into a dead reviewer. Withhold it and SAY SO.
+			return []string{fmt.Sprintf("%s (not staged: %v)", name, narrowErr)}, nil
+		case narrowErr != nil:
 			return nil, fmt.Errorf("narrow runtime input %q: %w", source, narrowErr)
 		}
 		data, dropped = narrowed.data, narrowed.dropped

--- a/internal/cli/daemon_worker.go
+++ b/internal/cli/daemon_worker.go
@@ -1684,9 +1684,13 @@ func readOnlyRuntimeSandboxGrants(home string, agent runtime.Agent, checkout str
 // `kimi login`, an owner action that cannot fix it). Three sites, one class: an
 // isolated home is missing something the runtime reads at startup.
 //
-// Adding or changing a runtime means declaring its inputs HERE, and
+// Adding or changing a runtime means declaring its STARTUP INPUTS here, and
 // TestReadOnlySeatStatePolicyCoversEveryRegisteredRuntime fails when a
-// registered runtime has no policy.
+// registered runtime has no policy. That test is the only enforced part, and it
+// covers this switch ALONE: a new runtime also needs
+// selectedRuntimeConfigDir, readOnlyRuntimeBaseEnv, produceRuntimeSandboxGrants
+// and buildLocalRuntimeAdapter, none of which this policy or its test can see.
+// Do not read the sentence above as "declare it here and you are done".
 type readOnlySeatStatePolicy struct {
 	// defaultSourceDir is the host state dir used when the agent declares none.
 	defaultSourceDir string
@@ -1699,11 +1703,18 @@ type readOnlySeatStatePolicy struct {
 	// validates it and can narrow it to credentialSection.
 	credentialFile    string
 	credentialSection string
+	// credentialUsable answers whether the NARROWED credential can actually
+	// authenticate, not merely whether it exists and parses. Nil means the
+	// runtime offers nothing cheap to check.
+	credentialUsable func([]byte) error
 	// requiredInputs are startup inputs staged verbatim. A missing one is an
 	// error naming the file, because the runtime's own message for it does not.
 	requiredInputs []string
-	// optionalInputs are staged verbatim when present and skipped when absent.
+	// optionalInputs are staged when present and skipped when absent.
 	optionalInputs []string
+	// inputNarrowers strip content an input must not carry into the seat,
+	// keyed by input name. An input with no narrower is staged verbatim.
+	inputNarrowers map[string]func([]byte) ([]byte, error)
 	// stateEnv names the environment variable that points the runtime at the
 	// staged dir. Empty when the runtime finds it through HOME.
 	stateEnv string
@@ -1722,6 +1733,7 @@ func readOnlySeatStatePolicyFor(runtimeName string, userHome string, gatewayMode
 		if !gatewayMode {
 			policy.credentialFile = ".credentials.json"
 			policy.credentialSection = "claudeAiOauth"
+			policy.credentialUsable = claudeOAuthUsable
 		}
 		return policy, true, nil
 	case runtime.CodexRuntime:
@@ -1729,11 +1741,16 @@ func readOnlySeatStatePolicyFor(runtimeName string, userHome string, gatewayMode
 			defaultSourceDir: filepath.Join(userHome, ".codex"),
 			relativeState:    ".codex",
 			credentialFile:   "auth.json",
-			// config.toml carries the model and sandbox settings. A seat without
-			// it silently falls back to the runtime default (ConfiguredCodexModel
-			// reads CODEX_HOME/config.toml), so stage it when the host has one.
+			// config.toml carries the model and sandbox settings. The codex CLI
+			// reads them from CODEX_HOME/config.toml itself, so a seat without
+			// the file falls back to the runtime default; stage it when the
+			// host has one. It is NARROWED first: the same file holds
+			// third-party credentials, and stateDir is writable by the seat.
 			optionalInputs: []string{"config.toml"},
-			stateEnv:       "CODEX_HOME",
+			inputNarrowers: map[string]func([]byte) ([]byte, error){
+				"config.toml": narrowCodexConfig,
+			},
+			stateEnv: "CODEX_HOME",
 		}, true, nil
 	case runtime.KimiRuntime:
 		return readOnlySeatStatePolicy{
@@ -1793,17 +1810,18 @@ func prepareReadOnlyRuntimeState(agent runtime.Agent, cacheRoot string, gatewayM
 			filepath.Join(sourceDir, policy.credentialFile),
 			filepath.Join(stateDir, policy.credentialFile),
 			policy.credentialSection,
+			policy.credentialUsable,
 		); err != nil {
 			return "", nil, err
 		}
 	}
 	for _, name := range policy.requiredInputs {
-		if err := stageReadOnlyRuntimeInput(sourceDir, stateDir, name, true); err != nil {
+		if err := stageReadOnlyRuntimeInput(sourceDir, stateDir, name, true, policy.inputNarrowers[name]); err != nil {
 			return "", nil, err
 		}
 	}
 	for _, name := range policy.optionalInputs {
-		if err := stageReadOnlyRuntimeInput(sourceDir, stateDir, name, false); err != nil {
+		if err := stageReadOnlyRuntimeInput(sourceDir, stateDir, name, false, policy.inputNarrowers[name]); err != nil {
 			return "", nil, err
 		}
 	}
@@ -1814,25 +1832,88 @@ func prepareReadOnlyRuntimeState(agent runtime.Agent, cacheRoot string, gatewayM
 	return stateDir, stateEnv, nil
 }
 
+// containedStagePath joins a staged input name under the seat's state dir and
+// refuses anything that escapes it.
+//
+// Every name is a separator-free constant today, and credentialFile is a
+// deliberate two-segment path, so this changes no current behaviour. It exists
+// because the safety of os.WriteFile(filepath.Join(stateDir, name)) rests
+// entirely on that convention, and the failure if the convention ever breaks is
+// a write OUTSIDE the sandbox's one writable root - too quiet to find later.
+func containedStagePath(stateDir, name string) (string, error) {
+	destination := filepath.Join(stateDir, name)
+	relative, err := filepath.Rel(stateDir, destination)
+	if err != nil {
+		return "", fmt.Errorf("resolve staged input %q under %q: %w", name, stateDir, err)
+	}
+	if relative == ".." || strings.HasPrefix(relative, ".."+string(filepath.Separator)) || filepath.IsAbs(relative) {
+		return "", fmt.Errorf("staged runtime input %q escapes the seat state dir %q", name, stateDir)
+	}
+	return destination, nil
+}
+
+// errStagedInputNotRegular is returned when a staged runtime input resolves to
+// something that is not a regular file. Callers name the file themselves,
+// because "runtime input" and "runtime state file" are different nouns to an
+// operator reading the failure.
+var errStagedInputNotRegular = errors.New("not a regular file")
+
+// resolveStagedRuntimeInput resolves one staged input to the regular file it
+// names, FOLLOWING SYMLINKS.
+//
+// A dotfiles manager (stow, chezmoi, or a hand-rolled dotfiles repo) keeps the
+// real file in its own tree and leaves a symlink where the runtime looks, so
+// refusing a symlink outright makes a perfectly valid host profile
+// unlaunchable. prepareReadOnlyRuntimeState already EvalSymlinks the source
+// DIRECTORY; not doing the same for the files inside it is the inconsistency.
+//
+// Everything that is not a regular file AFTER resolution is still refused: a
+// directory, socket, device or fifo is not a config, and reading one can block
+// forever. A dangling symlink resolves to os.ErrNotExist, so it takes the
+// caller's missing-file path - named for a required input, skipped for an
+// optional one - rather than a distinct third outcome.
+func resolveStagedRuntimeInput(source string) (string, os.FileInfo, error) {
+	info, err := os.Lstat(source)
+	if err != nil {
+		return "", nil, err
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		resolved, resolveErr := filepath.EvalSymlinks(source)
+		if resolveErr != nil {
+			return "", nil, resolveErr
+		}
+		resolvedInfo, statErr := os.Stat(resolved)
+		if statErr != nil {
+			return "", nil, statErr
+		}
+		source, info = resolved, resolvedInfo
+	}
+	if !info.Mode().IsRegular() {
+		return "", nil, errStagedInputNotRegular
+	}
+	return source, info, nil
+}
+
 // stageReadOnlyRuntimeInput copies one non-credential startup input into the
 // isolated state dir. A required input that the host does not have is an error
 // that NAMES the file: the runtime's own diagnostic for a missing config is
 // what cost a day here, so gitmoot must not depend on it.
-func stageReadOnlyRuntimeInput(sourceDir, stateDir, name string, required bool) error {
+func stageReadOnlyRuntimeInput(sourceDir, stateDir, name string, required bool, narrow func([]byte) ([]byte, error)) error {
 	source := filepath.Join(sourceDir, name)
-	info, err := os.Lstat(source)
+	resolved, info, err := resolveStagedRuntimeInput(source)
 	if errors.Is(err, os.ErrNotExist) {
 		if required {
 			return fmt.Errorf("read-only seat requires runtime input %q, and %s does not exist: the runtime will start and then refuse for a reason of its own choosing", name, source)
 		}
 		return nil
 	}
+	if errors.Is(err, errStagedInputNotRegular) {
+		return fmt.Errorf("runtime input %q must be a regular file", source)
+	}
 	if err != nil {
 		return fmt.Errorf("inspect runtime input %q: %w", source, err)
 	}
-	if !info.Mode().IsRegular() {
-		return fmt.Errorf("runtime input %q must be a regular file", source)
-	}
+	source = resolved
 	if info.Size() > maxReadOnlyRuntimeStateFileBytes {
 		return fmt.Errorf("runtime input %q must be no larger than %d bytes", source, maxReadOnlyRuntimeStateFileBytes)
 	}
@@ -1840,7 +1921,17 @@ func stageReadOnlyRuntimeInput(sourceDir, stateDir, name string, required bool) 
 	if err != nil {
 		return fmt.Errorf("read runtime input %q: %w", source, err)
 	}
-	destination := filepath.Join(stateDir, name)
+	if narrow != nil {
+		narrowed, narrowErr := narrow(data)
+		if narrowErr != nil {
+			return fmt.Errorf("narrow runtime input %q: %w", source, narrowErr)
+		}
+		data = narrowed
+	}
+	destination, err := containedStagePath(stateDir, name)
+	if err != nil {
+		return err
+	}
 	if err := os.MkdirAll(filepath.Dir(destination), 0o700); err != nil {
 		return fmt.Errorf("create runtime input directory for %q: %w", destination, err)
 	}
@@ -1850,18 +1941,18 @@ func stageReadOnlyRuntimeInput(sourceDir, stateDir, name string, required bool) 
 	return nil
 }
 
-func stageReadOnlyRuntimeCredential(source, destination, section string) error {
-	info, err := os.Lstat(source)
+func stageReadOnlyRuntimeCredential(source, destination, section string, usable func([]byte) error) error {
+	resolved, info, err := resolveStagedRuntimeInput(source)
 	if errors.Is(err, os.ErrNotExist) {
 		return nil
+	}
+	if errors.Is(err, errStagedInputNotRegular) || (err == nil && info.Size() > maxReadOnlyRuntimeStateFileBytes) {
+		return fmt.Errorf("runtime state file %q must be a regular file no larger than %d bytes", source, maxReadOnlyRuntimeStateFileBytes)
 	}
 	if err != nil {
 		return fmt.Errorf("inspect runtime state file %q: %w", source, err)
 	}
-	if !info.Mode().IsRegular() || info.Size() > maxReadOnlyRuntimeStateFileBytes {
-		return fmt.Errorf("runtime state file %q must be a regular file no larger than %d bytes", source, maxReadOnlyRuntimeStateFileBytes)
-	}
-	data, err := os.ReadFile(source)
+	data, err := os.ReadFile(resolved)
 	if err != nil {
 		return fmt.Errorf("read runtime state file %q: %w", source, err)
 	}
@@ -1882,6 +1973,11 @@ func stageReadOnlyRuntimeCredential(source, destination, section string) error {
 			return fmt.Errorf("isolate runtime credential %q: %w", source, err)
 		}
 	}
+	if usable != nil {
+		if err := usable(data); err != nil {
+			return fmt.Errorf("read-only seat credential %s is unusable: %w", source, err)
+		}
+	}
 	if err := os.MkdirAll(filepath.Dir(destination), 0o700); err != nil {
 		return fmt.Errorf("create isolated runtime state directory: %w", err)
 	}
@@ -1889,6 +1985,48 @@ func stageReadOnlyRuntimeCredential(source, destination, section string) error {
 		return fmt.Errorf("stage runtime state file %q: %w", destination, err)
 	}
 	return nil
+}
+
+// claudeOAuthUsable answers the question presence-and-shape validation cannot:
+// can this credential still authenticate?
+//
+// A claude profile whose OAuth has expired with no refresh token stages
+// perfectly - the file exists, it is JSON, it has a claudeAiOauth section - and
+// then the seat dies on the runtime's own opaque error, which is the exact
+// failure mode this policy exists to eliminate. Naming it here costs one
+// timestamp comparison.
+//
+// It judges ONLY what it can prove locally. An absent expiresAt is not a
+// verdict (nothing to compare), and an expired token WITH a refresh token is
+// fine, because refreshing it is the runtime's job. Rejecting either would turn
+// a late opaque failure into an early wrong one.
+func claudeOAuthUsable(data []byte) error {
+	var envelope struct {
+		OAuth struct {
+			AccessToken  string `json:"accessToken"`
+			RefreshToken string `json:"refreshToken"`
+			ExpiresAt    int64  `json:"expiresAt"`
+		} `json:"claudeAiOauth"`
+	}
+	if err := json.Unmarshal(data, &envelope); err != nil {
+		return fmt.Errorf("read claudeAiOauth section: %w", err)
+	}
+	oauth := envelope.OAuth
+	if strings.TrimSpace(oauth.AccessToken) == "" {
+		return errors.New("claudeAiOauth has no accessToken, so the seat has nothing to authenticate with")
+	}
+	if oauth.ExpiresAt <= 0 {
+		return nil
+	}
+	// claude records expiresAt in milliseconds.
+	expiry := time.UnixMilli(oauth.ExpiresAt).UTC()
+	if time.Now().UTC().Before(expiry) {
+		return nil
+	}
+	if strings.TrimSpace(oauth.RefreshToken) != "" {
+		return nil
+	}
+	return fmt.Errorf("claudeAiOauth expired at %s and carries no refreshToken, so the seat cannot obtain a working token: re-authenticate the host profile", expiry.Format(time.RFC3339))
 }
 
 func readOnlyRuntimeBaseEnv(runtimeName string, environ []string, githubDir string) []string {
@@ -2750,6 +2888,16 @@ func (w jobWorker) runWithTempWorker(ctx context.Context, job db.Job, payload wo
 	// after job was admitted. Every pre-flight terminal write below therefore
 	// remains anchored to job, while runtime work uses delegatedJob's metadata.
 	adapter, err := w.deliveryAdapterForBackend(backend, started.Agent, checkout)
+	if err == nil {
+		// #1807: the temp-worker fork leaves run() before the sandbox wrap at
+		// the normal delivery site, and startTempWorker COPIES the delivery
+		// agent, so ReadOnlySeat survives into this path. Without this the seat
+		// routes around both the Landlock wrap and the staging policy - the very
+		// property this path's caller was gated on. The wrap is a no-op for an
+		// ordinary temp worker (it returns the adapter unchanged unless
+		// ReadOnlySeat is set), so this cannot affect the common path.
+		adapter, err = wrapReadOnlySandboxAdapter(w.ConfigHome, started.Agent, checkout, adapter)
+	}
 	if err != nil {
 		if finishErr := w.finishQueuedJob(ctx, job, workflow.JobFailed, err); finishErr != nil {
 			return finishErr

--- a/internal/cli/daemon_worker.go
+++ b/internal/cli/daemon_worker.go
@@ -716,7 +716,15 @@ func (w jobWorker) run(ctx context.Context, job db.Job) error {
 		_ = w.postJobResultComment(ctx, job.ID, agent, checkout, err)
 		return nil
 	}
-	adapter, err = wrapReadOnlySandboxAdapter(w.ConfigHome, agent, deliveryCheckout, adapter)
+	adapter, narrowingDropped, err := wrapReadOnlySandboxAdapter(w.ConfigHome, agent, deliveryCheckout, adapter)
+	if err == nil && len(narrowingDropped) > 0 {
+		// Narrowing is not silent: a reviewer whose MCP tool is missing, or a
+		// seat that cannot authenticate to a provider whose key was withheld,
+		// can find out why from the job's own event log.
+		if eventErr := w.Store.AddJobEvent(ctx, db.JobEvent{JobID: job.ID, Kind: "read_only_seat_config_narrowed", Message: "withheld from the seat's staged config: " + strings.Join(narrowingDropped, ", ")}); eventErr != nil {
+			return eventErr
+		}
+	}
 	if err != nil {
 		if finishErr := w.finishQueuedJob(ctx, job, workflow.JobFailed, err); finishErr != nil {
 			return finishErr
@@ -1421,6 +1429,10 @@ func wrapProduceSandboxAdapter(action string, agent runtime.Agent, adapter workf
 const maxReadOnlyRuntimeStateFileBytes = 1 << 20
 
 type readOnlySandboxGrants struct {
+	// dropped names what narrowing withheld from the staged config, so the
+	// caller can record it. A seat that silently starts without its MCP
+	// servers gives the reviewer no way to learn why a tool is missing.
+	dropped   []string
 	reads     []string
 	readFiles []string
 	writes    []string
@@ -1457,14 +1469,14 @@ func (a readOnlyRuntimeAdapter) cleanup() error {
 	return nil
 }
 
-func wrapReadOnlySandboxAdapter(home string, agent runtime.Agent, checkout string, adapter workflow.DeliveryAdapter) (workflow.DeliveryAdapter, error) {
+func wrapReadOnlySandboxAdapter(home string, agent runtime.Agent, checkout string, adapter workflow.DeliveryAdapter) (workflow.DeliveryAdapter, []string, error) {
 	if !agent.ReadOnlySeat {
-		return adapter, nil
+		return adapter, nil, nil
 	}
 	_, gatewayMode := adapter.(modelGatewayRuntimeAdapter)
 	grants, err := readOnlyRuntimeSandboxGrants(home, agent, checkout, gatewayMode)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	wrap := func(runner subprocess.Runner) subprocess.Runner {
 		curated := graftRuntimeBaseRunner(runner, subprocess.CuratedGroupRunner{
@@ -1474,19 +1486,19 @@ func wrapReadOnlySandboxAdapter(home string, agent runtime.Agent, checkout strin
 	}
 	wrapped, err := wrapReadOnlyAdapterRunner(agent.Runtime, adapter, grants.stateDir, wrap)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	if grants.stateDir == "" {
-		return wrapped, nil
+		return wrapped, grants.dropped, nil
 	}
 	runtimeAdapter, ok := wrapped.(runtime.Adapter)
 	if !ok {
-		return nil, fmt.Errorf("read-only Landlock sandbox returned incompatible %T adapter", wrapped)
+		return nil, nil, fmt.Errorf("read-only Landlock sandbox returned incompatible %T adapter", wrapped)
 	}
 	return readOnlyRuntimeAdapter{
 		Adapter:     runtimeAdapter,
 		cleanupRoot: grants.cacheRoot,
-	}, nil
+	}, grants.dropped, nil
 }
 
 func wrapReadOnlyAdapterRunner(runtimeName string, adapter workflow.DeliveryAdapter, stateDir string, wrap func(subprocess.Runner) subprocess.Runner) (workflow.DeliveryAdapter, error) {
@@ -1590,10 +1602,20 @@ func resumableSessionRuntime(runtimeName string) bool {
 	}
 }
 
-// readOnlySeatRuntimeRef is the fresh session ref a read-only seat runs on.
-// queuedJobRuntimeResourceKey (the scheduler gate) and the worker's lock
-// acquisition both derive their key from this one function, so they cannot
-// disagree. That is the #1034 isolated-shell-stage shape. A job id is always
+// readOnlySeatRuntimeRef is the fresh session ref a read-only seat DELIVERS on.
+//
+// It is never a lock key, and that is the point: the seat locks on the agent's
+// REGISTERED ref (jobWorker.run keeps a pre-seat copy in sessionLockAgent) and
+// the scheduler gate needs no seat branch at all, because
+// queuedJobRuntimeResourceKey reads the stored agent and therefore computes the
+// same registered key. Gate and acquisition agree because neither one uses this
+// function.
+//
+// An earlier version of this comment claimed both derived their key from HERE.
+// That is the opposite of the code, and acting on it is exactly the mutation
+// TestDaemonWorkerLocksTheRegisteredSessionForAReadOnlySeat exists to kill. The
+// genuine #1034 shared-key shape is one branch up, in the
+// isolatedShellStageRuntimeSessionKey path. A job id is always
 // available at both call sites; the unnamed case still gets a fresh, never
 // resumed ref rather than silently falling back to a resumable session.
 func readOnlySeatRuntimeRef(jobID string) (string, error) {
@@ -1638,12 +1660,13 @@ func readOnlyRuntimeSandboxGrants(home string, agent runtime.Agent, checkout str
 	}
 	grants.reads = append(grants.reads, metadata...)
 
-	stateDir, stateEnv, err := prepareReadOnlyRuntimeState(agent, grants.cacheRoot, gatewayMode)
+	stateDir, stateEnv, dropped, err := prepareReadOnlyRuntimeState(agent, grants.cacheRoot, gatewayMode)
 	if err != nil {
 		return grants, err
 	}
 	grants.stateDir = stateDir
 	grants.env = append(grants.env, stateEnv...)
+	grants.dropped = dropped
 
 	tempDir := filepath.Join(grants.cacheRoot, "tmp")
 	grants.env = append(grants.env,
@@ -1713,8 +1736,9 @@ type readOnlySeatStatePolicy struct {
 	// optionalInputs are staged when present and skipped when absent.
 	optionalInputs []string
 	// inputNarrowers strip content an input must not carry into the seat,
-	// keyed by input name. An input with no narrower is staged verbatim.
-	inputNarrowers map[string]func([]byte) ([]byte, error)
+	// keyed by input name. An input with no narrower is staged VERBATIM, which
+	// is only correct for a file that cannot carry a third-party credential.
+	inputNarrowers map[string]func([]byte) (narrowedConfig, error)
 	// stateEnv names the environment variable that points the runtime at the
 	// staged dir. Empty when the runtime finds it through HOME.
 	stateEnv string
@@ -1747,8 +1771,8 @@ func readOnlySeatStatePolicyFor(runtimeName string, userHome string, gatewayMode
 			// host has one. It is NARROWED first: the same file holds
 			// third-party credentials, and stateDir is writable by the seat.
 			optionalInputs: []string{"config.toml"},
-			inputNarrowers: map[string]func([]byte) ([]byte, error){
-				"config.toml": narrowCodexConfig,
+			inputNarrowers: map[string]func([]byte) (narrowedConfig, error){
+				"config.toml": narrowCodexConfigDetailed,
 			},
 			stateEnv: "CODEX_HOME",
 		}, true, nil
@@ -1764,6 +1788,14 @@ func readOnlySeatStatePolicyFor(runtimeName string, userHome string, gatewayMode
 			// Without it kimi starts, authenticates, and then refuses with
 			// "No model configured", which reads as an auth failure.
 			requiredInputs: []string{"config.toml"},
+			// NARROWED for the same reason codex's is, and this file needs it
+			// MORE: measured on a live host it carries api_key under
+			// [services.*] and a key under [services.*.oauth], and for kimi
+			// stateAtCacheRoot puts the staged copy directly inside the seat's
+			// one writable root.
+			inputNarrowers: map[string]func([]byte) (narrowedConfig, error){
+				"config.toml": narrowKimiConfigDetailed,
+			},
 		}, true, nil
 	case runtime.ShellRuntime:
 		return readOnlySeatStatePolicy{}, false, nil
@@ -1774,14 +1806,14 @@ func readOnlySeatStatePolicyFor(runtimeName string, userHome string, gatewayMode
 	}
 }
 
-func prepareReadOnlyRuntimeState(agent runtime.Agent, cacheRoot string, gatewayMode bool) (string, []string, error) {
+func prepareReadOnlyRuntimeState(agent runtime.Agent, cacheRoot string, gatewayMode bool) (string, []string, []string, error) {
 	userHome, err := os.UserHomeDir()
 	if err != nil {
-		return "", nil, fmt.Errorf("resolve read-only runtime state home: %w", err)
+		return "", nil, nil, fmt.Errorf("resolve read-only runtime state home: %w", err)
 	}
 	policy, needsState, err := readOnlySeatStatePolicyFor(agent.Runtime, userHome, gatewayMode)
 	if err != nil || !needsState {
-		return "", nil, err
+		return "", nil, nil, err
 	}
 	sourceDir := strings.TrimSpace(agent.RuntimeConfigDir)
 	if sourceDir == "" {
@@ -1789,7 +1821,7 @@ func prepareReadOnlyRuntimeState(agent runtime.Agent, cacheRoot string, gatewayM
 	}
 	sourceDir, err = filepath.Abs(sourceDir)
 	if err != nil {
-		return "", nil, fmt.Errorf("resolve runtime state directory %q: %w", sourceDir, err)
+		return "", nil, nil, fmt.Errorf("resolve runtime state directory %q: %w", sourceDir, err)
 	}
 	if resolved, resolveErr := filepath.EvalSymlinks(sourceDir); resolveErr == nil {
 		sourceDir = resolved
@@ -1800,36 +1832,45 @@ func prepareReadOnlyRuntimeState(agent runtime.Agent, cacheRoot string, gatewayM
 	}
 	stateDir := filepath.Join(stateRoot, policy.relativeState)
 	if err := os.RemoveAll(stateDir); err != nil {
-		return "", nil, fmt.Errorf("reset isolated runtime state %q: %w", stateDir, err)
+		return "", nil, nil, fmt.Errorf("reset isolated runtime state %q: %w", stateDir, err)
 	}
 	if err := os.MkdirAll(stateDir, 0o700); err != nil {
-		return "", nil, fmt.Errorf("create isolated runtime state %q: %w", stateDir, err)
+		return "", nil, nil, fmt.Errorf("create isolated runtime state %q: %w", stateDir, err)
 	}
 	if policy.credentialFile != "" {
+		credentialDestination, err := containedStagePath(stateDir, policy.credentialFile)
+		if err != nil {
+			return "", nil, nil, err
+		}
 		if err := stageReadOnlyRuntimeCredential(
 			filepath.Join(sourceDir, policy.credentialFile),
-			filepath.Join(stateDir, policy.credentialFile),
+			credentialDestination,
 			policy.credentialSection,
 			policy.credentialUsable,
 		); err != nil {
-			return "", nil, err
+			return "", nil, nil, err
 		}
 	}
+	var dropped []string
 	for _, name := range policy.requiredInputs {
-		if err := stageReadOnlyRuntimeInput(sourceDir, stateDir, name, true, policy.inputNarrowers[name]); err != nil {
-			return "", nil, err
+		withheld, err := stageReadOnlyRuntimeInput(sourceDir, stateDir, name, true, policy.inputNarrowers[name])
+		if err != nil {
+			return "", nil, nil, err
 		}
+		dropped = append(dropped, withheld...)
 	}
 	for _, name := range policy.optionalInputs {
-		if err := stageReadOnlyRuntimeInput(sourceDir, stateDir, name, false, policy.inputNarrowers[name]); err != nil {
-			return "", nil, err
+		withheld, err := stageReadOnlyRuntimeInput(sourceDir, stateDir, name, false, policy.inputNarrowers[name])
+		if err != nil {
+			return "", nil, nil, err
 		}
+		dropped = append(dropped, withheld...)
 	}
 	var stateEnv []string
 	if policy.stateEnv != "" {
 		stateEnv = append(stateEnv, policy.stateEnv+"="+stateDir)
 	}
-	return stateDir, stateEnv, nil
+	return stateDir, stateEnv, dropped, nil
 }
 
 // containedStagePath joins a staged input name under the seat's state dir and
@@ -1898,47 +1939,69 @@ func resolveStagedRuntimeInput(source string) (string, os.FileInfo, error) {
 // isolated state dir. A required input that the host does not have is an error
 // that NAMES the file: the runtime's own diagnostic for a missing config is
 // what cost a day here, so gitmoot must not depend on it.
-func stageReadOnlyRuntimeInput(sourceDir, stateDir, name string, required bool, narrow func([]byte) ([]byte, error)) error {
+func stageReadOnlyRuntimeInput(sourceDir, stateDir, name string, required bool, narrow func([]byte) (narrowedConfig, error)) ([]string, error) {
 	source := filepath.Join(sourceDir, name)
 	resolved, info, err := resolveStagedRuntimeInput(source)
 	if errors.Is(err, os.ErrNotExist) {
 		if required {
-			return fmt.Errorf("read-only seat requires runtime input %q, and %s does not exist: the runtime will start and then refuse for a reason of its own choosing", name, source)
+			return nil, fmt.Errorf("read-only seat requires runtime input %q, and %s does not exist: the runtime will start and then refuse for a reason of its own choosing", name, source)
 		}
-		return nil
+		return nil, nil
 	}
 	if errors.Is(err, errStagedInputNotRegular) {
-		return fmt.Errorf("runtime input %q must be a regular file", source)
+		return nil, fmt.Errorf("runtime input %q must be a regular file", source)
 	}
 	if err != nil {
-		return fmt.Errorf("inspect runtime input %q: %w", source, err)
+		return nil, fmt.Errorf("inspect runtime input %q: %w", source, err)
 	}
 	source = resolved
 	if info.Size() > maxReadOnlyRuntimeStateFileBytes {
-		return fmt.Errorf("runtime input %q must be no larger than %d bytes", source, maxReadOnlyRuntimeStateFileBytes)
+		return nil, fmt.Errorf("runtime input %q must be no larger than %d bytes", source, maxReadOnlyRuntimeStateFileBytes)
 	}
-	data, err := os.ReadFile(source)
+	data, err := readStagedRuntimeInput(source)
 	if err != nil {
-		return fmt.Errorf("read runtime input %q: %w", source, err)
+		return nil, err
 	}
+	var dropped []string
 	if narrow != nil {
 		narrowed, narrowErr := narrow(data)
 		if narrowErr != nil {
-			return fmt.Errorf("narrow runtime input %q: %w", source, narrowErr)
+			return nil, fmt.Errorf("narrow runtime input %q: %w", source, narrowErr)
 		}
-		data = narrowed
+		data, dropped = narrowed.data, narrowed.dropped
 	}
 	destination, err := containedStagePath(stateDir, name)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	if err := os.MkdirAll(filepath.Dir(destination), 0o700); err != nil {
-		return fmt.Errorf("create runtime input directory for %q: %w", destination, err)
+		return nil, fmt.Errorf("create runtime input directory for %q: %w", destination, err)
 	}
 	if err := os.WriteFile(destination, data, 0o600); err != nil {
-		return fmt.Errorf("stage runtime input %q: %w", destination, err)
+		return nil, fmt.Errorf("stage runtime input %q: %w", destination, err)
 	}
-	return nil
+	return dropped, nil
+}
+
+// readStagedRuntimeInput reads a staged input under a HARD byte cap.
+//
+// The size check above uses the FileInfo from resolveStagedRuntimeInput, so on
+// its own it is advisory: the file can grow between the stat and the read. An
+// io.LimitReader makes the cap real, and costs nothing.
+func readStagedRuntimeInput(source string) ([]byte, error) {
+	handle, err := os.Open(source)
+	if err != nil {
+		return nil, fmt.Errorf("read runtime input %q: %w", source, err)
+	}
+	defer handle.Close()
+	data, err := io.ReadAll(io.LimitReader(handle, maxReadOnlyRuntimeStateFileBytes+1))
+	if err != nil {
+		return nil, fmt.Errorf("read runtime input %q: %w", source, err)
+	}
+	if int64(len(data)) > maxReadOnlyRuntimeStateFileBytes {
+		return nil, fmt.Errorf("runtime input %q must be no larger than %d bytes", source, maxReadOnlyRuntimeStateFileBytes)
+	}
+	return data, nil
 }
 
 func stageReadOnlyRuntimeCredential(source, destination, section string, usable func([]byte) error) error {
@@ -2002,31 +2065,76 @@ func stageReadOnlyRuntimeCredential(source, destination, section string, usable 
 // a late opaque failure into an early wrong one.
 func claudeOAuthUsable(data []byte) error {
 	var envelope struct {
-		OAuth struct {
-			AccessToken  string `json:"accessToken"`
-			RefreshToken string `json:"refreshToken"`
-			ExpiresAt    int64  `json:"expiresAt"`
-		} `json:"claudeAiOauth"`
+		OAuth json.RawMessage `json:"claudeAiOauth"`
 	}
 	if err := json.Unmarshal(data, &envelope); err != nil {
-		return fmt.Errorf("read claudeAiOauth section: %w", err)
+		// Not our file format: nothing to compare is not a verdict.
+		return nil
 	}
-	oauth := envelope.OAuth
+	var oauth struct {
+		AccessToken  string      `json:"accessToken"`
+		RefreshToken string      `json:"refreshToken"`
+		ExpiresAt    json.Number `json:"expiresAt"`
+	}
+	if err := json.Unmarshal(envelope.OAuth, &oauth); err != nil {
+		// A claudeAiOauth that is not the shape we read is the same "nothing
+		// to compare" case. Aborting here turned a third party's format drift
+		// into a hard seat outage reported as a raw Go unmarshal error.
+		return nil
+	}
 	if strings.TrimSpace(oauth.AccessToken) == "" {
 		return errors.New("claudeAiOauth has no accessToken, so the seat has nothing to authenticate with")
 	}
-	if oauth.ExpiresAt <= 0 {
-		return nil
-	}
-	// claude records expiresAt in milliseconds.
-	expiry := time.UnixMilli(oauth.ExpiresAt).UTC()
-	if time.Now().UTC().Before(expiry) {
-		return nil
-	}
 	if strings.TrimSpace(oauth.RefreshToken) != "" {
+		// Refreshing is the runtime's job, so an expiry cannot condemn it.
+		return nil
+	}
+	expiry, ok := claudeOAuthExpiry(oauth.ExpiresAt)
+	if !ok {
+		return nil
+	}
+	// A few minutes of grace: a seat refused for clock skew is a wrong
+	// verdict, and this path only fires when there is no refresh token at all.
+	if time.Now().UTC().Before(expiry.Add(claudeOAuthExpiryGrace)) {
 		return nil
 	}
 	return fmt.Errorf("claudeAiOauth expired at %s and carries no refreshToken, so the seat cannot obtain a working token: re-authenticate the host profile", expiry.Format(time.RFC3339))
+}
+
+// claudeOAuthExpiryGrace absorbs clock skew between the host that wrote the
+// credential and this one.
+const claudeOAuthExpiryGrace = 5 * time.Minute
+
+// claudeOAuthExpiry reads expiresAt without depending on how a third party
+// encodes it. A string, a float in exponent notation, and an integer all decode;
+// anything else is NO VERDICT rather than an error, because this function's
+// whole purpose is to avoid depending on another tool's diagnostics.
+//
+// The unit is milliseconds, and a value small enough to be seconds is rejected
+// as unreadable: read as milliseconds it lands in 1970, which produced a
+// confident and wrong "expired at 1971 - re-authenticate".
+func claudeOAuthExpiry(value json.Number) (time.Time, bool) {
+	text := strings.TrimSpace(value.String())
+	if text == "" {
+		return time.Time{}, false
+	}
+	milliseconds, err := value.Int64()
+	if err != nil {
+		float, floatErr := value.Float64()
+		if floatErr != nil {
+			return time.Time{}, false
+		}
+		milliseconds = int64(float)
+	}
+	if milliseconds <= 0 {
+		return time.Time{}, false
+	}
+	// 1e11 ms is 1973; any real millisecond expiry is far above it, and any
+	// plausible SECONDS value is far below.
+	if milliseconds < 100_000_000_000 {
+		return time.Time{}, false
+	}
+	return time.UnixMilli(milliseconds).UTC(), true
 }
 
 func readOnlyRuntimeBaseEnv(runtimeName string, environ []string, githubDir string) []string {
@@ -2896,7 +3004,13 @@ func (w jobWorker) runWithTempWorker(ctx context.Context, job db.Job, payload wo
 		// property this path's caller was gated on. The wrap is a no-op for an
 		// ordinary temp worker (it returns the adapter unchanged unless
 		// ReadOnlySeat is set), so this cannot affect the common path.
-		adapter, err = wrapReadOnlySandboxAdapter(w.ConfigHome, started.Agent, checkout, adapter)
+		var forkDropped []string
+		adapter, forkDropped, err = wrapReadOnlySandboxAdapter(w.ConfigHome, started.Agent, checkout, adapter)
+		if err == nil && len(forkDropped) > 0 {
+			if eventErr := w.Store.AddJobEvent(ctx, db.JobEvent{JobID: job.ID, Kind: "read_only_seat_config_narrowed", Message: "withheld from the seat's staged config: " + strings.Join(forkDropped, ", ")}); eventErr != nil {
+				return eventErr
+			}
+		}
 	}
 	if err != nil {
 		if finishErr := w.finishQueuedJob(ctx, job, workflow.JobFailed, err); finishErr != nil {

--- a/internal/cli/daemon_worker.go
+++ b/internal/cli/daemon_worker.go
@@ -717,7 +717,7 @@ func (w jobWorker) run(ctx context.Context, job db.Job) error {
 		return nil
 	}
 	adapter, narrowingDropped, err := wrapReadOnlySandboxAdapter(w.ConfigHome, agent, deliveryCheckout, adapter)
-	if err == nil && len(narrowingDropped) > 0 {
+	if len(narrowingDropped) > 0 {
 		// Narrowing is not silent: a reviewer whose MCP tool is missing, or a
 		// seat that cannot authenticate to a provider whose key was withheld,
 		// can find out why from the job's own event log.
@@ -1486,14 +1486,19 @@ func wrapReadOnlySandboxAdapter(home string, agent runtime.Agent, checkout strin
 	}
 	wrapped, err := wrapReadOnlyAdapterRunner(agent.Runtime, adapter, grants.stateDir, wrap)
 	if err != nil {
-		return nil, nil, err
+		// Staging and narrowing are already done at this point, so the
+		// withheld list is reported even though the wrap failed.
+		return nil, grants.dropped, err
 	}
 	if grants.stateDir == "" {
 		return wrapped, grants.dropped, nil
 	}
 	runtimeAdapter, ok := wrapped.(runtime.Adapter)
 	if !ok {
-		return nil, nil, fmt.Errorf("read-only Landlock sandbox returned incompatible %T adapter", wrapped)
+		// The narrowing already happened, so report it even though delivery
+		// cannot be built: a withheld credential is news whether or not the
+		// wrap succeeds.
+		return nil, grants.dropped, fmt.Errorf("read-only Landlock sandbox returned incompatible %T adapter", wrapped)
 	}
 	return readOnlyRuntimeAdapter{
 		Adapter:     runtimeAdapter,
@@ -1812,6 +1817,15 @@ func prepareReadOnlyRuntimeState(agent runtime.Agent, cacheRoot string, gatewayM
 		return "", nil, nil, fmt.Errorf("resolve read-only runtime state home: %w", err)
 	}
 	policy, needsState, err := readOnlySeatStatePolicyFor(agent.Runtime, userHome, gatewayMode)
+	if gatewayMode {
+		// The gateway supplies the credential, as the claude branch has always
+		// said. Only claude acted on it, so a gateway seat still staged
+		// codex's auth.json and kimi's token - neither of which it needs.
+		// Model settings (the narrowed config inputs) are still staged.
+		policy.credentialFile = ""
+		policy.credentialSection = ""
+		policy.credentialUsable = nil
+	}
 	if err != nil || !needsState {
 		return "", nil, nil, err
 	}
@@ -3006,7 +3020,7 @@ func (w jobWorker) runWithTempWorker(ctx context.Context, job db.Job, payload wo
 		// ReadOnlySeat is set), so this cannot affect the common path.
 		var forkDropped []string
 		adapter, forkDropped, err = wrapReadOnlySandboxAdapter(w.ConfigHome, started.Agent, checkout, adapter)
-		if err == nil && len(forkDropped) > 0 {
+		if len(forkDropped) > 0 {
 			if eventErr := w.Store.AddJobEvent(ctx, db.JobEvent{JobID: job.ID, Kind: "read_only_seat_config_narrowed", Message: "withheld from the seat's staged config: " + strings.Join(forkDropped, ", ")}); eventErr != nil {
 				return eventErr
 			}

--- a/internal/cli/readonly_seat_config_narrow.go
+++ b/internal/cli/readonly_seat_config_narrow.go
@@ -62,6 +62,11 @@ type tomlLine struct {
 	// readable is false for a pair whose key could not be parsed. Such a line
 	// is dropped rather than guessed at.
 	readable bool
+	// value is the pair's value with any trailing comment REMOVED and the
+	// key/value split done lexically, so no consumer re-parses raw. A trailing
+	// comment on model_provider used to become part of the selected provider
+	// name, which withheld the one credential the seat needed.
+	value string
 }
 
 // scanTOMLLines tokenizes a config file into classified lines.
@@ -102,9 +107,14 @@ func scanTOMLLines(data []byte) ([]tomlLine, error) {
 			continue
 		}
 
-		line := strings.TrimSpace(raw)
+		// Everything below classifies the COMMENT-FREE code portion and emits
+		// the raw line unchanged.
+		code, nextMultiline, nextPending := scanTOMLLineCode(raw)
+		line := strings.TrimSpace(code)
+		opens := nextMultiline != "" || nextPending > 0
+
 		switch {
-		case line == "" || strings.HasPrefix(line, "#"):
+		case line == "" || strings.HasPrefix(strings.TrimSpace(raw), "#"):
 			lines = append(lines, tomlLine{raw: raw, kind: tomlLineOther, section: section})
 		case strings.HasPrefix(line, "["):
 			path, ok := parseTOMLSectionHeader(line)
@@ -114,21 +124,20 @@ func scanTOMLLines(data []byte) ([]tomlLine, error) {
 			section = path
 			lines = append(lines, tomlLine{raw: raw, kind: tomlLineHeader, path: path, section: path, readable: true})
 		default:
-			key, value, isPair := strings.Cut(line, "=")
+			key, value, isPair := splitTOMLPair(line)
 			if !isPair {
 				lines = append(lines, tomlLine{raw: raw, kind: tomlLineOther, section: section})
 				continue
 			}
 			path, ok := parseTOMLKeyPath(strings.TrimSpace(key))
-			entry := tomlLine{raw: raw, kind: tomlLinePair, section: section, readable: ok}
+			entry := tomlLine{raw: raw, kind: tomlLinePair, section: section, readable: ok, value: strings.TrimSpace(value)}
 			if ok {
 				entry.path = append(append([]string{}, section...), path...)
 			}
-			nextMultiline, nextPending := advanceTOMLState(value, "", 0)
-			entry.opensRun = nextMultiline != "" || nextPending > 0
-			multiline, pending = nextMultiline, nextPending
+			entry.opensRun = opens
 			lines = append(lines, entry)
 		}
+		multiline, pending = nextMultiline, nextPending
 	}
 	if multiline != "" {
 		return nil, fmt.Errorf("config has a multi-line string that never closes, so narrowing it would corrupt the file: fix the file or remove it from the host state dir")
@@ -199,6 +208,101 @@ func advanceTOMLState(text, multiline string, pending int) (string, int) {
 		}
 	}
 	return multiline, pending
+}
+
+const (
+	tripleBasic   = "\"\"\""
+	tripleLiteral = "'''"
+)
+
+// scanTOMLLineCode splits one line into its CODE portion and the state it
+// leaves open, honouring strings, escapes and comments.
+//
+// Every consumer classifies on the code portion and emits the raw line, so a
+// trailing comment can never reach a section name, a key path or a value. That
+// was a P1: `[services] # see [docs]` had the comment's ']' swallowed into the
+// section NAME by a LastIndex scan, so the drop rule never matched and every
+// secret under that section was staged verbatim with dropped empty.
+func scanTOMLLineCode(text string) (code string, multiline string, pending int) {
+	runes := []rune(text)
+	for index := 0; index < len(runes); {
+		rest := string(runes[index:])
+		switch {
+		case strings.HasPrefix(rest, tripleBasic):
+			index += 3
+			index, multiline = consumeMultiline(runes, index, tripleBasic)
+		case strings.HasPrefix(rest, tripleLiteral):
+			index += 3
+			index, multiline = consumeMultiline(runes, index, tripleLiteral)
+		case runes[index] == '"' || runes[index] == '\'':
+			quote := runes[index]
+			index++
+			for index < len(runes) {
+				if quote == '"' && runes[index] == '\\' {
+					index += 2
+					continue
+				}
+				if runes[index] == quote {
+					index++
+					break
+				}
+				index++
+			}
+		case runes[index] == '#':
+			// Outside a string: the rest of the line is a comment.
+			return string(runes[:index]), multiline, pending
+		case runes[index] == '[' || runes[index] == '{':
+			pending++
+			index++
+		case runes[index] == ']' || runes[index] == '}':
+			pending--
+			if pending < 0 {
+				pending = 0
+			}
+			index++
+		default:
+			index++
+		}
+	}
+	return text, multiline, pending
+}
+
+// consumeMultiline advances past a multi-line string that may close on the same
+// line it opened. An unclosed one is reported back as still-open state.
+func consumeMultiline(runes []rune, index int, delimiter string) (int, string) {
+	for index < len(runes) {
+		if strings.HasPrefix(string(runes[index:]), delimiter) {
+			return index + len([]rune(delimiter)), ""
+		}
+		index++
+	}
+	return index, delimiter
+}
+
+// splitTOMLPair splits a key from its value on the first '=' OUTSIDE quotes, so
+// a valid quoted key containing '=' is not dropped as an anonymous unreadable
+// key.
+func splitTOMLPair(code string) (key string, value string, ok bool) {
+	runes := []rune(code)
+	var quote rune
+	for index := 0; index < len(runes); index++ {
+		r := runes[index]
+		switch {
+		case quote != 0:
+			if r == '\\' && quote == '"' {
+				index++
+				continue
+			}
+			if r == quote {
+				quote = 0
+			}
+		case r == '"' || r == '\'':
+			quote = r
+		case r == '=':
+			return string(runes[:index]), string(runes[index+1:]), true
+		}
+	}
+	return "", "", false
 }
 
 // narrowTOML rewrites a config file, dropping every path the classifier
@@ -487,11 +591,9 @@ func tomlTopLevelScalar(lines []tomlLine, wanted string) string {
 		if len(line.path) != 1 || line.path[0] != wanted {
 			continue
 		}
-		_, value, ok := strings.Cut(strings.TrimSpace(line.raw), "=")
-		if !ok {
-			continue
-		}
-		return strings.Trim(strings.TrimSpace(value), `"'`)
+		// line.value is already comment-free and lexically split, so a
+		// trailing comment cannot become part of the selected provider name.
+		return strings.Trim(line.value, "\"'")
 	}
 	return ""
 }

--- a/internal/cli/readonly_seat_config_narrow.go
+++ b/internal/cli/readonly_seat_config_narrow.go
@@ -2,50 +2,241 @@ package cli
 
 import (
 	"fmt"
+	"sort"
 	"strings"
 )
 
-// narrowCodexConfig removes third-party credentials from a codex config.toml
-// before it is staged into a read-only seat.
+// Narrowing a runtime's config file before it is staged into a read-only seat.
 //
-// The seat stages config.toml so the codex CLI keeps the operator's model and
-// sandbox settings. That file routinely also carries credentials that have
-// nothing to do with running the model: [mcp_servers.*.env] holds tokens for
-// third-party servers, and [model_providers.*] holds api_key and http_headers.
-// The seat's state dir lives inside the one WRITABLE path granted to the
+// The seat's state dir lives inside the ONE writable path granted to the
 // sandbox, so anything staged there is readable by the reviewer the seat runs.
+// Both codex and kimi keep model settings in the same file as credentials for
+// unrelated third parties, so the file cannot be copied through.
 //
-// Two dispositions, chosen for what each costs when it is wrong:
+// The rule both runtimes share: a seat needs the credential for the provider it
+// actually runs on, and no others. Everything else that carries a secret is
+// withheld, and WHAT WAS WITHHELD IS REPORTED, so a seat that then cannot
+// authenticate says so rather than leaving the runtime to explain.
+
+// narrowedConfig is the result of narrowing one config file.
+type narrowedConfig struct {
+	data []byte
+	// dropped names the sections and keys withheld from the seat. Silence was
+	// a review finding: a seat started without its MCP servers gave the
+	// reviewer no way to learn why a tool it expected was missing.
+	dropped []string
+}
+
+// narrowCodexConfig strips third-party credentials from a codex config.toml.
 //
-//   - mcp_servers is dropped WHOLESALE. Its env table is the token carrier, but
-//     args and command can carry a secret just as easily, and a read-only
-//     reviewer seat has no business spawning third-party servers. Dropping it
-//     cannot break startup: MCP servers are optional to codex.
-//   - model_providers keeps its structure and loses only api_key and
-//     http_headers. Dropping the section would be safer still and is wrong:
-//     when model names a custom provider, removing base_url and wire_api makes
-//     the model unresolvable, so a narrowing meant to protect the seat would
-//     stop it launching.
+//   - mcp_servers is dropped WHOLESALE. env holds tokens, args can hold them
+//     just as easily, and a read-only reviewer seat has no business spawning
+//     third-party servers. MCP servers are optional to codex, so this cannot
+//     stop a launch.
+//   - model_providers keeps its STRUCTURE - base_url and wire_api must survive
+//     or a custom model becomes unresolvable - and keeps api_key/http_headers
+//     ONLY for the provider that model_provider selects. Stripping the selected
+//     provider's key too was a review finding: env_key survives narrowing but
+//     names a variable readOnlyRuntimeBaseEnv's allowlist does not pass into
+//     the seat, so the seat was left with no way to authenticate at all.
 //
-// Unknown keys are KEPT, because they are the model and sandbox settings this
-// file is staged for. An unparseable section header is FAIL-CLOSED: it drops
-// through to the end of the file. Once a header cannot be attributed, no
-// following key can be classified, and the direction that leaks is the one
-// that guesses "probably fine".
+// Everything else is kept: those are the model and sandbox settings the file is
+// staged for.
 func narrowCodexConfig(data []byte) ([]byte, error) {
+	result, err := narrowCodexConfigDetailed(data)
+	if err != nil {
+		return nil, err
+	}
+	return result.data, nil
+}
+
+func narrowCodexConfigDetailed(data []byte) (narrowedConfig, error) {
+	selected := tomlTopLevelScalar(data, "model_provider")
+	return narrowTOML(data, func(path []string) (bool, string) {
+		if len(path) == 0 {
+			return false, ""
+		}
+		if path[0] == "mcp_servers" {
+			return true, "mcp_servers." + pathTail(path, 1)
+		}
+		if path[0] != "model_providers" || len(path) < 2 {
+			return false, ""
+		}
+		provider := path[1]
+		credential := false
+		for _, segment := range path[2:] {
+			// env_key and env_http_headers name environment VARIABLES rather
+			// than hold values, so they are not secrets and stay.
+			if segment == "api_key" || segment == "http_headers" {
+				credential = true
+			}
+		}
+		if !credential {
+			return false, ""
+		}
+		if selected != "" && provider == selected {
+			// The provider this seat will actually use: the one credential it
+			// legitimately needs.
+			return false, ""
+		}
+		return true, "model_providers." + provider + " credential"
+	})
+}
+
+// narrowKimiConfig strips third-party credentials from a kimi config.toml.
+//
+// This file is REQUIRED for a kimi seat and carries more than codex's does.
+// Measured on a live host: api_key under [services.*], a key under
+// [services.*.oauth], alongside [providers.*].
+//
+//   - services is dropped WHOLESALE, for the same reason as codex's
+//     mcp_servers: it configures optional tooling (moonshot search and fetch)
+//     and carries those tools' credentials. Dropping the section beats
+//     enumerating which of its keys is a secret, and it fails closed when a
+//     new one appears.
+//   - providers keeps its structure and keeps api_key / env only for the
+//     provider default_model resolves to. Dropping every provider credential
+//     is not an option: kimi fails at startup when both api_key and the env
+//     sub-table are absent, so the seat legitimately needs exactly one.
+func narrowKimiConfig(data []byte) ([]byte, error) {
+	result, err := narrowKimiConfigDetailed(data)
+	if err != nil {
+		return nil, err
+	}
+	return result.data, nil
+}
+
+func narrowKimiConfigDetailed(data []byte) (narrowedConfig, error) {
+	selected := kimiSelectedProvider(data)
+	return narrowTOML(data, func(path []string) (bool, string) {
+		if len(path) == 0 {
+			return false, ""
+		}
+		if path[0] == "services" {
+			return true, "services." + pathTail(path, 1)
+		}
+		if path[0] != "providers" || len(path) < 2 {
+			return false, ""
+		}
+		provider := path[1]
+		credential := false
+		for _, segment := range path[2:] {
+			if segment == "api_key" || segment == "env" {
+				credential = true
+			}
+		}
+		if !credential {
+			return false, ""
+		}
+		if selected != "" && provider == selected {
+			return false, ""
+		}
+		return true, "providers." + provider + " credential"
+	})
+}
+
+// kimiSelectedProvider resolves default_model to the provider that serves it.
+//
+// The repo's own fixture pins the shape: default_model = "kimi-code/k3" is
+// served by [providers."managed:kimi-code"], so the model's segment before the
+// first "/" matches the provider name's segment after the last ":".
+//
+// An empty result means NO provider was matched, and every provider credential
+// is then withheld: a credential nobody can prove is needed is not staged. The
+// withholding is reported, so the resulting startup failure names what gitmoot
+// removed instead of arriving as the runtime's own message.
+func kimiSelectedProvider(data []byte) string {
+	model := tomlTopLevelScalar(data, "default_model")
+	if model == "" {
+		return ""
+	}
+	wanted := model
+	if index := strings.Index(wanted, "/"); index >= 0 {
+		wanted = wanted[:index]
+	}
+	wanted = strings.TrimSpace(wanted)
+	if wanted == "" {
+		return ""
+	}
+	var match string
+	for _, provider := range tomlSectionNames(data, "providers") {
+		short := provider
+		if index := strings.LastIndex(short, ":"); index >= 0 {
+			short = short[index+1:]
+		}
+		if short != wanted && provider != wanted {
+			continue
+		}
+		if match != "" && match != provider {
+			// Ambiguous: withhold rather than guess which one is live.
+			return ""
+		}
+		match = provider
+	}
+	return match
+}
+
+func pathTail(path []string, from int) string {
+	if from >= len(path) {
+		return "*"
+	}
+	return strings.Join(path[from:], ".")
+}
+
+// narrowTOML rewrites a TOML file line by line, dropping every path the
+// classifier rejects. The classifier receives the FULL dotted path, so a
+// section header, a dotted key at top level, and a key inside a section are all
+// judged the same way.
+//
+// It is a line scanner, not a TOML parser, and the places that distinction
+// bites are handled explicitly:
+//
+//   - MULTI-LINE STRINGS. A line inside """ or ”' that begins with "[" is not
+//     a section header. Treating it as one both LEAKED (the fake header reset
+//     the section, so a following api_key was attributed to nothing) and
+//     CORRUPTED (it deleted lines out of a valid file and left an unterminated
+//     string, so codex reported a TOML error about a file gitmoot wrote).
+//   - UNBALANCED inline tables and arrays, which continue in the disposition of
+//     the key that opened them.
+//   - A UTF-8 BOM, which strings.TrimSpace does not remove, so a leading BOM
+//     hid the first header and classified everything under it against an empty
+//     path.
+//
+// An unreadable section header, and a multi-line string that never closes, both
+// FAIL CLOSED with an error naming the file. Once a header cannot be attributed
+// no following key can be classified, and the direction that leaks is the one
+// that guesses "probably fine".
+func narrowTOML(data []byte, drop func(path []string) (bool, string)) (narrowedConfig, error) {
 	var (
-		out       []string
-		section   []string
-		dropping  bool
-		unknown   bool
-		pending   int
-		pendingIn bool
+		out        []string
+		section    []string
+		dropping   bool
+		pending    int
+		pendingIn  bool
+		multiline  string
+		multiIn    bool
+		droppedSet = map[string]struct{}{}
 	)
-	for _, raw := range strings.Split(string(data), "\n") {
+	note := func(label string) {
+		if label != "" {
+			droppedSet[label] = struct{}{}
+		}
+	}
+
+	for _, raw := range strings.Split(strings.TrimPrefix(string(data), "\ufeff"), "\n") {
 		line := strings.TrimSpace(raw)
 
-		// A value that opened an unbalanced inline table or array continues in
-		// the disposition of the key that opened it.
+		// Inside a multi-line string nothing is a header and nothing is a key.
+		if multiline != "" {
+			if !multiIn {
+				out = append(out, raw)
+			}
+			if strings.Contains(raw, multiline) {
+				multiline = ""
+			}
+			continue
+		}
+
 		if pending != 0 {
 			pending += bracketBalance(line)
 			if !pendingIn {
@@ -58,24 +249,18 @@ func narrowCodexConfig(data []byte) ([]byte, error) {
 		}
 
 		if strings.HasPrefix(line, "[") {
-			path, ok := parseCodexSectionHeader(line)
+			path, ok := parseTOMLSectionHeader(line)
 			if !ok {
-				// Fail closed: an unattributable header means every key after it
-				// is unattributable too.
-				unknown = true
-				dropping = true
-				continue
+				return narrowedConfig{}, fmt.Errorf("config has a section header that is not readable, so its credentials cannot be located: fix the file or remove it from the host state dir")
 			}
 			section = path
-			dropping = codexPathCarriesCredentials(path)
+			var label string
+			dropping, label = drop(path)
 			if dropping {
+				note(label)
 				continue
 			}
 			out = append(out, raw)
-			continue
-		}
-
-		if unknown {
 			continue
 		}
 
@@ -86,57 +271,108 @@ func narrowCodexConfig(data []byte) ([]byte, error) {
 			continue
 		}
 
-		key, _, isPair := strings.Cut(line, "=")
-		drop := dropping
-		if isPair {
-			path, ok := parseCodexKeyPath(strings.TrimSpace(key))
+		key, value, isPair := strings.Cut(line, "=")
+		dropLine := dropping
+		if isPair && !dropping {
+			path, ok := parseTOMLKeyPath(strings.TrimSpace(key))
 			if !ok {
 				// A key whose name cannot be read cannot be cleared.
-				drop = true
-			} else if !dropping {
-				drop = codexPathCarriesCredentials(append(append([]string{}, section...), path...))
+				dropLine = true
+				note("unreadable key")
+			} else {
+				var label string
+				dropLine, label = drop(append(append([]string{}, section...), path...))
+				note(label)
 			}
 		}
-		if balance := bracketBalance(line); balance > 0 {
-			pending = balance
-			pendingIn = drop
+		if delimiter := openMultilineDelimiter(value); delimiter != "" {
+			multiline, multiIn = delimiter, dropLine
+		} else if balance := bracketBalance(line); balance > 0 {
+			pending, pendingIn = balance, dropLine
 		}
-		if drop {
+		if dropLine {
 			continue
 		}
 		out = append(out, raw)
 	}
-	if unknown {
-		return nil, fmt.Errorf("codex config.toml has a section header that is not readable, so its credentials cannot be located: fix the file or remove it from the host state dir")
+	if multiline != "" {
+		return narrowedConfig{}, fmt.Errorf("config has a multi-line string that never closes, so narrowing it would corrupt the file: fix the file or remove it from the host state dir")
 	}
-	return []byte(strings.Join(out, "\n")), nil
+
+	result := narrowedConfig{data: []byte(strings.Join(out, "\n"))}
+	for label := range droppedSet {
+		result.dropped = append(result.dropped, label)
+	}
+	sort.Strings(result.dropped)
+	return result, nil
 }
 
-// codexPathCarriesCredentials reports whether a dotted TOML path names a value
-// that must never reach a read-only seat.
-func codexPathCarriesCredentials(path []string) bool {
-	if len(path) == 0 {
-		return false
-	}
-	if path[0] == "mcp_servers" {
-		return true
-	}
-	if path[0] == "model_providers" {
-		for _, segment := range path[1:] {
-			// env_key and env_http_headers name environment VARIABLES, not
-			// values, so they are not secrets and stay.
-			if segment == "api_key" || segment == "http_headers" {
-				return true
-			}
+// openMultilineDelimiter reports the delimiter of a multi-line string opened on
+// this line and not closed on it: `"""a"""` opens and closes, `"""` stays open.
+func openMultilineDelimiter(value string) string {
+	for _, delimiter := range []string{`"""`, `'''`} {
+		if count := strings.Count(value, delimiter); count > 0 && count%2 == 1 {
+			return delimiter
 		}
 	}
-	return false
+	return ""
 }
 
-// parseCodexSectionHeader reads [a.b] and [[a.b]] into a dotted path. The
-// second result is false for a header that does not close, which is the case
-// narrowCodexConfig fails closed on.
-func parseCodexSectionHeader(line string) ([]string, bool) {
+// tomlTopLevelScalar reads a TOP-LEVEL scalar string key (model_provider,
+// default_model). Keys inside sections are ignored deliberately: both are
+// documented as top level, and a same-named key in a section must not be
+// mistaken for the selection.
+func tomlTopLevelScalar(data []byte, wanted string) string {
+	inSection := false
+	for _, raw := range strings.Split(strings.TrimPrefix(string(data), "\ufeff"), "\n") {
+		line := strings.TrimSpace(raw)
+		if strings.HasPrefix(line, "[") {
+			inSection = true
+			continue
+		}
+		if inSection || line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		key, value, ok := strings.Cut(line, "=")
+		if !ok {
+			continue
+		}
+		path, parsed := parseTOMLKeyPath(strings.TrimSpace(key))
+		if !parsed || len(path) != 1 || path[0] != wanted {
+			continue
+		}
+		return strings.Trim(strings.TrimSpace(value), `"'`)
+	}
+	return ""
+}
+
+// tomlSectionNames lists the second path segment of every section under root,
+// so [providers."managed:kimi-code"] yields `managed:kimi-code`.
+func tomlSectionNames(data []byte, root string) []string {
+	var names []string
+	seen := map[string]struct{}{}
+	for _, raw := range strings.Split(strings.TrimPrefix(string(data), "\ufeff"), "\n") {
+		line := strings.TrimSpace(raw)
+		if !strings.HasPrefix(line, "[") {
+			continue
+		}
+		path, ok := parseTOMLSectionHeader(line)
+		if !ok || len(path) < 2 || path[0] != root {
+			continue
+		}
+		if _, done := seen[path[1]]; done {
+			continue
+		}
+		seen[path[1]] = struct{}{}
+		names = append(names, path[1])
+	}
+	return names
+}
+
+// parseTOMLSectionHeader reads [a.b] and [[a.b]] into a dotted path. The second
+// result is false for a header that does not close, which narrowTOML fails
+// closed on.
+func parseTOMLSectionHeader(line string) ([]string, bool) {
 	body := strings.TrimPrefix(line, "[")
 	body = strings.TrimPrefix(body, "[")
 	end := strings.LastIndex(body, "]")
@@ -148,20 +384,32 @@ func parseCodexSectionHeader(line string) ([]string, bool) {
 	if strings.TrimSpace(body) == "" {
 		return nil, false
 	}
-	return parseCodexKeyPath(strings.TrimSpace(body))
+	return parseTOMLKeyPath(strings.TrimSpace(body))
 }
 
-// parseCodexKeyPath splits a dotted TOML key on separators that are not inside
-// quotes, so [mcp_servers."my server".env] classifies as mcp_servers.
-func parseCodexKeyPath(key string) ([]string, bool) {
+// parseTOMLKeyPath splits a dotted TOML key on separators outside quotes, so
+// [mcp_servers."my server".env] classifies as mcp_servers. A backslash escape
+// inside a basic string is honoured: ["a\"b".c] is valid TOML, and failing it
+// closed would refuse a whole seat over a file the runtime accepts.
+func parseTOMLKeyPath(key string) ([]string, bool) {
 	var (
 		path    []string
 		current strings.Builder
 		quote   rune
+		escaped bool
 	)
 	for _, r := range key {
 		switch {
 		case quote != 0:
+			if escaped {
+				escaped = false
+				current.WriteRune(r)
+				continue
+			}
+			if r == '\\' && quote == '"' {
+				escaped = true
+				continue
+			}
 			if r == quote {
 				quote = 0
 				continue

--- a/internal/cli/readonly_seat_config_narrow.go
+++ b/internal/cli/readonly_seat_config_narrow.go
@@ -17,6 +17,14 @@ import (
 // actually runs on, and no others. Everything else that carries a secret is
 // withheld, and WHAT WAS WITHHELD IS REPORTED, so a seat that then cannot
 // authenticate says so rather than leaving the runtime to explain.
+//
+// ONE SCANNER, ONE SET OF RULES. Earlier versions grew three independent line
+// scanners over the same file - the narrower plus two selector helpers - each
+// with its own idea of what a quote, a comment and a multi-line string are.
+// Hardening one of them left the others naive, and every round of review found
+// the same class of defect in whichever scanner had not been touched. So the
+// file is now tokenized ONCE by scanTOMLLines, and narrowing, provider
+// selection and section listing all read that single result.
 
 // narrowedConfig is the result of narrowing one config file.
 type narrowedConfig struct {
@@ -27,6 +35,243 @@ type narrowedConfig struct {
 	dropped []string
 }
 
+// tomlLineKind classifies one physical line of a config file.
+type tomlLineKind int
+
+const (
+	// tomlLineOther is blank, a comment, or a continuation of the value opened
+	// on an earlier line (a multi-line string, array or inline table).
+	tomlLineOther tomlLineKind = iota
+	tomlLineHeader
+	tomlLinePair
+)
+
+// tomlLine is one physical line plus the state needed to classify it.
+type tomlLine struct {
+	raw  string
+	kind tomlLineKind
+	// path is the FULL dotted path: section-qualified for a pair, absolute for
+	// a header. Empty for tomlLineOther.
+	path []string
+	// section is the header in force when this line was read, so a top-level
+	// key is exactly one whose section is empty.
+	section []string
+	// opensRun is true when this line opens a value that continues onto
+	// following lines; those lines inherit this line's disposition.
+	opensRun bool
+	// readable is false for a pair whose key could not be parsed. Such a line
+	// is dropped rather than guessed at.
+	readable bool
+}
+
+// scanTOMLLines tokenizes a config file into classified lines.
+//
+// It is a line scanner rather than a full TOML parser, and every place that
+// distinction has bitten is handled HERE, once, instead of in each consumer:
+//
+//   - BACKSLASH ESCAPES inside basic strings. `x = "say \"[hi\""` is valid
+//     TOML; reading the escaped quote as a real terminator made the following
+//     "[" look unclosed, which opened a continuation run that swallowed - and
+//     therefore staged verbatim - the entire rest of the file.
+//   - COMMENTS and SINGLE-LINE STRINGS that merely CONTAIN `"""` or `”'`.
+//     Counting raw substrings turned `note = 1 # see """ docs` into a
+//     never-closing multi-line string (refusing a valid file) and a second
+//     stray occurrence into a leak of everything between them.
+//   - MULTI-LINE STRINGS, whose interior lines are neither headers nor keys.
+//   - UNBALANCED arrays and inline tables, whose continuation lines belong to
+//     the key that opened them.
+//   - A UTF-8 BOM, which strings.TrimSpace does not remove.
+//
+// Both open states FAIL CLOSED at end of file: an unterminated string or an
+// unbalanced bracket means the tail of the file was never classified, and
+// staging an unclassified tail is exactly the leak this function exists to
+// prevent. An unreadable section header fails closed for the same reason -
+// once a header cannot be attributed, no key after it can be either.
+func scanTOMLLines(data []byte) ([]tomlLine, error) {
+	var (
+		lines     []tomlLine
+		section   []string
+		multiline string
+		pending   int
+	)
+	for _, raw := range strings.Split(strings.TrimPrefix(string(data), "\ufeff"), "\n") {
+		// A line inside an open run is a continuation, whatever it looks like.
+		if multiline != "" || pending != 0 {
+			multiline, pending = advanceTOMLState(raw, multiline, pending)
+			lines = append(lines, tomlLine{raw: raw, kind: tomlLineOther})
+			continue
+		}
+
+		line := strings.TrimSpace(raw)
+		switch {
+		case line == "" || strings.HasPrefix(line, "#"):
+			lines = append(lines, tomlLine{raw: raw, kind: tomlLineOther, section: section})
+		case strings.HasPrefix(line, "["):
+			path, ok := parseTOMLSectionHeader(line)
+			if !ok {
+				return nil, fmt.Errorf("config has a section header that is not readable, so its credentials cannot be located: fix the file or remove it from the host state dir")
+			}
+			section = path
+			lines = append(lines, tomlLine{raw: raw, kind: tomlLineHeader, path: path, section: path, readable: true})
+		default:
+			key, value, isPair := strings.Cut(line, "=")
+			if !isPair {
+				lines = append(lines, tomlLine{raw: raw, kind: tomlLineOther, section: section})
+				continue
+			}
+			path, ok := parseTOMLKeyPath(strings.TrimSpace(key))
+			entry := tomlLine{raw: raw, kind: tomlLinePair, section: section, readable: ok}
+			if ok {
+				entry.path = append(append([]string{}, section...), path...)
+			}
+			nextMultiline, nextPending := advanceTOMLState(value, "", 0)
+			entry.opensRun = nextMultiline != "" || nextPending > 0
+			multiline, pending = nextMultiline, nextPending
+			lines = append(lines, entry)
+		}
+	}
+	if multiline != "" {
+		return nil, fmt.Errorf("config has a multi-line string that never closes, so narrowing it would corrupt the file: fix the file or remove it from the host state dir")
+	}
+	if pending != 0 {
+		return nil, fmt.Errorf("config has an array or inline table that never closes, so the rest of the file cannot be classified: fix the file or remove it from the host state dir")
+	}
+	return lines, nil
+}
+
+// advanceTOMLState walks one line of TOML text and returns the string and
+// bracket state left open at its end.
+//
+// This is the single place quotes, escapes and comments are interpreted. A
+// comment ends the line only OUTSIDE a string; a basic string honours
+// backslash escapes; a literal string does not; and a triple delimiter opens a
+// multi-line string that a later occurrence on the same line can close again.
+func advanceTOMLState(text, multiline string, pending int) (string, int) {
+	runes := []rune(text)
+	for index := 0; index < len(runes); {
+		if multiline != "" {
+			if strings.HasPrefix(string(runes[index:]), multiline) {
+				index += len([]rune(multiline))
+				multiline = ""
+				continue
+			}
+			index++
+			continue
+		}
+		rest := string(runes[index:])
+		switch {
+		case strings.HasPrefix(rest, `"""`):
+			multiline = `"""`
+			index += 3
+		case strings.HasPrefix(rest, `'''`):
+			multiline = `'''`
+			index += 3
+		case runes[index] == '"' || runes[index] == '\'':
+			quote := runes[index]
+			index++
+			for index < len(runes) {
+				if quote == '"' && runes[index] == '\\' {
+					// An escaped character - including an escaped quote - is
+					// part of the string, not its terminator.
+					index += 2
+					continue
+				}
+				if runes[index] == quote {
+					index++
+					break
+				}
+				index++
+			}
+		case runes[index] == '#':
+			// Outside a string, the rest of the line is a comment.
+			return multiline, pending
+		case runes[index] == '[' || runes[index] == '{':
+			pending++
+			index++
+		case runes[index] == ']' || runes[index] == '}':
+			pending--
+			if pending < 0 {
+				pending = 0
+			}
+			index++
+		default:
+			index++
+		}
+	}
+	return multiline, pending
+}
+
+// narrowTOML rewrites a config file, dropping every path the classifier
+// rejects. The classifier receives the FULL dotted path, so a section header, a
+// dotted key at top level and a key inside a section are judged identically.
+func narrowTOML(lines []tomlLine, drop func(path []string) (bool, string)) narrowedConfig {
+	var (
+		out        []string
+		dropping   bool
+		inRun      bool
+		runDrop    bool
+		droppedSet = map[string]struct{}{}
+	)
+	note := func(label string) {
+		if label != "" {
+			droppedSet[label] = struct{}{}
+		}
+	}
+	for _, line := range lines {
+		// A continuation line inherits the disposition of the key that opened
+		// the run. The scanner classifies every continuation as tomlLineOther,
+		// so the run ends at the next header or pair.
+		if inRun && line.kind == tomlLineOther {
+			if !runDrop {
+				out = append(out, line.raw)
+			}
+			continue
+		}
+		inRun = false
+		switch line.kind {
+		case tomlLineHeader:
+			var label string
+			dropping, label = drop(line.path)
+			if dropping {
+				note(label)
+				continue
+			}
+			out = append(out, line.raw)
+		case tomlLinePair:
+			dropLine := dropping
+			if !dropping {
+				if !line.readable {
+					// A key whose name cannot be read cannot be cleared.
+					dropLine = true
+					note("unreadable key")
+				} else {
+					var label string
+					dropLine, label = drop(line.path)
+					note(label)
+				}
+			}
+			if line.opensRun {
+				inRun, runDrop = true, dropLine
+			}
+			if dropLine {
+				continue
+			}
+			out = append(out, line.raw)
+		default:
+			if !dropping {
+				out = append(out, line.raw)
+			}
+		}
+	}
+
+	result := narrowedConfig{data: []byte(strings.Join(out, "\n"))}
+	for label := range droppedSet {
+		result.dropped = append(result.dropped, label)
+	}
+	sort.Strings(result.dropped)
+	return result
+}
+
 // narrowCodexConfig strips third-party credentials from a codex config.toml.
 //
 //   - mcp_servers is dropped WHOLESALE. env holds tokens, args can hold them
@@ -35,13 +280,7 @@ type narrowedConfig struct {
 //     stop a launch.
 //   - model_providers keeps its STRUCTURE - base_url and wire_api must survive
 //     or a custom model becomes unresolvable - and keeps api_key/http_headers
-//     ONLY for the provider that model_provider selects. Stripping the selected
-//     provider's key too was a review finding: env_key survives narrowing but
-//     names a variable readOnlyRuntimeBaseEnv's allowlist does not pass into
-//     the seat, so the seat was left with no way to authenticate at all.
-//
-// Everything else is kept: those are the model and sandbox settings the file is
-// staged for.
+//     ONLY for the provider that model_provider selects.
 func narrowCodexConfig(data []byte) ([]byte, error) {
 	result, err := narrowCodexConfigDetailed(data)
 	if err != nil {
@@ -51,8 +290,12 @@ func narrowCodexConfig(data []byte) ([]byte, error) {
 }
 
 func narrowCodexConfigDetailed(data []byte) (narrowedConfig, error) {
-	selected := tomlTopLevelScalar(data, "model_provider")
-	return narrowTOML(data, func(path []string) (bool, string) {
+	lines, err := scanTOMLLines(data)
+	if err != nil {
+		return narrowedConfig{}, err
+	}
+	selected := tomlTopLevelScalar(lines, "model_provider")
+	result := narrowTOML(lines, func(path []string) (bool, string) {
 		if len(path) == 0 {
 			return false, ""
 		}
@@ -66,7 +309,7 @@ func narrowCodexConfigDetailed(data []byte) (narrowedConfig, error) {
 		credential := false
 		for _, segment := range path[2:] {
 			// env_key and env_http_headers name environment VARIABLES rather
-			// than hold values, so they are not secrets and stay.
+			// than hold values, so they are not secrets.
 			if segment == "api_key" || segment == "http_headers" {
 				credential = true
 			}
@@ -81,6 +324,46 @@ func narrowCodexConfigDetailed(data []byte) (narrowedConfig, error) {
 		}
 		return true, "model_providers." + provider + " credential"
 	})
+	if err := codexSelectedProviderIsReachable(lines, selected); err != nil {
+		return narrowedConfig{}, err
+	}
+	return result, nil
+}
+
+// codexSelectedProviderIsReachable refuses a seat that could not authenticate
+// anyway, NAMING the reason.
+//
+// A custom provider can authenticate with an inline api_key or with env_key,
+// which names an environment variable. The seat's environment is a strict
+// allowlist (readOnlyRuntimeBaseEnv) that does not pass an arbitrary provider
+// variable through, so an env_key-only provider leaves the seat with no
+// credential at all. Staging succeeded silently and the runtime failed later
+// for a reason of its own choosing - the exact failure mode this whole policy
+// exists to remove.
+func codexSelectedProviderIsReachable(lines []tomlLine, selected string) error {
+	if selected == "" {
+		return nil
+	}
+	var hasAPIKey, hasEnvKey, exists bool
+	for _, line := range lines {
+		if len(line.path) < 2 || line.path[0] != "model_providers" || line.path[1] != selected {
+			continue
+		}
+		exists = true
+		if line.kind != tomlLinePair {
+			continue
+		}
+		switch line.path[len(line.path)-1] {
+		case "api_key":
+			hasAPIKey = true
+		case "env_key":
+			hasEnvKey = true
+		}
+	}
+	if !exists || hasAPIKey || !hasEnvKey {
+		return nil
+	}
+	return fmt.Errorf("codex model_provider %q authenticates only through env_key, and a read-only seat's environment allowlist does not pass that variable through: set an inline api_key for it, or point model_provider at a provider the seat can reach", selected)
 }
 
 // narrowKimiConfig strips third-party credentials from a kimi config.toml.
@@ -90,13 +373,12 @@ func narrowCodexConfigDetailed(data []byte) (narrowedConfig, error) {
 // [services.*.oauth], alongside [providers.*].
 //
 //   - services is dropped WHOLESALE, for the same reason as codex's
-//     mcp_servers: it configures optional tooling (moonshot search and fetch)
-//     and carries those tools' credentials. Dropping the section beats
-//     enumerating which of its keys is a secret, and it fails closed when a
-//     new one appears.
+//     mcp_servers: it configures optional tooling and carries those tools'
+//     credentials. Dropping the section beats enumerating which of its keys is
+//     a secret, and it fails closed when a new one appears.
 //   - providers keeps its structure and keeps api_key / env only for the
 //     provider default_model resolves to. Dropping every provider credential
-//     is not an option: kimi fails at startup when both api_key and the env
+//     is not an option: kimi refuses to start when both api_key and the env
 //     sub-table are absent, so the seat legitimately needs exactly one.
 func narrowKimiConfig(data []byte) ([]byte, error) {
 	result, err := narrowKimiConfigDetailed(data)
@@ -107,8 +389,12 @@ func narrowKimiConfig(data []byte) ([]byte, error) {
 }
 
 func narrowKimiConfigDetailed(data []byte) (narrowedConfig, error) {
-	selected := kimiSelectedProvider(data)
-	return narrowTOML(data, func(path []string) (bool, string) {
+	lines, err := scanTOMLLines(data)
+	if err != nil {
+		return narrowedConfig{}, err
+	}
+	selected := kimiSelectedProvider(lines)
+	return narrowTOML(lines, func(path []string) (bool, string) {
 		if len(path) == 0 {
 			return false, ""
 		}
@@ -132,7 +418,7 @@ func narrowKimiConfigDetailed(data []byte) (narrowedConfig, error) {
 			return false, ""
 		}
 		return true, "providers." + provider + " credential"
-	})
+	}), nil
 }
 
 // kimiSelectedProvider resolves default_model to the provider that serves it.
@@ -142,11 +428,11 @@ func narrowKimiConfigDetailed(data []byte) (narrowedConfig, error) {
 // first "/" matches the provider name's segment after the last ":".
 //
 // An empty result means NO provider was matched, and every provider credential
-// is then withheld: a credential nobody can prove is needed is not staged. The
-// withholding is reported, so the resulting startup failure names what gitmoot
-// removed instead of arriving as the runtime's own message.
-func kimiSelectedProvider(data []byte) string {
-	model := tomlTopLevelScalar(data, "default_model")
+// is then withheld: a credential nobody can prove is needed is not staged, and
+// the withholding is reported so the resulting startup failure names what
+// gitmoot removed.
+func kimiSelectedProvider(lines []tomlLine) string {
+	model := tomlTopLevelScalar(lines, "default_model")
 	if model == "" {
 		return ""
 	}
@@ -159,7 +445,7 @@ func kimiSelectedProvider(data []byte) string {
 		return ""
 	}
 	var match string
-	for _, provider := range tomlSectionNames(data, "providers") {
+	for _, provider := range tomlSectionNames(lines, "providers") {
 		short := provider
 		if index := strings.LastIndex(short, ":"); index >= 0 {
 			short = short[index+1:]
@@ -183,162 +469,26 @@ func pathTail(path []string, from int) string {
 	return strings.Join(path[from:], ".")
 }
 
-// narrowTOML rewrites a TOML file line by line, dropping every path the
-// classifier rejects. The classifier receives the FULL dotted path, so a
-// section header, a dotted key at top level, and a key inside a section are all
-// judged the same way.
-//
-// It is a line scanner, not a TOML parser, and the places that distinction
-// bites are handled explicitly:
-//
-//   - MULTI-LINE STRINGS. A line inside """ or ”' that begins with "[" is not
-//     a section header. Treating it as one both LEAKED (the fake header reset
-//     the section, so a following api_key was attributed to nothing) and
-//     CORRUPTED (it deleted lines out of a valid file and left an unterminated
-//     string, so codex reported a TOML error about a file gitmoot wrote).
-//   - UNBALANCED inline tables and arrays, which continue in the disposition of
-//     the key that opened them.
-//   - A UTF-8 BOM, which strings.TrimSpace does not remove, so a leading BOM
-//     hid the first header and classified everything under it against an empty
-//     path.
-//
-// An unreadable section header, and a multi-line string that never closes, both
-// FAIL CLOSED with an error naming the file. Once a header cannot be attributed
-// no following key can be classified, and the direction that leaks is the one
-// that guesses "probably fine".
-func narrowTOML(data []byte, drop func(path []string) (bool, string)) (narrowedConfig, error) {
-	var (
-		out        []string
-		section    []string
-		dropping   bool
-		pending    int
-		pendingIn  bool
-		multiline  string
-		multiIn    bool
-		droppedSet = map[string]struct{}{}
-	)
-	note := func(label string) {
-		if label != "" {
-			droppedSet[label] = struct{}{}
-		}
-	}
-
-	for _, raw := range strings.Split(strings.TrimPrefix(string(data), "\ufeff"), "\n") {
-		line := strings.TrimSpace(raw)
-
-		// Inside a multi-line string nothing is a header and nothing is a key.
-		if multiline != "" {
-			if !multiIn {
-				out = append(out, raw)
-			}
-			if strings.Contains(raw, multiline) {
-				multiline = ""
-			}
-			continue
-		}
-
-		if pending != 0 {
-			pending += bracketBalance(line)
-			if !pendingIn {
-				out = append(out, raw)
-			}
-			if pending <= 0 {
-				pending = 0
-			}
-			continue
-		}
-
-		if strings.HasPrefix(line, "[") {
-			path, ok := parseTOMLSectionHeader(line)
-			if !ok {
-				return narrowedConfig{}, fmt.Errorf("config has a section header that is not readable, so its credentials cannot be located: fix the file or remove it from the host state dir")
-			}
-			section = path
-			var label string
-			dropping, label = drop(path)
-			if dropping {
-				note(label)
-				continue
-			}
-			out = append(out, raw)
-			continue
-		}
-
-		if line == "" || strings.HasPrefix(line, "#") {
-			if !dropping {
-				out = append(out, raw)
-			}
-			continue
-		}
-
-		key, value, isPair := strings.Cut(line, "=")
-		dropLine := dropping
-		if isPair && !dropping {
-			path, ok := parseTOMLKeyPath(strings.TrimSpace(key))
-			if !ok {
-				// A key whose name cannot be read cannot be cleared.
-				dropLine = true
-				note("unreadable key")
-			} else {
-				var label string
-				dropLine, label = drop(append(append([]string{}, section...), path...))
-				note(label)
-			}
-		}
-		if delimiter := openMultilineDelimiter(value); delimiter != "" {
-			multiline, multiIn = delimiter, dropLine
-		} else if balance := bracketBalance(line); balance > 0 {
-			pending, pendingIn = balance, dropLine
-		}
-		if dropLine {
-			continue
-		}
-		out = append(out, raw)
-	}
-	if multiline != "" {
-		return narrowedConfig{}, fmt.Errorf("config has a multi-line string that never closes, so narrowing it would corrupt the file: fix the file or remove it from the host state dir")
-	}
-
-	result := narrowedConfig{data: []byte(strings.Join(out, "\n"))}
-	for label := range droppedSet {
-		result.dropped = append(result.dropped, label)
-	}
-	sort.Strings(result.dropped)
-	return result, nil
-}
-
-// openMultilineDelimiter reports the delimiter of a multi-line string opened on
-// this line and not closed on it: `"""a"""` opens and closes, `"""` stays open.
-func openMultilineDelimiter(value string) string {
-	for _, delimiter := range []string{`"""`, `'''`} {
-		if count := strings.Count(value, delimiter); count > 0 && count%2 == 1 {
-			return delimiter
-		}
-	}
-	return ""
-}
-
 // tomlTopLevelScalar reads a TOP-LEVEL scalar string key (model_provider,
-// default_model). Keys inside sections are ignored deliberately: both are
-// documented as top level, and a same-named key in a section must not be
-// mistaken for the selection.
-func tomlTopLevelScalar(data []byte, wanted string) string {
-	inSection := false
-	for _, raw := range strings.Split(strings.TrimPrefix(string(data), "\ufeff"), "\n") {
-		line := strings.TrimSpace(raw)
-		if strings.HasPrefix(line, "[") {
-			inSection = true
+// default_model) from an already-scanned file, so it inherits the scanner's
+// multi-line-string and comment handling rather than reimplementing it. Keys
+// inside sections are ignored deliberately: both keys are documented as top
+// level, and a same-named key in a section must not be read as the selection.
+func tomlTopLevelScalar(lines []tomlLine, wanted string) string {
+	for _, line := range lines {
+		if line.kind != tomlLinePair || !line.readable {
 			continue
 		}
-		if inSection || line == "" || strings.HasPrefix(line, "#") {
+		// path is section-qualified, so a length of exactly one IS the
+		// top-level test: any key inside a section has its header prepended
+		// and cannot match. An earlier version also checked line.section
+		// explicitly, which was redundant - and unkillable by mutation, which
+		// is how the redundancy came to light.
+		if len(line.path) != 1 || line.path[0] != wanted {
 			continue
 		}
-		key, value, ok := strings.Cut(line, "=")
+		_, value, ok := strings.Cut(strings.TrimSpace(line.raw), "=")
 		if !ok {
-			continue
-		}
-		path, parsed := parseTOMLKeyPath(strings.TrimSpace(key))
-		if !parsed || len(path) != 1 || path[0] != wanted {
 			continue
 		}
 		return strings.Trim(strings.TrimSpace(value), `"'`)
@@ -348,29 +498,24 @@ func tomlTopLevelScalar(data []byte, wanted string) string {
 
 // tomlSectionNames lists the second path segment of every section under root,
 // so [providers."managed:kimi-code"] yields `managed:kimi-code`.
-func tomlSectionNames(data []byte, root string) []string {
+func tomlSectionNames(lines []tomlLine, root string) []string {
 	var names []string
 	seen := map[string]struct{}{}
-	for _, raw := range strings.Split(strings.TrimPrefix(string(data), "\ufeff"), "\n") {
-		line := strings.TrimSpace(raw)
-		if !strings.HasPrefix(line, "[") {
+	for _, line := range lines {
+		if line.kind != tomlLineHeader || len(line.path) < 2 || line.path[0] != root {
 			continue
 		}
-		path, ok := parseTOMLSectionHeader(line)
-		if !ok || len(path) < 2 || path[0] != root {
+		if _, done := seen[line.path[1]]; done {
 			continue
 		}
-		if _, done := seen[path[1]]; done {
-			continue
-		}
-		seen[path[1]] = struct{}{}
-		names = append(names, path[1])
+		seen[line.path[1]] = struct{}{}
+		names = append(names, line.path[1])
 	}
 	return names
 }
 
 // parseTOMLSectionHeader reads [a.b] and [[a.b]] into a dotted path. The second
-// result is false for a header that does not close, which narrowTOML fails
+// result is false for a header that does not close, which the scanner fails
 // closed on.
 func parseTOMLSectionHeader(line string) ([]string, bool) {
 	body := strings.TrimPrefix(line, "[")
@@ -434,30 +579,4 @@ func parseTOMLKeyPath(key string) ([]string, bool) {
 		}
 	}
 	return path, true
-}
-
-// bracketBalance counts unclosed inline-table and array brackets on one line,
-// ignoring quoted text and comments.
-func bracketBalance(line string) int {
-	var (
-		depth int
-		quote rune
-	)
-	for _, r := range line {
-		switch {
-		case quote != 0:
-			if r == quote {
-				quote = 0
-			}
-		case r == '"' || r == '\'':
-			quote = r
-		case r == '#':
-			return depth
-		case r == '{' || r == '[':
-			depth++
-		case r == '}' || r == ']':
-			depth--
-		}
-	}
-	return depth
 }

--- a/internal/cli/readonly_seat_config_narrow.go
+++ b/internal/cli/readonly_seat_config_narrow.go
@@ -1,0 +1,215 @@
+package cli
+
+import (
+	"fmt"
+	"strings"
+)
+
+// narrowCodexConfig removes third-party credentials from a codex config.toml
+// before it is staged into a read-only seat.
+//
+// The seat stages config.toml so the codex CLI keeps the operator's model and
+// sandbox settings. That file routinely also carries credentials that have
+// nothing to do with running the model: [mcp_servers.*.env] holds tokens for
+// third-party servers, and [model_providers.*] holds api_key and http_headers.
+// The seat's state dir lives inside the one WRITABLE path granted to the
+// sandbox, so anything staged there is readable by the reviewer the seat runs.
+//
+// Two dispositions, chosen for what each costs when it is wrong:
+//
+//   - mcp_servers is dropped WHOLESALE. Its env table is the token carrier, but
+//     args and command can carry a secret just as easily, and a read-only
+//     reviewer seat has no business spawning third-party servers. Dropping it
+//     cannot break startup: MCP servers are optional to codex.
+//   - model_providers keeps its structure and loses only api_key and
+//     http_headers. Dropping the section would be safer still and is wrong:
+//     when model names a custom provider, removing base_url and wire_api makes
+//     the model unresolvable, so a narrowing meant to protect the seat would
+//     stop it launching.
+//
+// Unknown keys are KEPT, because they are the model and sandbox settings this
+// file is staged for. An unparseable section header is FAIL-CLOSED: it drops
+// through to the end of the file. Once a header cannot be attributed, no
+// following key can be classified, and the direction that leaks is the one
+// that guesses "probably fine".
+func narrowCodexConfig(data []byte) ([]byte, error) {
+	var (
+		out       []string
+		section   []string
+		dropping  bool
+		unknown   bool
+		pending   int
+		pendingIn bool
+	)
+	for _, raw := range strings.Split(string(data), "\n") {
+		line := strings.TrimSpace(raw)
+
+		// A value that opened an unbalanced inline table or array continues in
+		// the disposition of the key that opened it.
+		if pending != 0 {
+			pending += bracketBalance(line)
+			if !pendingIn {
+				out = append(out, raw)
+			}
+			if pending <= 0 {
+				pending = 0
+			}
+			continue
+		}
+
+		if strings.HasPrefix(line, "[") {
+			path, ok := parseCodexSectionHeader(line)
+			if !ok {
+				// Fail closed: an unattributable header means every key after it
+				// is unattributable too.
+				unknown = true
+				dropping = true
+				continue
+			}
+			section = path
+			dropping = codexPathCarriesCredentials(path)
+			if dropping {
+				continue
+			}
+			out = append(out, raw)
+			continue
+		}
+
+		if unknown {
+			continue
+		}
+
+		if line == "" || strings.HasPrefix(line, "#") {
+			if !dropping {
+				out = append(out, raw)
+			}
+			continue
+		}
+
+		key, _, isPair := strings.Cut(line, "=")
+		drop := dropping
+		if isPair {
+			path, ok := parseCodexKeyPath(strings.TrimSpace(key))
+			if !ok {
+				// A key whose name cannot be read cannot be cleared.
+				drop = true
+			} else if !dropping {
+				drop = codexPathCarriesCredentials(append(append([]string{}, section...), path...))
+			}
+		}
+		if balance := bracketBalance(line); balance > 0 {
+			pending = balance
+			pendingIn = drop
+		}
+		if drop {
+			continue
+		}
+		out = append(out, raw)
+	}
+	if unknown {
+		return nil, fmt.Errorf("codex config.toml has a section header that is not readable, so its credentials cannot be located: fix the file or remove it from the host state dir")
+	}
+	return []byte(strings.Join(out, "\n")), nil
+}
+
+// codexPathCarriesCredentials reports whether a dotted TOML path names a value
+// that must never reach a read-only seat.
+func codexPathCarriesCredentials(path []string) bool {
+	if len(path) == 0 {
+		return false
+	}
+	if path[0] == "mcp_servers" {
+		return true
+	}
+	if path[0] == "model_providers" {
+		for _, segment := range path[1:] {
+			// env_key and env_http_headers name environment VARIABLES, not
+			// values, so they are not secrets and stay.
+			if segment == "api_key" || segment == "http_headers" {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// parseCodexSectionHeader reads [a.b] and [[a.b]] into a dotted path. The
+// second result is false for a header that does not close, which is the case
+// narrowCodexConfig fails closed on.
+func parseCodexSectionHeader(line string) ([]string, bool) {
+	body := strings.TrimPrefix(line, "[")
+	body = strings.TrimPrefix(body, "[")
+	end := strings.LastIndex(body, "]")
+	if end < 0 {
+		return nil, false
+	}
+	body = strings.TrimSpace(body[:end])
+	body = strings.TrimSuffix(body, "]")
+	if strings.TrimSpace(body) == "" {
+		return nil, false
+	}
+	return parseCodexKeyPath(strings.TrimSpace(body))
+}
+
+// parseCodexKeyPath splits a dotted TOML key on separators that are not inside
+// quotes, so [mcp_servers."my server".env] classifies as mcp_servers.
+func parseCodexKeyPath(key string) ([]string, bool) {
+	var (
+		path    []string
+		current strings.Builder
+		quote   rune
+	)
+	for _, r := range key {
+		switch {
+		case quote != 0:
+			if r == quote {
+				quote = 0
+				continue
+			}
+			current.WriteRune(r)
+		case r == '"' || r == '\'':
+			quote = r
+		case r == '.':
+			path = append(path, strings.TrimSpace(current.String()))
+			current.Reset()
+		default:
+			current.WriteRune(r)
+		}
+	}
+	if quote != 0 {
+		return nil, false
+	}
+	path = append(path, strings.TrimSpace(current.String()))
+	for _, segment := range path {
+		if segment == "" {
+			return nil, false
+		}
+	}
+	return path, true
+}
+
+// bracketBalance counts unclosed inline-table and array brackets on one line,
+// ignoring quoted text and comments.
+func bracketBalance(line string) int {
+	var (
+		depth int
+		quote rune
+	)
+	for _, r := range line {
+		switch {
+		case quote != 0:
+			if r == quote {
+				quote = 0
+			}
+		case r == '"' || r == '\'':
+			quote = r
+		case r == '#':
+			return depth
+		case r == '{' || r == '[':
+			depth++
+		case r == '}' || r == ']':
+			depth--
+		}
+	}
+	return depth
+}

--- a/internal/cli/readonly_seat_config_narrow_test.go
+++ b/internal/cli/readonly_seat_config_narrow_test.go
@@ -1,0 +1,104 @@
+package cli
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestNarrowCodexConfigRemovesCredentialsAndKeepsSettings(t *testing.T) {
+	const cfg = `model = "gpt-5"
+approval_policy = "never"
+
+[sandbox_workspace_write]
+network_access = false
+
+[mcp_servers.github]
+command = "npx"
+args = ["-y", "server", "--token=inline_secret"]
+[mcp_servers.github.env]
+GITHUB_TOKEN = "ghp_SECRET"
+
+[model_providers.mycorp]
+base_url = "https://api.mycorp.test/v1"
+wire_api = "chat"
+env_key = "MYCORP_API_KEY"
+api_key = "sk-SECRET"
+http_headers = { Authorization = "Bearer SECRET_HEADER" }
+`
+	got, err := narrowCodexConfig([]byte(cfg))
+	if err != nil {
+		t.Fatalf("narrow: %v", err)
+	}
+	out := string(got)
+	for _, secret := range []string{"ghp_SECRET", "sk-SECRET", "SECRET_HEADER", "inline_secret", "GITHUB_TOKEN", "mcp_servers"} {
+		if strings.Contains(out, secret) {
+			t.Errorf("narrowed config still carries %q:\n%s", secret, out)
+		}
+	}
+	// The settings the file is staged for must survive, including the provider
+	// definition that makes a custom model resolvable.
+	for _, keep := range []string{`model = "gpt-5"`, "approval_policy", "sandbox_workspace_write", "network_access", "[model_providers.mycorp]", "api.mycorp.test", "wire_api", `env_key = "MYCORP_API_KEY"`} {
+		if !strings.Contains(out, keep) {
+			t.Errorf("narrowed config dropped %q:\n%s", keep, out)
+		}
+	}
+}
+
+// TestNarrowCodexConfigClosesDottedAndQuotedBypasses pins the two shapes that
+// route around a scanner keyed on section headers alone: a top-level dotted key
+// that never opens a [mcp_servers] section, and a quoted server name whose dot
+// is inside the quotes.
+func TestNarrowCodexConfigClosesDottedAndQuotedBypasses(t *testing.T) {
+	cases := map[string]string{
+		"top-level dotted key":     "model = \"gpt-5\"\nmcp_servers.github.env.GITHUB_TOKEN = \"ghp_DOTTED\"\n",
+		"quoted server name":       "model = \"gpt-5\"\n[mcp_servers.\"my server\".env]\nTOKEN = \"ghp_QUOTED\"\n",
+		"dotted provider api_key":  "model = \"gpt-5\"\nmodel_providers.mycorp.api_key = \"sk-DOTTED\"\n",
+		"multi-line inline table":  "model = \"gpt-5\"\n[mcp_servers.github]\nenv = {\n  GITHUB_TOKEN = \"ghp_MULTILINE\"\n}\n",
+		"provider inline continue": "model = \"gpt-5\"\n[model_providers.p]\nhttp_headers = {\n  Authorization = \"Bearer SPANNED\"\n}\nbase_url = \"https://keep.test\"\n",
+	}
+	for name, cfg := range cases {
+		t.Run(name, func(t *testing.T) {
+			got, err := narrowCodexConfig([]byte(cfg))
+			if err != nil {
+				t.Fatalf("narrow: %v", err)
+			}
+			out := string(got)
+			for _, secret := range []string{"ghp_DOTTED", "ghp_QUOTED", "sk-DOTTED", "ghp_MULTILINE", "SPANNED"} {
+				if strings.Contains(out, secret) {
+					t.Errorf("bypass: %q survived narrowing:\n%s", secret, out)
+				}
+			}
+			if !strings.Contains(out, `model = "gpt-5"`) {
+				t.Errorf("narrowing dropped the model setting:\n%s", out)
+			}
+		})
+	}
+	// A value dropped mid-table must not take the following key with it.
+	got, err := narrowCodexConfig([]byte("[model_providers.p]\nhttp_headers = {\n  Authorization = \"Bearer SPANNED\"\n}\nbase_url = \"https://keep.test\"\n"))
+	if err != nil {
+		t.Fatalf("narrow: %v", err)
+	}
+	if !strings.Contains(string(got), "https://keep.test") {
+		t.Errorf("a dropped inline table swallowed the key after it:\n%s", got)
+	}
+}
+
+// TestNarrowCodexConfigFailsClosedOnUnreadableHeader pins the direction that
+// matters: once a header cannot be attributed, staging must refuse rather than
+// keep the rest of the file and hope it holds no credentials.
+func TestNarrowCodexConfigFailsClosedOnUnreadableHeader(t *testing.T) {
+	for name, cfg := range map[string]string{
+		"header never closes": "[mcp_servers.github\nGITHUB_TOKEN = \"ghp_AFTER_MALFORMED\"\n",
+		"empty header":        "[]\napi_key = \"sk-AFTER_EMPTY\"\n",
+	} {
+		t.Run(name, func(t *testing.T) {
+			got, err := narrowCodexConfig([]byte(cfg))
+			if err == nil {
+				t.Fatalf("expected a refusal, got a staged file:\n%s", got)
+			}
+			if !strings.Contains(err.Error(), "not readable") {
+				t.Errorf("error does not say what is wrong with the file: %v", err)
+			}
+		})
+	}
+}

--- a/internal/cli/readonly_seat_config_staging_test.go
+++ b/internal/cli/readonly_seat_config_staging_test.go
@@ -41,7 +41,7 @@ http_headers = { Authorization = "Bearer LEAKED-HEADER" }
 	}
 	cacheRoot := t.TempDir()
 	agent := runtime.Agent{Runtime: runtime.CodexRuntime, RuntimeConfigDir: src}
-	stateDir, _, err := prepareReadOnlyRuntimeState(agent, cacheRoot, false)
+	stateDir, _, _, err := prepareReadOnlyRuntimeState(agent, cacheRoot, false)
 	if err != nil {
 		t.Fatalf("prepare: %v", err)
 	}

--- a/internal/cli/readonly_seat_config_staging_test.go
+++ b/internal/cli/readonly_seat_config_staging_test.go
@@ -1,0 +1,63 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/gitmoot/gitmoot/internal/runtime"
+)
+
+// TestSeatStagesCodexConfigWithoutThirdPartySecrets pins the narrowing THROUGH
+// THE STAGING PATH, not through narrowCodexConfig directly.
+//
+// The narrowing is only worth anything if prepareReadOnlyRuntimeState actually
+// applies it: a policy that declares config.toml as an optional input and
+// forgets its narrower would leave the helper perfectly correct and the seat
+// still leaking. This test reads the file out of the seat's state dir.
+func TestSeatStagesCodexConfigWithoutThirdPartySecrets(t *testing.T) {
+	home := t.TempDir()
+	src := filepath.Join(home, ".codex")
+	if err := os.MkdirAll(src, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	const cfg = `model = "gpt-5"
+approval_policy = "never"
+
+[mcp_servers.github]
+command = "npx"
+[mcp_servers.github.env]
+GITHUB_TOKEN = "ghp_SUPERSECRET_TOKEN"
+
+[model_providers.mycorp]
+base_url = "https://api.mycorp.test/v1"
+wire_api = "chat"
+api_key = "sk-LEAKED-PROVIDER-KEY"
+http_headers = { Authorization = "Bearer LEAKED-HEADER" }
+`
+	if err := os.WriteFile(filepath.Join(src, "config.toml"), []byte(cfg), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	cacheRoot := t.TempDir()
+	agent := runtime.Agent{Runtime: runtime.CodexRuntime, RuntimeConfigDir: src}
+	stateDir, _, err := prepareReadOnlyRuntimeState(agent, cacheRoot, false)
+	if err != nil {
+		t.Fatalf("prepare: %v", err)
+	}
+	staged, err := os.ReadFile(filepath.Join(stateDir, "config.toml"))
+	if err != nil {
+		t.Fatalf("read staged: %v", err)
+	}
+	for _, secret := range []string{"ghp_SUPERSECRET_TOKEN", "sk-LEAKED-PROVIDER-KEY", "LEAKED-HEADER"} {
+		if strings.Contains(string(staged), secret) {
+			t.Errorf("the seat staged a third-party secret: %q is readable inside the sandbox", secret)
+		}
+	}
+	if !strings.Contains(string(staged), `model = "gpt-5"`) {
+		t.Errorf("narrowing dropped the model setting, which is what the file is staged for:\n%s", staged)
+	}
+	if !strings.Contains(string(staged), "api.mycorp.test") {
+		t.Errorf("narrowing dropped the provider base_url, so a custom model would not resolve:\n%s", staged)
+	}
+}

--- a/internal/cli/readonly_seat_credential_usable_test.go
+++ b/internal/cli/readonly_seat_credential_usable_test.go
@@ -85,7 +85,7 @@ func TestReadOnlySeatRefusesAnUnusableClaudeProfileByName(t *testing.T) {
 	}
 
 	agent := runtime.Agent{Runtime: runtime.ClaudeRuntime, RuntimeConfigDir: source}
-	_, _, err := prepareReadOnlyRuntimeState(agent, t.TempDir(), false)
+	_, _, _, err := prepareReadOnlyRuntimeState(agent, t.TempDir(), false)
 	if err == nil {
 		t.Fatal("an expired, unrefreshable claude profile staged cleanly; the seat would fail later and opaquely")
 	}
@@ -100,7 +100,7 @@ func TestReadOnlySeatRefusesAnUnusableClaudeProfileByName(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(source, ".credentials.json"), []byte(good), 0o600); err != nil {
 		t.Fatal(err)
 	}
-	stateDir, _, err := prepareReadOnlyRuntimeState(agent, t.TempDir(), false)
+	stateDir, _, _, err := prepareReadOnlyRuntimeState(agent, t.TempDir(), false)
 	if err != nil {
 		t.Fatalf("a working claude profile must stage, got: %v", err)
 	}
@@ -130,7 +130,7 @@ func TestReadOnlySeatGatewayModeStagesNoCredential(t *testing.T) {
 	}
 
 	agent := runtime.Agent{Runtime: runtime.ClaudeRuntime, RuntimeConfigDir: source}
-	stateDir, stateEnv, err := prepareReadOnlyRuntimeState(agent, t.TempDir(), true)
+	stateDir, stateEnv, _, err := prepareReadOnlyRuntimeState(agent, t.TempDir(), true)
 	if err != nil {
 		t.Fatalf("gateway mode must not stage or judge the host credential, got: %v", err)
 	}
@@ -139,5 +139,54 @@ func TestReadOnlySeatGatewayModeStagesNoCredential(t *testing.T) {
 	}
 	if len(stateEnv) == 0 || !strings.Contains(fmt.Sprint(stateEnv), "CLAUDE_CONFIG_DIR") {
 		t.Errorf("gateway mode state env = %v, want CLAUDE_CONFIG_DIR pointed at the isolated dir", stateEnv)
+	}
+}
+
+// TestClaudeOAuthToleratesFormatDrift is the round-2 P3: expiresAt decoded as a
+// strict int64, so a third party writing it as a STRING or in exponent
+// notation aborted the entire seat with a raw Go unmarshal error - a hard
+// outage caused by how gitmoot READS a file it does not own. Both staged fine
+// at merge base.
+func TestClaudeOAuthToleratesFormatDrift(t *testing.T) {
+	future := time.Now().Add(2 * time.Hour).UnixMilli()
+	noVerdict := map[string]string{
+		"expiresAt as a string":          `{"claudeAiOauth":{"accessToken":"t","expiresAt":"32503680000000"}}`,
+		"expiresAt in exponent form":     `{"claudeAiOauth":{"accessToken":"t","expiresAt":1.9e12}}`,
+		"expiresAt in SECONDS":           `{"claudeAiOauth":{"accessToken":"t","expiresAt":1756000000}}`,
+		"expiresAt as a bool":            `{"claudeAiOauth":{"accessToken":"t","expiresAt":true}}`,
+		"claudeAiOauth is not an object": `{"claudeAiOauth":"opaque"}`,
+		"not our format at all":          `{"somethingElse":{}}`,
+	}
+	for name, credential := range noVerdict {
+		t.Run("no verdict/"+name, func(t *testing.T) {
+			if err := claudeOAuthUsable([]byte(credential)); err != nil {
+				t.Fatalf("format drift became a hard seat outage: %v", err)
+			}
+		})
+	}
+
+	// Judgements it CAN prove are unchanged.
+	if err := claudeOAuthUsable([]byte(`{"claudeAiOauth":{"accessToken":"t","expiresAt":` + fmt.Sprint(future) + `}}`)); err != nil {
+		t.Errorf("an unexpired token was rejected: %v", err)
+	}
+	expired := time.Now().Add(-2 * time.Hour).UnixMilli()
+	if err := claudeOAuthUsable([]byte(`{"claudeAiOauth":{"accessToken":"t","expiresAt":` + fmt.Sprint(expired) + `}}`)); err == nil {
+		t.Error("an expired token with no refreshToken was accepted")
+	}
+
+	// A PAST exponent value decodes and yields the ordinary verdict - the
+	// round-2 finding was the raw unmarshal error, not the judgement.
+	err := claudeOAuthUsable([]byte(`{"claudeAiOauth":{"accessToken":"t","expiresAt":1.75e12}}`))
+	if err == nil {
+		t.Error("a past exponent-form expiry produced no verdict")
+	} else if strings.Contains(err.Error(), "cannot unmarshal") {
+		t.Errorf("exponent form still aborts with a raw Go json error: %v", err)
+	}
+
+	// Clock skew must not condemn a seat: a token that just expired is inside
+	// the grace window.
+	justExpired := time.Now().Add(-time.Minute).UnixMilli()
+	if err := claudeOAuthUsable([]byte(`{"claudeAiOauth":{"accessToken":"t","expiresAt":` + fmt.Sprint(justExpired) + `}}`)); err != nil {
+		t.Errorf("a token one minute past expiry was refused, which is a clock-skew verdict: %v", err)
 	}
 }

--- a/internal/cli/readonly_seat_credential_usable_test.go
+++ b/internal/cli/readonly_seat_credential_usable_test.go
@@ -1,0 +1,143 @@
+package cli
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gitmoot/gitmoot/internal/runtime"
+)
+
+func claudeCredential(t *testing.T, accessToken, refreshToken string, expiresAt int64) string {
+	t.Helper()
+	oauth := map[string]any{"accessToken": accessToken}
+	if refreshToken != "" {
+		oauth["refreshToken"] = refreshToken
+	}
+	if expiresAt != 0 {
+		oauth["expiresAt"] = expiresAt
+	}
+	encoded, err := json.Marshal(map[string]any{"claudeAiOauth": oauth})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(encoded)
+}
+
+// TestClaudeOAuthUsabilityIsJudgedOnlyWhenProvable pins BOTH directions.
+//
+// The policy previously validated presence and JSON shape and never usability,
+// so an expired-and-unrefreshable profile staged cleanly and the seat died on
+// the runtime's own opaque error. The check must catch that - and must NOT
+// invent a verdict where none is provable, which is how every bound added in
+// this campaign has previously broken valid input.
+func TestClaudeOAuthUsabilityIsJudgedOnlyWhenProvable(t *testing.T) {
+	past := time.Now().Add(-2 * time.Hour).UnixMilli()
+	future := time.Now().Add(2 * time.Hour).UnixMilli()
+
+	usable := map[string]string{
+		"unexpired":                 claudeCredential(t, "token", "", future),
+		"expired but refreshable":   claudeCredential(t, "token", "refresh", past),
+		"no expiry recorded":        claudeCredential(t, "token", "", 0),
+		"unexpired and refreshable": claudeCredential(t, "token", "refresh", future),
+	}
+	for name, credential := range usable {
+		t.Run("usable/"+name, func(t *testing.T) {
+			if err := claudeOAuthUsable([]byte(credential)); err != nil {
+				t.Fatalf("rejected a credential it cannot prove is broken: %v", err)
+			}
+		})
+	}
+
+	unusable := map[string]struct{ credential, wants string }{
+		"expired with no refresh token": {claudeCredential(t, "token", "", past), "refreshToken"},
+		"no access token":               {claudeCredential(t, "", "refresh", future), "accessToken"},
+	}
+	for name, tc := range unusable {
+		t.Run("unusable/"+name, func(t *testing.T) {
+			err := claudeOAuthUsable([]byte(tc.credential))
+			if err == nil {
+				t.Fatal("accepted a credential that cannot authenticate")
+			}
+			if !strings.Contains(err.Error(), tc.wants) {
+				t.Errorf("error = %v, want it to name %q so an operator knows what to fix", err, tc.wants)
+			}
+		})
+	}
+}
+
+// TestReadOnlySeatRefusesAnUnusableClaudeProfileByName drives the check through
+// the real staging path: the failure must arrive at STAGING time and name the
+// file, rather than later as the runtime's own message.
+func TestReadOnlySeatRefusesAnUnusableClaudeProfileByName(t *testing.T) {
+	home := t.TempDir()
+	source := filepath.Join(home, ".claude")
+	if err := os.MkdirAll(source, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	expired := claudeCredential(t, "token", "", time.Now().Add(-time.Hour).UnixMilli())
+	if err := os.WriteFile(filepath.Join(source, ".credentials.json"), []byte(expired), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	agent := runtime.Agent{Runtime: runtime.ClaudeRuntime, RuntimeConfigDir: source}
+	_, _, err := prepareReadOnlyRuntimeState(agent, t.TempDir(), false)
+	if err == nil {
+		t.Fatal("an expired, unrefreshable claude profile staged cleanly; the seat would fail later and opaquely")
+	}
+	for _, want := range []string{".credentials.json", "expired"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error = %v, want it to mention %q", err, want)
+		}
+	}
+
+	// A working profile must still stage, and the narrowed section must survive.
+	good := claudeCredential(t, "token", "refresh", time.Now().Add(time.Hour).UnixMilli())
+	if err := os.WriteFile(filepath.Join(source, ".credentials.json"), []byte(good), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	stateDir, _, err := prepareReadOnlyRuntimeState(agent, t.TempDir(), false)
+	if err != nil {
+		t.Fatalf("a working claude profile must stage, got: %v", err)
+	}
+	staged, err := os.ReadFile(filepath.Join(stateDir, ".credentials.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(staged), "claudeAiOauth") {
+		t.Errorf("staged credential lost its section: %s", staged)
+	}
+}
+
+// TestReadOnlySeatGatewayModeStagesNoCredential closes the reviewer's P3 on
+// gateway mode, which the coverage test never probed: in gateway mode the
+// credential is supplied by the gateway, so the seat must stage none - and the
+// usability check must therefore not run at all.
+func TestReadOnlySeatGatewayModeStagesNoCredential(t *testing.T) {
+	home := t.TempDir()
+	source := filepath.Join(home, ".claude")
+	if err := os.MkdirAll(source, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	// Deliberately unusable: gateway mode must not read it, let alone judge it.
+	expired := claudeCredential(t, "", "", time.Now().Add(-time.Hour).UnixMilli())
+	if err := os.WriteFile(filepath.Join(source, ".credentials.json"), []byte(expired), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	agent := runtime.Agent{Runtime: runtime.ClaudeRuntime, RuntimeConfigDir: source}
+	stateDir, stateEnv, err := prepareReadOnlyRuntimeState(agent, t.TempDir(), true)
+	if err != nil {
+		t.Fatalf("gateway mode must not stage or judge the host credential, got: %v", err)
+	}
+	if _, statErr := os.Stat(filepath.Join(stateDir, ".credentials.json")); !os.IsNotExist(statErr) {
+		t.Errorf("gateway mode staged a credential into the seat: %v", statErr)
+	}
+	if len(stateEnv) == 0 || !strings.Contains(fmt.Sprint(stateEnv), "CLAUDE_CONFIG_DIR") {
+		t.Errorf("gateway mode state env = %v, want CLAUDE_CONFIG_DIR pointed at the isolated dir", stateEnv)
+	}
+}

--- a/internal/cli/readonly_seat_daemon_lock_test.go
+++ b/internal/cli/readonly_seat_daemon_lock_test.go
@@ -1,0 +1,145 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gitmoot/gitmoot/internal/config"
+
+	"github.com/gitmoot/gitmoot/internal/db"
+	"github.com/gitmoot/gitmoot/internal/runtime"
+	"github.com/gitmoot/gitmoot/internal/workflow"
+)
+
+// TestDaemonWorkerLocksTheRegisteredSessionForAReadOnlySeat pins the invariant
+// this PR exists to protect, ON THE DAEMON PATH.
+//
+// jobWorker.run copies the agent into sessionLockAgent BEFORE applyReadOnlySeat
+// rewrites RuntimeRef to the seat's fresh ref, and acquires the lock with that
+// copy. Lock with the rewritten agent instead and a read-only seat stops
+// serializing behind the reviewer's registered session (#684).
+//
+// The existing coverage pins the same invariant on the dispatch path and, in
+// TestApplyReadOnlySeatLeavesTheSessionLockAgentIntact, on a LOCAL copy of the
+// idiom. Neither enters this function, which is why moving the acquisition here
+// onto the post-seat agent survives the whole package. A test that pins the
+// twin is not a test of this path.
+//
+// Method: hold the REGISTERED session's lock under a foreign owner, then drive
+// the real jobWorker.run. Keying the lock off the registered ref must observe
+// that conflict; keying it off the seat's per-job fresh ref cannot, because
+// nothing else can ever hold that key.
+func TestDaemonWorkerLocksTheRegisteredSessionForAReadOnlySeat(t *testing.T) {
+	ctx := context.Background()
+	home := t.TempDir()
+	store := openCLIJobStore(t, home)
+	defer store.Close()
+
+	const registeredRef = "019fa4c8-69c1-7bc2-8628-00ade8fa43c5"
+	// same_session = queue makes the busy outcome deterministic; the default
+	// fork_temp_session forks a temp worker instead, which is its own finding.
+	paths := config.PathsForHome(home)
+	if err := config.Initialize(paths); err != nil {
+		t.Fatalf("config.Initialize: %v", err)
+	}
+	queued := strings.Replace(config.DefaultConfig(paths), `same_session = "fork_temp_session"`, `same_session = "queue"`, 1)
+	if err := os.WriteFile(paths.ConfigFile, []byte(queued), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	checkout := t.TempDir()
+	runGit(t, checkout, "init", "-b", "main")
+	runGit(t, checkout, "config", "user.email", "gitmoot@example.com")
+	runGit(t, checkout, "config", "user.name", "Gitmoot")
+	runGit(t, checkout, "remote", "add", "origin", "https://github.com/owner/repo.git")
+	runGit(t, checkout, "commit", "--allow-empty", "-m", "init")
+	if err := store.UpsertRepoForce(ctx, db.Repo{Owner: "owner", Name: "repo", CheckoutPath: checkout, PrimaryCheckoutPath: checkout}); err != nil {
+		t.Fatalf("UpsertRepoForce: %v", err)
+	}
+	headSHA := strings.TrimSpace(runGitOutput(t, checkout, "rev-parse", "HEAD"))
+	registeredAgent := db.Agent{
+		Name:       "seat-reviewer",
+		Runtime:    runtime.CodexRuntime,
+		RuntimeRef: registeredRef,
+		RepoScope:  "owner/repo",
+	}
+
+	registeredKey, ok := runtimeSessionResourceKey(runtime.Agent{Runtime: runtime.CodexRuntime, RuntimeRef: registeredRef})
+	if !ok {
+		t.Fatal("a registered codex session must have a lock key")
+	}
+
+	// A foreign owner holds the registered session, exactly as a running
+	// reviewer would.
+	release, acquired, _, _, err := acquireRuntimeSessionLockWithKey(ctx, store, "other-job", registeredKey, true, time.Now().UTC(), time.Hour)
+	if err != nil {
+		t.Fatalf("seed the registered session lock: %v", err)
+	}
+	if !acquired {
+		t.Fatal("seeding the registered session lock did not acquire it")
+	}
+	defer func() { _ = release(context.Background()) }()
+
+	job := db.Job{
+		ID:    "local-review-seat-lock",
+		Agent: "seat-reviewer",
+		Type:  "review",
+		State: string(workflow.JobQueued),
+		Payload: mustJobPayload(t, workflow.JobPayload{
+			Repo:         "owner/repo",
+			Branch:       "main",
+			PullRequest:  7,
+			HeadSHA:      headSHA,
+			ReadOnlySeat: true,
+		}),
+	}
+	if err := store.CreateJobWithEvent(ctx, job, db.JobEvent{Kind: string(workflow.JobQueued), Message: "seed"}); err != nil {
+		t.Fatalf("CreateJobWithEvent: %v", err)
+	}
+
+	var output bytes.Buffer
+	worker := jobWorker{
+		Store:              store,
+		ConfigHome:         home,
+		ConfigHomeExplicit: true,
+		Stdout:             &output,
+		AgentLookup: func(context.Context, string) (db.Agent, error) {
+			return registeredAgent, nil
+		},
+		// The adapter is built before the lock is acquired, so the test needs
+		// one; it must never be delivered to, which the assertions below imply.
+		AdapterFactory: func(runtime.Agent, string) (workflow.DeliveryAdapter, error) {
+			return &cliWorkerFakeAdapter{}, nil
+		},
+	}
+	runErr := worker.run(ctx, job)
+
+	if !errors.Is(runErr, errRuntimeSessionBusy) {
+		t.Fatalf("run err = %v, want errRuntimeSessionBusy: the seat must contend for the REGISTERED session %q, not its own per-job fresh ref", runErr, registeredKey)
+	}
+
+	events, err := store.ListJobEvents(ctx, job.ID)
+	if err != nil {
+		t.Fatalf("ListJobEvents: %v", err)
+	}
+	var waited string
+	for _, event := range events {
+		if event.Kind == "runtime_lock_wait" {
+			waited = event.Message
+		}
+	}
+	if waited == "" {
+		t.Fatal("no runtime_lock_wait event: the daemon path recorded no contention for the registered session")
+	}
+	if !strings.Contains(waited, registeredKey) {
+		t.Fatalf("runtime_lock_wait names %q, want the registered session key %q", waited, registeredKey)
+	}
+	if strings.Contains(waited, job.ID) {
+		t.Fatalf("runtime_lock_wait names the seat's own job-scoped ref (%q): the lock moved onto the post-seat agent", waited)
+	}
+}

--- a/internal/cli/readonly_seat_narrow_round2_test.go
+++ b/internal/cli/readonly_seat_narrow_round2_test.go
@@ -1,0 +1,276 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/gitmoot/gitmoot/internal/runtime"
+)
+
+// TestKimiConfigIsNarrowedThroughTheStagingPath is the round-2 P1: kimi's
+// config.toml was staged VERBATIM and REQUIRED into the seat's writable root
+// while the same commit narrowed codex's. Measured on a live host, that file
+// carries api_key under [services.*] and a key under [services.*.oauth].
+func TestKimiConfigIsNarrowedThroughTheStagingPath(t *testing.T) {
+	home := t.TempDir()
+	source := filepath.Join(home, ".kimi-code")
+	if err := os.MkdirAll(filepath.Join(source, "credentials"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	const config = `default_model = "kimi-code/k3"
+
+[services.moonshot_search]
+base_url = "https://search.test"
+api_key = "sk-SEARCH-SECRET"
+
+[services.moonshot_search.oauth]
+storage = "keyring"
+key = "sk-OAUTH-SECRET"
+
+[providers."managed:kimi-code"]
+type = "kimi"
+api_key = "sk-SELECTED-PROVIDER"
+
+[providers."third-party-gateway"]
+type = "openai"
+base_url = "https://gateway.test/v1"
+api_key = "sk-OTHER-PROVIDER-SECRET"
+[providers."third-party-gateway".env]
+GATEWAY_TOKEN = "sk-OTHER-ENV-SECRET"
+`
+	if err := os.WriteFile(filepath.Join(source, "config.toml"), []byte(config), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(source, "credentials", "kimi-code.json"), []byte(`{"access_token":"t"}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	agent := runtime.Agent{Runtime: runtime.KimiRuntime, RuntimeConfigDir: source}
+	stateDir, _, dropped, err := prepareReadOnlyRuntimeState(agent, t.TempDir(), false)
+	if err != nil {
+		t.Fatalf("prepare: %v", err)
+	}
+	staged, err := os.ReadFile(filepath.Join(stateDir, "config.toml"))
+	if err != nil {
+		t.Fatalf("read staged config: %v", err)
+	}
+	out := string(staged)
+
+	for _, secret := range []string{"sk-SEARCH-SECRET", "sk-OAUTH-SECRET", "sk-OTHER-PROVIDER-SECRET", "sk-OTHER-ENV-SECRET", "services"} {
+		if strings.Contains(out, secret) {
+			t.Errorf("the seat staged %q, which it must never read:\n%s", secret, out)
+		}
+	}
+	// The seat legitimately needs the ONE provider default_model resolves to:
+	// kimi refuses to start when both api_key and the env sub-table are absent.
+	for _, keep := range []string{`default_model = "kimi-code/k3"`, `[providers."managed:kimi-code"]`, "sk-SELECTED-PROVIDER", "https://gateway.test/v1"} {
+		if !strings.Contains(out, keep) {
+			t.Errorf("narrowing dropped %q, which the seat needs:\n%s", keep, out)
+		}
+	}
+	if len(dropped) == 0 {
+		t.Error("narrowing withheld secrets but reported nothing, so a broken seat cannot say why")
+	}
+}
+
+// TestKimiSelectedProviderWithholdsWhenItCannotProveWhichIsLive pins the
+// fail-closed direction of the resolution rule.
+func TestKimiSelectedProviderWithholdsWhenItCannotProveWhichIsLive(t *testing.T) {
+	cases := map[string]struct{ config, want string }{
+		"prefix match on the provider suffix": {"default_model = \"kimi-code/k3\"\n[providers.\"managed:kimi-code\"]\n", "managed:kimi-code"},
+		"exact provider name":                 {"default_model = \"mine\"\n[providers.mine]\n", "mine"},
+		"no default_model":                    {"[providers.mine]\n", ""},
+		"no provider matches":                 {"default_model = \"absent/k3\"\n[providers.mine]\n", ""},
+		"ambiguous match":                     {"default_model = \"dup/k3\"\n[providers.\"a:dup\"]\n[providers.\"b:dup\"]\n", ""},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			if got := kimiSelectedProvider([]byte(tc.config)); got != tc.want {
+				t.Fatalf("kimiSelectedProvider = %q, want %q", got, tc.want)
+			}
+		})
+	}
+
+	// With no provider resolved, EVERY provider credential is withheld.
+	result, err := narrowKimiConfigDetailed([]byte("default_model = \"absent/k3\"\n[providers.mine]\napi_key = \"sk-UNPROVEN\"\n"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(result.data), "sk-UNPROVEN") {
+		t.Errorf("an unattributable provider credential was staged anyway:\n%s", result.data)
+	}
+	if len(result.dropped) == 0 {
+		t.Error("withholding every provider credential must be reported, or the startup failure is unexplainable")
+	}
+}
+
+// TestCodexKeepsTheSelectedProvidersKey is the round-2 P2 succeed-path
+// regression: keeping model_providers structure while stripping api_key left
+// the seat with no way to authenticate, because env_key survives narrowing but
+// readOnlyRuntimeBaseEnv's allowlist never passes that variable into the seat.
+func TestCodexKeepsTheSelectedProvidersKey(t *testing.T) {
+	const config = `model = "custom"
+model_provider = "mine"
+
+[model_providers.mine]
+base_url = "https://mine.test/v1"
+wire_api = "chat"
+env_key = "MY_API_KEY"
+api_key = "sk-SELECTED"
+
+[model_providers.other]
+base_url = "https://other.test/v1"
+api_key = "sk-UNUSED"
+http_headers = { Authorization = "Bearer OTHER" }
+`
+	result, err := narrowCodexConfigDetailed([]byte(config))
+	if err != nil {
+		t.Fatalf("narrow: %v", err)
+	}
+	out := string(result.data)
+	if !strings.Contains(out, "sk-SELECTED") {
+		t.Errorf("the SELECTED provider's key was stripped, so the seat cannot authenticate at all:\n%s", out)
+	}
+	for _, secret := range []string{"sk-UNUSED", "Bearer OTHER"} {
+		if strings.Contains(out, secret) {
+			t.Errorf("an unselected provider's credential %q reached the seat:\n%s", secret, out)
+		}
+	}
+	// Structure the model needs must survive for both providers.
+	for _, keep := range []string{"https://mine.test/v1", "https://other.test/v1", "wire_api"} {
+		if !strings.Contains(out, keep) {
+			t.Errorf("narrowing dropped %q:\n%s", keep, out)
+		}
+	}
+
+	// With no model_provider selected, codex uses its built-in provider and
+	// auth.json, so no inline provider key is needed.
+	unselected, err := narrowCodexConfigDetailed([]byte("model = \"gpt-5\"\n[model_providers.mine]\napi_key = \"sk-NOBODY-SELECTED\"\n"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(unselected.data), "sk-NOBODY-SELECTED") {
+		t.Errorf("an unselected provider's key was staged with no model_provider set:\n%s", unselected.data)
+	}
+}
+
+// TestNarrowingHandlesMultilineStrings is the round-2 P2 that failed in BOTH
+// directions: a line inside """ or ”' beginning with "[" parsed as a section
+// header, which re-attributed a following api_key (LEAK) and deleted lines out
+// of a valid file leaving an unterminated string (CORRUPTION).
+func TestNarrowingHandlesMultilineStrings(t *testing.T) {
+	t.Run("leak: fake header inside a multi-line string", func(t *testing.T) {
+		const config = `[model_providers.p]
+base_url = "u"
+notes = """
+[example section]
+"""
+api_key = "SEKRIT"
+`
+		result, err := narrowCodexConfigDetailed([]byte(config))
+		if err != nil {
+			t.Fatalf("narrow: %v", err)
+		}
+		if strings.Contains(string(result.data), "SEKRIT") {
+			t.Errorf("a fake header inside a multi-line string re-attributed api_key:\n%s", result.data)
+		}
+	})
+
+	t.Run("leak: mcp env table after a fake header", func(t *testing.T) {
+		const config = `[mcp_servers.gh]
+notes = """
+[model_providers.p]
+"""
+env = { TOKEN = "SEKRIT" }
+`
+		result, err := narrowCodexConfigDetailed([]byte(config))
+		if err != nil {
+			t.Fatalf("narrow: %v", err)
+		}
+		if strings.Contains(string(result.data), "SEKRIT") {
+			t.Errorf("an mcp_servers env table survived behind a fake header:\n%s", result.data)
+		}
+	})
+
+	t.Run("corruption: a valid file keeps its keys and closes its strings", func(t *testing.T) {
+		const config = `model = "m"
+notes = """
+[mcp_servers.x]
+"""
+approval_policy = "never"
+`
+		result, err := narrowCodexConfigDetailed([]byte(config))
+		if err != nil {
+			t.Fatalf("narrow: %v", err)
+		}
+		out := string(result.data)
+		if !strings.Contains(out, `approval_policy = "never"`) {
+			t.Errorf("a key after a multi-line string was silently deleted:\n%s", out)
+		}
+		if count := strings.Count(out, `"""`); count%2 != 0 {
+			t.Errorf("narrowing left an unterminated multi-line string, so the runtime reports a TOML error about a file gitmoot wrote:\n%s", out)
+		}
+		if out != strings.TrimPrefix(config, "") && strings.Contains(out, "mcp_servers.x") {
+			t.Errorf("the section name inside the string was treated as a real section:\n%s", out)
+		}
+	})
+
+	t.Run("literal delimiter and single-line form", func(t *testing.T) {
+		result, err := narrowCodexConfigDetailed([]byte("model = \"m\"\nnotes = '''\n[mcp_servers.x]\n'''\napproval_policy = \"never\"\ninline = \"\"\"one line\"\"\"\n"))
+		if err != nil {
+			t.Fatalf("narrow: %v", err)
+		}
+		for _, keep := range []string{"approval_policy", "inline"} {
+			if !strings.Contains(string(result.data), keep) {
+				t.Errorf("narrowing dropped %q around a literal multi-line string:\n%s", keep, result.data)
+			}
+		}
+	})
+
+	t.Run("an unclosed string fails closed rather than corrupting", func(t *testing.T) {
+		if _, err := narrowCodexConfigDetailed([]byte("model = \"m\"\nnotes = \"\"\"\nstill open\n")); err == nil {
+			t.Fatal("an unterminated multi-line string was staged")
+		}
+	})
+}
+
+// TestNarrowingHandlesBOMAndEscapedQuotes covers the two round-2 P3 parser
+// gaps: a UTF-8 BOM defeated header attribution for the WHOLE file, and a
+// backslash-escaped quote in a table key failed the seat closed on valid TOML.
+func TestNarrowingHandlesBOMAndEscapedQuotes(t *testing.T) {
+	t.Run("BOM does not defeat attribution", func(t *testing.T) {
+		for _, config := range []string{
+			"\ufeff[mcp_servers.gh.env]\nTOKEN = \"SEKRIT\"\n",
+			"\ufeff[model_providers.p]\napi_key = \"SEKRIT\"\n",
+		} {
+			result, err := narrowCodexConfigDetailed([]byte(config))
+			if err != nil {
+				t.Fatalf("narrow: %v", err)
+			}
+			if strings.Contains(string(result.data), "SEKRIT") {
+				t.Errorf("a leading BOM hid the section header and leaked the secret:\n%s", result.data)
+			}
+		}
+	})
+
+	t.Run("escaped quote in a table key is valid TOML and must not fail closed", func(t *testing.T) {
+		path, ok := parseTOMLKeyPath(`"a\"b".c`)
+		if !ok {
+			t.Fatal(`parseTOMLKeyPath rejected valid TOML ["a\"b".c], failing a whole seat closed`)
+		}
+		if len(path) != 2 || path[0] != `a"b` || path[1] != "c" {
+			t.Fatalf("parsed path = %q, want [a\"b c]", path)
+		}
+		if _, err := narrowCodexConfigDetailed([]byte("[mcp_servers.\"a\\\"b\".env]\nTOKEN = \"SEKRIT\"\n")); err != nil {
+			t.Fatalf("a file TOML accepts was refused: %v", err)
+		}
+	})
+
+	t.Run("an unreadable header still fails closed", func(t *testing.T) {
+		if _, err := narrowCodexConfigDetailed([]byte("[mcp_servers.gh\nTOKEN = \"SEKRIT\"\n")); err == nil {
+			t.Fatal("a header that never closes was accepted")
+		}
+	})
+}

--- a/internal/cli/readonly_seat_narrow_round2_test.go
+++ b/internal/cli/readonly_seat_narrow_round2_test.go
@@ -87,7 +87,11 @@ func TestKimiSelectedProviderWithholdsWhenItCannotProveWhichIsLive(t *testing.T)
 	}
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			if got := kimiSelectedProvider([]byte(tc.config)); got != tc.want {
+			lines, err := scanTOMLLines([]byte(tc.config))
+			if err != nil {
+				t.Fatalf("scan: %v", err)
+			}
+			if got := kimiSelectedProvider(lines); got != tc.want {
 				t.Fatalf("kimiSelectedProvider = %q, want %q", got, tc.want)
 			}
 		})

--- a/internal/cli/readonly_seat_narrow_round3_test.go
+++ b/internal/cli/readonly_seat_narrow_round3_test.go
@@ -1,0 +1,439 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/gitmoot/gitmoot/internal/db"
+	"github.com/gitmoot/gitmoot/internal/runtime"
+	"github.com/gitmoot/gitmoot/internal/workflow"
+)
+
+// stageKimiConfig runs one kimi config through the REAL staging path and
+// returns the staged bytes plus what narrowing reported withholding. The round-3
+// P1 was invisible to helper-level tests: the leak only shows when the file
+// reaches cacheRoot, which is the seat's one writable root.
+func stageKimiConfig(t *testing.T, config string) (string, []string) {
+	t.Helper()
+	home := t.TempDir()
+	source := filepath.Join(home, ".kimi-code")
+	if err := os.MkdirAll(filepath.Join(source, "credentials"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(source, "config.toml"), []byte(config), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(source, "credentials", "kimi-code.json"), []byte(`{"access_token":"t"}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	cacheRoot := t.TempDir()
+	agent := runtime.Agent{Runtime: runtime.KimiRuntime, RuntimeConfigDir: source}
+	stateDir, _, dropped, err := prepareReadOnlyRuntimeState(agent, cacheRoot, false)
+	if err != nil {
+		t.Fatalf("prepare: %v", err)
+	}
+	if !strings.HasPrefix(stateDir, cacheRoot) {
+		t.Fatalf("stateDir %q is not under the seat's writable root %q", stateDir, cacheRoot)
+	}
+	staged, err := os.ReadFile(filepath.Join(stateDir, "config.toml"))
+	if err != nil {
+		t.Fatalf("read staged config: %v", err)
+	}
+	return string(staged), dropped
+}
+
+// TestEscapedQuoteInAValueCannotStageTheRestOfTheFile is the round-3 P1.
+//
+// bracketBalance read an ESCAPED quote as a real terminator, so the "[" after
+// it looked unclosed. That opened a continuation run which emitted every
+// following line verbatim - and because the run had no end-of-file check, the
+// whole tail of the file was staged unclassified with dropped empty.
+func TestEscapedQuoteInAValueCannotStageTheRestOfTheFile(t *testing.T) {
+	const leaking = `default_model = "kimi-code/k3"
+instructions = "use \"[\" to open"
+
+[services.moonshot_search]
+api_key = "sk-SECRET-SERVICE"
+
+[services.moonshot_search.oauth]
+key = "sk-SECRET-OAUTH"
+
+[providers."managed:kimi-code"]
+type = "kimi"
+
+[providers."third-party-gateway"]
+api_key = "sk-SECRET-OTHER"
+`
+	staged, dropped := stageKimiConfig(t, leaking)
+	for _, secret := range []string{"sk-SECRET-SERVICE", "sk-SECRET-OAUTH", "sk-SECRET-OTHER"} {
+		if strings.Contains(staged, secret) {
+			t.Errorf("an escaped quote opened a phantom run and staged %q into the seat:\n%s", secret, staged)
+		}
+	}
+	if len(dropped) == 0 {
+		t.Error("nothing was reported withheld, so the narrowing event would be silent about a leak")
+	}
+	// The value itself is valid TOML and must survive untouched.
+	if !strings.Contains(staged, `instructions = "use \"[\" to open"`) {
+		t.Errorf("the valid escaped-quote value was mangled:\n%s", staged)
+	}
+
+	// POSITIVE CONTROL: the byte-identical file without the escape must narrow
+	// the same way. If this arm ever leaks, the assertions above prove nothing.
+	control, controlDropped := stageKimiConfig(t, strings.Replace(leaking, `instructions = "use \"[\" to open"`, `instructions = "use hi"`, 1))
+	for _, secret := range []string{"sk-SECRET-SERVICE", "sk-SECRET-OAUTH", "sk-SECRET-OTHER"} {
+		if strings.Contains(control, secret) {
+			t.Fatalf("INSTRUMENT FAILURE: the control arm leaks %q, so this test cannot detect the defect", secret)
+		}
+	}
+	if len(controlDropped) == 0 {
+		t.Fatal("INSTRUMENT FAILURE: the control arm reported nothing withheld")
+	}
+}
+
+// TestUnbalancedBracketsFailClosedAtEOF pins the missing end-of-file check: an
+// array or inline table that never closes leaves the tail of the file
+// unclassified, and staging an unclassified tail is the leak itself.
+func TestUnbalancedBracketsFailClosedAtEOF(t *testing.T) {
+	for name, config := range map[string]string{
+		"unclosed array":        "model = \"m\"\nlist = [\n  \"a\",\n",
+		"unclosed inline table": "model = \"m\"\ntable = {\n  a = 1\n",
+	} {
+		t.Run(name, func(t *testing.T) {
+			if _, err := narrowCodexConfigDetailed([]byte(config)); err == nil {
+				t.Fatal("an unbalanced run reached the end of the file and was staged anyway")
+			}
+		})
+	}
+	// A balanced multi-line array is still fine.
+	result, err := narrowCodexConfigDetailed([]byte("model = \"m\"\nlist = [\n  \"a\",\n]\napproval_policy = \"never\"\n"))
+	if err != nil {
+		t.Fatalf("a balanced multi-line array was refused: %v", err)
+	}
+	if !strings.Contains(string(result.data), "approval_policy") {
+		t.Errorf("a balanced array swallowed the key after it:\n%s", result.data)
+	}
+}
+
+// TestTripleDelimitersInCommentsAndStrings is the round-3 P2 that failed in
+// both directions: strings.Count over the raw value treated a `"""` inside a
+// COMMENT or inside a single-line string as opening a multi-line string.
+func TestTripleDelimitersInCommentsAndStrings(t *testing.T) {
+	t.Run("valid configs are no longer refused", func(t *testing.T) {
+		for name, config := range map[string]string{
+			"triple in a comment":        "model = \"m\"\nnote = 1 # see \"\"\" docs\napproval_policy = \"never\"\n",
+			"triple in a literal string": "model = \"m\"\ntpl = 'wrap in \"\"\" please'\napproval_policy = \"never\"\n",
+		} {
+			t.Run(name, func(t *testing.T) {
+				result, err := narrowCodexConfigDetailed([]byte(config))
+				if err != nil {
+					t.Fatalf("a valid config was refused, hard-failing the seat: %v", err)
+				}
+				if !strings.Contains(string(result.data), "approval_policy") {
+					t.Errorf("the phantom string swallowed a later key:\n%s", result.data)
+				}
+			})
+		}
+	})
+
+	t.Run("two stray delimiters no longer leak the span between them", func(t *testing.T) {
+		const config = `model = "m"
+note = 1 # see """ docs
+
+[services.search]
+api_key = "sk-SECRET-A"
+
+other = 2 # and """ again
+
+[services.other]
+api_key = "sk-SECRET-B"
+`
+		result, err := narrowKimiConfigDetailed([]byte(config))
+		if err != nil {
+			t.Fatalf("narrow: %v", err)
+		}
+		for _, secret := range []string{"sk-SECRET-A", "sk-SECRET-B"} {
+			if strings.Contains(string(result.data), secret) {
+				t.Errorf("stray triple delimiters left %q unclassified and staged:\n%s", secret, result.data)
+			}
+		}
+	})
+}
+
+// TestSelectorsShareTheScannersState is the round-3 P2 that reintroduced round
+// 2's own defect in the two scanners round 2 did not touch: a header-looking
+// line inside a multi-line string stopped top-level key reading, so
+// default_model / model_provider were never found and every provider
+// credential was withheld - breaking the succeed path.
+func TestSelectorsShareTheScannersState(t *testing.T) {
+	t.Run("kimi selection survives a documented example section", func(t *testing.T) {
+		const config = `instructions = """
+configure a provider like [providers.example]
+"""
+default_model = "kimi-code/k3"
+
+[providers."managed:kimi-code"]
+type = "kimi"
+api_key = "sk-SELECTED"
+`
+		staged, _ := stageKimiConfig(t, config)
+		if !strings.Contains(staged, "sk-SELECTED") {
+			t.Errorf("the selected provider's key was withheld because selection lost its state, so the seat cannot authenticate:\n%s", staged)
+		}
+	})
+
+	t.Run("codex selection survives the same shape", func(t *testing.T) {
+		const config = `instructions = """
+see [model_providers.example]
+"""
+model_provider = "mine"
+
+[model_providers.mine]
+base_url = "https://mine.test/v1"
+api_key = "sk-SELECTED"
+
+[model_providers.other]
+api_key = "sk-OTHER"
+`
+		result, err := narrowCodexConfigDetailed([]byte(config))
+		if err != nil {
+			t.Fatalf("narrow: %v", err)
+		}
+		if !strings.Contains(string(result.data), "sk-SELECTED") {
+			t.Errorf("selection lost its state and withheld the selected provider's key:\n%s", result.data)
+		}
+		if strings.Contains(string(result.data), "sk-OTHER") {
+			t.Errorf("an unselected provider's key survived:\n%s", result.data)
+		}
+	})
+
+	t.Run("a section name inside a string is not a real section", func(t *testing.T) {
+		lines, err := scanTOMLLines([]byte("doc = \"\"\"\n[providers.phantom]\n\"\"\"\n[providers.real]\n"))
+		if err != nil {
+			t.Fatalf("scan: %v", err)
+		}
+		names := tomlSectionNames(lines, "providers")
+		if len(names) != 1 || names[0] != "real" {
+			t.Fatalf("section names = %q, want only [real]: a name inside a multi-line string is not a section", names)
+		}
+	})
+}
+
+// TestCodexEnvKeyOnlyProviderFailsWithANamedCause is the round-3 P3: a selected
+// provider that authenticates only through env_key leaves the seat with no
+// credential, because the sandbox environment allowlist does not pass an
+// arbitrary variable through. Staging used to succeed silently.
+func TestCodexEnvKeyOnlyProviderFailsWithANamedCause(t *testing.T) {
+	_, err := narrowCodexConfigDetailed([]byte("model_provider = \"mine\"\n[model_providers.mine]\nbase_url = \"https://mine.test/v1\"\nenv_key = \"MY_API_KEY\"\n"))
+	if err == nil {
+		t.Fatal("an env_key-only selected provider staged cleanly; the seat would fail later and opaquely")
+	}
+	for _, want := range []string{"env_key", "mine"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error = %v, want it to name %q", err, want)
+		}
+	}
+
+	// Both working shapes must still stage: an inline key, and env_key
+	// ALONGSIDE an inline key.
+	for name, config := range map[string]string{
+		"inline api_key":        "model_provider = \"mine\"\n[model_providers.mine]\napi_key = \"sk-OK\"\n",
+		"env_key plus api_key":  "model_provider = \"mine\"\n[model_providers.mine]\nenv_key = \"MY_API_KEY\"\napi_key = \"sk-OK\"\n",
+		"no provider selected":  "model = \"gpt-5\"\n[model_providers.mine]\nenv_key = \"MY_API_KEY\"\n",
+		"selected but no block": "model_provider = \"absent\"\nmodel = \"gpt-5\"\n",
+	} {
+		t.Run(name, func(t *testing.T) {
+			if _, err := narrowCodexConfigDetailed([]byte(config)); err != nil {
+				t.Fatalf("a workable configuration was refused: %v", err)
+			}
+		})
+	}
+}
+
+// TestNarrowingEventReachesTheJobLog is the round-3 P3: the
+// read_only_seat_config_narrowed event had no test at all, and it is the ONLY
+// diagnostic a seat has for a credential the narrower withheld. Driven through
+// the real worker, not the helper.
+func TestNarrowingEventReachesTheJobLog(t *testing.T) {
+	ctx := context.Background()
+	home := t.TempDir()
+	store := openCLIJobStore(t, home)
+	defer store.Close()
+
+	hostKimi := filepath.Join(home, "host-kimi")
+	if err := os.MkdirAll(filepath.Join(hostKimi, "credentials"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(hostKimi, "config.toml"), []byte("default_model = \"kimi-code/k3\"\n\n[services.moonshot_search]\napi_key = \"sk-SECRET\"\n\n[providers.\"managed:kimi-code\"]\ntype = \"kimi\"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(hostKimi, "credentials", "kimi-code.json"), []byte(`{"access_token":"t"}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	checkout := t.TempDir()
+	runGit(t, checkout, "init", "-b", "main")
+	runGit(t, checkout, "config", "user.email", "gitmoot@example.com")
+	runGit(t, checkout, "config", "user.name", "Gitmoot")
+	runGit(t, checkout, "remote", "add", "origin", "https://github.com/owner/repo.git")
+	runGit(t, checkout, "commit", "--allow-empty", "-m", "init")
+	headSHA := strings.TrimSpace(runGitOutput(t, checkout, "rev-parse", "HEAD"))
+	if err := store.UpsertRepoForce(ctx, db.Repo{Owner: "owner", Name: "repo", CheckoutPath: checkout, PrimaryCheckoutPath: checkout}); err != nil {
+		t.Fatalf("UpsertRepoForce: %v", err)
+	}
+	registered := db.Agent{Name: "seat-kimi", Role: "reviewer", Runtime: runtime.KimiRuntime, RuntimeRef: "019fa4c8-69c1-7bc2-8628-00ade8fa43e1", RepoScope: "owner/repo"}
+
+	job := db.Job{
+		ID:    "local-review-seat-event",
+		Agent: "seat-kimi",
+		Type:  "review",
+		State: string(workflow.JobQueued),
+		Payload: mustJobPayload(t, workflow.JobPayload{
+			Repo: "owner/repo", Branch: "main", PullRequest: 3, HeadSHA: headSHA,
+			ReadOnlySeat: true, RuntimeConfigDir: hostKimi,
+		}),
+	}
+	if err := store.CreateJobWithEvent(ctx, job, db.JobEvent{Kind: string(workflow.JobQueued), Message: "seed"}); err != nil {
+		t.Fatalf("CreateJobWithEvent: %v", err)
+	}
+
+	var output bytes.Buffer
+	worker := jobWorker{
+		Store: store, ConfigHome: home, ConfigHomeExplicit: true, Stdout: &output,
+		AgentLookup:    func(context.Context, string) (db.Agent, error) { return registered, nil },
+		AdapterFactory: func(runtime.Agent, string) (workflow.DeliveryAdapter, error) { return &cliWorkerFakeAdapter{}, nil },
+	}
+	_ = worker.run(ctx, job)
+
+	events, err := store.ListJobEvents(ctx, job.ID)
+	if err != nil {
+		t.Fatalf("ListJobEvents: %v", err)
+	}
+	var narrowed string
+	for _, event := range events {
+		if event.Kind == "read_only_seat_config_narrowed" {
+			narrowed = event.Message
+		}
+	}
+	if narrowed == "" {
+		t.Fatalf("no read_only_seat_config_narrowed event: the seat's only diagnostic for a withheld credential is silent; events: %+v", events)
+	}
+	if !strings.Contains(narrowed, "services") {
+		t.Errorf("event message %q does not name what was withheld", narrowed)
+	}
+}
+
+// TestGatewayModeWithholdsEveryRuntimesCredential is the round-3 P3 asymmetry:
+// gatewayMode cleared claude's credential only, so a gateway seat still staged
+// codex's auth.json and kimi's token into its writable root.
+func TestGatewayModeWithholdsEveryRuntimesCredential(t *testing.T) {
+	home := t.TempDir()
+
+	codexSource := filepath.Join(home, ".codex")
+	if err := os.MkdirAll(codexSource, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(codexSource, "auth.json"), []byte(`{"OPENAI_API_KEY":"sk-SECRET","auth_mode":"apikey"}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(codexSource, "config.toml"), []byte("model = \"gpt-5\"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	kimiSource := filepath.Join(home, ".kimi-code")
+	if err := os.MkdirAll(filepath.Join(kimiSource, "credentials"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(kimiSource, "config.toml"), []byte("default_model = \"kimi-code/k3\"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(kimiSource, "credentials", "kimi-code.json"), []byte(`{"access_token":"sk-SECRET"}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	for name, tc := range map[string]struct{ runtimeName, source, credential string }{
+		"codex": {runtime.CodexRuntime, codexSource, "auth.json"},
+		"kimi":  {runtime.KimiRuntime, kimiSource, filepath.Join("credentials", "kimi-code.json")},
+	} {
+		t.Run(name, func(t *testing.T) {
+			agent := runtime.Agent{Runtime: tc.runtimeName, RuntimeConfigDir: tc.source}
+			stateDir, _, _, err := prepareReadOnlyRuntimeState(agent, t.TempDir(), true)
+			if err != nil {
+				t.Fatalf("gateway staging: %v", err)
+			}
+			if _, statErr := os.Stat(filepath.Join(stateDir, tc.credential)); !os.IsNotExist(statErr) {
+				t.Errorf("gateway mode staged %s's credential the gateway supplies: %v", name, statErr)
+			}
+			// Model settings are still needed and must still be staged.
+			if _, statErr := os.Stat(filepath.Join(stateDir, "config.toml")); statErr != nil {
+				t.Errorf("gateway mode dropped %s's model settings too: %v", name, statErr)
+			}
+		})
+	}
+
+	// Non-gateway staging must be unchanged.
+	agent := runtime.Agent{Runtime: runtime.CodexRuntime, RuntimeConfigDir: codexSource}
+	stateDir, _, _, err := prepareReadOnlyRuntimeState(agent, t.TempDir(), false)
+	if err != nil {
+		t.Fatalf("non-gateway staging: %v", err)
+	}
+	if _, statErr := os.Stat(filepath.Join(stateDir, "auth.json")); statErr != nil {
+		t.Errorf("a non-gateway codex seat lost the credential it needs: %v", statErr)
+	}
+}
+
+// TestSelectionIgnoresSameNamedKeysInsideSections closes a gap a surviving
+// mutant exposed: dropping the top-level requirement let a key named
+// default_model or model_provider INSIDE a section be read as the seat's
+// provider selection, which would keep a credential nothing selected.
+func TestSelectionIgnoresSameNamedKeysInsideSections(t *testing.T) {
+	t.Run("kimi", func(t *testing.T) {
+		// No TOP-LEVEL default_model, so nothing is selected and every
+		// provider credential must be withheld.
+		const config = `[providers.mine]
+default_model = "mine/k3"
+api_key = "sk-NOT-SELECTED"
+`
+		result, err := narrowKimiConfigDetailed([]byte(config))
+		if err != nil {
+			t.Fatalf("narrow: %v", err)
+		}
+		if strings.Contains(string(result.data), "sk-NOT-SELECTED") {
+			t.Errorf("a default_model inside a section was read as the selection, keeping a credential nothing selected:\n%s", result.data)
+		}
+		lines, err := scanTOMLLines([]byte(config))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got := kimiSelectedProvider(lines); got != "" {
+			t.Errorf("kimiSelectedProvider = %q, want empty: the key is not top level", got)
+		}
+	})
+
+	t.Run("codex", func(t *testing.T) {
+		const config = `[model_providers.mine]
+model_provider = "mine"
+api_key = "sk-NOT-SELECTED"
+`
+		result, err := narrowCodexConfigDetailed([]byte(config))
+		if err != nil {
+			t.Fatalf("narrow: %v", err)
+		}
+		if strings.Contains(string(result.data), "sk-NOT-SELECTED") {
+			t.Errorf("a model_provider inside a section was read as the selection:\n%s", result.data)
+		}
+	})
+
+	// The top-level form still selects, so the guard is not simply refusing.
+	lines, err := scanTOMLLines([]byte("default_model = \"mine/k3\"\n[providers.mine]\napi_key = \"sk-SELECTED\"\n"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := kimiSelectedProvider(lines); got != "mine" {
+		t.Errorf("kimiSelectedProvider = %q, want mine for a top-level key", got)
+	}
+}

--- a/internal/cli/readonly_seat_narrow_round4_test.go
+++ b/internal/cli/readonly_seat_narrow_round4_test.go
@@ -1,0 +1,233 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/gitmoot/gitmoot/internal/runtime"
+)
+
+// TestTrailingCommentsCannotDefeatClassification is the round-4 P1 and P2 in one
+// place, because they were one defect: nothing stripped comments, so a ']' in a
+// header's trailing comment was swallowed into the section NAME (secrets staged
+// verbatim, dropped empty) and a comment on model_provider / default_model was
+// swallowed into the selected provider name (the seat's own credential
+// withheld, and for kimi a hard fail of a required file).
+func TestTrailingCommentsCannotDefeatClassification(t *testing.T) {
+	t.Run("header comment containing a bracket still drops the section", func(t *testing.T) {
+		cases := map[string]string{
+			"kimi services":        "default_model = \"kimi-code/k3\"\n[services] # see [docs]\napi_key = \"sk-SECRET-DIRECT\"\n",
+			"kimi quoted services": "default_model = \"kimi-code/k3\"\n[\"services\"] # see [docs]\napi_key = \"sk-SECRET-QUOTED\"\n",
+			"kimi dotted":          "default_model = \"kimi-code/k3\"\n[services.search] # see [docs]\napi_key = \"sk-SECRET-DOTTED\"\n",
+		}
+		for name, config := range cases {
+			t.Run(name, func(t *testing.T) {
+				result, err := narrowKimiConfigDetailed([]byte(config))
+				if err != nil {
+					t.Fatalf("narrow: %v", err)
+				}
+				if strings.Contains(string(result.data), "sk-SECRET") {
+					t.Errorf("a trailing comment defeated classification and staged the secret:\n%s", result.data)
+				}
+				if len(result.dropped) == 0 {
+					t.Error("nothing reported withheld, so the narrowing event would be silent about a leak")
+				}
+			})
+		}
+
+		codex, err := narrowCodexConfigDetailed([]byte("[mcp_servers] # see [docs]\nenv = { TOKEN = \"sk-SECRET-MCP\" }\n"))
+		if err != nil {
+			t.Fatalf("narrow: %v", err)
+		}
+		if strings.Contains(string(codex.data), "sk-SECRET-MCP") {
+			t.Errorf("a commented mcp_servers header staged its token:\n%s", codex.data)
+		}
+	})
+
+	t.Run("selector comment does not withhold the selected credential", func(t *testing.T) {
+		for name, config := range map[string]string{
+			"space before hash": "default_model = \"kimi-code/k3\" # pinned\n[providers.\"managed:kimi-code\"]\napi_key = \"sk-KEEPME\"\n",
+			"no space":          "default_model = \"kimi-code/k3\"# pinned\n[providers.\"managed:kimi-code\"]\napi_key = \"sk-KEEPME\"\n",
+			"tab before hash":   "default_model = \"kimi-code/k3\"\t# pinned\n[providers.\"managed:kimi-code\"]\napi_key = \"sk-KEEPME\"\n",
+		} {
+			t.Run(name, func(t *testing.T) {
+				result, err := narrowKimiConfigDetailed([]byte(config))
+				if err != nil {
+					t.Fatalf("narrow: %v", err)
+				}
+				if !strings.Contains(string(result.data), "sk-KEEPME") {
+					t.Errorf("a trailing comment withheld the credential the seat requires:\n%s", result.data)
+				}
+			})
+		}
+
+		codex, err := narrowCodexConfigDetailed([]byte("model_provider = \"mine\" # chosen by ops\n[model_providers.mine]\napi_key = \"sk-KEEPME\"\n[model_providers.other]\napi_key = \"sk-DROPME\"\n"))
+		if err != nil {
+			t.Fatalf("narrow: %v", err)
+		}
+		if !strings.Contains(string(codex.data), "sk-KEEPME") {
+			t.Errorf("a commented model_provider withheld the selected credential:\n%s", codex.data)
+		}
+		if strings.Contains(string(codex.data), "sk-DROPME") {
+			t.Errorf("an unselected provider's credential survived:\n%s", codex.data)
+		}
+	})
+
+	// The comment text itself must survive into the staged file: this narrows
+	// credentials, it does not rewrite the operator's file.
+	t.Run("comments are preserved in the staged output", func(t *testing.T) {
+		result, err := narrowCodexConfigDetailed([]byte("model = \"gpt-5\" # keep me\n"))
+		if err != nil {
+			t.Fatalf("narrow: %v", err)
+		}
+		if !strings.Contains(string(result.data), "# keep me") {
+			t.Errorf("narrowing stripped the operator's comment:\n%s", result.data)
+		}
+	})
+}
+
+// TestSelectorWitnessFromTheMultilineBlock is the round-4 P2/F3: a mutant that
+// put tomlTopLevelScalar back on a naive raw scan SURVIVED the round-3 tests.
+// This is the reviewer's witness input, asserted on the selector's OUTPUT
+// rather than only on the staged bytes - the round-3 test could pass with the
+// selector broken because both arms withheld nothing observable.
+func TestSelectorWitnessFromTheMultilineBlock(t *testing.T) {
+	const config = `instructions = """
+[providers.example]
+"""
+default_model = "kimi-code/k3"
+
+[providers."managed:kimi-code"]
+api_key = "sk-SELECTED"
+`
+	lines, err := scanTOMLLines([]byte(config))
+	if err != nil {
+		t.Fatalf("scan: %v", err)
+	}
+	if got := tomlTopLevelScalar(lines, "default_model"); got != "kimi-code/k3" {
+		t.Fatalf("tomlTopLevelScalar = %q, want kimi-code/k3: a section-looking line inside a multi-line string ended the top-level region", got)
+	}
+	if got := kimiSelectedProvider(lines); got != "managed:kimi-code" {
+		t.Fatalf("kimiSelectedProvider = %q, want managed:kimi-code", got)
+	}
+
+	result, err := narrowKimiConfigDetailed([]byte(config))
+	if err != nil {
+		t.Fatalf("narrow: %v", err)
+	}
+	if !strings.Contains(string(result.data), "sk-SELECTED") {
+		t.Errorf("the selected provider's credential was withheld:\n%s", result.data)
+	}
+	if len(result.dropped) != 0 {
+		t.Errorf("nothing should have been withheld here, got %v", result.dropped)
+	}
+}
+
+// TestQuotedKeyContainingEqualsIsNotDropped is the round-4 P3/F4: splitting on
+// the first '=' with no lexical state dropped a VALID quoted key as an
+// anonymous "unreadable key".
+func TestQuotedKeyContainingEqualsIsNotDropped(t *testing.T) {
+	const config = "model = \"gpt-5\"\n[mcp_servers.gh]\n\"a=b\" = \"value\"\n"
+	result, err := narrowCodexConfigDetailed([]byte(config))
+	if err != nil {
+		t.Fatalf("narrow: %v", err)
+	}
+	for _, label := range result.dropped {
+		if strings.Contains(label, "unreadable key") {
+			t.Errorf("a valid quoted key containing '=' was dropped as unreadable: %v", result.dropped)
+		}
+	}
+
+	// And the same key under a KEPT section survives into the output.
+	kept, err := narrowCodexConfigDetailed([]byte("[settings]\n\"a=b\" = \"value\"\n"))
+	if err != nil {
+		t.Fatalf("narrow: %v", err)
+	}
+	if !strings.Contains(string(kept.data), "\"a=b\"") {
+		t.Errorf("a valid quoted key containing '=' was dropped from a kept section:\n%s", kept.data)
+	}
+}
+
+// TestOptionalInputRefusalDoesNotKillTheSeat is the round-4 F8: optionalInputs
+// was optional only for ABSENCE. Any narrowing refusal propagated and failed
+// the whole job, so a codex config.toml the codex CLI itself accepts could kill
+// a reviewer - while the policy's own comment reasons that a seat without the
+// file falls back to the runtime default.
+func TestOptionalInputRefusalDoesNotKillTheSeat(t *testing.T) {
+	home := t.TempDir()
+	source := filepath.Join(home, ".codex")
+	if err := os.MkdirAll(source, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	// Unbalanced '[' at EOF: one of the two refusals this work added.
+	if err := os.WriteFile(filepath.Join(source, "config.toml"), []byte("model = \"gpt-5\"\nlist = [\n  \"a\",\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(source, "auth.json"), []byte(`{"OPENAI_API_KEY":"k"}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	agent := runtime.Agent{Runtime: runtime.CodexRuntime, RuntimeConfigDir: source}
+	stateDir, _, dropped, err := prepareReadOnlyRuntimeState(agent, t.TempDir(), false)
+	if err != nil {
+		t.Fatalf("an unnarrowable OPTIONAL input killed the seat: %v", err)
+	}
+	if _, statErr := os.Stat(filepath.Join(stateDir, "config.toml")); !os.IsNotExist(statErr) {
+		t.Errorf("a file that could not be narrowed was staged anyway: %v", statErr)
+	}
+	if len(dropped) == 0 {
+		t.Fatal("the refusal was silent; an operator has no way to learn the config was not staged")
+	}
+	if !strings.Contains(strings.Join(dropped, " "), "config.toml") {
+		t.Errorf("dropped = %v, want it to name config.toml", dropped)
+	}
+
+	// kimi's config.toml is REQUIRED, so there fail-closed is right and must
+	// stay: the seat cannot run without it.
+	kimi := filepath.Join(home, ".kimi-code")
+	if err := os.MkdirAll(filepath.Join(kimi, "credentials"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(kimi, "config.toml"), []byte("default_model = \"k/3\"\nlist = [\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(kimi, "credentials", "kimi-code.json"), []byte(`{"access_token":"t"}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, _, err := prepareReadOnlyRuntimeState(runtime.Agent{Runtime: runtime.KimiRuntime, RuntimeConfigDir: kimi}, t.TempDir(), false); err == nil {
+		t.Error("an unnarrowable REQUIRED input staged cleanly; kimi cannot run without it")
+	}
+}
+
+// TestGatewayPolicyReportsWhatItEnforces is the round-4 F5: gateway mode was
+// applied at the staging call site, so the policy readOnlySeatStatePolicyFor
+// RETURNED still named codex's auth.json and kimi's token while the seat
+// withheld them - a policy that disagrees with itself, and the next reader
+// trusts the returned value.
+func TestGatewayPolicyReportsWhatItEnforces(t *testing.T) {
+	for _, runtimeName := range []string{runtime.ClaudeRuntime, runtime.CodexRuntime, runtime.KimiRuntime} {
+		t.Run(runtimeName, func(t *testing.T) {
+			gateway, needs, err := readOnlySeatStatePolicyFor(runtimeName, t.TempDir(), true)
+			if err != nil || !needs {
+				t.Fatalf("policy for %s: needs=%v err=%v", runtimeName, needs, err)
+			}
+			if gateway.credentialFile != "" {
+				t.Errorf("gateway policy still names credentialFile %q, which the seat does not stage", gateway.credentialFile)
+			}
+			if gateway.credentialUsable != nil {
+				t.Error("gateway policy still carries a usability check for a credential it does not stage")
+			}
+
+			// Non-gateway must be unchanged: the credential is needed there.
+			direct, needs, err := readOnlySeatStatePolicyFor(runtimeName, t.TempDir(), false)
+			if err != nil || !needs {
+				t.Fatalf("non-gateway policy for %s: needs=%v err=%v", runtimeName, needs, err)
+			}
+			if direct.credentialFile == "" {
+				t.Errorf("non-gateway policy for %s lost its credential file", runtimeName)
+			}
+		})
+	}
+}

--- a/internal/cli/readonly_seat_runtime_membership_test.go
+++ b/internal/cli/readonly_seat_runtime_membership_test.go
@@ -1,0 +1,58 @@
+package cli
+
+import (
+	"testing"
+
+	"github.com/gitmoot/gitmoot/internal/runtime"
+)
+
+// TestResumableSessionRuntimeMembershipIsPinned pins the membership of
+// resumableSessionRuntime, and pins it THROUGH BOTH consumers rather than by
+// calling the predicate alone.
+//
+// One token feeds two production paths: applyReadOnlySeat's seat fresh-ref
+// rewrite, and runtimeSessionResourceKey's lock key. Dropping a runtime from
+// the set silently disables BOTH for it - the seat resumes the reviewer's real
+// session instead of a fresh one, and the session stops locking - so a mutation
+// that removes a name must fail here rather than anywhere downstream.
+//
+// A runtime is added to this set when its RuntimeRef names a resumable session.
+// If that is genuinely no longer true for one of these, change this table in
+// the same commit and say why; do not delete the assertion.
+func TestResumableSessionRuntimeMembershipIsPinned(t *testing.T) {
+	resumable := map[string]string{
+		runtime.CodexRuntime:  "019fa4c8-69c1-7bc2-8628-00ade8fa43c5",
+		runtime.ClaudeRuntime: "019fa4c8-69c1-7bc2-8628-00ade8fa43c6",
+		runtime.KimiRuntime:   "019fa4c8-69c1-7bc2-8628-00ade8fa43c7",
+	}
+	for runtimeName, ref := range resumable {
+		t.Run(runtimeName, func(t *testing.T) {
+			if !resumableSessionRuntime(runtimeName) {
+				t.Fatalf("resumableSessionRuntime(%q) = false: its seat would resume the reviewer's registered session and its lock key would vanish", runtimeName)
+			}
+
+			// Consumer 1: the seat must be rewritten onto a fresh per-job ref.
+			agent := runtime.Agent{Runtime: runtimeName, RuntimeRef: ref}
+			if err := applyReadOnlySeat(true, "", "job-membership", &agent); err != nil {
+				t.Fatalf("applyReadOnlySeat: %v", err)
+			}
+			if agent.RuntimeRef == ref {
+				t.Fatalf("%s seat kept the registered ref %q: seat isolation is off for this runtime", runtimeName, ref)
+			}
+			if !runtime.IsFreshRef(agent.RuntimeRef) {
+				t.Fatalf("%s seat ref = %q, want a fresh ref", runtimeName, agent.RuntimeRef)
+			}
+
+			// Consumer 2: the registered session must still have a lock key.
+			if _, ok := runtimeSessionResourceKey(runtime.Agent{Runtime: runtimeName, RuntimeRef: ref}); !ok {
+				t.Fatalf("%s registered session has no lock key: its runtime sessions stopped serializing", runtimeName)
+			}
+		})
+	}
+
+	// The set is not "every runtime": a shell command ref is not a resumable
+	// session, and pinning that keeps the assertion above honest.
+	if resumableSessionRuntime(runtime.ShellRuntime) {
+		t.Errorf("resumableSessionRuntime(%q) = true, want false: a shell command ref is not a resumable session", runtime.ShellRuntime)
+	}
+}

--- a/internal/cli/readonly_seat_session_test.go
+++ b/internal/cli/readonly_seat_session_test.go
@@ -230,7 +230,7 @@ func TestPrepareReadOnlyRuntimeStateNamesAMissingRequiredInput(t *testing.T) {
 	}
 	agent := runtime.Agent{Runtime: runtime.KimiRuntime, RuntimeConfigDir: sourceDir, ReadOnlySeat: true}
 
-	_, _, err := prepareReadOnlyRuntimeState(agent, t.TempDir(), false)
+	_, _, _, err := prepareReadOnlyRuntimeState(agent, t.TempDir(), false)
 	if err == nil {
 		t.Fatal("a kimi seat without config.toml must be refused, not launched")
 	}
@@ -242,7 +242,7 @@ func TestPrepareReadOnlyRuntimeStateNamesAMissingRequiredInput(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(sourceDir, "config.toml"), []byte("default_model = \"kimi-code/k3\"\n"), 0o600); err != nil {
 		t.Fatal(err)
 	}
-	stateDir, _, err := prepareReadOnlyRuntimeState(agent, t.TempDir(), false)
+	stateDir, _, _, err := prepareReadOnlyRuntimeState(agent, t.TempDir(), false)
 	if err != nil {
 		t.Fatalf("prepareReadOnlyRuntimeState: %v", err)
 	}

--- a/internal/cli/readonly_seat_session_test.go
+++ b/internal/cli/readonly_seat_session_test.go
@@ -1,0 +1,174 @@
+package cli
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/gitmoot/gitmoot/internal/db"
+	"github.com/gitmoot/gitmoot/internal/runtime"
+	"github.com/gitmoot/gitmoot/internal/workflow"
+)
+
+// A read-only seat's runtime state dir is built EMPTY by
+// prepareReadOnlyRuntimeState (RemoveAll + MkdirAll, credential file only), so
+// the isolated home cannot contain the session a concrete ref names. Measured
+// failure: codex review job local-review-g7-review-18d1b8d23a6061a8 reached
+// running and died with "thread/resume: no rollout found for thread id
+// 019fa4c8-69c1-7bc2-8628-00ade8fa43c5" while that rollout sat in the real
+// ~/.codex/sessions tree the seat is sandboxed away from.
+func TestApplyReadOnlySeatRunsOnFreshSessionNotTheAgentsOwn(t *testing.T) {
+	const storedRef = "019fa4c8-69c1-7bc2-8628-00ade8fa43c5"
+	agent := runtime.Agent{Runtime: runtime.CodexRuntime, RuntimeRef: storedRef}
+
+	if err := applyReadOnlySeat(true, "/profiles/reviewer", "local-review-g7-review-18d1b8d2", &agent); err != nil {
+		t.Fatalf("applyReadOnlySeat: %v", err)
+	}
+
+	if agent.RuntimeRef == storedRef {
+		t.Fatalf("read-only seat kept the agent's resumable ref %q; the isolated home holds no session for it", storedRef)
+	}
+	if !runtime.IsFreshRef(agent.RuntimeRef) {
+		t.Fatalf("read-only seat ref = %q, want a fresh: ref so the runtime starts a new session instead of resuming", agent.RuntimeRef)
+	}
+	if want := runtime.FreshRefForJob("local-review-g7-review-18d1b8d2"); agent.RuntimeRef != want {
+		t.Fatalf("read-only seat ref = %q, want the job-scoped %q", agent.RuntimeRef, want)
+	}
+}
+
+// A seat that kept the stored ref would also take the runtime-session lock on
+// the agent's LIVE default-runtime session key: the lock is acquired on this
+// effective agent (acquireJobRuntimeSessionLock), so a disposable report-only
+// review would occupy the session a real job needs.
+func TestApplyReadOnlySeatDoesNotOccupyTheAgentsSessionLockKey(t *testing.T) {
+	stored := runtime.Agent{Runtime: runtime.CodexRuntime, RuntimeRef: "019fa4c8-69c1-7bc2-8628-00ade8fa43c5"}
+	storedKey, ok := runtimeSessionResourceKey(stored)
+	if !ok {
+		t.Fatal("stored codex session must have a lock key")
+	}
+
+	seat := stored
+	if err := applyReadOnlySeat(true, "", "job-seat-1", &seat); err != nil {
+		t.Fatalf("applyReadOnlySeat: %v", err)
+	}
+	seatKey, ok := runtimeSessionResourceKey(seat)
+	if !ok {
+		t.Fatal("read-only seat must still take a lock key")
+	}
+	if seatKey == storedKey {
+		t.Fatalf("read-only seat locks the agent's own session key %q", seatKey)
+	}
+
+	other := stored
+	if err := applyReadOnlySeat(true, "", "job-seat-2", &other); err != nil {
+		t.Fatalf("applyReadOnlySeat: %v", err)
+	}
+	otherKey, _ := runtimeSessionResourceKey(other)
+	if otherKey == seatKey {
+		t.Fatalf("two read-only seats of one agent must not share a lock key, both = %q", seatKey)
+	}
+}
+
+// An already-fresh ref is a per-job runtime override's minted ref or a
+// registered fresh:<seat> ref scoped by scopeRegisteredFreshRefForJob. Both are
+// unique per job AND are the keys the scheduler gate computed, so rewriting
+// them here would desync gate from acquisition.
+func TestApplyReadOnlySeatKeepsAnAlreadyFreshRef(t *testing.T) {
+	minted, err := runtime.NewFreshRef()
+	if err != nil {
+		t.Fatalf("NewFreshRef: %v", err)
+	}
+	agent := runtime.Agent{Runtime: runtime.CodexRuntime, RuntimeRef: minted}
+	if err := applyReadOnlySeat(true, "", "job-override", &agent); err != nil {
+		t.Fatalf("applyReadOnlySeat: %v", err)
+	}
+	if agent.RuntimeRef != minted {
+		t.Fatalf("override ref rewritten to %q, want the enqueue-minted %q", agent.RuntimeRef, minted)
+	}
+}
+
+// An ordinary (non-seat) job keeps its resumable session: this fix must not
+// silently convert every job into a fresh session.
+func TestApplyReadOnlySeatLeavesOrdinaryJobsResumable(t *testing.T) {
+	agent := runtime.Agent{Runtime: runtime.CodexRuntime, RuntimeRef: "019fa4c8-69c1-7bc2-8628-00ade8fa43c5"}
+	if err := applyReadOnlySeat(false, "/profiles/reviewer", "job-ordinary", &agent); err != nil {
+		t.Fatalf("applyReadOnlySeat: %v", err)
+	}
+	if agent.RuntimeRef != "019fa4c8-69c1-7bc2-8628-00ade8fa43c5" || agent.ReadOnlySeat {
+		t.Fatalf("ordinary job mutated: ref=%q seat=%v", agent.RuntimeRef, agent.ReadOnlySeat)
+	}
+}
+
+// A shell ref is a COMMAND, not a resumable session, and isolated shell
+// pipeline stages run with ReadOnlySeat=true. Rewriting that ref to a fresh
+// session ref would replace the stage's work with nothing, which is exactly
+// what the first version of this fix did to every shell pipeline E2E.
+func TestApplyReadOnlySeatKeepsShellCommandRef(t *testing.T) {
+	const command = `printf '%s' '{"gitmoot_result":{}}'`
+	agent := runtime.Agent{Runtime: runtime.ShellRuntime, RuntimeRef: command}
+	if err := applyReadOnlySeat(true, "", "pipe-run-stage-0", &agent); err != nil {
+		t.Fatalf("applyReadOnlySeat: %v", err)
+	}
+	if agent.RuntimeRef != command {
+		t.Fatalf("shell command ref rewritten to %q, want %q", agent.RuntimeRef, command)
+	}
+	if !agent.ReadOnlySeat {
+		t.Fatal("shell stage lost its read-only seat marker")
+	}
+}
+
+// The daemon SELECTOR must gate on exactly the key the worker ACQUIRES. A
+// mismatch is the #1034 shape: the gate serializes read-only seats behind the
+// agent's live session (or lets them through on a key nothing locks).
+func TestQueuedJobRuntimeResourceKeyReadOnlySeat(t *testing.T) {
+	ctx := context.Background()
+	store := daemonWorkerStore(t)
+	stored := db.Agent{
+		Name:       "gm-review-codex",
+		Runtime:    runtime.CodexRuntime,
+		RuntimeRef: "019fa4c8-69c1-7bc2-8628-00ade8fa43c5",
+	}
+	if err := store.UpsertAgent(ctx, stored); err != nil {
+		t.Fatalf("UpsertAgent: %v", err)
+	}
+
+	newJob := func(id string, seat bool) db.Job {
+		encoded, err := json.Marshal(workflow.JobPayload{
+			Repo:             "gitmoot/gitmoot",
+			ReadOnlySeat:     seat,
+			ReadOnlyWorktree: seat,
+			WorktreePath:     "/wt/" + id,
+		})
+		if err != nil {
+			t.Fatalf("marshal payload: %v", err)
+		}
+		return db.Job{ID: id, Agent: stored.Name, Payload: string(encoded)}
+	}
+
+	seatJob := newJob("local-review-seat-a", true)
+	gate := queuedJobRuntimeResourceKey(ctx, store, seatJob)
+
+	effective := runtimeAgent(stored)
+	if err := applyReadOnlySeat(true, "", seatJob.ID, &effective); err != nil {
+		t.Fatalf("applyReadOnlySeat: %v", err)
+	}
+	lockKey, ok := runtimeSessionResourceKey(effective)
+	if !ok {
+		t.Fatal("read-only seat must have an acquisition key")
+	}
+	if gate != lockKey {
+		t.Fatalf("selector key %q must equal the acquisition key %q", gate, lockKey)
+	}
+
+	storedKey, _ := runtimeSessionResourceKey(runtimeAgent(stored))
+	if gate == storedKey {
+		t.Fatalf("read-only seat gated on the agent's own session key %q", gate)
+	}
+
+	// A non-seat job for the same agent still gates on that agent's session, so
+	// real work continues to serialize on the session it actually resumes.
+	ordinary := newJob("implement-a", false)
+	if got := queuedJobRuntimeResourceKey(ctx, store, ordinary); got != storedKey {
+		t.Fatalf("ordinary job gate = %q, want the agent session key %q", got, storedKey)
+	}
+}

--- a/internal/cli/readonly_seat_session_test.go
+++ b/internal/cli/readonly_seat_session_test.go
@@ -3,6 +3,9 @@ package cli
 import (
 	"context"
 	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/gitmoot/gitmoot/internal/db"
@@ -36,36 +39,31 @@ func TestApplyReadOnlySeatRunsOnFreshSessionNotTheAgentsOwn(t *testing.T) {
 	}
 }
 
-// A seat that kept the stored ref would also take the runtime-session lock on
-// the agent's LIVE default-runtime session key: the lock is acquired on this
-// effective agent (acquireJobRuntimeSessionLock), so a disposable report-only
-// review would occupy the session a real job needs.
-func TestApplyReadOnlySeatDoesNotOccupyTheAgentsSessionLockKey(t *testing.T) {
+// The seat isolates DELIVERY only. Locking must stay on the agent's registered
+// session so #684 serialization is unchanged (that invariant is exercised end
+// to end by TestRunAgentReviewRequeuesQueuedJobWhenRuntimeSessionBusy, which
+// drives `agent review` with the registered session held by another owner).
+// applyReadOnlySeat takes a pointer, so callers keep a pre-seat copy for the
+// lock; this test pins that a copy taken before the call is unaffected.
+func TestApplyReadOnlySeatLeavesTheSessionLockAgentIntact(t *testing.T) {
 	stored := runtime.Agent{Runtime: runtime.CodexRuntime, RuntimeRef: "019fa4c8-69c1-7bc2-8628-00ade8fa43c5"}
-	storedKey, ok := runtimeSessionResourceKey(stored)
-	if !ok {
-		t.Fatal("stored codex session must have a lock key")
-	}
-
-	seat := stored
-	if err := applyReadOnlySeat(true, "", "job-seat-1", &seat); err != nil {
+	sessionLockAgent := stored
+	delivery := stored
+	if err := applyReadOnlySeat(true, "", "job-seat-1", &delivery); err != nil {
 		t.Fatalf("applyReadOnlySeat: %v", err)
 	}
-	seatKey, ok := runtimeSessionResourceKey(seat)
-	if !ok {
-		t.Fatal("read-only seat must still take a lock key")
-	}
-	if seatKey == storedKey {
-		t.Fatalf("read-only seat locks the agent's own session key %q", seatKey)
-	}
 
-	other := stored
-	if err := applyReadOnlySeat(true, "", "job-seat-2", &other); err != nil {
-		t.Fatalf("applyReadOnlySeat: %v", err)
+	lockKey, ok := runtimeSessionResourceKey(sessionLockAgent)
+	if !ok {
+		t.Fatal("registered codex session must have a lock key")
 	}
-	otherKey, _ := runtimeSessionResourceKey(other)
-	if otherKey == seatKey {
-		t.Fatalf("two read-only seats of one agent must not share a lock key, both = %q", seatKey)
+	storedKey, _ := runtimeSessionResourceKey(stored)
+	if lockKey != storedKey {
+		t.Fatalf("session lock key = %q, want the registered %q", lockKey, storedKey)
+	}
+	deliveryKey, _ := runtimeSessionResourceKey(delivery)
+	if deliveryKey == lockKey {
+		t.Fatalf("delivery ref %q was not isolated from the locked session", delivery.RuntimeRef)
 	}
 }
 
@@ -117,9 +115,12 @@ func TestApplyReadOnlySeatKeepsShellCommandRef(t *testing.T) {
 	}
 }
 
-// The daemon SELECTOR must gate on exactly the key the worker ACQUIRES. A
-// mismatch is the #1034 shape: the gate serializes read-only seats behind the
-// agent's live session (or lets them through on a key nothing locks).
+// The daemon SELECTOR gates on exactly the key the worker ACQUIRES, and a
+// read-only seat must not change that: the worker locks the agent's registered
+// session (jobWorker.run keeps a pre-seat copy) and the selector reads the
+// stored agent, so both sides keep naming one key. A seat that moved its LOCK
+// to a job-scoped ref would have to move the gate too, or the two disagree,
+// which is the #1034 shape.
 func TestQueuedJobRuntimeResourceKeyReadOnlySeat(t *testing.T) {
 	ctx := context.Background()
 	store := daemonWorkerStore(t)
@@ -145,30 +146,108 @@ func TestQueuedJobRuntimeResourceKeyReadOnlySeat(t *testing.T) {
 		return db.Job{ID: id, Agent: stored.Name, Payload: string(encoded)}
 	}
 
-	seatJob := newJob("local-review-seat-a", true)
-	gate := queuedJobRuntimeResourceKey(ctx, store, seatJob)
+	storedKey, ok := runtimeSessionResourceKey(runtimeAgent(stored))
+	if !ok {
+		t.Fatal("registered codex session must have a lock key")
+	}
 
-	effective := runtimeAgent(stored)
-	if err := applyReadOnlySeat(true, "", seatJob.ID, &effective); err != nil {
+	seatJob := newJob("local-review-seat-a", true)
+	if gate := queuedJobRuntimeResourceKey(ctx, store, seatJob); gate != storedKey {
+		t.Fatalf("seat gate = %q, want the registered session key %q", gate, storedKey)
+	}
+	if gate := queuedJobRuntimeResourceKey(ctx, store, newJob("implement-a", false)); gate != storedKey {
+		t.Fatalf("ordinary gate = %q, want the registered session key %q", gate, storedKey)
+	}
+
+	// ...and the seat still delivers on an isolated fresh session, so the key it
+	// gates on is deliberately NOT the session it talks to.
+	delivery := runtimeAgent(stored)
+	if err := applyReadOnlySeat(true, "", seatJob.ID, &delivery); err != nil {
 		t.Fatalf("applyReadOnlySeat: %v", err)
 	}
-	lockKey, ok := runtimeSessionResourceKey(effective)
-	if !ok {
-		t.Fatal("read-only seat must have an acquisition key")
+	if !runtime.IsFreshRef(delivery.RuntimeRef) {
+		t.Fatalf("seat delivery ref = %q, want a fresh ref", delivery.RuntimeRef)
 	}
-	if gate != lockKey {
-		t.Fatalf("selector key %q must equal the acquisition key %q", gate, lockKey)
+}
+
+// Every registered runtime must declare a seat staging policy. The seat has
+// omitted a required startup input three times (openssl.cnf, codex sessions/,
+// kimi config.toml), and the third one shipped because nothing forced a runtime
+// to say what it reads at startup. A new runtime added to the registry without
+// a policy fails here rather than at dispatch.
+func TestReadOnlySeatStatePolicyCoversEveryRegisteredRuntime(t *testing.T) {
+	userHome := t.TempDir()
+	for _, name := range runtime.SupportedRuntimes() {
+		t.Run(name, func(t *testing.T) {
+			policy, needsState, err := readOnlySeatStatePolicyFor(name, userHome, false)
+			switch name {
+			case runtime.OmpRuntime:
+				if err == nil {
+					t.Fatal("omp must be refused: it has no isolated credential broker")
+				}
+				return
+			case runtime.ShellRuntime:
+				if err != nil || needsState {
+					t.Fatalf("shell needsState=%v err=%v, want no isolated state and no error", needsState, err)
+				}
+				return
+			}
+			if err != nil || !needsState {
+				t.Fatalf("%s needsState=%v err=%v, want a declared policy", name, needsState, err)
+			}
+			if strings.TrimSpace(policy.relativeState) == "" {
+				t.Fatalf("%s policy declares no staging location", name)
+			}
+			if strings.TrimSpace(policy.defaultSourceDir) == "" {
+				t.Fatalf("%s policy declares no host source dir", name)
+			}
+			if policy.credentialFile == "" && len(policy.requiredInputs) == 0 {
+				t.Fatalf("%s policy stages nothing: a seat with an empty state dir starts and then refuses", name)
+			}
+		})
+	}
+}
+
+// An unregistered runtime must be refused rather than silently given an empty
+// state dir.
+func TestReadOnlySeatStatePolicyRefusesUnknownRuntime(t *testing.T) {
+	if _, _, err := readOnlySeatStatePolicyFor("codxe", t.TempDir(), false); err == nil {
+		t.Fatal("unknown runtime must be refused")
+	}
+}
+
+// A required input the host does not have must fail with a message that NAMES
+// the file. The runtime's own diagnostic for this case ("No model configured",
+// behind an auth error telling the reader to run kimi login) is what cost a day.
+func TestPrepareReadOnlyRuntimeStateNamesAMissingRequiredInput(t *testing.T) {
+	sourceDir := t.TempDir()
+	credentialDir := filepath.Join(sourceDir, "credentials")
+	if err := os.MkdirAll(credentialDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(credentialDir, "kimi-code.json"), []byte(`{"access_token":"host"}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	agent := runtime.Agent{Runtime: runtime.KimiRuntime, RuntimeConfigDir: sourceDir, ReadOnlySeat: true}
+
+	_, _, err := prepareReadOnlyRuntimeState(agent, t.TempDir(), false)
+	if err == nil {
+		t.Fatal("a kimi seat without config.toml must be refused, not launched")
+	}
+	if !strings.Contains(err.Error(), "config.toml") {
+		t.Fatalf("error must name the missing input, got: %v", err)
 	}
 
-	storedKey, _ := runtimeSessionResourceKey(runtimeAgent(stored))
-	if gate == storedKey {
-		t.Fatalf("read-only seat gated on the agent's own session key %q", gate)
+	// With the input present the same call stages it verbatim.
+	if err := os.WriteFile(filepath.Join(sourceDir, "config.toml"), []byte("default_model = \"kimi-code/k3\"\n"), 0o600); err != nil {
+		t.Fatal(err)
 	}
-
-	// A non-seat job for the same agent still gates on that agent's session, so
-	// real work continues to serialize on the session it actually resumes.
-	ordinary := newJob("implement-a", false)
-	if got := queuedJobRuntimeResourceKey(ctx, store, ordinary); got != storedKey {
-		t.Fatalf("ordinary job gate = %q, want the agent session key %q", got, storedKey)
+	stateDir, _, err := prepareReadOnlyRuntimeState(agent, t.TempDir(), false)
+	if err != nil {
+		t.Fatalf("prepareReadOnlyRuntimeState: %v", err)
+	}
+	staged, err := os.ReadFile(filepath.Join(stateDir, "config.toml"))
+	if err != nil || !strings.Contains(string(staged), "default_model") {
+		t.Fatalf("staged config.toml = %q, err=%v", staged, err)
 	}
 }

--- a/internal/cli/readonly_seat_symlink_test.go
+++ b/internal/cli/readonly_seat_symlink_test.go
@@ -41,7 +41,7 @@ func TestReadOnlySeatStagesSymlinkedInputsAndCredentials(t *testing.T) {
 	}
 
 	agent := runtime.Agent{Runtime: runtime.KimiRuntime, RuntimeConfigDir: source}
-	stateDir, _, err := prepareReadOnlyRuntimeState(agent, t.TempDir(), false)
+	stateDir, _, _, err := prepareReadOnlyRuntimeState(agent, t.TempDir(), false)
 	if err != nil {
 		t.Fatalf("a symlinked profile must be stageable, got: %v", err)
 	}
@@ -79,7 +79,7 @@ func TestReadOnlySeatStillRefusesInputsThatAreNotFiles(t *testing.T) {
 		t.Fatal(err)
 	}
 	agent := runtime.Agent{Runtime: runtime.CodexRuntime, RuntimeConfigDir: source}
-	_, _, err := prepareReadOnlyRuntimeState(agent, t.TempDir(), false)
+	_, _, _, err := prepareReadOnlyRuntimeState(agent, t.TempDir(), false)
 	if err == nil {
 		t.Fatal("a directory named config.toml was accepted as a runtime input")
 	}
@@ -96,7 +96,7 @@ func TestReadOnlySeatStillRefusesInputsThatAreNotFiles(t *testing.T) {
 		t.Fatal(err)
 	}
 	agent = runtime.Agent{Runtime: runtime.CodexRuntime, RuntimeConfigDir: linked}
-	if _, _, err := prepareReadOnlyRuntimeState(agent, t.TempDir(), false); err == nil {
+	if _, _, _, err := prepareReadOnlyRuntimeState(agent, t.TempDir(), false); err == nil {
 		t.Fatal("a symlink to a directory was accepted as a runtime input")
 	}
 }
@@ -115,7 +115,7 @@ func TestReadOnlySeatTreatsADanglingSymlinkAsMissing(t *testing.T) {
 	if err := os.Symlink(filepath.Join(home, "gone.toml"), filepath.Join(codexSource, "config.toml")); err != nil {
 		t.Fatal(err)
 	}
-	stateDir, _, err := prepareReadOnlyRuntimeState(runtime.Agent{Runtime: runtime.CodexRuntime, RuntimeConfigDir: codexSource}, t.TempDir(), false)
+	stateDir, _, _, err := prepareReadOnlyRuntimeState(runtime.Agent{Runtime: runtime.CodexRuntime, RuntimeConfigDir: codexSource}, t.TempDir(), false)
 	if err != nil {
 		t.Fatalf("a dangling optional input must be skipped, got: %v", err)
 	}
@@ -131,7 +131,7 @@ func TestReadOnlySeatTreatsADanglingSymlinkAsMissing(t *testing.T) {
 	if err := os.Symlink(filepath.Join(home, "gone.toml"), filepath.Join(kimiSource, "config.toml")); err != nil {
 		t.Fatal(err)
 	}
-	_, _, err = prepareReadOnlyRuntimeState(runtime.Agent{Runtime: runtime.KimiRuntime, RuntimeConfigDir: kimiSource}, t.TempDir(), false)
+	_, _, _, err = prepareReadOnlyRuntimeState(runtime.Agent{Runtime: runtime.KimiRuntime, RuntimeConfigDir: kimiSource}, t.TempDir(), false)
 	if err == nil {
 		t.Fatal("a dangling REQUIRED input was accepted")
 	}

--- a/internal/cli/readonly_seat_symlink_test.go
+++ b/internal/cli/readonly_seat_symlink_test.go
@@ -1,0 +1,165 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/gitmoot/gitmoot/internal/runtime"
+)
+
+// TestReadOnlySeatStagesSymlinkedInputsAndCredentials pins the succeed path.
+//
+// A dotfiles manager leaves a SYMLINK where the runtime looks and keeps the
+// real file in its own tree. Rejecting that made a valid kimi profile
+// unlaunchable. Both staging sites had the defect - the input path AND the
+// credential path - so both are pinned here; the reviewer named only the first.
+func TestReadOnlySeatStagesSymlinkedInputsAndCredentials(t *testing.T) {
+	home := t.TempDir()
+	real := t.TempDir()
+
+	// The real files live outside the runtime's state dir, as stow would keep them.
+	realConfig := filepath.Join(real, "config.toml")
+	if err := os.WriteFile(realConfig, []byte("model = \"kimi-k2\"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	realCredential := filepath.Join(real, "kimi-code.json")
+	if err := os.WriteFile(realCredential, []byte(`{"token":"kimi-token"}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	source := filepath.Join(home, "dotfiles-kimi")
+	if err := os.MkdirAll(filepath.Join(source, "credentials"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(realConfig, filepath.Join(source, "config.toml")); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(realCredential, filepath.Join(source, "credentials", "kimi-code.json")); err != nil {
+		t.Fatal(err)
+	}
+
+	agent := runtime.Agent{Runtime: runtime.KimiRuntime, RuntimeConfigDir: source}
+	stateDir, _, err := prepareReadOnlyRuntimeState(agent, t.TempDir(), false)
+	if err != nil {
+		t.Fatalf("a symlinked profile must be stageable, got: %v", err)
+	}
+	staged, err := os.ReadFile(filepath.Join(stateDir, "config.toml"))
+	if err != nil {
+		t.Fatalf("read staged config: %v", err)
+	}
+	if !strings.Contains(string(staged), "kimi-k2") {
+		t.Errorf("staged config = %q, want the symlink target's content", staged)
+	}
+	credential, err := os.ReadFile(filepath.Join(stateDir, "credentials", "kimi-code.json"))
+	if err != nil {
+		t.Fatalf("read staged credential: %v", err)
+	}
+	if !strings.Contains(string(credential), "kimi-token") {
+		t.Errorf("staged credential = %q, want the symlink target's content", credential)
+	}
+	// The staged copy must be a real file in the seat, not a symlink pointing
+	// back out of the sandbox at a path the seat cannot read.
+	info, err := os.Lstat(filepath.Join(stateDir, "config.toml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		t.Error("staged input is itself a symlink; the seat would follow it out of the sandbox")
+	}
+}
+
+// TestReadOnlySeatStillRefusesInputsThatAreNotFiles keeps the bound honest:
+// following symlinks must not turn into accepting anything.
+func TestReadOnlySeatStillRefusesInputsThatAreNotFiles(t *testing.T) {
+	home := t.TempDir()
+	source := filepath.Join(home, ".codex")
+	if err := os.MkdirAll(filepath.Join(source, "config.toml"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	agent := runtime.Agent{Runtime: runtime.CodexRuntime, RuntimeConfigDir: source}
+	_, _, err := prepareReadOnlyRuntimeState(agent, t.TempDir(), false)
+	if err == nil {
+		t.Fatal("a directory named config.toml was accepted as a runtime input")
+	}
+	if !strings.Contains(err.Error(), "must be a regular file") {
+		t.Errorf("error = %v, want it to say the input is not a regular file", err)
+	}
+
+	// A symlink TO a directory is the same refusal, reached through resolution.
+	linked := filepath.Join(home, ".codex-linked")
+	if err := os.MkdirAll(linked, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(t.TempDir(), filepath.Join(linked, "config.toml")); err != nil {
+		t.Fatal(err)
+	}
+	agent = runtime.Agent{Runtime: runtime.CodexRuntime, RuntimeConfigDir: linked}
+	if _, _, err := prepareReadOnlyRuntimeState(agent, t.TempDir(), false); err == nil {
+		t.Fatal("a symlink to a directory was accepted as a runtime input")
+	}
+}
+
+// TestReadOnlySeatTreatsADanglingSymlinkAsMissing pins that a broken link takes
+// the missing-file path rather than a third outcome: skipped when the input is
+// optional, and NAMED when it is required.
+func TestReadOnlySeatTreatsADanglingSymlinkAsMissing(t *testing.T) {
+	home := t.TempDir()
+
+	// codex config.toml is OPTIONAL: a dangling link is skipped, seat launches.
+	codexSource := filepath.Join(home, ".codex")
+	if err := os.MkdirAll(codexSource, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(filepath.Join(home, "gone.toml"), filepath.Join(codexSource, "config.toml")); err != nil {
+		t.Fatal(err)
+	}
+	stateDir, _, err := prepareReadOnlyRuntimeState(runtime.Agent{Runtime: runtime.CodexRuntime, RuntimeConfigDir: codexSource}, t.TempDir(), false)
+	if err != nil {
+		t.Fatalf("a dangling optional input must be skipped, got: %v", err)
+	}
+	if _, statErr := os.Stat(filepath.Join(stateDir, "config.toml")); !os.IsNotExist(statErr) {
+		t.Errorf("a dangling optional input was staged anyway: %v", statErr)
+	}
+
+	// kimi config.toml is REQUIRED: the failure must name the file.
+	kimiSource := filepath.Join(home, ".kimi-code")
+	if err := os.MkdirAll(kimiSource, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(filepath.Join(home, "gone.toml"), filepath.Join(kimiSource, "config.toml")); err != nil {
+		t.Fatal(err)
+	}
+	_, _, err = prepareReadOnlyRuntimeState(runtime.Agent{Runtime: runtime.KimiRuntime, RuntimeConfigDir: kimiSource}, t.TempDir(), false)
+	if err == nil {
+		t.Fatal("a dangling REQUIRED input was accepted")
+	}
+	if !strings.Contains(err.Error(), "config.toml") {
+		t.Errorf("error = %v, want it to name config.toml rather than leave the runtime to explain", err)
+	}
+}
+
+// TestStagedInputNamesCannotEscapeTheSeatStateDir pins the containment check.
+// Every real name is a separator-free constant, so this is a guard against a
+// future policy edit, not a live bug - which is exactly why it needs a test
+// rather than a convention.
+func TestStagedInputNamesCannotEscapeTheSeatStateDir(t *testing.T) {
+	stateDir := t.TempDir()
+	for _, name := range []string{"..", filepath.Join("..", "escaped.toml"), filepath.Join("a", "..", "..", "escaped.toml")} {
+		if _, err := containedStagePath(stateDir, name); err == nil {
+			t.Errorf("containedStagePath(%q) allowed a write outside the seat state dir", name)
+		}
+	}
+	// The shapes in use must still be allowed, including the nested credential.
+	for _, name := range []string{"config.toml", filepath.Join("credentials", "kimi-code.json")} {
+		got, err := containedStagePath(stateDir, name)
+		if err != nil {
+			t.Errorf("containedStagePath(%q) refused a name in use: %v", name, err)
+			continue
+		}
+		if !strings.HasPrefix(got, stateDir) {
+			t.Errorf("containedStagePath(%q) = %q, want it under %q", name, got, stateDir)
+		}
+	}
+}

--- a/internal/cli/readonly_seat_temp_worker_test.go
+++ b/internal/cli/readonly_seat_temp_worker_test.go
@@ -1,0 +1,173 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gitmoot/gitmoot/internal/db"
+	"github.com/gitmoot/gitmoot/internal/execbackend"
+	"github.com/gitmoot/gitmoot/internal/runtime"
+	"github.com/gitmoot/gitmoot/internal/workflow"
+)
+
+// TestTempWorkerForkStillSandboxesAReadOnlySeat drives the FORK path, not the
+// wrap helper.
+//
+// When the registered session is busy and parallel_sessions.same_session is
+// fork_temp_session, control leaves jobWorker.run before the delivery-site
+// sandbox wrap, and startTempWorker copies the delivery agent - so ReadOnlySeat
+// survives into a path that never wrapped it. A read-only seat therefore ran
+// outside Landlock and outside this PR's staging policy.
+//
+// The observable is the staging the wrap performs: with the wrap in place the
+// seat's isolated runtime state exists on disk under the config home. Without
+// it, nothing is staged, because nothing on the fork path ever asks.
+func TestTempWorkerForkStillSandboxesAReadOnlySeat(t *testing.T) {
+	ctx := context.Background()
+	home := t.TempDir()
+	store := openCLIJobStore(t, home)
+	defer store.Close()
+
+	// The host profile the seat must stage a narrowed copy of.
+	hostCodex := filepath.Join(home, "host-codex")
+	if err := os.MkdirAll(hostCodex, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(hostCodex, "config.toml"), []byte("model = \"gpt-5\"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	checkout := t.TempDir()
+	runGit(t, checkout, "init", "-b", "main")
+	runGit(t, checkout, "config", "user.email", "gitmoot@example.com")
+	runGit(t, checkout, "config", "user.name", "Gitmoot")
+	runGit(t, checkout, "remote", "add", "origin", "https://github.com/owner/repo.git")
+	runGit(t, checkout, "commit", "--allow-empty", "-m", "init")
+	headSHA := strings.TrimSpace(runGitOutput(t, checkout, "rev-parse", "HEAD"))
+	if err := store.UpsertRepoForce(ctx, db.Repo{Owner: "owner", Name: "repo", CheckoutPath: checkout, PrimaryCheckoutPath: checkout}); err != nil {
+		t.Fatalf("UpsertRepoForce: %v", err)
+	}
+
+	const registeredRef = "019fa4c8-69c1-7bc2-8628-00ade8fa43d1"
+	registeredAgent := db.Agent{
+		Name:       "seat-reviewer",
+		Role:       "reviewer",
+		Runtime:    runtime.CodexRuntime,
+		RuntimeRef: registeredRef,
+		RepoScope:  "owner/repo",
+		Model:      "gpt-5",
+	}
+	if err := store.UpsertAgent(ctx, registeredAgent); err != nil {
+		t.Fatalf("UpsertAgent: %v", err)
+	}
+
+	// Hold the registered session so the fork path is the one taken. The
+	// default config leaves same_session = fork_temp_session.
+	registeredKey, ok := runtimeSessionResourceKey(runtime.Agent{Runtime: runtime.CodexRuntime, RuntimeRef: registeredRef})
+	if !ok {
+		t.Fatal("registered codex session must have a lock key")
+	}
+	release, acquired, _, _, err := acquireRuntimeSessionLockWithKey(ctx, store, "other-job", registeredKey, true, time.Now().UTC(), time.Hour)
+	if err != nil || !acquired {
+		t.Fatalf("seed registered lock: err=%v acquired=%v", err, acquired)
+	}
+	defer func() { _ = release(context.Background()) }()
+
+	job := db.Job{
+		ID:    "local-review-seat-fork",
+		Agent: "seat-reviewer",
+		Type:  "review",
+		State: string(workflow.JobQueued),
+		Payload: mustJobPayload(t, workflow.JobPayload{
+			Repo:             "owner/repo",
+			Branch:           "main",
+			PullRequest:      11,
+			HeadSHA:          headSHA,
+			ReadOnlySeat:     true,
+			RuntimeConfigDir: hostCodex,
+		}),
+	}
+	if err := store.CreateJobWithEvent(ctx, job, db.JobEvent{Kind: string(workflow.JobQueued), Message: "seed"}); err != nil {
+		t.Fatalf("CreateJobWithEvent: %v", err)
+	}
+
+	var output bytes.Buffer
+	worker := jobWorker{
+		Store:              store,
+		ConfigHome:         home,
+		ConfigHomeExplicit: true,
+		Stdout:             &output,
+		AgentLookup: func(context.Context, string) (db.Agent, error) {
+			return registeredAgent, nil
+		},
+		AdapterFactory: func(runtime.Agent, string) (workflow.DeliveryAdapter, error) {
+			return &cliWorkerFakeAdapter{}, nil
+		},
+		StartAdapterFactory: func(execbackend.Backend, string, string) (runtime.Adapter, error) {
+			return &cliWorkerFakeAdapter{}, nil
+		},
+	}
+	_ = worker.run(ctx, job)
+
+	events, err := store.ListJobEvents(ctx, job.ID)
+	if err != nil {
+		t.Fatalf("ListJobEvents: %v", err)
+	}
+	forked := false
+	for _, event := range events {
+		if event.Kind == "temp_worker_eligible" {
+			forked = true
+		}
+	}
+	if !forked {
+		t.Fatalf("the run never took the temp-worker fork, so this test is not exercising the path it names; events: %+v", events)
+	}
+
+	// The fake adapter cannot be Landlock-wrapped, so the wrap REFUSING it is
+	// itself proof the fork path now asks - and the staging below happens inside
+	// that same call, before the refusal.
+	wrapAttempted := false
+	for _, event := range events {
+		if strings.Contains(event.Message, "read-only Landlock sandbox") {
+			wrapAttempted = true
+		}
+	}
+	if !wrapAttempted {
+		t.Error("no evidence the fork path applied the read-only sandbox wrap")
+	}
+
+	staged := stagedSeatStateUnder(t, home)
+	if staged == "" {
+		t.Fatalf("the forked read-only seat staged no isolated runtime state under %q: it ran outside the sandbox and outside the staging policy", home)
+	}
+	contents, err := os.ReadFile(staged)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(contents), "gpt-5") {
+		t.Errorf("staged seat config = %q, want the host model setting", contents)
+	}
+}
+
+// stagedSeatStateUnder finds a staged seat config.toml anywhere under home. The
+// cache root is chosen by the isolated-tool-cache grant, so the test asks
+// whether staging HAPPENED rather than hard-coding where.
+func stagedSeatStateUnder(t *testing.T, home string) string {
+	t.Helper()
+	var found string
+	_ = filepath.WalkDir(home, func(path string, entry os.DirEntry, err error) error {
+		if err != nil || entry.IsDir() || found != "" {
+			return nil //nolint:nilerr // an unreadable subtree is not a result
+		}
+		if filepath.Base(path) == "config.toml" && strings.Contains(path, "runtime-state") {
+			found = path
+		}
+		return nil
+	})
+	return found
+}

--- a/internal/cli/runtime_lock.go
+++ b/internal/cli/runtime_lock.go
@@ -164,9 +164,7 @@ func startRuntimeSessionLockHeartbeatWithCadence(ctx context.Context, store *db.
 func runtimeSessionResourceKey(agent runtime.Agent) (string, bool) {
 	runtimeName := strings.TrimSpace(agent.Runtime)
 	runtimeRef := strings.TrimSpace(agent.RuntimeRef)
-	switch runtimeName {
-	case runtime.CodexRuntime, runtime.ClaudeRuntime, runtime.KimiRuntime:
-	default:
+	if !resumableSessionRuntime(runtimeName) {
 		return "", false
 	}
 	if runtimeRef == "" {

--- a/internal/cli/sandbox_produce_test.go
+++ b/internal/cli/sandbox_produce_test.go
@@ -164,8 +164,8 @@ func (r *repairStateRunner) RunEnv(_ context.Context, _ string, env []string, co
 func (r *repairStateRunner) LookPath(file string) (string, error) { return file, nil }
 
 type kimiHomeStateRunner struct {
-	home               string
-	credentialObserved bool
+	home                string
+	credentialObserved  bool
 	modelConfigObserved bool
 }
 
@@ -893,7 +893,7 @@ func TestStageReadOnlyRuntimeCredentialCopiesOnlyProviderSection(t *testing.T) {
 	if err := os.WriteFile(source, []byte(sourceCredential), 0o600); err != nil {
 		t.Fatal(err)
 	}
-	if err := stageReadOnlyRuntimeCredential(source, staged, "claudeAiOauth"); err != nil {
+	if err := stageReadOnlyRuntimeCredential(source, staged, "claudeAiOauth", nil); err != nil {
 		t.Fatal(err)
 	}
 	stagedData, err := os.ReadFile(staged)

--- a/internal/cli/sandbox_produce_test.go
+++ b/internal/cli/sandbox_produce_test.go
@@ -368,7 +368,7 @@ func TestWrapReadOnlySandboxAdapterUsesExplicitReadsAndIsolatedState(t *testing.
 		ReadOnlySeat:     true,
 		RuntimeConfigDir: stateDir,
 	}
-	wrapped, err := wrapReadOnlySandboxAdapter(configHome, agent, checkout, runtime.ClaudeAdapter{Runner: subprocess.GroupRunner{}})
+	wrapped, _, err := wrapReadOnlySandboxAdapter(configHome, agent, checkout, runtime.ClaudeAdapter{Runner: subprocess.GroupRunner{}})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -440,7 +440,7 @@ func TestWrapReadOnlySandboxAdapterKeepsModelGatewayCredentialFree(t *testing.T)
 		Adapter: runtime.ClaudeAdapter{Runner: gatewayRunner},
 		runner:  gatewayRunner,
 	}
-	wrapped, err := wrapReadOnlySandboxAdapter(t.TempDir(), runtime.Agent{
+	wrapped, _, err := wrapReadOnlySandboxAdapter(t.TempDir(), runtime.Agent{
 		Runtime:          runtime.ClaudeRuntime,
 		ReadOnlySeat:     true,
 		RuntimeConfigDir: sourceState,
@@ -794,7 +794,7 @@ func TestForegroundReviewRuntimeStateSurvivesRepairAndCleansAtBoundary(t *testin
 
 	previousAdapterFactory := localAgentDispatchRuntimeAdapterFor
 	localAgentDispatchRuntimeAdapterFor = func(configHome string, agent runtime.Agent, deliveryCheckout string) (runtime.Adapter, error) {
-		delivery, err := wrapReadOnlySandboxAdapter(configHome, agent, deliveryCheckout, runtime.ClaudeAdapter{Runner: runner})
+		delivery, _, err := wrapReadOnlySandboxAdapter(configHome, agent, deliveryCheckout, runtime.ClaudeAdapter{Runner: runner})
 		if err != nil {
 			return nil, err
 		}
@@ -854,7 +854,7 @@ func TestReadOnlyRuntimeAdapterNeverPersistsStagedCredential(t *testing.T) {
 		AutonomyPolicy: runtime.AutonomyPolicyReadOnly, ReadOnlySeat: true,
 		RuntimeConfigDir: sourceDir,
 	}
-	wrapped, err := wrapReadOnlySandboxAdapter(configHome, agent, checkout, runtime.ClaudeAdapter{
+	wrapped, _, err := wrapReadOnlySandboxAdapter(configHome, agent, checkout, runtime.ClaudeAdapter{
 		Runner: &sandboxAdapterCaptureRunner{stdout: `{"result":"done"}`},
 	})
 	if err != nil {
@@ -920,7 +920,7 @@ func TestWrapReadOnlySandboxAdapterRejectsOmpWithoutCredentialBroker(t *testing.
 		t.Fatal(err)
 	}
 	agent := runtime.Agent{Runtime: runtime.OmpRuntime, ReadOnlySeat: true}
-	_, err := wrapReadOnlySandboxAdapter(t.TempDir(), agent, checkout, runtime.OmpAdapter{})
+	_, _, err := wrapReadOnlySandboxAdapter(t.TempDir(), agent, checkout, runtime.OmpAdapter{})
 	if err == nil || !strings.Contains(err.Error(), "isolated credential broker") {
 		t.Fatalf("omp read-only seat error = %v", err)
 	}

--- a/internal/cli/sandbox_produce_test.go
+++ b/internal/cli/sandbox_produce_test.go
@@ -166,6 +166,7 @@ func (r *repairStateRunner) LookPath(file string) (string, error) { return file,
 type kimiHomeStateRunner struct {
 	home               string
 	credentialObserved bool
+	modelConfigObserved bool
 }
 
 func (r *kimiHomeStateRunner) Run(context.Context, string, string, ...string) (subprocess.Result, error) {
@@ -182,6 +183,18 @@ func (r *kimiHomeStateRunner) RunEnv(_ context.Context, _ string, env []string, 
 		return subprocess.Result{}, fmt.Errorf("read Kimi credential under HOME: %w", err)
 	}
 	r.credentialObserved = true
+	// Kimi reads default_model plus its provider and model blocks from
+	// config.toml. Staging only the credential produced a seat that
+	// authenticated and then refused with "No model configured" behind an auth
+	// message, so this runner reads what the real runtime reads at startup.
+	modelConfig, err := os.ReadFile(filepath.Join(r.home, ".kimi-code", "config.toml"))
+	if err != nil {
+		return subprocess.Result{}, fmt.Errorf("read Kimi config.toml under HOME: %w", err)
+	}
+	if !strings.Contains(string(modelConfig), "default_model") {
+		return subprocess.Result{}, errors.New("staged Kimi config.toml carries no default_model")
+	}
+	r.modelConfigObserved = true
 	return subprocess.Result{
 		Command: command,
 		Args:    args,
@@ -565,6 +578,10 @@ func TestWorkerKimiReadOnlySeatStagesProfileUnderEffectiveHome(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(credentialDir, "kimi-code.json"), []byte(sourceCredential), 0o600); err != nil {
 		t.Fatal(err)
 	}
+	const sourceModelConfig = "default_model = \"kimi-code/k3\"\n\n[providers.\"managed:kimi-code\"]\ntype = \"kimi\"\n"
+	if err := os.WriteFile(filepath.Join(sourceDir, "config.toml"), []byte(sourceModelConfig), 0o600); err != nil {
+		t.Fatal(err)
+	}
 	seedDaemonWorkerAgentWithPolicy(t, store, "kimi-reviewer", runtime.KimiRuntime,
 		"session_550e8400-e29b-41d4-a716-446655440000", []string{"review"}, "owner/repo", runtime.AutonomyPolicyReadOnly)
 	enqueueDaemonWorkerJob(t, store, workflow.JobRequest{
@@ -590,8 +607,8 @@ func TestWorkerKimiReadOnlySeatStagesProfileUnderEffectiveHome(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if stored.State != string(workflow.JobSucceeded) || !runner.credentialObserved {
-		t.Fatalf("Kimi job state=%q credentialObserved=%v payload=%s", stored.State, runner.credentialObserved, stored.Payload)
+	if stored.State != string(workflow.JobSucceeded) || !runner.credentialObserved || !runner.modelConfigObserved {
+		t.Fatalf("Kimi job state=%q credentialObserved=%v modelConfigObserved=%v payload=%s", stored.State, runner.credentialObserved, runner.modelConfigObserved, stored.Payload)
 	}
 	if data, err := os.ReadFile(filepath.Join(credentialDir, "kimi-code.json")); err != nil || string(data) != sourceCredential {
 		t.Fatalf("shared Kimi credential changed to %q, err=%v", data, err)

--- a/internal/cli/sandbox_produce_test.go
+++ b/internal/cli/sandbox_produce_test.go
@@ -926,7 +926,9 @@ func TestApplyReadOnlySeatClearsInheritedGrants(t *testing.T) {
 				ReadablePaths: []string{"/host"},
 				ReadableFiles: []string{"/host/secret"},
 			}
-			applyReadOnlySeat(test.marked, " /profiles/reviewer ", &agent)
+			if err := applyReadOnlySeat(test.marked, " /profiles/reviewer ", "job-grants", &agent); err != nil {
+				t.Fatalf("applyReadOnlySeat: %v", err)
+			}
 			if agent.ReadOnlySeat != test.wantSeat || agent.RuntimeConfigDir != test.wantConfig {
 				t.Fatalf("read-only marker = %v config = %q, want %v %q", agent.ReadOnlySeat, agent.RuntimeConfigDir, test.wantSeat, test.wantConfig)
 			}

--- a/website/docs/operations/troubleshooting.md
+++ b/website/docs/operations/troubleshooting.md
@@ -666,6 +666,35 @@ is missing - or a seat that cannot reach a provider - can find out why:
 gitmoot job events <job-id> | grep read_only_seat_config_narrowed
 ```
 
+### Two more refusals, and what gateway mode withholds
+
+Narrowing reads the file with ONE scanner shared by narrowing and provider
+selection, so escapes, comments, multi-line strings and unbalanced brackets are
+interpreted identically everywhere. Two shapes are refused rather than staged,
+because in both cases part of the file could not be classified, and staging an
+unclassified tail is the leak the narrowing exists to prevent:
+
+- `config has an array or inline table that never closes` - an unbalanced `[`
+  or `{` reached the end of the file.
+- `config has a multi-line string that never closes` - as before.
+
+A triple delimiter inside a COMMENT or inside a single-line string is not a
+multi-line string, and a backslash-escaped quote is valid TOML that stages
+unchanged.
+
+One provider shape is refused for a different reason:
+
+- `codex model_provider "<name>" authenticates only through env_key, and a
+  read-only seat's environment allowlist does not pass that variable through` -
+  set an inline `api_key` for that provider, or point `model_provider` at one
+  the seat can reach. Previously this staged cleanly and the seat failed later
+  with the runtime's own message.
+
+In GATEWAY mode the gateway supplies the credential, so a gateway seat stages
+NO credential file for any runtime - claude's `.credentials.json`, codex's
+`auth.json` and kimi's `credentials/kimi-code.json` are all withheld. Model
+settings are still staged, narrowed as above.
+
 ## Isolated worktrees duplicate gigabytes of tool cache
 
 An isolated-worktree job re-materializing its own `uv`/`go`/`npm`/`pip` cache

--- a/website/docs/operations/troubleshooting.md
+++ b/website/docs/operations/troubleshooting.md
@@ -630,6 +630,42 @@ Dotted and quoted forms are classified the same way, so
 `mcp_servers.github.env.TOKEN = "..."` at the top level and
 `[mcp_servers."my server".env]` are both dropped.
 
+### The staged kimi config.toml is narrowed too
+
+kimi's `config.toml` is REQUIRED, and it carries more than codex's does:
+measured on a live host, `api_key` under `[services.*]` and a key under
+`[services.*.oauth]` alongside `[providers.*]`. For kimi the staged copy lands
+directly inside the seat's writable root, so it is narrowed on the same rule:
+
+- `[services.*]` is dropped ENTIRELY. It configures optional tooling (moonshot
+  search and fetch) and carries those tools' credentials.
+- `[providers.*]` keeps its structure and keeps `api_key` and its `env`
+  sub-table ONLY for the provider `default_model` resolves to - the model's
+  segment before the first `/` matched against the provider name's segment
+  after the last `:`, so `default_model = "kimi-code/k3"` selects
+  `[providers."managed:kimi-code"]`. Dropping every provider credential is not
+  an option: kimi refuses to start when both `api_key` and the `env` sub-table
+  are absent, so the seat legitimately needs exactly one.
+- If NO provider can be resolved, or two match ambiguously, every provider
+  credential is withheld. A credential nobody can prove is needed is not
+  staged.
+
+The same rule now applies to codex: `[model_providers.*]` keeps `api_key` and
+`http_headers` for the provider `model_provider` selects and strips every
+other. Stripping the selected provider's key too left the seat unable to
+authenticate at all, because `env_key` names a variable the sandbox's
+environment allowlist does not pass through.
+
+### Finding out what was withheld
+
+Narrowing is not silent. When anything is withheld the job records a
+`read_only_seat_config_narrowed` event naming it, so a reviewer whose MCP tool
+is missing - or a seat that cannot reach a provider - can find out why:
+
+```sh
+gitmoot job events <job-id> | grep read_only_seat_config_narrowed
+```
+
 ## Isolated worktrees duplicate gigabytes of tool cache
 
 An isolated-worktree job re-materializing its own `uv`/`go`/`npm`/`pip` cache

--- a/website/docs/operations/troubleshooting.md
+++ b/website/docs/operations/troubleshooting.md
@@ -695,6 +695,33 @@ NO credential file for any runtime - claude's `.credentials.json`, codex's
 `auth.json` and kimi's `credentials/kimi-code.json` are all withheld. Model
 settings are still staged, narrowed as above.
 
+### Comments, and what a seat does when a config cannot be narrowed
+
+Narrowing classifies the COMMENT-FREE part of each line and stages the line
+unchanged, so an ordinary TOML comment cannot change what is withheld. Both
+directions were defects: `[services] # see [docs]` used to have the comment's
+`]` swallowed into the section name, staging that section's secrets verbatim,
+and `default_model = "kimi-code/k3" # pinned` used to make the comment part of
+the provider name, withholding the one credential the seat needs. Your comments
+survive into the staged file.
+
+A key/value pair is split on the first `=` OUTSIDE quotes, so a quoted key
+containing `=` is kept rather than dropped.
+
+**A config that cannot be narrowed is treated by whether the runtime needs it:**
+
+- codex's `config.toml` is OPTIONAL. If it cannot be narrowed - an unbalanced
+  `[` or `{` at end of file, an unreadable section header, or a selected
+  provider that can only authenticate through `env_key` - the seat starts
+  WITHOUT it and falls back to the runtime default. The file is not staged and
+  the reason is named in the `read_only_seat_config_narrowed` job event.
+- kimi's `config.toml` is REQUIRED, so the same refusal fails the seat by name.
+  kimi cannot start without it, and a silent fallback would surface later as
+  "No model configured".
+
+In GATEWAY mode no runtime stages a credential file, and the policy the seat
+computes says so rather than naming files it then withholds.
+
 ## Isolated worktrees duplicate gigabytes of tool cache
 
 An isolated-worktree job re-materializing its own `uv`/`go`/`npm`/`pip` cache

--- a/website/docs/operations/troubleshooting.md
+++ b/website/docs/operations/troubleshooting.md
@@ -572,6 +572,64 @@ Verify that `job show` still reports `succeeded`, `failed`, or `cancelled` and
 the same `payload.worktree_path`. Never remove a worktree for a blocked, queued,
 or running job; settle it first.
 
+## Read-Only Reviewer Seat Refuses To Start
+
+A read-only seat runs the runtime against an ISOLATED home rather than yours, so
+anything the runtime reads at startup must be staged into that home first. When
+a startup input is missing, Gitmoot now fails BY NAME instead of letting the
+runtime report something unrelated.
+
+Symptoms:
+
+- `read-only seat requires runtime input "config.toml", and <path> does not
+  exist` - the host profile has no such file. This is a HARD PREREQUISITE for
+  kimi: `~/.kimi-code/config.toml` must exist on the host, or the seat cannot
+  start. Previously this surfaced as "No model configured" behind an auth
+  message that pointed at `kimi login`, which cannot fix it.
+- `runtime input "<path>" must be a regular file` - the path is a directory,
+  socket, device or fifo. A SYMLINK is fine and is followed, so a
+  stow/chezmoi-managed profile works; a symlink whose target is missing counts
+  as missing, and a symlink to a directory is refused.
+- `read-only seat credential <path> is unusable: claudeAiOauth expired at
+  <time> and carries no refreshToken` - the profile stages and parses but cannot
+  authenticate. Re-authenticate the host claude profile. An expired token WITH a
+  refresh token is accepted, because refreshing it is the runtime's job.
+- `narrow runtime input "<path>": codex config.toml has a section header that is
+  not readable` - the file has a section header that never closes, so Gitmoot
+  cannot locate the credentials it must strip. It refuses rather than stage a
+  file it cannot classify. Fix the TOML or remove it from the host state dir.
+
+What the seat stages, per runtime:
+
+| runtime | staged from | inputs |
+| --- | --- | --- |
+| claude | `~/.claude` | `.credentials.json`, narrowed to `claudeAiOauth` and checked for usability. Nothing is staged in gateway mode, where the gateway supplies the credential. |
+| codex | `~/.codex` | `auth.json`, plus `config.toml` when present - NARROWED, see below |
+| kimi | `~/.kimi-code` | `config.toml` (REQUIRED), `credentials/kimi-code.json` |
+
+### Why the staged codex config.toml is not a copy
+
+The seat's staged state lives inside the one writable path granted to the
+sandbox, so a reviewer can read anything placed there. A codex `config.toml`
+routinely carries credentials that have nothing to do with running the model, so
+Gitmoot narrows it before staging:
+
+- `[mcp_servers.*]` is dropped ENTIRELY. Its `env` table holds tokens, `args`
+  can hold them just as easily, and a read-only reviewer seat has no business
+  spawning third-party servers. MCP servers are optional to codex, so dropping
+  them cannot stop the seat starting.
+- `[model_providers.*]` KEEPS its structure and loses only `api_key` and
+  `http_headers`. Dropping the section would look stricter and would break a
+  custom `model`, because removing `base_url` and `wire_api` makes the provider
+  unresolvable. `env_key` and `env_http_headers` name environment variables
+  rather than hold values, so they stay.
+- Everything else is kept: those are the model and sandbox settings the file is
+  staged for.
+
+Dotted and quoted forms are classified the same way, so
+`mcp_servers.github.env.TOKEN = "..."` at the top level and
+`[mcp_servers."my server".env]` are both dropped.
+
 ## Isolated worktrees duplicate gigabytes of tool cache
 
 An isolated-worktree job re-materializing its own `uv`/`go`/`npm`/`pip` cache


### PR DESCRIPTION
Closes #1804. Closes #1806.

## What was wrong

The read-only seat's isolated runtime state dir is built EMPTY (`RemoveAll`, `MkdirAll`, then only the credential file is staged) and `CODEX_HOME` / `CLAUDE_CONFIG_DIR` / the sandbox `HOME` point at it. It has now omitted a required startup input three times, each presenting as something else:

| omitted input | how it presented | issue |
|---|---|---|
| `/etc/ssl/openssl.cnf` | `OpenSSL configuration error` | #1802, fixed in #1803 |
| codex `sessions/` | `thread/resume: no rollout found for thread id <uuid>` | #1804 |
| kimi `config.toml` | `No model configured`, behind an auth message telling the reader to run `kimi login` | #1806 |

Review jobs with `read_only_seat=true` measured 6 failed, 1 queued, 0 succeeded before any of this. Claude then produced a verdict in the same seat, which is what localized the remaining failures to per-runtime staging rather than the seat as a whole.

## What this changes

1. **A declarative staging policy per runtime** (`readOnlySeatStatePolicy`) replaces the ad-hoc switch in `prepareReadOnlyRuntimeState`: host source dir, staging location, credential file and section, plus `requiredInputs` and `optionalInputs`. Kimi's `config.toml` is required; codex's `config.toml` is staged when present, because without it `ConfiguredCodexModel` silently falls back to the runtime default.
2. **A missing required input fails with an error that names the file.** gitmoot no longer depends on the runtime's own diagnostic, which is what misdirected a day of work at `kimi login`.
3. **Delivery runs on a job-scoped fresh ref.** An isolated home holds no session to resume, so a seat carrying the agent's stored ref could only fail. `runtime.IsFreshRef` also keeps the mailbox from persisting the minted session id onto the stored agent row.
4. **The runtime-session LOCK stays on the agent's registered session.** This is deliberate and is the narrower of the two options I considered: it leaves #684 serialization exactly as it was (a busy reviewer session still leaves a review queued) and keeps the scheduler gate computing the same key the worker acquires, so no gate change is needed. The seat isolates DELIVERY, not scheduling.
5. **Only resumable runtimes are rewritten.** A shell ref is a command, not a session. The first version of this change rewrote it and broke 19 pipeline and daemon E2Es, which is why that guard is load-bearing rather than defensive.

## Verification

`go build ./...`, `go vet ./...`, `go generate ./...` clean with no diff, and `go test ./...` green.

Four mutants, each run against a green baseline and each killed:

| mutant | tests that failed |
|---|---|
| seat keeps the agent's stored resumable ref | `TestApplyReadOnlySeatRunsOnFreshSessionNotTheAgentsOwn`, `TestApplyReadOnlySeatLeavesTheSessionLockAgentIntact`, `TestQueuedJobRuntimeResourceKeyReadOnlySeat` |
| kimi `config.toml` no longer staged | `TestPrepareReadOnlyRuntimeStateNamesAMissingRequiredInput`, `TestWorkerKimiReadOnlySeatStagesProfileUnderEffectiveHome` |
| worker locks the seat's fresh ref | `TestRunQueuedJobs*` serialization tests |
| foreground locks the seat's fresh ref | `TestRunAgentReviewRequeuesQueuedJobWhenRuntimeSessionBusy` |

The kimi guard reads what the runtime reads: the fake runner now opens the staged `config.toml` under the isolated `HOME` and requires `default_model`, so staging that omits it fails at the runtime boundary rather than in a helper.

## Not verified

That this clears the LIVE codex failure. That is only provable after merge and deploy, because the daemon runs the deployed binary. The `#1806` half is covered by the runtime-boundary test above, not by a live kimi run.

`TestReadOnlySeatStatePolicyCoversEveryRegisteredRuntime` iterates `runtime.SupportedRuntimes()`, so a new runtime added without declared staging fails in CI rather than at dispatch. It does not launch the real CLIs; a genuine per-runtime launch smoke test needs runtime auth and stays manual.

## Deploy notes

Rebuild and replace BOTH service binaries (`gitmoot` and `gitmoot-dashboard-web`) per the AGENTS.md recipe, then restart at idle. No config or migration change.