### PR TITLE
fix(workflow): accept object elements in gitmoot_result string lists (#1805)

### DIFF
--- a/internal/workflow/gates_content_free_test.go
+++ b/internal/workflow/gates_content_free_test.go
@@ -1,0 +1,83 @@
+package workflow
+
+import (
+	"context"
+	"testing"
+
+	"github.com/gitmoot/gitmoot/internal/runtime"
+)
+
+// TestMailboxRunDoesNotRecordContentFreeNeeds is the #1809 review's N1: the
+// gate-RECORDING path kept a raw len() after the judging gates were fixed, so
+// `needs: [{}]` was admitted and written to job_gates verbatim. A human then
+// saw a gate row reading "{}" through `gitmoot job gates` and the dashboard's
+// "Needs a human" view.
+//
+// Driven through the real mailbox, not the helper: this is the consumer
+// literally named gates, and the principle the branch already stated is that
+// two gates disagreeing about one input is the defect.
+func TestMailboxRunDoesNotRecordContentFreeNeeds(t *testing.T) {
+	ctx := context.Background()
+	store := openTestStore(t)
+	mailbox := Mailbox{store: store, resolveDeliveryWorktree: ExcludedDeliveryWorktreeResolver("test_explicit_no_worktree")}
+	agent := runtime.Agent{Name: "audit", Runtime: runtime.ShellRuntime, RuntimeRef: "printf ok", RepoScope: "gitmoot/gitmoot", Role: "reviewer"}
+	adapter := &fakeDelivery{outputs: []string{
+		`{"gitmoot_result":{"decision":"blocked","summary":"blocked","findings":[],"changes_made":[],"tests_run":[],"needs":[{},{"name":"","detail":""}],"delegations":[]}}`,
+	}}
+
+	if _, err := mailbox.Enqueue(ctx, JobRequest{ID: "job-1", Agent: "audit", Action: "review", Repo: "gitmoot/gitmoot"}); err != nil {
+		t.Fatalf("Enqueue: %v", err)
+	}
+	if _, err := mailbox.Run(ctx, "job-1", agent, adapter); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	gates, err := store.ListJobGates(ctx, "job-1")
+	if err != nil {
+		t.Fatalf("ListJobGates: %v", err)
+	}
+	if len(gates) != 0 {
+		t.Fatalf("gates = %+v, want none: a content-free need must not become a durable row a human reads", gates)
+	}
+	events, err := store.ListJobEvents(ctx, "job-1")
+	if err != nil {
+		t.Fatalf("ListJobEvents: %v", err)
+	}
+	if hasEvent(events, "gates_recorded") {
+		t.Fatalf("events = %+v, want NO gates_recorded event for content-free needs", events)
+	}
+}
+
+// TestMailboxRunStillRecordsMixedNeeds keeps the fix from becoming a bigger
+// defect than the one it closes: a real need alongside a content-free one is
+// still recorded, and only the empty one is dropped.
+func TestMailboxRunStillRecordsMixedNeeds(t *testing.T) {
+	ctx := context.Background()
+	store := openTestStore(t)
+	mailbox := Mailbox{store: store, resolveDeliveryWorktree: ExcludedDeliveryWorktreeResolver("test_explicit_no_worktree")}
+	agent := runtime.Agent{Name: "audit", Runtime: runtime.ShellRuntime, RuntimeRef: "printf ok", RepoScope: "gitmoot/gitmoot", Role: "reviewer"}
+	adapter := &fakeDelivery{outputs: []string{
+		`{"gitmoot_result":{"decision":"blocked","summary":"blocked","findings":[],"changes_made":[],"tests_run":[],"needs":[{},"API key"],"delegations":[]}}`,
+	}}
+
+	if _, err := mailbox.Enqueue(ctx, JobRequest{ID: "job-1", Agent: "audit", Action: "review", Repo: "gitmoot/gitmoot"}); err != nil {
+		t.Fatalf("Enqueue: %v", err)
+	}
+	if _, err := mailbox.Run(ctx, "job-1", agent, adapter); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	gates, err := store.ListJobGates(ctx, "job-1")
+	if err != nil {
+		t.Fatalf("ListJobGates: %v", err)
+	}
+	if len(gates) != 1 || gates[0].Need != "API key" {
+		t.Fatalf("gates = %+v, want exactly the real need", gates)
+	}
+	events, err := store.ListJobEvents(ctx, "job-1")
+	if err != nil {
+		t.Fatalf("ListJobEvents: %v", err)
+	}
+	if !hasEvent(events, "gates_recorded") {
+		t.Fatalf("events = %+v, want a gates_recorded event for the real need", events)
+	}
+}

--- a/internal/workflow/mailbox.go
+++ b/internal/workflow/mailbox.go
@@ -1831,9 +1831,15 @@ func (m Mailbox) finishWithPayload(ctx context.Context, jobID string, state JobS
 	// clear` RetryJob the OLD stage job id — an orphaned re-execution the
 	// pipeline advancer never folds, and a double execution once the run is
 	// properly resumed.
-	if state == JobBlocked && payload.Result != nil && len(payload.Result.Needs) > 0 && payload.Sender != PipelineJobSender {
-		if _, gateErr := m.store.RecordJobGates(writeCtx, jobID, payload.Result.Needs); gateErr == nil {
-			_ = m.addEvent(writeCtx, jobID, "gates_recorded", fmt.Sprintf("recorded %d resumable gate(s) from needs", len(payload.Result.Needs)))
+	// Content-free needs are dropped BEFORE admission and before recording:
+	// `needs: [{}]` used to be admitted on a raw len() and written to
+	// job_gates verbatim, so a human saw a gate row reading "{}".
+	if state == JobBlocked && payload.Result != nil && payload.Sender != PipelineJobSender {
+		recordable := actionableEntries(payload.Result.Needs)
+		if len(recordable) > 0 {
+			if _, gateErr := m.store.RecordJobGates(writeCtx, jobID, recordable); gateErr == nil {
+				_ = m.addEvent(writeCtx, jobID, "gates_recorded", fmt.Sprintf("recorded %d resumable gate(s) from needs", len(recordable)))
+			}
 		}
 	}
 	return nil

--- a/internal/workflow/result.go
+++ b/internal/workflow/result.go
@@ -177,11 +177,26 @@ func (l *ResultStringList) UnmarshalJSON(data []byte) error {
 	}
 	list := make(ResultStringList, 0, len(elements))
 	for _, element := range elements {
-		element = bytes.TrimSpace(element)
-		if len(element) == 0 {
-			continue
-		}
+		// No TrimSpace and no empty-element guard: encoding/json hands each
+		// element as a complete JSON value with no surrounding whitespace and
+		// never zero-length, so both were unreachable and no mutant could kill
+		// them (#1809 review, P3-5). Measured rather than reasoned: decoding
+		// `[ "a" , "b" ]` and a multi-line array yields elements "a" and "b"
+		// with no padding. A guard nothing can reach is a claim about the input
+		// that the input does not make.
 		switch element[0] {
+		case 'n':
+			// A null element decoded to an EMPTY ENTRY before #1805 (verified
+			// differentially at parent 0965c458: ["a",null,"b"] produced
+			// ["a","","b"]). Rejecting it would narrow the contract in the same
+			// breath as widening it, and burn a repair attempt on an envelope
+			// that used to parse - the exact failure #1805 exists to remove.
+			// Only the literal null reaches here; anything else beginning with
+			// 'n' falls through to the default arm below.
+			if !bytes.Equal(element, []byte("null")) {
+				return fmt.Errorf("gitmoot_result list element must be a string or an object, got %s", string(element))
+			}
+			list = append(list, "")
 		case '"':
 			var value string
 			if err := json.Unmarshal(element, &value); err != nil {
@@ -192,21 +207,118 @@ func (l *ResultStringList) UnmarshalJSON(data []byte) error {
 			// Re-encode through a map so key order is canonical (encoding/json
 			// sorts map keys) and two agents reporting the same object produce
 			// the same entry.
-			var object map[string]json.RawMessage
-			if err := json.Unmarshal(element, &object); err != nil {
-				return err
-			}
-			encoded, err := json.Marshal(object)
+			//
+			// DUPLICATE KEYS ARE REJECTED, not collapsed. map[string]json.RawMessage
+			// silently keeps the LAST duplicate, so [{"name":"first","name":"second"}]
+			// used to decode without error to {"name":"second"} - losing a field while
+			// the doc claimed every field is kept. Duplicate keys are exactly the
+			// malformed-but-parseable JSON a runtime emits, and silently dropping
+			// data is the one option that is wrong; rejecting is visible and the
+			// repair prompt can act on it.
+			object, err := decodeObjectElementRejectingDuplicates(element)
 			if err != nil {
 				return err
 			}
-			list = append(list, string(encoded))
+			// SetEscapeHTML(false): json.Marshal escapes <, > and & to \u003c,
+			// \u003e and \u0026, so a recorded command like `go test ./... 2>&1`
+			// came back as `go test ./... 2\u003e\u00261` and could not be
+			// copy-pasted back. A tests_run entry that is not the command that ran
+			// is evidence damage.
+			encoded, err := marshalCanonicalNoHTMLEscape(object)
+			if err != nil {
+				return err
+			}
+			list = append(list, encoded)
 		default:
 			return fmt.Errorf("gitmoot_result list element must be a string or an object, got %s", string(element))
 		}
 	}
 	*l = list
 	return nil
+}
+
+// decodeObjectElementRejectingDuplicates decodes one object element and refuses
+// duplicate keys rather than letting map assignment keep the last one.
+//
+// It streams tokens instead of unmarshalling into a map because a map cannot
+// represent the duplicate at all - by the time you hold the map, the evidence is
+// already gone.
+func decodeObjectElementRejectingDuplicates(element []byte) (map[string]json.RawMessage, error) {
+	decoder := json.NewDecoder(bytes.NewReader(element))
+	token, err := decoder.Token()
+	if err != nil {
+		return nil, err
+	}
+	if delimiter, ok := token.(json.Delim); !ok || delimiter != '{' {
+		return nil, fmt.Errorf("gitmoot_result list element is not an object: %s", string(element))
+	}
+	object := map[string]json.RawMessage{}
+	for decoder.More() {
+		keyToken, err := decoder.Token()
+		if err != nil {
+			return nil, err
+		}
+		key, ok := keyToken.(string)
+		if !ok {
+			return nil, fmt.Errorf("gitmoot_result list element has a non-string key: %v", keyToken)
+		}
+		if _, exists := object[key]; exists {
+			return nil, fmt.Errorf("gitmoot_result list element has duplicate key %q: %s", key, string(element))
+		}
+		var value json.RawMessage
+		if err := decoder.Decode(&value); err != nil {
+			return nil, err
+		}
+		object[key] = value
+	}
+	if _, err := decoder.Token(); err != nil {
+		return nil, err
+	}
+	return object, nil
+}
+
+// marshalCanonicalNoHTMLEscape marshals with map-key ordering (canonical, so two
+// agents reporting the same object produce the same entry) but WITHOUT HTML
+// escaping, so shell metacharacters in a recorded command survive verbatim.
+func marshalCanonicalNoHTMLEscape(object map[string]json.RawMessage) (string, error) {
+	var buffer bytes.Buffer
+	encoder := json.NewEncoder(&buffer)
+	encoder.SetEscapeHTML(false)
+	if err := encoder.Encode(object); err != nil {
+		return "", err
+	}
+	return string(bytes.TrimRight(buffer.Bytes(), "\n")), nil
+}
+
+// nameFailingListField restores the FIELD NAME in a list-element decode error.
+//
+// Pre-#1805, encoding/json produced "cannot unmarshal object into Go struct
+// field AgentResult.tests_run", and the repair prompt used that name to tell the
+// agent which list to fix. ResultStringList.UnmarshalJSON returns its own error,
+// which encoding/json passes through unwrapped, so the name was lost - and a
+// repair attempt that cannot see WHICH field failed is a wasted attempt, the
+// same cost #1805 exists to save (#1809 review, P3-4).
+//
+// It re-decodes each list field ALONE to find the offender rather than parsing
+// the error string, so it cannot drift when a message is reworded. If no single
+// field reproduces the failure the original error is returned unchanged: naming
+// the wrong field would be worse than naming none.
+func nameFailingListField(raw json.RawMessage, original error) error {
+	var fields map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &fields); err != nil {
+		return original
+	}
+	for _, name := range []string{"changes_made", "tests_run", "needs"} {
+		value, present := fields[name]
+		if !present {
+			continue
+		}
+		var list ResultStringList
+		if err := json.Unmarshal(value, &list); err != nil {
+			return fmt.Errorf("gitmoot_result field %s: %w", name, err)
+		}
+	}
+	return original
 }
 
 type AgentResult struct {
@@ -339,7 +451,7 @@ func ExtractAgentResult(output string) (AgentResult, error) {
 		var result AgentResult
 		if err := json.Unmarshal(raw, &result); err != nil {
 			if validationErr == nil {
-				validationErr = err
+				validationErr = nameFailingListField(raw, err)
 			}
 			continue
 		}

--- a/internal/workflow/result.go
+++ b/internal/workflow/result.go
@@ -1,6 +1,7 @@
 package workflow
 
 import (
+	"bytes"
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
@@ -135,6 +136,79 @@ type Learning struct {
 // falls back to the default "repo" and is accepted separately).
 var LearningScopes = []string{"repo", "general"}
 
+// ResultStringList is a gitmoot_result list of strings that also accepts OBJECT
+// elements, because agents send them and a strict element decode failed the
+// whole envelope.
+//
+// Measured: review job local-review-gm-review-opus-18d1b91052453964 returned
+//
+//	"tests_run":[{"name":"PR diff scope confirmation","command":"git show --stat 663321c9...","result":"pass","detail":"..."}]
+//
+// and the decode failed with "json: cannot unmarshal object into Go struct
+// field AgentResult.tests_run of type string", which burned repair_retry
+// attempt 1 of 2. The job had done the work and reported it in a richer shape;
+// the parser made that indistinguishable from returning nothing.
+//
+// An object element is re-encoded as compact JSON rather than reduced to one of
+// its fields. The contract names no element fields, so picking "command" or
+// "name" would be a guess, and dropping the rest would lose what the agent
+// measured. Consumers treat entries as opaque strings (they are printed,
+// written into PR comments, counted, and digested), so a JSON-shaped entry is
+// legible and lossless.
+//
+// Nothing else widens. A number, a boolean, null in place of the array, or a
+// bare string where an array belongs still fails: there is no evidence agents
+// send those, and accepting them would change the contract on a guess. The
+// prompt contract keeps asking for strings.
+type ResultStringList []string
+
+func (l *ResultStringList) UnmarshalJSON(data []byte) error {
+	if l == nil {
+		return errors.New("unmarshal into nil ResultStringList")
+	}
+	trimmed := bytes.TrimSpace(data)
+	if len(trimmed) == 0 || bytes.Equal(trimmed, []byte("null")) {
+		*l = nil
+		return nil
+	}
+	var elements []json.RawMessage
+	if err := json.Unmarshal(trimmed, &elements); err != nil {
+		return err
+	}
+	list := make(ResultStringList, 0, len(elements))
+	for _, element := range elements {
+		element = bytes.TrimSpace(element)
+		if len(element) == 0 {
+			continue
+		}
+		switch element[0] {
+		case '"':
+			var value string
+			if err := json.Unmarshal(element, &value); err != nil {
+				return err
+			}
+			list = append(list, value)
+		case '{':
+			// Re-encode through a map so key order is canonical (encoding/json
+			// sorts map keys) and two agents reporting the same object produce
+			// the same entry.
+			var object map[string]json.RawMessage
+			if err := json.Unmarshal(element, &object); err != nil {
+				return err
+			}
+			encoded, err := json.Marshal(object)
+			if err != nil {
+				return err
+			}
+			list = append(list, string(encoded))
+		default:
+			return fmt.Errorf("gitmoot_result list element must be a string or an object, got %s", string(element))
+		}
+	}
+	*l = list
+	return nil
+}
+
 type AgentResult struct {
 	Decision string `json:"decision"`
 	// SupersededPullRequestClosed marks a SYNTHETIC result minted by the closed-PR
@@ -154,9 +228,9 @@ type AgentResult struct {
 	Severity     string            `json:"severity,omitempty"`
 	Summary      string            `json:"summary"`
 	Findings     []json.RawMessage `json:"findings"`
-	ChangesMade  []string          `json:"changes_made"`
-	TestsRun     []string          `json:"tests_run"`
-	Needs        []string          `json:"needs"`
+	ChangesMade  ResultStringList  `json:"changes_made"`
+	TestsRun     ResultStringList  `json:"tests_run"`
+	Needs        ResultStringList  `json:"needs"`
 	Delegations  []Delegation      `json:"delegations"`
 	ArtifactBody string            `json:"artifact_body,omitempty"`
 	// Learnings, when non-empty, carries durable keyed facts the agent chose to

--- a/internal/workflow/result_checks.go
+++ b/internal/workflow/result_checks.go
@@ -319,8 +319,6 @@ func isActionableAnswer(r AgentResult) bool {
 	return len(r.Findings) > 0
 }
 
-// hasActionableEntries reports whether a string slice contains at least one
-// non-blank entry, so an all-empty or single-blank list counts as no entries.
 // rawJSONCarriesContent applies the content test to one JSON value taken from
 // inside a container.
 //
@@ -343,6 +341,30 @@ func rawJSONCarriesContent(raw json.RawMessage) bool {
 	return entryCarriesContent(trimmed)
 }
 
+// actionableEntries returns only the entries that carry information.
+//
+// hasActionableEntries answers "is there anything here"; this answers "which of
+// these is worth persisting". The gate-RECORDING path needs the second: the
+// #1809 review found that `needs: [{}]` was admitted on a raw len() and written
+// to job_gates verbatim, so a durable row whose need column is the two-byte
+// text {} surfaced to a human through `gitmoot job gates` and the dashboard's
+// "Needs a human" view. Filtering here keeps the gate that RECORDS agreeing
+// with the gates that JUDGE - the principle this branch already applied to
+// implement-changes-listed and implement-tests-listed, applied to the consumer
+// literally named gates.
+func actionableEntries(values []string) []string {
+	filtered := make([]string, 0, len(values))
+	for _, value := range values {
+		if entryCarriesContent(value) {
+			filtered = append(filtered, value)
+		}
+	}
+	return filtered
+}
+
+// hasActionableEntries reports whether a string slice contains at least one
+// entry that carries information, so an all-empty list - including one whose
+// only entries are content-free containers - counts as no entries.
 func hasActionableEntries(values []string) bool {
 	for _, v := range values {
 		if entryCarriesContent(v) {

--- a/internal/workflow/result_checks.go
+++ b/internal/workflow/result_checks.go
@@ -1,6 +1,7 @@
 package workflow
 
 import (
+	"encoding/json"
 	"fmt"
 	"strings"
 
@@ -319,11 +320,47 @@ func isActionableAnswer(r AgentResult) bool {
 // non-blank entry, so an all-empty or single-blank list counts as no entries.
 func hasActionableEntries(values []string) bool {
 	for _, v := range values {
-		if strings.TrimSpace(v) != "" {
+		if entryCarriesContent(v) {
 			return true
 		}
 	}
 	return false
+}
+
+// entryCarriesContent reports whether one list entry says anything.
+//
+// Trimming whitespace is no longer sufficient (#1805): object elements now
+// decode into entries, so `needs: [{}]` arrives as the two-character string
+// "{}" - non-empty to TrimSpace, and therefore actionable to the old check.
+// That let a BLOCKED result whose ONLY blocker is an empty object pass the
+// evidence heuristic, which is a GATE behaviour change rather than a cosmetic
+// one. A content-free JSON container carries exactly as much information as ""
+// and is treated the same.
+//
+// An object WITH fields still counts: the test is emptiness, not shape.
+func entryCarriesContent(value string) bool {
+	trimmed := strings.TrimSpace(value)
+	if trimmed == "" {
+		return false
+	}
+	switch trimmed[0] {
+	case '{', '[':
+		var container []json.RawMessage
+		if trimmed[0] == '{' {
+			var object map[string]json.RawMessage
+			if err := json.Unmarshal([]byte(trimmed), &object); err == nil {
+				return len(object) > 0
+			}
+			// Unparseable: it is still text a human can read, so keep it.
+			return true
+		}
+		if err := json.Unmarshal([]byte(trimmed), &container); err == nil {
+			return len(container) > 0
+		}
+		return true
+	default:
+		return true
+	}
 }
 
 // minReviewRationaleChars is the floor at which a review summary can carry the

--- a/internal/workflow/result_checks.go
+++ b/internal/workflow/result_checks.go
@@ -150,7 +150,10 @@ func RunResultChecks(in ResultCheckInput) []ResultCheck {
 		// list the tests it ran, so a human/continuation can see what actually
 		// happened rather than trusting the summary prose.
 		if r.Decision == "implemented" {
-			madePass := len(r.ChangesMade) > 0
+			// Same content test the needs gate uses: two gates disagreeing
+			// about the same input is the defect, not the leniency. Before
+			// this, the {} that the needs gate rejects satisfied these.
+			madePass := hasActionableEntries(r.ChangesMade)
 			checks = append(checks, ResultCheck{
 				ID:          "implement-changes-listed",
 				Action:      "implement",
@@ -175,7 +178,7 @@ func RunResultChecks(in ResultCheckInput) []ResultCheck {
 					)),
 				})
 			}
-			testsPass := len(r.TestsRun) > 0
+			testsPass := hasActionableEntries(r.TestsRun)
 			checks = append(checks, ResultCheck{
 				ID:          "implement-tests-listed",
 				Action:      "implement",
@@ -318,6 +321,28 @@ func isActionableAnswer(r AgentResult) bool {
 
 // hasActionableEntries reports whether a string slice contains at least one
 // non-blank entry, so an all-empty or single-blank list counts as no entries.
+// rawJSONCarriesContent applies the content test to one JSON value taken from
+// inside a container.
+//
+// The unquoting step is load-bearing and my own test caught its absence: a
+// container's values arrive as RAW JSON, so an empty string inside one is the
+// two-byte text `""`, which reads as non-empty text unless it is decoded
+// first. Without this, {"name":"","command":""} still counted as evidence -
+// the exact false-accept this round is closing.
+func rawJSONCarriesContent(raw json.RawMessage) bool {
+	trimmed := strings.TrimSpace(string(raw))
+	if trimmed == "" || trimmed == "null" {
+		return false
+	}
+	if trimmed[0] == '"' {
+		var text string
+		if err := json.Unmarshal(raw, &text); err == nil {
+			return strings.TrimSpace(text) != ""
+		}
+	}
+	return entryCarriesContent(trimmed)
+}
+
 func hasActionableEntries(values []string) bool {
 	for _, v := range values {
 		if entryCarriesContent(v) {
@@ -349,13 +374,29 @@ func entryCarriesContent(value string) bool {
 		if trimmed[0] == '{' {
 			var object map[string]json.RawMessage
 			if err := json.Unmarshal([]byte(trimmed), &object); err == nil {
-				return len(object) > 0
+				// NOT len(object) > 0: an object whose VALUES are all empty
+				// carries no more information than "". A review reporting
+				// {"name":"","command":""} reads as populated evidence to a
+				// coordinator while saying nothing, which is worse than a hard
+				// failure - the false-accept this check exists to close was
+				// only half closed by counting keys.
+				for _, value := range object {
+					if rawJSONCarriesContent(value) {
+						return true
+					}
+				}
+				return false
 			}
 			// Unparseable: it is still text a human can read, so keep it.
 			return true
 		}
 		if err := json.Unmarshal([]byte(trimmed), &container); err == nil {
-			return len(container) > 0
+			for _, value := range container {
+				if rawJSONCarriesContent(value) {
+					return true
+				}
+			}
+			return false
 		}
 		return true
 	default:

--- a/internal/workflow/result_checks_content_test.go
+++ b/internal/workflow/result_checks_content_test.go
@@ -1,0 +1,89 @@
+package workflow
+
+import "testing"
+
+// TestEntryCarriesContentRejectsContainersWithOnlyEmptyValues is the round-N F3:
+// the false-accept was only HALF closed. Counting keys made
+// {"name":"","command":""} read as populated evidence, which is worse than a
+// hard failure because a coordinator sees a populated tests_run and believes
+// the job looked.
+func TestEntryCarriesContentRejectsContainersWithOnlyEmptyValues(t *testing.T) {
+	empty := map[string]string{
+		"empty object":              `{}`,
+		"object of empty strings":   `{"name":"","command":""}`,
+		"nested empty object":       `{"a":{"b":""}}`,
+		"empty array":               `[]`,
+		"array of empty strings":    `["",""]`,
+		"array of empty containers": `[{},[]]`,
+		"whitespace":                "   ",
+		"empty string":              "",
+	}
+	for name, value := range empty {
+		t.Run("no content/"+name, func(t *testing.T) {
+			if entryCarriesContent(value) {
+				t.Fatalf("%s reads as evidence but carries no information", name)
+			}
+		})
+	}
+
+	populated := map[string]string{
+		"object with a value":       `{"name":"diff scope"}`,
+		"object with one populated": `{"name":"","command":"go test ./..."}`,
+		"nested populated":          `{"a":{"b":"real"}}`,
+		"array with a value":        `["go test ./..."]`,
+		"plain text":                "go test ./...",
+		"unparseable container":     `{not json`,
+	}
+	for name, value := range populated {
+		t.Run("content/"+name, func(t *testing.T) {
+			if !entryCarriesContent(value) {
+				t.Fatalf("%s carries information but was rejected", name)
+			}
+		})
+	}
+}
+
+// TestImplementGatesAgreeWithTheNeedsGate is the round-N F5: implement-changes-listed
+// and implement-tests-listed used raw len(), so the SAME {} the needs gate
+// rejects satisfied them. Two gates disagreeing about one input is the defect.
+func TestImplementGatesAgreeWithTheNeedsGate(t *testing.T) {
+	contentFree := []string{"{}"}
+	if hasActionableEntries(contentFree) {
+		t.Fatal("the needs gate would reject {} - the shared test must too")
+	}
+
+	// Driven through the production gate list rather than the helper: an
+	// implement result whose only entries are content-free must not pass the
+	// listed checks.
+	result := AgentResult{
+		Decision:    "implemented",
+		Summary:     "did the thing",
+		ChangesMade: []string{"{}"},
+		TestsRun:    []string{"{}"},
+	}
+	checks := RunResultChecks(ResultCheckInput{Action: "implement", Result: result})
+	for _, check := range checks {
+		switch check.ID {
+		case "implement-changes-listed", "implement-tests-listed":
+			if check.Pass {
+				t.Errorf("%s passed on a content-free entry that the needs gate rejects", check.ID)
+			}
+		}
+	}
+
+	// A real entry must still pass, so this is not simply refusing everything.
+	real := AgentResult{
+		Decision:    "implemented",
+		Summary:     "did the thing",
+		ChangesMade: []string{"internal/workflow/result.go: fixed the gate"},
+		TestsRun:    []string{"go test ./internal/workflow/"},
+	}
+	for _, check := range RunResultChecks(ResultCheckInput{Action: "implement", Result: real}) {
+		switch check.ID {
+		case "implement-changes-listed", "implement-tests-listed":
+			if !check.Pass {
+				t.Errorf("%s failed on a populated entry", check.ID)
+			}
+		}
+	}
+}

--- a/internal/workflow/result_list_review_test.go
+++ b/internal/workflow/result_list_review_test.go
@@ -1,0 +1,145 @@
+package workflow
+
+import (
+	"strings"
+	"testing"
+)
+
+// envelopeWithList builds a minimal valid gitmoot_result envelope whose named
+// list field carries the given JSON array, so every case below enters through
+// the PRODUCTION path (ExtractAgentResult) rather than poking the decoder.
+func envelopeWithList(field, list string) string {
+	lists := map[string]string{"changes_made": "[]", "tests_run": "[]", "needs": "[]"}
+	lists[field] = list
+	return `{"gitmoot_result":{"decision":"approved","summary":"s","findings":[],"changes_made":` +
+		lists["changes_made"] + `,"tests_run":` + lists["tests_run"] +
+		`,"needs":` + lists["needs"] + `,"delegations":[]}}`
+}
+
+// TestNullListElementStaysAnEmptyEntry is the #1809 P2 regression.
+//
+// A JSON null element PARSED at parent 0965c458 and decoded to an empty entry:
+// ["a",null,"b"] produced ["a","","b"], verified differentially against that
+// commit. The first version of this PR rejected it, which failed the whole
+// envelope and burned a repair attempt - the exact failure #1805 exists to
+// remove, arriving as a narrowing alongside the intended widening.
+//
+// It fails if a null element ever starts failing the envelope again.
+func TestNullListElementStaysAnEmptyEntry(t *testing.T) {
+	for _, field := range []string{"changes_made", "tests_run", "needs"} {
+		result, err := ExtractAgentResult(envelopeWithList(field, `["a",null,"b"]`))
+		if err != nil {
+			t.Fatalf("%s: a null element must not fail the envelope: %v", field, err)
+		}
+		var got ResultStringList
+		switch field {
+		case "changes_made":
+			got = result.ChangesMade
+		case "tests_run":
+			got = result.TestsRun
+		case "needs":
+			got = result.Needs
+		}
+		if len(got) != 3 || got[0] != "a" || got[1] != "" || got[2] != "b" {
+			t.Fatalf("%s = %#v, want [a, \"\", b] to match parent 0965c458", field, got)
+		}
+	}
+}
+
+// TestObjectElementKeepsShellMetacharacters is the P3-1 regression. json.Marshal
+// HTML-escapes <, > and &, so a recorded command came back as
+// `go test ./... 2\u003e\u00261` - unusable as evidence, because a tests_run
+// entry that cannot be copy-pasted back is not the command that ran.
+func TestObjectElementKeepsShellMetacharacters(t *testing.T) {
+	// The command is embedded LITERALLY, as a runtime actually emits it: raw <, >
+	// and & are legal inside a JSON string. Building this input with json.Marshal
+	// would escape them BEFORE the decoder saw them - json.Marshal HTML-escapes by
+	// default - and json.RawMessage copies values verbatim, so the escapes would
+	// survive and the test would fail for its own input rather than for the
+	// behaviour under test. That is exactly how the first version of this test
+	// failed.
+	const command = `go test ./... 2>&1 && echo <done>`
+	result, err := ExtractAgentResult(envelopeWithList("tests_run", `[{"command":"`+command+`"}]`))
+	if err != nil {
+		t.Fatalf("unexpected rejection: %v", err)
+	}
+	if len(result.TestsRun) != 1 {
+		t.Fatalf("tests_run = %#v, want one entry", result.TestsRun)
+	}
+	if !strings.Contains(result.TestsRun[0], command) {
+		t.Fatalf("entry %q lost the verbatim command %q", result.TestsRun[0], command)
+	}
+	for _, escaped := range []string{`\u003e`, `\u0026`, `\u003c`} {
+		if strings.Contains(result.TestsRun[0], escaped) {
+			t.Fatalf("entry %q contains HTML escape %s", result.TestsRun[0], escaped)
+		}
+	}
+}
+
+// TestDuplicateKeysAreRejectedNotCollapsed is the P3-3 regression.
+// map[string]json.RawMessage silently keeps the LAST duplicate, so
+// [{"name":"first","name":"second"}] decoded without error to {"name":"second"},
+// losing a field while the docs claimed every field is kept. Duplicate keys are
+// exactly the malformed-but-parseable JSON a runtime emits; silence is the one
+// option that is wrong.
+func TestDuplicateKeysAreRejectedNotCollapsed(t *testing.T) {
+	_, err := ExtractAgentResult(envelopeWithList("tests_run", `[{"name":"first","name":"second"}]`))
+	if err == nil {
+		t.Fatal("duplicate keys were accepted; they must be rejected rather than silently collapsed")
+	}
+	if !strings.Contains(err.Error(), "duplicate key") || !strings.Contains(err.Error(), "name") {
+		t.Fatalf("error %q must name the duplicate key", err)
+	}
+}
+
+// TestListElementErrorNamesItsField is the P3-4 regression. Pre-#1805
+// encoding/json reported "AgentResult.tests_run"; the custom decoder's error is
+// passed through unwrapped, so the name was lost - and a repair attempt that
+// cannot see WHICH list failed is a wasted attempt.
+func TestListElementErrorNamesItsField(t *testing.T) {
+	for _, field := range []string{"changes_made", "tests_run", "needs"} {
+		_, err := ExtractAgentResult(envelopeWithList(field, `[123]`))
+		if err == nil {
+			t.Fatalf("%s: a number element must be rejected", field)
+		}
+		if !strings.Contains(err.Error(), field) {
+			t.Fatalf("error for %s does not name the field: %v", field, err)
+		}
+	}
+}
+
+// TestReachableDecoderGuardsArePinned covers the two guards that survive the
+// P3-5 cleanup. Both are reachable ONLY by a direct call, which is legitimate
+// because UnmarshalJSON is exported: the element guards were deleted instead,
+// because encoding/json never produces a padded or zero-length element and no
+// mutant could kill them.
+func TestReachableDecoderGuardsArePinned(t *testing.T) {
+	var nilList *ResultStringList
+	if err := nilList.UnmarshalJSON([]byte(`["a"]`)); err == nil {
+		t.Fatal("nil receiver must error rather than panic")
+	}
+	var list ResultStringList
+	if err := list.UnmarshalJSON(nil); err != nil {
+		t.Fatalf("empty data must decode to nil, got %v", err)
+	}
+	if list != nil {
+		t.Fatalf("empty data produced %#v, want nil", list)
+	}
+}
+
+// TestEmptyObjectEntryIsNotActionableEvidence is the P3-6 regression, and it is
+// a GATE behaviour test rather than a decoder one. needs:[{}] now decodes to the
+// entry "{}", which is non-empty to TrimSpace, so a BLOCKED result whose only
+// blocker was an empty object passed the evidence heuristic.
+func TestEmptyObjectEntryIsNotActionableEvidence(t *testing.T) {
+	for _, empty := range []string{"{}", "[]", "", "   "} {
+		if hasActionableEntries([]string{empty}) {
+			t.Fatalf("entry %q must not count as actionable", empty)
+		}
+	}
+	for _, real := range []string{`{"blocker":"needs credentials"}`, "run the migration", "{unparseable"} {
+		if !hasActionableEntries([]string{real}) {
+			t.Fatalf("entry %q must count as actionable", real)
+		}
+	}
+}

--- a/internal/workflow/result_string_list_test.go
+++ b/internal/workflow/result_string_list_test.go
@@ -1,0 +1,126 @@
+package workflow
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// The exact envelope shape that failed in production: review job
+// local-review-gm-review-opus-18d1b91052453964 reported its tests as objects,
+// the strict element decode failed the WHOLE result with "json: cannot
+// unmarshal object into Go struct field AgentResult.tests_run of type string",
+// and it burned repair_retry attempt 1 of 2. A job that did the work and
+// reported it richly was indistinguishable from one that returned nothing.
+func TestExtractAgentResultAcceptsObjectElementsInTestsRun(t *testing.T) {
+	output := `{"gitmoot_result":{"decision":"approved","summary":"docs change verified","severity":"P3",` +
+		`"findings":[],"changes_made":[],` +
+		`"tests_run":[{"name":"PR diff scope confirmation","command":"git show --stat 663321c9","result":"pass","detail":"one file changed"},` +
+		`"go test ./internal/workflow/"],` +
+		`"needs":[],"delegations":[]}}`
+
+	result, err := ExtractAgentResult(output)
+	if err != nil {
+		t.Fatalf("ExtractAgentResult returned error for object tests_run elements: %v", err)
+	}
+	if len(result.TestsRun) != 2 {
+		t.Fatalf("tests_run = %#v, want both entries preserved", result.TestsRun)
+	}
+	// The object element keeps every field it carried: choosing one field would
+	// be a guess (the contract names none) and would drop what was measured.
+	for _, want := range []string{"PR diff scope confirmation", "git show --stat 663321c9", "pass", "one file changed"} {
+		if !strings.Contains(result.TestsRun[0], want) {
+			t.Fatalf("object element %q lost %q", result.TestsRun[0], want)
+		}
+	}
+	if result.TestsRun[1] != "go test ./internal/workflow/" {
+		t.Fatalf("string element = %q, want it unchanged", result.TestsRun[1])
+	}
+}
+
+// Object elements are re-encoded through a map so key order is canonical: two
+// agents reporting the same object must produce the same entry, or a digest or
+// a comparison over tests_run sees a spurious change.
+func TestResultStringListCanonicalizesObjectKeyOrder(t *testing.T) {
+	var first, second ResultStringList
+	if err := json.Unmarshal([]byte(`[{"command":"go test","name":"unit","result":"pass"}]`), &first); err != nil {
+		t.Fatalf("unmarshal first: %v", err)
+	}
+	if err := json.Unmarshal([]byte(`[{"result":"pass","name":"unit","command":"go test"}]`), &second); err != nil {
+		t.Fatalf("unmarshal second: %v", err)
+	}
+	if first[0] != second[0] {
+		t.Fatalf("key order changed the entry:\n %q\n %q", first[0], second[0])
+	}
+}
+
+// The marshalled shape must not change: payloads persist, and every consumer
+// (PR comments, printStringList, result digests) reads an array of strings.
+func TestResultStringListMarshalsAsAnArrayOfStrings(t *testing.T) {
+	var list ResultStringList
+	if err := json.Unmarshal([]byte(`["go build ./...",{"name":"unit","result":"pass"}]`), &list); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	encoded, err := json.Marshal(list)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var back []string
+	if err := json.Unmarshal(encoded, &back); err != nil {
+		t.Fatalf("re-decode as []string failed, so the wire shape changed: %v (%s)", err, encoded)
+	}
+	if len(back) != 2 || back[0] != "go build ./..." {
+		t.Fatalf("round trip = %#v", back)
+	}
+}
+
+// Nothing beyond the measured shapes is accepted. Widening to numbers,
+// booleans, nested arrays, or a bare string in place of the array would change
+// the contract on a guess: no agent has been observed sending them.
+func TestResultStringListRejectsUnevidencedShapes(t *testing.T) {
+	for name, payload := range map[string]string{
+		"number element":  `[1]`,
+		"boolean element": `[true]`,
+		"nested array":    `[["go test"]]`,
+		"bare string":     `"go test"`,
+		"object instead":  `{"tests_run":"go test"}`,
+	} {
+		t.Run(name, func(t *testing.T) {
+			var list ResultStringList
+			if err := json.Unmarshal([]byte(payload), &list); err == nil {
+				t.Fatalf("%s was accepted as %#v, want a decode error", name, list)
+			}
+		})
+	}
+}
+
+// null and an absent list stay nil so normalizeAgentResult keeps owning the
+// empty-slice normalization.
+func TestResultStringListAcceptsNull(t *testing.T) {
+	list := ResultStringList{"stale"}
+	if err := json.Unmarshal([]byte(`null`), &list); err != nil {
+		t.Fatalf("null must decode: %v", err)
+	}
+	if list != nil {
+		t.Fatalf("null decoded to %#v, want nil", list)
+	}
+}
+
+// changes_made and needs share the type and take the same input class, so the
+// same object shape must not fail them either.
+func TestExtractAgentResultAcceptsObjectElementsInEveryStringList(t *testing.T) {
+	output := `{"gitmoot_result":{"decision":"implemented","summary":"did the thing",` +
+		`"findings":[],"changes_made":[{"file":"a.go","change":"added a guard"}],` +
+		`"tests_run":[],"needs":[{"blocked_on":"owner","why":"merge authority"}],"delegations":[]}}`
+
+	result, err := ExtractAgentResult(output)
+	if err != nil {
+		t.Fatalf("ExtractAgentResult returned error: %v", err)
+	}
+	if len(result.ChangesMade) != 1 || !strings.Contains(result.ChangesMade[0], "added a guard") {
+		t.Fatalf("changes_made = %#v", result.ChangesMade)
+	}
+	if len(result.Needs) != 1 || !strings.Contains(result.Needs[0], "merge authority") {
+		t.Fatalf("needs = %#v", result.Needs)
+	}
+}

--- a/skills/gitmoot/references/RESULT_CONTRACT.md
+++ b/skills/gitmoot/references/RESULT_CONTRACT.md
@@ -84,11 +84,11 @@ was rejected with `cannot unmarshal object into Go struct field
 AgentResult.tests_run of type string` and spent a repair attempt, which made a
 job that did the work and reported it richly indistinguishable from one that
 returned nothing. An object element is now stored as compact JSON with its keys
-in canonical order, and every field is carried through verbatim — including
+in canonical order at the TOP level, and every field is carried through verbatim — including
 shell metacharacters, so a recorded `command` can be copy-pasted back. The
 contract names none of the keys, so picking one would be a guess.
 
-**Duplicate keys are rejected**, not merged. `[{"name":"a","name":"b"}]` fails
+**Duplicate keys are rejected** at the top level, not merged. `[{"name":"a","name":"b"}]` fails
 with the duplicate named, because the alternative is keeping one silently and
 losing the other, which would contradict the guarantee above.
 
@@ -96,6 +96,28 @@ A `null` element is accepted and becomes an **empty entry**, which is what it
 did before object elements were supported. It is not an error: failing the whole
 result over one null would spend a repair attempt on an envelope that already
 parsed.
+
+**Both properties stop at the top level, and the digest consumes nested values.**
+A NESTED object keeps whatever key order the agent sent, and a duplicate key
+inside a nested object is resolved silently by the decoder rather than rejected.
+Only the outermost object of a list element is canonicalised and duplicate-checked.
+So two agents reporting the same nested entry can produce different bytes, and
+the result digest reads those bytes.
+
+**The evidence gate also changed, not only the decoder.** A list entry that
+decodes cleanly but carries no information — `{}`, `[]`, `{"name":"","command":""}`,
+`["",""]` — is NOT evidence. `changes_made` and `tests_run` are judged by the
+same test the `needs` gate uses, so a content-free entry no longer satisfies
+`implement-changes-listed` or `implement-tests-listed`. An entry with at least
+one populated value, at any depth, still counts.
+
+**Which lists accept an object at all.** Only the narrative lists an agent
+writes for a human: `changes_made`, `tests_run` and `needs`. The engine's
+structural lists stay STRICT and reject an object element — `capabilities`,
+`artifacts`, `deps` and `choices` are identifiers the engine consumes (a
+capability name, an artifact path, a delegation id, a prompt option), so an
+object there is not a richer report, it is an unusable value that would corrupt
+routing. That asymmetry is deliberate.
 
 Nothing else is accepted. A number, a boolean, a nested array, or a bare string
 where the array belongs still fails the result — and the error names the field,

--- a/skills/gitmoot/references/RESULT_CONTRACT.md
+++ b/skills/gitmoot/references/RESULT_CONTRACT.md
@@ -98,15 +98,21 @@ result over one null would spend a repair attempt on an envelope that already
 parsed.
 
 **Both properties stop at the top level, and the digest consumes nested values.**
-A NESTED object keeps whatever key order the agent sent, and a duplicate key
-inside a nested object is resolved silently by the decoder rather than rejected.
+A NESTED object keeps whatever key order the agent sent, and a duplicate key inside a nested object is
+NEITHER rejected NOR resolved: BOTH copies are kept verbatim in the stored
+entry, because the value is copied as raw bytes and re-marshalling only
+compacts it. Measured, not inferred.
 Only the outermost object of a list element is canonicalised and duplicate-checked.
 So two agents reporting the same nested entry can produce different bytes, and
 the result digest reads those bytes.
 
 **The evidence gate also changed, not only the decoder.** A list entry that
-decodes cleanly but carries no information — `{}`, `[]`, `{"name":"","command":""}`,
-`["",""]` — is NOT evidence. `changes_made` and `tests_run` are judged by the
+decodes cleanly but carries no information — `{}`, or an object whose values
+are all empty such as `{"name":"","command":""}` — is NOT evidence. A bare
+array element like `[]` or `["",""]` is NOT in this category: the decoder
+rejects any element that is not a string or an object, so those fail the whole
+result rather than reaching the gate. Empty containers ARE reachable nested
+inside an object value, and are judged there.
 same test the `needs` gate uses, so a content-free entry no longer satisfies
 `implement-changes-listed` or `implement-tests-listed`. An entry with at least
 one populated value, at any depth, still counts.

--- a/skills/gitmoot/references/RESULT_CONTRACT.md
+++ b/skills/gitmoot/references/RESULT_CONTRACT.md
@@ -68,6 +68,29 @@ None of these keys is mandatory. String findings still render exactly as the
 plain text you provide, and any finding the renderer cannot map (for example a
 top-level array) falls back to a pretty-printed fenced ```json``` block.
 
+## String lists: `changes_made`, `tests_run`, `needs`
+
+Emit **strings**. That is the contract, and it is what the renderers and the
+result digest are built for.
+
+An **object** element is also accepted, because agents send them and refusing
+one used to fail the entire result. A review that reported
+
+```json
+"tests_run": [{"name": "diff scope", "command": "git show --stat", "result": "pass"}]
+```
+
+was rejected with `cannot unmarshal object into Go struct field
+AgentResult.tests_run of type string` and spent a repair attempt, which made a
+job that did the work and reported it richly indistinguishable from one that
+returned nothing. An object element is now stored as compact JSON with its keys
+in canonical order: every field is kept, because the contract names none of them
+and picking one would be a guess.
+
+Nothing else is accepted. A number, a boolean, a nested array, or a bare string
+where the array belongs still fails the result. Prefer a string and put the
+detail in it.
+
 ## Delegations
 
 Orchestra is gitmoot's name for structured multi-agent delegation: a conductor

--- a/skills/gitmoot/references/RESULT_CONTRACT.md
+++ b/skills/gitmoot/references/RESULT_CONTRACT.md
@@ -84,12 +84,23 @@ was rejected with `cannot unmarshal object into Go struct field
 AgentResult.tests_run of type string` and spent a repair attempt, which made a
 job that did the work and reported it richly indistinguishable from one that
 returned nothing. An object element is now stored as compact JSON with its keys
-in canonical order: every field is kept, because the contract names none of them
-and picking one would be a guess.
+in canonical order, and every field is carried through verbatim — including
+shell metacharacters, so a recorded `command` can be copy-pasted back. The
+contract names none of the keys, so picking one would be a guess.
+
+**Duplicate keys are rejected**, not merged. `[{"name":"a","name":"b"}]` fails
+with the duplicate named, because the alternative is keeping one silently and
+losing the other, which would contradict the guarantee above.
+
+A `null` element is accepted and becomes an **empty entry**, which is what it
+did before object elements were supported. It is not an error: failing the whole
+result over one null would spend a repair attempt on an envelope that already
+parsed.
 
 Nothing else is accepted. A number, a boolean, a nested array, or a bare string
-where the array belongs still fails the result. Prefer a string and put the
-detail in it.
+where the array belongs still fails the result — and the error names the field,
+so a repair attempt knows which list to fix. Prefer a string and put the detail
+in it.
 
 ## Delegations
 

--- a/website/docs/reference/result-contract.md
+++ b/website/docs/reference/result-contract.md
@@ -84,6 +84,24 @@ for missing credentials, unclear scope, unavailable tools, failing external
 services, or required human decisions.
 Always redact secrets from summaries, findings, raw command output, and examples.
 
+## String lists: `changes_made`, `tests_run`, `needs`
+
+Emit **strings**. An **object** element is also accepted, because agents send
+them and refusing one used to fail the entire result: a review reporting
+
+```json
+"tests_run": [{"name": "diff scope", "command": "git show --stat", "result": "pass"}]
+```
+
+was rejected with `cannot unmarshal object into Go struct field
+AgentResult.tests_run of type string` and spent a repair attempt, which made a
+job that did the work indistinguishable from one that returned nothing. An
+object element is stored as compact JSON with keys in canonical order: every
+field is kept, since the contract names none of them.
+
+Nothing else is accepted. A number, a boolean, a nested array, or a bare string
+where the array belongs still fails the result.
+
 ## Display-only in-session review state
 
 An inline PR review can be recorded with `job open --type review --pr <n>

--- a/website/docs/reference/result-contract.md
+++ b/website/docs/reference/result-contract.md
@@ -96,15 +96,37 @@ them and refusing one used to fail the entire result: a review reporting
 was rejected with `cannot unmarshal object into Go struct field
 AgentResult.tests_run of type string` and spent a repair attempt, which made a
 job that did the work indistinguishable from one that returned nothing. An
-object element is stored as compact JSON with keys in canonical order, and every
+object element is stored as compact JSON with keys in canonical order at the TOP level, and every
 field is carried through verbatim — including shell metacharacters, so a
 recorded `command` can be copy-pasted back.
 
-**Duplicate keys are rejected**, not merged: `[{"name":"a","name":"b"}]` fails
+**Duplicate keys are rejected** at the top level, not merged: `[{"name":"a","name":"b"}]` fails
 with the duplicate named, rather than silently keeping one of them.
 
 A `null` element is accepted and becomes an **empty entry**, matching the
 behaviour before object elements were supported.
+
+**Both properties stop at the top level, and the digest consumes nested values.**
+A NESTED object keeps whatever key order the agent sent, and a duplicate key
+inside a nested object is resolved silently by the decoder rather than rejected.
+Only the outermost object of a list element is canonicalised and duplicate-checked.
+So two agents reporting the same nested entry can produce different bytes, and
+the result digest reads those bytes.
+
+**The evidence gate also changed, not only the decoder.** A list entry that
+decodes cleanly but carries no information — `{}`, `[]`, `{"name":"","command":""}`,
+`["",""]` — is NOT evidence. `changes_made` and `tests_run` are judged by the
+same test the `needs` gate uses, so a content-free entry no longer satisfies
+`implement-changes-listed` or `implement-tests-listed`. An entry with at least
+one populated value, at any depth, still counts.
+
+**Which lists accept an object at all.** Only the narrative lists an agent
+writes for a human: `changes_made`, `tests_run` and `needs`. The engine's
+structural lists stay STRICT and reject an object element — `capabilities`,
+`artifacts`, `deps` and `choices` are identifiers the engine consumes (a
+capability name, an artifact path, a delegation id, a prompt option), so an
+object there is not a richer report, it is an unusable value that would corrupt
+routing. That asymmetry is deliberate.
 
 Nothing else is accepted. A number, a boolean, a nested array, or a bare string
 where the array belongs still fails the result, and the error names the field so

--- a/website/docs/reference/result-contract.md
+++ b/website/docs/reference/result-contract.md
@@ -107,15 +107,21 @@ A `null` element is accepted and becomes an **empty entry**, matching the
 behaviour before object elements were supported.
 
 **Both properties stop at the top level, and the digest consumes nested values.**
-A NESTED object keeps whatever key order the agent sent, and a duplicate key
-inside a nested object is resolved silently by the decoder rather than rejected.
+A NESTED object keeps whatever key order the agent sent, and a duplicate key inside a nested object is
+NEITHER rejected NOR resolved: BOTH copies are kept verbatim in the stored
+entry, because the value is copied as raw bytes and re-marshalling only
+compacts it. Measured, not inferred.
 Only the outermost object of a list element is canonicalised and duplicate-checked.
 So two agents reporting the same nested entry can produce different bytes, and
 the result digest reads those bytes.
 
 **The evidence gate also changed, not only the decoder.** A list entry that
-decodes cleanly but carries no information — `{}`, `[]`, `{"name":"","command":""}`,
-`["",""]` — is NOT evidence. `changes_made` and `tests_run` are judged by the
+decodes cleanly but carries no information — `{}`, or an object whose values
+are all empty such as `{"name":"","command":""}` — is NOT evidence. A bare
+array element like `[]` or `["",""]` is NOT in this category: the decoder
+rejects any element that is not a string or an object, so those fail the whole
+result rather than reaching the gate. Empty containers ARE reachable nested
+inside an object value, and are judged there.
 same test the `needs` gate uses, so a content-free entry no longer satisfies
 `implement-changes-listed` or `implement-tests-listed`. An entry with at least
 one populated value, at any depth, still counts.

--- a/website/docs/reference/result-contract.md
+++ b/website/docs/reference/result-contract.md
@@ -96,11 +96,19 @@ them and refusing one used to fail the entire result: a review reporting
 was rejected with `cannot unmarshal object into Go struct field
 AgentResult.tests_run of type string` and spent a repair attempt, which made a
 job that did the work indistinguishable from one that returned nothing. An
-object element is stored as compact JSON with keys in canonical order: every
-field is kept, since the contract names none of them.
+object element is stored as compact JSON with keys in canonical order, and every
+field is carried through verbatim — including shell metacharacters, so a
+recorded `command` can be copy-pasted back.
+
+**Duplicate keys are rejected**, not merged: `[{"name":"a","name":"b"}]` fails
+with the duplicate named, rather than silently keeping one of them.
+
+A `null` element is accepted and becomes an **empty entry**, matching the
+behaviour before object elements were supported.
 
 Nothing else is accepted. A number, a boolean, a nested array, or a bare string
-where the array belongs still fails the result.
+where the array belongs still fails the result, and the error names the field so
+a repair attempt knows which list to fix.
 
 ## Display-only in-session review state
 


### PR DESCRIPTION
Closes #1805.

## What was wrong

Review job `local-review-gm-review-opus-18d1b91052453964` reported its tests as objects:

```json
"tests_run":[{"name":"PR diff scope confirmation","command":"git show --stat 663321c9...","result":"pass","detail":"..."}]
```

The strict `[]string` element decode failed the **whole envelope** with `json: cannot unmarshal object into Go struct field AgentResult.tests_run of type string`, and burned `repair_retry` attempt 1 of 2. That job produced a verdict only because the repair prompt worked on the second attempt. So every review was one unlucky shape away from spending its repair budget, including the reviews that verify other fixes. `changes_made` and `needs` are the same type and take the same input class.

## What this changes

`changes_made`, `tests_run` and `needs` share a new `ResultStringList`:

- a **string** element is unchanged;
- an **object** element is re-encoded as compact JSON, through a `map` so key order is canonical. Every field is kept. The contract names no element fields, so picking `command` or `name` would be a guess, and dropping the rest would lose what the agent measured. Consumers treat entries as opaque strings (printed, written into PR comments, counted, digested), so a JSON-shaped entry is legible and lossless;
- the **marshalled** shape is unchanged, so persisted payloads and every consumer still read an array of strings;
- `null` still decodes to nil, leaving `normalizeAgentResult` to own the empty-slice normalization.

**Nothing else widens.** A number, a boolean, a nested array, or a bare string in place of the array still fails the result. There is no evidence agents send those, and accepting them would change the contract on a guess. The prompt contract keeps asking for strings; both docs trees now state what an object element does.

## Verification

`go build ./...`, `go vet ./...`, `go generate ./...` clean with no diff, and `go test ./...` green.

Four mutants, each against a green baseline, each killed:

| mutant | tests that failed |
|---|---|
| revert the fields to strict `[]string` (the production defect) | `TestExtractAgentResultAcceptsObjectElementsInTestsRun`, `TestExtractAgentResultAcceptsObjectElementsInEveryStringList` |
| render an object from one field only (the lossy guess) | same two, on the dropped fields |
| drop canonicalization and pass the raw element through | `TestResultStringListCanonicalizesObjectKeyOrder` |
| accept any element type | `TestResultStringListRejectsUnevidencedShapes` (number, boolean, nested array) |

The first mutant reproduces the exact production error string, so the guard fails for the measured reason rather than an adjacent one.

## Not verified

No live agent round-trip: with claude auth down (#1808) and kimi blocked until #1807 deploys, there is no reviewer family available to exercise this end to end today. The regression enters through `ExtractAgentResult`, the same function the mailbox calls, using the exact payload from the failed job.

## Deploy notes

Rebuild and replace BOTH service binaries per the AGENTS.md recipe. No config or migration change. Docs updated in the same PR: `skills/gitmoot/references/RESULT_CONTRACT.md` and `website/docs/reference/result-contract.md`.