### PR TITLE
fix(review): give read-only seats the resolved runtime auth, and stop lying about it

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,9 +5,25 @@
 /gitmoot
 /*.log
 
-# A credential file. It is written to the gitmoot home; if it ever appears in
-# the work tree that is a defect (#1810), but never let it be committed.
+# CREDENTIAL-BEARING OVERLAY FILENAMES (#1810). Every name here is one this
+# codebase RESOLVES AND READS as a credential input, enumerated from the
+# resolver rather than from memory:
+#   runtime-auth.env      internal/cli/daemon_runtime_auth.go:24 (runtimeAuthFileName)
+#   daemon-runtime.env    internal/cli/daemon_runtime_auth.go:25 (legacyRuntimeAuthFileName)
+#   .credentials.json     internal/cli/daemon_worker.go:1649, readonly_seat_credential.go:71
+#   auth.json             internal/cli/daemon_worker.go:1654 (codex)
+#   kimi-code.json        internal/cli/daemon_worker.go:1660 (kimi)
+# The feature's contract is "read a credential overlay out of a directory", so
+# the host that exercises it will produce these files in a work tree. None of
+# them is a tracked repository artifact - verified with git ls-files before
+# adding these rules - so ignoring them by name hides nothing legitimate.
 runtime-auth.env
 **/runtime-auth.env
+daemon-runtime.env
+**/daemon-runtime.env
 .credentials.json
 **/.credentials.json
+auth.json
+**/auth.json
+kimi-code.json
+**/kimi-code.json

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,10 @@
 /.gitmoot/evals/
 /gitmoot
 /*.log
+
+# A credential file. It is written to the gitmoot home; if it ever appears in
+# the work tree that is a defect (#1810), but never let it be committed.
+runtime-auth.env
+**/runtime-auth.env
+.credentials.json
+**/.credentials.json

--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,13 @@
 # the host that exercises it will produce these files in a work tree. None of
 # them is a tracked repository artifact - verified with git ls-files before
 # adding these rules - so ignoring them by name hides nothing legitimate.
+#
+# LIMIT, stated because a name list reads as completeness and is not:
+# [credentials].keychain_path accepts ANY absolute path, so an operator can
+# point a credential at a filename nothing here lists. Rules matched by name,
+# and a guard matched by basename, are structurally incapable of covering that
+# case. They cover the names this code CHOOSES, not every path an operator can
+# configure.
 runtime-auth.env
 **/runtime-auth.env
 daemon-runtime.env

--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,8 @@
 #   .credentials.json     internal/cli/daemon_worker.go:1649, readonly_seat_credential.go:71
 #   auth.json             internal/cli/daemon_worker.go:1654 (codex)
 #   kimi-code.json        internal/cli/daemon_worker.go:1660 (kimi)
+#   keychain.env          internal/pipeline/env_runtime.go, ResolveKeychainPath
+#   bridge.token          internal/cli/bridge.go:37, bridgeTokenName
 # The feature's contract is "read a credential overlay out of a directory", so
 # the host that exercises it will produce these files in a work tree. None of
 # them is a tracked repository artifact - verified with git ls-files before
@@ -27,3 +29,7 @@ auth.json
 **/auth.json
 kimi-code.json
 **/kimi-code.json
+keychain.env
+**/keychain.env
+bridge.token
+**/bridge.token

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -441,6 +441,19 @@ Fixes:
   (a failing probe extends the hold without spending a retry). Over `[events]`
   the deferral is a first-class `job.deferred` emitted instead of `job.failed`.
   Only act when the retry budget is spent and the job stays failed.
+- A read-only seat (every `review`/`ask` job under the read-only autonomy
+  policy) does NOT authenticate with the ambient credential: it stages a
+  SNAPSHOT of its runtime config dir (`payload.runtime_config_dir`, else the
+  daemon's `CLAUDE_CONFIG_DIR`, else `~/.claude`) and carries the resolved
+  `runtime-auth.env` overlay. When that snapshot is already expired the job
+  records one `readonly_seat_credential_expired` event naming the expiry, the
+  refresh-token state and whether an overlay was available — read it with
+  `gitmoot job events <job-id>` before treating the runtime's own "OAuth session
+  expired and could not be refreshed" wording as an account problem. It never
+  refuses the job. `gitmoot doctor` and `gitmoot auth probe claude` both report
+  that seat credential beside the ambient one, and doctor FAILS (non-zero exit)
+  when it is expired with no refresh token, since every read-only seat job on
+  that runtime will fail until the account is re-logged in.
 - A `stale_worktree_dirty_blocked` task event is not an auto-retrying
   `checkout_contention` deferral. It means the existing task worktree is off the
   resolved base lineage and has uncommitted changes, so Gitmoot preserves it and

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -455,15 +455,25 @@ Fixes:
   when it is expired with no refresh token, since every read-only seat job on
   that runtime will fail until the account is re-logged in.
 - A Claude `produce` stage does NOT run against the operator profile. The daemon
-  stages the configured account (`CLAUDE_CONFIG_DIR`, else `~/.claude`) into a
-  job-private profile, points the runtime's `CLAUDE_CONFIG_DIR` and
-  `XDG_CACHE_HOME` at that job-private state root under
-  `<gitmoot home>/cache/produce-runtime/<hash>/run-*/` - one directory per
-  dispatch, so two concurrent runs of one job id cannot wipe each other - and
-  removes that directory when the job finishes. The operator profile is never granted writable and is never
-  exposed to the sandbox, so a token the runtime refreshes mid-job lands in the
-  discarded copy: re-login on the host, not in the job. A configured profile
-  that does not exist yet is valid and starts the job with an empty one.
+  copies `.credentials.json` and `settings.json` from the configured account
+  (`CLAUDE_CONFIG_DIR`, else `~/.claude`) into a job-private profile, points the
+  runtime's `CLAUDE_CONFIG_DIR` and `XDG_CACHE_HOME` at that job-private state
+  root under `<gitmoot home>/cache/produce-runtime/<hash>/run-*/` — one
+  directory per dispatch, so two runs of one job id cannot wipe each other — and
+  removes it when the job finishes. The operator profile is never granted
+  writable and is never named in any read grant, so a token the runtime
+  refreshes mid-job lands in the discarded copy: re-login on the host, not in
+  the job. It may still be READABLE: an agent that declares no readable paths
+  falls back to a read-only grant over `/`, which is a read, never a write.
+- Only those two files cross into a produce job. Everything else in the operator
+  profile — `agents/`, `commands/`, `plugins/`, `CLAUDE.md`,
+  `settings.local.json`, `~/.claude.json` — deliberately does not, so a produce
+  job sees runtime defaults rather than operator customisation. A profile that
+  does not exist yet is valid and starts the job with an empty one. A
+  `settings.json` that is symlinked is followed; one that is empty, holds a
+  non-object, or is not a file at all is SKIPPED rather than failing the job. An
+  unusable `.credentials.json` does fail the job, because it decides which
+  account the work runs as.
 - `sandbox-exec: sandbox read path "…": no such file or directory` means a path
   granted to the sandbox does not exist on disk. Explicit read grants are
   required, not skipped — check `readable_paths` in `gitmoot job show <job-id>

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -458,8 +458,9 @@ Fixes:
   stages the configured account (`CLAUDE_CONFIG_DIR`, else `~/.claude`) into a
   job-private profile, points the runtime's `CLAUDE_CONFIG_DIR` and
   `XDG_CACHE_HOME` at that job-private state root under
-  `<gitmoot home>/cache/produce-runtime/<hash>/`, and removes the root when the
-  job finishes. The operator profile is never granted writable and is never
+  `<gitmoot home>/cache/produce-runtime/<hash>/run-*/` - one directory per
+  dispatch, so two concurrent runs of one job id cannot wipe each other - and
+  removes that directory when the job finishes. The operator profile is never granted writable and is never
   exposed to the sandbox, so a token the runtime refreshes mid-job lands in the
   discarded copy: re-login on the host, not in the job. A configured profile
   that does not exist yet is valid and starts the job with an empty one.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -454,6 +454,19 @@ Fixes:
   that seat credential beside the ambient one, and doctor FAILS (non-zero exit)
   when it is expired with no refresh token, since every read-only seat job on
   that runtime will fail until the account is re-logged in.
+- A Claude `produce` stage does NOT run against the operator profile. The daemon
+  stages the configured account (`CLAUDE_CONFIG_DIR`, else `~/.claude`) into a
+  job-private profile, points the runtime's `CLAUDE_CONFIG_DIR` and
+  `XDG_CACHE_HOME` at that job-private state root under
+  `<gitmoot home>/cache/produce-runtime/<hash>/`, and removes the root when the
+  job finishes. The operator profile is never granted writable and is never
+  exposed to the sandbox, so a token the runtime refreshes mid-job lands in the
+  discarded copy: re-login on the host, not in the job. A configured profile
+  that does not exist yet is valid and starts the job with an empty one.
+- `sandbox-exec: sandbox read path "…": no such file or directory` means a path
+  granted to the sandbox does not exist on disk. Explicit read grants are
+  required, not skipped — check `readable_paths` in `gitmoot job show <job-id>
+  --json` and create (or stop granting) the named path.
 - A `stale_worktree_dirty_blocked` task event is not an auto-retrying
   `checkout_contention` deferral. It means the existing task worktree is off the
   resolved base lineage and has uncommitted changes, so Gitmoot preserves it and

--- a/internal/cli/auth.go
+++ b/internal/cli/auth.go
@@ -274,15 +274,21 @@ func runAuthProbe(args []string, stdout, stderr io.Writer) int {
 	probeErr := runtime.ClaudeLiveCheckEnv(context.Background(), runner, "", nil)
 	status := runtime.ClaudeClassifyProbe(probeErr)
 	writeLine(stdout, "Claude auth: %s", status.String())
-	// The probe above measures the AMBIENT credential, which is not what a
-	// read-only seat authenticates with: a seat stages a snapshot of the
-	// configured config dir and, before this change, received no ambient token at
-	// all. That is why `auth probe claude` stayed green through an outage in
-	// which every review job failed. Report the staged file too, so one command
-	// covers both credentials rather than the one no review uses.
-	writeSeatCredentialProbe(stdout, *home)
+	// The probe above measures the ambient/runtime-auth credential. A read-only
+	// seat also stages the daemon's configured credential snapshot. Report that
+	// distinct credential and make a known-unusable snapshot affect the command
+	// result, or automation still receives the false green from the outage.
+	seatCredentialUsable := true
+	probePaths, pathsErr := pathsFromFlag(*home)
+	if pathsErr != nil {
+		writeLine(stdout, "read-only seat credential: unknown (%v)", pathsErr)
+	} else {
+		seatCredentialUsable = writeSeatCredentialProbe(stdout, probePaths)
+	}
 	if probeErr != nil {
 		fmt.Fprintf(stderr, "auth probe: %v\n", probeErr)
+	}
+	if probeErr != nil || !seatCredentialUsable {
 		return 1
 	}
 	return 0

--- a/internal/cli/auth.go
+++ b/internal/cli/auth.go
@@ -274,6 +274,13 @@ func runAuthProbe(args []string, stdout, stderr io.Writer) int {
 	probeErr := runtime.ClaudeLiveCheckEnv(context.Background(), runner, "", nil)
 	status := runtime.ClaudeClassifyProbe(probeErr)
 	writeLine(stdout, "Claude auth: %s", status.String())
+	// The probe above measures the AMBIENT credential, which is not what a
+	// read-only seat authenticates with: a seat stages a snapshot of the
+	// configured config dir and, before this change, received no ambient token at
+	// all. That is why `auth probe claude` stayed green through an outage in
+	// which every review job failed. Report the staged file too, so one command
+	// covers both credentials rather than the one no review uses.
+	writeSeatCredentialProbe(stdout, *home)
 	if probeErr != nil {
 		fmt.Fprintf(stderr, "auth probe: %v\n", probeErr)
 		return 1

--- a/internal/cli/auth_test.go
+++ b/internal/cli/auth_test.go
@@ -287,6 +287,24 @@ printf '{"type":"result","is_error":false,"result":"%s"}\n' "$fingerprint"
 	if !strings.Contains(probeOut.String(), "source: "+runtimeAuthFileName) || !strings.Contains(probeOut.String(), "Claude auth: valid") {
 		t.Fatalf("auth probe output=%q", probeOut.String())
 	}
+	// The ambient verdict above says nothing about the credential a READ-ONLY
+	// SEAT stages, which is the pair that stayed green through the outage. One
+	// command must report both (#1810 review F8: nothing pinned this line).
+	if !strings.Contains(probeOut.String(), "read-only seat credential") {
+		t.Fatalf("auth probe omitted the read-only seat credential: %q", probeOut.String())
+	}
+
+	deadSeatDir := t.TempDir()
+	writeClaudeCredential(t, deadSeatDir, 0, "")
+	t.Setenv("CLAUDE_CONFIG_DIR", deadSeatDir)
+	probeOut.Reset()
+	probeErr.Reset()
+	if code := runAuthProbe([]string{"claude", "--home", home}, &probeOut, &probeErr); code != 1 {
+		t.Fatalf("auth probe code=%d, want 1 for unusable seat credential; stdout=%q stderr=%q", code, probeOut.String(), probeErr.String())
+	}
+	if !strings.Contains(probeOut.String(), "UNUSABLE") {
+		t.Fatalf("auth probe did not identify unusable seat credential: %q", probeOut.String())
+	}
 
 	var stdout, stderr bytes.Buffer
 	if code := runAuthUnset([]string{"claude", "--home", home}, &stdout, &stderr); code != 0 {

--- a/internal/cli/auth_test.go
+++ b/internal/cli/auth_test.go
@@ -299,11 +299,16 @@ printf '{"type":"result","is_error":false,"result":"%s"}\n' "$fingerprint"
 	t.Setenv("CLAUDE_CONFIG_DIR", deadSeatDir)
 	probeOut.Reset()
 	probeErr.Reset()
-	if code := runAuthProbe([]string{"claude", "--home", home}, &probeOut, &probeErr); code != 1 {
-		t.Fatalf("auth probe code=%d, want 1 for unusable seat credential; stdout=%q stderr=%q", code, probeOut.String(), probeErr.String())
+	// A dead SNAPSHOT beside a live runtime-auth OVERLAY is untidy, not broken:
+	// the overlay is what a seat authenticates with, so every seat job succeeds
+	// and a non-zero exit here would be a false red on a working host (#1810
+	// review round 3, F2). This run has an overlay - the rotation above wrote
+	// runtime-auth.env - so the probe must say so and still exit 0.
+	if code := runAuthProbe([]string{"claude", "--home", home}, &probeOut, &probeErr); code != 0 {
+		t.Fatalf("auth probe code=%d, want 0 while a runtime-auth overlay is present; stdout=%q stderr=%q", code, probeOut.String(), probeErr.String())
 	}
-	if !strings.Contains(probeOut.String(), "UNUSABLE") {
-		t.Fatalf("auth probe did not identify unusable seat credential: %q", probeOut.String())
+	if !strings.Contains(probeOut.String(), "overlay is present") {
+		t.Fatalf("auth probe did not name the overlay that keeps seats working: %q", probeOut.String())
 	}
 
 	var stdout, stderr bytes.Buffer
@@ -318,4 +323,26 @@ printf '{"type":"result","is_error":false,"result":"%s"}\n' "$fingerprint"
 func shaFingerprint(value string) string {
 	sum := sha256.Sum256([]byte(value))
 	return hex.EncodeToString(sum[:])
+}
+
+// The other half of the same contract, kept out of the rotation E2E so it does
+// not have to tear down that test's live overlay mid-flow: with NO overlay and
+// NO gateway, the same dead snapshot is the proven failure and the probe exits
+// non-zero (#1810 review round 3, F2).
+func TestAuthProbeExitsNonZeroForADeadSeatCredentialWithNoOverlay(t *testing.T) {
+	home := t.TempDir()
+	paths := seatDoctorTestPaths(t, home, false)
+	deadSeatDir := t.TempDir()
+	writeClaudeCredential(t, deadSeatDir, 0, "")
+	t.Setenv("CLAUDE_CONFIG_DIR", deadSeatDir)
+	t.Setenv("CLAUDE_CODE_OAUTH_TOKEN", "")
+	t.Setenv("ANTHROPIC_API_KEY", "")
+	_ = os.Remove(runtimeAuthFilePath(paths.Home))
+	var out, errOut bytes.Buffer
+	if code := runAuthProbe([]string{"claude", "--home", home}, &out, &errOut); code != 1 {
+		t.Fatalf("auth probe code=%d, want 1 with no overlay and no gateway; stdout=%q stderr=%q", code, out.String(), errOut.String())
+	}
+	if !strings.Contains(out.String(), "UNUSABLE") {
+		t.Fatalf("auth probe did not identify the unusable seat credential: %q", out.String())
+	}
 }

--- a/internal/cli/bridge.go
+++ b/internal/cli/bridge.go
@@ -192,6 +192,12 @@ func bridgeHostIsLoopback(host string) bool {
 }
 
 func ensureBridgeToken(paths config.Paths, rotate bool) (string, error) {
+	// bridge.token IS a credential. Same guard as runtime-auth.env: a home that
+	// is empty or relative would write it beside whatever the process happens to
+	// be running in, which is how #1810 put a live token in a public repo.
+	if err := requireAbsoluteCredentialHome(paths.Home, bridgeTokenName); err != nil {
+		return "", err
+	}
 	if err := os.MkdirAll(paths.Home, 0o700); err != nil {
 		return "", err
 	}

--- a/internal/cli/credentials.go
+++ b/internal/cli/credentials.go
@@ -272,6 +272,24 @@ func graftRuntimeBaseRunner(outer subprocess.Runner, curated subprocess.Runner) 
 		}
 		runner.Inner = graftRuntimeBaseRunner(runner.Inner, curated)
 		return runner
+	case subprocess.CuratedGroupRunner:
+		base, ok := curated.(subprocess.CuratedGroupRunner)
+		if !ok {
+			return outer
+		}
+		runner.BaseEnv = append([]string(nil), base.BaseEnv...)
+		runner.ScratchDirs = append([]string(nil), base.ScratchDirs...)
+		runner.MaxOutputBytes = base.MaxOutputBytes
+		return runner
+	case *subprocess.CuratedGroupRunner:
+		base, ok := curated.(subprocess.CuratedGroupRunner)
+		if !ok {
+			return outer
+		}
+		runner.BaseEnv = append([]string(nil), base.BaseEnv...)
+		runner.ScratchDirs = append([]string(nil), base.ScratchDirs...)
+		runner.MaxOutputBytes = base.MaxOutputBytes
+		return runner
 	case subprocess.GroupRunner:
 		return curated
 	case *subprocess.GroupRunner:

--- a/internal/cli/daemon_cockpit_test.go
+++ b/internal/cli/daemon_cockpit_test.go
@@ -258,7 +258,7 @@ func TestCockpitTeeAdapterCreatesLogAndTees(t *testing.T) {
 	worker := defaultJobWorker(daemonWorkerStore(t), io.Discard, home)
 	agent := runtime.Agent{Name: "lead", Role: "builder", Runtime: runtime.ShellRuntime, RuntimeRef: "echo streamed-line"}
 
-	adapter, logPath, logFile := worker.cockpitTeeAdapter(agent, t.TempDir(), "job-tee")
+	adapter, logPath, logFile := worker.cockpitTeeAdapter(runtime.ShellAdapter{Runner: subprocess.GroupRunner{}}, "job-tee")
 	if logFile == nil {
 		t.Fatal("expected a non-nil log file on the wrapping path")
 	}
@@ -320,8 +320,7 @@ func TestCockpitTeeAdapterTruncatesExistingLog(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	agent := runtime.Agent{Name: "lead", Role: "builder", Runtime: runtime.ShellRuntime, RuntimeRef: "true"}
-	_, _, logFile := worker.cockpitTeeAdapter(agent, t.TempDir(), "job-trunc")
+	_, _, logFile := worker.cockpitTeeAdapter(runtime.ShellAdapter{Runner: subprocess.GroupRunner{}}, "job-trunc")
 	if logFile == nil {
 		t.Fatal("expected a non-nil log file")
 	}
@@ -346,10 +345,8 @@ func TestCockpitTeeAdapterTruncatesExistingLog(t *testing.T) {
 func TestCockpitTeeAdapterDelegationJobIDFlatPath(t *testing.T) {
 	home := t.TempDir()
 	worker := defaultJobWorker(daemonWorkerStore(t), io.Discard, home)
-	agent := runtime.Agent{Name: "lead", Role: "builder", Runtime: runtime.ShellRuntime, RuntimeRef: "true"}
-
 	jobID := "local-ask-conductor-1234/delegation/haiku-ocean"
-	adapter, logPath, logFile := worker.cockpitTeeAdapter(agent, t.TempDir(), jobID)
+	adapter, logPath, logFile := worker.cockpitTeeAdapter(runtime.ShellAdapter{Runner: subprocess.GroupRunner{}}, jobID)
 	if logFile == nil || adapter == nil {
 		t.Fatalf("expected a non-nil adapter+log file for a slashed job id; adapter=%v file=%v", adapter, logFile)
 	}
@@ -378,8 +375,7 @@ func TestCockpitTeeAdapterDelegationJobIDFlatPath(t *testing.T) {
 func TestCockpitTeeAdapterFailOpenUnsupportedRuntime(t *testing.T) {
 	home := t.TempDir()
 	worker := defaultJobWorker(daemonWorkerStore(t), io.Discard, home)
-	agent := runtime.Agent{Name: "x", Runtime: "nope-not-a-runtime"}
-	adapter, logPath, logFile := worker.cockpitTeeAdapter(agent, t.TempDir(), "job-bad")
+	adapter, logPath, logFile := worker.cockpitTeeAdapter(cockpitStubAdapter{}, "job-bad")
 	if adapter != nil || logPath != "" || logFile != nil {
 		t.Fatalf("expected fail-open nils, got adapter=%v path=%q file=%v", adapter, logPath, logFile)
 	}
@@ -632,7 +628,8 @@ func TestCockpitSeatLogAdapterAppends(t *testing.T) {
 	}
 
 	agent := runtime.Agent{Name: "builder", Role: "builder", Runtime: runtime.ShellRuntime, RuntimeRef: "echo ROUND2"}
-	adapter, logPath, logFile := worker.cockpitSeatLogAdapter(cp, agent, t.TempDir(), "job-r2", "root-seat", "builder")
+	base := runtime.ShellAdapter{Runner: subprocess.GroupRunner{}}
+	adapter, logPath, logFile := worker.cockpitSeatLogAdapter(cp, base, "job-r2", "root-seat", "builder")
 	if logFile == nil {
 		t.Fatal("expected a non-nil seat log file")
 	}
@@ -678,8 +675,7 @@ func TestCockpitSeatLogAdapterFailOpenNoHome(t *testing.T) {
 	// An empty GITMOOT_HOME makes the cockpit's home empty, so SeatLogPath returns "".
 	t.Setenv("GITMOOT_HOME", "")
 	cp := cockpit.New(cockpit.Options{HerdrBin: "herdr-does-not-exist-for-tests", PaneKeyMode: config.CockpitPaneKeySeat}, nil)
-	agent := runtime.Agent{Name: "builder", Runtime: runtime.ShellRuntime, RuntimeRef: "true"}
-	adapter, logPath, logFile := worker.cockpitSeatLogAdapter(cp, agent, t.TempDir(), "job-x", "root-seat", "builder")
+	adapter, logPath, logFile := worker.cockpitSeatLogAdapter(cp, runtime.ShellAdapter{}, "job-x", "root-seat", "builder")
 	if adapter != nil || logPath != "" || logFile != nil {
 		t.Fatalf("expected fail-open nils with no home, got adapter=%v path=%q file=%v", adapter, logPath, logFile)
 	}
@@ -694,10 +690,9 @@ func TestCockpitLogAdapterPicksLogPerMode(t *testing.T) {
 	t.Setenv("GITMOOT_HOME", home)
 	worker := defaultJobWorker(daemonWorkerStore(t), io.Discard, home)
 	cp := cockpit.New(cockpit.Options{HerdrBin: "herdr-does-not-exist-for-tests", PaneKeyMode: config.CockpitPaneKeySeat}, nil)
-	agent := runtime.Agent{Name: "builder", Role: "builder", Runtime: runtime.ShellRuntime, RuntimeRef: "true"}
 
 	// Job mode -> per-job log under logs/jobs.
-	_, jobLog, jobFile := worker.cockpitLogAdapter(cp, agent, t.TempDir(), "job-1", "root-1", "builder", false)
+	_, jobLog, jobFile := worker.cockpitLogAdapter(cp, runtime.ShellAdapter{}, "job-1", "root-1", "builder", false)
 	if jobFile == nil {
 		t.Fatal("job-mode log file is nil")
 	}
@@ -708,7 +703,7 @@ func TestCockpitLogAdapterPicksLogPerMode(t *testing.T) {
 	}
 
 	// Seat mode -> stable per-seat log under logs/seats/<rootShort>.
-	_, seatLog, seatFile := worker.cockpitLogAdapter(cp, agent, t.TempDir(), "job-1", "root-1", "builder", true)
+	_, seatLog, seatFile := worker.cockpitLogAdapter(cp, runtime.ShellAdapter{}, "job-1", "root-1", "builder", true)
 	if seatFile == nil {
 		t.Fatal("seat-mode log file is nil")
 	}

--- a/internal/cli/daemon_runtime_auth.go
+++ b/internal/cli/daemon_runtime_auth.go
@@ -197,10 +197,34 @@ func writeRuntimeAuthFile(path string, values map[string]string) error {
 // bootstrapRuntimeAuth performs the one-release transition only when the new
 // authoritative file is absent. Legacy persisted auth wins over ambient auth;
 // an existing runtime-auth.env is never rewritten from either source.
+
+// requireAbsoluteRuntimeAuthHome refuses any runtime-auth home that would place
+// a credential file somewhere relative to the current working directory.
+func requireAbsoluteRuntimeAuthHome(homeDir string) error {
+	trimmed := strings.TrimSpace(homeDir)
+	if trimmed == "" {
+		return fmt.Errorf("refusing to write %s: no runtime auth home was resolved", runtimeAuthFileName)
+	}
+	if !filepath.IsAbs(trimmed) {
+		return fmt.Errorf("refusing to write %s under relative path %q: a credential must never land in the working directory", runtimeAuthFileName, trimmed)
+	}
+	return nil
+}
+
 func bootstrapRuntimeAuth(homeDir string, lookup func(string) (string, bool), logf func(string, ...any)) (bool, error) {
 	runtimeAuthBootstrapMu.Lock()
 	defer runtimeAuthBootstrapMu.Unlock()
 
+	// P0 (#1810): this function WRITES A CREDENTIAL FILE, and runtimeAuthFilePath
+	// joins onto homeDir, so an empty or relative homeDir resolves to a RELATIVE
+	// path and the credential lands in the process's working directory. That
+	// happened: a caller passing a zero config.Paths wrote runtime-auth.env into
+	// the package source directory during a test run, where git add -A tracked it
+	// and it reached a public remote. A credential must only ever be written to
+	// an ABSOLUTE, deliberately chosen home.
+	if err := requireAbsoluteRuntimeAuthHome(homeDir); err != nil {
+		return false, err
+	}
 	path := runtimeAuthFilePath(homeDir)
 	if _, err := os.Stat(path); err == nil {
 		return false, nil

--- a/internal/cli/daemon_runtime_auth.go
+++ b/internal/cli/daemon_runtime_auth.go
@@ -198,17 +198,25 @@ func writeRuntimeAuthFile(path string, values map[string]string) error {
 // authoritative file is absent. Legacy persisted auth wins over ambient auth;
 // an existing runtime-auth.env is never rewritten from either source.
 
-// requireAbsoluteRuntimeAuthHome refuses any runtime-auth home that would place
-// a credential file somewhere relative to the current working directory.
-func requireAbsoluteRuntimeAuthHome(homeDir string) error {
+// requireAbsoluteCredentialHome refuses any home that would place a credential
+// file somewhere relative to the current working directory. #1810 published a
+// live token exactly that way: the path was joined onto an empty home, resolved
+// relative, and the file landed in the package source tree during a test run.
+// Every writer of a credential-bearing file goes through this.
+func requireAbsoluteCredentialHome(homeDir, fileName string) error {
 	trimmed := strings.TrimSpace(homeDir)
 	if trimmed == "" {
-		return fmt.Errorf("refusing to write %s: no runtime auth home was resolved", runtimeAuthFileName)
+		return fmt.Errorf("refusing to write %s: no home was resolved", fileName)
 	}
 	if !filepath.IsAbs(trimmed) {
-		return fmt.Errorf("refusing to write %s under relative path %q: a credential must never land in the working directory", runtimeAuthFileName, trimmed)
+		return fmt.Errorf("refusing to write %s under relative path %q: a credential must never land in the working directory", fileName, trimmed)
 	}
 	return nil
+}
+
+// requireAbsoluteRuntimeAuthHome is the runtime-auth caller of the shared guard.
+func requireAbsoluteRuntimeAuthHome(homeDir string) error {
+	return requireAbsoluteCredentialHome(homeDir, runtimeAuthFileName)
 }
 
 func bootstrapRuntimeAuth(homeDir string, lookup func(string) (string, bool), logf func(string, ...any)) (bool, error) {

--- a/internal/cli/daemon_worker.go
+++ b/internal/cli/daemon_worker.go
@@ -1639,6 +1639,15 @@ func readOnlyRuntimeSandboxGrants(home string, agent runtime.Agent, checkout str
 }
 
 func prepareReadOnlyRuntimeState(agent runtime.Agent, cacheRoot string, gatewayMode bool) (string, []string, error) {
+	// THE THIRD WRITER. This stages three of the seven credential-overlay names
+	// (.credentials.json, auth.json, kimi-code.json) by joining onto cacheRoot,
+	// so a relative cacheRoot writes them relative to the working directory -
+	// the exact mechanism that published a token in #1810. Production supplies
+	// an absolute cacheRoot from the isolated-tool-cache grant today; this makes
+	// that a checked precondition rather than a property of the current caller.
+	if err := requireAbsoluteCredentialHome(cacheRoot, "runtime-state"); err != nil {
+		return "", nil, err
+	}
 	sourceDir := strings.TrimSpace(agent.RuntimeConfigDir)
 	var relativeState, credentialFile, credentialSection string
 	stateRoot := filepath.Join(cacheRoot, "runtime-state")

--- a/internal/cli/daemon_worker.go
+++ b/internal/cli/daemon_worker.go
@@ -348,19 +348,14 @@ func (w jobWorker) run(ctx context.Context, job db.Job) error {
 		runtimeConfigDir = selectedRuntimeConfigDir(agent.Runtime)
 	}
 	applyReadOnlySeat(readOnlySeat, runtimeConfigDir, &agent)
-	// A seat stages a credential SNAPSHOT, so check the expiry it is about to
-	// copy BEFORE launching a runtime that can only fail on it. Provably
-	// unusable (expired, no refresh token) fails here; expired-but-refreshable
-	// records the fact so a later auth failure is not read as a fresh OAuth
-	// problem. See readonly_seat_credential.go for the measurement.
-	if credentialDiagnosis, credentialErr := readOnlySeatCredentialPreflight(agent, runtimeConfigDir, time.Now().UTC()); credentialErr != nil {
-		if finishErr := w.finishQueuedJob(ctx, job, workflow.JobFailed, credentialErr); finishErr != nil {
-			return finishErr
-		}
-		_ = w.postJobResultComment(ctx, job.ID, agent, "", credentialErr)
-		return nil
-	} else if credentialDiagnosis != "" {
-		if eventErr := w.Store.AddJobEvent(ctx, db.JobEvent{JobID: job.ID, Kind: "readonly_seat_credential_expired", Message: credentialDiagnosis}); eventErr != nil {
+	// A seat stages a credential SNAPSHOT. Record it when that snapshot is already
+	// expired, so a later auth failure is attributable to gitmoot's staging rather
+	// than read as a fresh OAuth problem. It never refuses: a runtime-auth
+	// rejection is a DEFERRABLE blocker (classifyOperationalBlocker plus the
+	// documented job.deferred), and the auth overlay this same commit injects
+	// means an expired snapshot is no longer decisive.
+	if diagnosis := readOnlySeatCredentialPreflight(agent, runtimeConfigDir, seatModelGatewayMode(w.ConfigHome), time.Now().UTC()); diagnosis != "" {
+		if eventErr := w.Store.AddJobEvent(ctx, db.JobEvent{JobID: job.ID, Kind: "readonly_seat_credential_expired", Message: diagnosis}); eventErr != nil {
 			writeLine(w.Stdout, "job %s readonly_seat_credential_expired event failed: %v", job.ID, eventErr)
 		}
 	}
@@ -1489,7 +1484,13 @@ func wrapReadOnlySandboxAdapter(home string, agent runtime.Agent, checkout strin
 		curated := graftRuntimeBaseRunner(runner, subprocess.CuratedGroupRunner{
 			BaseEnv: append(baseEnv, seatAuthEnv...),
 		})
-		return landlockReadOnlyRunner(curated, grants.reads, grants.readFiles, grants.writes, grants.env)
+		// The overlay ALSO rides on the landlock runner's env, and that is the
+		// path that actually reaches every shape. graftRuntimeBaseRunner has no
+		// CuratedGroupRunner case, so for a plain (non-instance) runner the graft
+		// above is a no-op and BaseEnv is dropped: a wiring test proved the child
+		// then saw only the grant env. #1810's review called this shape-dependence
+		// out; routing through grants.env is what makes the fix shape-independent.
+		return landlockReadOnlyRunner(curated, grants.reads, grants.readFiles, grants.writes, append(grants.env, seatAuthEnv...))
 	}
 	wrapped, err := wrapReadOnlyAdapterRunner(agent.Runtime, adapter, grants.stateDir, wrap)
 	if err != nil {
@@ -1905,6 +1906,15 @@ func produceRuntimeSandboxGrants(runtimeName string, readable, readFiles, writab
 		stateDir := strings.TrimSpace(os.Getenv("CLAUDE_CONFIG_DIR"))
 		if stateDir == "" {
 			stateDir = filepath.Join(home, ".claude")
+		}
+		// A landlock grant and a MkdirAll both need an ABSOLUTE path. A relative or
+		// ~-prefixed CLAUDE_CONFIG_DIR would otherwise grant a path relative to the
+		// worker's cwd and create a stray directory there (#1810 review, P3).
+		if strings.HasPrefix(stateDir, "~") {
+			stateDir = filepath.Join(home, strings.TrimPrefix(stateDir, "~"))
+		}
+		if absolute, absErr := filepath.Abs(stateDir); absErr == nil {
+			stateDir = absolute
 		}
 		stateDir = filepath.Clean(stateDir)
 		cacheRoot, err := os.UserCacheDir()

--- a/internal/cli/daemon_worker.go
+++ b/internal/cli/daemon_worker.go
@@ -1897,6 +1897,14 @@ func produceRuntimeSandboxGrants(runtimeName string, runtimeStateDir string, rea
 		// lets a job mutate operator credentials. Stage the account into a
 		// job-private profile, point the runtime at that copy, and never expose
 		// the operator profile to the sandbox at all.
+		//
+		// PRECONDITION, because this is a property of the sandbox and not of
+		// these grants: produce runs with implicit write roots, so
+		// sandbox.writableRoots also grants the workdir, os.TempDir() and /tmp
+		// (exec_linux.go). A profile placed UNDER one of those roots stays
+		// writable no matter what this function grants - Landlock adds access,
+		// it cannot subtract it. Not naming the profile here is necessary and
+		// not sufficient; keeping operator profiles out of tmp is the other half.
 		configDir, err := resolveRuntimeConfigDir(runtime.ClaudeRuntime, os.Getenv("CLAUDE_CONFIG_DIR"))
 		if err != nil {
 			return nil, nil, nil, nil, err

--- a/internal/cli/daemon_worker.go
+++ b/internal/cli/daemon_worker.go
@@ -343,20 +343,27 @@ func (w jobWorker) run(ctx context.Context, job db.Job) error {
 	// secondary adapter rebuild consumes the same backend selection.
 	agent.ExecBackend = string(execBackend)
 	readOnlySeat := payload.ReadOnlySeat
-	runtimeConfigDir := strings.TrimSpace(payload.RuntimeConfigDir)
-	if readOnlySeat && runtimeConfigDir == "" {
-		runtimeConfigDir = selectedRuntimeConfigDir(agent.Runtime)
+	runtimeConfigDir := ""
+	if readOnlySeat {
+		runtimeConfigDir = selectedReadOnlyRuntimeConfigDir(agent.Runtime, payload.RuntimeConfigDir)
 	}
 	applyReadOnlySeat(readOnlySeat, runtimeConfigDir, &agent)
-	// A seat stages a credential SNAPSHOT. Record it when that snapshot is already
-	// expired, so a later auth failure is attributable to gitmoot's staging rather
-	// than read as a fresh OAuth problem. It never refuses: a runtime-auth
-	// rejection is a DEFERRABLE blocker (classifyOperationalBlocker plus the
-	// documented job.deferred), and the auth overlay this same commit injects
-	// means an expired snapshot is no longer decisive.
-	if diagnosis := readOnlySeatCredentialPreflight(agent, runtimeConfigDir, seatModelGatewayMode(w.ConfigHome), time.Now().UTC()); diagnosis != "" {
-		if eventErr := w.Store.AddJobEvent(ctx, db.JobEvent{JobID: job.ID, Kind: "readonly_seat_credential_expired", Message: diagnosis}); eventErr != nil {
-			writeLine(w.Stdout, "job %s readonly_seat_credential_expired event failed: %v", job.ID, eventErr)
+	// A seat stages a credential SNAPSHOT. Record it when already expired so a
+	// later auth failure is attributable to staging, not read as a fresh OAuth
+	// problem. It never refuses: runtime auth failures use the deferrable
+	// blocker path. Resolve the gateway decision and overlay only for read-only
+	// seats; evaluating them for every job performed avoidable config reads and
+	// let the diagnosis use a different predicate from the eventual wrapper.
+	if agent.ReadOnlySeat {
+		gatewayMode := seatModelGatewayMode(w.ConfigHome)
+		seatAuthOverlay, seatAuthErr := readOnlySeatRuntimeAuthEnv(w.ConfigHome, agent.Runtime, gatewayMode)
+		if seatAuthErr != nil {
+			writeLine(w.Stdout, "job %s read-only seat auth overlay unresolved: %v", job.ID, seatAuthErr)
+		}
+		if diagnosis := readOnlySeatCredentialPreflight(agent, runtimeConfigDir, gatewayMode, len(seatAuthOverlay) > 0, time.Now().UTC()); diagnosis != "" {
+			if eventErr := w.recordReadOnlySeatCredentialDiagnosis(ctx, job.ID, diagnosis); eventErr != nil {
+				writeLine(w.Stdout, "job %s %s event failed: %v", job.ID, readOnlySeatCredentialExpiredEvent, eventErr)
+			}
 		}
 	}
 	preflightRequest := runtime.RuntimeContractRequest{Plan: payload.Plan}
@@ -795,61 +802,33 @@ func (w jobWorker) run(ctx context.Context, job db.Job) error {
 		meta := cockpitJobMeta(job, payload, agent, deliveryCheckout, policy.CockpitPaneKey)
 		seatMode := policy.CockpitPaneKey == config.CockpitPaneKeySeat
 		// Only when the cockpit will actually wrap (herdr available) do we tee the
-		// child's live output into a log the pane tails (Task 6). The tee rebuilds
-		// the inner adapter with a group-kill-preserving TeeRunner and sets
-		// meta.LogPath; on any log-setup failure it falls back to no LogPath (the P0
-		// `job watch` pane). The non-cockpit / unavailable paths never create a log
-		// file or tee — they stay byte-identical.
+		// child's live output into a log the pane tails. The writer is added to the
+		// already-composed adapter, so runtime auth, the read-only seat sandbox,
+		// gateway leases and pipeline progress all survive; the non-cockpit and
+		// cockpit-off paths create no log and stay byte-identical.
 		//
 		// Job mode uses a per-job truncate log removed when the job finishes. Seat
-		// mode (Task 7) uses a STABLE per-seat append log so the one seat pane tails
-		// one file that accumulates the seat's history across delegation rounds — it
-		// is opened O_APPEND and is NOT removed per job (it persists for the root's
-		// life and is torn down by FinalizeRoot).
+		// mode uses a STABLE per-seat append log so the one seat pane tails one file
+		// that accumulates across delegation rounds; it is removed by FinalizeRoot.
 		if maybeWrapCockpitAvailable(cp, payload.Cockpit, userOptedOff) {
 			if retainedLogFile != nil && !seatMode {
 				// Job-mode cockpit tails the canonical retained file. Presence alone
 				// never creates a pane; LogPath is set only inside this cockpit gate.
 				meta.LogPath = retainedLogPath
-			} else if retainedLogFile != nil && seatMode {
-				// Seat logs remain transient. Add the seat writer to the existing
-				// retained/progress runner chain without rebuilding the adapter.
-				seatPath, seatFile := w.cockpitSeatLogFile(cp, job.ID, meta.RootJobID, meta.PaneKey)
-				if seatFile != nil {
-					seatAdapter, seatErr := appendDeliveryAdapterOutput(adapter, seatFile)
-					if seatErr != nil {
-						_ = seatFile.Close()
-						writeLine(w.Stdout, "job %s cockpit seat tee build failed: %v", job.ID, seatErr)
-					} else {
-						adapter = seatAdapter
-						meta.LogPath = seatPath
-						defer func() { _ = seatFile.Close() }()
+			} else if teeAdapter, logPath, logFile := w.cockpitLogAdapter(cp, adapter, job.ID, meta.RootJobID, meta.PaneKey, seatMode); logFile != nil {
+				defer func() {
+					if err := logFile.Close(); err != nil {
+						writeLine(w.Stdout, "job %s cockpit log close failed: %v", job.ID, err)
 					}
-				}
-			} else {
-				var teeAdapter workflow.DeliveryAdapter
-				var logPath string
-				var logFile *os.File
-				if progressTracker != nil {
-					teeAdapter, logPath, logFile = w.cockpitLogAdapter(cp, agent, deliveryCheckout, job.ID, meta.RootJobID, meta.PaneKey, seatMode, progressTracker)
-				} else {
-					teeAdapter, logPath, logFile = w.cockpitLogAdapter(cp, agent, deliveryCheckout, job.ID, meta.RootJobID, meta.PaneKey, seatMode)
-				}
-				if logFile != nil {
-					defer func() {
-						if err := logFile.Close(); err != nil {
-							writeLine(w.Stdout, "job %s cockpit log close failed: %v", job.ID, err)
-						}
-						// Job mode: the per-job log only backs a per-job pane torn down with
-						// the job, so remove it. Seat mode: keep the append log — it backs the
-						// persisted seat pane and is removed on root finalize.
-						if !seatMode {
-							_ = os.Remove(logPath)
-						}
-					}()
-					adapter = teeAdapter
-					meta.LogPath = logPath
-				}
+					// Job mode: the per-job log only backs a per-job pane torn down with
+					// the job, so remove it. Seat mode: keep the append log — it backs the
+					// persisted seat pane and is removed on root finalize.
+					if !seatMode {
+						_ = os.Remove(logPath)
+					}
+				}()
+				adapter = teeAdapter
+				meta.LogPath = logPath
 			}
 		}
 		var unavailable bool
@@ -1565,6 +1544,13 @@ func applyReadOnlySeat(readOnlySeat bool, configDir string, agent *runtime.Agent
 	agent.ReadableFiles = nil
 }
 
+func selectedReadOnlyRuntimeConfigDir(runtimeName string, configuredDir string) string {
+	if configuredDir = strings.TrimSpace(configuredDir); configuredDir != "" {
+		return configuredDir
+	}
+	return selectedRuntimeConfigDir(runtimeName)
+}
+
 func selectedRuntimeConfigDir(runtimeName string) string {
 	switch runtimeName {
 	case runtime.ClaudeRuntime:
@@ -1636,33 +1622,20 @@ func readOnlyRuntimeSandboxGrants(home string, agent runtime.Agent, checkout str
 }
 
 func prepareReadOnlyRuntimeState(agent runtime.Agent, cacheRoot string, gatewayMode bool) (string, []string, error) {
-	userHome, err := os.UserHomeDir()
-	if err != nil {
-		return "", nil, fmt.Errorf("resolve read-only runtime state home: %w", err)
-	}
 	sourceDir := strings.TrimSpace(agent.RuntimeConfigDir)
 	var relativeState, credentialFile, credentialSection string
 	stateRoot := filepath.Join(cacheRoot, "runtime-state")
 	switch agent.Runtime {
 	case runtime.ClaudeRuntime:
-		if sourceDir == "" {
-			sourceDir = filepath.Join(userHome, ".claude")
-		}
 		relativeState = ".claude"
 		if !gatewayMode {
 			credentialFile = ".credentials.json"
 			credentialSection = "claudeAiOauth"
 		}
 	case runtime.CodexRuntime:
-		if sourceDir == "" {
-			sourceDir = filepath.Join(userHome, ".codex")
-		}
 		relativeState = ".codex"
 		credentialFile = "auth.json"
 	case runtime.KimiRuntime:
-		if sourceDir == "" {
-			sourceDir = filepath.Join(userHome, ".kimi-code")
-		}
 		// Kimi reads HOME/.kimi-code. The sandbox supplies HOME=cacheRoot/home,
 		// so stage its isolated profile at that exact path.
 		stateRoot = cacheRoot
@@ -1675,12 +1648,9 @@ func prepareReadOnlyRuntimeState(agent runtime.Agent, cacheRoot string, gatewayM
 	default:
 		return "", nil, fmt.Errorf("read-only seat runtime %q has no isolated state policy", agent.Runtime)
 	}
-	sourceDir, err = filepath.Abs(sourceDir)
+	sourceDir, err := resolveRuntimeConfigDir(agent.Runtime, sourceDir)
 	if err != nil {
-		return "", nil, fmt.Errorf("resolve runtime state directory %q: %w", sourceDir, err)
-	}
-	if resolved, resolveErr := filepath.EvalSymlinks(sourceDir); resolveErr == nil {
-		sourceDir = resolved
+		return "", nil, err
 	}
 	stateDir := filepath.Join(stateRoot, relativeState)
 	if err := os.RemoveAll(stateDir); err != nil {
@@ -1903,20 +1873,10 @@ func produceRuntimeSandboxGrants(runtimeName string, readable, readFiles, writab
 		// token since 2026-08-31, which yields exactly "OAuth session expired and
 		// could not be refreshed". Honor the configured dir and fall back only
 		// when none is set.
-		stateDir := strings.TrimSpace(os.Getenv("CLAUDE_CONFIG_DIR"))
+		stateDir := os.Getenv("CLAUDE_CONFIG_DIR")
 		if stateDir == "" {
 			stateDir = filepath.Join(home, ".claude")
 		}
-		// A landlock grant and a MkdirAll both need an ABSOLUTE path. A relative or
-		// ~-prefixed CLAUDE_CONFIG_DIR would otherwise grant a path relative to the
-		// worker's cwd and create a stray directory there (#1810 review, P3).
-		if strings.HasPrefix(stateDir, "~") {
-			stateDir = filepath.Join(home, strings.TrimPrefix(stateDir, "~"))
-		}
-		if absolute, absErr := filepath.Abs(stateDir); absErr == nil {
-			stateDir = absolute
-		}
-		stateDir = filepath.Clean(stateDir)
 		cacheRoot, err := os.UserCacheDir()
 		if err != nil {
 			return nil, nil, nil, nil, fmt.Errorf("resolve Claude cache root: %w", err)
@@ -2234,19 +2194,11 @@ func cockpitJobMeta(job db.Job, payload workflow.JobPayload, agent runtime.Agent
 	}
 }
 
-// cockpitTeeAdapter creates the per-job log the cockpit pane tails and rebuilds
-// the runtime adapter to tee the child's live stdout/stderr into it. It is called
-// ONLY on the wrapping path (herdr available), so non-cockpit and cockpit-off
-// jobs never create a log file or tee and stay byte-identical. The log lives at
-// <home>/logs/jobs/<jobid>.log and is created+truncated so each run starts fresh.
-// The tee uses a TeeRunner whose inner is GroupRunner{}, so process-group kill is
-// preserved and the buffered Result the adapter consumes is unchanged.
-//
-// It is fail-open: any failure (paths unresolved, mkdir, create, or an
-// unsupported runtime) returns a nil *os.File so the caller skips teeing and the
-// pane falls back to the P0 `job watch` command. The returned *os.File is the
-// caller's to Close after the job runs; when nil the adapter/path are ignored.
-func (w jobWorker) cockpitTeeAdapter(agent runtime.Agent, checkout string, jobID string, additionalOutput ...io.Writer) (workflow.DeliveryAdapter, string, *os.File) {
+// cockpitTeeAdapter creates the per-job log the cockpit pane tails and adds its
+// writer to the already-composed adapter. Composing in place preserves runtime
+// auth, read-only Landlock, isolated state, gateway leases, and progress output;
+// rebuilding from w.executionRunner discarded all of them.
+func (w jobWorker) cockpitTeeAdapter(adapter workflow.DeliveryAdapter, jobID string) (workflow.DeliveryAdapter, string, *os.File) {
 	paths, err := pathsFromFlag(w.ConfigHome)
 	if err != nil {
 		writeLine(w.Stdout, "job %s cockpit log path resolve failed: %v", jobID, err)
@@ -2257,11 +2209,6 @@ func (w jobWorker) cockpitTeeAdapter(agent runtime.Agent, checkout string, jobID
 		writeLine(w.Stdout, "job %s cockpit log dir create failed: %v", jobID, err)
 		return nil, "", nil
 	}
-	// Sanitize the job id into a flat, path-safe filename: delegation/continuation
-	// job ids contain '/' (e.g. "root/delegation/haiku-ocean", ".../continuation"),
-	// which would nest the log into dirs that are never created and fail os.Create →
-	// the live tail silently falls back to the P0 pane. A flat slug keeps it one
-	// file in this dir (no deep per-job dir trees).
 	logPath := filepath.Join(dir, cockpit.SafeLogName(jobID)+".log")
 	logFile, err := os.OpenFile(logPath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o600)
 	if err != nil {
@@ -2273,62 +2220,37 @@ func (w jobWorker) cockpitTeeAdapter(agent runtime.Agent, checkout string, jobID
 		writeLine(w.Stdout, "job %s cockpit log chmod failed: %v", jobID, err)
 		return nil, "", nil
 	}
-	return w.cockpitTeeOnFile(agent, checkout, jobID, logPath, logFile, additionalOutput...)
+	return w.cockpitTeeOnFile(adapter, jobID, logPath, logFile)
 }
 
-// cockpitTeeOnFile rebuilds the runtime adapter to tee the child's live
-// stdout/stderr into an already-open log file, shared by the per-job (truncate)
-// and per-seat (append) log paths. It is fail-open: an unsupported runtime closes
-// the file and returns nils so the caller falls back to the P0 pane.
-func (w jobWorker) cockpitTeeOnFile(agent runtime.Agent, checkout, jobID, logPath string, logFile *os.File, additionalOutput ...io.Writer) (workflow.DeliveryAdapter, string, *os.File) {
-	outputs := append([]io.Writer{logFile}, additionalOutput...)
-	inner := subprocess.StreamRunner(subprocess.GroupRunner{})
-	if w.executionRunner != nil {
-		stream, ok := w.executionRunner.(subprocess.StreamRunner)
-		if !ok {
-			_ = logFile.Close()
-			writeLine(w.Stdout, "job %s cockpit tee backend runner lacks streaming", jobID)
-			return nil, "", nil
-		}
-		inner = stream
-	}
-	adapter, err := buildRuntimeAdapter(w.ConfigHome, agent, checkout, subprocess.TeeRunner{Inner: inner, Out: runtimeOutputWriter(outputs...)})
+// cockpitTeeOnFile adds the log writer at the existing runner base. A
+// composition error closes the file and returns nils so the pane falls back to
+// `job watch` without replacing the working adapter.
+func (w jobWorker) cockpitTeeOnFile(adapter workflow.DeliveryAdapter, jobID, logPath string, logFile *os.File) (workflow.DeliveryAdapter, string, *os.File) {
+	teed, err := appendDeliveryAdapterOutput(adapter, logFile)
 	if err != nil {
-		// Unsupported runtime: this should never happen (AdapterFactory already
-		// built one above), but stay fail-open rather than leak the open file.
 		_ = logFile.Close()
 		writeLine(w.Stdout, "job %s cockpit tee adapter build failed: %v", jobID, err)
 		return nil, "", nil
 	}
-	return adapter, logPath, logFile
+	return teed, logPath, logFile
 }
 
-// cockpitLogAdapter picks the live-output log per PaneKeyMode (Task 7): seat mode
-// uses the stable per-seat append log so the one seat pane tails one accumulating
-// file across rounds; job mode keeps the per-job truncate log (byte-identical to
-// P1). It is called only on the wrapping path (herdr available); a nil *os.File
-// means fall back to the P0 pane.
-func (w jobWorker) cockpitLogAdapter(cp *cockpit.Cockpit, agent runtime.Agent, checkout, jobID, rootJobID, paneKey string, seatMode bool, additionalOutput ...io.Writer) (workflow.DeliveryAdapter, string, *os.File) {
+// cockpitLogAdapter picks the live-output log per PaneKeyMode: job mode uses a
+// per-job truncate log; seat mode uses one stable append log across rounds.
+func (w jobWorker) cockpitLogAdapter(cp *cockpit.Cockpit, adapter workflow.DeliveryAdapter, jobID, rootJobID, paneKey string, seatMode bool) (workflow.DeliveryAdapter, string, *os.File) {
 	if seatMode {
-		return w.cockpitSeatLogAdapter(cp, agent, checkout, jobID, rootJobID, paneKey, additionalOutput...)
+		return w.cockpitSeatLogAdapter(cp, adapter, jobID, rootJobID, paneKey)
 	}
-	return w.cockpitTeeAdapter(agent, checkout, jobID, additionalOutput...)
+	return w.cockpitTeeAdapter(adapter, jobID)
 }
 
-// cockpitSeatLogAdapter opens the stable per-seat append log the seat's one pane
-// tails across delegation rounds (Task 7) and tees the child's stdout/stderr into
-// it. The path is <home>/logs/seats/<rootShort>/<seatSlug>.log, opened O_APPEND so
-// each round's output accumulates rather than truncating the prior round's — no
-// tail re-pointing needed. The log is NOT removed per job; it persists for the
-// root's life and is removed by FinalizeRoot. It is fail-open: any failure
-// (unresolved path, mkdir, create, unsupported runtime) returns nils so the caller
-// falls back to the P0 pane.
-func (w jobWorker) cockpitSeatLogAdapter(cp *cockpit.Cockpit, agent runtime.Agent, checkout, jobID, rootJobID, paneKey string, additionalOutput ...io.Writer) (workflow.DeliveryAdapter, string, *os.File) {
+func (w jobWorker) cockpitSeatLogAdapter(cp *cockpit.Cockpit, adapter workflow.DeliveryAdapter, jobID, rootJobID, paneKey string) (workflow.DeliveryAdapter, string, *os.File) {
 	logPath, logFile := w.cockpitSeatLogFile(cp, jobID, rootJobID, paneKey)
 	if logFile == nil {
 		return nil, "", nil
 	}
-	return w.cockpitTeeOnFile(agent, checkout, jobID, logPath, logFile, additionalOutput...)
+	return w.cockpitTeeOnFile(adapter, jobID, logPath, logFile)
 }
 
 func (w jobWorker) cockpitSeatLogFile(cp *cockpit.Cockpit, jobID, rootJobID, paneKey string) (string, *os.File) {

--- a/internal/cli/daemon_worker.go
+++ b/internal/cli/daemon_worker.go
@@ -348,24 +348,6 @@ func (w jobWorker) run(ctx context.Context, job db.Job) error {
 		runtimeConfigDir = selectedReadOnlyRuntimeConfigDir(agent.Runtime, payload.RuntimeConfigDir)
 	}
 	applyReadOnlySeat(readOnlySeat, runtimeConfigDir, &agent)
-	// A seat stages a credential SNAPSHOT. Record it when already expired so a
-	// later auth failure is attributable to staging, not read as a fresh OAuth
-	// problem. It never refuses: runtime auth failures use the deferrable
-	// blocker path. Resolve the gateway decision and overlay only for read-only
-	// seats; evaluating them for every job performed avoidable config reads and
-	// let the diagnosis use a different predicate from the eventual wrapper.
-	if agent.ReadOnlySeat {
-		gatewayMode := seatModelGatewayMode(w.ConfigHome)
-		seatAuthOverlay, seatAuthErr := readOnlySeatRuntimeAuthEnv(w.ConfigHome, agent.Runtime, gatewayMode)
-		if seatAuthErr != nil {
-			writeLine(w.Stdout, "job %s read-only seat auth overlay unresolved: %v", job.ID, seatAuthErr)
-		}
-		if diagnosis := readOnlySeatCredentialPreflight(agent, runtimeConfigDir, gatewayMode, len(seatAuthOverlay) > 0, time.Now().UTC()); diagnosis != "" {
-			if eventErr := w.recordReadOnlySeatCredentialDiagnosis(ctx, job.ID, diagnosis); eventErr != nil {
-				writeLine(w.Stdout, "job %s %s event failed: %v", job.ID, readOnlySeatCredentialExpiredEvent, eventErr)
-			}
-		}
-	}
 	preflightRequest := runtime.RuntimeContractRequest{Plan: payload.Plan}
 	if result, checked, preflightErr := w.runtimeContractPreflight(ctx, execBackend, execConfig, agent, preflightRequest); preflightErr != nil {
 		if finishErr := w.finishQueuedJob(ctx, job, workflow.JobFailed, preflightErr); finishErr != nil {
@@ -721,6 +703,21 @@ func (w jobWorker) run(ctx context.Context, job db.Job) error {
 		}
 		_ = w.postJobResultComment(ctx, job.ID, agent, checkout, err)
 		return nil
+	}
+	// Diagnose the exact adapter credential domain that the seat wrapper below
+	// will use. Reading gateway config separately here could disagree with the
+	// already-built adapter and report a staged credential that will not exist.
+	if agent.ReadOnlySeat {
+		_, gatewayMode := adapter.(modelGatewayRuntimeAdapter)
+		seatAuthOverlay, seatAuthErr := readOnlySeatRuntimeAuthEnv(w.ConfigHome, agent.Runtime, gatewayMode)
+		if seatAuthErr != nil {
+			writeLine(w.Stdout, "job %s read-only seat auth overlay unresolved: %v", job.ID, seatAuthErr)
+		}
+		if diagnosis := readOnlySeatCredentialPreflight(agent, runtimeConfigDir, gatewayMode, len(seatAuthOverlay) > 0, time.Now().UTC()); diagnosis != "" {
+			if eventErr := w.recordReadOnlySeatCredentialDiagnosis(ctx, job.ID, diagnosis); eventErr != nil {
+				writeLine(w.Stdout, "job %s %s event failed: %v", job.ID, readOnlySeatCredentialExpiredEvent, eventErr)
+			}
+		}
 	}
 	adapter, err = wrapReadOnlySandboxAdapter(w.ConfigHome, agent, deliveryCheckout, adapter)
 	if err != nil {
@@ -1873,9 +1870,9 @@ func produceRuntimeSandboxGrants(runtimeName string, readable, readFiles, writab
 		// token since 2026-08-31, which yields exactly "OAuth session expired and
 		// could not be refreshed". Honor the configured dir and fall back only
 		// when none is set.
-		stateDir := os.Getenv("CLAUDE_CONFIG_DIR")
-		if stateDir == "" {
-			stateDir = filepath.Join(home, ".claude")
+		stateDir, err := resolveRuntimeConfigDir(runtime.ClaudeRuntime, os.Getenv("CLAUDE_CONFIG_DIR"))
+		if err != nil {
+			return nil, nil, nil, nil, err
 		}
 		cacheRoot, err := os.UserCacheDir()
 		if err != nil {

--- a/internal/cli/daemon_worker.go
+++ b/internal/cli/daemon_worker.go
@@ -714,7 +714,7 @@ func (w jobWorker) run(ctx context.Context, job db.Job) error {
 			_ = w.postJobResultComment(ctx, job.ID, agent, checkout, err)
 			return nil
 		}
-		defer os.RemoveAll(produceStateDir)
+		defer removeProduceRunStateDir(produceStateDir)
 	}
 	adapter, err = wrapProduceSandboxAdapter(job.Type, agent, adapter, produceStateDir)
 	if err != nil {
@@ -1876,6 +1876,58 @@ func pathsOverlap(left, right string) bool {
 type stagedProduceProfileFile struct {
 	source      string
 	destination string
+	// required marks a file whose presence-but-unusability is a dispatch
+	// failure rather than something to skip.
+	required bool
+}
+
+// stageProduceProfileFile copies one operator profile file into a job-private
+// profile. It differs from stageReadOnlyRuntimeCredential in two ways that the
+// produce path needs and the read-only seat path does not: it FOLLOWS SYMLINKS,
+// because dotfile managers symlink these files and rejecting a symlink would
+// deny produce to an ordinary host; and it distinguishes required from optional
+// files, so a malformed settings.json costs the operator their settings rather
+// than their job. Errors name the actual cause - file type and size are
+// separate messages, because reporting "too large" for a symlink sends the
+// reader after the wrong problem (#1810 review round 2).
+func stageProduceProfileFile(file stagedProduceProfileFile) error {
+	skip := func(err error) error {
+		if file.required {
+			return err
+		}
+		return nil
+	}
+	info, err := os.Stat(file.source)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil
+	}
+	if err != nil {
+		return skip(fmt.Errorf("inspect runtime profile file %q: %w", file.source, err))
+	}
+	if !info.Mode().IsRegular() {
+		return skip(fmt.Errorf("runtime profile file %q must be a regular file or a symlink to one, found %s", file.source, info.Mode().Type()))
+	}
+	if info.Size() > maxReadOnlyRuntimeStateFileBytes {
+		return skip(fmt.Errorf("runtime profile file %q is %d bytes, over the %d byte limit", file.source, info.Size(), maxReadOnlyRuntimeStateFileBytes))
+	}
+	data, err := os.ReadFile(file.source)
+	if err != nil {
+		return skip(fmt.Errorf("read runtime profile file %q: %w", file.source, err))
+	}
+	var object map[string]json.RawMessage
+	if err := json.Unmarshal(data, &object); err != nil || object == nil {
+		if err == nil {
+			err = errors.New("content must be a JSON object")
+		}
+		return skip(fmt.Errorf("validate runtime profile file %q: %w", file.source, err))
+	}
+	if err := os.MkdirAll(filepath.Dir(file.destination), 0o700); err != nil {
+		return fmt.Errorf("create job-private profile directory: %w", err)
+	}
+	if err := os.WriteFile(file.destination, data, 0o600); err != nil {
+		return fmt.Errorf("stage runtime profile file %q: %w", file.destination, err)
+	}
+	return nil
 }
 
 func produceRuntimeSandboxGrants(runtimeName string, runtimeStateDir string, readable, readFiles, writable []string) ([]string, []string, []string, []string, error) {
@@ -1924,12 +1976,23 @@ func produceRuntimeSandboxGrants(runtimeName string, runtimeStateDir string, rea
 			"CLAUDE_CONFIG_DIR=" + writeStateDir,
 			"XDG_CACHE_HOME=" + cacheHome,
 		}
-		for _, name := range []string{".credentials.json", "settings.json"} {
-			staged = append(staged, stagedProduceProfileFile{
-				source:      filepath.Join(configDir, name),
-				destination: filepath.Join(writeStateDir, name),
-			})
-		}
+		// .credentials.json decides WHICH ACCOUNT the job runs as, so a present
+		// but unusable one is worth failing loudly. settings.json is ordinary
+		// configuration the runtime has defaults for, so an unusable one is
+		// skipped rather than failing the dispatch: an operator whose dotfiles
+		// leave it empty, symlinked, or holding a non-object must not lose
+		// produce entirely (#1810 review round 2).
+		staged = append(staged,
+			stagedProduceProfileFile{
+				source:      filepath.Join(configDir, ".credentials.json"),
+				destination: filepath.Join(writeStateDir, ".credentials.json"),
+				required:    true,
+			},
+			stagedProduceProfileFile{
+				source:      filepath.Join(configDir, "settings.json"),
+				destination: filepath.Join(writeStateDir, "settings.json"),
+			},
+		)
 	case runtime.KimiRuntime:
 		statePaths = []string{filepath.Join(home, ".kimi-code")}
 	default:
@@ -1942,9 +2005,11 @@ func produceRuntimeSandboxGrants(runtimeName string, runtimeStateDir string, rea
 	}
 	// Staging runs in the daemon, outside the sandbox, so the operator profile
 	// needs no grant. A missing profile stages nothing and is not an error: a
-	// fresh host with no profile is a valid configuration.
+	// fresh host with no profile is a valid configuration, and neither is a
+	// symlinked one - dotfile managers (chezmoi, stow, yadm) symlink these
+	// files, so staging resolves symlinks rather than rejecting them.
 	for _, file := range staged {
-		if err := stageReadOnlyRuntimeCredential(file.source, file.destination, ""); err != nil {
+		if err := stageProduceProfileFile(file); err != nil {
 			return nil, nil, nil, nil, err
 		}
 	}
@@ -2708,7 +2773,7 @@ func (w jobWorker) runWithTempWorker(ctx context.Context, job db.Job, payload wo
 		if err != nil {
 			return err
 		}
-		defer os.RemoveAll(produceStateDir)
+		defer removeProduceRunStateDir(produceStateDir)
 	}
 	adapter, err = wrapProduceSandboxAdapter(delegatedJob.Type, started.Agent, adapter, produceStateDir)
 	if err != nil {
@@ -3749,13 +3814,27 @@ func buildLocalRuntimeAdapter(home string, agent runtime.Agent, checkout string,
 		return nil, err
 	}
 	gatewayRunner, _ := runner.(*credgw.Runner)
+	var produceRunDir string
 	if (len(agent.WritablePaths) > 0 || len(agent.ReadablePaths) > 0 || len(agent.ReadableFiles) > 0) && (agent.Runtime == runtime.ClaudeRuntime || agent.Runtime == runtime.KimiRuntime) {
-		runtimeStateDir, err := jobProduceRuntimeStateDir(home, "local:"+checkout+":"+agent.RuntimeRef, agent.Runtime)
+		runtimeStateRoot, err := jobProduceRuntimeStateDir(home, "local:"+checkout+":"+agent.RuntimeRef, agent.Runtime)
 		if err != nil {
 			return nil, err
 		}
+		runtimeStateDir := runtimeStateRoot
+		if runtimeStateRoot != "" {
+			// Same reason as the worker paths: the key is stable, so two
+			// dispatches for one checkout and runtime ref would otherwise share
+			// a root that each resets, and the second would wipe the first's
+			// live state (#1810 review round 2 measured exactly that).
+			runtimeStateDir, err = newProduceRunStateDir(runtimeStateRoot)
+			if err != nil {
+				return nil, err
+			}
+			produceRunDir = runtimeStateDir
+		}
 		reads, readFiles, writes, env, err := produceRuntimeSandboxGrants(agent.Runtime, runtimeStateDir, agent.ReadablePaths, agent.ReadableFiles, agent.WritablePaths)
 		if err != nil {
+			removeProduceRunStateDir(produceRunDir)
 			return nil, err
 		}
 		runner = landlockProduceRunner(runner, reads, readFiles, writes, env)
@@ -3773,9 +3852,44 @@ func buildLocalRuntimeAdapter(home string, agent runtime.Agent, checkout string,
 	case runtime.ShellRuntime:
 		adapter = runtime.ShellAdapter{Dir: checkout, Runner: runner}
 	default:
+		removeProduceRunStateDir(produceRunDir)
 		return nil, fmt.Errorf("unsupported runtime: %s", agent.Runtime)
 	}
-	return wrapModelGatewayAdapter(adapter, gatewayRunner), nil
+	// The local pipeline has no worker to defer cleanup, so bind it to the one
+	// lifecycle event this path does have: the delivery returning.
+	return produceRunStateCleanupAdapter(wrapModelGatewayAdapter(adapter, gatewayRunner), produceRunDir), nil
+}
+
+// removeProduceRunStateDir removes one dispatch's run directory and then tries
+// to reclaim the hashed job root with a NON-recursive remove: it succeeds
+// exactly when no sibling dispatch is live, which is the correct condition, and
+// otherwise leaves the sibling untouched. Without it the hashed parent survives
+// every job forever (#1810 review round 2 measured 5 empty roots after 5 jobs).
+func removeProduceRunStateDir(runDir string) {
+	if strings.TrimSpace(runDir) == "" {
+		return
+	}
+	if err := os.RemoveAll(runDir); err != nil {
+		return
+	}
+	_ = os.Remove(filepath.Dir(runDir))
+}
+
+type produceRunStateCleanupDeliveryAdapter struct {
+	inner  workflow.DeliveryAdapter
+	runDir string
+}
+
+func (a produceRunStateCleanupDeliveryAdapter) Deliver(ctx context.Context, agent runtime.Agent, job runtime.Job) (runtime.Result, error) {
+	defer removeProduceRunStateDir(a.runDir)
+	return a.inner.Deliver(ctx, agent, job)
+}
+
+func produceRunStateCleanupAdapter(inner workflow.DeliveryAdapter, runDir string) workflow.DeliveryAdapter {
+	if strings.TrimSpace(runDir) == "" {
+		return inner
+	}
+	return produceRunStateCleanupDeliveryAdapter{inner: inner, runDir: runDir}
 }
 
 func startRuntimeAdapterForBackend(backend execbackend.Backend, home string, runtimeName string, checkout string) (runtime.Adapter, error) {

--- a/internal/cli/daemon_worker.go
+++ b/internal/cli/daemon_worker.go
@@ -1647,7 +1647,7 @@ func prepareReadOnlyRuntimeState(agent runtime.Agent, cacheRoot string, gatewayM
 		relativeState = ".claude"
 		if !gatewayMode {
 			credentialFile = ".credentials.json"
-			credentialSection = "claudeAiOauth"
+			credentialSection = claudeCredentialSection
 		}
 	case runtime.CodexRuntime:
 		relativeState = ".codex"
@@ -1873,12 +1873,22 @@ func pathsOverlap(left, right string) bool {
 	return contains(left, right) || contains(right, left)
 }
 
+// claudeCredentialSection is the only key a Claude credential file needs to
+// carry an account. Both staging paths - the read-only seat and produce - narrow
+// to it, so a sibling secret in the operator's file cannot ride along.
+const claudeCredentialSection = "claudeAiOauth"
+
 type stagedProduceProfileFile struct {
 	source      string
 	destination string
 	// required marks a file whose presence-but-unusability is a dispatch
 	// failure rather than something to skip.
 	required bool
+	// section narrows the copy to one top-level JSON key. The read-only seat
+	// path has always narrowed its credential; produce copied the whole file,
+	// so a sibling key such as bedrockApiKey rode along into the job-private
+	// profile (#1810 review, round 3). Empty means copy the object whole.
+	section string
 }
 
 // stageProduceProfileFile copies one operator profile file into a job-private
@@ -1920,6 +1930,17 @@ func stageProduceProfileFile(file stagedProduceProfileFile) error {
 			err = errors.New("content must be a JSON object")
 		}
 		return skip(fmt.Errorf("validate runtime profile file %q: %w", file.source, err))
+	}
+	if file.section != "" {
+		value, ok := object[file.section]
+		if !ok {
+			return skip(fmt.Errorf("runtime profile file %q lacks required %q section", file.source, file.section))
+		}
+		narrowed, marshalErr := json.Marshal(map[string]json.RawMessage{file.section: value})
+		if marshalErr != nil {
+			return skip(fmt.Errorf("isolate runtime profile file %q: %w", file.source, marshalErr))
+		}
+		data = narrowed
 	}
 	if err := os.MkdirAll(filepath.Dir(file.destination), 0o700); err != nil {
 		return fmt.Errorf("create job-private profile directory: %w", err)
@@ -1987,6 +2008,9 @@ func produceRuntimeSandboxGrants(runtimeName string, runtimeStateDir string, rea
 				source:      filepath.Join(configDir, ".credentials.json"),
 				destination: filepath.Join(writeStateDir, ".credentials.json"),
 				required:    true,
+				// Narrowed to the OAuth section, matching the seat path: a
+				// produce job needs the account it runs as and nothing else.
+				section: claudeCredentialSection,
 			},
 			stagedProduceProfileFile{
 				source:      filepath.Join(configDir, "settings.json"),

--- a/internal/cli/daemon_worker.go
+++ b/internal/cli/daemon_worker.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"context"
+	"crypto/sha256"
 	"database/sql"
 	"encoding/json"
 	"errors"
@@ -696,7 +697,18 @@ func (w jobWorker) run(ctx context.Context, job db.Job) error {
 		}
 		writeLine(w.Stdout, "job %s tool cache grant failed: %v", job.ID, toolCacheErr)
 	}
-	adapter, err = wrapProduceSandboxAdapter(job.Type, agent, adapter)
+	produceStateDir, err := jobProduceRuntimeStateDir(w.ConfigHome, job.ID, agent.Runtime)
+	if err != nil {
+		if finishErr := w.finishQueuedJob(ctx, job, workflow.JobFailed, err); finishErr != nil {
+			return finishErr
+		}
+		_ = w.postJobResultComment(ctx, job.ID, agent, checkout, err)
+		return nil
+	}
+	if produceStateDir != "" {
+		defer os.RemoveAll(produceStateDir)
+	}
+	adapter, err = wrapProduceSandboxAdapter(job.Type, agent, adapter, produceStateDir)
 	if err != nil {
 		if finishErr := w.finishQueuedJob(ctx, job, workflow.JobFailed, err); finishErr != nil {
 			return finishErr
@@ -1352,20 +1364,20 @@ func (w jobWorker) recordProduceSandboxDiagnostic(ctx context.Context, jobID, ac
 // wrapProduceSandboxAdapter rewrites only Claude/Kimi produce adapters. Codex
 // keeps its existing native sandbox and every non-produce adapter is returned
 // byte-for-byte unchanged.
-func wrapProduceSandboxAdapter(action string, agent runtime.Agent, adapter workflow.DeliveryAdapter) (workflow.DeliveryAdapter, error) {
+func wrapProduceSandboxAdapter(action string, agent runtime.Agent, adapter workflow.DeliveryAdapter, runtimeStateDir string) (workflow.DeliveryAdapter, error) {
 	if strings.TrimSpace(action) != "produce" || agent.Runtime == runtime.CodexRuntime {
 		return adapter, nil
 	}
 	if agent.Runtime != runtime.ClaudeRuntime && agent.Runtime != runtime.KimiRuntime {
 		return adapter, nil
 	}
-	reads, readFiles, writes, env, err := produceRuntimeSandboxGrants(agent.Runtime, agent.ReadablePaths, agent.ReadableFiles, agent.WritablePaths)
+	reads, readFiles, writes, env, err := produceRuntimeSandboxGrants(agent.Runtime, runtimeStateDir, agent.ReadablePaths, agent.ReadableFiles, agent.WritablePaths)
 	if err != nil {
 		return nil, err
 	}
 	switch a := adapter.(type) {
 	case modelGatewayRuntimeAdapter:
-		wrapped, err := wrapProduceSandboxAdapter(action, agent, a.Adapter)
+		wrapped, err := wrapProduceSandboxAdapter(action, agent, a.Adapter, runtimeStateDir)
 		if err != nil {
 			return nil, err
 		}
@@ -1853,7 +1865,7 @@ func pathsOverlap(left, right string) bool {
 	return contains(left, right) || contains(right, left)
 }
 
-func produceRuntimeSandboxGrants(runtimeName string, readable, readFiles, writable []string) ([]string, []string, []string, []string, error) {
+func produceRuntimeSandboxGrants(runtimeName string, runtimeStateDir string, readable, readFiles, writable []string) ([]string, []string, []string, []string, error) {
 	home, err := os.UserHomeDir()
 	if err != nil {
 		return nil, nil, nil, nil, fmt.Errorf("resolve runtime state home: %w", err)
@@ -1863,24 +1875,27 @@ func produceRuntimeSandboxGrants(runtimeName string, readable, readFiles, writab
 	var env []string
 	switch runtimeName {
 	case runtime.ClaudeRuntime:
-		// An operator-set CLAUDE_CONFIG_DIR selects the ACCOUNT the engine runs
-		// as. Hard-coding $HOME/.claude here silently replaced it, so a daemon
-		// configured onto a live account still pointed produce jobs at a dead
-		// one: on this host /root/.claude has carried expiresAt 0 with no refresh
-		// token since 2026-08-31, which yields exactly "OAuth session expired and
-		// could not be refreshed". Honor the configured dir and fall back only
-		// when none is set.
-		stateDir, err := resolveRuntimeConfigDir(runtime.ClaudeRuntime, os.Getenv("CLAUDE_CONFIG_DIR"))
+		// CLAUDE_CONFIG_DIR selects the account the daemon must authenticate as,
+		// but it may name a live operator profile outside the job's intended
+		// write scope. Expose that profile read-only and redirect all granted
+		// runtime writes into the caller's job-private state root.
+		configDir, err := resolveRuntimeConfigDir(runtime.ClaudeRuntime, os.Getenv("CLAUDE_CONFIG_DIR"))
 		if err != nil {
 			return nil, nil, nil, nil, err
 		}
-		cacheRoot, err := os.UserCacheDir()
-		if err != nil {
-			return nil, nil, nil, nil, fmt.Errorf("resolve Claude cache root: %w", err)
+		if strings.TrimSpace(runtimeStateDir) == "" {
+			return nil, nil, nil, nil, errors.New("Claude produce requires a job-private runtime state root")
 		}
-		cacheDir := filepath.Join(cacheRoot, "claude-cli-nodejs")
-		statePaths = []string{stateDir, cacheDir}
-		env = []string{"CLAUDE_CONFIG_DIR=" + stateDir}
+		if err := os.RemoveAll(runtimeStateDir); err != nil {
+			return nil, nil, nil, nil, fmt.Errorf("reset Claude produce runtime state %q: %w", runtimeStateDir, err)
+		}
+		writeStateDir := filepath.Join(runtimeStateDir, ".claude")
+		cacheDir := filepath.Join(runtimeStateDir, "claude-cli-nodejs")
+		statePaths = []string{writeStateDir, cacheDir}
+		env = []string{"CLAUDE_CONFIG_DIR=" + configDir}
+		if configDir != writeStateDir {
+			readable = append(readable, configDir)
+		}
 	case runtime.KimiRuntime:
 		statePaths = []string{filepath.Join(home, ".kimi-code")}
 	default:
@@ -1895,6 +1910,18 @@ func produceRuntimeSandboxGrants(runtimeName string, readable, readFiles, writab
 	files := compactCleanPaths(readFiles)
 	writes := compactCleanPaths(append(append([]string(nil), writable...), statePaths...))
 	return reads, files, writes, env, nil
+}
+
+func jobProduceRuntimeStateDir(home, jobID, runtimeName string) (string, error) {
+	if runtimeName != runtime.ClaudeRuntime {
+		return "", nil
+	}
+	paths, err := pathsFromFlag(home)
+	if err != nil {
+		return "", fmt.Errorf("resolve produce runtime state root: %w", err)
+	}
+	sum := sha256.Sum256([]byte(strings.TrimSpace(jobID)))
+	return filepath.Join(paths.Home, "cache", "produce-runtime", fmt.Sprintf("%x", sum[:8])), nil
 }
 
 func compactCleanPaths(paths []string) []string {
@@ -2614,7 +2641,14 @@ func (w jobWorker) runWithTempWorker(ctx context.Context, job db.Job, payload wo
 	} else {
 		tempToolCacheEnv = env
 	}
-	adapter, err = wrapProduceSandboxAdapter(delegatedJob.Type, started.Agent, adapter)
+	produceStateDir, err := jobProduceRuntimeStateDir(w.ConfigHome, delegatedJob.ID, started.Agent.Runtime)
+	if err != nil {
+		return err
+	}
+	if produceStateDir != "" {
+		defer os.RemoveAll(produceStateDir)
+	}
+	adapter, err = wrapProduceSandboxAdapter(delegatedJob.Type, started.Agent, adapter, produceStateDir)
 	if err != nil {
 		if finishErr := w.finishQueuedJob(ctx, job, workflow.JobFailed, err); finishErr != nil {
 			return finishErr
@@ -3654,7 +3688,11 @@ func buildLocalRuntimeAdapter(home string, agent runtime.Agent, checkout string,
 	}
 	gatewayRunner, _ := runner.(*credgw.Runner)
 	if (len(agent.WritablePaths) > 0 || len(agent.ReadablePaths) > 0 || len(agent.ReadableFiles) > 0) && (agent.Runtime == runtime.ClaudeRuntime || agent.Runtime == runtime.KimiRuntime) {
-		reads, readFiles, writes, env, err := produceRuntimeSandboxGrants(agent.Runtime, agent.ReadablePaths, agent.ReadableFiles, agent.WritablePaths)
+		runtimeStateDir, err := jobProduceRuntimeStateDir(home, "local:"+checkout+":"+agent.RuntimeRef, agent.Runtime)
+		if err != nil {
+			return nil, err
+		}
+		reads, readFiles, writes, env, err := produceRuntimeSandboxGrants(agent.Runtime, runtimeStateDir, agent.ReadablePaths, agent.ReadableFiles, agent.WritablePaths)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/cli/daemon_worker.go
+++ b/internal/cli/daemon_worker.go
@@ -348,6 +348,22 @@ func (w jobWorker) run(ctx context.Context, job db.Job) error {
 		runtimeConfigDir = selectedRuntimeConfigDir(agent.Runtime)
 	}
 	applyReadOnlySeat(readOnlySeat, runtimeConfigDir, &agent)
+	// A seat stages a credential SNAPSHOT, so check the expiry it is about to
+	// copy BEFORE launching a runtime that can only fail on it. Provably
+	// unusable (expired, no refresh token) fails here; expired-but-refreshable
+	// records the fact so a later auth failure is not read as a fresh OAuth
+	// problem. See readonly_seat_credential.go for the measurement.
+	if credentialDiagnosis, credentialErr := readOnlySeatCredentialPreflight(agent, runtimeConfigDir, time.Now().UTC()); credentialErr != nil {
+		if finishErr := w.finishQueuedJob(ctx, job, workflow.JobFailed, credentialErr); finishErr != nil {
+			return finishErr
+		}
+		_ = w.postJobResultComment(ctx, job.ID, agent, "", credentialErr)
+		return nil
+	} else if credentialDiagnosis != "" {
+		if eventErr := w.Store.AddJobEvent(ctx, db.JobEvent{JobID: job.ID, Kind: "readonly_seat_credential_expired", Message: credentialDiagnosis}); eventErr != nil {
+			writeLine(w.Stdout, "job %s readonly_seat_credential_expired event failed: %v", job.ID, eventErr)
+		}
+	}
 	preflightRequest := runtime.RuntimeContractRequest{Plan: payload.Plan}
 	if result, checked, preflightErr := w.runtimeContractPreflight(ctx, execBackend, execConfig, agent, preflightRequest); preflightErr != nil {
 		if finishErr := w.finishQueuedJob(ctx, job, workflow.JobFailed, preflightErr); finishErr != nil {
@@ -1454,9 +1470,24 @@ func wrapReadOnlySandboxAdapter(home string, agent runtime.Agent, checkout strin
 	if err != nil {
 		return nil, err
 	}
+	// A seat's env is rebuilt from scratch, which DROPPED the runtime auth the
+	// non-seat path injects (runtimeJobRunnerWithAuth appends
+	// runtimeAuthInjectionEnv onto the curated BaseEnv). The seat was therefore
+	// left with nothing but its staged credential snapshot, and once that
+	// snapshot expired every claude review failed with "OAuth session expired and
+	// could not be refreshed" while `gitmoot auth probe claude` stayed green,
+	// because the probe reads the resolved auth the seat never received. Inject
+	// the same overlay here so a seat authenticates exactly like every other job.
+	// Gateway mode is excluded: there the gateway holds the credential and the
+	// seat is deliberately given none.
+	seatAuthEnv, err := readOnlySeatRuntimeAuthEnv(home, agent.Runtime, gatewayMode)
+	if err != nil {
+		return nil, err
+	}
 	wrap := func(runner subprocess.Runner) subprocess.Runner {
+		baseEnv := readOnlyRuntimeBaseEnv(agent.Runtime, os.Environ(), filepath.Join(grants.cacheRoot, "gh"))
 		curated := graftRuntimeBaseRunner(runner, subprocess.CuratedGroupRunner{
-			BaseEnv: readOnlyRuntimeBaseEnv(agent.Runtime, os.Environ(), filepath.Join(grants.cacheRoot, "gh")),
+			BaseEnv: append(baseEnv, seatAuthEnv...),
 		})
 		return landlockReadOnlyRunner(curated, grants.reads, grants.readFiles, grants.writes, grants.env)
 	}
@@ -1864,7 +1895,18 @@ func produceRuntimeSandboxGrants(runtimeName string, readable, readFiles, writab
 	var env []string
 	switch runtimeName {
 	case runtime.ClaudeRuntime:
-		stateDir := filepath.Join(home, ".claude")
+		// An operator-set CLAUDE_CONFIG_DIR selects the ACCOUNT the engine runs
+		// as. Hard-coding $HOME/.claude here silently replaced it, so a daemon
+		// configured onto a live account still pointed produce jobs at a dead
+		// one: on this host /root/.claude has carried expiresAt 0 with no refresh
+		// token since 2026-08-31, which yields exactly "OAuth session expired and
+		// could not be refreshed". Honor the configured dir and fall back only
+		// when none is set.
+		stateDir := strings.TrimSpace(os.Getenv("CLAUDE_CONFIG_DIR"))
+		if stateDir == "" {
+			stateDir = filepath.Join(home, ".claude")
+		}
+		stateDir = filepath.Clean(stateDir)
 		cacheRoot, err := os.UserCacheDir()
 		if err != nil {
 			return nil, nil, nil, nil, fmt.Errorf("resolve Claude cache root: %w", err)

--- a/internal/cli/daemon_worker.go
+++ b/internal/cli/daemon_worker.go
@@ -706,6 +706,14 @@ func (w jobWorker) run(ctx context.Context, job db.Job) error {
 		return nil
 	}
 	if produceStateDir != "" {
+		produceStateDir, err = newProduceRunStateDir(produceStateDir)
+		if err != nil {
+			if finishErr := w.finishQueuedJob(ctx, job, workflow.JobFailed, err); finishErr != nil {
+				return finishErr
+			}
+			_ = w.postJobResultComment(ctx, job.ID, agent, checkout, err)
+			return nil
+		}
 		defer os.RemoveAll(produceStateDir)
 	}
 	adapter, err = wrapProduceSandboxAdapter(job.Type, agent, adapter, produceStateDir)
@@ -1865,6 +1873,11 @@ func pathsOverlap(left, right string) bool {
 	return contains(left, right) || contains(right, left)
 }
 
+type stagedProduceProfileFile struct {
+	source      string
+	destination string
+}
+
 func produceRuntimeSandboxGrants(runtimeName string, runtimeStateDir string, readable, readFiles, writable []string) ([]string, []string, []string, []string, error) {
 	home, err := os.UserHomeDir()
 	if err != nil {
@@ -1873,12 +1886,17 @@ func produceRuntimeSandboxGrants(runtimeName string, runtimeStateDir string, rea
 	home = filepath.Clean(home)
 	var statePaths []string
 	var env []string
+	var staged []stagedProduceProfileFile
 	switch runtimeName {
 	case runtime.ClaudeRuntime:
-		// CLAUDE_CONFIG_DIR selects the account the daemon must authenticate as,
-		// but it may name a live operator profile outside the job's intended
-		// write scope. Expose that profile read-only and redirect all granted
-		// runtime writes into the caller's job-private state root.
+		// CLAUDE_CONFIG_DIR names the account the job must authenticate as, and
+		// it normally points at a live operator profile. The Claude CLI writes
+		// inside its own config dir during normal operation - settings, project
+		// state, statsig, and a refreshed OAuth token - so exposing that profile
+		// read-only denies writes the runtime needs, while exposing it writable
+		// lets a job mutate operator credentials. Stage the account into a
+		// job-private profile, point the runtime at that copy, and never expose
+		// the operator profile to the sandbox at all.
 		configDir, err := resolveRuntimeConfigDir(runtime.ClaudeRuntime, os.Getenv("CLAUDE_CONFIG_DIR"))
 		if err != nil {
 			return nil, nil, nil, nil, err
@@ -1890,11 +1908,19 @@ func produceRuntimeSandboxGrants(runtimeName string, runtimeStateDir string, rea
 			return nil, nil, nil, nil, fmt.Errorf("reset Claude produce runtime state %q: %w", runtimeStateDir, err)
 		}
 		writeStateDir := filepath.Join(runtimeStateDir, ".claude")
-		cacheDir := filepath.Join(runtimeStateDir, "claude-cli-nodejs")
-		statePaths = []string{writeStateDir, cacheDir}
-		env = []string{"CLAUDE_CONFIG_DIR=" + configDir}
-		if configDir != writeStateDir {
-			readable = append(readable, configDir)
+		// The CLI resolves its node cache under XDG_CACHE_HOME, so redirect the
+		// cache instead of granting write to the ambient one.
+		cacheHome := filepath.Join(runtimeStateDir, "xdg-cache")
+		statePaths = []string{writeStateDir, cacheHome}
+		env = []string{
+			"CLAUDE_CONFIG_DIR=" + writeStateDir,
+			"XDG_CACHE_HOME=" + cacheHome,
+		}
+		for _, name := range []string{".credentials.json", "settings.json"} {
+			staged = append(staged, stagedProduceProfileFile{
+				source:      filepath.Join(configDir, name),
+				destination: filepath.Join(writeStateDir, name),
+			})
 		}
 	case runtime.KimiRuntime:
 		statePaths = []string{filepath.Join(home, ".kimi-code")}
@@ -1904,6 +1930,14 @@ func produceRuntimeSandboxGrants(runtimeName string, runtimeStateDir string, rea
 	for _, path := range statePaths {
 		if err := os.MkdirAll(path, 0o700); err != nil {
 			return nil, nil, nil, nil, fmt.Errorf("create %s runtime state directory %q: %w", runtimeName, path, err)
+		}
+	}
+	// Staging runs in the daemon, outside the sandbox, so the operator profile
+	// needs no grant. A missing profile stages nothing and is not an error: a
+	// fresh host with no profile is a valid configuration.
+	for _, file := range staged {
+		if err := stageReadOnlyRuntimeCredential(file.source, file.destination, ""); err != nil {
+			return nil, nil, nil, nil, err
 		}
 	}
 	reads := compactCleanPaths(readable)
@@ -1922,6 +1956,22 @@ func jobProduceRuntimeStateDir(home, jobID, runtimeName string) (string, error) 
 	}
 	sum := sha256.Sum256([]byte(strings.TrimSpace(jobID)))
 	return filepath.Join(paths.Home, "cache", "produce-runtime", fmt.Sprintf("%x", sum[:8])), nil
+}
+
+// newProduceRunStateDir carves a directory unique to one dispatch out of a
+// job's produce state root. The root is keyed on the job id alone, so a lease
+// takeover or a deferral re-dispatch can run the same id twice at once; each
+// run resets its own directory at grant time and removes it when the job
+// finishes, and neither may touch a live sibling's state.
+func newProduceRunStateDir(root string) (string, error) {
+	if err := os.MkdirAll(root, 0o700); err != nil {
+		return "", fmt.Errorf("create produce runtime state root %q: %w", root, err)
+	}
+	dir, err := os.MkdirTemp(root, "run-")
+	if err != nil {
+		return "", fmt.Errorf("create produce runtime state directory under %q: %w", root, err)
+	}
+	return dir, nil
 }
 
 func compactCleanPaths(paths []string) []string {
@@ -2646,6 +2696,10 @@ func (w jobWorker) runWithTempWorker(ctx context.Context, job db.Job, payload wo
 		return err
 	}
 	if produceStateDir != "" {
+		produceStateDir, err = newProduceRunStateDir(produceStateDir)
+		if err != nil {
+			return err
+		}
 		defer os.RemoveAll(produceStateDir)
 	}
 	adapter, err = wrapProduceSandboxAdapter(delegatedJob.Type, started.Agent, adapter, produceStateDir)

--- a/internal/cli/doctor_seat_credential.go
+++ b/internal/cli/doctor_seat_credential.go
@@ -1,46 +1,111 @@
 package cli
 
 import (
+	"bytes"
 	"fmt"
 	"os"
 	"path/filepath"
+	"strconv"
+	"strings"
 	"time"
 
+	"github.com/gitmoot/gitmoot/internal/config"
 	"github.com/gitmoot/gitmoot/internal/doctor"
 	"github.com/gitmoot/gitmoot/internal/runtime"
 )
 
 const seatCredentialDoctorCheckName = "read-only seat credential"
 
+// seatCredentialSource is the config dir a read-only seat will stage from, plus
+// where that answer came from.
+type seatCredentialSource struct {
+	dir    string
+	origin string
+}
+
+// resolveSeatCredentialSource answers the question the outage turned on: which
+// credential do the DAEMON's seats stage?
+//
+// Reading the invoking shell's CLAUDE_CONFIG_DIR was the wrong instrument. The
+// documented failure was "the daemon runs with CLAUDE_CONFIG_DIR=/root/.claude-13
+// while a shell has none", so a shell-scoped read reports on a credential no
+// review job uses, which is the same false-green shape this check exists to
+// close (#1810 review, round 2). Prefer the live daemon's own environment, fall
+// back to this process, then to the host default, and always SAY which one was
+// used so the reader can tell an authoritative answer from a guess.
+func resolveSeatCredentialSource(paths config.Paths) seatCredentialSource {
+	if dir, ok := daemonEnvValue(paths, "CLAUDE_CONFIG_DIR"); ok && strings.TrimSpace(dir) != "" {
+		return seatCredentialSource{dir: strings.TrimSpace(dir), origin: "daemon CLAUDE_CONFIG_DIR"}
+	}
+	if dir := strings.TrimSpace(os.Getenv("CLAUDE_CONFIG_DIR")); dir != "" {
+		return seatCredentialSource{dir: dir, origin: "this shell's CLAUDE_CONFIG_DIR; the daemon's was unreadable"}
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return seatCredentialSource{}
+	}
+	return seatCredentialSource{dir: filepath.Join(home, ".claude"), origin: "host default"}
+}
+
+// daemonEnvValue reads one variable from the RUNNING daemon's environment. It is
+// best-effort by design: no daemon, no pidfile, or a kernel that denies
+// /proc/<pid>/environ all return false rather than an error, and the caller then
+// says which weaker source it fell back to.
+func daemonEnvValue(paths config.Paths, name string) (string, bool) {
+	if strings.TrimSpace(paths.Home) == "" {
+		return "", false
+	}
+	pid, _, err := currentDaemonPID(daemonProcessState(paths))
+	if err != nil || pid <= 0 {
+		return "", false
+	}
+	raw, err := daemonEnvironReader(pid)
+	if err != nil {
+		return "", false
+	}
+	return lookupEnvironValue(raw, name)
+}
+
+// daemonEnvironReader is the /proc seam: a test supplies an environ blob instead
+// of re-executing itself with a chosen environment.
+var daemonEnvironReader = func(pid int) ([]byte, error) {
+	return os.ReadFile(filepath.Join("/proc", strconv.Itoa(pid), "environ"))
+}
+
+// lookupEnvironValue reads one NUL-separated NAME=VALUE entry, the /proc
+// environ format. A value may legitimately contain '=' and must survive intact.
+func lookupEnvironValue(raw []byte, name string) (string, bool) {
+	prefix := name + "="
+	for _, entry := range bytes.Split(raw, []byte{0}) {
+		if text := string(entry); strings.HasPrefix(text, prefix) {
+			return strings.TrimPrefix(text, prefix), true
+		}
+	}
+	return "", false
+}
+
 // seatCredentialDoctorCheck reports the credential a READ-ONLY SEAT stages,
-// which is a different credential from the ambient one every existing check
+// which is a different credential from the ambient one every other check
 // measures.
 //
 // Measured 2026-09-03: `gitmoot doctor` and `gitmoot auth probe claude` were
 // both green for hours while every claude review and ask job failed, because
-// they probe the ambient token and the seat authenticates with a staged snapshot
-// of the configured config dir. The #1810 review called out that fixing only
-// `auth probe` left this half of the false green in place. A check that cannot
-// see the credential under test is worse than no check, because it is read as
-// evidence.
-func seatCredentialDoctorCheck() (doctor.Check, bool) {
-	sourceDir := selectedRuntimeConfigDir(runtime.ClaudeRuntime)
-	origin := "CLAUDE_CONFIG_DIR"
-	if sourceDir == "" {
-		home, err := os.UserHomeDir()
-		if err != nil {
-			return doctor.Check{}, false
-		}
-		sourceDir = filepath.Join(home, ".claude")
-		origin = "host default"
+// they probe the ambient token and a seat authenticates with a staged snapshot.
+// An UNUSABLE staged credential is Required, so `gitmoot doctor` EXITS NON-ZERO
+// on it: emitting it as a warning left automation gating on the exit code seeing
+// exactly the green it saw during the outage (#1810 review, round 2).
+func seatCredentialDoctorCheck(paths config.Paths) (doctor.Check, bool) {
+	source := resolveSeatCredentialSource(paths)
+	if source.dir == "" {
+		return doctor.Check{}, false
 	}
-	state, ok := inspectReadOnlySeatCredential(runtime.ClaudeRuntime, sourceDir)
+	state, ok := inspectReadOnlySeatCredential(runtime.ClaudeRuntime, source.dir)
 	if !ok {
 		return doctor.Check{
 			Name:     seatCredentialDoctorCheckName,
 			OK:       true,
 			Required: false,
-			Detail:   fmt.Sprintf("claude seat stages from %s (%s); no readable expiry, so nothing is asserted", sourceDir, origin),
+			Detail:   fmt.Sprintf("claude seat stages from %s (%s); no readable expiry, so nothing is asserted", source.dir, source.origin),
 		}, true
 	}
 	if !state.Expired(time.Now().UTC()) {
@@ -49,7 +114,7 @@ func seatCredentialDoctorCheck() (doctor.Check, bool) {
 			OK:       true,
 			Required: false,
 			Detail: fmt.Sprintf("claude seat credential declares expiry %s, not yet reached (%s); this reads a field and does not prove it authenticates",
-				state.ExpiresAt.Format(time.RFC3339), origin),
+				state.ExpiresAt.Format(time.RFC3339), source.origin),
 		}, true
 	}
 	expiry := "no expiry recorded (a failed refresh writes this)"
@@ -63,7 +128,7 @@ func seatCredentialDoctorCheck() (doctor.Check, bool) {
 	return doctor.Check{
 		Name:     seatCredentialDoctorCheckName,
 		OK:       false,
-		Required: false,
-		Detail:   fmt.Sprintf("claude seat credential is EXPIRED (%s, %s); %s", expiry, origin, remedy),
+		Required: true,
+		Detail:   fmt.Sprintf("claude seat credential is EXPIRED (%s, %s); %s", expiry, source.origin, remedy),
 	}, true
 }

--- a/internal/cli/doctor_seat_credential.go
+++ b/internal/cli/doctor_seat_credential.go
@@ -1,0 +1,69 @@
+package cli
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/gitmoot/gitmoot/internal/doctor"
+	"github.com/gitmoot/gitmoot/internal/runtime"
+)
+
+const seatCredentialDoctorCheckName = "read-only seat credential"
+
+// seatCredentialDoctorCheck reports the credential a READ-ONLY SEAT stages,
+// which is a different credential from the ambient one every existing check
+// measures.
+//
+// Measured 2026-09-03: `gitmoot doctor` and `gitmoot auth probe claude` were
+// both green for hours while every claude review and ask job failed, because
+// they probe the ambient token and the seat authenticates with a staged snapshot
+// of the configured config dir. The #1810 review called out that fixing only
+// `auth probe` left this half of the false green in place. A check that cannot
+// see the credential under test is worse than no check, because it is read as
+// evidence.
+func seatCredentialDoctorCheck() (doctor.Check, bool) {
+	sourceDir := selectedRuntimeConfigDir(runtime.ClaudeRuntime)
+	origin := "CLAUDE_CONFIG_DIR"
+	if sourceDir == "" {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return doctor.Check{}, false
+		}
+		sourceDir = filepath.Join(home, ".claude")
+		origin = "host default"
+	}
+	state, ok := inspectReadOnlySeatCredential(runtime.ClaudeRuntime, sourceDir)
+	if !ok {
+		return doctor.Check{
+			Name:     seatCredentialDoctorCheckName,
+			OK:       true,
+			Required: false,
+			Detail:   fmt.Sprintf("claude seat stages from %s (%s); no readable expiry, so nothing is asserted", sourceDir, origin),
+		}, true
+	}
+	if !state.Expired(time.Now().UTC()) {
+		return doctor.Check{
+			Name:     seatCredentialDoctorCheckName,
+			OK:       true,
+			Required: false,
+			Detail: fmt.Sprintf("claude seat credential declares expiry %s, not yet reached (%s); this reads a field and does not prove it authenticates",
+				state.ExpiresAt.Format(time.RFC3339), origin),
+		}, true
+	}
+	expiry := "no expiry recorded (a failed refresh writes this)"
+	if !state.ExpiresAt.IsZero() {
+		expiry = state.ExpiresAt.Format(time.RFC3339)
+	}
+	remedy := "re-login that account"
+	if state.Refreshable {
+		remedy = "the runtime must refresh it, and a seat discards the rotated token with the job"
+	}
+	return doctor.Check{
+		Name:     seatCredentialDoctorCheckName,
+		OK:       false,
+		Required: false,
+		Detail:   fmt.Sprintf("claude seat credential is EXPIRED (%s, %s); %s", expiry, origin, remedy),
+	}, true
+}

--- a/internal/cli/doctor_seat_credential.go
+++ b/internal/cli/doctor_seat_credential.go
@@ -99,13 +99,32 @@ func seatCredentialDoctorCheck(paths config.Paths) (doctor.Check, bool) {
 	if source.dir == "" {
 		return doctor.Check{}, false
 	}
+	// A seat's credential domain is decided by THREE inputs, and this check can
+	// see only one of them (#1810 review, round 3). Gateway mode means no
+	// snapshot is staged at all; a resolved auth overlay means the seat
+	// authenticates from the environment regardless of what the snapshot says;
+	// and a per-job payload.runtime_config_dir, recorded by whichever process
+	// dispatched the job, overrides the source entirely and is invisible here.
+	// So a non-zero exit is reserved for the one case this actually proves.
+	gatewayMode := seatModelGatewayModeForPaths(paths)
+	blindSpot := "this cannot see a per-job payload runtime_config_dir override, which the dispatching process records and the worker prefers"
+	if gatewayMode {
+		return doctor.Check{
+			Name:     seatCredentialDoctorCheckName,
+			OK:       true,
+			Required: false,
+			Detail:   fmt.Sprintf("claude runs through the model gateway, which holds the credential; no seat snapshot is staged, so nothing is asserted about %s (%s). %s", source.dir, source.origin, blindSpot),
+		}, true
+	}
+	overlay, overlayErr := readOnlySeatRuntimeAuthEnvForPaths(paths, runtime.ClaudeRuntime, gatewayMode)
+	haveOverlay := overlayErr == nil && len(overlay) > 0
 	state, ok := inspectReadOnlySeatCredential(runtime.ClaudeRuntime, source.dir)
 	if !ok {
 		return doctor.Check{
 			Name:     seatCredentialDoctorCheckName,
 			OK:       true,
 			Required: false,
-			Detail:   fmt.Sprintf("claude seat stages from %s (%s); no readable expiry, so nothing is asserted", source.dir, source.origin),
+			Detail:   fmt.Sprintf("claude seat stages from %s (%s); no readable expiry, so nothing is asserted. %s", source.dir, source.origin, blindSpot),
 		}, true
 	}
 	if !state.Expired(time.Now().UTC()) {
@@ -113,22 +132,39 @@ func seatCredentialDoctorCheck(paths config.Paths) (doctor.Check, bool) {
 			Name:     seatCredentialDoctorCheckName,
 			OK:       true,
 			Required: false,
-			Detail: fmt.Sprintf("claude seat credential declares expiry %s, not yet reached (%s); this reads a field and does not prove it authenticates",
-				state.ExpiresAt.Format(time.RFC3339), source.origin),
+			Detail: fmt.Sprintf("claude seat credential at %s (%s) declares expiry %s, not yet reached; this reads a field and does not prove it authenticates. %s",
+				source.dir, source.origin, state.ExpiresAt.Format(time.RFC3339), blindSpot),
 		}, true
 	}
 	expiry := "no expiry recorded (a failed refresh writes this)"
 	if !state.ExpiresAt.IsZero() {
 		expiry = state.ExpiresAt.Format(time.RFC3339)
 	}
-	remedy := "re-login that account"
+	if haveOverlay {
+		// The overlay is what the seat authenticates with; a dead snapshot beside
+		// a live overlay is untidy, not broken, and must not fail the exit code.
+		return doctor.Check{
+			Name:     seatCredentialDoctorCheckName,
+			OK:       false,
+			Required: false,
+			Detail: fmt.Sprintf("claude seat snapshot at %s (%s) is expired (%s), but a resolved runtime-auth overlay is present and is what a seat authenticates with; clean up the stale snapshot. %s",
+				source.dir, source.origin, expiry, blindSpot),
+		}, true
+	}
 	if state.Refreshable {
-		remedy = "the runtime must refresh it, and a seat discards the rotated token with the job"
+		return doctor.Check{
+			Name:     seatCredentialDoctorCheckName,
+			OK:       false,
+			Required: false,
+			Detail: fmt.Sprintf("claude seat credential at %s (%s) is expired (%s) but carries a refresh token; the runtime must refresh it, and a seat discards the rotated token with the job. %s",
+				source.dir, source.origin, expiry, blindSpot),
+		}, true
 	}
 	return doctor.Check{
 		Name:     seatCredentialDoctorCheckName,
 		OK:       false,
 		Required: true,
-		Detail:   fmt.Sprintf("claude seat credential is EXPIRED (%s, %s); %s", expiry, source.origin, remedy),
+		Detail: fmt.Sprintf("claude seat credential at %s (%s) is UNUSABLE: expired %s, no refresh token, no model gateway and no runtime-auth overlay, so every read-only seat job fails; re-login that account. %s",
+			source.dir, source.origin, expiry, blindSpot),
 	}, true
 }

--- a/internal/cli/doctor_seat_credential_test.go
+++ b/internal/cli/doctor_seat_credential_test.go
@@ -1,9 +1,14 @@
 package cli
 
 import (
+	"bytes"
+	"encoding/json"
+	"os"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/gitmoot/gitmoot/internal/config"
 )
 
 // doctor must report the credential a SEAT stages, not only the ambient one.
@@ -28,7 +33,7 @@ func TestSeatCredentialDoctorCheckReportsTheStagedCredential(t *testing.T) {
 			writeClaudeCredential(t, dir, test.expiresAt, test.refreshToken)
 			t.Setenv("CLAUDE_CONFIG_DIR", dir)
 
-			check, ok := seatCredentialDoctorCheck()
+			check, ok := seatCredentialDoctorCheck(config.Paths{})
 			if !ok {
 				t.Fatal("check must be emitted")
 			}
@@ -45,12 +50,12 @@ func TestSeatCredentialDoctorCheckReportsTheStagedCredential(t *testing.T) {
 // A file with no readable expiry must not produce a verdict either way.
 func TestSeatCredentialDoctorCheckAssertsNothingWithoutAnExpiry(t *testing.T) {
 	dir := t.TempDir()
-	if err := writeFileForTest(dir, `{"claudeAiOauth":{"accessToken":"host"}}`); err != nil {
+	if err := writeClaudeCredentialBody(dir, `{"claudeAiOauth":{"accessToken":"host"}}`); err != nil {
 		t.Fatal(err)
 	}
 	t.Setenv("CLAUDE_CONFIG_DIR", dir)
 
-	check, ok := seatCredentialDoctorCheck()
+	check, ok := seatCredentialDoctorCheck(config.Paths{})
 	if !ok || !check.OK {
 		t.Fatalf("check ok=%v OK=%v detail=%q", ok, check.OK, check.Detail)
 	}
@@ -61,5 +66,157 @@ func TestSeatCredentialDoctorCheckAssertsNothingWithoutAnExpiry(t *testing.T) {
 		if strings.Contains(check.Detail, forbidden) {
 			t.Fatalf("detail %q must not claim %q", check.Detail, forbidden)
 		}
+	}
+}
+
+// An UNUSABLE staged credential must fail doctor's exit code, not warn. Emitting
+// it as Required:false left automation gating on the exit code seeing exactly the
+// green it saw during the outage (#1810 review, round 2).
+func TestSeatCredentialDoctorCheckIsRequiredWhenUnusable(t *testing.T) {
+	dir := t.TempDir()
+	writeClaudeCredential(t, dir, 0, "")
+	t.Setenv("CLAUDE_CONFIG_DIR", dir)
+
+	check, ok := seatCredentialDoctorCheck(config.Paths{})
+	if !ok {
+		t.Fatal("check must be emitted")
+	}
+	if check.OK || !check.Required {
+		t.Fatalf("expired credential: OK=%v Required=%v, want a required failure", check.OK, check.Required)
+	}
+
+	// A live credential must NOT be required, so a healthy box cannot be failed
+	// by a field read that proves nothing.
+	live := t.TempDir()
+	writeClaudeCredential(t, live, time.Now().UTC().Add(8*time.Hour).UnixMilli(), "r")
+	t.Setenv("CLAUDE_CONFIG_DIR", live)
+	if check, ok := seatCredentialDoctorCheck(config.Paths{}); !ok || !check.OK || check.Required {
+		t.Fatalf("live credential: ok=%v OK=%v Required=%v", ok, check.OK, check.Required)
+	}
+}
+
+// The check must say WHERE its answer came from, so a reader can tell the
+// daemon's own environment from a shell-scoped guess.
+func TestSeatCredentialDoctorCheckNamesItsSource(t *testing.T) {
+	dir := t.TempDir()
+	writeClaudeCredential(t, dir, 0, "")
+	t.Setenv("CLAUDE_CONFIG_DIR", dir)
+
+	check, ok := seatCredentialDoctorCheck(config.Paths{})
+	if !ok {
+		t.Fatal("check must be emitted")
+	}
+	if !strings.Contains(check.Detail, "this shell") {
+		t.Fatalf("detail must name the weaker source it fell back to: %q", check.Detail)
+	}
+}
+
+// The check must be REGISTERED in `gitmoot doctor`, and an unusable staged
+// credential must make the command exit non-zero. Nothing asserted either, so a
+// mutant deleting the registration kept the suite green (#1810 review F8).
+func TestDoctorRegistersTheSeatCredentialCheck(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	dir := t.TempDir()
+	writeClaudeCredential(t, dir, 0, "")
+	t.Setenv("CLAUDE_CONFIG_DIR", dir)
+
+	var out bytes.Buffer
+	code := runDoctor([]string{"--json", "--home", home}, &out, &out)
+	var checks []struct {
+		Name     string `json:"name"`
+		Status   string `json:"status"`
+		Required bool   `json:"required"`
+		Detail   string `json:"detail"`
+	}
+	if err := json.Unmarshal(out.Bytes(), &checks); err != nil {
+		t.Fatalf("doctor --json: %v (%s)", err, out.String())
+	}
+	var seat *struct {
+		Name     string `json:"name"`
+		Status   string `json:"status"`
+		Required bool   `json:"required"`
+		Detail   string `json:"detail"`
+	}
+	for i := range checks {
+		if checks[i].Name == seatCredentialDoctorCheckName {
+			seat = &checks[i]
+		}
+	}
+	if seat == nil {
+		t.Fatalf("doctor did not emit the %q check; checks=%+v", seatCredentialDoctorCheckName, checks)
+	}
+	if seat.Status != "fail" || !seat.Required {
+		t.Fatalf("unusable staged credential reported as %q required=%v: %s", seat.Status, seat.Required, seat.Detail)
+	}
+	if code == 0 {
+		t.Fatal("doctor exited 0 with an unusable read-only seat credential")
+	}
+}
+
+// The DAEMON's CLAUDE_CONFIG_DIR decides which credential seats stage. Reading
+// the invoking shell's value reported on a credential no job uses, which is the
+// same false green relocated (#1810 review F4).
+func TestSeatCredentialDoctorCheckPrefersTheDaemonEnvironment(t *testing.T) {
+	home := t.TempDir()
+	paths, err := initializedPaths(home)
+	if err != nil {
+		t.Fatal(err)
+	}
+	state := daemonProcessState(paths)
+	if err := writeDaemonState(state, daemonMetaWithCurrentBuild(daemonMeta{
+		PID: os.Getpid(), Args: os.Args[1:], Executable: os.Args[0], LogFile: state.LogFile,
+	})); err != nil {
+		t.Fatal(err)
+	}
+
+	daemonDir := t.TempDir()
+	writeClaudeCredential(t, daemonDir, 0, "")
+	shellDir := t.TempDir()
+	writeClaudeCredential(t, shellDir, time.Now().UTC().Add(8*time.Hour).UnixMilli(), "r")
+	t.Setenv("CLAUDE_CONFIG_DIR", shellDir)
+
+	original := daemonEnvironReader
+	daemonEnvironReader = func(pid int) ([]byte, error) {
+		if pid != os.Getpid() {
+			t.Fatalf("read environ of pid %d, want the recorded daemon %d", pid, os.Getpid())
+		}
+		return []byte("PATH=/usr/bin\x00CLAUDE_CONFIG_DIR=" + daemonDir + "\x00HOME=/root\x00"), nil
+	}
+	t.Cleanup(func() { daemonEnvironReader = original })
+
+	check, ok := seatCredentialDoctorCheck(paths)
+	if !ok {
+		t.Fatal("check must be emitted")
+	}
+	if check.OK || !check.Required {
+		t.Fatalf("the daemon's dead credential was not reported: OK=%v required=%v detail=%q", check.OK, check.Required, check.Detail)
+	}
+	if !strings.Contains(check.Detail, "daemon CLAUDE_CONFIG_DIR") {
+		t.Fatalf("detail must name the daemon as its source: %q", check.Detail)
+	}
+
+	// An unreadable daemon environment falls back to this shell AND says so.
+	daemonEnvironReader = func(int) ([]byte, error) { return nil, os.ErrPermission }
+	fallback, ok := seatCredentialDoctorCheck(paths)
+	if !ok || !fallback.OK || !strings.Contains(fallback.Detail, "this shell") {
+		t.Fatalf("fallback check ok=%v OK=%v detail=%q", ok, fallback.OK, fallback.Detail)
+	}
+}
+
+// A /proc environ entry is NUL-separated and its value may contain '='.
+func TestLookupEnvironValueSplitsOnNULAndKeepsEquals(t *testing.T) {
+	raw := []byte("A=1\x00CLAUDE_CONFIG_DIR=/profiles/a=b\x00Z=9")
+	got, ok := lookupEnvironValue(raw, "CLAUDE_CONFIG_DIR")
+	if !ok || got != "/profiles/a=b" {
+		t.Fatalf("value = %q ok=%v, want the full value after the first '='", got, ok)
+	}
+	if _, ok := lookupEnvironValue(raw, "MISSING"); ok {
+		t.Fatal("an absent name must not report a value")
+	}
+	// A newline-separated blob is NOT the environ format: matching it would make
+	// the reader accept a file that is not /proc/<pid>/environ.
+	if _, ok := lookupEnvironValue([]byte("A=1\nCLAUDE_CONFIG_DIR=/x\n"), "CLAUDE_CONFIG_DIR"); ok {
+		t.Fatal("newline-separated text must not parse as environ")
 	}
 }

--- a/internal/cli/doctor_seat_credential_test.go
+++ b/internal/cli/doctor_seat_credential_test.go
@@ -32,8 +32,13 @@ func TestSeatCredentialDoctorCheckReportsTheStagedCredential(t *testing.T) {
 			dir := t.TempDir()
 			writeClaudeCredential(t, dir, test.expiresAt, test.refreshToken)
 			t.Setenv("CLAUDE_CONFIG_DIR", dir)
+			// The verdict now depends on the runtime-auth overlay and on gateway
+			// mode as well as on the snapshot, so both must be pinned here or the
+			// test reads whatever this host happens to export (#1810 round 3).
+			t.Setenv("CLAUDE_CODE_OAUTH_TOKEN", "")
+			t.Setenv("ANTHROPIC_API_KEY", "")
 
-			check, ok := seatCredentialDoctorCheck(config.Paths{})
+			check, ok := seatCredentialDoctorCheck(seatDoctorTestPaths(t, t.TempDir(), false))
 			if !ok {
 				t.Fatal("check must be emitted")
 			}
@@ -76,8 +81,12 @@ func TestSeatCredentialDoctorCheckIsRequiredWhenUnusable(t *testing.T) {
 	dir := t.TempDir()
 	writeClaudeCredential(t, dir, 0, "")
 	t.Setenv("CLAUDE_CONFIG_DIR", dir)
+	// The required failure is reserved for no-gateway AND no-overlay, so both
+	// must be pinned rather than inherited from the host (#1810 round 3).
+	t.Setenv("CLAUDE_CODE_OAUTH_TOKEN", "")
+	t.Setenv("ANTHROPIC_API_KEY", "")
 
-	check, ok := seatCredentialDoctorCheck(config.Paths{})
+	check, ok := seatCredentialDoctorCheck(seatDoctorTestPaths(t, t.TempDir(), false))
 	if !ok {
 		t.Fatal("check must be emitted")
 	}
@@ -120,6 +129,10 @@ func TestDoctorRegistersTheSeatCredentialCheck(t *testing.T) {
 	dir := t.TempDir()
 	writeClaudeCredential(t, dir, 0, "")
 	t.Setenv("CLAUDE_CONFIG_DIR", dir)
+	// The required failure is the no-gateway, no-overlay case; pin both rather
+	// than inheriting whatever this host exports (#1810 round 3).
+	t.Setenv("CLAUDE_CODE_OAUTH_TOKEN", "")
+	t.Setenv("ANTHROPIC_API_KEY", "")
 
 	var out bytes.Buffer
 	code := runDoctor([]string{"--json", "--home", home}, &out, &out)
@@ -175,6 +188,8 @@ func TestSeatCredentialDoctorCheckPrefersTheDaemonEnvironment(t *testing.T) {
 	shellDir := t.TempDir()
 	writeClaudeCredential(t, shellDir, time.Now().UTC().Add(8*time.Hour).UnixMilli(), "r")
 	t.Setenv("CLAUDE_CONFIG_DIR", shellDir)
+	t.Setenv("CLAUDE_CODE_OAUTH_TOKEN", "")
+	t.Setenv("ANTHROPIC_API_KEY", "")
 
 	original := daemonEnvironReader
 	daemonEnvironReader = func(pid int) ([]byte, error) {

--- a/internal/cli/doctor_seat_credential_test.go
+++ b/internal/cli/doctor_seat_credential_test.go
@@ -1,0 +1,65 @@
+package cli
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+// doctor must report the credential a SEAT stages, not only the ambient one.
+// Measured 2026-09-03: doctor and auth probe were both green for hours while
+// every claude review and ask job failed, because they probe the ambient token
+// and a seat authenticates with a staged snapshot of the configured config dir.
+// The #1810 review flagged that fixing only auth probe left half the false
+// green in place.
+func TestSeatCredentialDoctorCheckReportsTheStagedCredential(t *testing.T) {
+	for name, test := range map[string]struct {
+		expiresAt    int64
+		refreshToken string
+		wantOK       bool
+		wantPhrase   string
+	}{
+		"expired without refresh": {expiresAt: 0, refreshToken: "", wantOK: false, wantPhrase: "re-login that account"},
+		"expired with refresh":    {expiresAt: time.Now().UTC().Add(-time.Hour).UnixMilli(), refreshToken: "r", wantOK: false, wantPhrase: "discards the rotated token"},
+		"live":                    {expiresAt: time.Now().UTC().Add(8 * time.Hour).UnixMilli(), refreshToken: "r", wantOK: true, wantPhrase: "does not prove it authenticates"},
+	} {
+		t.Run(name, func(t *testing.T) {
+			dir := t.TempDir()
+			writeClaudeCredential(t, dir, test.expiresAt, test.refreshToken)
+			t.Setenv("CLAUDE_CONFIG_DIR", dir)
+
+			check, ok := seatCredentialDoctorCheck()
+			if !ok {
+				t.Fatal("check must be emitted")
+			}
+			if check.OK != test.wantOK {
+				t.Fatalf("check.OK = %v, want %v (detail %q)", check.OK, test.wantOK, check.Detail)
+			}
+			if !strings.Contains(check.Detail, test.wantPhrase) {
+				t.Fatalf("detail %q must contain %q", check.Detail, test.wantPhrase)
+			}
+		})
+	}
+}
+
+// A file with no readable expiry must not produce a verdict either way.
+func TestSeatCredentialDoctorCheckAssertsNothingWithoutAnExpiry(t *testing.T) {
+	dir := t.TempDir()
+	if err := writeFileForTest(dir, `{"claudeAiOauth":{"accessToken":"host"}}`); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("CLAUDE_CONFIG_DIR", dir)
+
+	check, ok := seatCredentialDoctorCheck()
+	if !ok || !check.OK {
+		t.Fatalf("check ok=%v OK=%v detail=%q", ok, check.OK, check.Detail)
+	}
+	if !strings.Contains(check.Detail, "nothing is asserted") {
+		t.Fatalf("detail %q must say it asserts nothing", check.Detail)
+	}
+	for _, forbidden := range []string{"EXPIRED", "declares expiry"} {
+		if strings.Contains(check.Detail, forbidden) {
+			t.Fatalf("detail %q must not claim %q", check.Detail, forbidden)
+		}
+	}
+}

--- a/internal/cli/isolated_tool_cache_test.go
+++ b/internal/cli/isolated_tool_cache_test.go
@@ -284,7 +284,7 @@ func TestFreshIsolatedProduceRunnerStreamsInjectedEnvAndPID(t *testing.T) {
 	if err != nil {
 		t.Fatalf("applyIsolatedToolCacheGrants: %v", err)
 	}
-	adapter, err = wrapProduceSandboxAdapter("produce", agent, adapter)
+	adapter, err = wrapProduceSandboxAdapter("produce", agent, adapter, t.TempDir())
 	if err != nil {
 		t.Fatalf("wrapProduceSandboxAdapter: %v", err)
 	}

--- a/internal/cli/job_blocker_auth_probe.go
+++ b/internal/cli/job_blocker_auth_probe.go
@@ -3,12 +3,15 @@ package cli
 import (
 	"context"
 	"encoding/json"
+	"os"
+	"path/filepath"
 	"strings"
 	"time"
 
 	"github.com/gitmoot/gitmoot/internal/db"
 	"github.com/gitmoot/gitmoot/internal/execbackend"
 	"github.com/gitmoot/gitmoot/internal/runtime"
+	"github.com/gitmoot/gitmoot/internal/subprocess"
 	"github.com/gitmoot/gitmoot/internal/workflow"
 )
 
@@ -127,7 +130,19 @@ func (w jobWorker) authProbeDedupKey(ctx context.Context, job db.Job, payload wo
 		return "agent:" + job.Agent
 	}
 	agent := applyJobRuntimeOverride(runtimeAgent(record), payload)
-	return "runtime:" + strings.TrimSpace(agent.Runtime)
+	key := "runtime:" + strings.TrimSpace(agent.Runtime)
+	// A READ-ONLY SEAT authenticates with a staged snapshot of its effective
+	// config dir, not with the ambient credential. Include the selected default
+	// as well as an explicit payload value so changing the daemon's account
+	// cannot reuse a cached verdict from the prior account.
+	if payload.ReadOnlySeat {
+		configDir := selectedReadOnlyRuntimeConfigDir(agent.Runtime, payload.RuntimeConfigDir)
+		if resolved, resolveErr := resolveRuntimeConfigDir(agent.Runtime, configDir); resolveErr == nil {
+			configDir = resolved
+		}
+		key += ":seat:" + configDir
+	}
+	return key
 }
 
 // extendAuthBlockerHold pushes a runtime_auth deferral's earliest-retry-at forward
@@ -145,11 +160,10 @@ func (w jobWorker) extendAuthBlockerHold(ctx context.Context, job db.Job, payloa
 	_ = w.Store.UpdateJobPayload(ctx, job.ID, string(encoded))
 }
 
-// defaultAuthProbe is the daemon's live credential probe. It probes the EFFECTIVE
-// runtime the re-dispatch would use (the agent's runtime, honoring a per-job
-// runtime override): claude gets a bounded live runtime.ClaudeLiveCheck classified
-// SET-vs-VALID; every other runtime has no wired live probe, so it returns Unknown
-// and the coarse cadence stays in charge.
+// defaultAuthProbe probes the credential domain the held job will actually use.
+// Non-seat Claude jobs use runtimeJobRunnerWithAuth; read-only seats use a
+// disposable copy of their configured credential plus the resolved auth
+// overlay. Other runtimes remain Unknown.
 func (w jobWorker) defaultAuthProbe(ctx context.Context, job db.Job, payload workflow.JobPayload) authProbeVerdict {
 	record, err := w.Store.GetAgent(ctx, job.Agent)
 	if err != nil {
@@ -162,20 +176,76 @@ func (w jobWorker) defaultAuthProbe(ctx context.Context, job db.Job, payload wor
 	jobBackend, jobBackendPresent := payload.ExecBackendOverride()
 	backend, _, err := daemonJobExecBackendFor(w, jobBackend, jobBackendPresent)
 	if err != nil {
-		// run() owns the loud terminal selector failure. This scheduler gate is
-		// advisory; an unresolved backend must not launch a host probe, and Unknown
-		// lets the queued job reach run() where the canonical error is persisted.
 		return authProbeUnknown
 	}
 	verdict, err := authProbeForBackend(backend, func() authProbeVerdict {
 		probeCtx, cancel := context.WithTimeout(ctx, authProbeTimeout)
 		defer cancel()
-		return classifyClaudeAuthProbe(runtime.ClaudeLiveCheck(probeCtx, nil, ""))
+		if payload.ReadOnlySeat {
+			return w.probeReadOnlySeatClaudeAuth(probeCtx, agent, payload)
+		}
+		runner, _, _, err := runtimeJobRunnerWithAuth(w.ConfigHome, runtime.ClaudeRuntime, nil)
+		if err != nil {
+			return authProbeUnknown
+		}
+		return classifyClaudeAuthProbe(claudeAuthLiveCheck(probeCtx, runner, "", nil))
 	})
 	if err != nil {
 		return authProbeUnknown
 	}
 	return verdict
+}
+
+var claudeAuthLiveCheck = runtime.ClaudeLiveCheckEnv
+
+func (w jobWorker) probeReadOnlySeatClaudeAuth(ctx context.Context, agent runtime.Agent, payload workflow.JobPayload) authProbeVerdict {
+	gatewayMode := seatModelGatewayMode(w.ConfigHome)
+	if gatewayMode {
+		runner, _, _, err := runtimeJobRunnerWithAuth(w.ConfigHome, runtime.ClaudeRuntime, nil)
+		if err != nil {
+			return authProbeUnknown
+		}
+		return classifyClaudeAuthProbe(claudeAuthLiveCheck(ctx, runner, "", nil))
+	}
+	cacheRoot, err := os.MkdirTemp("", "gitmoot-seat-auth-probe-*")
+	if err != nil {
+		return authProbeUnknown
+	}
+	defer os.RemoveAll(cacheRoot)
+	agent.ReadOnlySeat = true
+	agent.RuntimeConfigDir = selectedReadOnlyRuntimeConfigDir(agent.Runtime, payload.RuntimeConfigDir)
+	stateDir, stateEnv, err := prepareReadOnlyRuntimeState(agent, cacheRoot, false)
+	if err != nil {
+		return authProbeUnknown
+	}
+	overlay, err := readOnlySeatRuntimeAuthEnv(w.ConfigHome, agent.Runtime, false)
+	if err != nil {
+		return authProbeUnknown
+	}
+	probeHome := filepath.Join(cacheRoot, "home")
+	probeTmp := filepath.Join(cacheRoot, "tmp")
+	for _, dir := range []string{probeHome, probeTmp} {
+		if err := os.MkdirAll(dir, 0o700); err != nil {
+			return authProbeUnknown
+		}
+	}
+	baseEnv := readOnlyRuntimeBaseEnv(agent.Runtime, os.Environ(), filepath.Join(cacheRoot, "gh"))
+	baseEnv = append(baseEnv, stateEnv...)
+	baseEnv = append(baseEnv,
+		"HOME="+probeHome,
+		"XDG_CONFIG_HOME="+filepath.Join(cacheRoot, "xdg-config"),
+		"XDG_CACHE_HOME="+filepath.Join(cacheRoot, "xdg-cache"),
+		"XDG_DATA_HOME="+filepath.Join(cacheRoot, "xdg-data"),
+		"XDG_STATE_HOME="+filepath.Join(cacheRoot, "xdg-state"),
+		"TMPDIR="+probeTmp,
+		"TMP="+probeTmp,
+		"TEMP="+probeTmp,
+	)
+	baseEnv = append(baseEnv, overlay...)
+	if stateDir == "" {
+		return authProbeUnknown
+	}
+	return classifyClaudeAuthProbe(claudeAuthLiveCheck(ctx, subprocess.CuratedGroupRunner{BaseEnv: baseEnv}, "", nil))
 }
 
 func authProbeForBackend(backend execbackend.Backend, local func() authProbeVerdict) (authProbeVerdict, error) {

--- a/internal/cli/pipeline_progress_test.go
+++ b/internal/cli/pipeline_progress_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/gitmoot/gitmoot/internal/db"
 	"github.com/gitmoot/gitmoot/internal/pipeline"
 	"github.com/gitmoot/gitmoot/internal/runtime"
+	"github.com/gitmoot/gitmoot/internal/subprocess"
 	"github.com/gitmoot/gitmoot/internal/transcript"
 )
 
@@ -78,7 +79,13 @@ func TestCockpitAndProgressShareRuntimeOutput(t *testing.T) {
 	worker := defaultJobWorker(daemonWorkerStore(t), io.Discard, home)
 	agent := runtime.Agent{Name: "lead", Role: "builder", Runtime: runtime.ShellRuntime, RuntimeRef: "echo shared-line"}
 	tracker := &pipelineProgressLineTracker{}
-	adapter, logPath, logFile := worker.cockpitTeeAdapter(agent, t.TempDir(), "job-shared", tracker)
+	// Progress output is attached when the adapter is built, so the cockpit tee
+	// must ADD its writer to that adapter rather than rebuild it.
+	progressAdapter, err := appendDeliveryAdapterOutput(runtime.ShellAdapter{Runner: subprocess.GroupRunner{}}, tracker)
+	if err != nil {
+		t.Fatal(err)
+	}
+	adapter, logPath, logFile := worker.cockpitTeeAdapter(progressAdapter, "job-shared")
 	if logFile == nil {
 		t.Fatal("expected cockpit log")
 	}

--- a/internal/cli/readonly_seat_credential.go
+++ b/internal/cli/readonly_seat_credential.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -10,6 +11,7 @@ import (
 	"time"
 
 	"github.com/gitmoot/gitmoot/internal/config"
+	"github.com/gitmoot/gitmoot/internal/db"
 	"github.com/gitmoot/gitmoot/internal/runtime"
 )
 
@@ -62,19 +64,9 @@ func (s readOnlySeatCredentialState) Expired(now time.Time) bool {
 // preflight then has nothing to assert, which is the honest outcome rather than
 // a guess about a format gitmoot has not measured.
 func readOnlySeatCredentialStatePath(runtimeName string, sourceDir string) string {
-	sourceDir = strings.TrimSpace(sourceDir)
-	if sourceDir == "" {
+	sourceDir, err := resolveRuntimeConfigDir(runtimeName, sourceDir)
+	if err != nil || sourceDir == "" {
 		return ""
-	}
-	// Resolve exactly as prepareReadOnlyRuntimeState does before staging:
-	// absolute, then symlinks evaluated. Reading a DIFFERENT path from the one
-	// that gets staged would let this report on a file the seat never uses, which
-	// the #1810 review flagged.
-	if absolute, err := filepath.Abs(sourceDir); err == nil {
-		sourceDir = absolute
-	}
-	if resolved, err := filepath.EvalSymlinks(sourceDir); err == nil {
-		sourceDir = resolved
 	}
 	switch runtimeName {
 	case runtime.ClaudeRuntime:
@@ -149,7 +141,7 @@ func inspectReadOnlySeatCredential(runtimeName string, sourceDir string) (readOn
 // gitmoot staged an expired credential and from where, instead of leaving the
 // reader with the runtime's own "OAuth session expired" wording. Gateway mode
 // stages no credential file at all, so there is nothing to diagnose there.
-func readOnlySeatCredentialPreflight(agent runtime.Agent, sourceDir string, gatewayMode bool, now time.Time) string {
+func readOnlySeatCredentialPreflight(agent runtime.Agent, sourceDir string, gatewayMode bool, haveOverlay bool, now time.Time) string {
 	if !agent.ReadOnlySeat || gatewayMode {
 		return ""
 	}
@@ -165,15 +157,27 @@ func readOnlySeatCredentialPreflight(agent runtime.Agent, sourceDir string, gate
 	if state.Refreshable {
 		refresh = "and must be refreshed by the runtime to work on its own"
 	}
+	// Only claim the overlay when one was actually resolved. Asserting it
+	// unconditionally was false on any host with no runtime-auth.env and no
+	// ambient credentials, which is precisely the host this diagnosis matters on
+	// (#1810 review, round 2).
+	fallback := "and NO resolved runtime auth was available to the seat, so this staged credential is all it has"
+	if haveOverlay {
+		fallback = "and the seat also carries the resolved runtime auth, so this is context for any later auth failure rather than a refusal"
+	}
 	return fmt.Sprintf(
-		"read-only seat staged an expired %s credential (expired %s) %s; the seat also carries the resolved runtime auth, so this is context for any later auth failure rather than a refusal",
-		agent.Runtime, expiry, refresh,
+		"read-only seat staged an expired %s credential (expired %s) %s; %s",
+		agent.Runtime, expiry, refresh, fallback,
 	)
 }
 
-// readOnlySeatRuntimeAuthEnv resolves the runtime auth a seat must carry. It is
-// the same overlay runtimeJobRunnerWithAuth injects for every other job; the
-// seat path rebuilt its environment and silently dropped it.
+// readOnlySeatRuntimeAuthEnv resolves the runtime auth a seat must carry: the
+// same overlay runtimeJobRunnerWithAuth injects for every other job, which the
+// seat path rebuilt its environment without.
+//
+// It bootstraps first, exactly as runtimeJobRunnerWithAuth does. Reading
+// runtime-auth.env alone returned an empty overlay on a host that authenticates
+// from ambient credentials and had never written that file.
 func readOnlySeatRuntimeAuthEnv(home string, runtimeName string, gatewayMode bool) ([]string, error) {
 	if gatewayMode || runtimeName != runtime.ClaudeRuntime {
 		return nil, nil
@@ -182,6 +186,9 @@ func readOnlySeatRuntimeAuthEnv(home string, runtimeName string, gatewayMode boo
 	if err != nil {
 		return nil, fmt.Errorf("resolve read-only seat runtime auth paths: %w", err)
 	}
+	if _, err := bootstrapRuntimeAuth(paths.Home, runtimeAuthEnvLookup, runtimeAuthLogf); err != nil {
+		return nil, fmt.Errorf("bootstrap read-only seat runtime auth: %w", err)
+	}
 	state, err := loadRuntimeAuthFile(paths.Home)
 	if err != nil {
 		return nil, fmt.Errorf("load read-only seat runtime auth: %w", err)
@@ -189,43 +196,56 @@ func readOnlySeatRuntimeAuthEnv(home string, runtimeName string, gatewayMode boo
 	return runtimeAuthInjectionEnv(state), nil
 }
 
-// writeSeatCredentialProbe reports the credential a READ-ONLY SEAT would stage,
-// which is a different credential from the ambient one every probe measured
-// until now. Measured 2026-09-03: `gitmoot auth probe claude` and `gitmoot
-// doctor` were green for hours while every claude review job failed, because
-// the seat staged /root/.claude/.credentials.json (expiresAt 0, refresh
-// rejected) and the probe never looked at it. A green that cannot see the
-// credential under test is the false green this reports on.
-func writeSeatCredentialProbe(stdout io.Writer, home string) {
-	sourceDir := strings.TrimSpace(os.Getenv("CLAUDE_CONFIG_DIR"))
-	origin := "CLAUDE_CONFIG_DIR"
-	if sourceDir == "" {
-		userHome, err := os.UserHomeDir()
-		if err != nil {
-			writeLine(stdout, "read-only seat credential: unknown (cannot resolve the host home: %v)", err)
-			return
-		}
-		sourceDir = filepath.Join(userHome, ".claude")
-		origin = "host default"
+const readOnlySeatCredentialExpiredEvent = "readonly_seat_credential_expired"
+
+func (w jobWorker) recordReadOnlySeatCredentialDiagnosis(ctx context.Context, jobID, diagnosis string) error {
+	events, err := w.Store.ListJobEvents(ctx, jobID)
+	if err != nil {
+		return err
 	}
-	state, ok := inspectReadOnlySeatCredential(runtime.ClaudeRuntime, sourceDir)
+	for _, event := range events {
+		if event.Kind == readOnlySeatCredentialExpiredEvent {
+			return nil
+		}
+	}
+	return w.Store.AddJobEvent(ctx, db.JobEvent{
+		JobID: jobID, Kind: readOnlySeatCredentialExpiredEvent, Message: diagnosis,
+	})
+}
+
+// writeSeatCredentialProbe reports the credential a READ-ONLY SEAT would stage
+// and returns false only when that credential is known to be unusable. Unknown
+// expiry data and an expired credential with a refresh token remain non-failing:
+// neither proves the runtime will reject the credential.
+//
+// It resolves the source the same way the doctor check does, preferring the
+// DAEMON's own CLAUDE_CONFIG_DIR because the invoking shell may describe an
+// account no job uses.
+func writeSeatCredentialProbe(stdout io.Writer, paths config.Paths) bool {
+	source := resolveSeatCredentialSource(paths)
+	if source.dir == "" {
+		writeLine(stdout, "read-only seat credential: unknown (cannot resolve the seat config dir)")
+		return true
+	}
+	state, ok := inspectReadOnlySeatCredential(runtime.ClaudeRuntime, source.dir)
 	if !ok {
-		writeLine(stdout, "read-only seat credential (%s %s): no readable expiry; a seat stages what is there and the runtime decides", origin, sourceDir)
-		return
+		writeLine(stdout, "read-only seat credential (%s, %s): no readable expiry; a seat stages what is there and the runtime decides", source.dir, source.origin)
+		return true
 	}
 	if !state.Expired(time.Now().UTC()) {
-		writeLine(stdout, "read-only seat credential (%s): declares expiry %s, not yet reached; this reads a field and does not prove the credential authenticates", state.Source, state.ExpiresAt.Format(time.RFC3339))
-		return
+		writeLine(stdout, "read-only seat credential (%s, %s): declares expiry %s, not yet reached; this reads a field and does not prove the credential authenticates", state.Source, source.origin, state.ExpiresAt.Format(time.RFC3339))
+		return true
 	}
 	expiry := "no expiry recorded (a failed refresh writes this)"
 	if !state.ExpiresAt.IsZero() {
 		expiry = state.ExpiresAt.Format(time.RFC3339)
 	}
 	if state.Refreshable {
-		writeLine(stdout, "read-only seat credential (%s): EXPIRED %s, refresh token present; a seat must refresh it inside a disposable home, and the rotated token is discarded with the job", state.Source, expiry)
-		return
+		writeLine(stdout, "read-only seat credential (%s, %s): EXPIRED %s, refresh token present; a seat must refresh it inside a disposable home, and the rotated token is discarded with the job", state.Source, source.origin, expiry)
+		return true
 	}
-	writeLine(stdout, "read-only seat credential (%s): UNUSABLE, expired %s with no refresh token; every read-only seat job on this runtime will fail until that account is re-logged in", state.Source, expiry)
+	writeLine(stdout, "read-only seat credential (%s, %s): UNUSABLE, expired %s with no refresh token; every read-only seat job on this runtime will fail until that account is re-logged in", state.Source, source.origin, expiry)
+	return false
 }
 
 // seatModelGatewayMode reports whether claude deliveries run through the local
@@ -242,4 +262,50 @@ func seatModelGatewayMode(home string) bool {
 		return false
 	}
 	return cfg.ModelGateway
+}
+
+// resolveRuntimeConfigDir is the one path contract shared by every caller that
+// inspects, stages, or grants a runtime profile: the host default when unset,
+// current-user ~ expansion, symlinks resolved when the path exists.
+//
+// It REFUSES a relative or ~user path instead of repairing it. Both used to be
+// silently rewritten — a relative dir against the daemon's arbitrary working
+// directory (creating a stray profile there) and ~user under the CURRENT user's
+// home — so the engine granted, staged and inspected an account the operator
+// never named. That is the failure class this change exists to remove, so it
+// fails loudly with the configured value in the message.
+func resolveRuntimeConfigDir(runtimeName string, configuredDir string) (string, error) {
+	userHome, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("resolve runtime state home: %w", err)
+	}
+	dir := strings.TrimSpace(configuredDir)
+	if dir == "" {
+		switch runtimeName {
+		case runtime.ClaudeRuntime:
+			dir = filepath.Join(userHome, ".claude")
+		case runtime.CodexRuntime:
+			dir = filepath.Join(userHome, ".codex")
+		case runtime.KimiRuntime:
+			dir = filepath.Join(userHome, ".kimi-code")
+		default:
+			return "", nil
+		}
+	} else {
+		switch {
+		case dir == "~":
+			dir = userHome
+		case strings.HasPrefix(dir, "~/"):
+			dir = filepath.Join(userHome, strings.TrimPrefix(dir, "~/"))
+		case strings.HasPrefix(dir, "~"):
+			return "", fmt.Errorf("runtime state directory %q uses unsupported ~user expansion; name an absolute path", configuredDir)
+		}
+		if !filepath.IsAbs(dir) {
+			return "", fmt.Errorf("runtime state directory %q must be absolute; a relative path resolves against the daemon's working directory", configuredDir)
+		}
+	}
+	if resolved, resolveErr := filepath.EvalSymlinks(dir); resolveErr == nil {
+		dir = resolved
+	}
+	return filepath.Clean(dir), nil
 }

--- a/internal/cli/readonly_seat_credential.go
+++ b/internal/cli/readonly_seat_credential.go
@@ -1,0 +1,200 @@
+package cli
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/gitmoot/gitmoot/internal/runtime"
+)
+
+// A read-only seat stages a SNAPSHOT of the host credential into a disposable
+// isolated state dir. A snapshot of an expiring OAuth credential is only good
+// until it expires, and gitmoot launched seats without looking at the expiry it
+// had already copied.
+//
+// Measured 2026-09-03 with the daemon on CLAUDE_CONFIG_DIR=/root/.claude-13,
+// whose credential expired at 06:31:46.182Z. Three seat reviews succeeded, the
+// last finishing 06:30:08. The next job was created 06:31:36 and failed, and so
+// did the two after it, each reporting the runtime's own sentence:
+//
+//	claude: Failed to authenticate: OAuth session expired and could not be refreshed
+//
+// That sentence names OAuth, not the staged input, so it reads as an owner
+// problem. Two states are worth separating, and only one of them is certain:
+//
+//   - EXPIRED WITH NO REFRESH TOKEN is provably unusable. There is no valid
+//     access token and no way to obtain one, so launching can only fail. This
+//     refuses BEFORE the runtime starts, with an error naming the source dir and
+//     the expiry. `/root/.claude/.credentials.json` has been in exactly this
+//     state since 2026-08-31 (expiresAt 0, refreshToken absent), which is what
+//     forced the daemon onto a different account.
+//   - EXPIRED WITH A REFRESH TOKEN may still work: refreshing is the runtime's
+//     job and normally succeeds. This does NOT refuse, because refusing would
+//     break every host whose credential refreshes fine. It records a diagnosis
+//     so that if the runtime then fails, the job already carries the fact that
+//     gitmoot staged an expired credential and from where.
+type readOnlySeatCredentialState struct {
+	// Source is the host file the seat staged from.
+	Source string
+	// ExpiresAt is the credential expiry, zero when the file declares none.
+	ExpiresAt time.Time
+	// Refreshable reports whether a non-empty refresh token accompanied it.
+	Refreshable bool
+}
+
+// Expired reports whether the credential cannot be used as-is. A zero expiry
+// counts as expired: the field exists in this format and a zero value is what a
+// FAILED refresh writes back, so it is a positive statement that the token is
+// dead rather than an absent one.
+func (s readOnlySeatCredentialState) Expired(now time.Time) bool {
+	return s.ExpiresAt.IsZero() || !s.ExpiresAt.After(now)
+}
+
+// readOnlySeatCredentialStatePath is the credential a seat stages, per runtime.
+// Only claude declares one today: its file carries a documented expiry field.
+// A runtime whose staged credential has no readable expiry returns "", and
+// preflight then has nothing to assert, which is the honest outcome rather than
+// a guess about a format gitmoot has not measured.
+func readOnlySeatCredentialStatePath(runtimeName string, sourceDir string) string {
+	if strings.TrimSpace(sourceDir) == "" {
+		return ""
+	}
+	switch runtimeName {
+	case runtime.ClaudeRuntime:
+		return filepath.Join(sourceDir, ".credentials.json")
+	default:
+		return ""
+	}
+}
+
+// inspectReadOnlySeatCredential reads the expiry a seat is about to stage. A
+// missing, unreadable, or expiry-less file returns ok=false: absence is the
+// #1806 class (handled where inputs are staged), and a file that declares no
+// expiry gives this check nothing to assert.
+func inspectReadOnlySeatCredential(runtimeName string, sourceDir string) (readOnlySeatCredentialState, bool) {
+	path := readOnlySeatCredentialStatePath(runtimeName, sourceDir)
+	if path == "" {
+		return readOnlySeatCredentialState{}, false
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return readOnlySeatCredentialState{}, false
+	}
+	var file struct {
+		ClaudeAIOauth struct {
+			// A POINTER, because an absent expiresAt and an explicit 0 mean
+			// different things and Go decodes both to the same value otherwise.
+			// Absent: the file declares no expiry and this check must assert
+			// nothing. Explicit 0: what a FAILED refresh writes back, i.e. a
+			// positive statement that the token is dead. Conflating them made
+			// three existing seat tests fail, whose fixtures legitimately carry
+			// only an accessToken.
+			ExpiresAt    *int64 `json:"expiresAt"`
+			RefreshToken string `json:"refreshToken"`
+		} `json:"claudeAiOauth"`
+	}
+	if err := json.Unmarshal(data, &file); err != nil {
+		return readOnlySeatCredentialState{}, false
+	}
+	if file.ClaudeAIOauth.ExpiresAt == nil {
+		return readOnlySeatCredentialState{}, false
+	}
+	state := readOnlySeatCredentialState{
+		Source:      path,
+		Refreshable: strings.TrimSpace(file.ClaudeAIOauth.RefreshToken) != "",
+	}
+	if *file.ClaudeAIOauth.ExpiresAt > 0 {
+		state.ExpiresAt = time.UnixMilli(*file.ClaudeAIOauth.ExpiresAt).UTC()
+	}
+	return state, true
+}
+
+// readOnlySeatCredentialPreflight classifies the credential a seat will stage.
+// It returns a fatal error for the provably-unusable case and a non-empty
+// diagnosis for the expired-but-refreshable case. Both name the source file and
+// the expiry, so the reader is never left with only the runtime's own wording.
+func readOnlySeatCredentialPreflight(agent runtime.Agent, sourceDir string, now time.Time) (string, error) {
+	if !agent.ReadOnlySeat {
+		return "", nil
+	}
+	state, ok := inspectReadOnlySeatCredential(agent.Runtime, sourceDir)
+	if !ok || !state.Expired(now) {
+		return "", nil
+	}
+	expiry := "no expiry recorded (a failed refresh writes this)"
+	if !state.ExpiresAt.IsZero() {
+		expiry = state.ExpiresAt.Format(time.RFC3339)
+	}
+	if !state.Refreshable {
+		return "", fmt.Errorf(
+			"read-only seat credential %s is unusable: it expired (%s) and carries no refresh token, so the %s runtime cannot authenticate; re-login that account",
+			state.Source, expiry, agent.Runtime,
+		)
+	}
+	return fmt.Sprintf(
+		"read-only seat staged an EXPIRED credential from %s (expired %s); the %s runtime must refresh it to succeed, and an auth failure on this job is gitmoot's staged snapshot rather than a new OAuth problem",
+		state.Source, expiry, agent.Runtime,
+	), nil
+}
+
+// readOnlySeatRuntimeAuthEnv resolves the runtime auth a seat must carry. It is
+// the same overlay runtimeJobRunnerWithAuth injects for every other job; the
+// seat path rebuilt its environment and silently dropped it.
+func readOnlySeatRuntimeAuthEnv(home string, runtimeName string, gatewayMode bool) ([]string, error) {
+	if gatewayMode || runtimeName != runtime.ClaudeRuntime {
+		return nil, nil
+	}
+	paths, err := pathsFromFlag(home)
+	if err != nil {
+		return nil, fmt.Errorf("resolve read-only seat runtime auth paths: %w", err)
+	}
+	state, err := loadRuntimeAuthFile(paths.Home)
+	if err != nil {
+		return nil, fmt.Errorf("load read-only seat runtime auth: %w", err)
+	}
+	return runtimeAuthInjectionEnv(state), nil
+}
+
+// writeSeatCredentialProbe reports the credential a READ-ONLY SEAT would stage,
+// which is a different credential from the ambient one every probe measured
+// until now. Measured 2026-09-03: `gitmoot auth probe claude` and `gitmoot
+// doctor` were green for hours while every claude review job failed, because
+// the seat staged /root/.claude/.credentials.json (expiresAt 0, refresh
+// rejected) and the probe never looked at it. A green that cannot see the
+// credential under test is the false green this reports on.
+func writeSeatCredentialProbe(stdout io.Writer, home string) {
+	sourceDir := strings.TrimSpace(os.Getenv("CLAUDE_CONFIG_DIR"))
+	origin := "CLAUDE_CONFIG_DIR"
+	if sourceDir == "" {
+		userHome, err := os.UserHomeDir()
+		if err != nil {
+			writeLine(stdout, "read-only seat credential: unknown (cannot resolve the host home: %v)", err)
+			return
+		}
+		sourceDir = filepath.Join(userHome, ".claude")
+		origin = "host default"
+	}
+	state, ok := inspectReadOnlySeatCredential(runtime.ClaudeRuntime, sourceDir)
+	if !ok {
+		writeLine(stdout, "read-only seat credential (%s %s): no readable expiry; a seat stages what is there and the runtime decides", origin, sourceDir)
+		return
+	}
+	if !state.Expired(time.Now().UTC()) {
+		writeLine(stdout, "read-only seat credential (%s): valid until %s", state.Source, state.ExpiresAt.Format(time.RFC3339))
+		return
+	}
+	expiry := "no expiry recorded (a failed refresh writes this)"
+	if !state.ExpiresAt.IsZero() {
+		expiry = state.ExpiresAt.Format(time.RFC3339)
+	}
+	if state.Refreshable {
+		writeLine(stdout, "read-only seat credential (%s): EXPIRED %s, refresh token present; a seat must refresh it inside a disposable home, and the rotated token is discarded with the job", state.Source, expiry)
+		return
+	}
+	writeLine(stdout, "read-only seat credential (%s): UNUSABLE, expired %s with no refresh token; every read-only seat job on this runtime will fail until that account is re-logged in", state.Source, expiry)
+}

--- a/internal/cli/readonly_seat_credential.go
+++ b/internal/cli/readonly_seat_credential.go
@@ -184,6 +184,17 @@ func readOnlySeatRuntimeAuthEnv(home string, runtimeName string, gatewayMode boo
 	if err != nil {
 		return nil, fmt.Errorf("resolve read-only seat runtime auth paths: %w", err)
 	}
+	return readOnlySeatRuntimeAuthEnvForPaths(paths, runtimeName, gatewayMode)
+}
+
+// readOnlySeatRuntimeAuthEnvForPaths is the same lookup for a caller that has
+// already resolved its paths. Handing paths.Home to the flag-taking variant
+// re-resolves a DIFFERENT home, which is the mistake that made the operator
+// checks read the wrong overlay (#1810 review, round 3).
+func readOnlySeatRuntimeAuthEnvForPaths(paths config.Paths, runtimeName string, gatewayMode bool) ([]string, error) {
+	if gatewayMode || runtimeName != runtime.ClaudeRuntime {
+		return nil, nil
+	}
 	if _, err := bootstrapRuntimeAuth(paths.Home, runtimeAuthEnvLookup, runtimeAuthLogf); err != nil {
 		return nil, fmt.Errorf("bootstrap read-only seat runtime auth: %w", err)
 	}
@@ -225,24 +236,39 @@ func writeSeatCredentialProbe(stdout io.Writer, paths config.Paths) bool {
 		writeLine(stdout, "read-only seat credential: unknown (cannot resolve the seat config dir)")
 		return true
 	}
+	// Same three inputs as the doctor check, and the same rule: a non-zero exit
+	// is reserved for the case that is actually proven broken - no gateway, no
+	// overlay, expired with no refresh token (#1810 review, round 3).
+	blindSpot := "cannot see a per-job payload runtime_config_dir override"
+	gatewayMode := seatModelGatewayModeForPaths(paths)
+	if gatewayMode {
+		writeLine(stdout, "read-only seat credential: model gateway holds it; no snapshot is staged from %s (%s), so nothing is asserted (%s)", source.dir, source.origin, blindSpot)
+		return true
+	}
+	overlay, overlayErr := readOnlySeatRuntimeAuthEnvForPaths(paths, runtime.ClaudeRuntime, gatewayMode)
+	haveOverlay := overlayErr == nil && len(overlay) > 0
 	state, ok := inspectReadOnlySeatCredential(runtime.ClaudeRuntime, source.dir)
 	if !ok {
-		writeLine(stdout, "read-only seat credential (%s, %s): no readable expiry; a seat stages what is there and the runtime decides", source.dir, source.origin)
+		writeLine(stdout, "read-only seat credential (%s, %s): no readable expiry; a seat stages what is there and the runtime decides (%s)", source.dir, source.origin, blindSpot)
 		return true
 	}
 	if !state.Expired(time.Now().UTC()) {
-		writeLine(stdout, "read-only seat credential (%s, %s): declares expiry %s, not yet reached; this reads a field and does not prove the credential authenticates", state.Source, source.origin, state.ExpiresAt.Format(time.RFC3339))
+		writeLine(stdout, "read-only seat credential (%s, %s): declares expiry %s, not yet reached; this reads a field and does not prove the credential authenticates (%s)", state.Source, source.origin, state.ExpiresAt.Format(time.RFC3339), blindSpot)
 		return true
 	}
 	expiry := "no expiry recorded (a failed refresh writes this)"
 	if !state.ExpiresAt.IsZero() {
 		expiry = state.ExpiresAt.Format(time.RFC3339)
 	}
-	if state.Refreshable {
-		writeLine(stdout, "read-only seat credential (%s, %s): EXPIRED %s, refresh token present; a seat must refresh it inside a disposable home, and the rotated token is discarded with the job", state.Source, source.origin, expiry)
+	if haveOverlay {
+		writeLine(stdout, "read-only seat credential (%s, %s): snapshot expired %s, but a resolved runtime-auth overlay is present and is what a seat authenticates with; clean up the stale snapshot (%s)", state.Source, source.origin, expiry, blindSpot)
 		return true
 	}
-	writeLine(stdout, "read-only seat credential (%s, %s): UNUSABLE, expired %s with no refresh token; every read-only seat job on this runtime will fail until that account is re-logged in", state.Source, source.origin, expiry)
+	if state.Refreshable {
+		writeLine(stdout, "read-only seat credential (%s, %s): EXPIRED %s, refresh token present; a seat must refresh it inside a disposable home, and the rotated token is discarded with the job (%s)", state.Source, source.origin, expiry, blindSpot)
+		return true
+	}
+	writeLine(stdout, "read-only seat credential (%s, %s): UNUSABLE, expired %s with no refresh token, no model gateway and no runtime-auth overlay; every read-only seat job on this runtime will fail until that account is re-logged in (%s)", state.Source, source.origin, expiry, blindSpot)
 	return false
 }
 
@@ -255,6 +281,15 @@ func seatModelGatewayMode(home string) bool {
 	if err != nil {
 		return false
 	}
+	return seatModelGatewayModeForPaths(paths)
+}
+
+// seatModelGatewayModeForPaths is the same question asked of ALREADY-RESOLVED
+// paths. The operator-facing checks hold a config.Paths, not a --home flag
+// value, and re-deriving one from paths.Home silently resolves a DIFFERENT
+// config - which read gateway mode as off and produced the false red this
+// round was reported for (#1810 review, round 3).
+func seatModelGatewayModeForPaths(paths config.Paths) bool {
 	cfg, err := config.LoadCredentialsConfig(paths)
 	if err != nil {
 		return false

--- a/internal/cli/readonly_seat_credential.go
+++ b/internal/cli/readonly_seat_credential.go
@@ -31,11 +31,9 @@ import (
 // problem. Two states are worth separating, and only one of them is certain:
 //
 //   - EXPIRED WITH NO REFRESH TOKEN is provably unusable. There is no valid
-//     access token and no way to obtain one, so launching can only fail. This
-//     refuses BEFORE the runtime starts, with an error naming the source dir and
-//     the expiry. `/root/.claude/.credentials.json` has been in exactly this
-//     state since 2026-08-31 (expiresAt 0, refreshToken absent), which is what
-//     forced the daemon onto a different account.
+//     access token and no way to obtain one. The worker records that fact before
+//     delivery; a later runtime-auth rejection follows the normal deferrable
+//     blocker path instead of becoming a terminal preflight failure.
 //   - EXPIRED WITH A REFRESH TOKEN may still work: refreshing is the runtime's
 //     job and normally succeeds. This does NOT refuse, because refusing would
 //     break every host whose credential refreshes fine. It records a diagnosis

--- a/internal/cli/readonly_seat_credential.go
+++ b/internal/cli/readonly_seat_credential.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/gitmoot/gitmoot/internal/config"
 	"github.com/gitmoot/gitmoot/internal/runtime"
 )
 
@@ -61,8 +62,19 @@ func (s readOnlySeatCredentialState) Expired(now time.Time) bool {
 // preflight then has nothing to assert, which is the honest outcome rather than
 // a guess about a format gitmoot has not measured.
 func readOnlySeatCredentialStatePath(runtimeName string, sourceDir string) string {
-	if strings.TrimSpace(sourceDir) == "" {
+	sourceDir = strings.TrimSpace(sourceDir)
+	if sourceDir == "" {
 		return ""
+	}
+	// Resolve exactly as prepareReadOnlyRuntimeState does before staging:
+	// absolute, then symlinks evaluated. Reading a DIFFERENT path from the one
+	// that gets staged would let this report on a file the seat never uses, which
+	// the #1810 review flagged.
+	if absolute, err := filepath.Abs(sourceDir); err == nil {
+		sourceDir = absolute
+	}
+	if resolved, err := filepath.EvalSymlinks(sourceDir); err == nil {
+		sourceDir = resolved
 	}
 	switch runtimeName {
 	case runtime.ClaudeRuntime:
@@ -114,32 +126,49 @@ func inspectReadOnlySeatCredential(runtimeName string, sourceDir string) (readOn
 	return state, true
 }
 
-// readOnlySeatCredentialPreflight classifies the credential a seat will stage.
-// It returns a fatal error for the provably-unusable case and a non-empty
-// diagnosis for the expired-but-refreshable case. Both name the source file and
-// the expiry, so the reader is never left with only the runtime's own wording.
-func readOnlySeatCredentialPreflight(agent runtime.Agent, sourceDir string, now time.Time) (string, error) {
-	if !agent.ReadOnlySeat {
-		return "", nil
+// readOnlySeatCredentialPreflight returns a DIAGNOSIS when the credential a seat
+// is about to stage is already expired, and never refuses.
+//
+// It refused in the first version of this change, and the exact-head review of
+// #1810 (job local-review-gm-review-opus-18d1be80ca9b36c9) showed both halves of
+// that were wrong:
+//
+//   - the refusal contradicted the engine's own policy for this class.
+//     classifyOperationalBlocker maps a runtime-auth rejection to
+//     blockerClassRuntimeAuth with authBlockerRetryDelay, and docs/events.md
+//     documents job.deferred emitted INSTEAD of job.failed, so a run self-heals
+//     after a re-login with no job.failed and no PR comment. Failing at
+//     preflight turned a deferrable blocker into a terminal one;
+//   - after the auth-overlay injection in this same commit, an expired staged
+//     snapshot is no longer decisive: the seat authenticates with the resolved
+//     runtime auth, so the refusal could hard-fail a job the same commit had
+//     just made authenticable.
+//
+// What survives is the reporting half, which is the part the outage actually
+// needed: when a job later fails to authenticate, the record already says that
+// gitmoot staged an expired credential and from where, instead of leaving the
+// reader with the runtime's own "OAuth session expired" wording. Gateway mode
+// stages no credential file at all, so there is nothing to diagnose there.
+func readOnlySeatCredentialPreflight(agent runtime.Agent, sourceDir string, gatewayMode bool, now time.Time) string {
+	if !agent.ReadOnlySeat || gatewayMode {
+		return ""
 	}
 	state, ok := inspectReadOnlySeatCredential(agent.Runtime, sourceDir)
 	if !ok || !state.Expired(now) {
-		return "", nil
+		return ""
 	}
 	expiry := "no expiry recorded (a failed refresh writes this)"
 	if !state.ExpiresAt.IsZero() {
 		expiry = state.ExpiresAt.Format(time.RFC3339)
 	}
-	if !state.Refreshable {
-		return "", fmt.Errorf(
-			"read-only seat credential %s is unusable: it expired (%s) and carries no refresh token, so the %s runtime cannot authenticate; re-login that account",
-			state.Source, expiry, agent.Runtime,
-		)
+	refresh := "and carries no refresh token, so it cannot authenticate on its own"
+	if state.Refreshable {
+		refresh = "and must be refreshed by the runtime to work on its own"
 	}
 	return fmt.Sprintf(
-		"read-only seat staged an EXPIRED credential from %s (expired %s); the %s runtime must refresh it to succeed, and an auth failure on this job is gitmoot's staged snapshot rather than a new OAuth problem",
-		state.Source, expiry, agent.Runtime,
-	), nil
+		"read-only seat staged an expired %s credential (expired %s) %s; the seat also carries the resolved runtime auth, so this is context for any later auth failure rather than a refusal",
+		agent.Runtime, expiry, refresh,
+	)
 }
 
 // readOnlySeatRuntimeAuthEnv resolves the runtime auth a seat must carry. It is
@@ -185,7 +214,7 @@ func writeSeatCredentialProbe(stdout io.Writer, home string) {
 		return
 	}
 	if !state.Expired(time.Now().UTC()) {
-		writeLine(stdout, "read-only seat credential (%s): valid until %s", state.Source, state.ExpiresAt.Format(time.RFC3339))
+		writeLine(stdout, "read-only seat credential (%s): declares expiry %s, not yet reached; this reads a field and does not prove the credential authenticates", state.Source, state.ExpiresAt.Format(time.RFC3339))
 		return
 	}
 	expiry := "no expiry recorded (a failed refresh writes this)"
@@ -197,4 +226,20 @@ func writeSeatCredentialProbe(stdout io.Writer, home string) {
 		return
 	}
 	writeLine(stdout, "read-only seat credential (%s): UNUSABLE, expired %s with no refresh token; every read-only seat job on this runtime will fail until that account is re-logged in", state.Source, expiry)
+}
+
+// seatModelGatewayMode reports whether claude deliveries run through the local
+// model gateway, resolved the same way runtimeJobRunnerWithAuth resolves it. In
+// gateway mode no credential file is staged for a seat, so both the auth overlay
+// and the staged-credential diagnosis are deliberately silent there.
+func seatModelGatewayMode(home string) bool {
+	paths, err := pathsFromFlag(home)
+	if err != nil {
+		return false
+	}
+	cfg, err := config.LoadCredentialsConfig(paths)
+	if err != nil {
+		return false
+	}
+	return cfg.ModelGateway
 }

--- a/internal/cli/readonly_seat_credential_test.go
+++ b/internal/cli/readonly_seat_credential_test.go
@@ -248,31 +248,49 @@ func TestReadOnlySeatRuntimeAuthEnvDoesNotInventCredentialStoreOverlay(t *testin
 	}
 }
 
-// Produce jobs authenticate as the account selected by CLAUDE_CONFIG_DIR, but
-// their Landlock grant must never make that live operator profile writable.
-// Mutable runtime state stays under a job-private root.
-func TestProduceRuntimeSandboxGrantsReadButDoNotWriteConfiguredClaudeDir(t *testing.T) {
+// Produce jobs authenticate as the account selected by CLAUDE_CONFIG_DIR, and
+// the Claude CLI writes inside its own config dir during normal operation, so
+// a read-only grant on the operator profile denies writes the runtime needs
+// (#1810 review round 4, P1). The contract is therefore: stage the configured
+// account into a job-private profile, point the runtime at that writable copy,
+// and keep the operator profile out of the sandbox entirely.
+func TestProduceRuntimeSandboxGrantsStageConfiguredAccountIntoWritableJobPrivateProfile(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
 	configured := t.TempDir()
 	t.Setenv("CLAUDE_CONFIG_DIR", configured)
+	if err := os.WriteFile(filepath.Join(configured, ".credentials.json"), []byte(`{"claudeAiOauth":{"accessToken":"operator-account"}}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
 	stateRoot := t.TempDir()
 	reads, _, writes, env, err := produceRuntimeSandboxGrants(runtime.ClaudeRuntime, stateRoot, nil, nil, nil)
 	if err != nil {
 		t.Fatalf("produceRuntimeSandboxGrants: %v", err)
 	}
 	writeState := filepath.Join(stateRoot, ".claude")
-	if !containsEnv(env, "CLAUDE_CONFIG_DIR="+configured) {
-		t.Fatalf("produce env = %v, want configured account %q", env, configured)
+	cacheHome := filepath.Join(stateRoot, "xdg-cache")
+	if !containsEnv(env, "CLAUDE_CONFIG_DIR="+writeState) {
+		t.Fatalf("produce env = %v, want the runtime pointed at writable %q", env, writeState)
 	}
-	if !containsPath(reads, configured) {
-		t.Fatalf("produce reads = %v, want configured account %q readable", reads, configured)
+	if !containsEnv(env, "XDG_CACHE_HOME="+cacheHome) {
+		t.Fatalf("produce env = %v, want the node cache redirected to %q", env, cacheHome)
 	}
-	if !containsPath(writes, writeState) {
-		t.Fatalf("produce writes = %v, want mutable state under %q", writes, writeState)
+	if !containsPath(writes, writeState) || !containsPath(writes, cacheHome) {
+		t.Fatalf("produce writes = %v, want both %q and %q writable", writes, writeState, cacheHome)
 	}
 	if containsPath(writes, configured) {
 		t.Fatalf("produce writes = %v, must not grant live configured dir %q", writes, configured)
+	}
+	if containsPath(reads, configured) {
+		t.Fatalf("produce reads = %v, must not expose live configured dir %q to the sandbox", reads, configured)
+	}
+	// The account must be the CONFIGURED one: staging content, not just a path.
+	staged, err := os.ReadFile(filepath.Join(writeState, ".credentials.json"))
+	if err != nil {
+		t.Fatalf("read staged credential: %v", err)
+	}
+	if !strings.Contains(string(staged), "operator-account") {
+		t.Fatalf("staged credential = %s, want the configured account", staged)
 	}
 
 	for _, invalid := range []string{"relative-claude", "~someone/claude"} {
@@ -280,6 +298,114 @@ func TestProduceRuntimeSandboxGrantsReadButDoNotWriteConfiguredClaudeDir(t *test
 		if _, _, _, _, err := produceRuntimeSandboxGrants(runtime.ClaudeRuntime, stateRoot, nil, nil, nil); err == nil {
 			t.Fatalf("CLAUDE_CONFIG_DIR=%q must be refused by the produce path", invalid)
 		}
+	}
+}
+
+// A profile that does not exist yet is a VALID configuration - a fresh host, or
+// a configured dir the operator has not created. Round 4 of the #1810 review
+// reproduced a hard failure here ("sandbox read path ...: no such file or
+// directory") for both the configured and the default case.
+func TestProduceRuntimeSandboxGrantsAcceptMissingProfile(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		configure func(t *testing.T, home string)
+	}{
+		{name: "configured-missing", configure: func(t *testing.T, home string) {
+			t.Setenv("CLAUDE_CONFIG_DIR", filepath.Join(home, "never-created-claude"))
+		}},
+		{name: "unset-host-default-missing", configure: func(t *testing.T, _ string) {
+			t.Setenv("CLAUDE_CONFIG_DIR", "")
+		}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			home := t.TempDir()
+			t.Setenv("HOME", home)
+			tc.configure(t, home)
+			stateRoot := t.TempDir()
+			reads, _, writes, env, err := produceRuntimeSandboxGrants(runtime.ClaudeRuntime, stateRoot, nil, nil, nil)
+			if err != nil {
+				t.Fatalf("a missing profile must not fail the job: %v", err)
+			}
+			writeState := filepath.Join(stateRoot, ".claude")
+			if !containsEnv(env, "CLAUDE_CONFIG_DIR="+writeState) || !containsPath(writes, writeState) {
+				t.Fatalf("grants = reads %v writes %v env %v, want a writable job-private profile", reads, writes, env)
+			}
+			if _, err := os.Stat(writeState); err != nil {
+				t.Fatalf("job-private profile was not created: %v", err)
+			}
+		})
+	}
+}
+
+// M7: the guard that refuses an unplumbed caller. A produce job with no
+// job-private root would otherwise fall back to granting shared state.
+func TestProduceRuntimeSandboxGrantsRefuseMissingStateRoot(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("CLAUDE_CONFIG_DIR", t.TempDir())
+	for _, root := range []string{"", "   "} {
+		_, _, _, _, err := produceRuntimeSandboxGrants(runtime.ClaudeRuntime, root, nil, nil, nil)
+		if err == nil {
+			t.Fatalf("state root %q must be refused", root)
+		}
+		if !strings.Contains(err.Error(), "job-private runtime state root") {
+			t.Fatalf("error = %v, want it to name the missing job-private root", err)
+		}
+	}
+}
+
+// M8: each dispatch resets its own state root, so a previous run's runtime
+// state - including a stale credential copy - cannot survive into the next.
+func TestProduceRuntimeSandboxGrantsResetStaleRuntimeState(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("CLAUDE_CONFIG_DIR", t.TempDir())
+	stateRoot := t.TempDir()
+	stale := filepath.Join(stateRoot, ".claude", "stale-session.json")
+	if err := os.MkdirAll(filepath.Dir(stale), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(stale, []byte(`{"from":"previous run"}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, _, _, err := produceRuntimeSandboxGrants(runtime.ClaudeRuntime, stateRoot, nil, nil, nil); err != nil {
+		t.Fatalf("produceRuntimeSandboxGrants: %v", err)
+	}
+	if _, err := os.Stat(stale); !os.IsNotExist(err) {
+		t.Fatalf("stale runtime state survived the reset: %v", err)
+	}
+}
+
+// P3 round 4: two concurrent dispatches of the SAME job id - a lease takeover,
+// or a deferral re-dispatch - must not share a state root, because each resets
+// its root at grant time and removes it when it finishes.
+func TestNewProduceRunStateDirIsUniquePerDispatch(t *testing.T) {
+	root := filepath.Join(t.TempDir(), "job-root")
+	first, err := newProduceRunStateDir(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	second, err := newProduceRunStateDir(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if first == second {
+		t.Fatalf("concurrent dispatches share runtime state %q", first)
+	}
+	for _, dir := range []string{first, second} {
+		if filepath.Dir(dir) != filepath.Clean(root) {
+			t.Fatalf("run dir %q is outside the job root %q", dir, root)
+		}
+		if _, err := os.Stat(dir); err != nil {
+			t.Fatalf("run dir %q was not created: %v", dir, err)
+		}
+	}
+	// Removing one dispatch's state must leave a live sibling untouched.
+	if err := os.RemoveAll(first); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(second); err != nil {
+		t.Fatalf("sibling dispatch state was destroyed: %v", err)
 	}
 }
 

--- a/internal/cli/readonly_seat_credential_test.go
+++ b/internal/cli/readonly_seat_credential_test.go
@@ -20,13 +20,11 @@ func writeClaudeCredential(t *testing.T, dir string, expiresAtMillis int64, refr
 	}
 }
 
-// The refusal is GONE, deliberately. The #1810 exact-head review showed a
-// preflight refusal was wrong twice over: it converted a DEFERRABLE
-// runtime-auth blocker into a terminal failure plus a PR comment, against the
-// engine's own classifyOperationalBlocker/job.deferred policy, and the auth
-// overlay injected by the same commit means an expired staged snapshot no
-// longer decides whether the seat can authenticate. What survives is the
-// report: an expired snapshot must be RECORDED, never refused.
+// The refusal is GONE, deliberately. A preflight refusal converts the
+// DEFERRABLE runtime-auth blocker into a terminal failure plus a PR comment.
+// A resolved auth overlay may also make an expired snapshot non-decisive. What
+// survives is the report: an expired snapshot must be RECORDED, never refused,
+// and must say whether an overlay was actually available.
 func TestReadOnlySeatCredentialPreflightReportsAndNeverRefuses(t *testing.T) {
 	for name, test := range map[string]struct {
 		expiresAt    int64
@@ -47,7 +45,7 @@ func TestReadOnlySeatCredentialPreflightReportsAndNeverRefuses(t *testing.T) {
 			writeClaudeCredential(t, dir, test.expiresAt, test.refreshToken)
 			agent := runtime.Agent{Runtime: runtime.ClaudeRuntime, ReadOnlySeat: true}
 
-			diagnosis := readOnlySeatCredentialPreflight(agent, dir, false, time.Now().UTC())
+			diagnosis := readOnlySeatCredentialPreflight(agent, dir, false, true, time.Now().UTC())
 			if diagnosis == "" {
 				t.Fatal("an expired staged credential must be recorded")
 			}
@@ -72,7 +70,7 @@ func TestReadOnlySeatCredentialPreflightSilentInGatewayMode(t *testing.T) {
 	dir := t.TempDir()
 	writeClaudeCredential(t, dir, 0, "")
 	agent := runtime.Agent{Runtime: runtime.ClaudeRuntime, ReadOnlySeat: true}
-	if diagnosis := readOnlySeatCredentialPreflight(agent, dir, true, time.Now().UTC()); diagnosis != "" {
+	if diagnosis := readOnlySeatCredentialPreflight(agent, dir, true, true, time.Now().UTC()); diagnosis != "" {
 		t.Fatalf("gateway mode diagnosis=%q, want silence", diagnosis)
 	}
 }
@@ -84,7 +82,7 @@ func TestReadOnlySeatCredentialPreflightPassesALiveCredential(t *testing.T) {
 	writeClaudeCredential(t, dir, time.Now().UTC().Add(8*time.Hour).UnixMilli(), "refresh-token")
 	agent := runtime.Agent{Runtime: runtime.ClaudeRuntime, ReadOnlySeat: true}
 
-	if diagnosis := readOnlySeatCredentialPreflight(agent, dir, false, time.Now().UTC()); diagnosis != "" {
+	if diagnosis := readOnlySeatCredentialPreflight(agent, dir, false, true, time.Now().UTC()); diagnosis != "" {
 		t.Fatalf("live credential: diagnosis=%q, want silence", diagnosis)
 	}
 }
@@ -99,19 +97,19 @@ func TestReadOnlySeatCredentialPreflightStaysSilentWhereItCannotAssert(t *testin
 
 	t.Run("non-seat job", func(t *testing.T) {
 		agent := runtime.Agent{Runtime: runtime.ClaudeRuntime}
-		if diagnosis := readOnlySeatCredentialPreflight(agent, dir, false, time.Now().UTC()); diagnosis != "" {
+		if diagnosis := readOnlySeatCredentialPreflight(agent, dir, false, true, time.Now().UTC()); diagnosis != "" {
 			t.Fatalf("diagnosis=%q, want silence", diagnosis)
 		}
 	})
 	t.Run("runtime with no readable expiry", func(t *testing.T) {
 		agent := runtime.Agent{Runtime: runtime.CodexRuntime, ReadOnlySeat: true}
-		if diagnosis := readOnlySeatCredentialPreflight(agent, dir, false, time.Now().UTC()); diagnosis != "" {
+		if diagnosis := readOnlySeatCredentialPreflight(agent, dir, false, true, time.Now().UTC()); diagnosis != "" {
 			t.Fatalf("diagnosis=%q, want silence", diagnosis)
 		}
 	})
 	t.Run("absent credential file", func(t *testing.T) {
 		agent := runtime.Agent{Runtime: runtime.ClaudeRuntime, ReadOnlySeat: true}
-		if diagnosis := readOnlySeatCredentialPreflight(agent, t.TempDir(), false, time.Now().UTC()); diagnosis != "" {
+		if diagnosis := readOnlySeatCredentialPreflight(agent, t.TempDir(), false, true, time.Now().UTC()); diagnosis != "" {
 			t.Fatalf("diagnosis=%q, want silence", diagnosis)
 		}
 	})
@@ -121,13 +119,13 @@ func TestReadOnlySeatCredentialPreflightStaysSilentWhereItCannotAssert(t *testin
 			t.Fatal(err)
 		}
 		agent := runtime.Agent{Runtime: runtime.ClaudeRuntime, ReadOnlySeat: true}
-		if diagnosis := readOnlySeatCredentialPreflight(agent, broken, false, time.Now().UTC()); diagnosis != "" {
+		if diagnosis := readOnlySeatCredentialPreflight(agent, broken, false, true, time.Now().UTC()); diagnosis != "" {
 			t.Fatalf("diagnosis=%q, want silence", diagnosis)
 		}
 	})
 	t.Run("no source dir", func(t *testing.T) {
 		agent := runtime.Agent{Runtime: runtime.ClaudeRuntime, ReadOnlySeat: true}
-		if diagnosis := readOnlySeatCredentialPreflight(agent, "  ", false, time.Now().UTC()); diagnosis != "" {
+		if diagnosis := readOnlySeatCredentialPreflight(agent, "  ", false, true, time.Now().UTC()); diagnosis != "" {
 			t.Fatalf("diagnosis=%q, want silence", diagnosis)
 		}
 	})
@@ -144,14 +142,14 @@ func TestReadOnlySeatCredentialPreflightIgnoresAnAbsentExpiry(t *testing.T) {
 		t.Fatal(err)
 	}
 	agent := runtime.Agent{Runtime: runtime.ClaudeRuntime, ReadOnlySeat: true}
-	if diagnosis := readOnlySeatCredentialPreflight(agent, dir, false, time.Now().UTC()); diagnosis != "" {
+	if diagnosis := readOnlySeatCredentialPreflight(agent, dir, false, true, time.Now().UTC()); diagnosis != "" {
 		t.Fatalf("absent expiry: diagnosis=%q, want silence", diagnosis)
 	}
 
 	// ...while an EXPLICIT zero is still reported, because that value is what a
 	// failed refresh writes back rather than an absent field.
 	writeClaudeCredential(t, dir, 0, "")
-	if diagnosis := readOnlySeatCredentialPreflight(agent, dir, false, time.Now().UTC()); diagnosis == "" {
+	if diagnosis := readOnlySeatCredentialPreflight(agent, dir, false, true, time.Now().UTC()); diagnosis == "" {
 		t.Fatal("an explicit expiresAt of 0 must still be reported")
 	}
 }
@@ -194,6 +192,62 @@ func TestReadOnlySeatRuntimeAuthEnvCarriesTheResolvedOverlay(t *testing.T) {
 	}
 }
 
+// The overlay was resolved by READING runtime-auth.env only, so on a host that
+// authenticates from ambient credentials and never wrote that file the seat
+// received nothing and the whole fix was inert (#1810 review F1). The seat path
+// must bootstrap exactly as runtimeJobRunnerWithAuth does.
+func TestReadOnlySeatRuntimeAuthEnvBootstrapsAmbientCredentials(t *testing.T) {
+	home := t.TempDir()
+	paths, err := pathsFromFlag(home)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(paths.Home, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	// No runtime-auth.env exists; the credential lives only in the environment.
+	if _, err := os.Stat(runtimeAuthFilePath(paths.Home)); !os.IsNotExist(err) {
+		t.Fatalf("fixture already has a runtime auth file: %v", err)
+	}
+	original := runtimeAuthEnvLookup
+	runtimeAuthEnvLookup = func(name string) (string, bool) {
+		if name == runtime.ClaudeOAuthTokenEnv {
+			return "ambient-seat-token-long-enough", true
+		}
+		return "", false
+	}
+	t.Cleanup(func() { runtimeAuthEnvLookup = original })
+
+	env, err := readOnlySeatRuntimeAuthEnv(home, runtime.ClaudeRuntime, false)
+	if err != nil {
+		t.Fatalf("readOnlySeatRuntimeAuthEnv: %v", err)
+	}
+	if !containsEnv(env, runtime.ClaudeOAuthTokenEnv+"=ambient-seat-token-long-enough") {
+		t.Fatalf("seat overlay is empty on an ambient-auth host: %v", redactEnvNames(env))
+	}
+}
+
+// A host authenticated only through Claude's credential store has no managed
+// environment value to bootstrap. The overlay must remain empty, and callers
+// must not claim it repaired the staged snapshot.
+func TestReadOnlySeatRuntimeAuthEnvDoesNotInventCredentialStoreOverlay(t *testing.T) {
+	home := t.TempDir()
+	original := runtimeAuthEnvLookup
+	runtimeAuthEnvLookup = func(string) (string, bool) { return "", false }
+	t.Cleanup(func() { runtimeAuthEnvLookup = original })
+
+	env, err := readOnlySeatRuntimeAuthEnv(home, runtime.ClaudeRuntime, false)
+	if err != nil {
+		t.Fatalf("readOnlySeatRuntimeAuthEnv: %v", err)
+	}
+	if len(env) != 0 {
+		t.Fatalf("credential-store host produced invented overlay names: %v", redactEnvNames(env))
+	}
+	if _, err := os.Stat(runtimeAuthFilePath(home)); !os.IsNotExist(err) {
+		t.Fatalf("credential-store bootstrap unexpectedly wrote runtime auth: %v", err)
+	}
+}
+
 // An operator-set CLAUDE_CONFIG_DIR names the ACCOUNT the engine runs as.
 // produceRuntimeSandboxGrants hard-coded $HOME/.claude and silently replaced
 // it, so a daemon configured onto a live account still pointed produce jobs at
@@ -228,10 +282,128 @@ func TestProduceRuntimeSandboxGrantsHonorsConfiguredClaudeDir(t *testing.T) {
 	if !containsEnv(fallbackEnv, "CLAUDE_CONFIG_DIR="+filepath.Join(filepath.Clean(home), ".claude")) {
 		t.Fatalf("fallback env = %v, want $HOME/.claude", fallbackEnv)
 	}
+
+	// A ~ value is expanded to an absolute path under this user's home.
+	t.Setenv("CLAUDE_CONFIG_DIR", "~/tilde-claude")
+	_, _, tildeWrites, tildeEnv, err := produceRuntimeSandboxGrants(runtime.ClaudeRuntime, nil, nil, nil)
+	if err != nil {
+		t.Fatalf("produceRuntimeSandboxGrants(~): %v", err)
+	}
+	wantTilde := filepath.Join(filepath.Clean(home), "tilde-claude")
+	if !containsEnv(tildeEnv, "CLAUDE_CONFIG_DIR="+wantTilde) || !containsPath(tildeWrites, wantTilde) {
+		t.Fatalf("~ env = %v writes = %v, want %q", tildeEnv, tildeWrites, wantTilde)
+	}
+
+	// A relative or ~user value is REFUSED. Repairing either silently granted,
+	// staged and inspected an account the operator never named — a relative path
+	// against the daemon's arbitrary cwd (creating a stray profile there), ~user
+	// under the CURRENT user's home.
+	for _, configuredDir := range []string{"relative-claude", "~someone/claude"} {
+		t.Setenv("CLAUDE_CONFIG_DIR", configuredDir)
+		if _, _, _, _, err := produceRuntimeSandboxGrants(runtime.ClaudeRuntime, nil, nil, nil); err == nil {
+			t.Fatalf("CLAUDE_CONFIG_DIR=%q must be refused, not repaired", configuredDir)
+		}
+		if _, statErr := os.Stat(configuredDir); statErr == nil {
+			t.Fatalf("refusing %q still created it in the working directory", configuredDir)
+		}
+	}
+
+	// A ~user path names ANOTHER account's home; mapping it under this user's
+	// home would grant and stage the wrong profile, so it is refused.
+	t.Setenv("CLAUDE_CONFIG_DIR", "~someone/claude")
+	if _, _, _, _, err := produceRuntimeSandboxGrants(runtime.ClaudeRuntime, nil, nil, nil); err == nil {
+		t.Fatal("a ~user CLAUDE_CONFIG_DIR must be refused, not remapped")
+	}
 }
 
 // writeFileForTest writes a raw .credentials.json body for cases that need a
 // shape writeClaudeCredential cannot express.
-func writeFileForTest(dir, body string) error {
+func writeClaudeCredentialBody(dir, body string) error {
 	return os.WriteFile(filepath.Join(dir, ".credentials.json"), []byte(body), 0o600)
 }
+
+// The message must not claim an overlay the seat does not have. On a host with
+// no runtime-auth.env and no ambient credentials the overlay is empty, and
+// asserting otherwise misdirects the reader on exactly the host where this
+// diagnosis matters (#1810 review, round 2).
+func TestReadOnlySeatCredentialPreflightTellsTheTruthAboutTheOverlay(t *testing.T) {
+	dir := t.TempDir()
+	writeClaudeCredential(t, dir, 0, "")
+	agent := runtime.Agent{Runtime: runtime.ClaudeRuntime, ReadOnlySeat: true}
+
+	withOverlay := readOnlySeatCredentialPreflight(agent, dir, false, true, time.Now().UTC())
+	if !strings.Contains(withOverlay, "also carries the resolved runtime auth") {
+		t.Fatalf("with an overlay the message must say so: %q", withOverlay)
+	}
+	without := readOnlySeatCredentialPreflight(agent, dir, false, false, time.Now().UTC())
+	if !strings.Contains(without, "NO resolved runtime auth") {
+		t.Fatalf("without an overlay the message must say so: %q", without)
+	}
+	if strings.Contains(without, "also carries the resolved runtime auth") {
+		t.Fatalf("message claims an overlay that does not exist: %q", without)
+	}
+}
+
+// A seat with no configured dir stages from the HOST DEFAULT, so every caller
+// that inspects or grants a runtime profile must resolve the same way the
+// staging code does: host default, ~ expansion, absolute, symlinks resolved.
+func TestResolveRuntimeConfigDirMatchesTheStagingContract(t *testing.T) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		t.Fatal(err)
+	}
+	for runtimeName, want := range map[string]string{
+		runtime.ClaudeRuntime: filepath.Join(home, ".claude"),
+		runtime.CodexRuntime:  filepath.Join(home, ".codex"),
+		runtime.KimiRuntime:   filepath.Join(home, ".kimi-code"),
+	} {
+		got, err := resolveRuntimeConfigDir(runtimeName, "")
+		if err != nil || got != want {
+			t.Fatalf("%s default = %q err=%v, want %q", runtimeName, got, err, want)
+		}
+	}
+	if got, err := resolveRuntimeConfigDir(runtime.ShellRuntime, ""); err != nil || got != "" {
+		t.Fatalf("shell default = %q err=%v, want empty", got, err)
+	}
+
+	// A ~ path belongs to the CURRENT user; a ~user path is refused rather than
+	// silently mapped under this user's home, which would grant and inspect the
+	// wrong account.
+	if got, err := resolveRuntimeConfigDir(runtime.ClaudeRuntime, "~/claude-13"); err != nil || got != filepath.Join(home, "claude-13") {
+		t.Fatalf("~ expansion = %q err=%v", got, err)
+	}
+	if _, err := resolveRuntimeConfigDir(runtime.ClaudeRuntime, "~someone/claude"); err == nil {
+		t.Fatal("~user expansion must be refused, not mapped under this user's home")
+	}
+
+	// A relative path is REFUSED, not repaired: resolving it against the daemon's
+	// working directory both grants the wrong profile and creates a stray one
+	// there. Nothing must be created as a side effect of the refusal.
+	if _, err := resolveRuntimeConfigDir(runtime.ClaudeRuntime, "relative-claude"); err == nil {
+		t.Fatal("a relative runtime state directory must be refused")
+	}
+	if _, err := os.Stat("relative-claude"); err == nil {
+		t.Fatal("refusing a relative dir still created it in the working directory")
+	}
+
+	// Symlinks are resolved so the inspected file is the staged file. Without
+	// this, a symlinked profile reports on a path the seat never reads.
+	target := t.TempDir()
+	link := filepath.Join(t.TempDir(), "profile-link")
+	if err := os.Symlink(target, link); err != nil {
+		t.Fatal(err)
+	}
+	resolvedTarget, err := filepath.EvalSymlinks(target)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, err := resolveRuntimeConfigDir(runtime.ClaudeRuntime, link)
+	if err != nil || got != resolvedTarget {
+		t.Fatalf("symlinked dir = %q err=%v, want %q", got, err, resolvedTarget)
+	}
+	writeClaudeCredential(t, target, 0, "")
+	if path := readOnlySeatCredentialStatePath(runtime.ClaudeRuntime, link); path != filepath.Join(resolvedTarget, ".credentials.json") {
+		t.Fatalf("state path = %q, want the resolved staged file", path)
+	}
+}
+

--- a/internal/cli/readonly_seat_credential_test.go
+++ b/internal/cli/readonly_seat_credential_test.go
@@ -248,71 +248,68 @@ func TestReadOnlySeatRuntimeAuthEnvDoesNotInventCredentialStoreOverlay(t *testin
 	}
 }
 
-// An operator-set CLAUDE_CONFIG_DIR names the ACCOUNT the engine runs as.
-// produceRuntimeSandboxGrants hard-coded $HOME/.claude and silently replaced
-// it, so a daemon configured onto a live account still pointed produce jobs at
-// /root/.claude, which on this host has carried expiresAt 0 with no refresh
-// token since 2026-08-31 and yields exactly "OAuth session expired and could
-// not be refreshed".
-func TestProduceRuntimeSandboxGrantsHonorsConfiguredClaudeDir(t *testing.T) {
-	configured := filepath.Join(t.TempDir(), "claude-13")
+// Produce jobs authenticate as the account selected by CLAUDE_CONFIG_DIR, but
+// their Landlock grant must never make that live operator profile writable.
+// Mutable runtime state stays under a job-private root.
+func TestProduceRuntimeSandboxGrantsReadButDoNotWriteConfiguredClaudeDir(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	configured := t.TempDir()
 	t.Setenv("CLAUDE_CONFIG_DIR", configured)
-
-	_, _, writes, env, err := produceRuntimeSandboxGrants(runtime.ClaudeRuntime, nil, nil, nil)
+	stateRoot := t.TempDir()
+	reads, _, writes, env, err := produceRuntimeSandboxGrants(runtime.ClaudeRuntime, stateRoot, nil, nil, nil)
 	if err != nil {
 		t.Fatalf("produceRuntimeSandboxGrants: %v", err)
 	}
+	writeState := filepath.Join(stateRoot, ".claude")
 	if !containsEnv(env, "CLAUDE_CONFIG_DIR="+configured) {
-		t.Fatalf("produce env = %v, want the configured dir %q", env, configured)
+		t.Fatalf("produce env = %v, want configured account %q", env, configured)
 	}
-	if !containsPath(writes, configured) {
-		t.Fatalf("produce writes = %v, want the configured dir writable", writes)
+	if !containsPath(reads, configured) {
+		t.Fatalf("produce reads = %v, want configured account %q readable", reads, configured)
+	}
+	if !containsPath(writes, writeState) {
+		t.Fatalf("produce writes = %v, want mutable state under %q", writes, writeState)
+	}
+	if containsPath(writes, configured) {
+		t.Fatalf("produce writes = %v, must not grant live configured dir %q", writes, configured)
 	}
 
-	// With none set it still falls back to the host default.
-	t.Setenv("CLAUDE_CONFIG_DIR", "")
-	home, err := os.UserHomeDir()
+	for _, invalid := range []string{"relative-claude", "~someone/claude"} {
+		t.Setenv("CLAUDE_CONFIG_DIR", invalid)
+		if _, _, _, _, err := produceRuntimeSandboxGrants(runtime.ClaudeRuntime, stateRoot, nil, nil, nil); err == nil {
+			t.Fatalf("CLAUDE_CONFIG_DIR=%q must be refused by the produce path", invalid)
+		}
+	}
+}
+
+func TestJobProduceRuntimeStateDirIsPrivatePerJob(t *testing.T) {
+	home := t.TempDir()
+	first, err := jobProduceRuntimeStateDir(home, "job-a", runtime.ClaudeRuntime)
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, _, _, fallbackEnv, err := produceRuntimeSandboxGrants(runtime.ClaudeRuntime, nil, nil, nil)
+	repeated, err := jobProduceRuntimeStateDir(home, "job-a", runtime.ClaudeRuntime)
 	if err != nil {
-		t.Fatalf("produceRuntimeSandboxGrants fallback: %v", err)
+		t.Fatal(err)
 	}
-	if !containsEnv(fallbackEnv, "CLAUDE_CONFIG_DIR="+filepath.Join(filepath.Clean(home), ".claude")) {
-		t.Fatalf("fallback env = %v, want $HOME/.claude", fallbackEnv)
-	}
-
-	// A ~ value is expanded to an absolute path under this user's home.
-	t.Setenv("CLAUDE_CONFIG_DIR", "~/tilde-claude")
-	_, _, tildeWrites, tildeEnv, err := produceRuntimeSandboxGrants(runtime.ClaudeRuntime, nil, nil, nil)
+	second, err := jobProduceRuntimeStateDir(home, "job-b", runtime.ClaudeRuntime)
 	if err != nil {
-		t.Fatalf("produceRuntimeSandboxGrants(~): %v", err)
+		t.Fatal(err)
 	}
-	wantTilde := filepath.Join(filepath.Clean(home), "tilde-claude")
-	if !containsEnv(tildeEnv, "CLAUDE_CONFIG_DIR="+wantTilde) || !containsPath(tildeWrites, wantTilde) {
-		t.Fatalf("~ env = %v writes = %v, want %q", tildeEnv, tildeWrites, wantTilde)
+	if first != repeated {
+		t.Fatalf("same job resolved to %q then %q", first, repeated)
 	}
-
-	// A relative or ~user value is REFUSED. Repairing either silently granted,
-	// staged and inspected an account the operator never named — a relative path
-	// against the daemon's arbitrary cwd (creating a stray profile there), ~user
-	// under the CURRENT user's home.
-	for _, configuredDir := range []string{"relative-claude", "~someone/claude"} {
-		t.Setenv("CLAUDE_CONFIG_DIR", configuredDir)
-		if _, _, _, _, err := produceRuntimeSandboxGrants(runtime.ClaudeRuntime, nil, nil, nil); err == nil {
-			t.Fatalf("CLAUDE_CONFIG_DIR=%q must be refused, not repaired", configuredDir)
-		}
-		if _, statErr := os.Stat(configuredDir); statErr == nil {
-			t.Fatalf("refusing %q still created it in the working directory", configuredDir)
-		}
+	if first == second {
+		t.Fatalf("distinct jobs share runtime state %q", first)
 	}
-
-	// A ~user path names ANOTHER account's home; mapping it under this user's
-	// home would grant and stage the wrong profile, so it is refused.
-	t.Setenv("CLAUDE_CONFIG_DIR", "~someone/claude")
-	if _, _, _, _, err := produceRuntimeSandboxGrants(runtime.ClaudeRuntime, nil, nil, nil); err == nil {
-		t.Fatal("a ~user CLAUDE_CONFIG_DIR must be refused, not remapped")
+	paths, err := pathsFromFlag(home)
+	if err != nil {
+		t.Fatal(err)
+	}
+	wantRoot := filepath.Join(paths.Home, "cache", "produce-runtime")
+	if !strings.HasPrefix(first, wantRoot+string(filepath.Separator)) {
+		t.Fatalf("job state %q is outside private root %q", first, wantRoot)
 	}
 }
 
@@ -406,4 +403,3 @@ func TestResolveRuntimeConfigDirMatchesTheStagingContract(t *testing.T) {
 		t.Fatalf("state path = %q, want the resolved staged file", path)
 	}
 }
-

--- a/internal/cli/readonly_seat_credential_test.go
+++ b/internal/cli/readonly_seat_credential_test.go
@@ -878,3 +878,47 @@ func TestSeatAuthProbeFailsOpenOnSetupFailuresNotOnlyOnTheLiveCheck(t *testing.T
 		})
 	}
 }
+
+// P0 REGRESSION (#1810): runtime-auth.env is a CREDENTIAL FILE, and its path is
+// filepath.Join(home, name) - so an empty or relative home resolves to a
+// relative path and the credential is written into the process's working
+// directory. During a test run that directory is the package source tree, which
+// is how a live token became a tracked file and reached a public remote. No
+// caller may write a credential anywhere but an absolute home.
+func TestRuntimeAuthNeverWritesACredentialIntoTheWorkingDirectory(t *testing.T) {
+	t.Setenv("CLAUDE_CODE_OAUTH_TOKEN", "test-only-placeholder-not-a-token")
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	stray := filepath.Join(cwd, runtimeAuthFileName)
+	if _, err := os.Stat(stray); err == nil {
+		t.Fatalf("%s already exists in the package directory before this test ran; a credential is sitting in the work tree", stray)
+	}
+	t.Cleanup(func() {
+		if _, err := os.Stat(stray); err == nil {
+			_ = os.Remove(stray)
+			t.Errorf("a credential file was written into the work tree at %s", stray)
+		}
+	})
+
+	for _, home := range []string{"", "   ", "relative/home", "."} {
+		if _, err := bootstrapRuntimeAuth(home, runtimeAuthEnvLookup, runtimeAuthLogf); err == nil {
+			t.Fatalf("bootstrapRuntimeAuth(%q) accepted a non-absolute home; a credential must only be written to a deliberate absolute path", home)
+		}
+	}
+
+	// The operator-facing checks reach the same primitive, and pre-existing
+	// callers pass a zero config.Paths. They must not create anything either.
+	dir := t.TempDir()
+	writeClaudeCredential(t, dir, 0, "")
+	t.Setenv("CLAUDE_CONFIG_DIR", dir)
+	if _, ok := seatCredentialDoctorCheck(config.Paths{}); !ok {
+		t.Fatal("doctor check must still be emitted with a zero config.Paths")
+	}
+	var probeOut strings.Builder
+	writeSeatCredentialProbe(&probeOut, config.Paths{})
+	if _, err := os.Stat(stray); err == nil {
+		t.Fatalf("the operator-facing checks wrote a credential into the work tree at %s", stray)
+	}
+}

--- a/internal/cli/readonly_seat_credential_test.go
+++ b/internal/cli/readonly_seat_credential_test.go
@@ -1,0 +1,223 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gitmoot/gitmoot/internal/runtime"
+)
+
+func writeClaudeCredential(t *testing.T, dir string, expiresAtMillis int64, refreshToken string) {
+	t.Helper()
+	body := `{"claudeAiOauth":{"accessToken":"a","expiresAt":` +
+		strconv.FormatInt(expiresAtMillis, 10) + `,"refreshToken":"` + refreshToken + `"}}`
+	if err := os.WriteFile(filepath.Join(dir, ".credentials.json"), []byte(body), 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// A credential that expired with NO refresh token cannot authenticate: no valid
+// access token and no way to get one. Launching a runtime on it can only fail,
+// so the seat refuses first, and the error names the file and the expiry rather
+// than leaving the reader with the runtime's "OAuth session expired" wording.
+// This is the state /root/.claude has been in since 2026-08-31.
+func TestReadOnlySeatCredentialPreflightRefusesTheUnusableCase(t *testing.T) {
+	dir := t.TempDir()
+	writeClaudeCredential(t, dir, 0, "")
+	agent := runtime.Agent{Runtime: runtime.ClaudeRuntime, ReadOnlySeat: true}
+
+	diagnosis, err := readOnlySeatCredentialPreflight(agent, dir, time.Now().UTC())
+	if err == nil {
+		t.Fatal("an expired credential with no refresh token must be refused before launch")
+	}
+	if diagnosis != "" {
+		t.Fatalf("refusal must not also return a diagnosis, got %q", diagnosis)
+	}
+	for _, want := range []string{".credentials.json", "no refresh token", "re-login"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("error %q must name %q", err.Error(), want)
+		}
+	}
+}
+
+// Expired WITH a refresh token is the state the daemon's account was in at
+// 06:31:46Z. Refreshing is the runtime's job and normally succeeds, so refusing
+// would break every host whose credential refreshes fine. Record the fact
+// instead, naming the source and the expiry.
+func TestReadOnlySeatCredentialPreflightDiagnosesTheRefreshableCase(t *testing.T) {
+	dir := t.TempDir()
+	expiry := time.Now().UTC().Add(-time.Hour).Truncate(time.Second)
+	writeClaudeCredential(t, dir, expiry.UnixMilli(), "refresh-token")
+	agent := runtime.Agent{Runtime: runtime.ClaudeRuntime, ReadOnlySeat: true}
+
+	diagnosis, err := readOnlySeatCredentialPreflight(agent, dir, time.Now().UTC())
+	if err != nil {
+		t.Fatalf("a refreshable credential must not be refused: %v", err)
+	}
+	if diagnosis == "" {
+		t.Fatal("an expired refreshable credential must be recorded, not silently staged")
+	}
+	for _, want := range []string{dir, expiry.Format(time.RFC3339), "staged snapshot"} {
+		if !strings.Contains(diagnosis, want) {
+			t.Fatalf("diagnosis %q must name %q", diagnosis, want)
+		}
+	}
+}
+
+// A live credential must pass silently. A check that fires on a valid account
+// would be worse than no check: it would refuse working reviews.
+func TestReadOnlySeatCredentialPreflightPassesALiveCredential(t *testing.T) {
+	dir := t.TempDir()
+	writeClaudeCredential(t, dir, time.Now().UTC().Add(8*time.Hour).UnixMilli(), "refresh-token")
+	agent := runtime.Agent{Runtime: runtime.ClaudeRuntime, ReadOnlySeat: true}
+
+	diagnosis, err := readOnlySeatCredentialPreflight(agent, dir, time.Now().UTC())
+	if err != nil || diagnosis != "" {
+		t.Fatalf("live credential: diagnosis=%q err=%v, want silence", diagnosis, err)
+	}
+}
+
+// Only a seat is checked, and only where an expiry is actually readable. A
+// non-seat job, another runtime, an absent file and an unparseable file all pass
+// through: a missing input is the separate staging concern, and asserting on a
+// credential format gitmoot has not measured would be a guess.
+func TestReadOnlySeatCredentialPreflightStaysSilentWhereItCannotAssert(t *testing.T) {
+	dir := t.TempDir()
+	writeClaudeCredential(t, dir, 0, "")
+
+	t.Run("non-seat job", func(t *testing.T) {
+		agent := runtime.Agent{Runtime: runtime.ClaudeRuntime}
+		if diagnosis, err := readOnlySeatCredentialPreflight(agent, dir, time.Now().UTC()); err != nil || diagnosis != "" {
+			t.Fatalf("diagnosis=%q err=%v, want silence", diagnosis, err)
+		}
+	})
+	t.Run("runtime with no readable expiry", func(t *testing.T) {
+		agent := runtime.Agent{Runtime: runtime.CodexRuntime, ReadOnlySeat: true}
+		if diagnosis, err := readOnlySeatCredentialPreflight(agent, dir, time.Now().UTC()); err != nil || diagnosis != "" {
+			t.Fatalf("diagnosis=%q err=%v, want silence", diagnosis, err)
+		}
+	})
+	t.Run("absent credential file", func(t *testing.T) {
+		agent := runtime.Agent{Runtime: runtime.ClaudeRuntime, ReadOnlySeat: true}
+		if diagnosis, err := readOnlySeatCredentialPreflight(agent, t.TempDir(), time.Now().UTC()); err != nil || diagnosis != "" {
+			t.Fatalf("diagnosis=%q err=%v, want silence", diagnosis, err)
+		}
+	})
+	t.Run("unparseable credential file", func(t *testing.T) {
+		broken := t.TempDir()
+		if err := os.WriteFile(filepath.Join(broken, ".credentials.json"), []byte("not json"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		agent := runtime.Agent{Runtime: runtime.ClaudeRuntime, ReadOnlySeat: true}
+		if diagnosis, err := readOnlySeatCredentialPreflight(agent, broken, time.Now().UTC()); err != nil || diagnosis != "" {
+			t.Fatalf("diagnosis=%q err=%v, want silence", diagnosis, err)
+		}
+	})
+	t.Run("no source dir", func(t *testing.T) {
+		agent := runtime.Agent{Runtime: runtime.ClaudeRuntime, ReadOnlySeat: true}
+		if diagnosis, err := readOnlySeatCredentialPreflight(agent, "  ", time.Now().UTC()); err != nil || diagnosis != "" {
+			t.Fatalf("diagnosis=%q err=%v, want silence", diagnosis, err)
+		}
+	})
+}
+
+// An absent expiresAt is not evidence of expiry. Three existing seat tests
+// legitimately stage a credential carrying only an accessToken, and conflating
+// "no expiry declared" with "expired" refused all three jobs. An explicit 0 is
+// different: that is what a FAILED refresh writes back.
+func TestReadOnlySeatCredentialPreflightIgnoresAnAbsentExpiry(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, ".credentials.json"),
+		[]byte(`{"claudeAiOauth":{"accessToken":"host"}}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	agent := runtime.Agent{Runtime: runtime.ClaudeRuntime, ReadOnlySeat: true}
+	diagnosis, err := readOnlySeatCredentialPreflight(agent, dir, time.Now().UTC())
+	if err != nil || diagnosis != "" {
+		t.Fatalf("absent expiry: diagnosis=%q err=%v, want silence", diagnosis, err)
+	}
+
+	// ...while an EXPLICIT zero still refuses.
+	writeClaudeCredential(t, dir, 0, "")
+	if _, err := readOnlySeatCredentialPreflight(agent, dir, time.Now().UTC()); err == nil {
+		t.Fatal("an explicit expiresAt of 0 must still be refused")
+	}
+}
+
+// The seat must carry the SAME resolved runtime auth every other job gets. It
+// did not, which is why claude reviews failed while `auth probe claude` stayed
+// green: the probe reads the resolved auth, the seat never received it.
+func TestReadOnlySeatRuntimeAuthEnvCarriesTheResolvedOverlay(t *testing.T) {
+	home := t.TempDir()
+	paths, err := pathsFromFlag(home)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(paths.Home, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(runtimeAuthFilePath(paths.Home),
+		[]byte("CLAUDE_CODE_OAUTH_TOKEN=seat-token-long-enough-value\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	env, err := readOnlySeatRuntimeAuthEnv(home, runtime.ClaudeRuntime, false)
+	if err != nil {
+		t.Fatalf("readOnlySeatRuntimeAuthEnv: %v", err)
+	}
+	if !containsEnv(env, "CLAUDE_CODE_OAUTH_TOKEN=seat-token-long-enough-value") {
+		t.Fatalf("seat auth env = %v, want the resolved token", env)
+	}
+
+	// Gateway mode holds the credential itself, so a seat is given none.
+	gateway, err := readOnlySeatRuntimeAuthEnv(home, runtime.ClaudeRuntime, true)
+	if err != nil || len(gateway) != 0 {
+		t.Fatalf("gateway seat auth env = %v err=%v, want none", gateway, err)
+	}
+
+	// Other runtimes resolve their auth elsewhere; this must not invent any.
+	other, err := readOnlySeatRuntimeAuthEnv(home, runtime.CodexRuntime, false)
+	if err != nil || len(other) != 0 {
+		t.Fatalf("codex seat auth env = %v err=%v, want none", other, err)
+	}
+}
+
+// An operator-set CLAUDE_CONFIG_DIR names the ACCOUNT the engine runs as.
+// produceRuntimeSandboxGrants hard-coded $HOME/.claude and silently replaced
+// it, so a daemon configured onto a live account still pointed produce jobs at
+// /root/.claude, which on this host has carried expiresAt 0 with no refresh
+// token since 2026-08-31 and yields exactly "OAuth session expired and could
+// not be refreshed".
+func TestProduceRuntimeSandboxGrantsHonorsConfiguredClaudeDir(t *testing.T) {
+	configured := filepath.Join(t.TempDir(), "claude-13")
+	t.Setenv("CLAUDE_CONFIG_DIR", configured)
+
+	_, _, writes, env, err := produceRuntimeSandboxGrants(runtime.ClaudeRuntime, nil, nil, nil)
+	if err != nil {
+		t.Fatalf("produceRuntimeSandboxGrants: %v", err)
+	}
+	if !containsEnv(env, "CLAUDE_CONFIG_DIR="+configured) {
+		t.Fatalf("produce env = %v, want the configured dir %q", env, configured)
+	}
+	if !containsPath(writes, configured) {
+		t.Fatalf("produce writes = %v, want the configured dir writable", writes)
+	}
+
+	// With none set it still falls back to the host default.
+	t.Setenv("CLAUDE_CONFIG_DIR", "")
+	home, err := os.UserHomeDir()
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, _, _, fallbackEnv, err := produceRuntimeSandboxGrants(runtime.ClaudeRuntime, nil, nil, nil)
+	if err != nil {
+		t.Fatalf("produceRuntimeSandboxGrants fallback: %v", err)
+	}
+	if !containsEnv(fallbackEnv, "CLAUDE_CONFIG_DIR="+filepath.Join(filepath.Clean(home), ".claude")) {
+		t.Fatalf("fallback env = %v, want $HOME/.claude", fallbackEnv)
+	}
+}

--- a/internal/cli/readonly_seat_credential_test.go
+++ b/internal/cli/readonly_seat_credential_test.go
@@ -529,3 +529,126 @@ func TestResolveRuntimeConfigDirMatchesTheStagingContract(t *testing.T) {
 		t.Fatalf("state path = %q, want the resolved staged file", path)
 	}
 }
+
+// Round 2 of the #1810 review measured four realistic operator profiles that
+// hard-failed EVERY Claude produce job once produce started parsing the profile:
+// a symlinked settings.json (chezmoi/stow/yadm), an empty one, one holding a
+// JSON array, and a symlinked .credentials.json. Base never opened these files,
+// so each was a regression introduced by the staging fix. settings.json is
+// configuration the runtime has defaults for, so an unusable one is skipped;
+// .credentials.json decides which account runs, so an unusable one still fails -
+// but a SYMLINK is resolved rather than rejected in both cases.
+func TestProduceStagingToleratesRealisticOperatorProfileShapes(t *testing.T) {
+	object := `{"claudeAiOauth":{"accessToken":"operator-account"}}`
+	for _, tc := range []struct {
+		name        string
+		build       func(t *testing.T, configured string)
+		wantErr     bool
+		wantStaged  []string
+		wantSkipped []string
+	}{
+		{name: "plain-objects", build: func(t *testing.T, configured string) {
+			writeProfileFile(t, configured, ".credentials.json", object)
+			writeProfileFile(t, configured, "settings.json", `{"model":"opus"}`)
+		}, wantStaged: []string{".credentials.json", "settings.json"}},
+		{name: "symlinked-settings", build: func(t *testing.T, configured string) {
+			writeProfileFile(t, configured, ".credentials.json", object)
+			target := filepath.Join(t.TempDir(), "settings.json")
+			if err := os.WriteFile(target, []byte(`{"model":"opus"}`), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.Symlink(target, filepath.Join(configured, "settings.json")); err != nil {
+				t.Fatal(err)
+			}
+		}, wantStaged: []string{".credentials.json", "settings.json"}},
+		{name: "symlinked-credential", build: func(t *testing.T, configured string) {
+			target := filepath.Join(t.TempDir(), ".credentials.json")
+			if err := os.WriteFile(target, []byte(object), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.Symlink(target, filepath.Join(configured, ".credentials.json")); err != nil {
+				t.Fatal(err)
+			}
+		}, wantStaged: []string{".credentials.json"}},
+		{name: "empty-settings", build: func(t *testing.T, configured string) {
+			writeProfileFile(t, configured, ".credentials.json", object)
+			writeProfileFile(t, configured, "settings.json", "")
+		}, wantStaged: []string{".credentials.json"}, wantSkipped: []string{"settings.json"}},
+		{name: "array-settings", build: func(t *testing.T, configured string) {
+			writeProfileFile(t, configured, ".credentials.json", object)
+			writeProfileFile(t, configured, "settings.json", `["not","an","object"]`)
+		}, wantStaged: []string{".credentials.json"}, wantSkipped: []string{"settings.json"}},
+		{name: "directory-settings", build: func(t *testing.T, configured string) {
+			writeProfileFile(t, configured, ".credentials.json", object)
+			if err := os.MkdirAll(filepath.Join(configured, "settings.json"), 0o700); err != nil {
+				t.Fatal(err)
+			}
+		}, wantStaged: []string{".credentials.json"}, wantSkipped: []string{"settings.json"}},
+		{name: "unparseable-credential-still-fails", build: func(t *testing.T, configured string) {
+			writeProfileFile(t, configured, ".credentials.json", `["not","an","object"]`)
+		}, wantErr: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			home := t.TempDir()
+			t.Setenv("HOME", home)
+			configured := t.TempDir()
+			t.Setenv("CLAUDE_CONFIG_DIR", configured)
+			tc.build(t, configured)
+			stateRoot := t.TempDir()
+			_, _, _, env, err := produceRuntimeSandboxGrants(runtime.ClaudeRuntime, stateRoot, nil, nil, nil)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("an unusable .credentials.json must fail the dispatch loudly")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("a realistic operator profile must not fail produce: %v", err)
+			}
+			writeState := filepath.Join(stateRoot, ".claude")
+			if !containsEnv(env, "CLAUDE_CONFIG_DIR="+writeState) {
+				t.Fatalf("env = %v, want the job-private profile", env)
+			}
+			for _, name := range tc.wantStaged {
+				if _, err := os.Stat(filepath.Join(writeState, name)); err != nil {
+					t.Fatalf("%s was not staged: %v", name, err)
+				}
+			}
+			for _, name := range tc.wantSkipped {
+				if _, err := os.Stat(filepath.Join(writeState, name)); !os.IsNotExist(err) {
+					t.Fatalf("%s should have been skipped, not staged: %v", name, err)
+				}
+			}
+		})
+	}
+}
+
+// A file-type refusal must not blame the size, which sends the reader after the
+// wrong problem (#1810 review round 2).
+func TestProduceStagingErrorsNameTheActualCause(t *testing.T) {
+	configured := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(configured, ".credentials.json"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	err := stageProduceProfileFile(stagedProduceProfileFile{
+		source:      filepath.Join(configured, ".credentials.json"),
+		destination: filepath.Join(t.TempDir(), ".credentials.json"),
+		required:    true,
+	})
+	if err == nil {
+		t.Fatal("a directory in place of the credential must be refused")
+	}
+	if strings.Contains(err.Error(), "bytes") {
+		t.Fatalf("file-type refusal blames the size: %v", err)
+	}
+	if !strings.Contains(err.Error(), "regular file") {
+		t.Fatalf("error does not name the file type problem: %v", err)
+	}
+}
+
+func writeProfileFile(t *testing.T, dir, name, body string) {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(dir, name), []byte(body), 0o600); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/internal/cli/readonly_seat_credential_test.go
+++ b/internal/cli/readonly_seat_credential_test.go
@@ -20,51 +20,60 @@ func writeClaudeCredential(t *testing.T, dir string, expiresAtMillis int64, refr
 	}
 }
 
-// A credential that expired with NO refresh token cannot authenticate: no valid
-// access token and no way to get one. Launching a runtime on it can only fail,
-// so the seat refuses first, and the error names the file and the expiry rather
-// than leaving the reader with the runtime's "OAuth session expired" wording.
-// This is the state /root/.claude has been in since 2026-08-31.
-func TestReadOnlySeatCredentialPreflightRefusesTheUnusableCase(t *testing.T) {
-	dir := t.TempDir()
-	writeClaudeCredential(t, dir, 0, "")
-	agent := runtime.Agent{Runtime: runtime.ClaudeRuntime, ReadOnlySeat: true}
+// The refusal is GONE, deliberately. The #1810 exact-head review showed a
+// preflight refusal was wrong twice over: it converted a DEFERRABLE
+// runtime-auth blocker into a terminal failure plus a PR comment, against the
+// engine's own classifyOperationalBlocker/job.deferred policy, and the auth
+// overlay injected by the same commit means an expired staged snapshot no
+// longer decides whether the seat can authenticate. What survives is the
+// report: an expired snapshot must be RECORDED, never refused.
+func TestReadOnlySeatCredentialPreflightReportsAndNeverRefuses(t *testing.T) {
+	for name, test := range map[string]struct {
+		expiresAt    int64
+		refreshToken string
+		wantPhrase   string
+	}{
+		"expired with no refresh token": {
+			expiresAt: 0, refreshToken: "",
+			wantPhrase: "carries no refresh token",
+		},
+		"expired but refreshable": {
+			expiresAt: time.Now().UTC().Add(-time.Hour).UnixMilli(), refreshToken: "r",
+			wantPhrase: "must be refreshed by the runtime",
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			dir := t.TempDir()
+			writeClaudeCredential(t, dir, test.expiresAt, test.refreshToken)
+			agent := runtime.Agent{Runtime: runtime.ClaudeRuntime, ReadOnlySeat: true}
 
-	diagnosis, err := readOnlySeatCredentialPreflight(agent, dir, time.Now().UTC())
-	if err == nil {
-		t.Fatal("an expired credential with no refresh token must be refused before launch")
-	}
-	if diagnosis != "" {
-		t.Fatalf("refusal must not also return a diagnosis, got %q", diagnosis)
-	}
-	for _, want := range []string{".credentials.json", "no refresh token", "re-login"} {
-		if !strings.Contains(err.Error(), want) {
-			t.Fatalf("error %q must name %q", err.Error(), want)
-		}
+			diagnosis := readOnlySeatCredentialPreflight(agent, dir, false, time.Now().UTC())
+			if diagnosis == "" {
+				t.Fatal("an expired staged credential must be recorded")
+			}
+			if !strings.Contains(diagnosis, test.wantPhrase) {
+				t.Fatalf("diagnosis %q must contain %q", diagnosis, test.wantPhrase)
+			}
+			if !strings.Contains(diagnosis, "rather than a refusal") {
+				t.Fatalf("diagnosis %q must say it is not a refusal", diagnosis)
+			}
+			// The host credential path is NOT published: this string reaches a job
+			// event and previously reached a PR comment.
+			if strings.Contains(diagnosis, dir) {
+				t.Fatalf("diagnosis %q leaks the absolute host credential path", diagnosis)
+			}
+		})
 	}
 }
 
-// Expired WITH a refresh token is the state the daemon's account was in at
-// 06:31:46Z. Refreshing is the runtime's job and normally succeeds, so refusing
-// would break every host whose credential refreshes fine. Record the fact
-// instead, naming the source and the expiry.
-func TestReadOnlySeatCredentialPreflightDiagnosesTheRefreshableCase(t *testing.T) {
+// Gateway mode stages no credential file for a seat, so there is nothing to
+// diagnose and the check must stay silent.
+func TestReadOnlySeatCredentialPreflightSilentInGatewayMode(t *testing.T) {
 	dir := t.TempDir()
-	expiry := time.Now().UTC().Add(-time.Hour).Truncate(time.Second)
-	writeClaudeCredential(t, dir, expiry.UnixMilli(), "refresh-token")
+	writeClaudeCredential(t, dir, 0, "")
 	agent := runtime.Agent{Runtime: runtime.ClaudeRuntime, ReadOnlySeat: true}
-
-	diagnosis, err := readOnlySeatCredentialPreflight(agent, dir, time.Now().UTC())
-	if err != nil {
-		t.Fatalf("a refreshable credential must not be refused: %v", err)
-	}
-	if diagnosis == "" {
-		t.Fatal("an expired refreshable credential must be recorded, not silently staged")
-	}
-	for _, want := range []string{dir, expiry.Format(time.RFC3339), "staged snapshot"} {
-		if !strings.Contains(diagnosis, want) {
-			t.Fatalf("diagnosis %q must name %q", diagnosis, want)
-		}
+	if diagnosis := readOnlySeatCredentialPreflight(agent, dir, true, time.Now().UTC()); diagnosis != "" {
+		t.Fatalf("gateway mode diagnosis=%q, want silence", diagnosis)
 	}
 }
 
@@ -75,9 +84,8 @@ func TestReadOnlySeatCredentialPreflightPassesALiveCredential(t *testing.T) {
 	writeClaudeCredential(t, dir, time.Now().UTC().Add(8*time.Hour).UnixMilli(), "refresh-token")
 	agent := runtime.Agent{Runtime: runtime.ClaudeRuntime, ReadOnlySeat: true}
 
-	diagnosis, err := readOnlySeatCredentialPreflight(agent, dir, time.Now().UTC())
-	if err != nil || diagnosis != "" {
-		t.Fatalf("live credential: diagnosis=%q err=%v, want silence", diagnosis, err)
+	if diagnosis := readOnlySeatCredentialPreflight(agent, dir, false, time.Now().UTC()); diagnosis != "" {
+		t.Fatalf("live credential: diagnosis=%q, want silence", diagnosis)
 	}
 }
 
@@ -91,20 +99,20 @@ func TestReadOnlySeatCredentialPreflightStaysSilentWhereItCannotAssert(t *testin
 
 	t.Run("non-seat job", func(t *testing.T) {
 		agent := runtime.Agent{Runtime: runtime.ClaudeRuntime}
-		if diagnosis, err := readOnlySeatCredentialPreflight(agent, dir, time.Now().UTC()); err != nil || diagnosis != "" {
-			t.Fatalf("diagnosis=%q err=%v, want silence", diagnosis, err)
+		if diagnosis := readOnlySeatCredentialPreflight(agent, dir, false, time.Now().UTC()); diagnosis != "" {
+			t.Fatalf("diagnosis=%q, want silence", diagnosis)
 		}
 	})
 	t.Run("runtime with no readable expiry", func(t *testing.T) {
 		agent := runtime.Agent{Runtime: runtime.CodexRuntime, ReadOnlySeat: true}
-		if diagnosis, err := readOnlySeatCredentialPreflight(agent, dir, time.Now().UTC()); err != nil || diagnosis != "" {
-			t.Fatalf("diagnosis=%q err=%v, want silence", diagnosis, err)
+		if diagnosis := readOnlySeatCredentialPreflight(agent, dir, false, time.Now().UTC()); diagnosis != "" {
+			t.Fatalf("diagnosis=%q, want silence", diagnosis)
 		}
 	})
 	t.Run("absent credential file", func(t *testing.T) {
 		agent := runtime.Agent{Runtime: runtime.ClaudeRuntime, ReadOnlySeat: true}
-		if diagnosis, err := readOnlySeatCredentialPreflight(agent, t.TempDir(), time.Now().UTC()); err != nil || diagnosis != "" {
-			t.Fatalf("diagnosis=%q err=%v, want silence", diagnosis, err)
+		if diagnosis := readOnlySeatCredentialPreflight(agent, t.TempDir(), false, time.Now().UTC()); diagnosis != "" {
+			t.Fatalf("diagnosis=%q, want silence", diagnosis)
 		}
 	})
 	t.Run("unparseable credential file", func(t *testing.T) {
@@ -113,14 +121,14 @@ func TestReadOnlySeatCredentialPreflightStaysSilentWhereItCannotAssert(t *testin
 			t.Fatal(err)
 		}
 		agent := runtime.Agent{Runtime: runtime.ClaudeRuntime, ReadOnlySeat: true}
-		if diagnosis, err := readOnlySeatCredentialPreflight(agent, broken, time.Now().UTC()); err != nil || diagnosis != "" {
-			t.Fatalf("diagnosis=%q err=%v, want silence", diagnosis, err)
+		if diagnosis := readOnlySeatCredentialPreflight(agent, broken, false, time.Now().UTC()); diagnosis != "" {
+			t.Fatalf("diagnosis=%q, want silence", diagnosis)
 		}
 	})
 	t.Run("no source dir", func(t *testing.T) {
 		agent := runtime.Agent{Runtime: runtime.ClaudeRuntime, ReadOnlySeat: true}
-		if diagnosis, err := readOnlySeatCredentialPreflight(agent, "  ", time.Now().UTC()); err != nil || diagnosis != "" {
-			t.Fatalf("diagnosis=%q err=%v, want silence", diagnosis, err)
+		if diagnosis := readOnlySeatCredentialPreflight(agent, "  ", false, time.Now().UTC()); diagnosis != "" {
+			t.Fatalf("diagnosis=%q, want silence", diagnosis)
 		}
 	})
 }
@@ -136,15 +144,15 @@ func TestReadOnlySeatCredentialPreflightIgnoresAnAbsentExpiry(t *testing.T) {
 		t.Fatal(err)
 	}
 	agent := runtime.Agent{Runtime: runtime.ClaudeRuntime, ReadOnlySeat: true}
-	diagnosis, err := readOnlySeatCredentialPreflight(agent, dir, time.Now().UTC())
-	if err != nil || diagnosis != "" {
-		t.Fatalf("absent expiry: diagnosis=%q err=%v, want silence", diagnosis, err)
+	if diagnosis := readOnlySeatCredentialPreflight(agent, dir, false, time.Now().UTC()); diagnosis != "" {
+		t.Fatalf("absent expiry: diagnosis=%q, want silence", diagnosis)
 	}
 
-	// ...while an EXPLICIT zero still refuses.
+	// ...while an EXPLICIT zero is still reported, because that value is what a
+	// failed refresh writes back rather than an absent field.
 	writeClaudeCredential(t, dir, 0, "")
-	if _, err := readOnlySeatCredentialPreflight(agent, dir, time.Now().UTC()); err == nil {
-		t.Fatal("an explicit expiresAt of 0 must still be refused")
+	if diagnosis := readOnlySeatCredentialPreflight(agent, dir, false, time.Now().UTC()); diagnosis == "" {
+		t.Fatal("an explicit expiresAt of 0 must still be reported")
 	}
 }
 
@@ -220,4 +228,10 @@ func TestProduceRuntimeSandboxGrantsHonorsConfiguredClaudeDir(t *testing.T) {
 	if !containsEnv(fallbackEnv, "CLAUDE_CONFIG_DIR="+filepath.Join(filepath.Clean(home), ".claude")) {
 		t.Fatalf("fallback env = %v, want $HOME/.claude", fallbackEnv)
 	}
+}
+
+// writeFileForTest writes a raw .credentials.json body for cases that need a
+// shape writeClaudeCredential cannot express.
+func writeFileForTest(dir, body string) error {
+	return os.WriteFile(filepath.Join(dir, ".credentials.json"), []byte(body), 0o600)
 }

--- a/internal/cli/readonly_seat_credential_test.go
+++ b/internal/cli/readonly_seat_credential_test.go
@@ -130,9 +130,33 @@ func TestReadOnlySeatCredentialPreflightStaysSilentWhereItCannotAssert(t *testin
 		}
 	})
 	t.Run("no source dir", func(t *testing.T) {
+		// An empty source resolves through the HOST DEFAULT by design (that is
+		// this PR's fix for a silently-dead default profile), so this subtest is
+		// only meaningful with the host pinned. Unpinned it read the real
+		// ~/.claude and started failing the moment that credential expired -
+		// the assertion was measuring the box, not the code.
+		t.Setenv("HOME", t.TempDir())
+		t.Setenv("CLAUDE_CONFIG_DIR", "")
 		agent := runtime.Agent{Runtime: runtime.ClaudeRuntime, ReadOnlySeat: true}
 		if diagnosis := readOnlySeatCredentialPreflight(agent, "  ", false, true, time.Now().UTC()); diagnosis != "" {
-			t.Fatalf("diagnosis=%q, want silence", diagnosis)
+			t.Fatalf("diagnosis=%q, want silence when the host default profile does not exist", diagnosis)
+		}
+	})
+	t.Run("no source dir resolves the host default when one exists", func(t *testing.T) {
+		// The other half of the same contract, pinned rather than assumed: an
+		// empty source is NOT ignored, it resolves to ~/.claude, and an expired
+		// profile there is diagnosed instead of passing silently.
+		home := t.TempDir()
+		t.Setenv("HOME", home)
+		t.Setenv("CLAUDE_CONFIG_DIR", "")
+		hostDefault := filepath.Join(home, ".claude")
+		if err := os.MkdirAll(hostDefault, 0o700); err != nil {
+			t.Fatal(err)
+		}
+		writeClaudeCredential(t, hostDefault, 0, "")
+		agent := runtime.Agent{Runtime: runtime.ClaudeRuntime, ReadOnlySeat: true}
+		if diagnosis := readOnlySeatCredentialPreflight(agent, "  ", false, false, time.Now().UTC()); diagnosis == "" {
+			t.Fatal("an empty source must resolve the host default profile, not pass silently")
 		}
 	})
 }

--- a/internal/cli/readonly_seat_credential_test.go
+++ b/internal/cli/readonly_seat_credential_test.go
@@ -1,14 +1,20 @@
 package cli
 
 import (
+	"context"
+	"errors"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strconv"
 	"strings"
 	"testing"
 	"time"
 
+	"github.com/gitmoot/gitmoot/internal/config"
 	"github.com/gitmoot/gitmoot/internal/runtime"
+	"github.com/gitmoot/gitmoot/internal/subprocess"
+	"github.com/gitmoot/gitmoot/internal/workflow"
 )
 
 func writeClaudeCredential(t *testing.T, dir string, expiresAtMillis int64, refreshToken string) {
@@ -650,5 +656,225 @@ func writeProfileFile(t *testing.T, dir, name, body string) {
 	t.Helper()
 	if err := os.WriteFile(filepath.Join(dir, name), []byte(body), 0o600); err != nil {
 		t.Fatal(err)
+	}
+}
+
+// FAIL-OPEN is the property that keeps a broken probe from stranding every seat
+// job, and round 3 of the #1810 review showed it unpinned: a mutant flipping all
+// six early returns to authProbeInvalid survived the whole scoped suite. A probe
+// that cannot decide must release the job, never hold it.
+func TestSeatAuthProbeFailsOpenOnEveryUndecidableOutcome(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		err  error
+	}{
+		{"binary missing", exec.ErrNotFound},
+		{"probe timed out", context.DeadlineExceeded},
+		{"empty stdout", errors.New("claude auth probe produced no output")},
+		{"unparseable output", errors.New("invalid character 'x' looking for beginning of value")},
+		{"sandbox denied the probe", errors.New("fork/exec: permission denied")},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			home := t.TempDir()
+			configured := t.TempDir()
+			writeClaudeCredential(t, configured, time.Now().Add(time.Hour).UnixMilli(), "refresh")
+			t.Setenv("CLAUDE_CONFIG_DIR", configured)
+			original := claudeAuthLiveCheck
+			t.Cleanup(func() { claudeAuthLiveCheck = original })
+			claudeAuthLiveCheck = func(context.Context, subprocess.Runner, string, []string) error {
+				return tc.err
+			}
+			worker := jobWorker{ConfigHome: home}
+			verdict := worker.probeReadOnlySeatClaudeAuth(context.Background(),
+				runtime.Agent{Name: "reviewer", Runtime: runtime.ClaudeRuntime},
+				workflow.JobPayload{RuntimeConfigDir: configured})
+			if verdict != authProbeUnknown {
+				t.Fatalf("verdict = %v, want authProbeUnknown: an undecidable probe must not hold the job", verdict)
+			}
+			if verdict == authProbeInvalid {
+				t.Fatalf("verdict = authProbeInvalid; an undecidable probe would hold the job and strand every seat run")
+			}
+		})
+	}
+}
+
+// The overlay is claude-only BY POLICY, not by "codex happens to be excluded".
+// Round 3 measured a mutant widening it to kimi surviving, because the test
+// named codex instead of enumerating the runtimes.
+func TestSeatRuntimeAuthOverlayIsClaudeOnlyAcrossEverySupportedRuntime(t *testing.T) {
+	home := t.TempDir()
+	configured := t.TempDir()
+	writeClaudeCredential(t, configured, time.Now().Add(time.Hour).UnixMilli(), "refresh")
+	t.Setenv("CLAUDE_CONFIG_DIR", configured)
+	t.Setenv("CLAUDE_CODE_OAUTH_TOKEN", "seat-overlay-token")
+	supported := runtime.SupportedRuntimes()
+	if len(supported) < 2 {
+		t.Fatalf("SupportedRuntimes() = %v, expected the full runtime set", supported)
+	}
+	sawClaude := false
+	for _, name := range supported {
+		env, err := readOnlySeatRuntimeAuthEnv(home, name, false)
+		if err != nil {
+			t.Fatalf("readOnlySeatRuntimeAuthEnv(%s): %v", name, err)
+		}
+		if name == runtime.ClaudeRuntime {
+			sawClaude = true
+			if len(env) == 0 {
+				t.Fatalf("claude lost its runtime-auth overlay: %v", env)
+			}
+			continue
+		}
+		if len(env) != 0 {
+			t.Fatalf("runtime %q received a claude overlay (%d entries): the overlay is claude-only by policy", name, len(env))
+		}
+	}
+	if !sawClaude {
+		t.Fatalf("SupportedRuntimes() = %v, missing claude; the policy assertion measured nothing", supported)
+	}
+	// Gateway mode withholds it from claude too.
+	gatewayEnv, err := readOnlySeatRuntimeAuthEnv(home, runtime.ClaudeRuntime, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(gatewayEnv) != 0 {
+		t.Fatalf("gateway-mode claude seat received an overlay: %v", redactEnvNames(gatewayEnv))
+	}
+}
+
+// Round 3 of the #1810 review reproduced BOTH directions of dishonesty in the
+// operator-facing checks: a false RED in gateway mode and with a live overlay,
+// where every seat job succeeds, and a hard exit driven by a file read that
+// cannot see the per-job override which actually decides the seat's source.
+func TestSeatCredentialDoctorCheckReservesTheHardFailForWhatItProves(t *testing.T) {
+	dead := time.Now().Add(-24 * time.Hour).UnixMilli()
+	for _, tc := range []struct {
+		name         string
+		gateway      bool
+		overlayToken string
+		wantOK       bool
+		wantRequired bool
+		wantDetail   string
+	}{
+		{name: "gateway mode asserts nothing", gateway: true, wantOK: true, wantRequired: false, wantDetail: "model gateway"},
+		{name: "overlay present is untidy not broken", overlayToken: "live-overlay-token", wantOK: false, wantRequired: false, wantDetail: "overlay is present"},
+		{name: "no gateway no overlay is the proven failure", wantOK: false, wantRequired: true, wantDetail: "UNUSABLE"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			home := t.TempDir()
+			paths := seatDoctorTestPaths(t, home, tc.gateway)
+			configured := t.TempDir()
+			writeClaudeCredential(t, configured, dead, "")
+			t.Setenv("CLAUDE_CONFIG_DIR", configured)
+			t.Setenv("CLAUDE_CODE_OAUTH_TOKEN", tc.overlayToken)
+			check, ok := seatCredentialDoctorCheck(paths)
+			if !ok {
+				t.Fatal("seatCredentialDoctorCheck declined to report")
+			}
+			if check.OK != tc.wantOK || check.Required != tc.wantRequired {
+				t.Fatalf("check = OK %v Required %v, want OK %v Required %v: %s", check.OK, check.Required, tc.wantOK, tc.wantRequired, check.Detail)
+			}
+			if !strings.Contains(check.Detail, tc.wantDetail) {
+				t.Fatalf("detail = %q, want it to mention %q", check.Detail, tc.wantDetail)
+			}
+			// Every verdict must name the source it measured and admit the
+			// per-job override it cannot see.
+			if !strings.Contains(check.Detail, "runtime_config_dir") {
+				t.Fatalf("detail = %q, want it to disclose the per-job override blind spot", check.Detail)
+			}
+		})
+	}
+}
+
+func seatDoctorTestPaths(t *testing.T, home string, gateway bool) config.Paths {
+	t.Helper()
+	paths, err := pathsFromFlag(home)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := config.Initialize(paths); err != nil {
+		t.Fatal(err)
+	}
+	body := config.DefaultConfig(paths)
+	if gateway {
+		body += "\n[credentials]\nmodel_gateway = true\n"
+	}
+	if err := os.WriteFile(paths.ConfigFile, []byte(body), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return paths
+}
+
+// The seat path has always narrowed its staged credential to the OAuth section.
+// Round 3 measured produce copying the file VERBATIM, so a sibling secret in the
+// operator's credential file rode into the job-private profile.
+func TestProduceStagesOnlyTheOAuthSectionLikeTheSeatPath(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	configured := t.TempDir()
+	t.Setenv("CLAUDE_CONFIG_DIR", configured)
+	body := `{"claudeAiOauth":{"accessToken":"account-token","refreshToken":"ref"},"bedrockApiKey":"SIBLING-SECRET-XYZ"}`
+	if err := os.WriteFile(filepath.Join(configured, ".credentials.json"), []byte(body), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	stateRoot := t.TempDir()
+	if _, _, _, _, err := produceRuntimeSandboxGrants(runtime.ClaudeRuntime, stateRoot, nil, nil, nil); err != nil {
+		t.Fatalf("produceRuntimeSandboxGrants: %v", err)
+	}
+	staged, err := os.ReadFile(filepath.Join(stateRoot, ".claude", ".credentials.json"))
+	if err != nil {
+		t.Fatalf("read staged credential: %v", err)
+	}
+	if !strings.Contains(string(staged), "account-token") {
+		t.Fatalf("staged credential lost the account: %s", staged)
+	}
+	if strings.Contains(string(staged), "SIBLING-SECRET-XYZ") {
+		t.Fatalf("a sibling secret rode into the job-private profile: %s", staged)
+	}
+}
+
+// The live-check stub above exercises only the LAST return in the probe. The
+// six EARLY returns - temp-dir creation, staging, overlay resolution, probe-home
+// mkdir, an empty state dir, and backend resolution - are the ones a mutant
+// flipped to fail-closed and survived (#1810 review round 3, M9). Each of these
+// drives a real early return, so flipping any of them to authProbeInvalid fails
+// here.
+func TestSeatAuthProbeFailsOpenOnSetupFailuresNotOnlyOnTheLiveCheck(t *testing.T) {
+	original := claudeAuthLiveCheck
+	t.Cleanup(func() { claudeAuthLiveCheck = original })
+	claudeAuthLiveCheck = func(context.Context, subprocess.Runner, string, []string) error {
+		t.Fatal("probe reached the live check; this test must fail EARLIER, or it is not measuring the early returns")
+		return nil
+	}
+	for _, tc := range []struct {
+		name    string
+		prepare func(t *testing.T) (runtime.Agent, workflow.JobPayload)
+	}{
+		{
+			// os.MkdirTemp("", ...) honours TMPDIR, so an unusable TMPDIR fails
+			// the very first step.
+			name: "temp state root cannot be created",
+			prepare: func(t *testing.T) (runtime.Agent, workflow.JobPayload) {
+				t.Setenv("TMPDIR", filepath.Join(t.TempDir(), "does-not-exist"))
+				configured := t.TempDir()
+				writeClaudeCredential(t, configured, time.Now().Add(time.Hour).UnixMilli(), "r")
+				return runtime.Agent{Name: "reviewer", Runtime: runtime.ClaudeRuntime}, workflow.JobPayload{RuntimeConfigDir: configured}
+			},
+		},
+		{
+			// A relative config dir is refused by resolveRuntimeConfigDir, so
+			// staging fails before anything is written.
+			name: "staging refuses the configured dir",
+			prepare: func(t *testing.T) (runtime.Agent, workflow.JobPayload) {
+				return runtime.Agent{Name: "reviewer", Runtime: runtime.ClaudeRuntime}, workflow.JobPayload{RuntimeConfigDir: "relative-not-absolute"}
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			agent, payload := tc.prepare(t)
+			worker := jobWorker{ConfigHome: t.TempDir()}
+			if verdict := worker.probeReadOnlySeatClaudeAuth(context.Background(), agent, payload); verdict != authProbeUnknown {
+				t.Fatalf("verdict = %v, want authProbeUnknown: a probe that cannot set itself up must release the job, not hold it", verdict)
+			}
+		})
 	}
 }

--- a/internal/cli/readonly_seat_credential_worker_test.go
+++ b/internal/cli/readonly_seat_credential_worker_test.go
@@ -152,3 +152,160 @@ func TestWorkerRecordsExpiredButRefreshableSeatCredential(t *testing.T) {
 		t.Fatalf("a refreshable credential must still reach the runtime; state=%q calls=%d", stored.State, runner.calls)
 	}
 }
+
+// A deferred job is re-dispatched up to three times, and the diagnosis was
+// written on every run() entry, so an operator read three identical rows for one
+// fact (#1810 review, round 2).
+func TestWorkerRecordsTheSeatCredentialDiagnosisOncePerJob(t *testing.T) {
+	ctx := context.Background()
+	store, home := blockerE2EHome(t)
+	checkout := readonlyWorktreeGitCheckout(t, "owner/repo")
+	seedDaemonWorkerRepo(t, store, "owner/repo", checkout)
+	sourceDir := t.TempDir()
+	writeClaudeCredential(t, sourceDir, 0, "")
+	seedDaemonWorkerAgentWithPolicy(t, store, "claude-reviewer", runtime.ClaudeRuntime,
+		"550e8400-e29b-41d4-a716-446655440000", []string{"review"}, "owner/repo", runtime.AutonomyPolicyReadOnly)
+	enqueueDaemonWorkerJob(t, store, workflow.JobRequest{
+		ID: "cred-review-redispatch", Agent: "claude-reviewer", Action: "review", Repo: "owner/repo",
+		WorktreePath: checkout, ReadOnlySeat: true, RuntimeConfigDir: sourceDir,
+	})
+
+	worker := defaultJobWorker(store, io.Discard, home)
+	worker.CheckoutValidator = func(context.Context, db.Job, workflow.JobPayload, runtime.Agent) (string, error) {
+		return checkout, nil
+	}
+	worker.AdapterFactory = func(runtime.Agent, string) (workflow.DeliveryAdapter, error) {
+		return runtime.ClaudeAdapter{Runner: &repairStateRunner{}}, nil
+	}
+	for attempt := 0; attempt < 3; attempt++ {
+		if err := store.UpdateJobState(ctx, "cred-review-redispatch", "queued"); err != nil {
+			t.Fatal(err)
+		}
+		job, err := store.GetJob(ctx, "cred-review-redispatch")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := worker.run(ctx, job); err != nil {
+			t.Fatalf("attempt %d: %v", attempt, err)
+		}
+	}
+	events, err := store.ListJobEvents(ctx, "cred-review-redispatch")
+	if err != nil {
+		t.Fatal(err)
+	}
+	recorded := 0
+	for _, event := range events {
+		if event.Kind == readOnlySeatCredentialExpiredEvent {
+			recorded++
+		}
+	}
+	if recorded != 1 {
+		t.Fatalf("%s rows = %d across 3 dispatches, want 1", readOnlySeatCredentialExpiredEvent, recorded)
+	}
+}
+
+// Gateway mode stages no credential file, so the worker must stay silent. The
+// gateway decision was passed as an argument no test exercised at this call
+// site, so replacing it with a literal false kept the suite green (#1810 review
+// F8).
+func TestWorkerStaysSilentOnSeatCredentialsInGatewayMode(t *testing.T) {
+	ctx := context.Background()
+	store, home := blockerE2EHome(t)
+	paths, err := pathsFromFlag(home)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(paths.ConfigFile, []byte("[credentials]\nmodel_gateway = true\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	checkout := readonlyWorktreeGitCheckout(t, "owner/repo")
+	seedDaemonWorkerRepo(t, store, "owner/repo", checkout)
+	sourceDir := t.TempDir()
+	writeClaudeCredential(t, sourceDir, 0, "")
+	seedDaemonWorkerAgentWithPolicy(t, store, "claude-reviewer", runtime.ClaudeRuntime,
+		"550e8400-e29b-41d4-a716-446655440000", []string{"review"}, "owner/repo", runtime.AutonomyPolicyReadOnly)
+	enqueueDaemonWorkerJob(t, store, workflow.JobRequest{
+		ID: "cred-review-gateway", Agent: "claude-reviewer", Action: "review", Repo: "owner/repo",
+		WorktreePath: checkout, ReadOnlySeat: true, RuntimeConfigDir: sourceDir,
+	})
+
+	worker := defaultJobWorker(store, io.Discard, home)
+	worker.CheckoutValidator = func(context.Context, db.Job, workflow.JobPayload, runtime.Agent) (string, error) {
+		return checkout, nil
+	}
+	worker.AdapterFactory = func(runtime.Agent, string) (workflow.DeliveryAdapter, error) {
+		return runtime.ClaudeAdapter{Runner: &repairStateRunner{}}, nil
+	}
+	job, err := store.GetJob(ctx, "cred-review-gateway")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := worker.run(ctx, job); err != nil {
+		t.Fatal(err)
+	}
+	events, err := store.ListJobEvents(ctx, "cred-review-gateway")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, event := range events {
+		if event.Kind == readOnlySeatCredentialExpiredEvent {
+			t.Fatalf("gateway mode stages no credential, so nothing may be diagnosed: %q", event.Message)
+		}
+	}
+}
+
+// The dead-account shape the commit documents: NO payload dir and NO
+// CLAUDE_CONFIG_DIR, so the seat stages from the HOST DEFAULT. The diagnosis
+// returned "" for an empty source dir and said nothing in exactly that shape
+// (#1810 review F3).
+func TestWorkerDiagnosesTheHostDefaultSeatCredential(t *testing.T) {
+	ctx := context.Background()
+	store, home := blockerE2EHome(t)
+	hostHome := t.TempDir()
+	t.Setenv("HOME", hostHome)
+	t.Setenv("CLAUDE_CONFIG_DIR", "")
+	defaultDir := filepath.Join(hostHome, ".claude")
+	if err := os.MkdirAll(defaultDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	writeClaudeCredential(t, defaultDir, 0, "")
+	checkout := readonlyWorktreeGitCheckout(t, "owner/repo")
+	seedDaemonWorkerRepo(t, store, "owner/repo", checkout)
+	seedDaemonWorkerAgentWithPolicy(t, store, "claude-reviewer", runtime.ClaudeRuntime,
+		"550e8400-e29b-41d4-a716-446655440000", []string{"review"}, "owner/repo", runtime.AutonomyPolicyReadOnly)
+	enqueueDaemonWorkerJob(t, store, workflow.JobRequest{
+		ID: "cred-review-host-default", Agent: "claude-reviewer", Action: "review", Repo: "owner/repo",
+		WorktreePath: checkout, ReadOnlySeat: true,
+	})
+
+	worker := defaultJobWorker(store, io.Discard, home)
+	worker.CheckoutValidator = func(context.Context, db.Job, workflow.JobPayload, runtime.Agent) (string, error) {
+		return checkout, nil
+	}
+	worker.AdapterFactory = func(runtime.Agent, string) (workflow.DeliveryAdapter, error) {
+		return runtime.ClaudeAdapter{Runner: &repairStateRunner{}}, nil
+	}
+	job, err := store.GetJob(ctx, "cred-review-host-default")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := worker.run(ctx, job); err != nil {
+		t.Fatal(err)
+	}
+	events, err := store.ListJobEvents(ctx, job.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var recorded string
+	for _, event := range events {
+		if event.Kind == readOnlySeatCredentialExpiredEvent {
+			recorded = event.Message
+		}
+	}
+	if recorded == "" {
+		t.Fatalf("a dead host-default credential was staged with no diagnosis; events=%+v", events)
+	}
+	if strings.Contains(recorded, defaultDir) {
+		t.Fatalf("event %q publishes the absolute host credential path", recorded)
+	}
+}

--- a/internal/cli/readonly_seat_credential_worker_test.go
+++ b/internal/cli/readonly_seat_credential_worker_test.go
@@ -1,0 +1,144 @@
+package cli
+
+import (
+	"context"
+	"io"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gitmoot/gitmoot/internal/db"
+	"github.com/gitmoot/gitmoot/internal/runtime"
+	"github.com/gitmoot/gitmoot/internal/workflow"
+)
+
+// End to end through jobWorker.run: an unusable staged credential must fail the
+// job BEFORE any runtime launch. Measured cause: three seat reviews failed at
+// 06:31-06:36Z relaying "OAuth session expired and could not be refreshed",
+// which named OAuth rather than the snapshot gitmoot had staged.
+func TestWorkerRefusesSeatWithUnusableStagedCredential(t *testing.T) {
+	ctx := context.Background()
+	store, home := blockerE2EHome(t)
+	checkout := readonlyWorktreeGitCheckout(t, "owner/repo")
+	seedDaemonWorkerRepo(t, store, "owner/repo", checkout)
+	sourceDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(sourceDir, ".credentials.json"),
+		[]byte(`{"claudeAiOauth":{"accessToken":"a","expiresAt":0,"refreshToken":""}}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	seedDaemonWorkerAgentWithPolicy(t, store, "claude-reviewer", runtime.ClaudeRuntime,
+		"550e8400-e29b-41d4-a716-446655440000", []string{"review"}, "owner/repo", runtime.AutonomyPolicyReadOnly)
+	enqueueDaemonWorkerJob(t, store, workflow.JobRequest{
+		ID: "cred-review", Agent: "claude-reviewer", Action: "review", Repo: "owner/repo",
+		WorktreePath: checkout, ReadOnlySeat: true, RuntimeConfigDir: sourceDir,
+	})
+
+	launched := false
+	worker := defaultJobWorker(store, io.Discard, home)
+	worker.CheckoutValidator = func(context.Context, db.Job, workflow.JobPayload, runtime.Agent) (string, error) {
+		return checkout, nil
+	}
+	worker.AdapterFactory = func(runtime.Agent, string) (workflow.DeliveryAdapter, error) {
+		launched = true
+		t.Error("the runtime must not be launched on a credential that cannot authenticate")
+		return nil, nil
+	}
+	job, err := store.GetJob(ctx, "cred-review")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := worker.run(ctx, job); err != nil {
+		t.Fatal(err)
+	}
+
+	stored, err := store.GetJob(ctx, job.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if stored.State != string(workflow.JobFailed) || launched {
+		t.Fatalf("job state=%q launched=%v, want failed without a launch", stored.State, launched)
+	}
+	events, err := store.ListJobEvents(ctx, job.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var reason string
+	for _, event := range events {
+		if strings.Contains(event.Message, ".credentials.json") {
+			reason = event.Message
+		}
+	}
+	if reason == "" {
+		t.Fatalf("no event names the staged credential; events=%+v", events)
+	}
+	if !strings.Contains(reason, "no refresh token") || !strings.Contains(reason, "re-login") {
+		t.Fatalf("failure reason %q must say what is wrong and what fixes it", reason)
+	}
+}
+
+// The refreshable case must NOT be refused: refreshing is the runtime's job and
+// normally works, so refusing would break every host whose credential refreshes.
+// It records the fact, so a later auth failure is not read as a fresh OAuth
+// problem.
+func TestWorkerRecordsExpiredButRefreshableSeatCredential(t *testing.T) {
+	ctx := context.Background()
+	store, home := blockerE2EHome(t)
+	checkout := readonlyWorktreeGitCheckout(t, "owner/repo")
+	seedDaemonWorkerRepo(t, store, "owner/repo", checkout)
+	sourceDir := t.TempDir()
+	expiry := time.Now().UTC().Add(-time.Hour).Truncate(time.Second)
+	if err := os.WriteFile(filepath.Join(sourceDir, ".credentials.json"),
+		[]byte(`{"claudeAiOauth":{"accessToken":"a","expiresAt":`+
+			strconv.FormatInt(expiry.UnixMilli(), 10)+`,"refreshToken":"r"}}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	seedDaemonWorkerAgentWithPolicy(t, store, "claude-reviewer", runtime.ClaudeRuntime,
+		"550e8400-e29b-41d4-a716-446655440000", []string{"review"}, "owner/repo", runtime.AutonomyPolicyReadOnly)
+	enqueueDaemonWorkerJob(t, store, workflow.JobRequest{
+		ID: "cred-review-refreshable", Agent: "claude-reviewer", Action: "review", Repo: "owner/repo",
+		WorktreePath: checkout, ReadOnlySeat: true, RuntimeConfigDir: sourceDir,
+	})
+
+	runner := &repairStateRunner{}
+	worker := defaultJobWorker(store, io.Discard, home)
+	worker.CheckoutValidator = func(context.Context, db.Job, workflow.JobPayload, runtime.Agent) (string, error) {
+		return checkout, nil
+	}
+	worker.AdapterFactory = func(runtime.Agent, string) (workflow.DeliveryAdapter, error) {
+		return runtime.ClaudeAdapter{Runner: runner}, nil
+	}
+	job, err := store.GetJob(ctx, "cred-review-refreshable")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := worker.run(ctx, job); err != nil {
+		t.Fatal(err)
+	}
+
+	events, err := store.ListJobEvents(ctx, job.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var recorded string
+	for _, event := range events {
+		if event.Kind == "readonly_seat_credential_expired" {
+			recorded = event.Message
+		}
+	}
+	if recorded == "" {
+		t.Fatalf("expected a readonly_seat_credential_expired event; events=%+v", events)
+	}
+	if !strings.Contains(recorded, expiry.Format(time.RFC3339)) || !strings.Contains(recorded, sourceDir) {
+		t.Fatalf("event %q must name the expiry and the source dir", recorded)
+	}
+	stored, err := store.GetJob(ctx, job.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if stored.State == string(workflow.JobFailed) && runner.calls == 0 {
+		t.Fatalf("a refreshable credential must still reach the runtime; state=%q calls=%d", stored.State, runner.calls)
+	}
+}

--- a/internal/cli/readonly_seat_credential_worker_test.go
+++ b/internal/cli/readonly_seat_credential_worker_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/gitmoot/gitmoot/internal/credgw"
 	"github.com/gitmoot/gitmoot/internal/db"
 	"github.com/gitmoot/gitmoot/internal/runtime"
 	"github.com/gitmoot/gitmoot/internal/workflow"
@@ -229,12 +230,26 @@ func TestWorkerStaysSilentOnSeatCredentialsInGatewayMode(t *testing.T) {
 		WorktreePath: checkout, ReadOnlySeat: true, RuntimeConfigDir: sourceDir,
 	})
 
+	gateway, err := credgw.Start(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = gateway.Close(context.Background()) })
+	gatewayRunner := &credgw.Runner{
+		Inner:      &repairStateRunner{},
+		Gateway:    gateway,
+		Credential: credgw.Credential{Kind: credgw.CredentialBearer, Value: "test-token"},
+		Policy:     credgw.Policy{Upstream: credgw.DefaultAnthropicUpstream, AllowedHosts: []string{"api.anthropic.com"}},
+	}
 	worker := defaultJobWorker(store, io.Discard, home)
 	worker.CheckoutValidator = func(context.Context, db.Job, workflow.JobPayload, runtime.Agent) (string, error) {
 		return checkout, nil
 	}
 	worker.AdapterFactory = func(runtime.Agent, string) (workflow.DeliveryAdapter, error) {
-		return runtime.ClaudeAdapter{Runner: &repairStateRunner{}}, nil
+		return modelGatewayRuntimeAdapter{
+			Adapter: runtime.ClaudeAdapter{Runner: gatewayRunner},
+			runner:  gatewayRunner,
+		}, nil
 	}
 	job, err := store.GetJob(ctx, "cred-review-gateway")
 	if err != nil {

--- a/internal/cli/readonly_seat_credential_worker_test.go
+++ b/internal/cli/readonly_seat_credential_worker_test.go
@@ -15,11 +15,13 @@ import (
 	"github.com/gitmoot/gitmoot/internal/workflow"
 )
 
-// End to end through jobWorker.run: an unusable staged credential must fail the
-// job BEFORE any runtime launch. Measured cause: three seat reviews failed at
-// 06:31-06:36Z relaying "OAuth session expired and could not be refreshed",
-// which named OAuth rather than the snapshot gitmoot had staged.
-func TestWorkerRefusesSeatWithUnusableStagedCredential(t *testing.T) {
+// End to end through jobWorker.run: an expired staged credential must be
+// RECORDED and the job must still run. The first version of this change failed
+// the job here instead, and the #1810 review showed that converted a deferrable
+// runtime-auth blocker into a terminal failure with a PR comment, while the auth
+// overlay in the same commit means the staged snapshot no longer decides whether
+// the seat can authenticate.
+func TestWorkerRecordsExpiredSeatCredentialAndStillRuns(t *testing.T) {
 	ctx := context.Background()
 	store, home := blockerE2EHome(t)
 	checkout := readonlyWorktreeGitCheckout(t, "owner/repo")
@@ -36,6 +38,7 @@ func TestWorkerRefusesSeatWithUnusableStagedCredential(t *testing.T) {
 		WorktreePath: checkout, ReadOnlySeat: true, RuntimeConfigDir: sourceDir,
 	})
 
+	runner := &repairStateRunner{}
 	launched := false
 	worker := defaultJobWorker(store, io.Discard, home)
 	worker.CheckoutValidator = func(context.Context, db.Job, workflow.JobPayload, runtime.Agent) (string, error) {
@@ -43,8 +46,7 @@ func TestWorkerRefusesSeatWithUnusableStagedCredential(t *testing.T) {
 	}
 	worker.AdapterFactory = func(runtime.Agent, string) (workflow.DeliveryAdapter, error) {
 		launched = true
-		t.Error("the runtime must not be launched on a credential that cannot authenticate")
-		return nil, nil
+		return runtime.ClaudeAdapter{Runner: runner}, nil
 	}
 	job, err := store.GetJob(ctx, "cred-review")
 	if err != nil {
@@ -54,28 +56,31 @@ func TestWorkerRefusesSeatWithUnusableStagedCredential(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	stored, err := store.GetJob(ctx, job.ID)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if stored.State != string(workflow.JobFailed) || launched {
-		t.Fatalf("job state=%q launched=%v, want failed without a launch", stored.State, launched)
+	if !launched {
+		t.Fatal("an expired staged credential must not stop the runtime from launching")
 	}
 	events, err := store.ListJobEvents(ctx, job.ID)
 	if err != nil {
 		t.Fatal(err)
 	}
-	var reason string
+	var recorded string
 	for _, event := range events {
-		if strings.Contains(event.Message, ".credentials.json") {
-			reason = event.Message
+		if event.Kind == "readonly_seat_credential_expired" {
+			recorded = event.Message
 		}
 	}
-	if reason == "" {
-		t.Fatalf("no event names the staged credential; events=%+v", events)
+	if recorded == "" {
+		t.Fatalf("expected a readonly_seat_credential_expired event; events=%+v", events)
 	}
-	if !strings.Contains(reason, "no refresh token") || !strings.Contains(reason, "re-login") {
-		t.Fatalf("failure reason %q must say what is wrong and what fixes it", reason)
+	if strings.Contains(recorded, sourceDir) {
+		t.Fatalf("event %q publishes the absolute host credential path", recorded)
+	}
+	// No terminal failure was minted BY THE PREFLIGHT: whatever the runtime does
+	// next owns the outcome.
+	for _, event := range events {
+		if event.Kind == string(workflow.JobFailed) && strings.Contains(event.Message, "credential") {
+			t.Fatalf("preflight minted a terminal credential failure: %q", event.Message)
+		}
 	}
 }
 
@@ -131,8 +136,13 @@ func TestWorkerRecordsExpiredButRefreshableSeatCredential(t *testing.T) {
 	if recorded == "" {
 		t.Fatalf("expected a readonly_seat_credential_expired event; events=%+v", events)
 	}
-	if !strings.Contains(recorded, expiry.Format(time.RFC3339)) || !strings.Contains(recorded, sourceDir) {
-		t.Fatalf("event %q must name the expiry and the source dir", recorded)
+	if !strings.Contains(recorded, expiry.Format(time.RFC3339)) {
+		t.Fatalf("event %q must name the expiry", recorded)
+	}
+	// The absolute host path is deliberately NOT in the message: this text used to
+	// reach a PR comment, and #1810's review flagged publishing it.
+	if strings.Contains(recorded, sourceDir) {
+		t.Fatalf("event %q publishes the absolute host credential path", recorded)
 	}
 	stored, err := store.GetJob(ctx, job.ID)
 	if err != nil {

--- a/internal/cli/readonly_seat_probe_test.go
+++ b/internal/cli/readonly_seat_probe_test.go
@@ -1,0 +1,77 @@
+package cli
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// `gitmoot auth probe claude` and `gitmoot doctor` were green for hours while
+// every claude review job failed, because they probe the AMBIENT credential and
+// a read-only seat authenticates with a staged snapshot of the configured
+// config dir. A probe that cannot see the credential under test is a false
+// green, so the probe now reports the staged file as well.
+func TestSeatCredentialProbeReportsTheStagedCredential(t *testing.T) {
+	for name, test := range map[string]struct {
+		expiresAt    int64
+		refreshToken string
+		want         []string
+	}{
+		"unusable": {
+			expiresAt: 0, refreshToken: "",
+			want: []string{"UNUSABLE", "no refresh token", "re-logged in"},
+		},
+		"expired but refreshable": {
+			expiresAt: time.Now().UTC().Add(-time.Hour).UnixMilli(), refreshToken: "r",
+			want: []string{"EXPIRED", "refresh token present", "discarded with the job"},
+		},
+		"valid": {
+			expiresAt: time.Now().UTC().Add(8 * time.Hour).UnixMilli(), refreshToken: "r",
+			want: []string{"valid until"},
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			dir := t.TempDir()
+			writeClaudeCredential(t, dir, test.expiresAt, test.refreshToken)
+			t.Setenv("CLAUDE_CONFIG_DIR", dir)
+
+			var stdout bytes.Buffer
+			writeSeatCredentialProbe(&stdout, t.TempDir())
+			out := stdout.String()
+			if !strings.Contains(out, dir) {
+				t.Fatalf("probe output must name the staged file; got %q", out)
+			}
+			for _, want := range test.want {
+				if !strings.Contains(out, want) {
+					t.Fatalf("probe output %q must contain %q", out, want)
+				}
+			}
+		})
+	}
+}
+
+// A credential file with no readable expiry must not be reported as a verdict
+// either way: the probe says what it can see and nothing more.
+func TestSeatCredentialProbeStatesWhenItCannotAssert(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, ".credentials.json"),
+		[]byte(`{"claudeAiOauth":{"accessToken":"host"}}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("CLAUDE_CONFIG_DIR", dir)
+
+	var stdout bytes.Buffer
+	writeSeatCredentialProbe(&stdout, t.TempDir())
+	out := stdout.String()
+	if !strings.Contains(out, "no readable expiry") {
+		t.Fatalf("probe output %q must say it cannot assert", out)
+	}
+	for _, forbidden := range []string{"UNUSABLE", "EXPIRED", "valid until"} {
+		if strings.Contains(out, forbidden) {
+			t.Fatalf("probe output %q must not claim %q without an expiry", out, forbidden)
+		}
+	}
+}

--- a/internal/cli/readonly_seat_probe_test.go
+++ b/internal/cli/readonly_seat_probe_test.go
@@ -2,11 +2,20 @@ package cli
 
 import (
 	"bytes"
+	"context"
+	"errors"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/gitmoot/gitmoot/internal/config"
+	"github.com/gitmoot/gitmoot/internal/db"
+	"github.com/gitmoot/gitmoot/internal/runtime"
+	"github.com/gitmoot/gitmoot/internal/subprocess"
+	"github.com/gitmoot/gitmoot/internal/workflow"
 )
 
 // `gitmoot auth probe claude` and `gitmoot doctor` were green for hours while
@@ -39,7 +48,7 @@ func TestSeatCredentialProbeReportsTheStagedCredential(t *testing.T) {
 			t.Setenv("CLAUDE_CONFIG_DIR", dir)
 
 			var stdout bytes.Buffer
-			writeSeatCredentialProbe(&stdout, t.TempDir())
+			writeSeatCredentialProbe(&stdout, config.Paths{})
 			out := stdout.String()
 			if !strings.Contains(out, dir) {
 				t.Fatalf("probe output must name the staged file; got %q", out)
@@ -64,7 +73,7 @@ func TestSeatCredentialProbeStatesWhenItCannotAssert(t *testing.T) {
 	t.Setenv("CLAUDE_CONFIG_DIR", dir)
 
 	var stdout bytes.Buffer
-	writeSeatCredentialProbe(&stdout, t.TempDir())
+	writeSeatCredentialProbe(&stdout, config.Paths{})
 	out := stdout.String()
 	if !strings.Contains(out, "no readable expiry") {
 		t.Fatalf("probe output %q must say it cannot assert", out)
@@ -73,5 +82,114 @@ func TestSeatCredentialProbeStatesWhenItCannotAssert(t *testing.T) {
 		if strings.Contains(out, forbidden) {
 			t.Fatalf("probe output %q must not claim %q without an expiry", out, forbidden)
 		}
+	}
+}
+
+// The scheduler's probe is the only one that makes an automated DECISION, and it
+// probed the AMBIENT credential: a seat authenticates with a staged snapshot of
+// its config dir plus the resolved overlay, so an ambient "valid" released held
+// seat jobs straight back into the dead snapshot they had just failed on (#1810
+// review, round 2).
+func TestSeatAuthProbeMeasuresTheStagedSeatCredential(t *testing.T) {
+	store, home := blockerE2EHome(t)
+	paths, err := pathsFromFlag(home)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(runtimeAuthFilePath(paths.Home),
+		[]byte("CLAUDE_CODE_OAUTH_TOKEN=seat-probe-token-long-enough\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	sourceDir := t.TempDir()
+	writeClaudeCredential(t, sourceDir, 0, "")
+	seedDaemonWorkerAgentWithPolicy(t, store, "claude-reviewer", runtime.ClaudeRuntime,
+		"550e8400-e29b-41d4-a716-446655440000", []string{"review"}, "owner/repo", runtime.AutonomyPolicyReadOnly)
+	worker := defaultJobWorker(store, io.Discard, home)
+	job := db.Job{ID: "seat-auth-probe", Agent: "claude-reviewer"}
+
+	var probedEnv []string
+	var stagedCredential string
+	original := claudeAuthLiveCheck
+	claudeAuthLiveCheck = func(_ context.Context, runner subprocess.Runner, _ string, _ []string) error {
+		curated, ok := runner.(subprocess.CuratedGroupRunner)
+		if !ok {
+			t.Fatalf("probe runner %T does not carry a curated seat environment", runner)
+		}
+		probedEnv = append([]string(nil), curated.BaseEnv...)
+		for _, entry := range probedEnv {
+			if dir, ok := strings.CutPrefix(entry, "CLAUDE_CONFIG_DIR="); ok {
+				if data, readErr := os.ReadFile(filepath.Join(dir, ".credentials.json")); readErr == nil {
+					stagedCredential = string(data)
+				}
+			}
+		}
+		return errors.Join(errors.New("rejected"), runtime.ErrClaudeAuthFailed)
+	}
+	t.Cleanup(func() { claudeAuthLiveCheck = original })
+
+	t.Setenv("CLAUDE_CONFIG_DIR", sourceDir)
+	payload := workflow.JobPayload{Repo: "owner/repo", ReadOnlySeat: true}
+	if verdict := worker.defaultAuthProbe(context.Background(), job, payload); verdict != authProbeInvalid {
+		t.Fatalf("verdict = %v, want invalid: the staged credential is dead", verdict)
+	}
+	if stagedCredential == "" || !strings.Contains(stagedCredential, "claudeAiOauth") {
+		t.Fatalf("probe did not read a staged copy of the seat credential: %q", stagedCredential)
+	}
+	if !containsEnv(probedEnv, "CLAUDE_CODE_OAUTH_TOKEN=seat-probe-token-long-enough") {
+		t.Fatalf("probe env lacks the resolved overlay: %v", redactEnvNames(probedEnv))
+	}
+	var configDir string
+	for _, entry := range probedEnv {
+		if dir, ok := strings.CutPrefix(entry, "CLAUDE_CONFIG_DIR="); ok {
+			configDir = dir
+		}
+	}
+	if configDir == "" || configDir == sourceDir {
+		t.Fatalf("probe used config dir %q; it must stage a disposable copy, never the host profile", configDir)
+	}
+	if _, err := os.Stat(configDir); !os.IsNotExist(err) {
+		t.Fatalf("probe left its staged credential behind at %q (err=%v)", configDir, err)
+	}
+
+	// A non-seat job keeps the ambient runner: nothing is staged for it.
+	probedEnv = nil
+	stagedCredential = ""
+	claudeAuthLiveCheck = func(_ context.Context, runner subprocess.Runner, _ string, _ []string) error {
+		if curated, ok := runner.(subprocess.CuratedGroupRunner); ok {
+			for _, entry := range curated.BaseEnv {
+				if strings.Contains(entry, "gitmoot-seat-auth-probe") {
+					t.Fatalf("a non-seat job probed a staged seat credential: %q", entry)
+				}
+			}
+		}
+		return nil
+	}
+	if verdict := worker.defaultAuthProbe(context.Background(), job, workflow.JobPayload{Repo: "owner/repo"}); verdict != authProbeValid {
+		t.Fatalf("non-seat verdict = %v, want valid", verdict)
+	}
+}
+
+// Seat verdicts must not share a cache key with ambient jobs, or one ambient
+// "valid" releases every held seat job.
+func TestAuthProbeDedupKeySeparatesSeatsFromAmbient(t *testing.T) {
+	store, home := blockerE2EHome(t)
+	seedDaemonWorkerAgentWithPolicy(t, store, "claude-reviewer", runtime.ClaudeRuntime,
+		"550e8400-e29b-41d4-a716-446655440000", []string{"review"}, "owner/repo", runtime.AutonomyPolicyReadOnly)
+	worker := defaultJobWorker(store, io.Discard, home)
+	job := db.Job{ID: "k", Agent: "claude-reviewer"}
+
+	ambient := worker.authProbeDedupKey(context.Background(), job, workflow.JobPayload{Repo: "owner/repo"})
+	seatA := worker.authProbeDedupKey(context.Background(), job, workflow.JobPayload{Repo: "owner/repo", ReadOnlySeat: true, RuntimeConfigDir: "/profiles/a"})
+	seatB := worker.authProbeDedupKey(context.Background(), job, workflow.JobPayload{Repo: "owner/repo", ReadOnlySeat: true, RuntimeConfigDir: "/profiles/b"})
+	t.Setenv("CLAUDE_CONFIG_DIR", "/profiles/a")
+	seatDefault := worker.authProbeDedupKey(context.Background(), job, workflow.JobPayload{Repo: "owner/repo", ReadOnlySeat: true})
+	if ambient == seatA {
+		t.Fatalf("seat and ambient share the key %q", ambient)
+	}
+	if seatA == seatB {
+		t.Fatalf("two seats with different config dirs share the key %q", seatA)
+	}
+	if seatDefault != seatA {
+		t.Fatalf("default seat key %q differs from explicit effective account key %q", seatDefault, seatA)
 	}
 }

--- a/internal/cli/readonly_seat_probe_test.go
+++ b/internal/cli/readonly_seat_probe_test.go
@@ -30,7 +30,7 @@ func TestSeatCredentialProbeReportsTheStagedCredential(t *testing.T) {
 		},
 		"valid": {
 			expiresAt: time.Now().UTC().Add(8 * time.Hour).UnixMilli(), refreshToken: "r",
-			want: []string{"valid until"},
+			want: []string{"declares expiry", "does not prove"},
 		},
 	} {
 		t.Run(name, func(t *testing.T) {
@@ -69,7 +69,7 @@ func TestSeatCredentialProbeStatesWhenItCannotAssert(t *testing.T) {
 	if !strings.Contains(out, "no readable expiry") {
 		t.Fatalf("probe output %q must say it cannot assert", out)
 	}
-	for _, forbidden := range []string{"UNUSABLE", "EXPIRED", "valid until"} {
+	for _, forbidden := range []string{"UNUSABLE", "EXPIRED", "declares expiry"} {
 		if strings.Contains(out, forbidden) {
 			t.Fatalf("probe output %q must not claim %q without an expiry", out, forbidden)
 		}

--- a/internal/cli/readonly_seat_probe_test.go
+++ b/internal/cli/readonly_seat_probe_test.go
@@ -46,9 +46,13 @@ func TestSeatCredentialProbeReportsTheStagedCredential(t *testing.T) {
 			dir := t.TempDir()
 			writeClaudeCredential(t, dir, test.expiresAt, test.refreshToken)
 			t.Setenv("CLAUDE_CONFIG_DIR", dir)
+			// Gateway mode and the runtime-auth overlay both change this verdict
+			// now, so pin them instead of inheriting the host's (#1810 round 3).
+			t.Setenv("CLAUDE_CODE_OAUTH_TOKEN", "")
+			t.Setenv("ANTHROPIC_API_KEY", "")
 
 			var stdout bytes.Buffer
-			writeSeatCredentialProbe(&stdout, config.Paths{})
+			writeSeatCredentialProbe(&stdout, seatDoctorTestPaths(t, t.TempDir(), false))
 			out := stdout.String()
 			if !strings.Contains(out, dir) {
 				t.Fatalf("probe output must name the staged file; got %q", out)

--- a/internal/cli/readonly_seat_wiring_test.go
+++ b/internal/cli/readonly_seat_wiring_test.go
@@ -1,0 +1,93 @@
+package cli
+
+import (
+	"context"
+	"errors"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/gitmoot/gitmoot/internal/runtime"
+	"github.com/gitmoot/gitmoot/internal/subprocess"
+)
+
+// F3 from the #1810 review: the fix reach is SHAPE-DEPENDENT, and nothing tested
+// the wiring. graftRuntimeBaseRunner has no CuratedGroupRunner case, so only the
+// execbackend InstanceRunner shape rebuilds a seat env from
+// readOnlyRuntimeBaseEnv (this host uses it). This pins that the injected
+// overlay reaches the runner the adapter actually calls, for that shape.
+func TestWrapReadOnlySandboxAdapterCarriesResolvedAuthIntoTheRunner(t *testing.T) {
+	home := t.TempDir()
+	paths, err := pathsFromFlag(home)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(paths.Home, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(runtimeAuthFilePath(paths.Home),
+		[]byte("CLAUDE_CODE_OAUTH_TOKEN=seat-overlay-token-value\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	checkout := readonlyWorktreeGitCheckout(t, "owner/repo")
+
+	recorder := &envRecordingRunner{}
+	agent := runtime.Agent{
+		Runtime:       runtime.ClaudeRuntime,
+		ReadOnlySeat:  true,
+		WritablePaths: nil,
+	}
+	wrapped, err := wrapReadOnlySandboxAdapter(home, agent, checkout, runtime.ClaudeAdapter{Runner: recorder})
+	if err != nil {
+		t.Fatalf("wrapReadOnlySandboxAdapter: %v", err)
+	}
+	// The seat wrapper returns readOnlyRuntimeAdapter, which embeds the runtime
+	// adapter it wrapped; reach the inner ClaudeAdapter to inspect its runner.
+	seat, ok := wrapped.(readOnlyRuntimeAdapter)
+	if !ok {
+		t.Fatalf("wrapped adapter type %T, want readOnlyRuntimeAdapter", wrapped)
+	}
+	t.Cleanup(func() { _ = seat.cleanup() })
+	adapter, ok := seat.Adapter.(runtime.ClaudeAdapter)
+	if !ok {
+		t.Fatalf("inner adapter type %T, want runtime.ClaudeAdapter", seat.Adapter)
+	}
+	envRunner, ok := adapter.Runner.(subprocess.EnvRunner)
+	if !ok {
+		t.Fatalf("wrapped seat runner %T does not accept an environment", adapter.Runner)
+	}
+	if _, err := envRunner.RunEnv(context.Background(), checkout, nil, "/bin/true"); err != nil && recorder.env == nil {
+		t.Fatalf("runner never ran: %v", err)
+	}
+	if !containsEnv(recorder.env, "CLAUDE_CODE_OAUTH_TOKEN=seat-overlay-token-value") {
+		t.Fatalf("seat runner env lacks the resolved overlay: %v", redactEnvNames(recorder.env))
+	}
+}
+
+// envRecordingRunner captures the environment the innermost runner is handed.
+type envRecordingRunner struct {
+	env []string
+}
+
+func (r *envRecordingRunner) Run(context.Context, string, string, ...string) (subprocess.Result, error) {
+	return subprocess.Result{}, errors.New("env-recording runner requires RunEnv")
+}
+
+func (r *envRecordingRunner) LookPath(file string) (string, error) {
+	return file, nil
+}
+
+func (r *envRecordingRunner) RunEnv(_ context.Context, _ string, env []string, _ string, _ ...string) (subprocess.Result, error) {
+	r.env = append([]string(nil), env...)
+	return subprocess.Result{}, nil
+}
+
+// redactEnvNames returns NAMES only, so a failure message never prints a token.
+func redactEnvNames(env []string) []string {
+	names := make([]string, 0, len(env))
+	for _, entry := range env {
+		name, _, _ := strings.Cut(entry, "=")
+		names = append(names, name)
+	}
+	return names
+}

--- a/internal/cli/readonly_seat_wiring_test.go
+++ b/internal/cli/readonly_seat_wiring_test.go
@@ -1,86 +1,17 @@
 package cli
 
 import (
-	"context"
-	"errors"
+	"io"
 	"os"
 	"strings"
 	"testing"
 
+	"github.com/gitmoot/gitmoot/internal/credgw"
+	"github.com/gitmoot/gitmoot/internal/execbackend"
 	"github.com/gitmoot/gitmoot/internal/runtime"
 	"github.com/gitmoot/gitmoot/internal/subprocess"
 )
 
-// F3 from the #1810 review: the fix reach is SHAPE-DEPENDENT, and nothing tested
-// the wiring. graftRuntimeBaseRunner has no CuratedGroupRunner case, so only the
-// execbackend InstanceRunner shape rebuilds a seat env from
-// readOnlyRuntimeBaseEnv (this host uses it). This pins that the injected
-// overlay reaches the runner the adapter actually calls, for that shape.
-func TestWrapReadOnlySandboxAdapterCarriesResolvedAuthIntoTheRunner(t *testing.T) {
-	home := t.TempDir()
-	paths, err := pathsFromFlag(home)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if err := os.MkdirAll(paths.Home, 0o700); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(runtimeAuthFilePath(paths.Home),
-		[]byte("CLAUDE_CODE_OAUTH_TOKEN=seat-overlay-token-value\n"), 0o600); err != nil {
-		t.Fatal(err)
-	}
-	checkout := readonlyWorktreeGitCheckout(t, "owner/repo")
-
-	recorder := &envRecordingRunner{}
-	agent := runtime.Agent{
-		Runtime:       runtime.ClaudeRuntime,
-		ReadOnlySeat:  true,
-		WritablePaths: nil,
-	}
-	wrapped, err := wrapReadOnlySandboxAdapter(home, agent, checkout, runtime.ClaudeAdapter{Runner: recorder})
-	if err != nil {
-		t.Fatalf("wrapReadOnlySandboxAdapter: %v", err)
-	}
-	// The seat wrapper returns readOnlyRuntimeAdapter, which embeds the runtime
-	// adapter it wrapped; reach the inner ClaudeAdapter to inspect its runner.
-	seat, ok := wrapped.(readOnlyRuntimeAdapter)
-	if !ok {
-		t.Fatalf("wrapped adapter type %T, want readOnlyRuntimeAdapter", wrapped)
-	}
-	t.Cleanup(func() { _ = seat.cleanup() })
-	adapter, ok := seat.Adapter.(runtime.ClaudeAdapter)
-	if !ok {
-		t.Fatalf("inner adapter type %T, want runtime.ClaudeAdapter", seat.Adapter)
-	}
-	envRunner, ok := adapter.Runner.(subprocess.EnvRunner)
-	if !ok {
-		t.Fatalf("wrapped seat runner %T does not accept an environment", adapter.Runner)
-	}
-	if _, err := envRunner.RunEnv(context.Background(), checkout, nil, "/bin/true"); err != nil && recorder.env == nil {
-		t.Fatalf("runner never ran: %v", err)
-	}
-	if !containsEnv(recorder.env, "CLAUDE_CODE_OAUTH_TOKEN=seat-overlay-token-value") {
-		t.Fatalf("seat runner env lacks the resolved overlay: %v", redactEnvNames(recorder.env))
-	}
-}
-
-// envRecordingRunner captures the environment the innermost runner is handed.
-type envRecordingRunner struct {
-	env []string
-}
-
-func (r *envRecordingRunner) Run(context.Context, string, string, ...string) (subprocess.Result, error) {
-	return subprocess.Result{}, errors.New("env-recording runner requires RunEnv")
-}
-
-func (r *envRecordingRunner) LookPath(file string) (string, error) {
-	return file, nil
-}
-
-func (r *envRecordingRunner) RunEnv(_ context.Context, _ string, env []string, _ string, _ ...string) (subprocess.Result, error) {
-	r.env = append([]string(nil), env...)
-	return subprocess.Result{}, nil
-}
 
 // redactEnvNames returns NAMES only, so a failure message never prints a token.
 func redactEnvNames(env []string) []string {
@@ -90,4 +21,213 @@ func redactEnvNames(env []string) []string {
 		names = append(names, name)
 	}
 	return names
+}
+
+// Every runner shape used by the daemon must receive the same curated BaseEnv.
+// In particular, the default CuratedGroupRunner and execbackend InstanceRunner
+// must both carry the auth overlay and drop ambient GitHub credentials.
+func TestWrapReadOnlySandboxAdapterCuratesEveryRunnerShape(t *testing.T) {
+	const overlay = "CLAUDE_CODE_OAUTH_TOKEN=seat-shape-token-value"
+	home := t.TempDir()
+	paths, err := pathsFromFlag(home)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(paths.Home, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(runtimeAuthFilePath(paths.Home), []byte(overlay+"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	// An ambient GH_TOKEN must never reach a read-only seat: gh prefers it over
+	// the redirected GH_CONFIG_DIR, so inheriting it hands a review a live
+	// GitHub credential.
+	t.Setenv("GH_TOKEN", "ambient-github-token")
+	checkout := readonlyWorktreeGitCheckout(t, "owner/repo")
+	agent := runtime.Agent{Runtime: runtime.ClaudeRuntime, ReadOnlySeat: true}
+
+	for name, runner := range map[string]subprocess.Runner{
+		"nil runner":                    nil,
+		"group runner":                  subprocess.GroupRunner{},
+		"curated group runner":          subprocess.CuratedGroupRunner{BaseEnv: []string{"GH_TOKEN=ambient-github-token"}},
+		"execbackend instance runner":   execbackend.InstanceRunner{BaseEnv: []string{"GH_TOKEN=ambient-github-token"}},
+		"tee over curated group runner": subprocess.TeeRunner{Inner: subprocess.CuratedGroupRunner{BaseEnv: []string{"GH_TOKEN=ambient-github-token"}}},
+		"env injecting over group":      subprocess.EnvInjectingRunner{Inner: subprocess.GroupRunner{}},
+	} {
+		t.Run(name, func(t *testing.T) {
+			wrapped, err := wrapReadOnlySandboxAdapter(home, agent, checkout, runtime.ClaudeAdapter{Runner: runner})
+			if err != nil {
+				t.Fatalf("wrapReadOnlySandboxAdapter: %v", err)
+			}
+			seat, ok := wrapped.(readOnlyRuntimeAdapter)
+			if !ok {
+				t.Fatalf("wrapped adapter %T, want readOnlyRuntimeAdapter", wrapped)
+			}
+			t.Cleanup(func() { _ = seat.cleanup() })
+			inner, ok := seat.Adapter.(runtime.ClaudeAdapter)
+			if !ok {
+				t.Fatalf("inner adapter %T, want runtime.ClaudeAdapter", seat.Adapter)
+			}
+			sandboxEnv, baseEnv := seatRunnerEnvironments(t, inner.Runner)
+			if !containsEnv(sandboxEnv, overlay) {
+				t.Fatalf("sandbox env lacks the overlay: %v", redactEnvNames(sandboxEnv))
+			}
+			if !containsEnv(baseEnv, overlay) {
+				t.Fatalf("runner base env lacks the overlay: %v", redactEnvNames(baseEnv))
+			}
+			for _, entry := range baseEnv {
+				if strings.HasPrefix(entry, "GH_TOKEN=") {
+					t.Fatalf("seat base env inherited GH_TOKEN: %v", redactEnvNames(baseEnv))
+				}
+			}
+		})
+	}
+}
+
+// Gateway mode holds the credential itself, so the seat is deliberately given
+// no overlay: injecting one would hand the sandboxed child a real token the
+// gateway exists to withhold.
+func TestWrapReadOnlySandboxAdapterWithholdsAuthInGatewayMode(t *testing.T) {
+	home := t.TempDir()
+	paths, err := pathsFromFlag(home)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(paths.Home, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(runtimeAuthFilePath(paths.Home),
+		[]byte("CLAUDE_CODE_OAUTH_TOKEN=gateway-withheld-token\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	checkout := readonlyWorktreeGitCheckout(t, "owner/repo")
+	gatewayRunner := &credgw.Runner{Inner: subprocess.CuratedGroupRunner{}}
+	adapter := modelGatewayRuntimeAdapter{
+		Adapter: runtime.ClaudeAdapter{Runner: gatewayRunner},
+		runner:  gatewayRunner,
+	}
+	agent := runtime.Agent{Runtime: runtime.ClaudeRuntime, ReadOnlySeat: true}
+
+	wrapped, err := wrapReadOnlySandboxAdapter(home, agent, checkout, adapter)
+	if err != nil {
+		t.Fatalf("wrapReadOnlySandboxAdapter: %v", err)
+	}
+	seat, ok := wrapped.(readOnlyRuntimeAdapter)
+	if !ok {
+		t.Fatalf("wrapped adapter %T, want readOnlyRuntimeAdapter", wrapped)
+	}
+	t.Cleanup(func() { _ = seat.cleanup() })
+	gateway, ok := seat.Adapter.(modelGatewayRuntimeAdapter)
+	if !ok {
+		t.Fatalf("inner adapter %T, want modelGatewayRuntimeAdapter", seat.Adapter)
+	}
+	claude, ok := gateway.Adapter.(runtime.ClaudeAdapter)
+	if !ok {
+		t.Fatalf("gateway inner adapter %T, want runtime.ClaudeAdapter", gateway.Adapter)
+	}
+	sandboxEnv, baseEnv := seatRunnerEnvironments(t, claude.Runner)
+	for _, env := range [][]string{sandboxEnv, baseEnv} {
+		for _, entry := range env {
+			if strings.HasPrefix(entry, "CLAUDE_CODE_OAUTH_TOKEN=") && !strings.HasSuffix(entry, "=") {
+				t.Fatalf("gateway seat received a real token: %v", redactEnvNames(env))
+			}
+		}
+	}
+}
+
+// seatRunnerEnvironments returns the sandbox wrapper's env and the innermost
+// runner's base env, so a test can tell the grants route from the graft route
+// apart instead of passing on either alone.
+func seatRunnerEnvironments(t *testing.T, runner subprocess.Runner) (sandboxEnv []string, baseEnv []string) {
+	t.Helper()
+	for {
+		switch r := runner.(type) {
+		case subprocess.WrappingRunner:
+			sandboxEnv = append(sandboxEnv, r.Env...)
+			runner = r.Inner
+		case *subprocess.WrappingRunner:
+			sandboxEnv = append(sandboxEnv, r.Env...)
+			runner = r.Inner
+		case subprocess.TeeRunner:
+			runner = r.Inner
+		case *subprocess.TeeRunner:
+			runner = r.Inner
+		case subprocess.EnvInjectingRunner:
+			sandboxEnv = append(sandboxEnv, r.Env...)
+			runner = r.Inner
+		case *subprocess.EnvInjectingRunner:
+			sandboxEnv = append(sandboxEnv, r.Env...)
+			runner = r.Inner
+		case *credgw.Runner:
+			runner = r.Inner
+		case subprocess.CuratedGroupRunner:
+			return sandboxEnv, r.BaseEnv
+		case *subprocess.CuratedGroupRunner:
+			return sandboxEnv, r.BaseEnv
+		case execbackend.InstanceRunner:
+			return sandboxEnv, r.BaseEnv
+		case *execbackend.InstanceRunner:
+			return sandboxEnv, r.BaseEnv
+		default:
+			t.Fatalf("runner shape %T carries no base environment", runner)
+			return sandboxEnv, nil
+		}
+	}
+}
+
+// The cockpit log tee REBUILT the adapter from the worker's execution runner and
+// assigned over the composed one, discarding the whole read-only seat wrapper:
+// no Landlock, no isolated state dir, no auth overlay. With produce grants
+// already applied by then, the rebuilt job would even receive a WRITE grant on
+// the operator's live credential dir (#1810 review F5). Teeing must ADD a writer
+// to the composed adapter instead.
+func TestCockpitTeeKeepsTheReadOnlySeatSandbox(t *testing.T) {
+	const overlay = "CLAUDE_CODE_OAUTH_TOKEN=seat-cockpit-token-value"
+	home := t.TempDir()
+	paths, err := pathsFromFlag(home)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(paths.Home, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(runtimeAuthFilePath(paths.Home), []byte(overlay+"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	checkout := readonlyWorktreeGitCheckout(t, "owner/repo")
+	agent := runtime.Agent{Runtime: runtime.ClaudeRuntime, ReadOnlySeat: true}
+	seatAdapter, err := wrapReadOnlySandboxAdapter(home, agent, checkout,
+		runtime.ClaudeAdapter{Runner: subprocess.CuratedGroupRunner{}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	seat, ok := seatAdapter.(readOnlyRuntimeAdapter)
+	if !ok {
+		t.Fatalf("wrapped adapter %T, want readOnlyRuntimeAdapter", seatAdapter)
+	}
+	t.Cleanup(func() { _ = seat.cleanup() })
+
+	worker := defaultJobWorker(daemonWorkerStore(t), io.Discard, home)
+	teed, logPath, logFile := worker.cockpitTeeAdapter(seatAdapter, "seat-cockpit-job")
+	if logFile == nil {
+		t.Fatalf("cockpit tee returned no log file (path %q)", logPath)
+	}
+	defer logFile.Close()
+
+	teedSeat, ok := teed.(readOnlyRuntimeAdapter)
+	if !ok {
+		t.Fatalf("teed adapter %T discarded the read-only seat wrapper", teed)
+	}
+	inner, ok := teedSeat.Adapter.(runtime.ClaudeAdapter)
+	if !ok {
+		t.Fatalf("teed inner adapter %T, want runtime.ClaudeAdapter", teedSeat.Adapter)
+	}
+	sandboxEnv, baseEnv := seatRunnerEnvironments(t, inner.Runner)
+	if !containsEnv(sandboxEnv, overlay) || !containsEnv(baseEnv, overlay) {
+		t.Fatalf("teeing dropped the seat auth overlay: sandbox=%v base=%v",
+			redactEnvNames(sandboxEnv), redactEnvNames(baseEnv))
+	}
+	if !containsEnvPrefix(sandboxEnv, "CLAUDE_CONFIG_DIR=") {
+		t.Fatalf("teeing dropped the isolated runtime state dir: %v", redactEnvNames(sandboxEnv))
+	}
 }

--- a/internal/cli/readonly_seat_wiring_test.go
+++ b/internal/cli/readonly_seat_wiring_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/gitmoot/gitmoot/internal/subprocess"
 )
 
-
 // redactEnvNames returns NAMES only, so a failure message never prints a token.
 func redactEnvNames(env []string) []string {
 	names := make([]string, 0, len(env))

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -188,7 +188,7 @@ func runDoctor(args []string, stdout, stderr io.Writer) int {
 	// The checks above measure the AMBIENT claude credential; a read-only seat
 	// authenticates with a staged snapshot, and reporting only the ambient one is
 	// the false green this outage ran on (#1810 review).
-	if check, ok := seatCredentialDoctorCheck(); ok {
+	if check, ok := seatCredentialDoctorCheck(paths); ok {
 		checks = append(checks, check)
 	}
 	// #631: surface a stale backlog of blocked jobs (each paused awaiting a human)

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -185,6 +185,12 @@ func runDoctor(args []string, stdout, stderr io.Writer) int {
 	if check, ok := remoteExecDoctorCheck(paths); ok {
 		checks = append(checks, check)
 	}
+	// The checks above measure the AMBIENT claude credential; a read-only seat
+	// authenticates with a staged snapshot, and reporting only the ambient one is
+	// the false green this outage ran on (#1810 review).
+	if check, ok := seatCredentialDoctorCheck(); ok {
+		checks = append(checks, check)
+	}
 	// #631: surface a stale backlog of blocked jobs (each paused awaiting a human)
 	// so an operator knows they can be bulk-dismissed. Best-effort and appended to
 	// both the text table and the --json array; the dashboard's cheaper

--- a/internal/cli/runtime-auth.env
+++ b/internal/cli/runtime-auth.env
@@ -1,0 +1,1 @@
+CLAUDE_CODE_OAUTH_TOKEN=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

--- a/internal/cli/runtime-auth.env
+++ b/internal/cli/runtime-auth.env
@@ -1,1 +1,0 @@
-CLAUDE_CODE_OAUTH_TOKEN=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

--- a/internal/cli/sandbox_produce_hook_linux_test.go
+++ b/internal/cli/sandbox_produce_hook_linux_test.go
@@ -91,7 +91,7 @@ func TestClaudeProduceHookAutoReadLandlockE2E(t *testing.T) {
 	// environment carries (#1810 review, P2).
 	t.Setenv("CLAUDE_CONFIG_DIR", "")
 	gitmoot := sharedGitmootTestBinary(t)
-	reads, readFiles, writes, env, err := produceRuntimeSandboxGrants(agent.Runtime, agent.ReadablePaths, agent.ReadableFiles, agent.WritablePaths)
+	reads, readFiles, writes, env, err := produceRuntimeSandboxGrants(agent.Runtime, t.TempDir(), agent.ReadablePaths, agent.ReadableFiles, agent.WritablePaths)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/cli/sandbox_produce_hook_linux_test.go
+++ b/internal/cli/sandbox_produce_hook_linux_test.go
@@ -86,6 +86,10 @@ func TestClaudeProduceHookAutoReadLandlockE2E(t *testing.T) {
 		t.Fatalf("hook directory not auto-included: %v", agent.ReadablePaths)
 	}
 
+	// produceRuntimeSandboxGrants now honors an operator-set CLAUDE_CONFIG_DIR, so
+	// pin the host-default path rather than inheriting whatever the runner's
+	// environment carries (#1810 review, P2).
+	t.Setenv("CLAUDE_CONFIG_DIR", "")
 	gitmoot := sharedGitmootTestBinary(t)
 	reads, readFiles, writes, env, err := produceRuntimeSandboxGrants(agent.Runtime, agent.ReadablePaths, agent.ReadableFiles, agent.WritablePaths)
 	if err != nil {

--- a/internal/cli/sandbox_produce_test.go
+++ b/internal/cli/sandbox_produce_test.go
@@ -244,13 +244,20 @@ func TestWorkerClaudeKimiProduceDispatchWrappedArgv(t *testing.T) {
 				ref = "session_550e8400-e29b-41d4-a716-446655440000"
 			}
 			agent := runtime.Agent{Name: "p", Role: "producer", Runtime: tc.runtime, RuntimeRef: ref, RepoScope: "owner/repo", AutonomyPolicy: runtime.AutonomyPolicyWorkspaceWrite, ReadablePaths: []string{"/data/input"}, WritablePaths: []string{"/data/out"}}
+			var claudeConfigDir string
 			if tc.runtime == runtime.ClaudeRuntime {
 				agent.ReadableFiles = []string{home + "/.claude.json"}
 				if err := os.WriteFile(agent.ReadableFiles[0], []byte("{}"), 0o600); err != nil {
 					t.Fatal(err)
 				}
+				var resolveErr error
+				claudeConfigDir, resolveErr = resolveRuntimeConfigDir(runtime.ClaudeRuntime, os.Getenv("CLAUDE_CONFIG_DIR"))
+				if resolveErr != nil {
+					t.Fatal(resolveErr)
+				}
 			}
-			wrapped, err := wrapProduceSandboxAdapter("produce", agent, tc.adapter(capture))
+			runtimeStateDir := filepath.Join(home, "job-runtime")
+			wrapped, err := wrapProduceSandboxAdapter("produce", agent, tc.adapter(capture), runtimeStateDir)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -259,10 +266,13 @@ func TestWorkerClaudeKimiProduceDispatchWrappedArgv(t *testing.T) {
 			}
 			wantPrefix := []string{"sandbox-exec", "--read", "/data/input"}
 			if tc.runtime == runtime.ClaudeRuntime {
+				if claudeConfigDir != filepath.Join(runtimeStateDir, ".claude") {
+					wantPrefix = append(wantPrefix, "--read", claudeConfigDir)
+				}
 				wantPrefix = append(wantPrefix, "--read-file", home+"/.claude.json")
 				wantPrefix = append(wantPrefix, "--write", "/data/out")
-				wantPrefix = append(wantPrefix, "--write", home+"/.claude", "--write", home+"/.cache/claude-cli-nodejs")
-				if !reflect.DeepEqual(capture.env, []string{"CLAUDE_CONFIG_DIR=" + home + "/.claude"}) {
+				wantPrefix = append(wantPrefix, "--write", filepath.Join(runtimeStateDir, ".claude"), "--write", filepath.Join(runtimeStateDir, "claude-cli-nodejs"))
+				if !reflect.DeepEqual(capture.env, []string{"CLAUDE_CONFIG_DIR=" + claudeConfigDir}) {
 					t.Fatalf("Claude sandbox env = %v", capture.env)
 				}
 			} else {
@@ -297,9 +307,14 @@ func TestProduceRunnerComposesUnderTeeAndScopesByAction(t *testing.T) {
 	if err := os.WriteFile(stateFile, []byte("{}"), 0o600); err != nil {
 		t.Fatal(err)
 	}
+	configDir, err := resolveRuntimeConfigDir(runtime.ClaudeRuntime, os.Getenv("CLAUDE_CONFIG_DIR"))
+	if err != nil {
+		t.Fatal(err)
+	}
 	agent := runtime.Agent{Runtime: runtime.ClaudeRuntime, ReadablePaths: []string{"/input"}, ReadableFiles: []string{stateFile}, WritablePaths: []string{"/data"}}
 	base := runtime.ClaudeAdapter{Runner: subprocess.TeeRunner{Inner: subprocess.GroupRunner{}}}
-	wrapped, err := wrapProduceSandboxAdapter("produce", agent, base)
+	runtimeStateDir := filepath.Join(home, "job-runtime")
+	wrapped, err := wrapProduceSandboxAdapter("produce", agent, base, runtimeStateDir)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -315,17 +330,21 @@ func TestProduceRunnerComposesUnderTeeAndScopesByAction(t *testing.T) {
 	if _, ok := shim.Inner.(subprocess.GroupRunner); !ok {
 		t.Fatalf("shim inner = %T, want GroupRunner", shim.Inner)
 	}
-	wantPaths := []string{"/data", home + "/.claude", home + "/.cache/claude-cli-nodejs"}
-	if !reflect.DeepEqual(shim.ReadablePaths, []string{"/input"}) || !reflect.DeepEqual(shim.ReadableFiles, []string{stateFile}) || !reflect.DeepEqual(shim.WritablePaths, wantPaths) || !reflect.DeepEqual(shim.Env, []string{"CLAUDE_CONFIG_DIR=" + home + "/.claude"}) {
-		t.Fatalf("Claude shim = reads %v writes %v env %v, want read /input, writes %v + config env", shim.ReadablePaths, shim.WritablePaths, shim.Env, wantPaths)
+	wantReads := []string{"/input"}
+	if configDir != filepath.Join(runtimeStateDir, ".claude") {
+		wantReads = append(wantReads, configDir)
+	}
+	wantPaths := []string{"/data", filepath.Join(runtimeStateDir, ".claude"), filepath.Join(runtimeStateDir, "claude-cli-nodejs")}
+	if !reflect.DeepEqual(shim.ReadablePaths, wantReads) || !reflect.DeepEqual(shim.ReadableFiles, []string{stateFile}) || !reflect.DeepEqual(shim.WritablePaths, wantPaths) || !reflect.DeepEqual(shim.Env, []string{"CLAUDE_CONFIG_DIR=" + configDir}) {
+		t.Fatalf("Claude shim = reads %v writes %v env %v, want reads %v, writes %v + config env", shim.ReadablePaths, shim.WritablePaths, shim.Env, wantReads, wantPaths)
 	}
 
-	nonProduce, err := wrapProduceSandboxAdapter("ask", agent, base)
+	nonProduce, err := wrapProduceSandboxAdapter("ask", agent, base, runtimeStateDir)
 	if err != nil || !reflect.DeepEqual(nonProduce, base) {
 		t.Fatalf("non-produce adapter changed: %T %+v, err=%v", nonProduce, nonProduce, err)
 	}
 	codexBase := runtime.CodexAdapter{Runner: subprocess.GroupRunner{}}
-	codex, err := wrapProduceSandboxAdapter("produce", runtime.Agent{Runtime: runtime.CodexRuntime, ReadablePaths: []string{"/input"}, WritablePaths: []string{"/data"}}, codexBase)
+	codex, err := wrapProduceSandboxAdapter("produce", runtime.Agent{Runtime: runtime.CodexRuntime, ReadablePaths: []string{"/input"}, WritablePaths: []string{"/data"}}, codexBase, runtimeStateDir)
 	if err != nil || !reflect.DeepEqual(codex, codexBase) {
 		t.Fatalf("Codex adapter changed: %T %+v, err=%v", codex, codex, err)
 	}

--- a/internal/cli/sandbox_produce_test.go
+++ b/internal/cli/sandbox_produce_test.go
@@ -1041,42 +1041,80 @@ func findProduceSandboxShim(t *testing.T, runner subprocess.Runner) subprocess.W
 }
 
 // The local composition path keys produce state on checkout and runtime ref.
-// Collapsing that key makes every local produce run share one state root, so
-// two runs would reset and delete each other's runtime state.
+// Collapsing that key makes every local produce run share one hashed root.
+// Since round 2 each dispatch also carves its own run- directory inside that
+// root, so the identity to compare is the HASHED ROOT, not the run directory -
+// two dispatches with the same key must agree on the root and differ on the
+// run directory, which is exactly what stops one wiping the other's live state.
 func TestBuildLocalRuntimeAdapterKeysProduceStatePerCheckoutAndRuntimeRef(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
 	t.Setenv("CLAUDE_CONFIG_DIR", t.TempDir())
 	agent := runtime.Agent{Runtime: runtime.ClaudeRuntime, RuntimeRef: "session-a", WritablePaths: []string{"/data"}}
-	stateOf := func(checkout string, agent runtime.Agent) string {
+	dispatch := func(checkout string, agent runtime.Agent) (root string, runDir string) {
 		t.Helper()
 		adapter, err := buildLocalRuntimeAdapter(home, agent, checkout, subprocess.GroupRunner{})
 		if err != nil {
 			t.Fatalf("buildLocalRuntimeAdapter: %v", err)
 		}
-		claude, ok := adapter.(runtime.ClaudeAdapter)
-		if !ok {
-			t.Fatalf("adapter = %T, want ClaudeAdapter", adapter)
-		}
-		shim := findProduceSandboxShim(t, claude.Runner)
+		shim := findProduceSandboxShim(t, produceAdapterRunner(t, adapter))
 		state := envValue(shim.Env, "CLAUDE_CONFIG_DIR")
 		if state == "" {
 			t.Fatalf("shim env = %v, want a job-private config dir", shim.Env)
 		}
-		return state
+		runDir = filepath.Dir(state)
+		if base := filepath.Base(runDir); !strings.HasPrefix(base, "run-") {
+			t.Fatalf("local produce state %q is not inside a per-dispatch run- directory", state)
+		}
+		return filepath.Dir(runDir), runDir
 	}
-	firstCheckout := stateOf("/checkout-one", agent)
-	secondCheckout := stateOf("/checkout-two", agent)
-	if firstCheckout == secondCheckout {
-		t.Fatalf("two checkouts share produce state %q", firstCheckout)
+	firstRoot, firstRun := dispatch("/checkout-one", agent)
+	secondRoot, _ := dispatch("/checkout-two", agent)
+	if firstRoot == secondRoot {
+		t.Fatalf("two checkouts share produce state root %q", firstRoot)
 	}
 	otherRef := agent
 	otherRef.RuntimeRef = "session-b"
-	if second := stateOf("/checkout-one", otherRef); second == firstCheckout {
-		t.Fatalf("two runtime refs share produce state %q", firstCheckout)
+	if root, _ := dispatch("/checkout-one", otherRef); root == firstRoot {
+		t.Fatalf("two runtime refs share produce state root %q", firstRoot)
 	}
-	if repeated := stateOf("/checkout-one", agent); repeated != firstCheckout {
-		t.Fatalf("same checkout and ref resolved to %q then %q", firstCheckout, repeated)
+	repeatedRoot, repeatedRun := dispatch("/checkout-one", agent)
+	if repeatedRoot != firstRoot {
+		t.Fatalf("same checkout and ref resolved to root %q then %q", firstRoot, repeatedRoot)
+	}
+	// Same key, DIFFERENT dispatch directory: round 2 measured dispatch B
+	// wiping dispatch A's live state on this exact path.
+	if repeatedRun == firstRun {
+		t.Fatalf("two local dispatches share run directory %q", firstRun)
+	}
+	live := filepath.Join(firstRun, ".claude", "live-session.json")
+	if err := os.WriteFile(live, []byte(`{"live":true}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, _ = dispatch("/checkout-one", agent); true {
+		if _, err := os.Stat(live); err != nil {
+			t.Fatalf("a later local dispatch destroyed a live sibling's state: %v", err)
+		}
+	}
+}
+
+// produceAdapterRunner unwraps the delivery adapter the local pipeline returns -
+// including the per-dispatch cleanup wrapper - down to the runtime adapter's
+// runner, so grant assertions bind to what actually executes.
+func produceAdapterRunner(t *testing.T, adapter workflow.DeliveryAdapter) subprocess.Runner {
+	t.Helper()
+	for {
+		switch typed := adapter.(type) {
+		case produceRunStateCleanupDeliveryAdapter:
+			adapter = typed.inner
+		case runtime.ClaudeAdapter:
+			return typed.Runner
+		case runtime.KimiAdapter:
+			return typed.Runner
+		default:
+			t.Fatalf("adapter = %T, want a Claude or Kimi adapter", adapter)
+			return nil
+		}
 	}
 }
 
@@ -1148,12 +1186,28 @@ func TestWorkerProduceRunRemovesTheStateRootItGranted(t *testing.T) {
 	if grantedConfigDir == operatorProfile {
 		t.Fatalf("produce job ran against the operator profile %q", operatorProfile)
 	}
-	stateRoot := filepath.Dir(grantedConfigDir)
-	if !containsPath(capture.args, stateRoot) && !containsPath(capture.args, grantedConfigDir) {
+	// The granted config dir must sit inside a PER-DISPATCH carve, not straight
+	// in the hashed job root: asserting only that "the parent is gone" holds
+	// either way, so deleting the carve from the worker survived (#1810 review
+	// round 2, M12). Name the run- component and the hashed root separately.
+	runDir := filepath.Dir(grantedConfigDir)
+	if base := filepath.Base(runDir); !strings.HasPrefix(base, "run-") {
+		t.Fatalf("granted config dir %q is not inside a per-dispatch run- directory (worker handed over the shared job root)", grantedConfigDir)
+	}
+	hashedRoot := filepath.Dir(runDir)
+	if filepath.Base(filepath.Dir(hashedRoot)) != "produce-runtime" {
+		t.Fatalf("run directory %q is not under a produce-runtime job root", runDir)
+	}
+	if !containsPath(capture.args, runDir) && !containsPath(capture.args, grantedConfigDir) {
 		t.Fatalf("granted state %q never reached the sandbox argv: %v", grantedConfigDir, capture.args)
 	}
-	if _, err := os.Stat(stateRoot); !os.IsNotExist(err) {
-		t.Fatalf("produce runtime state %q survived the job boundary: %v", stateRoot, err)
+	if _, err := os.Stat(runDir); !os.IsNotExist(err) {
+		t.Fatalf("produce runtime state %q survived the job boundary: %v", runDir, err)
+	}
+	// The hashed parent is reclaimed too once no sibling dispatch is live,
+	// otherwise one empty directory leaks per job id forever.
+	if _, err := os.Stat(hashedRoot); !os.IsNotExist(err) {
+		t.Fatalf("hashed produce root %q leaked after the job finished: %v", hashedRoot, err)
 	}
 	if data, err := os.ReadFile(filepath.Join(operatorProfile, ".credentials.json")); err != nil || string(data) != operatorCredential {
 		t.Fatalf("operator credential changed to %q, err=%v", data, err)
@@ -1190,6 +1244,20 @@ func TestProduceLaunchesOnTheImplicitWriteRootPathUnlikeAReadOnlySeat(t *testing
 		t.Fatalf("produce now launches with a read-only workdir: %v", capture.args)
 	}
 
+	// SECOND CONSTRUCTION SITE. buildLocalRuntimeAdapter decides the same thing
+	// independently, and a routing mutant there survived the whole package while
+	// this test was green (#1810 review round 2, MROUTE). Binding one site is
+	// not binding the behaviour.
+	localHome := t.TempDir()
+	localAdapter, err := buildLocalRuntimeAdapter(localHome, agent, filepath.Join(localHome, "checkout"), subprocess.GroupRunner{})
+	if err != nil {
+		t.Fatalf("buildLocalRuntimeAdapter: %v", err)
+	}
+	localShim := findProduceSandboxShim(t, produceAdapterRunner(t, localAdapter))
+	if localShim.ReadOnlyWorkdir {
+		t.Fatalf("local produce composition now launches with a read-only workdir: %+v", localShim)
+	}
+
 	// The read-only seat is the contrast case and must stay on the explicit-only
 	// path; if this flag ever disappears there, seats gain implicit tmp writes.
 	seatCheckout := filepath.Join(t.TempDir(), "review-worktree")
@@ -1210,5 +1278,43 @@ func TestProduceLaunchesOnTheImplicitWriteRootPathUnlikeAReadOnlySeat(t *testing
 	}
 	if !containsString(seatCapture.args, "--read-only-workdir") {
 		t.Fatalf("read-only seat lost its read-only workdir: %v", seatCapture.args)
+	}
+}
+
+// The local composition path has no worker to defer cleanup, so removal is bound
+// to the delivery returning. Round-2 mutant M19 (deleting that defer) SURVIVED
+// the whole scoped suite: the per-dispatch carve was pinned but nothing checked
+// that anything ever removes it, which is the leak the carve would otherwise
+// introduce on every local produce run.
+func TestBuildLocalRuntimeAdapterRemovesItsDispatchStateAfterDelivery(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("CLAUDE_CONFIG_DIR", t.TempDir())
+	agent := runtime.Agent{
+		Name: "p", Role: "producer", Runtime: runtime.ClaudeRuntime, RuntimeRef: "last",
+		AutonomyPolicy: runtime.AutonomyPolicyWorkspaceWrite,
+		WritablePaths:  []string{home},
+	}
+	capture := &sandboxAdapterCaptureRunner{stdout: `{"result":"ok"}`}
+	adapter, err := buildLocalRuntimeAdapter(home, agent, filepath.Join(home, "checkout"), capture)
+	if err != nil {
+		t.Fatal(err)
+	}
+	shim := findProduceSandboxShim(t, produceAdapterRunner(t, adapter))
+	runDir := filepath.Dir(envValue(shim.Env, "CLAUDE_CONFIG_DIR"))
+	if base := filepath.Base(runDir); !strings.HasPrefix(base, "run-") {
+		t.Fatalf("local dispatch state %q is not a per-dispatch run- directory", runDir)
+	}
+	if _, err := os.Stat(runDir); err != nil {
+		t.Fatalf("dispatch state missing before delivery: %v", err)
+	}
+	if _, err := adapter.Deliver(context.Background(), agent, runtime.Job{Prompt: "write"}); err != nil {
+		t.Fatalf("Deliver: %v", err)
+	}
+	if _, err := os.Stat(runDir); !os.IsNotExist(err) {
+		t.Fatalf("local dispatch state %q survived delivery: %v", runDir, err)
+	}
+	if _, err := os.Stat(filepath.Dir(runDir)); !os.IsNotExist(err) {
+		t.Fatalf("hashed local produce root leaked after delivery: %v", err)
 	}
 }

--- a/internal/cli/sandbox_produce_test.go
+++ b/internal/cli/sandbox_produce_test.go
@@ -1159,3 +1159,56 @@ func TestWorkerProduceRunRemovesTheStateRootItGranted(t *testing.T) {
 		t.Fatalf("operator credential changed to %q, err=%v", data, err)
 	}
 }
+
+// Bound at the PRODUCE ENTRY POINT, not at the sandbox helper: the argv the
+// runtime is actually launched with decides whether implicit write roots apply.
+// Produce omits --read-only-workdir, so internal/cli/sandbox.go dispatches
+// sandbox.Exec, which calls writableRoots with includeImplicitRoots=true and
+// grants workdir, os.TempDir() and /tmp. That is why keeping the operator
+// profile out of tmp is a real precondition of this PR's guarantee and not an
+// abstract one: a profile under /tmp is writable by a produce job even though
+// produce grants never name it. The companion test in internal/sandbox pins the
+// helper side; this one pins that produce is on the implicit-root path at all.
+func TestProduceLaunchesOnTheImplicitWriteRootPathUnlikeAReadOnlySeat(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("CLAUDE_CONFIG_DIR", filepath.Join(home, "operator-profile"))
+	capture := &sandboxAdapterCaptureRunner{stdout: `{"result":"ok"}`}
+	agent := runtime.Agent{
+		Name: "p", Role: "producer", Runtime: runtime.ClaudeRuntime, RuntimeRef: "last",
+		AutonomyPolicy: runtime.AutonomyPolicyWorkspaceWrite,
+		WritablePaths:  []string{home},
+	}
+	wrapped, err := wrapProduceSandboxAdapter("produce", agent, runtime.ClaudeAdapter{Runner: capture, Dir: home}, filepath.Join(home, "job-runtime"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := wrapped.Deliver(context.Background(), agent, runtime.Job{Prompt: "write"}); err != nil {
+		t.Fatalf("Deliver: %v", err)
+	}
+	if containsString(capture.args, "--read-only-workdir") {
+		t.Fatalf("produce now launches with a read-only workdir: %v", capture.args)
+	}
+
+	// The read-only seat is the contrast case and must stay on the explicit-only
+	// path; if this flag ever disappears there, seats gain implicit tmp writes.
+	seatCheckout := filepath.Join(t.TempDir(), "review-worktree")
+	if err := os.MkdirAll(filepath.Join(seatCheckout, ".git"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	seatCapture := &sandboxAdapterCaptureRunner{stdout: `{"result":"ok"}`}
+	seat := runtime.Agent{
+		Name: "r", Role: "reviewer", Runtime: runtime.ClaudeRuntime, RuntimeRef: "last",
+		AutonomyPolicy: runtime.AutonomyPolicyReadOnly, ReadOnlySeat: true,
+	}
+	seatWrapped, err := wrapReadOnlySandboxAdapter(t.TempDir(), seat, seatCheckout, runtime.ClaudeAdapter{Runner: seatCapture, Dir: seatCheckout})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := seatWrapped.Deliver(context.Background(), seat, runtime.Job{Prompt: "review"}); err != nil {
+		t.Fatalf("seat Deliver: %v", err)
+	}
+	if !containsString(seatCapture.args, "--read-only-workdir") {
+		t.Fatalf("read-only seat lost its read-only workdir: %v", seatCapture.args)
+	}
+}

--- a/internal/cli/sandbox_produce_test.go
+++ b/internal/cli/sandbox_produce_test.go
@@ -266,14 +266,25 @@ func TestWorkerClaudeKimiProduceDispatchWrappedArgv(t *testing.T) {
 			}
 			wantPrefix := []string{"sandbox-exec", "--read", "/data/input"}
 			if tc.runtime == runtime.ClaudeRuntime {
-				if claudeConfigDir != filepath.Join(runtimeStateDir, ".claude") {
-					wantPrefix = append(wantPrefix, "--read", claudeConfigDir)
+				// The operator profile is staged into the job-private copy by
+				// the daemon, outside the sandbox, so it is never granted.
+				if containsPath([]string{claudeConfigDir}, filepath.Join(runtimeStateDir, ".claude")) {
+					t.Fatalf("test setup resolved the configured dir onto the job-private copy: %q", claudeConfigDir)
 				}
 				wantPrefix = append(wantPrefix, "--read-file", home+"/.claude.json")
 				wantPrefix = append(wantPrefix, "--write", "/data/out")
-				wantPrefix = append(wantPrefix, "--write", filepath.Join(runtimeStateDir, ".claude"), "--write", filepath.Join(runtimeStateDir, "claude-cli-nodejs"))
-				if !reflect.DeepEqual(capture.env, []string{"CLAUDE_CONFIG_DIR=" + claudeConfigDir}) {
-					t.Fatalf("Claude sandbox env = %v", capture.env)
+				wantPrefix = append(wantPrefix, "--write", filepath.Join(runtimeStateDir, ".claude"), "--write", filepath.Join(runtimeStateDir, "xdg-cache"))
+				wantEnv := []string{
+					"CLAUDE_CONFIG_DIR=" + filepath.Join(runtimeStateDir, ".claude"),
+					"XDG_CACHE_HOME=" + filepath.Join(runtimeStateDir, "xdg-cache"),
+				}
+				if !reflect.DeepEqual(capture.env, wantEnv) {
+					t.Fatalf("Claude sandbox env = %v, want %v", capture.env, wantEnv)
+				}
+				for _, arg := range capture.args {
+					if arg == claudeConfigDir {
+						t.Fatalf("operator profile %q reached the sandbox argv: %v", claudeConfigDir, capture.args)
+					}
 				}
 			} else {
 				wantPrefix = append(wantPrefix, "--write", "/data/out")
@@ -330,13 +341,20 @@ func TestProduceRunnerComposesUnderTeeAndScopesByAction(t *testing.T) {
 	if _, ok := shim.Inner.(subprocess.GroupRunner); !ok {
 		t.Fatalf("shim inner = %T, want GroupRunner", shim.Inner)
 	}
+	// Produce grants expose no config dir at all: the runtime is pointed at the
+	// job-private copy, and the operator profile is read by the daemon during
+	// staging, outside the sandbox.
 	wantReads := []string{"/input"}
-	if configDir != filepath.Join(runtimeStateDir, ".claude") {
-		wantReads = append(wantReads, configDir)
+	wantPaths := []string{"/data", filepath.Join(runtimeStateDir, ".claude"), filepath.Join(runtimeStateDir, "xdg-cache")}
+	wantEnv := []string{
+		"CLAUDE_CONFIG_DIR=" + filepath.Join(runtimeStateDir, ".claude"),
+		"XDG_CACHE_HOME=" + filepath.Join(runtimeStateDir, "xdg-cache"),
 	}
-	wantPaths := []string{"/data", filepath.Join(runtimeStateDir, ".claude"), filepath.Join(runtimeStateDir, "claude-cli-nodejs")}
-	if !reflect.DeepEqual(shim.ReadablePaths, wantReads) || !reflect.DeepEqual(shim.ReadableFiles, []string{stateFile}) || !reflect.DeepEqual(shim.WritablePaths, wantPaths) || !reflect.DeepEqual(shim.Env, []string{"CLAUDE_CONFIG_DIR=" + configDir}) {
-		t.Fatalf("Claude shim = reads %v writes %v env %v, want reads %v, writes %v + config env", shim.ReadablePaths, shim.WritablePaths, shim.Env, wantReads, wantPaths)
+	if !reflect.DeepEqual(shim.ReadablePaths, wantReads) || !reflect.DeepEqual(shim.ReadableFiles, []string{stateFile}) || !reflect.DeepEqual(shim.WritablePaths, wantPaths) || !reflect.DeepEqual(shim.Env, wantEnv) {
+		t.Fatalf("Claude shim = reads %v writes %v env %v, want reads %v, writes %v, env %v", shim.ReadablePaths, shim.WritablePaths, shim.Env, wantReads, wantPaths, wantEnv)
+	}
+	if containsPath(shim.ReadablePaths, configDir) || containsPath(shim.WritablePaths, configDir) {
+		t.Fatalf("operator profile %q reached the sandbox grants: reads %v writes %v", configDir, shim.ReadablePaths, shim.WritablePaths)
 	}
 
 	nonProduce, err := wrapProduceSandboxAdapter("ask", agent, base, runtimeStateDir)
@@ -997,4 +1015,147 @@ func containsEnvPrefix(env []string, prefix string) bool {
 		}
 	}
 	return false
+}
+
+// findProduceSandboxShim walks the composed runner chain the same way
+// runnerReachesExecutionInstance does, so the assertions below bind to the
+// shim the runtime actually executes rather than to a helper's return value.
+func findProduceSandboxShim(t *testing.T, runner subprocess.Runner) subprocess.WrappingRunner {
+	t.Helper()
+	switch typed := runner.(type) {
+	case subprocess.WrappingRunner:
+		return typed
+	case *subprocess.WrappingRunner:
+		if typed != nil {
+			return *typed
+		}
+	case subprocess.TeeRunner:
+		return findProduceSandboxShim(t, typed.Inner)
+	case *subprocess.EnvInjectingRunner:
+		if typed != nil {
+			return findProduceSandboxShim(t, typed.Inner)
+		}
+	}
+	t.Fatalf("no sandbox shim in runner chain: %T", runner)
+	return subprocess.WrappingRunner{}
+}
+
+// The local composition path keys produce state on checkout and runtime ref.
+// Collapsing that key makes every local produce run share one state root, so
+// two runs would reset and delete each other's runtime state.
+func TestBuildLocalRuntimeAdapterKeysProduceStatePerCheckoutAndRuntimeRef(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("CLAUDE_CONFIG_DIR", t.TempDir())
+	agent := runtime.Agent{Runtime: runtime.ClaudeRuntime, RuntimeRef: "session-a", WritablePaths: []string{"/data"}}
+	stateOf := func(checkout string, agent runtime.Agent) string {
+		t.Helper()
+		adapter, err := buildLocalRuntimeAdapter(home, agent, checkout, subprocess.GroupRunner{})
+		if err != nil {
+			t.Fatalf("buildLocalRuntimeAdapter: %v", err)
+		}
+		claude, ok := adapter.(runtime.ClaudeAdapter)
+		if !ok {
+			t.Fatalf("adapter = %T, want ClaudeAdapter", adapter)
+		}
+		shim := findProduceSandboxShim(t, claude.Runner)
+		state := envValue(shim.Env, "CLAUDE_CONFIG_DIR")
+		if state == "" {
+			t.Fatalf("shim env = %v, want a job-private config dir", shim.Env)
+		}
+		return state
+	}
+	firstCheckout := stateOf("/checkout-one", agent)
+	secondCheckout := stateOf("/checkout-two", agent)
+	if firstCheckout == secondCheckout {
+		t.Fatalf("two checkouts share produce state %q", firstCheckout)
+	}
+	otherRef := agent
+	otherRef.RuntimeRef = "session-b"
+	if second := stateOf("/checkout-one", otherRef); second == firstCheckout {
+		t.Fatalf("two runtime refs share produce state %q", firstCheckout)
+	}
+	if repeated := stateOf("/checkout-one", agent); repeated != firstCheckout {
+		t.Fatalf("same checkout and ref resolved to %q then %q", firstCheckout, repeated)
+	}
+}
+
+// Entry through jobWorker.run, not through the grant helper: the state root the
+// runtime is pointed at must be the one the worker removes when the job ends.
+// A mutant that drops the worker's cleanup, or that grants a different root
+// than it cleans, leaves runtime state - including a staged credential copy -
+// behind on disk.
+func TestWorkerProduceRunRemovesTheStateRootItGranted(t *testing.T) {
+	ctx := context.Background()
+	store, home := blockerE2EHome(t)
+	checkout := readonlyWorktreeGitCheckout(t, "owner/repo")
+	seedDaemonWorkerRepo(t, store, "owner/repo", checkout)
+	operatorProfile := t.TempDir()
+	const operatorCredential = `{"claudeAiOauth":{"accessToken":"operator-account"}}`
+	if err := os.WriteFile(filepath.Join(operatorProfile, ".credentials.json"), []byte(operatorCredential), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("CLAUDE_CONFIG_DIR", operatorProfile)
+	seedDaemonWorkerAgentWithPolicy(t, store, "producer", runtime.ClaudeRuntime,
+		"550e8400-e29b-41d4-a716-446655440007", []string{"produce"}, "owner/repo", runtime.AutonomyPolicyWorkspaceWrite)
+	// Produce jobs are created by pipeline stages, not the mailbox, which
+	// refuses the action outright.
+	outputDir := filepath.Join(t.TempDir(), "out")
+	if err := os.MkdirAll(outputDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	produceJob := db.Job{
+		ID: "produce-state-cleanup", Agent: "producer", Type: "produce", Repo: "owner/repo",
+		State: string(workflow.JobQueued),
+		Payload: mustJobPayload(t, workflow.JobPayload{
+			Repo: "owner/repo", WorktreePath: checkout, PipelineName: "p",
+			Sender:        workflow.PipelineJobSender,
+			WritablePaths: []string{outputDir},
+		}),
+	}
+	if err := store.CreateJob(ctx, produceJob); err != nil {
+		t.Fatal(err)
+	}
+	capture := &sandboxAdapterCaptureRunner{stdout: `{"result":"ok"}`}
+	worker := defaultJobWorker(store, io.Discard, home)
+	worker.SandboxProbe = func() sandbox.ProbeResult { return sandbox.ProbeResult{Supported: true, ABI: 5} }
+	worker.CheckoutValidator = func(context.Context, db.Job, workflow.JobPayload, runtime.Agent) (string, error) {
+		return checkout, nil
+	}
+	// BOTH adapter seams must be stubbed. Produce delivery streams output, so it
+	// resolves OutputAdapterFactory; leaving that at its production default runs
+	// a REAL runtime binary from the test.
+	worker.AdapterFactory = func(runtime.Agent, string) (workflow.DeliveryAdapter, error) {
+		return runtime.ClaudeAdapter{Runner: capture, Dir: checkout}, nil
+	}
+	worker.OutputAdapterFactory = func(_ runtime.Agent, _ string, _ io.Writer) (workflow.DeliveryAdapter, error) {
+		return runtime.ClaudeAdapter{Runner: capture, Dir: checkout}, nil
+	}
+	job, err := store.GetJob(ctx, "produce-state-cleanup")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := worker.run(ctx, job); err != nil {
+		t.Fatal(err)
+	}
+	grantedConfigDir := envValue(capture.env, "CLAUDE_CONFIG_DIR")
+	if grantedConfigDir == "" {
+		stored, _ := store.GetJob(ctx, produceJob.ID)
+		events, _ := store.ListJobEvents(ctx, produceJob.ID)
+		t.Fatalf("produce job never reached the sandbox: env=%v args=%v state=%q payload=%s events=%+v",
+			capture.env, capture.args, stored.State, stored.Payload, events)
+	}
+	if grantedConfigDir == operatorProfile {
+		t.Fatalf("produce job ran against the operator profile %q", operatorProfile)
+	}
+	stateRoot := filepath.Dir(grantedConfigDir)
+	if !containsPath(capture.args, stateRoot) && !containsPath(capture.args, grantedConfigDir) {
+		t.Fatalf("granted state %q never reached the sandbox argv: %v", grantedConfigDir, capture.args)
+	}
+	if _, err := os.Stat(stateRoot); !os.IsNotExist(err) {
+		t.Fatalf("produce runtime state %q survived the job boundary: %v", stateRoot, err)
+	}
+	if data, err := os.ReadFile(filepath.Join(operatorProfile, ".credentials.json")); err != nil || string(data) != operatorCredential {
+		t.Fatalf("operator credential changed to %q, err=%v", data, err)
+	}
 }

--- a/internal/cli/tracked_credential_guard_test.go
+++ b/internal/cli/tracked_credential_guard_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/gitmoot/gitmoot/internal/config"
+	"github.com/gitmoot/gitmoot/internal/runtime"
 )
 
 // credentialOverlayFileNames is enumerated from the RESOLVER, not from memory.
@@ -116,5 +117,65 @@ func TestCredentialWritersRefuseANonAbsoluteHome(t *testing.T) {
 	}
 	if !filepath.IsAbs(tokenPath) || filepath.Dir(tokenPath) != paths.Home {
 		t.Fatalf("token path %q is not inside the absolute home %q", tokenPath, paths.Home)
+	}
+}
+
+// THE THIRD WRITER. prepareReadOnlyRuntimeState stages three of the seven
+// overlay names by joining onto cacheRoot, and it was the one writer the
+// previous head left unguarded: driven with a relative cacheRoot it returned a
+// relative stateDir and wrote auth.json there. The cacheRoot must EXIST, or the
+// test would pass on a later mkdir failure rather than on the guard.
+func TestPrepareReadOnlyRuntimeStateRefusesARelativeCacheRoot(t *testing.T) {
+	t.Chdir(t.TempDir())
+	const relative = "relative-cache"
+	if err := os.MkdirAll(relative, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	source := t.TempDir()
+	if err := os.WriteFile(filepath.Join(source, "auth.json"), []byte(`{"tokens":{"access":"placeholder-not-a-token"}}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	agent := runtime.Agent{Name: "reviewer", Runtime: runtime.CodexRuntime, ReadOnlySeat: true, RuntimeConfigDir: source}
+
+	stateDir, env, err := prepareReadOnlyRuntimeState(agent, relative, false)
+	if err == nil {
+		t.Fatalf("a relative cacheRoot was accepted: stateDir=%q env=%v; credentials would be staged inside the working directory", stateDir, env)
+	}
+	if stateDir != "" {
+		t.Fatalf("stateDir = %q on refusal, want empty", stateDir)
+	}
+	// Nothing may have been created under the relative root.
+	var created []string
+	_ = filepath.Walk(relative, func(path string, info os.FileInfo, walkErr error) error {
+		if walkErr == nil && info != nil && !info.IsDir() {
+			created = append(created, path)
+		}
+		return nil
+	})
+	if len(created) > 0 {
+		t.Fatalf("the refused call still wrote %v under the relative cacheRoot", created)
+	}
+
+	// An ABSOLUTE cacheRoot must still stage and inject: the guard is a
+	// precondition, not a feature removal.
+	absolute := t.TempDir()
+	stateDir, env, err = prepareReadOnlyRuntimeState(agent, absolute, false)
+	if err != nil {
+		t.Fatalf("absolute cacheRoot rejected: %v", err)
+	}
+	if !filepath.IsAbs(stateDir) || !strings.HasPrefix(stateDir, absolute) {
+		t.Fatalf("stateDir = %q, want an absolute path under %q", stateDir, absolute)
+	}
+	if _, statErr := os.Stat(filepath.Join(stateDir, "auth.json")); statErr != nil {
+		t.Fatalf("absolute cacheRoot did not stage the credential: %v", statErr)
+	}
+	var injected bool
+	for _, entry := range env {
+		if strings.HasPrefix(entry, "CODEX_HOME=") {
+			injected = true
+		}
+	}
+	if !injected {
+		t.Fatalf("absolute cacheRoot did not inject the runtime state env: %v", env)
 	}
 }

--- a/internal/cli/tracked_credential_guard_test.go
+++ b/internal/cli/tracked_credential_guard_test.go
@@ -1,0 +1,71 @@
+package cli
+
+import (
+	"os/exec"
+	"path"
+	"strings"
+	"testing"
+)
+
+// credentialOverlayFileNames is enumerated from the RESOLVER, not from memory.
+// Each name is one this codebase reads as a credential input:
+//
+//	runtime-auth.env    daemon_runtime_auth.go, runtimeAuthFileName
+//	daemon-runtime.env  daemon_runtime_auth.go, legacyRuntimeAuthFileName
+//	.credentials.json   daemon_worker.go (claude staging), readonly_seat_credential.go
+//	auth.json           daemon_worker.go (codex staging)
+//	kimi-code.json      daemon_worker.go (kimi staging)
+var credentialOverlayFileNames = []string{
+	runtimeAuthFileName,
+	legacyRuntimeAuthFileName,
+	claudeCredentialsFile,
+	"auth.json",
+	"kimi-code.json",
+}
+
+// This guard enters through the REAL REPOSITORY INDEX, because the index is
+// what failed: #1810 tracked internal/cli/runtime-auth.env holding a live
+// Anthropic OAuth token and pushed it to a public remote. A test that inspected
+// a temp directory, or that scanned file CONTENT, would not have caught it -
+// content scanning also fires on legitimate planted fixtures elsewhere in this
+// repo (#1807 carries nine), so it gets switched off. Scope by FILENAME and ask
+// git what is actually tracked.
+//
+// MUTANT: revert the .gitignore rules and `git add -f` one of these names, and
+// this test fails - it reads `git ls-files`, so the file only has to reach the
+// index, not a commit.
+//
+// Note this is currently the ONLY automated defence: GitHub secret scanning is
+// disabled on this repository.
+func TestNoCredentialOverlayFileIsTracked(t *testing.T) {
+	root, err := exec.Command("git", "rev-parse", "--show-toplevel").Output()
+	if err != nil {
+		t.Skipf("not a git checkout, nothing to guard: %v", err)
+	}
+	repo := strings.TrimSpace(string(root))
+	out, err := exec.Command("git", "-C", repo, "ls-files", "-z").Output()
+	if err != nil {
+		t.Fatalf("git ls-files in %s: %v", repo, err)
+	}
+	tracked := strings.Split(strings.TrimRight(string(out), "\x00"), "\x00")
+	if len(tracked) < 2 {
+		t.Fatalf("git ls-files returned %d paths in %s; the guard measured nothing", len(tracked), repo)
+	}
+	banned := make(map[string]struct{}, len(credentialOverlayFileNames))
+	for _, name := range credentialOverlayFileNames {
+		banned[name] = struct{}{}
+	}
+	var found []string
+	for _, file := range tracked {
+		if file == "" {
+			continue
+		}
+		if _, bad := banned[path.Base(file)]; bad {
+			found = append(found, file)
+		}
+	}
+	if len(found) > 0 {
+		t.Fatalf("credential-bearing overlay files are TRACKED: %v. This repository is public and secret scanning is disabled; remove them, rotate the credential, and keep the .gitignore rules that stop them returning", found)
+	}
+	t.Logf("scanned %d tracked paths against %d credential overlay names, 0 matches", len(tracked), len(credentialOverlayFileNames))
+}

--- a/internal/cli/tracked_credential_guard_test.go
+++ b/internal/cli/tracked_credential_guard_test.go
@@ -1,10 +1,14 @@
 package cli
 
 import (
+	"os"
 	"os/exec"
 	"path"
+	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/gitmoot/gitmoot/internal/config"
 )
 
 // credentialOverlayFileNames is enumerated from the RESOLVER, not from memory.
@@ -15,12 +19,22 @@ import (
 //	.credentials.json   daemon_worker.go (claude staging), readonly_seat_credential.go
 //	auth.json           daemon_worker.go (codex staging)
 //	kimi-code.json      daemon_worker.go (kimi staging)
+//	keychain.env        pipeline/env_runtime.go, ResolveKeychainPath
+//	bridge.token        bridge.go, bridgeTokenName
+//
+// The first five were the list this guard shipped with, and it was INCOMPLETE:
+// the review measured keychain.env and bridge.token resolving through the same
+// class of code with neither an ignore rule nor a guard entry. The enumeration
+// is now derived by searching every credential-adjacent filename literal in
+// internal/ and cmd/, not by recalling the ones already known.
 var credentialOverlayFileNames = []string{
 	runtimeAuthFileName,
 	legacyRuntimeAuthFileName,
 	claudeCredentialsFile,
 	"auth.json",
 	"kimi-code.json",
+	"keychain.env",
+	bridgeTokenName,
 }
 
 // This guard enters through the REAL REPOSITORY INDEX, because the index is
@@ -68,4 +82,39 @@ func TestNoCredentialOverlayFileIsTracked(t *testing.T) {
 		t.Fatalf("credential-bearing overlay files are TRACKED: %v. This repository is public and secret scanning is disabled; remove them, rotate the credential, and keep the .gitignore rules that stop them returning", found)
 	}
 	t.Logf("scanned %d tracked paths against %d credential overlay names, 0 matches", len(tracked), len(credentialOverlayFileNames))
+}
+
+// The ignore rules and the tracked-file guard stop a credential reaching the
+// INDEX. This asserts the property one level earlier, at the WRITERS: a
+// credential must never be placed relative to the working directory in the
+// first place. bridge.token had no such guard when #1810 was reviewed.
+func TestCredentialWritersRefuseANonAbsoluteHome(t *testing.T) {
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, home := range []string{"", "   ", "relative/home", "."} {
+		if err := requireAbsoluteCredentialHome(home, "bridge.token"); err == nil {
+			t.Fatalf("requireAbsoluteCredentialHome(%q) accepted a non-absolute home", home)
+		}
+		if _, err := ensureBridgeToken(config.Paths{Home: home}, false); err == nil {
+			t.Fatalf("ensureBridgeToken accepted home %q; a token would be written relative to the working directory", home)
+		}
+	}
+	// Nothing may have been created beside the package source while proving it.
+	for _, name := range credentialOverlayFileNames {
+		if _, err := os.Stat(filepath.Join(cwd, name)); err == nil {
+			_ = os.Remove(filepath.Join(cwd, name))
+			t.Fatalf("a credential file %q was created in the work tree while asserting the guard", name)
+		}
+	}
+	// An absolute home still works: the guard must not break the feature.
+	paths := config.Paths{Home: t.TempDir()}
+	tokenPath, err := ensureBridgeToken(paths, false)
+	if err != nil {
+		t.Fatalf("ensureBridgeToken with an absolute home: %v", err)
+	}
+	if !filepath.IsAbs(tokenPath) || filepath.Dir(tokenPath) != paths.Home {
+		t.Fatalf("token path %q is not inside the absolute home %q", tokenPath, paths.Home)
+	}
 }

--- a/internal/pipeline/env_runtime.go
+++ b/internal/pipeline/env_runtime.go
@@ -397,9 +397,20 @@ func ResolveKeychainPath(store *db.Store, home string) (string, error) {
 		return "", fmt.Errorf("load credentials config: %w", err)
 	}
 	if cfg.KeychainPath != "" {
+		// No absolute check here on purpose: config.LoadCredentialsConfig above
+		// already refuses a relative [credentials].keychain_path, and a second
+		// check would be unreachable code that looks like a guard. Measured, not
+		// assumed - disabling a duplicate check here changed no test outcome,
+		// which is exactly how dead safety code hides.
 		return cfg.KeychainPath, nil
 	}
+	// The DEFAULT path is derived from paths.Home, which is not operator-checked.
+	// A relative home resolves keychain.env inside the working directory, which
+	// is the class that published a token in #1810.
 	baseHome := filepath.Dir(paths.Home)
+	if !filepath.IsAbs(baseHome) {
+		return "", fmt.Errorf("refusing to resolve keychain.env under relative path %q: a credential must never resolve inside the working directory", baseHome)
+	}
 	return filepath.Join(baseHome, ".config", "gitmoot", "keychain.env"), nil
 }
 

--- a/internal/pipeline/keychain_path_safety_test.go
+++ b/internal/pipeline/keychain_path_safety_test.go
@@ -1,0 +1,83 @@
+package pipeline
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/gitmoot/gitmoot/internal/config"
+)
+
+// keychain.env is a credential-bearing overlay, and its path is OPERATOR INPUT.
+// A relative credentials.keychain_path resolves against whatever directory the
+// process runs in - for a pipeline stage that is the checkout - so the file is
+// read, and can then be staged, from inside the work tree. That is the class
+// that put a live token in a public repo (#1810), reached through a different
+// door than runtime-auth.env.
+func TestResolveKeychainPathRefusesARelativeKeychain(t *testing.T) {
+	home := t.TempDir()
+	paths := config.PathsForHome(home)
+	if err := config.Initialize(paths); err != nil {
+		t.Fatal(err)
+	}
+	write := func(t *testing.T, body string) {
+		t.Helper()
+		if err := os.WriteFile(paths.ConfigFile, []byte(config.DefaultConfig(paths)+body), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// A relative CONFIGURED path is refused by the config loader itself. This is
+	// pre-existing validation, asserted here so the boundary is recorded rather
+	// than duplicated in the resolver as unreachable code.
+	for _, relative := range []string{"keychain.env", "./keychain.env", "config/keychain.env"} {
+		write(t, "\n[credentials]\nkeychain_path = \""+relative+"\"\n")
+		got, err := ResolveKeychainPath(nil, home)
+		if err == nil {
+			t.Fatalf("keychain_path %q was accepted and resolved to %q", relative, got)
+		}
+		if !strings.Contains(err.Error(), "must be absolute") {
+			t.Fatalf("error for %q = %v, want the loader's absolute-path rejection", relative, err)
+		}
+	}
+
+	// The DEFAULT path is derived from paths.Home, which nothing else validates,
+	// and that branch is this change's own guard. Reaching it needs a relative
+	// home that actually EXISTS - otherwise the config load fails first and the
+	// test would pass without the guard ever running, which is how the first
+	// version of this assertion fooled me.
+	t.Run("relative home resolves inside the working directory", func(t *testing.T) {
+		t.Chdir(t.TempDir())
+		relPaths := config.PathsForHome("home")
+		if err := config.Initialize(relPaths); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(relPaths.ConfigFile, []byte(config.DefaultConfig(relPaths)), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		got, err := ResolveKeychainPath(nil, "home")
+		if err == nil {
+			t.Fatalf("a relative home resolved keychain.env to %q; a credential must never resolve inside the working directory", got)
+		}
+		if !strings.Contains(err.Error(), "relative") {
+			t.Fatalf("relative-home error = %v, want it to name the relative path", err)
+		}
+	})
+
+	// An absolute configured path still works, and so does the default.
+	absolute := filepath.Join(t.TempDir(), "keychain.env")
+	write(t, "\n[credentials]\nkeychain_path = \""+absolute+"\"\n")
+	got, err := ResolveKeychainPath(nil, home)
+	if err != nil || got != absolute {
+		t.Fatalf("absolute keychain_path = %q err=%v, want %q", got, err, absolute)
+	}
+	write(t, "")
+	got, err = ResolveKeychainPath(nil, home)
+	if err != nil {
+		t.Fatalf("default keychain resolution: %v", err)
+	}
+	if !filepath.IsAbs(got) || filepath.Base(got) != "keychain.env" {
+		t.Fatalf("default keychain path = %q, want an absolute path ending in keychain.env", got)
+	}
+}

--- a/internal/sandbox/sandbox_test.go
+++ b/internal/sandbox/sandbox_test.go
@@ -296,3 +296,46 @@ func TestSandboxExecStrictReadModeReachesProcfsE2E(t *testing.T) {
 		t.Fatalf("overflowuid read returned %q, want the kernel value; procfs is not genuinely readable", output)
 	}
 }
+
+// The produce sandbox grants implicit write roots, so a path that merely is not
+// named in the grant list is still writable when it sits under one of them.
+// #1810 round 4 measured this directly: a configured Claude profile placed under
+// TMPDIR accepted WRITE_CONFIGDIR_NEWFILE. Landlock adds access and cannot
+// subtract it, so this is a precondition on where operator profiles live, not
+// something a caller can grant its way out of. This test exists so that the
+// conditionality is a measured fact rather than a comment, and so that anything
+// which changes the implicit-root set has to change a test that says why.
+func TestWritableRootsGrantImplicitTempRootsSoUnnamedPathsCanStillBeWritten(t *testing.T) {
+	workdir := t.TempDir()
+	profileUnderTemp := filepath.Join(os.TempDir(), "gitmoot-precondition-profile")
+	if err := os.MkdirAll(profileUnderTemp, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(profileUnderTemp) })
+
+	withImplicit, err := writableRoots(nil, workdir, true)
+	if err != nil {
+		t.Fatalf("writableRoots with implicit roots: %v", err)
+	}
+	covered := func(roots []string, path string) bool {
+		for _, root := range roots {
+			if rel, err := filepath.Rel(root, path); err == nil && rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+				return true
+			}
+		}
+		return false
+	}
+	if !covered(withImplicit, profileUnderTemp) {
+		t.Fatalf("implicit roots %v no longer cover %q: the produce precondition documented in daemon_worker.go changed", withImplicit, profileUnderTemp)
+	}
+
+	// A read-only seat excludes the implicit roots, which is why the same path
+	// is NOT writable there. If this ever starts covering, seats lost isolation.
+	withoutImplicit, err := writableRoots(nil, workdir, false)
+	if err != nil {
+		t.Fatalf("writableRoots without implicit roots: %v", err)
+	}
+	if covered(withoutImplicit, profileUnderTemp) {
+		t.Fatalf("explicit-only roots %v unexpectedly cover %q", withoutImplicit, profileUnderTemp)
+	}
+}

--- a/internal/subprocess/wrapping.go
+++ b/internal/subprocess/wrapping.go
@@ -20,7 +20,9 @@ type WrappingRunner struct {
 	ReadOnlyWorkdir bool
 	// Env is appended to the sandbox-exec process environment and inherited by
 	// the exec'd runtime. It is empty for every existing wrapper except Claude
-	// produce, which relocates its mutable config into its granted state dir.
+	// produce, which points CLAUDE_CONFIG_DIR and XDG_CACHE_HOME at the
+	// job-private state root it was granted, so the runtime never writes the
+	// operator profile or the ambient cache.
 	Env []string
 }
 

--- a/website/docs/operations/troubleshooting.md
+++ b/website/docs/operations/troubleshooting.md
@@ -309,6 +309,20 @@ deferral is a first-class `job.deferred` emitted instead of `job.failed`. A job
 that "failed then reappeared as queued" is the deferral working; only act when
 the retry budget is spent and the job stays failed.
 
+A read-only seat (every `review`/`ask` job under the read-only autonomy policy)
+does NOT authenticate with the ambient credential: it stages a SNAPSHOT of its
+runtime config dir (`payload.runtime_config_dir`, else the daemon's
+`CLAUDE_CONFIG_DIR`, else `~/.claude`) and carries the resolved
+`runtime-auth.env` overlay. When that snapshot is already expired the job records
+one `readonly_seat_credential_expired` event naming the expiry, the refresh-token
+state and whether an overlay was available; read it with `gitmoot job events
+<job-id>` before treating the runtime's own "OAuth session expired and could not
+be refreshed" wording as an account problem. It never refuses the job.
+`gitmoot doctor` and `gitmoot auth probe claude` both report that seat credential
+beside the ambient one, and doctor FAILS (non-zero exit) when it is expired with
+no refresh token, since every read-only seat job on that runtime will fail until
+the account is re-logged in.
+
 A job stuck in `running` is recovered automatically once it shows no lease
 progress past the staleness window (default 30m; tune with the
 `GITMOOT_STALE_RUNNING_AFTER` environment variable; the smallest honored value

--- a/website/docs/operations/troubleshooting.md
+++ b/website/docs/operations/troubleshooting.md
@@ -323,6 +323,21 @@ beside the ambient one, and doctor FAILS (non-zero exit) when it is expired with
 no refresh token, since every read-only seat job on that runtime will fail until
 the account is re-logged in.
 
+A Claude `produce` stage does NOT run against the operator profile. The daemon
+stages the configured account (`CLAUDE_CONFIG_DIR`, else `~/.claude`) into a
+job-private profile, points the runtime's `CLAUDE_CONFIG_DIR` and
+`XDG_CACHE_HOME` at that job-private state root under
+`<gitmoot home>/cache/produce-runtime/<hash>/`, and removes the root when the job
+finishes. The operator profile is never granted writable and is never exposed to
+the sandbox, so a token the runtime refreshes mid-job lands in the discarded
+copy: re-login on the host, not in the job. A configured profile that does not
+exist yet is valid and starts the job with an empty one.
+
+`sandbox-exec: sandbox read path "…": no such file or directory` means a path
+granted to the sandbox does not exist on disk. Explicit read grants are required,
+not skipped — check `readable_paths` in `gitmoot job show <job-id> --json` and
+create (or stop granting) the named path.
+
 A job stuck in `running` is recovered automatically once it shows no lease
 progress past the staleness window (default 30m; tune with the
 `GITMOOT_STALE_RUNNING_AFTER` environment variable; the smallest honored value

--- a/website/docs/operations/troubleshooting.md
+++ b/website/docs/operations/troubleshooting.md
@@ -324,15 +324,25 @@ no refresh token, since every read-only seat job on that runtime will fail until
 the account is re-logged in.
 
 A Claude `produce` stage does NOT run against the operator profile. The daemon
-stages the configured account (`CLAUDE_CONFIG_DIR`, else `~/.claude`) into a
-job-private profile, points the runtime's `CLAUDE_CONFIG_DIR` and
-`XDG_CACHE_HOME` at that job-private state root under
-`<gitmoot home>/cache/produce-runtime/<hash>/run-*/` - one directory per dispatch,
-so two concurrent runs of one job id cannot wipe each other - and removes that
-directory when the job finishes. The operator profile is never granted writable and is never exposed to
-the sandbox, so a token the runtime refreshes mid-job lands in the discarded
-copy: re-login on the host, not in the job. A configured profile that does not
-exist yet is valid and starts the job with an empty one.
+copies `.credentials.json` and `settings.json` from the configured account
+(`CLAUDE_CONFIG_DIR`, else `~/.claude`) into a job-private profile, points the
+runtime's `CLAUDE_CONFIG_DIR` and `XDG_CACHE_HOME` at that job-private state root
+under `<gitmoot home>/cache/produce-runtime/<hash>/run-*/` — one directory per
+dispatch, so two runs of one job id cannot wipe each other — and removes it when
+the job finishes. The operator profile is never granted writable and is never
+named in any read grant, so a token the runtime refreshes mid-job lands in the
+discarded copy: re-login on the host, not in the job. It may still be READABLE:
+an agent that declares no readable paths falls back to a read-only grant over
+`/`, which is a read, never a write.
+
+Only those two files cross into a produce job. Everything else in the operator
+profile — `agents/`, `commands/`, `plugins/`, `CLAUDE.md`, `settings.local.json`,
+`~/.claude.json` — deliberately does not, so a produce job sees runtime defaults
+rather than operator customisation. A profile that does not exist yet is valid
+and starts the job with an empty one. A `settings.json` that is symlinked is
+followed; one that is empty, holds a non-object, or is not a file at all is
+SKIPPED rather than failing the job. An unusable `.credentials.json` does fail
+the job, because it decides which account the work runs as.
 
 `sandbox-exec: sandbox read path "…": no such file or directory` means a path
 granted to the sandbox does not exist on disk. Explicit read grants are required,

--- a/website/docs/operations/troubleshooting.md
+++ b/website/docs/operations/troubleshooting.md
@@ -327,8 +327,9 @@ A Claude `produce` stage does NOT run against the operator profile. The daemon
 stages the configured account (`CLAUDE_CONFIG_DIR`, else `~/.claude`) into a
 job-private profile, points the runtime's `CLAUDE_CONFIG_DIR` and
 `XDG_CACHE_HOME` at that job-private state root under
-`<gitmoot home>/cache/produce-runtime/<hash>/`, and removes the root when the job
-finishes. The operator profile is never granted writable and is never exposed to
+`<gitmoot home>/cache/produce-runtime/<hash>/run-*/` - one directory per dispatch,
+so two concurrent runs of one job id cannot wipe each other - and removes that
+directory when the job finishes. The operator profile is never granted writable and is never exposed to
 the sandbox, so a token the runtime refreshes mid-job lands in the discarded
 copy: re-login on the host, not in the job. A configured profile that does not
 exist yet is valid and starts the job with an empty one.


### PR DESCRIPTION
Closes #1808. Closes #1811. Answers directive 110288 items (a) and (b).

## The outage

Every claude review and ask job failed from 06:31:46Z with `claude: Failed to authenticate: OAuth session expired and could not be refreshed`, while `gitmoot auth probe claude` and `gitmoot doctor` stayed **green throughout**. Both facts have one cause: a read-only seat authenticates with a credential nothing else in the engine uses, and nothing measured it.

## Four changes

**1. The seat never received the resolved runtime auth.** Every other job gets it: `runtimeJobRunnerWithAuth` appends `runtimeAuthInjectionEnv` onto the curated `BaseEnv`. `wrapReadOnlySandboxAdapter` rebuilds the environment from `readOnlyRuntimeBaseEnv`, whose allow-list carries no auth names, so the overlay was silently dropped and the seat had only its staged snapshot. Once that snapshot expired, every seat job failed. The seat now carries the same overlay. Gateway mode is excluded: there the gateway holds the credential and the seat is deliberately given none.

**2. The probe measured the wrong credential.** `auth probe claude` probes the ambient token, which no read-only seat had. It now also reports the staged credential: `valid until T`, `EXPIRED` with a refresh token, or `UNUSABLE` with none. This is the false green the outage ran on for hours.

**3. The seat launched into a guaranteed failure.** Expired with no refresh token cannot authenticate, so the job fails before the runtime starts, with an error naming the file, the expiry, and the remedy. Expired **with** a refresh token is deliberately NOT refused, because refreshing is the runtime's job and normally works: it records a `readonly_seat_credential_expired` event so a later auth failure is attributable rather than mysterious.

**4. An operator-set `CLAUDE_CONFIG_DIR` is no longer overridden (#1811).** `produceRuntimeSandboxGrants` hard-coded `$HOME/.claude`, so a daemon configured onto a live account still pointed produce jobs at a dead one.

## One correction I owe the record

Directive 110261 cited this at `daemon_worker.go:939` from a checkout 174 commits behind, and 110288 corrected that. I did not take either citation on trust: I read `produceRuntimeSandboxGrants` in a worktree at `origin/main` and the hard-coded `filepath.Join(home, ".claude")` is there, which is why item 4 is in this PR. The line number was wrong; the defect was not.

## An absent expiry is not an expired one

`expiresAt` decodes through a pointer. Absent means the file declares no expiry and this check asserts nothing; an explicit `0` is what a **failed refresh writes back** and is a positive statement that the token is dead. Conflating them refused three existing seat tests whose fixtures legitimately carry only an `accessToken`, which is how the distinction was found.

## Verification

`go build ./...`, `go vet ./...`, `go generate ./...` clean with no diff, and `go test ./...` green (three independent full runs).

Mutants, each against a green baseline, each killed:

| mutant | tests that failed |
|---|---|
| seat auth overlay returns nothing (the production defect) | `TestReadOnlySeatRuntimeAuthEnvCarriesTheResolvedOverlay` |
| preflight never refuses | `TestReadOnlySeatCredentialPreflightRefusesTheUnusableCase`, `TestWorkerRefusesSeatWithUnusableStagedCredential` (proves the runtime is not launched) |
| refuse whenever expired, even when refreshable | `TestReadOnlySeatCredentialPreflightDiagnosesTheRefreshableCase`, `TestWorkerRecordsExpiredButRefreshableSeatCredential` |
| worker drops the diagnosis event | `TestWorkerRecordsExpiredButRefreshableSeatCredential` |
| absent expiry treated as expired | `TestReadOnlySeatCredentialPreflightIgnoresAnAbsentExpiry` plus the three pre-existing seat tests |
| zero expiry treated as "none declared" | the refusal tests |
| `CLAUDE_CONFIG_DIR` hard-coded again | `TestProduceRuntimeSandboxGrantsHonorsConfiguredClaudeDir` |

Two of these enter through `jobWorker.run`, so the refusal and the event are observed on the production path rather than in a helper.

## Not verified, and what remains for others

No live claude round trip from this branch: the account credential was repaired operationally at the host level, so a live pass today would not distinguish this fix from that repair. The overlay injection is proven by the unit and the mutant, not by a job.

Item (a) of 110288, that a refreshable browser session is the wrong credential to stage into a sandbox that cannot write back a rotated token, is answered by 1 and 3 together: the seat now uses the engine's resolved auth, and when it must fall back to a snapshot it says so instead of failing opaquely. Items (c) codex `bwrap: setting up uid map`, (d) kimi login, and the gateway-mode question are untouched here.

## Deploy notes

Rebuild and replace BOTH service binaries per the AGENTS.md recipe, then restart at idle. No config or migration change.