### PR TITLE
feat(org): retire a seat whose pane is gone with seat rm --force (#1813)

### DIFF
--- a/internal/cli/org.go
+++ b/internal/cli/org.go
@@ -143,7 +143,7 @@ func printOrgUsage(w io.Writer) {
 	fmt.Fprintln(w, "  gitmoot org status [--json] [--home DIR]")
 	fmt.Fprintln(w, "  gitmoot org recycle ROLE --kind KIND --handoff NOTE [--pane ID] [--json] [--home DIR]")
 	fmt.Fprintln(w, "  gitmoot org seat add NAME [--pane ID_OR_LABEL] [--parent ROLE] [--scope REPO,...] [--merge-rule owner|self|none] [--home DIR]")
-	fmt.Fprintln(w, "  gitmoot org seat rm NAME [--home DIR]")
+	fmt.Fprintln(w, "  gitmoot org seat rm NAME [--force] [--home DIR]")
 	fmt.Fprintln(w, "  gitmoot org escalate --to ROLE --workflow LABEL [--org-role ROLE] [--repo OWNER/REPO] [--json] [--home DIR] \"QUESTION\"")
 	fmt.Fprintln(w, "  gitmoot org message send --to ROLE --workflow LABEL [--org-role ROLE] [--repo OWNER/REPO] [--json] [--home DIR] \"MESSAGE\"")
 	fmt.Fprintln(w, "  gitmoot org escalate resolve NOTE_ID [--by ROLE] [--note ANSWER_NOTE_ID] [--home DIR]")
@@ -182,7 +182,7 @@ func runOrgSeat(args []string, stdout, stderr io.Writer) int {
 func printOrgSeatUsage(w io.Writer) {
 	fmt.Fprintln(w, "Usage:")
 	fmt.Fprintln(w, "  gitmoot org seat add NAME [--pane ID_OR_LABEL] [--parent ROLE] [--scope REPO,...] [--merge-rule owner|self|none] [--home DIR]")
-	fmt.Fprintln(w, "  gitmoot org seat rm NAME [--home DIR]")
+	fmt.Fprintln(w, "  gitmoot org seat rm NAME [--force] [--home DIR]")
 }
 
 func runOrgSeatAdd(args []string, stdout, stderr io.Writer) int {
@@ -383,6 +383,18 @@ func runOrgSeatRemove(args []string, stdout, stderr io.Writer) int {
 	fs := flag.NewFlagSet("org seat rm", flag.ContinueOnError)
 	fs.SetOutput(stderr)
 	home := fs.String("home", "", "home directory to use instead of the current user's home")
+	// A seat whose configured pane no longer resolves cannot be removed without
+	// this, and that is deliberate: a stale id or an ambiguous label may still
+	// name a LIVE pane holding work, which is why
+	// TestOrgSeatRemoveStalePaneIDFailsClosed and
+	// TestOrgSeatRemoveAmbiguousPaneLabelFailsClosed exist. But a seat whose pane
+	// is permanently gone then has no retirement path at all: measured on this
+	// host, gm-omp-e2b, gm-omp-nag and gm-omp-verdict were all undeletable while
+	// gm-omp-e2b accrued 19 missed wakes, and per #1175 an unbound role is a
+	// defect with exactly two remedies, bind or remove. --force is the operator
+	// stating that the pane is gone and accepting the unverified removal; it
+	// never skips the branch check on a pane that DOES resolve.
+	force := fs.Bool("force", false, "remove even when the configured pane cannot be resolved (stale id or ambiguous label)")
 	nameArg, flagArgs := leadingOrgSeatName(args)
 	if err := fs.Parse(flagArgs); err != nil {
 		if errors.Is(err, flag.ErrHelp) {
@@ -443,24 +455,32 @@ func runOrgSeatRemove(args []string, stdout, stderr io.Writer) int {
 		}
 		binding := snapshot.PaneBindings[role.Name]
 		unresolvedDetail = firstNonEmpty(binding.Detail, "no live pane binding")
+		// An unresolved binding stays FAIL-CLOSED by default: a stale id or an
+		// ambiguous label may still name a live pane holding work, which is what
+		// TestOrgSeatRemoveStalePaneIDFailsClosed and
+		// TestOrgSeatRemoveAmbiguousPaneLabelFailsClosed defend. --force is the
+		// operator asserting the pane is gone, which is the only retirement path
+		// for a seat whose pane will never resolve again (#1175: an unbound role
+		// is a defect with two remedies, bind or remove).
 		if strings.TrimSpace(binding.PaneID) == "" {
-			fmt.Fprintf(
-				stderr,
-				"org seat rm: role %q pane is unresolved: %s; rebind with gitmoot org seat add %s --pane ID_OR_LABEL\n",
-				role.Name, unresolvedDetail, role.Name,
-			)
-			return 1
-		}
-		pane, ok = orgSeatPaneByID(snapshot.Panes, binding.PaneID)
-		if !ok {
+			if !*force {
+				fmt.Fprintf(
+					stderr,
+					"org seat rm: role %q pane is unresolved: %s; rebind with gitmoot org seat add %s --pane ID_OR_LABEL, or pass --force to retire a seat whose pane is gone\n",
+					role.Name, unresolvedDetail, role.Name,
+				)
+				return 1
+			}
+			writeLine(stdout, "org seat rm: %s pane check skipped under --force: %s", role.Name, unresolvedDetail)
+		} else if pane, ok = orgSeatPaneByID(snapshot.Panes, binding.PaneID); !ok {
 			fmt.Fprintf(stderr, "org seat rm: resolved pane %s is absent from the live snapshot\n", binding.PaneID)
 			return 1
-		}
-		if err := orgSeatBranchCheck(ctx, pane); err != nil {
+		} else if err := orgSeatBranchCheck(ctx, pane); err != nil {
 			fmt.Fprintf(stderr, "org seat rm: refusing to remove %q: %v\n", role.Name, err)
 			return 1
+		} else {
+			hasLivePane = true
 		}
-		hasLivePane = true
 	}
 	store, err := db.Open(paths.Database)
 	if err != nil {

--- a/internal/cli/org.go
+++ b/internal/cli/org.go
@@ -471,7 +471,20 @@ func runOrgSeatRemove(args []string, stdout, stderr io.Writer) int {
 				)
 				return 1
 			}
-			writeLine(stdout, "org seat rm: %s pane check skipped under --force: %s", role.Name, unresolvedDetail)
+			risk := "a stale binding may still name a LIVE pane whose work was not inspected"
+			if binding.Ambiguous {
+				var paneIDs []string
+				for _, candidate := range snapshot.Panes {
+					if candidate.PaneID != "" && candidate.Label == strings.TrimSpace(role.Pane) {
+						paneIDs = append(paneIDs, candidate.PaneID)
+					}
+				}
+				sort.Strings(paneIDs)
+				if len(paneIDs) != 0 {
+					risk = fmt.Sprintf("matching LIVE panes %s may still hold work that was not inspected", strings.Join(paneIDs, ", "))
+				}
+			}
+			writeLine(stdout, "org seat rm: %s pane check skipped under --force: %s; %s", role.Name, unresolvedDetail, risk)
 		} else if pane, ok = orgSeatPaneByID(snapshot.Panes, binding.PaneID); !ok {
 			fmt.Fprintf(stderr, "org seat rm: resolved pane %s is absent from the live snapshot\n", binding.PaneID)
 			return 1

--- a/internal/cli/org_seat_test.go
+++ b/internal/cli/org_seat_test.go
@@ -1256,3 +1256,114 @@ func listOrgSeatTestRules(t *testing.T, paths config.Paths) []db.EventRule {
 	}
 	return rules
 }
+
+// A seat whose configured pane will never resolve again had no retirement path:
+// removal fails closed on an unresolved binding (correctly, since a stale id or
+// ambiguous label may still name a LIVE pane), which left --force as the only
+// way to satisfy #1175's "bind it or remove it" for a seat whose pane is gone.
+// Measured on this host: gm-omp-e2b, gm-omp-nag and gm-omp-verdict were all
+// undeletable while gm-omp-e2b accrued 19 missed wakes.
+func TestOrgSeatRemoveForceRetiresAnUnresolvedSeat(t *testing.T) {
+	home, paths, panes := setupOrgSeatTestHome(t)
+	edit, _, err := config.UpsertOrgSeatRole(paths, config.OrgRole{
+		Name: "worker", Parent: "owner", Scope: []string{"*"}, Pane: "w1:p9",
+	}, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !edit.Changed() {
+		t.Fatal("stale worker config edit did not change config")
+	}
+	addOrgSeatWorkerRoutes(t, paths)
+	withOrgSeatFixtureProvider(t, &panes)
+	originalBranchCheck := orgSeatBranchCheck
+	orgSeatBranchCheck = func(context.Context, org.LivePane) error {
+		t.Fatal("forced removal of an unresolved seat must not attempt a branch check")
+		return nil
+	}
+	t.Cleanup(func() { orgSeatBranchCheck = originalBranchCheck })
+	originalClose := orgSeatClosePane
+	orgSeatClosePane = func(context.Context, string) error {
+		t.Fatal("forced removal of an unresolved seat must not close a pane")
+		return nil
+	}
+	t.Cleanup(func() { orgSeatClosePane = originalClose })
+
+	// Default still fails closed, and the refusal must name the escape hatch.
+	var stdout, stderr bytes.Buffer
+	if code := runOrg([]string{"seat", "rm", "worker", "--home", home}, &stdout, &stderr); code == 0 {
+		t.Fatalf("unforced rm of an unresolved seat must fail closed; out=%q err=%q", stdout.String(), stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "--force") {
+		t.Fatalf("refusal must name --force; err=%q", stderr.String())
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	if code := runOrg([]string{"seat", "rm", "worker", "--force", "--home", home}, &stdout, &stderr); code != 0 {
+		t.Fatalf("forced rm code=%d out=%q err=%q", code, stdout.String(), stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "pane check skipped under --force") {
+		t.Fatalf("forced removal must SAY the check was skipped; out=%q", stdout.String())
+	}
+	cfg, err := config.LoadOrg(paths)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := cfg.Role("worker"); ok {
+		t.Fatal("forced removal left the role in the registry")
+	}
+}
+
+// --force is scoped to an UNRESOLVED binding. It must never wave through a pane
+// that DOES resolve and whose branch check fails: that is live work about to be
+// destroyed. Without this test the scoping is vacuous, which a mutant proved by
+// making --force skip the branch check with every other test still green.
+func TestOrgSeatRemoveForceStillRefusesUnshippedBranchWork(t *testing.T) {
+	home, paths, panes := setupOrgSeatTestHome(t)
+	appendOrgSeatWorker(t, paths)
+	addOrgSeatWorkerRoutes(t, paths)
+
+	repo := t.TempDir()
+	remote := filepath.Join(t.TempDir(), "remote.git")
+	runGit(t, repo, "init", "-b", "main")
+	runGit(t, repo, "config", "user.name", "Seat Test")
+	runGit(t, repo, "config", "user.email", "seat@example.test")
+	if err := os.WriteFile(filepath.Join(repo, "README.md"), []byte("base\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	runGit(t, repo, "add", "README.md")
+	runGit(t, repo, "commit", "-m", "base")
+	runGit(t, t.TempDir(), "init", "--bare", remote)
+	runGit(t, remote, "symbolic-ref", "HEAD", "refs/heads/main")
+	runGit(t, repo, "remote", "add", "origin", remote)
+	runGit(t, repo, "push", "-u", "origin", "main")
+	runGit(t, repo, "checkout", "-b", "worker-unshipped")
+	if err := os.WriteFile(filepath.Join(repo, "work.txt"), []byte("not merged\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	runGit(t, repo, "add", "work.txt")
+	runGit(t, repo, "commit", "-m", "unshipped")
+	panes[1].CWD = repo
+	panes[1].ForegroundCWD = repo
+	withOrgSeatFixtureProvider(t, &panes)
+	originalClose := orgSeatClosePane
+	orgSeatClosePane = func(context.Context, string) error {
+		t.Fatal("forced removal closed a pane holding unshipped work")
+		return nil
+	}
+	t.Cleanup(func() { orgSeatClosePane = originalClose })
+
+	var stdout, stderr bytes.Buffer
+	code := runOrg([]string{"seat", "rm", "worker", "--force", "--home", home}, &stdout, &stderr)
+	if code != 1 || !strings.Contains(stderr.String(), "not merged into origin/main") {
+		t.Fatalf("forced rm over a resolved pane with unshipped work: code=%d out=%q err=%q", code, stdout.String(), stderr.String())
+	}
+	cfg, err := config.LoadOrg(paths)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := cfg.Role("worker"); !ok {
+		t.Fatal("forced removal deleted a role whose pane holds unshipped work")
+	}
+}

--- a/internal/cli/org_seat_test.go
+++ b/internal/cli/org_seat_test.go
@@ -764,26 +764,7 @@ func TestOrgSeatRemoveRefusesUnshippedBranchWork(t *testing.T) {
 	appendOrgSeatWorker(t, paths)
 	addOrgSeatWorkerRoutes(t, paths)
 
-	repo := t.TempDir()
-	remote := filepath.Join(t.TempDir(), "remote.git")
-	runGit(t, repo, "init", "-b", "main")
-	runGit(t, repo, "config", "user.name", "Seat Test")
-	runGit(t, repo, "config", "user.email", "seat@example.test")
-	if err := os.WriteFile(filepath.Join(repo, "README.md"), []byte("base\n"), 0o600); err != nil {
-		t.Fatal(err)
-	}
-	runGit(t, repo, "add", "README.md")
-	runGit(t, repo, "commit", "-m", "base")
-	runGit(t, t.TempDir(), "init", "--bare", remote)
-	runGit(t, remote, "symbolic-ref", "HEAD", "refs/heads/main")
-	runGit(t, repo, "remote", "add", "origin", remote)
-	runGit(t, repo, "push", "-u", "origin", "main")
-	runGit(t, repo, "checkout", "-b", "worker-unshipped")
-	if err := os.WriteFile(filepath.Join(repo, "work.txt"), []byte("not merged\n"), 0o600); err != nil {
-		t.Fatal(err)
-	}
-	runGit(t, repo, "add", "work.txt")
-	runGit(t, repo, "commit", "-m", "unshipped")
+	repo := newOrgSeatUnshippedRepo(t)
 	panes[1].CWD = repo
 	panes[1].ForegroundCWD = repo
 	withOrgSeatFixtureProvider(t, &panes)
@@ -941,6 +922,28 @@ func TestOrgSeatRemoveAmbiguousPaneLabelFailsClosed(t *testing.T) {
 	}
 	if got := len(listOrgSeatTestRules(t, paths)); got != 6 {
 		t.Fatalf("ambiguous removal changed routes: %d", got)
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	if code := runOrg([]string{"seat", "rm", "worker", "--force", "--home", home}, &stdout, &stderr); code != 0 {
+		t.Fatalf("forced ambiguous seat rm code=%d out=%q err=%q", code, stdout.String(), stderr.String())
+	}
+	for _, want := range []string{
+		`multiple Herdr panes labeled "Worker"`,
+		"matching LIVE panes w1:p2, w1:p3 may still hold work that was not inspected",
+	} {
+		if !strings.Contains(stdout.String(), want) {
+			t.Fatalf("forced ambiguous removal warning missing %q: %q", want, stdout.String())
+		}
+	}
+	if cfg, err := config.LoadOrg(paths); err != nil {
+		t.Fatal(err)
+	} else if _, ok := cfg.Role("worker"); ok {
+		t.Fatal("forced ambiguous removal left worker in the registry")
+	}
+	if got := len(listOrgSeatTestRules(t, paths)); got != 1 {
+		t.Fatalf("forced ambiguous removal left worker routes: %d total routes, want owner route only", got)
 	}
 }
 
@@ -1192,6 +1195,31 @@ func withOrgSeatFixtureProvider(t *testing.T, panes *[]org.LivePane) {
 	t.Cleanup(func() { newOrgProvider = original })
 }
 
+func newOrgSeatUnshippedRepo(t *testing.T) string {
+	t.Helper()
+	repo := t.TempDir()
+	remote := filepath.Join(t.TempDir(), "remote.git")
+	runGit(t, repo, "init", "-b", "main")
+	runGit(t, repo, "config", "user.name", "Seat Test")
+	runGit(t, repo, "config", "user.email", "seat@example.test")
+	if err := os.WriteFile(filepath.Join(repo, "README.md"), []byte("base\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	runGit(t, repo, "add", "README.md")
+	runGit(t, repo, "commit", "-m", "base")
+	runGit(t, t.TempDir(), "init", "--bare", remote)
+	runGit(t, remote, "symbolic-ref", "HEAD", "refs/heads/main")
+	runGit(t, repo, "remote", "add", "origin", remote)
+	runGit(t, repo, "push", "-u", "origin", "main")
+	runGit(t, repo, "checkout", "-b", "worker-unshipped")
+	if err := os.WriteFile(filepath.Join(repo, "work.txt"), []byte("not merged\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	runGit(t, repo, "add", "work.txt")
+	runGit(t, repo, "commit", "-m", "unshipped")
+	return repo
+}
+
 func addOrgSeatCoordinator(t *testing.T, paths config.Paths, mergeRule string) {
 	t.Helper()
 	edit, _, err := config.UpsertOrgSeatRole(paths, config.OrgRole{
@@ -1303,8 +1331,9 @@ func TestOrgSeatRemoveForceRetiresAnUnresolvedSeat(t *testing.T) {
 	if code := runOrg([]string{"seat", "rm", "worker", "--force", "--home", home}, &stdout, &stderr); code != 0 {
 		t.Fatalf("forced rm code=%d out=%q err=%q", code, stdout.String(), stderr.String())
 	}
-	if !strings.Contains(stdout.String(), "pane check skipped under --force") {
-		t.Fatalf("forced removal must SAY the check was skipped; out=%q", stdout.String())
+	wantWarning := `org seat rm: worker pane check skipped under --force: no Herdr pane bound as "w1:p9"; a stale binding may still name a LIVE pane whose work was not inspected`
+	if !strings.Contains(stdout.String(), wantWarning) {
+		t.Fatalf("forced removal warning missing %q: %q", wantWarning, stdout.String())
 	}
 	cfg, err := config.LoadOrg(paths)
 	if err != nil {
@@ -1324,26 +1353,7 @@ func TestOrgSeatRemoveForceStillRefusesUnshippedBranchWork(t *testing.T) {
 	appendOrgSeatWorker(t, paths)
 	addOrgSeatWorkerRoutes(t, paths)
 
-	repo := t.TempDir()
-	remote := filepath.Join(t.TempDir(), "remote.git")
-	runGit(t, repo, "init", "-b", "main")
-	runGit(t, repo, "config", "user.name", "Seat Test")
-	runGit(t, repo, "config", "user.email", "seat@example.test")
-	if err := os.WriteFile(filepath.Join(repo, "README.md"), []byte("base\n"), 0o600); err != nil {
-		t.Fatal(err)
-	}
-	runGit(t, repo, "add", "README.md")
-	runGit(t, repo, "commit", "-m", "base")
-	runGit(t, t.TempDir(), "init", "--bare", remote)
-	runGit(t, remote, "symbolic-ref", "HEAD", "refs/heads/main")
-	runGit(t, repo, "remote", "add", "origin", remote)
-	runGit(t, repo, "push", "-u", "origin", "main")
-	runGit(t, repo, "checkout", "-b", "worker-unshipped")
-	if err := os.WriteFile(filepath.Join(repo, "work.txt"), []byte("not merged\n"), 0o600); err != nil {
-		t.Fatal(err)
-	}
-	runGit(t, repo, "add", "work.txt")
-	runGit(t, repo, "commit", "-m", "unshipped")
+	repo := newOrgSeatUnshippedRepo(t)
 	panes[1].CWD = repo
 	panes[1].ForegroundCWD = repo
 	withOrgSeatFixtureProvider(t, &panes)
@@ -1365,5 +1375,111 @@ func TestOrgSeatRemoveForceStillRefusesUnshippedBranchWork(t *testing.T) {
 	}
 	if _, ok := cfg.Role("worker"); !ok {
 		t.Fatal("forced removal deleted a role whose pane holds unshipped work")
+	}
+}
+
+// --force is scoped to an UNRESOLVED binding. A provider ERROR is a different
+// state: the snapshot could not be read at all, so nothing is known about the
+// pane and forcing through would delete a seat whose work was never inspected.
+// The #1815 review named this guard as undefended, and it was.
+func TestOrgSeatRemoveForceStillFailsClosedOnProviderOutage(t *testing.T) {
+	home, paths, _ := setupOrgSeatTestHome(t)
+	appendOrgSeatWorker(t, paths)
+	addOrgSeatWorkerRoutes(t, paths)
+	originalProvider := newOrgProvider
+	newOrgProvider = func([]config.OrgRole) org.Provider {
+		return orgSeatProviderFunc(func(context.Context) (org.Snapshot, error) {
+			return org.Snapshot{}, errors.New("provider down")
+		})
+	}
+	t.Cleanup(func() { newOrgProvider = originalProvider })
+	originalClose := orgSeatClosePane
+	orgSeatClosePane = func(context.Context, string) error {
+		t.Fatal("a provider outage under --force attempted to close a pane")
+		return nil
+	}
+	t.Cleanup(func() { orgSeatClosePane = originalClose })
+
+	var stdout, stderr bytes.Buffer
+	if code := runOrg([]string{"seat", "rm", "worker", "--force", "--home", home}, &stdout, &stderr); code == 0 {
+		t.Fatalf("--force must not force through a provider outage; out=%q err=%q", stdout.String(), stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "provider down") {
+		t.Fatalf("provider outage reason missing from refusal: %q", stderr.String())
+	}
+	if strings.Contains(stdout.String(), "pane check skipped under --force") {
+		t.Fatalf("provider outage was misreported as an unresolved binding: %q", stdout.String())
+	}
+	cfg, err := config.LoadOrg(paths)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := cfg.Role("worker"); !ok {
+		t.Fatal("a provider outage under --force removed the role anyway")
+	}
+	if got := len(listOrgSeatTestRules(t, paths)); got != 6 {
+		t.Fatalf("a provider outage under --force changed routes: %d", got)
+	}
+}
+
+// --force must be a NO-OP on a healthy resolved seat: same removal, same pane
+// close, same validation, and no skip warning. Nothing asserted that before.
+func TestOrgSeatRemoveForceIsANoOpOnAHealthyResolvedSeat(t *testing.T) {
+	for _, forced := range []bool{false, true} {
+		name := "unforced"
+		if forced {
+			name = "forced"
+		}
+		t.Run(name, func(t *testing.T) {
+			home, paths, panes := setupOrgSeatTestHome(t)
+			appendOrgSeatWorker(t, paths)
+			addOrgSeatWorkerRoutes(t, paths)
+			withOrgSeatFixtureProvider(t, &panes)
+			branchChecks := 0
+			originalBranchCheck := orgSeatBranchCheck
+			orgSeatBranchCheck = func(context.Context, org.LivePane) error {
+				branchChecks++
+				return nil
+			}
+			t.Cleanup(func() { orgSeatBranchCheck = originalBranchCheck })
+			closed := 0
+			originalClose := orgSeatClosePane
+			orgSeatClosePane = func(_ context.Context, paneID string) error {
+				for i, pane := range panes {
+					if pane.PaneID == paneID {
+						panes = append(panes[:i], panes[i+1:]...)
+						closed++
+						return nil
+					}
+				}
+				return errors.New("pane not found")
+			}
+			t.Cleanup(func() { orgSeatClosePane = originalClose })
+
+			args := []string{"seat", "rm", "worker"}
+			if forced {
+				args = append(args, "--force")
+			}
+			var stdout, stderr bytes.Buffer
+			if code := runOrg(append(args, "--home", home), &stdout, &stderr); code != 0 {
+				t.Fatalf("%s rm code=%d out=%q err=%q", name, code, stdout.String(), stderr.String())
+			}
+			if closed != 1 {
+				t.Fatalf("%s rm closed %d panes, want 1", name, closed)
+			}
+			if strings.Contains(stdout.String(), "pane check skipped") {
+				t.Fatalf("%s rm skipped the pane check on a resolved seat: %q", name, stdout.String())
+			}
+			if branchChecks != 1 {
+				t.Fatalf("%s rm ran %d branch checks, want 1", name, branchChecks)
+			}
+			cfg, err := config.LoadOrg(paths)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if _, ok := cfg.Role("worker"); ok {
+				t.Fatalf("%s rm left the role in the registry", name)
+			}
+		})
 	}
 }

--- a/skills/gitmoot/references/CLI.md
+++ b/skills/gitmoot/references/CLI.md
@@ -1626,10 +1626,10 @@ matching label binding, or replaces a non-empty binding only when its former
 target no longer resolves. It does not rewrite existing policy or duplicate
 routes.
 
-`gitmoot org seat rm <name> [--home DIR]` resolves the role's live pane when it
-has a binding and checks every distinct Git checkout reported by that pane's
-`cwd` and `foreground_cwd`. It refuses a dirty checkout or a branch whose `HEAD`
-is not merged into the locally known `origin/HEAD` (falling back to
+`gitmoot org seat rm <name> [--force] [--home DIR]` resolves the role's live pane
+when it has a binding and checks every distinct Git checkout reported by that
+pane's `cwd` and `foreground_cwd`. It refuses a dirty checkout or a branch whose
+`HEAD` is not merged into the locally known `origin/HEAD` (falling back to
 `origin/main`); unreadable branch state also fails closed. A safe removal deletes
 the role and all of its wake routes, closes a resolved live pane, and validates
 that the role, routes, and closed pane are absent. A role with no configured
@@ -1638,6 +1638,20 @@ its routes. A configured binding that is stale, absent, or ambiguous fails
 closed before mutation and reports the `org seat add` rebind command. A provider
 error for a configured binding also fails closed. Roles that still parent
 another role cannot be removed.
+
+`--force` retires a seat whose configured pane will never resolve again, which
+is otherwise unreachable: rebinding is impossible when the pane is gone, so the
+role and its wake routes cannot be deleted at all. Per #1175 an unbound role is
+a defect with two remedies, bind it or remove it, and `--force` is the second
+one. It applies ONLY to an unresolved binding, and the removal prints
+`pane check skipped under --force` with the reason the binding did not resolve.
+A stale id may still name a LIVE pane holding work that the check cannot
+inspect, so forcing a stale binding asserts that pane is gone. An ambiguous
+label warning names every matching live pane ID; removal does not guess which
+one belongs to the role and therefore closes none of them. Inspect or close
+those panes separately before forcing the removal. `--force` does not weaken
+anything else: a pane that DOES resolve is still refused when its branch check
+fails, and a provider error still fails closed rather than being forced through.
 
 The five provisioned routes are enabled, addressed, and have an empty match
 filter. Remove one by its stable ID with `org events rule rm` to quiet that kind;

--- a/website/docs/reference/cli.md
+++ b/website/docs/reference/cli.md
@@ -1459,10 +1459,10 @@ matching label binding, or replaces a non-empty binding only when its former
 target no longer resolves. It does not rewrite existing policy or duplicate
 routes.
 
-`gitmoot org seat rm <name> [--home DIR]` resolves the role's live pane when it
-has a binding and checks every distinct Git checkout reported by that pane's
-`cwd` and `foreground_cwd`. It refuses a dirty checkout or a branch whose `HEAD`
-is not merged into the locally known `origin/HEAD` (falling back to
+`gitmoot org seat rm <name> [--force] [--home DIR]` resolves the role's live pane
+when it has a binding and checks every distinct Git checkout reported by that
+pane's `cwd` and `foreground_cwd`. It refuses a dirty checkout or a branch whose
+`HEAD` is not merged into the locally known `origin/HEAD` (falling back to
 `origin/main`); unreadable branch state also fails closed. A safe removal deletes
 the role and all of its wake routes, closes a resolved live pane, and validates
 that the role, routes, and closed pane are absent. A role with no configured
@@ -1471,6 +1471,20 @@ its routes. A configured binding that is stale, absent, or ambiguous fails
 closed before mutation and reports the `org seat add` rebind command. A provider
 error for a configured binding also fails closed. Roles that still parent
 another role cannot be removed.
+
+`--force` retires a seat whose configured pane will never resolve again, which
+is otherwise unreachable: rebinding is impossible when the pane is gone, so the
+role and its wake routes cannot be deleted at all. Per #1175 an unbound role is
+a defect with two remedies, bind it or remove it, and `--force` is the second
+one. It applies ONLY to an unresolved binding, and the removal prints
+`pane check skipped under --force` with the reason the binding did not resolve.
+A stale id may still name a LIVE pane holding work that the check cannot
+inspect, so forcing a stale binding asserts that pane is gone. An ambiguous
+label warning names every matching live pane ID; removal does not guess which
+one belongs to the role and therefore closes none of them. Inspect or close
+those panes separately before forcing the removal. `--force` does not weaken
+anything else: a pane that DOES resolve is still refused when its branch check
+fails, and a provider error still fails closed rather than being forced through.
 
 The five provisioned routes are enabled, addressed, and have an empty match
 filter. Remove one by its stable ID with `org events rule rm` to quiet that kind;


### PR DESCRIPTION
Closes #1813. Serves the #1175 hygiene item raised in directive 110376.

## Why

Per #1175 an unbound role is a defect with two remedies: bind it or remove it. The second was unreachable. `seat rm` fails closed on an unresolved binding and prints "rebind with `gitmoot org seat add ... --pane ID_OR_LABEL`", which is impossible advice when the pane no longer exists.

Measured on this host: `gm-omp-e2b` unbound since 2026-09-02 05:08:51 carrying **19 missed wakes**, `gm-omp-nag` since 2026-08-31 03:14:44, `gm-omp-verdict` since 2026-09-01 11:55:09. All three undeletable.

## The fail-closed default is not the bug

My first patch skipped the pane check for every unresolved binding and immediately broke `TestOrgSeatRemoveStalePaneIDFailsClosed` and `TestOrgSeatRemoveAmbiguousPaneLabelFailsClosed`. Those tests are right: an unresolved binding is **not** the same fact as "no pane". A stale id or an ambiguous label may still name a LIVE pane holding unshipped work, and the code cannot tell which case it is in. That is the same absent-versus-explicit-zero error as `expiresAt` in #1808, in a different dress, and the existing tests caught it in one run.

## What this adds

`gitmoot org seat rm NAME --force`: the operator asserts the pane is gone and accepts an unverified removal.

- default behaviour unchanged and still fails closed;
- the refusal message now names the escape hatch instead of only impossible advice;
- `--force` is scoped to the **unresolved** case. A pane that DOES resolve and fails its branch check is still refused;
- the forced path prints `pane check skipped under --force: <detail>`, so the removal says what it did not verify.

## Verification

`go build ./...`, `go vet ./...`, `go generate ./...` clean with no diff, `go test ./...` green.

Mutants against a green baseline:

| mutant | result |
|---|---|
| `--force` ignored, unresolved removal always allowed | killed: `TestOrgSeatRemoveStalePaneIDFailsClosed`, `TestOrgSeatRemoveAmbiguousPaneLabelFailsClosed`, `TestOrgSeatRemoveForceRetiresAnUnresolvedSeat` |
| `--force` also skips a RESOLVED pane's branch check | **SURVIVED the whole suite on the first attempt** |

The survivor is the useful part of this PR. The scoping clause was vacuous, so `TestOrgSeatRemoveForceStillRefusesUnshippedBranchWork` now builds a real repo with an unmerged branch, points a resolved pane at it, and asserts the removal is refused and no pane is closed. With that test the mutant fails on exactly the property it broke: it closed a pane holding unshipped work.

## Not verified

I have not run `--force` against the three live seats. Doing that needs this merged and deployed, and it is a destructive registry edit I would rather perform on a reviewed build than on a local one.

## Deploy notes

Rebuild and replace BOTH service binaries per the AGENTS.md recipe. No config or migration change. `gitmoot org seat rm` usage text updated in both help surfaces.