### PR TITLE
fix(daemon): bound the pool pass's wait so queued same-repo work is not invisible (#1830)

### DIFF
--- a/internal/cli/daemon_dispatch_tracked_test.go
+++ b/internal/cli/daemon_dispatch_tracked_test.go
@@ -49,9 +49,19 @@ func (b *syncBuffer) String() string {
 // startTrackedWedgeLoop wires the common scaffolding for the tracked-loop
 // regression tests: a real store, one repo + shell agent, the given adapter, and
 // the REAL production single-repo worker loop at a fast interval.
-func startTrackedWedgeLoop(t *testing.T, ctx context.Context, store *db.Store, adapter workflow.DeliveryAdapter, workers int, usePool bool, stdout io.Writer) (*inflightJobTracker, <-chan error) {
+//
+// configure runs against the assembled worker before the loop starts, for a test
+// that needs a field this harness leaves zero. ConfigHome is the one that bites:
+// left empty, allocatePoolIsolationWorktree returns "not isolable" with a NIL
+// error before it can reach the failure branch, so a test asserting on the skip
+// event or the retry backoff would be pinning a path that never executes.
+// Variadic, so every existing caller is unchanged.
+func startTrackedWedgeLoop(t *testing.T, ctx context.Context, store *db.Store, adapter workflow.DeliveryAdapter, workers int, usePool bool, stdout io.Writer, configure ...func(*jobWorker)) (*inflightJobTracker, <-chan error) {
 	t.Helper()
 	worker := poolSchedulerWorker(t, store, adapter, usePool)
+	for _, apply := range configure {
+		apply(&worker)
+	}
 	live := newDaemonReloadableConfig(30*time.Second, workers, usePool)
 	var checkoutLock sync.Mutex
 	tracker := newInflightJobTracker(ctx)

--- a/internal/cli/daemon_scheduler.go
+++ b/internal/cli/daemon_scheduler.go
@@ -2141,24 +2141,57 @@ func runQueuedJobsForRepoPool(ctx context.Context, worker jobWorker, limit int, 
 // operator can state instead of "however long the longest running job takes"
 // (measured starvation before the bound: 22m42s and 27m40s).
 //
-// Cost, stated precisely because the first version of this comment was wrong:
-// one listPendingQueuedJobs per interval per repo that has a job IN FLIGHT and
-// nothing dispatchable. An EMPTY QUEUE does reach this seam whenever something
-// is running — that is exactly what
+// Cost, stated precisely because the first two versions of this comment were
+// wrong: per interval, per repo that has a job IN FLIGHT and nothing
+// dispatchable, the pass re-pays the WHOLE top of the loop, not just one query.
+// That is one listPendingQueuedJobs store scan, the admission estimate for every
+// job the selector considers, AND one allocatePoolIsolationWorktree attempt per
+// isolation-eligible blocked job — each of which can spend up to
+// workflow.ReadOnlyWorktreeDispatchLockWaitBudget waiting on the checkout
+// mutation lock. The isolation retries are therefore paced by
+// poolIsolationRetryBackoff rather than by this interval; without that backoff a
+// 2s interval and a 5s lock budget compose into a permanent lock-wait spin on a
+// job that can never isolate. An EMPTY QUEUE does reach this seam whenever
+// something is running — that is exactly what
 // TestPoolRequeryBoundIsPacedAndDispatchesNothingWhenIdle constructs. What
 // returns above is `running == 0 && dispatched == 0`, i.e. nothing running AND
-// nothing dispatchable, so a fully idle daemon never re-queries. That query is
-// a store scan whose cost grows with the queue, not an O(1) probe; the bound
-// caps its FREQUENCY, not its size.
+// nothing dispatchable, so a fully idle daemon never re-queries. The store scan's
+// cost grows with the queue, not an O(1) probe, and it is skipped entirely when
+// the repo has no dispatch slots; the bound caps its FREQUENCY, not its size.
 //
 // A var, not a const, so tests can shorten it; production never reassigns it.
 var poolRequeryInterval = 2 * time.Second
+
+// poolIsolationRetryBackoff / poolIsolationRetryBackoffMax pace a FAILING
+// allocatePoolIsolationWorktree retry inside one live pass. The retry cost is
+// not the 2s re-query it rides on: each attempt can spend up to
+// workflow.ReadOnlyWorktreeDispatchLockWaitBudget (5s) waiting on the checkout
+// mutation lock, on the dispatcher goroutine, so an unpaced retry both exceeds
+// the interval it is supposed to obey and keeps a lock the merge gate wants
+// under permanent contention. The delay doubles from the first value to the max
+// per consecutive failure of the SAME job, and is dropped as soon as that job
+// leaves the pending set (allocated, dispatched, reaped, or gone), so a
+// transient failure recovers on the next re-query while a job that can never
+// isolate settles at one attempt per max interval.
+//
+// Vars, not consts, so tests can shorten them; production never reassigns them.
+var (
+	poolIsolationRetryBackoff    = 2 * time.Second
+	poolIsolationRetryBackoffMax = 30 * time.Second
+)
 
 // poolRequeryObserver is a test hook fired when the bound (rather than a job
 // completion) wakes the pass. nil in production. It lets a test distinguish
 // "re-queries on the bound" from "re-queries in a tight loop", which a
 // wall-clock assertion cannot.
 var poolRequeryObserver func()
+
+// poolIsolationAttemptObserver is a test hook fired immediately before each
+// allocatePoolIsolationWorktree ATTEMPT. nil in production. It exists because
+// the retry cost this backoff bounds is otherwise unobservable: the skip EVENT
+// is throttled to one row per job, so an event count cannot distinguish "retried
+// once" from "retried every re-query" — the two behaviours the backoff separates.
+var poolIsolationAttemptObserver func(jobID string)
 
 // poolDispatchSlots is a pool pass's dispatch budget: the repo's free slots,
 // clamped by the host-global remainder (hostCap − tracked in-flight across ALL
@@ -2225,6 +2258,13 @@ func runQueuedJobsForRepoPoolTracked(ctx context.Context, worker jobWorker, limi
 	// above, so no lock; reset each invocation, so a later pass reports the skip
 	// again for a job that is still serialized.
 	isolationSkipLogged := map[string]bool{}
+	// isolationRetryNext / isolationRetryDelay pace a FAILING isolation allocation
+	// for one job across the re-queries of THIS pass (see poolIsolationRetryBackoff).
+	// Both are keyed by job id, pruned to the live pending set on every pass so a
+	// long-lived pass cannot accumulate entries for jobs that have left the queue,
+	// and dispatcher-goroutine-owned like the sets above, so no lock.
+	isolationRetryNext := map[string]time.Time{}
+	isolationRetryDelay := map[string]time.Duration{}
 	// runtimeKeyMemo caches queuedJobRuntimeResourceKey per job id for the lifetime of
 	// this dispatcher invocation (#615 review). excludeBouncedBusy re-derives the key
 	// for every still-pending job on every dispatch pass, and each miss is a GetAgent
@@ -2310,10 +2350,23 @@ func runQueuedJobsForRepoPoolTracked(ctx context.Context, worker jobWorker, limi
 
 		dispatched := 0
 		if firstErr == nil {
-			pending, err := listPendingQueuedJobs(ctx, worker, repoFilter, rootFilter, true)
-			if err != nil {
-				firstErr = err
-			} else if slots := poolDispatchSlots(limit, running, hostCap, tracker); slots > 0 {
+			// Ask for the budget BEFORE the scan. A saturated repo (every slot taken,
+			// or the host-global remainder exhausted) cannot dispatch anything this
+			// pass, and the old order paid a full listPendingQueuedJobs store scan
+			// every poolRequeryInterval only to discard the result at the `slots > 0`
+			// test. The wake still happens — the pass must stay alive to reap — it
+			// just no longer re-scans a queue it is not allowed to draw from.
+			slots := poolDispatchSlots(limit, running, hostCap, tracker)
+			pending := []db.Job(nil)
+			if slots > 0 {
+				scanned, err := listPendingQueuedJobs(ctx, worker, repoFilter, rootFilter, true)
+				if err != nil {
+					firstErr = err
+				} else {
+					pending = scanned
+				}
+			}
+			if firstErr == nil && slots > 0 {
 				// Drop jobs that already bounced busy this invocation before ANY
 				// selection (#598). pending is fresh each pass and feeds BOTH the
 				// primary selection and the isolation `remaining` loop below, so
@@ -2323,6 +2376,27 @@ func runQueuedJobsForRepoPoolTracked(ctx context.Context, worker jobWorker, limi
 				// busy-excluded the loop reaches dispatched==0 && running==0 and
 				// returns, so "busy must not count as progress" holds structurally.
 				pending = excludeBouncedBusy(ctx, worker, pending, bouncedBusy, bouncedBusyRuntimes, runtimeKeyMemo)
+				// Prune the isolation retry/skip state to the jobs still queued. This
+				// pass can outlive many jobs (it holds poolRuns[repo] for as long as
+				// anything runs), so without this the three maps would grow with every
+				// job id the pass ever saw. Dropping a job also drops its backoff, which
+				// is the intended semantics: a job that leaves and returns is a fresh
+				// isolation attempt, not a continuation of the old one's penalty.
+				live := make(map[string]bool, len(pending))
+				for _, job := range pending {
+					live[job.ID] = true
+				}
+				for id := range isolationRetryNext {
+					if !live[id] {
+						delete(isolationRetryNext, id)
+						delete(isolationRetryDelay, id)
+					}
+				}
+				for id := range isolationSkipLogged {
+					if !live[id] {
+						delete(isolationSkipLogged, id)
+					}
+				}
 				// Union in the supervisor tracker's in-flight keys (#562): a tracked
 				// non-pool job (e.g. dispatched before a warm scheduler flip) must
 				// block same-key pool dispatch exactly like a pool-local one. Jobs
@@ -2403,6 +2477,14 @@ func runQueuedJobsForRepoPoolTracked(ctx context.Context, worker jobWorker, limi
 						!(inflightCheckouts["repo:"+payload.Repo] || seedCheckouts["repo:"+payload.Repo]) {
 						continue // not blocked by a contended same-repo checkout
 					}
+					// Backoff gate: a failing allocation is retried on a doubling delay
+					// rather than on every re-query. Placed after the cheap eligibility
+					// and contention filters and BEFORE the admission reservation, so a
+					// backed-off job neither reserves admission nor touches the checkout
+					// mutation lock this pass.
+					if next, ok := isolationRetryNext[job.ID]; ok && time.Now().Before(next) {
+						continue
+					}
 					runtimeKey := queuedJobRuntimeResourceKey(ctx, worker.Store, job)
 					if runtimeKey != "" && (inflightRuntimes[runtimeKey] || seedRuntimes[runtimeKey] || runtimeResourceLocked(ctx, worker.Store, runtimeKey)) {
 						continue // also runtime-contended; leave it to the runtime/temp-worker path
@@ -2416,6 +2498,9 @@ func runQueuedJobsForRepoPoolTracked(ctx context.Context, worker jobWorker, limi
 						continue
 					}
 					payloadBeforeIsolation := job.Payload
+					if poolIsolationAttemptObserver != nil {
+						poolIsolationAttemptObserver(job.ID)
+					}
 					iso, ok, allocErr := worker.allocatePoolIsolationWorktree(ctx, job, payload)
 					if !ok {
 						worker.Admission.Release(job.ID)
@@ -2426,15 +2511,39 @@ func runQueuedJobsForRepoPoolTracked(ctx context.Context, worker jobWorker, limi
 						// allocErr means the job was simply not isolable (no home/checkout) —
 						// not a failure — so stay quiet there.
 						// Throttled to once per job per pass invocation: this branch is
-						// reached on EVERY re-query, and re-queries are now paced by
-						// poolRequeryInterval rather than by job completions, so an
-						// unthrottled write turned one event per completion into one every
-						// two seconds for as long as the job stayed blocked.
+						// reached on every retry, so an unthrottled write turned one event
+						// per completion into one row per retry for as long as the job
+						// stayed blocked. The flag MUST be set here — reading it without
+						// ever writing it is a throttle that throttles nothing, which is
+						// what the first version of this branch shipped.
 						if allocErr != nil && !isolationSkipLogged[job.ID] {
+							isolationSkipLogged[job.ID] = true
 							_ = worker.Store.AddJobEvent(ctx, db.JobEvent{JobID: job.ID, Kind: "pool_isolation_skipped", Message: fmt.Sprintf("pool read-only isolation skipped (#739); job stays serialized in the shared checkout: %v", allocErr)})
+						}
+						// Arm the backoff on a real FAILURE only. allocErr == nil means the
+						// job was simply not isolable, which is cheap and stateless to
+						// re-test, and the expensive lock wait never happened.
+						if allocErr != nil {
+							delay := isolationRetryDelay[job.ID]
+							if delay <= 0 {
+								delay = poolIsolationRetryBackoff
+							} else if delay < poolIsolationRetryBackoffMax {
+								delay *= 2
+								if delay > poolIsolationRetryBackoffMax {
+									delay = poolIsolationRetryBackoffMax
+								}
+							}
+							isolationRetryDelay[job.ID] = delay
+							isolationRetryNext[job.ID] = time.Now().Add(delay)
 						}
 						continue
 					}
+					// Allocation succeeded: drop this job's backoff and skip-throttle so a
+					// later blocked spell starts from a clean slate rather than inheriting
+					// the penalty of an earlier one.
+					delete(isolationRetryNext, job.ID)
+					delete(isolationRetryDelay, job.ID)
+					delete(isolationSkipLogged, job.ID)
 					if !tracker.beginWithin(hostCap, iso.job.ID, repoFilter, iso.checkoutKey, iso.runtimeKey) {
 						worker.Admission.Release(iso.job.ID)
 						// Undo the allocation completely: the payload now points at the
@@ -2494,7 +2603,13 @@ func runQueuedJobsForRepoPoolTracked(ctx context.Context, worker jobWorker, limi
 				timer.Stop()
 				reap(f)
 			case <-timer.C:
-				if poolRequeryObserver != nil {
+				// Fire the observer ONLY when a re-query will actually follow. Once
+				// firstErr is set (including a cancelled ctx) the top of the loop skips
+				// the whole dispatch block and the pass is just draining in-flight
+				// workers, so a wake here re-queries nothing. A test that counts these
+				// wakes as re-queries would otherwise credit the bound with work it did
+				// not do — the same class of false positive as an unwritten throttle.
+				if firstErr == nil && ctx.Err() == nil && poolRequeryObserver != nil {
 					poolRequeryObserver()
 				}
 			}

--- a/internal/cli/daemon_scheduler.go
+++ b/internal/cli/daemon_scheduler.go
@@ -2367,21 +2367,21 @@ func runQueuedJobsForRepoPoolTracked(ctx context.Context, worker jobWorker, limi
 				}
 			}
 			if firstErr == nil && slots > 0 {
-				// Drop jobs that already bounced busy this invocation before ANY
-				// selection (#598). pending is fresh each pass and feeds BOTH the
-				// primary selection and the isolation `remaining` loop below, so
-				// filtering it here excludes bounced jobs from both. A bounced job
-				// removed from pending is never re-selected, so dispatched is not
-				// re-incremented for it: once every remaining pending job is
-				// busy-excluded the loop reaches dispatched==0 && running==0 and
-				// returns, so "busy must not count as progress" holds structurally.
-				pending = excludeBouncedBusy(ctx, worker, pending, bouncedBusy, bouncedBusyRuntimes, runtimeKeyMemo)
-				// Prune the isolation retry/skip state to the jobs still queued. This
-				// pass can outlive many jobs (it holds poolRuns[repo] for as long as
-				// anything runs), so without this the three maps would grow with every
-				// job id the pass ever saw. Dropping a job also drops its backoff, which
-				// is the intended semantics: a job that leaves and returns is a fresh
-				// isolation attempt, not a continuation of the old one's penalty.
+				// Prune the isolation retry/skip state to the jobs still queued, BEFORE
+				// excludeBouncedBusy and against the freshly scanned queue. This pass can
+				// outlive many jobs (it holds poolRuns[repo] for as long as anything
+				// runs), so without pruning the three maps would grow with every job id
+				// the pass ever saw. Dropping a job also drops its backoff, which is the
+				// intended semantics: a job that leaves the QUEUE and returns is a fresh
+				// isolation attempt, not a continuation of an old penalty.
+				//
+				// The ORDER is load-bearing and the first version had it backwards. A job
+				// that bounced runtime-busy this pass is REMOVED from pending, so pruning
+				// against the post-exclusion list deleted that job's isolation penalty
+				// even though it never waited the penalty out — and it would then re-pay
+				// the 5s-lock-budget allocation immediately on its next appearance, which
+				// is the spin the backoff exists to stop. A busy bounce and an isolation
+				// failure are independent facts about a job; neither may clear the other.
 				live := make(map[string]bool, len(pending))
 				for _, job := range pending {
 					live[job.ID] = true
@@ -2397,6 +2397,15 @@ func runQueuedJobsForRepoPoolTracked(ctx context.Context, worker jobWorker, limi
 						delete(isolationSkipLogged, id)
 					}
 				}
+				// Drop jobs that already bounced busy this invocation before ANY
+				// selection (#598). pending is fresh each pass and feeds BOTH the
+				// primary selection and the isolation `remaining` loop below, so
+				// filtering it here excludes bounced jobs from both. A bounced job
+				// removed from pending is never re-selected, so dispatched is not
+				// re-incremented for it: once every remaining pending job is
+				// busy-excluded the loop reaches dispatched==0 && running==0 and
+				// returns, so "busy must not count as progress" holds structurally.
+				pending = excludeBouncedBusy(ctx, worker, pending, bouncedBusy, bouncedBusyRuntimes, runtimeKeyMemo)
 				// Union in the supervisor tracker's in-flight keys (#562): a tracked
 				// non-pool job (e.g. dispatched before a warm scheduler flip) must
 				// block same-key pool dispatch exactly like a pool-local one. Jobs
@@ -2473,17 +2482,20 @@ func runQueuedJobsForRepoPoolTracked(ctx context.Context, worker jobWorker, limi
 					if perr != nil || !poolIsolationEligible(job, payload) {
 						continue
 					}
+					// Backoff gate FIRST, before anything that reads the store or
+					// reserves admission. The reviewer measured the earlier placement:
+					// 19 attempts over 400ms at a 20ms interval, each one still paying
+					// queuedJobCheckoutKey, queuedJobRuntimeResourceKey and an admission
+					// estimate before being turned away — so "backed off" cost almost as
+					// much as attempting. daemonJobPayload and poolIsolationEligible are
+					// pure functions of the job row already in hand, so they stay above
+					// the gate; everything below it touches the store.
+					if next, ok := isolationRetryNext[job.ID]; ok && time.Now().Before(next) {
+						continue
+					}
 					if queuedJobCheckoutKey(ctx, worker.Store, job) != "repo:"+payload.Repo ||
 						!(inflightCheckouts["repo:"+payload.Repo] || seedCheckouts["repo:"+payload.Repo]) {
 						continue // not blocked by a contended same-repo checkout
-					}
-					// Backoff gate: a failing allocation is retried on a doubling delay
-					// rather than on every re-query. Placed after the cheap eligibility
-					// and contention filters and BEFORE the admission reservation, so a
-					// backed-off job neither reserves admission nor touches the checkout
-					// mutation lock this pass.
-					if next, ok := isolationRetryNext[job.ID]; ok && time.Now().Before(next) {
-						continue
 					}
 					runtimeKey := queuedJobRuntimeResourceKey(ctx, worker.Store, job)
 					if runtimeKey != "" && (inflightRuntimes[runtimeKey] || seedRuntimes[runtimeKey] || runtimeResourceLocked(ctx, worker.Store, runtimeKey)) {
@@ -2520,22 +2532,31 @@ func runQueuedJobsForRepoPoolTracked(ctx context.Context, worker jobWorker, limi
 							isolationSkipLogged[job.ID] = true
 							_ = worker.Store.AddJobEvent(ctx, db.JobEvent{JobID: job.ID, Kind: "pool_isolation_skipped", Message: fmt.Sprintf("pool read-only isolation skipped (#739); job stays serialized in the shared checkout: %v", allocErr)})
 						}
-						// Arm the backoff on a real FAILURE only. allocErr == nil means the
-						// job was simply not isolable, which is cheap and stateless to
-						// re-test, and the expensive lock wait never happened.
-						if allocErr != nil {
-							delay := isolationRetryDelay[job.ID]
-							if delay <= 0 {
-								delay = poolIsolationRetryBackoff
-							} else if delay < poolIsolationRetryBackoffMax {
-								delay *= 2
-								if delay > poolIsolationRetryBackoffMax {
-									delay = poolIsolationRetryBackoffMax
-								}
+						// Arm the backoff on EITHER outcome, and my earlier claim here was
+						// wrong: I wrote that allocErr == nil ("not isolable") was "cheap
+						// and stateless to re-test", and the reviewer measured otherwise —
+						// 19 attempts over 400ms, each reaching this point only after two
+						// or three store reads and an admission reserve/release pair.
+						// Nothing about that is cheap, and the not-isolable verdict is a
+						// stable property of the job and its repo, so re-testing it every
+						// re-query buys nothing. A real FAILURE additionally paid the lock
+						// wait, so it keeps the doubling curve; a not-isolable job is held
+						// flat at the first interval, which stops the spin without
+						// delaying a job whose repo config might legitimately change.
+						delay := isolationRetryDelay[job.ID]
+						switch {
+						case allocErr == nil:
+							delay = poolIsolationRetryBackoff
+						case delay <= 0:
+							delay = poolIsolationRetryBackoff
+						case delay < poolIsolationRetryBackoffMax:
+							delay *= 2
+							if delay > poolIsolationRetryBackoffMax {
+								delay = poolIsolationRetryBackoffMax
 							}
-							isolationRetryDelay[job.ID] = delay
-							isolationRetryNext[job.ID] = time.Now().Add(delay)
 						}
+						isolationRetryDelay[job.ID] = delay
+						isolationRetryNext[job.ID] = time.Now().Add(delay)
 						continue
 					}
 					// Allocation succeeded: drop this job's backoff and skip-throttle so a

--- a/internal/cli/daemon_scheduler.go
+++ b/internal/cli/daemon_scheduler.go
@@ -2139,11 +2139,19 @@ func runQueuedJobsForRepoPool(ctx context.Context, worker jobWorker, limit int, 
 //
 // Two seconds: a queued job's worst-case invisibility becomes a bound the
 // operator can state instead of "however long the longest running job takes"
-// (measured starvation before the bound: 22m42s and 27m40s). It costs at most
-// one listPendingQueuedJobs per 2s per repo that has work IN FLIGHT and nothing
-// dispatchable — the empty-queue path never reaches here, because `running == 0
-// && dispatched == 0` returns above. A var, not a const, so tests can shorten
-// it; production never reassigns it.
+// (measured starvation before the bound: 22m42s and 27m40s).
+//
+// Cost, stated precisely because the first version of this comment was wrong:
+// one listPendingQueuedJobs per interval per repo that has a job IN FLIGHT and
+// nothing dispatchable. An EMPTY QUEUE does reach this seam whenever something
+// is running — that is exactly what
+// TestPoolRequeryBoundIsPacedAndDispatchesNothingWhenIdle constructs. What
+// returns above is `running == 0 && dispatched == 0`, i.e. nothing running AND
+// nothing dispatchable, so a fully idle daemon never re-queries. That query is
+// a store scan whose cost grows with the queue, not an O(1) probe; the bound
+// caps its FREQUENCY, not its size.
+//
+// A var, not a const, so tests can shorten it; production never reassigns it.
 var poolRequeryInterval = 2 * time.Second
 
 // poolRequeryObserver is a test hook fired when the bound (rather than a job
@@ -2209,6 +2217,14 @@ func runQueuedJobsForRepoPoolTracked(ctx context.Context, worker jobWorker, limi
 	// is retried on a later worker tick.
 	bouncedBusy := map[string]bool{}
 	bouncedBusyRuntimes := map[string]bool{}
+	// isolationSkipLogged bounds the pool_isolation_skipped event to once per job
+	// per invocation. The skip branch is reached on every re-query, and re-queries
+	// are now paced by poolRequeryInterval instead of by completions, so writing it
+	// unthrottled turned one row per completion into one row every two seconds for
+	// as long as a job stayed blocked. Dispatcher-goroutine-owned like the sets
+	// above, so no lock; reset each invocation, so a later pass reports the skip
+	// again for a job that is still serialized.
+	isolationSkipLogged := map[string]bool{}
 	// runtimeKeyMemo caches queuedJobRuntimeResourceKey per job id for the lifetime of
 	// this dispatcher invocation (#615 review). excludeBouncedBusy re-derives the key
 	// for every still-pending job on every dispatch pass, and each miss is a GetAgent
@@ -2409,7 +2425,12 @@ func runQueuedJobsForRepoPoolTracked(ctx context.Context, worker jobWorker, limi
 						// skip event so a lost-parallelism serialize is observable. A nil
 						// allocErr means the job was simply not isolable (no home/checkout) —
 						// not a failure — so stay quiet there.
-						if allocErr != nil {
+						// Throttled to once per job per pass invocation: this branch is
+						// reached on EVERY re-query, and re-queries are now paced by
+						// poolRequeryInterval rather than by job completions, so an
+						// unthrottled write turned one event per completion into one every
+						// two seconds for as long as the job stayed blocked.
+						if allocErr != nil && !isolationSkipLogged[job.ID] {
 							_ = worker.Store.AddJobEvent(ctx, db.JobEvent{JobID: job.ID, Kind: "pool_isolation_skipped", Message: fmt.Sprintf("pool read-only isolation skipped (#739); job stays serialized in the shared checkout: %v", allocErr)})
 						}
 						continue

--- a/internal/cli/daemon_scheduler.go
+++ b/internal/cli/daemon_scheduler.go
@@ -2132,6 +2132,26 @@ func runQueuedJobsForRepoPool(ctx context.Context, worker jobWorker, limit int, 
 	return runQueuedJobsForRepoPoolTracked(ctx, worker, limit, limit, repoFilter, rootFilter, nil)
 }
 
+// poolRequeryInterval bounds how long a LIVE pool pass may wait on a job
+// completion before looking at the queue again. It exists because a pass that
+// only wakes on completions cannot see work enqueued after it parked, and the
+// single-flight guard forbids a replacement pass while it lives.
+//
+// Two seconds: a queued job's worst-case invisibility becomes a bound the
+// operator can state instead of "however long the longest running job takes"
+// (measured starvation before the bound: 22m42s and 27m40s). It costs at most
+// one listPendingQueuedJobs per 2s per repo that has work IN FLIGHT and nothing
+// dispatchable — the empty-queue path never reaches here, because `running == 0
+// && dispatched == 0` returns above. A var, not a const, so tests can shorten
+// it; production never reassigns it.
+var poolRequeryInterval = 2 * time.Second
+
+// poolRequeryObserver is a test hook fired when the bound (rather than a job
+// completion) wakes the pass. nil in production. It lets a test distinguish
+// "re-queries on the bound" from "re-queries in a tight loop", which a
+// wall-clock assertion cannot.
+var poolRequeryObserver func()
+
 // poolDispatchSlots is a pool pass's dispatch budget: the repo's free slots,
 // clamped by the host-global remainder (hostCap − tracked in-flight across ALL
 // repos) so concurrent per-repo passes never exceed the daemon-wide cap. With a
@@ -2433,9 +2453,30 @@ func runQueuedJobsForRepoPoolTracked(ctx context.Context, worker jobWorker, limi
 			continue
 		}
 		if dispatched == 0 {
-			// No progress is possible until a running worker frees a resource; block
-			// for one, then re-query (which may now include newly-queued jobs).
-			reap(<-done)
+			// A job newly enqueued for this repo is progress that IS possible, and
+			// a pass parked on `done` cannot see it: the old blind receive only
+			// woke on a COMPLETION. That starved every later arrival for the
+			// running job's remaining lifetime (measured: 22m42s and 27m40s waits
+			// for a 3-second stage), and no replacement pass can cover for it
+			// because this one still holds poolRuns[repo] via tryBeginPool while
+			// the `running == 0` return above keeps it alive. Worse, it made the
+			// owner-configured per-agent max_background unreachable for a second
+			// same-repo job. So wake on a completion OR the re-query bound,
+			// whichever comes first, and let the top of the loop re-query.
+			//
+			// Single-flight is untouched: the same dispatcher goroutine simply
+			// looks again sooner, so no second selector exists and no two jobs
+			// can be dispatched onto one checkout key.
+			timer := time.NewTimer(poolRequeryInterval)
+			select {
+			case f := <-done:
+				timer.Stop()
+				reap(f)
+			case <-timer.C:
+				if poolRequeryObserver != nil {
+					poolRequeryObserver()
+				}
+			}
 		}
 	}
 }

--- a/internal/cli/pool_requery_bound_test.go
+++ b/internal/cli/pool_requery_bound_test.go
@@ -241,3 +241,183 @@ func TestPoolRequeryObserverIsSilentOnTheBarrierPath(t *testing.T) {
 		t.Fatal("worker loop did not stop after context cancellation")
 	}
 }
+
+// TestPoolIsolationSkipEventIsThrottledAndRetriesBackOff is the production-path
+// proof for the two P2s the round-4 review found in the code this PR added.
+//
+// Scenario, through the same real supervisor wiring as the tests above: job A
+// hangs holding the shared repo checkout key, then job B — an ask job with no
+// worktree, so isolation-ELIGIBLE — is enqueued behind it. The repo's checkout
+// path is a plain directory rather than a git repo, so every
+// allocatePoolIsolationWorktree call FAILS with an error, which is precisely the
+// state both defects live in.
+//
+// DESIRED, and both halves are separate mutants:
+//  1. exactly ONE pool_isolation_skipped row for B, however many retries happen.
+//     FAILS WITHOUT THE FIX: isolationSkipLogged was read and never written, so
+//     the "once per job per pass" throttle throttled nothing and the row was
+//     written on every retry. Mutation proof: delete the
+//     `isolationSkipLogged[job.ID] = true` line and this assertion fails with a
+//     row count that tracks the retry count.
+//  2. retries are paced by poolIsolationRetryBackoff, NOT by poolRequeryInterval.
+//     FAILS WITHOUT THE FIX: each re-query re-ran an allocation that can spend
+//     up to workflow.ReadOnlyWorktreeDispatchLockWaitBudget (5s in production)
+//     on the checkout mutation lock, so a 2s interval and a 5s lock budget
+//     composed into a permanent lock-wait spin. Mutation proof: delete the
+//     backoff gate and attempts jump from <=5 to ~window/interval.
+//
+// The attempt count is read from poolIsolationAttemptObserver rather than from
+// the event rows on purpose: the throttle makes the EVENT count 1 either way, so
+// an event-based assertion cannot see a retry spin at all — it would be a check
+// that passes on the code it is meant to reject.
+func TestPoolIsolationSkipEventIsThrottledAndRetriesBackOff(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	const repo = "owner/repo"
+	const intervalMS, backoffMS, windowMS = 20, 200, 700
+	var attempts int64
+	restoreInterval, restoreAttempt := poolRequeryInterval, poolIsolationAttemptObserver
+	restoreBackoff, restoreBackoffMax := poolIsolationRetryBackoff, poolIsolationRetryBackoffMax
+	poolRequeryInterval = intervalMS * time.Millisecond
+	poolIsolationRetryBackoff = backoffMS * time.Millisecond
+	poolIsolationRetryBackoffMax = backoffMS * time.Millisecond
+	poolIsolationAttemptObserver = func(jobID string) {
+		if jobID == "job-b" {
+			atomic.AddInt64(&attempts, 1)
+		}
+	}
+	t.Cleanup(func() {
+		poolRequeryInterval, poolIsolationAttemptObserver = restoreInterval, restoreAttempt
+		poolIsolationRetryBackoff, poolIsolationRetryBackoffMax = restoreBackoff, restoreBackoffMax
+	})
+
+	store := daemonWorkerStore(t)
+	// A plain directory, NOT a git repo: the read-only worktree allocation fails
+	// with an error, which is the allocErr != nil branch under test. A nil
+	// allocErr ("not isolable") is a different, quiet path.
+	seedDaemonWorkerRepo(t, store, repo, t.TempDir())
+	seedDaemonWorkerAgent(t, store, "audit", runtime.ShellRuntime, "unused", []string{"ask"}, repo)
+
+	adapter := newWedgeBlockingAdapter("job-a")
+	enqueueDaemonWorkerJob(t, store, workflow.JobRequest{ID: "job-a", Agent: "audit", Action: "ask", Repo: repo, Branch: "main", PullRequest: 1})
+	// ConfigHome must be non-empty or the allocation short-circuits to "not
+	// isolable" with a nil error and this test pins a path that never runs — which
+	// is exactly what the first version of it did.
+	_, errCh := startTrackedWedgeLoop(t, ctx, store, adapter, 2, true, io.Discard, func(w *jobWorker) {
+		w.ConfigHome = t.TempDir()
+	})
+
+	if !waitForCondition(t, 5*time.Second, adapter.stillBlocked) {
+		t.Fatalf("job-a never started delivering; delivered=%v", adapter.deliveredJobs())
+	}
+	// Enqueue B only once A genuinely holds the checkout, so B is blocked by
+	// contention rather than by arrival order.
+	enqueueDaemonWorkerJob(t, store, workflow.JobRequest{ID: "job-b", Agent: "audit", Action: "ask", Repo: repo, Branch: "main", PullRequest: 2})
+	if !waitForCondition(t, 5*time.Second, func() bool { return atomic.LoadInt64(&attempts) > 0 }) {
+		t.Fatal("no isolation attempt was made for job-b; the scenario never reached the isolation path")
+	}
+	time.Sleep(windowMS * time.Millisecond)
+
+	gotAttempts := atomic.LoadInt64(&attempts)
+	// Paced by the backoff the window fits about 700/200 = 3.5, so ~4 with the
+	// first attempt. Paced by the re-query interval it would be ~35. The cap is
+	// generous enough that a slow box cannot fail it (a timer can only fire FEWER
+	// times than expected) and still an order of magnitude below unpaced.
+	if maxPaced := int64(windowMS/backoffMS + 2); gotAttempts > maxPaced {
+		t.Fatalf("isolation retried %d times in %dms at a %dms backoff, want <= %d (retries are paced by the re-query interval, not by the backoff)", gotAttempts, windowMS, backoffMS, maxPaced)
+	}
+	events, err := store.ListJobEvents(ctx, "job-b")
+	if err != nil {
+		t.Fatalf("ListJobEvents(job-b): %v", err)
+	}
+	skips := 0
+	for _, event := range events {
+		if event.Kind == "pool_isolation_skipped" {
+			skips++
+		}
+	}
+	if skips == 0 {
+		t.Fatalf("no pool_isolation_skipped event for job-b after %d isolation attempts; the lost-parallelism serialize is unobservable", gotAttempts)
+	}
+	if skips != 1 {
+		t.Fatalf("pool_isolation_skipped rows for job-b = %d after %d attempts, want exactly 1; the throttle is not writing isolationSkipLogged", skips, gotAttempts)
+	}
+
+	close(adapter.release)
+	if got := waitForJobState(t, store, "job-a", string(workflow.JobSucceeded), 10*time.Second); got != string(workflow.JobSucceeded) {
+		t.Fatalf("job-a state = %q after release, want succeeded", got)
+	}
+	cancel()
+	select {
+	case <-errCh:
+	case <-time.After(5 * time.Second):
+		t.Fatal("worker loop did not stop after context cancellation")
+	}
+}
+
+// TestPoolRequeryObserverIsSilentWhileDrainingAfterCancellation pins the third
+// round-4 finding: the bounded wait also fired while the pass was DRAINING after
+// cancellation, when the top of the loop skips dispatch entirely and no re-query
+// follows.
+//
+// The blocking job is deliberately deaf to context cancellation (ignoreCtx), so
+// the pass stays parked in its bounded wait with a worker still in flight long
+// after ctx is cancelled — the drain window a ctx-obeying job does not leave.
+//
+// DESIRED: zero observer fires after cancellation.
+//
+// FAILS WITHOUT THE FIX: the timer branch called the observer unconditionally,
+// so a draining pass reported ~window/interval re-queries it never performed —
+// crediting the bound with work it did not do, the same class of false positive
+// as the unwritten throttle above.
+func TestPoolRequeryObserverIsSilentWhileDrainingAfterCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	const repo = "owner/repo"
+	const intervalMS, drainMS = 20, 300
+	var wakes int64
+	restoreInterval, restoreObserver := poolRequeryInterval, poolRequeryObserver
+	poolRequeryInterval = intervalMS * time.Millisecond
+	poolRequeryObserver = func() { atomic.AddInt64(&wakes, 1) }
+	t.Cleanup(func() { poolRequeryInterval, poolRequeryObserver = restoreInterval, restoreObserver })
+
+	store := daemonWorkerStore(t)
+	seedDaemonWorkerRepo(t, store, repo, t.TempDir())
+	seedDaemonWorkerAgent(t, store, "audit", runtime.ShellRuntime, "unused", []string{"ask"}, repo)
+
+	adapter := newWedgeBlockingAdapter("job-a")
+	adapter.ignoreCtx = true
+	enqueueDaemonWorkerJob(t, store, workflow.JobRequest{ID: "job-a", Agent: "audit", Action: "ask", Repo: repo, Branch: "main", PullRequest: 1})
+	_, errCh := startTrackedWedgeLoop(t, ctx, store, adapter, 2, true, io.Discard)
+
+	if !waitForCondition(t, 5*time.Second, adapter.stillBlocked) {
+		t.Fatalf("job-a never started delivering; delivered=%v", adapter.deliveredJobs())
+	}
+	// Positive control FIRST: the observer must be firing while the pass is live,
+	// otherwise a zero after cancellation proves nothing about the gate.
+	if !waitForCondition(t, 5*time.Second, func() bool { return atomic.LoadInt64(&wakes) > 0 }) {
+		t.Fatal("bound never fired while the pass was live; a post-cancellation zero would be an instrument failure, not a result")
+	}
+
+	cancel()
+	// Let the pass observe cancellation before sampling, so the baseline is taken
+	// from a pass that is already draining rather than one still dispatching.
+	time.Sleep(4 * poolRequeryInterval)
+	baseline := atomic.LoadInt64(&wakes)
+	time.Sleep(drainMS * time.Millisecond)
+	if drained := atomic.LoadInt64(&wakes) - baseline; drained != 0 {
+		t.Fatalf("bound fired %d times in %dms while DRAINING after cancellation, want 0 (the wake re-queries nothing once firstErr is set)", drained, drainMS)
+	}
+	if !adapter.stillBlocked() {
+		t.Fatal("job-a stopped blocking; the drain window was not exercised")
+	}
+
+	close(adapter.release)
+	select {
+	case <-errCh:
+	case <-time.After(10 * time.Second):
+		t.Fatal("worker loop did not stop after the blocking job was released")
+	}
+}

--- a/internal/cli/pool_requery_bound_test.go
+++ b/internal/cli/pool_requery_bound_test.go
@@ -137,7 +137,7 @@ func TestPoolRequeryBoundIsPacedAndDispatchesNothingWhenIdle(t *testing.T) {
 
 	adapter := newWedgeBlockingAdapter("job-a")
 	enqueueDaemonWorkerJob(t, store, workflow.JobRequest{ID: "job-a", Agent: "audit", Action: "ask", Repo: repo, Branch: "main", PullRequest: 1})
-	_, _ = startTrackedWedgeLoop(t, ctx, store, adapter, 2, true, io.Discard)
+	_, errCh := startTrackedWedgeLoop(t, ctx, store, adapter, 2, true, io.Discard)
 
 	if !waitForCondition(t, 5*time.Second, adapter.stillBlocked) {
 		t.Fatalf("job-a never started delivering; delivered=%v", adapter.deliveredJobs())
@@ -169,5 +169,75 @@ func TestPoolRequeryBoundIsPacedAndDispatchesNothingWhenIdle(t *testing.T) {
 	close(adapter.release)
 	if got := waitForJobState(t, store, "job-a", string(workflow.JobSucceeded), 10*time.Second); got != string(workflow.JobSucceeded) {
 		t.Fatalf("job-a state = %q after release, want succeeded (the empty-queue path must be unchanged)", got)
+	}
+
+	// Stop the loop HERE rather than relying on cleanup ordering. Restoring
+	// poolRequeryInterval while a pool pass is still parked on the shortened
+	// timer is safe today only because t.Cleanup runs LIFO — this test's restore
+	// was registered before startTrackedWedgeLoop's drain — and because
+	// tryBeginPool/endPool bracket the pass in the tracker's WaitGroup so drain
+	// genuinely waits for that goroutine. Both are true and neither is obvious,
+	// so the ordering is made explicit instead of inherited: cancel, wait for the
+	// loop to exit, and only then let the restore run.
+	cancel()
+	select {
+	case <-errCh:
+	case <-time.After(5 * time.Second):
+		t.Fatal("worker loop did not stop after context cancellation")
+	}
+}
+
+// TestPoolRequeryObserverIsSilentOnTheBarrierPath pins the DISCRIMINATOR the two
+// tests above rely on, rather than trusting it.
+//
+// poolRequeryObserver is a production hook whose only caller in production is
+// nil, so a reader is right to ask what it proves. It proves "the POOL pass's
+// bounded wait fired" only if it stays silent when dispatch is NOT on the pool
+// path — otherwise the assertions built on it in
+// TestPoolPassSeesJobEnqueuedWhileAnotherRuns would pass on a barrier build and
+// the pool-path claim would be unfounded again, which is exactly the round-1
+// finding. Same scenario, barrier scheduler: the observer must never fire.
+func TestPoolRequeryObserverIsSilentOnTheBarrierPath(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	const repo = "owner/repo"
+	var wakes int64
+	restoreInterval, restoreObserver := poolRequeryInterval, poolRequeryObserver
+	poolRequeryInterval = 20 * time.Millisecond
+	poolRequeryObserver = func() { atomic.AddInt64(&wakes, 1) }
+	t.Cleanup(func() { poolRequeryInterval, poolRequeryObserver = restoreInterval, restoreObserver })
+
+	store := daemonWorkerStore(t)
+	seedDaemonWorkerRepo(t, store, repo, t.TempDir())
+	seedDaemonWorkerAgent(t, store, "audit", runtime.ShellRuntime, "unused", []string{"ask"}, repo)
+
+	adapter := newWedgeBlockingAdapter("job-a")
+	enqueueDaemonWorkerJob(t, store, workflow.JobRequest{ID: "job-a", Agent: "audit", Action: "ask", Repo: repo, Branch: "main", PullRequest: 1})
+	// usePool=false: the BARRIER scheduler, which re-queries on its own tick and
+	// has no bounded wait to instrument.
+	tracker, errCh := startTrackedWedgeLoop(t, ctx, store, adapter, 2, false, io.Discard)
+
+	if !waitForCondition(t, 5*time.Second, adapter.stillBlocked) {
+		t.Fatalf("job-a never started delivering; delivered=%v", adapter.deliveredJobs())
+	}
+	time.Sleep(300 * time.Millisecond)
+
+	if tracker.poolRunning(repo) {
+		t.Fatalf("a pool pass is live on the barrier scheduler; the control does not exercise the barrier path")
+	}
+	if got := atomic.LoadInt64(&wakes); got != 0 {
+		t.Fatalf("pool re-query observer fired %d times on the BARRIER path, want 0; the discriminator the pool-path tests rely on does not discriminate", got)
+	}
+
+	close(adapter.release)
+	if got := waitForJobState(t, store, "job-a", string(workflow.JobSucceeded), 10*time.Second); got != string(workflow.JobSucceeded) {
+		t.Fatalf("job-a state = %q after release, want succeeded", got)
+	}
+	cancel()
+	select {
+	case <-errCh:
+	case <-time.After(5 * time.Second):
+		t.Fatal("worker loop did not stop after context cancellation")
 	}
 }

--- a/internal/cli/pool_requery_bound_test.go
+++ b/internal/cli/pool_requery_bound_test.go
@@ -421,3 +421,180 @@ func TestPoolRequeryObserverIsSilentWhileDrainingAfterCancellation(t *testing.T)
 		t.Fatal("worker loop did not stop after the blocking job was released")
 	}
 }
+
+// TestPoolIsolationPenaltyIsDroppedWhenAJobLeavesTheQueue pins the prune block
+// that the reviewer's M5 mutant SURVIVED against the whole package — the
+// clearest kind of coverage gap, since disabling the prune broke nothing any
+// test asserted.
+//
+// The prune's OBSERVABLE contract is not "the maps stay small": it is that a job
+// which leaves the pending queue and comes back is a FRESH isolation attempt
+// rather than a continuation of an old penalty. So this measures the TIMING of
+// the retry, not the size of a map — a map-size assertion would have to reach
+// inside the pass and would still pass on a build that pruned the wrong entries.
+//
+// Scenario: job B is blocked and fails isolation, arming a backoff far longer
+// than the test's patience. B is then deleted from the queue and re-enqueued
+// under the same id. With the prune the new B is attempted promptly; without it
+// the stale isolationRetryNext entry suppresses attempts for the full backoff.
+func TestPoolIsolationPenaltyIsDroppedWhenAJobLeavesTheQueue(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	const repo = "owner/repo"
+	const intervalMS, backoffMS = 20, 60000
+	var attempts int64
+	restoreInterval, restoreAttempt := poolRequeryInterval, poolIsolationAttemptObserver
+	restoreBackoff, restoreBackoffMax := poolIsolationRetryBackoff, poolIsolationRetryBackoffMax
+	poolRequeryInterval = intervalMS * time.Millisecond
+	// A backoff far beyond this test's own timeouts: any attempt observed after
+	// the re-enqueue can ONLY come from the penalty having been dropped.
+	poolIsolationRetryBackoff = backoffMS * time.Millisecond
+	poolIsolationRetryBackoffMax = backoffMS * time.Millisecond
+	poolIsolationAttemptObserver = func(jobID string) {
+		if jobID == "job-b" {
+			atomic.AddInt64(&attempts, 1)
+		}
+	}
+	t.Cleanup(func() {
+		poolRequeryInterval, poolIsolationAttemptObserver = restoreInterval, restoreAttempt
+		poolIsolationRetryBackoff, poolIsolationRetryBackoffMax = restoreBackoff, restoreBackoffMax
+	})
+
+	store := daemonWorkerStore(t)
+	seedDaemonWorkerRepo(t, store, repo, t.TempDir())
+	seedDaemonWorkerAgent(t, store, "audit", runtime.ShellRuntime, "unused", []string{"ask"}, repo)
+
+	adapter := newWedgeBlockingAdapter("job-a")
+	enqueueDaemonWorkerJob(t, store, workflow.JobRequest{ID: "job-a", Agent: "audit", Action: "ask", Repo: repo, Branch: "main", PullRequest: 1})
+	_, errCh := startTrackedWedgeLoop(t, ctx, store, adapter, 2, true, io.Discard, func(w *jobWorker) {
+		w.ConfigHome = t.TempDir()
+	})
+
+	if !waitForCondition(t, 5*time.Second, adapter.stillBlocked) {
+		t.Fatalf("job-a never started delivering; delivered=%v", adapter.deliveredJobs())
+	}
+	enqueueDaemonWorkerJob(t, store, workflow.JobRequest{ID: "job-b", Agent: "audit", Action: "ask", Repo: repo, Branch: "main", PullRequest: 2})
+	if !waitForCondition(t, 5*time.Second, func() bool { return atomic.LoadInt64(&attempts) >= 1 }) {
+		t.Fatal("no isolation attempt for job-b; the scenario never reached the isolation path")
+	}
+	// The penalty is now armed for a minute. Prove it BINDS before relying on its
+	// release, or the release proves nothing.
+	first := atomic.LoadInt64(&attempts)
+	time.Sleep(200 * time.Millisecond)
+	if again := atomic.LoadInt64(&attempts); again != first {
+		t.Fatalf("isolation attempts went %d -> %d while the %dms backoff was armed; the penalty does not bind", first, again, backoffMS)
+	}
+
+	// B LEAVES the pending queue (a cancel is the cheapest real transition out of
+	// it) and then RETURNS under the same id. The prune runs on a pass that sees
+	// B absent, so the penalty must be gone when B comes back.
+	if err := store.UpdateJobState(ctx, "job-b", string(workflow.JobCancelled)); err != nil {
+		t.Fatalf("UpdateJobState(job-b, cancelled): %v", err)
+	}
+	// Give the pass at least one re-query with B absent - that is when the prune
+	// runs.
+	time.Sleep(6 * poolRequeryInterval)
+	baseline := atomic.LoadInt64(&attempts)
+	if err := store.UpdateJobState(ctx, "job-b", string(workflow.JobQueued)); err != nil {
+		t.Fatalf("UpdateJobState(job-b, queued): %v", err)
+	}
+
+	if !waitForCondition(t, 5*time.Second, func() bool { return atomic.LoadInt64(&attempts) > baseline }) {
+		t.Fatalf("job-b was re-enqueued and never re-attempted within 5s while its backoff was %dms; the stale isolation penalty survived the job leaving the queue, so the prune is not running", backoffMS)
+	}
+
+	close(adapter.release)
+	if got := waitForJobState(t, store, "job-a", string(workflow.JobSucceeded), 10*time.Second); got != string(workflow.JobSucceeded) {
+		t.Fatalf("job-a state = %q after release, want succeeded", got)
+	}
+	cancel()
+	select {
+	case <-errCh:
+	case <-time.After(5 * time.Second):
+		t.Fatal("worker loop did not stop after context cancellation")
+	}
+}
+
+// TestPoolIsolationNotIsolablePathIsPacedToo pins the round-1 F-1 fix, and it
+// exists because my own comment asserted the opposite. The first remediation
+// armed the backoff only when allocErr != nil, on the stated grounds that the
+// nil-error "not isolable" verdict was "cheap and stateless to re-test". The
+// reviewer measured that claim and it was false: 19 attempts over 400ms, each
+// reaching the allocation only after two or three store reads and an admission
+// reserve/release pair.
+//
+// Here worker.ConfigHome is left EMPTY, which is exactly the shape that returns
+// (false, nil) — not isolable, no error, no lock wait. The attempts must still
+// be paced by the backoff rather than by the re-query interval.
+//
+// Mutation proof: restrict the arming switch to allocErr != nil again and this
+// test fails with an attempt count that tracks the re-query interval.
+func TestPoolIsolationNotIsolablePathIsPacedToo(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	const repo = "owner/repo"
+	const intervalMS, backoffMS, windowMS = 20, 200, 700
+	var attempts int64
+	restoreInterval, restoreAttempt := poolRequeryInterval, poolIsolationAttemptObserver
+	restoreBackoff, restoreBackoffMax := poolIsolationRetryBackoff, poolIsolationRetryBackoffMax
+	poolRequeryInterval = intervalMS * time.Millisecond
+	poolIsolationRetryBackoff = backoffMS * time.Millisecond
+	poolIsolationRetryBackoffMax = backoffMS * time.Millisecond
+	poolIsolationAttemptObserver = func(jobID string) {
+		if jobID == "job-b" {
+			atomic.AddInt64(&attempts, 1)
+		}
+	}
+	t.Cleanup(func() {
+		poolRequeryInterval, poolIsolationAttemptObserver = restoreInterval, restoreAttempt
+		poolIsolationRetryBackoff, poolIsolationRetryBackoffMax = restoreBackoff, restoreBackoffMax
+	})
+
+	store := daemonWorkerStore(t)
+	seedDaemonWorkerRepo(t, store, repo, t.TempDir())
+	seedDaemonWorkerAgent(t, store, "audit", runtime.ShellRuntime, "unused", []string{"ask"}, repo)
+
+	adapter := newWedgeBlockingAdapter("job-a")
+	enqueueDaemonWorkerJob(t, store, workflow.JobRequest{ID: "job-a", Agent: "audit", Action: "ask", Repo: repo, Branch: "main", PullRequest: 1})
+	// NO ConfigHome override: the allocation short-circuits to "not isolable"
+	// with a nil error, which is the branch under test.
+	_, errCh := startTrackedWedgeLoop(t, ctx, store, adapter, 2, true, io.Discard)
+
+	if !waitForCondition(t, 5*time.Second, adapter.stillBlocked) {
+		t.Fatalf("job-a never started delivering; delivered=%v", adapter.deliveredJobs())
+	}
+	enqueueDaemonWorkerJob(t, store, workflow.JobRequest{ID: "job-b", Agent: "audit", Action: "ask", Repo: repo, Branch: "main", PullRequest: 2})
+	if !waitForCondition(t, 5*time.Second, func() bool { return atomic.LoadInt64(&attempts) > 0 }) {
+		t.Fatal("no isolation attempt for job-b; the not-isolable branch was never reached")
+	}
+	time.Sleep(windowMS * time.Millisecond)
+
+	gotAttempts := atomic.LoadInt64(&attempts)
+	if maxPaced := int64(windowMS/backoffMS + 2); gotAttempts > maxPaced {
+		t.Fatalf("not-isolable isolation retried %d times in %dms at a %dms backoff, want <= %d (the nil-allocErr branch is still paced by the re-query interval)", gotAttempts, windowMS, backoffMS, maxPaced)
+	}
+
+	// A not-isolable job must be QUIET: the skip event is for real failures.
+	events, err := store.ListJobEvents(ctx, "job-b")
+	if err != nil {
+		t.Fatalf("ListJobEvents(job-b): %v", err)
+	}
+	for _, event := range events {
+		if event.Kind == "pool_isolation_skipped" {
+			t.Fatalf("a not-isolable job emitted pool_isolation_skipped; that event means a real allocation failure")
+		}
+	}
+
+	close(adapter.release)
+	if got := waitForJobState(t, store, "job-a", string(workflow.JobSucceeded), 10*time.Second); got != string(workflow.JobSucceeded) {
+		t.Fatalf("job-a state = %q after release, want succeeded", got)
+	}
+	cancel()
+	select {
+	case <-errCh:
+	case <-time.After(5 * time.Second):
+		t.Fatal("worker loop did not stop after context cancellation")
+	}
+}

--- a/internal/cli/pool_requery_bound_test.go
+++ b/internal/cli/pool_requery_bound_test.go
@@ -45,13 +45,28 @@ func TestPoolPassSeesJobEnqueuedWhileAnotherRuns(t *testing.T) {
 	seedDaemonWorkerRepo(t, store, repo, t.TempDir())
 	seedDaemonWorkerAgent(t, store, "audit", runtime.ShellRuntime, "unused", []string{"ask"}, repo)
 
+	// Count bound-driven wakes. This is the POOL pass's discriminator: the
+	// barrier scheduler has no such wait, so a mutant that routes dispatch away
+	// from the pool leaves this at zero even though the barrier would re-query
+	// on its own tick and satisfy a bare "job-b eventually ran" assertion.
+	var wakes int64
+	restoreObserver := poolRequeryObserver
+	poolRequeryObserver = func() { atomic.AddInt64(&wakes, 1) }
+	t.Cleanup(func() { poolRequeryObserver = restoreObserver })
+
 	adapter := newWedgeBlockingAdapter("job-a")
 	// Job A: no worktree -> the shared "repo:owner/repo" checkout key.
 	enqueueDaemonWorkerJob(t, store, workflow.JobRequest{ID: "job-a", Agent: "audit", Action: "ask", Repo: repo, Branch: "main", PullRequest: 1})
-	_, errCh := startTrackedWedgeLoop(t, ctx, store, adapter, 2, true, io.Discard)
+	tracker, errCh := startTrackedWedgeLoop(t, ctx, store, adapter, 2, true, io.Discard)
 
 	if !waitForCondition(t, 5*time.Second, adapter.stillBlocked) {
 		t.Fatalf("job-a never started delivering; delivered=%v", adapter.deliveredJobs())
+	}
+	// A POOL pass must own dispatch for this repo. Without this the test passes
+	// on a build where dispatch fell back to the barrier, which is a mutant a
+	// reviewer killed in round 1 (`if worker.UsePool` -> `if false`).
+	if !waitForCondition(t, 5*time.Second, func() bool { return tracker.poolRunning(repo) }) {
+		t.Fatalf("no pool pass is live for %s; dispatch is not on the pool path this test claims to pin", repo)
 	}
 	// The pass has now dispatched A, found nothing else, and is waiting. Enqueue
 	// B only at this point, so its arrival is strictly after the wait began.
@@ -61,6 +76,14 @@ func TestPoolPassSeesJobEnqueuedWhileAnotherRuns(t *testing.T) {
 	// finishes" (A never finishes on its own in this test).
 	if got := waitForJobState(t, store, "job-b", string(workflow.JobSucceeded), 15*time.Second); got != string(workflow.JobSucceeded) {
 		t.Fatalf("job-b state = %q while job-a hangs, want succeeded within the re-query bound (a live pool pass must not sleep through a new arrival)", got)
+	}
+	// ...and it was the POOL pass's bounded wait that noticed, not some other
+	// selector: the bound must have fired at least once while job-a hung.
+	if got := atomic.LoadInt64(&wakes); got == 0 {
+		t.Fatalf("pool re-query bound never fired while job-a hung, so job-b was claimed by some other path; this test must pin the pool seam, not merely observe that something re-queried")
+	}
+	if !tracker.poolRunning(repo) {
+		t.Fatalf("pool pass ended while job-a is still in flight; the dispatch under test did not come from a live pool pass")
 	}
 	if !adapter.stillBlocked() {
 		t.Fatalf("job-a finished before job-b was claimed; the scenario did not exercise the blind wait")
@@ -89,17 +112,22 @@ func TestPoolPassSeesJobEnqueuedWhileAnotherRuns(t *testing.T) {
 // With one job hung and NOTHING else queued, the pass has no progress available.
 // It must wake at the BOUND — not in a tight loop — and dispatch nothing. The
 // observer count is the discriminator a wall-clock assertion cannot give: a busy
-// loop and a paced one both "take 300ms", but a busy loop wakes thousands of
-// times. The upper bound is deliberately loose (a slow CI box wakes fewer times,
-// never more) while still being orders of magnitude below a spin.
+// loop and a paced one both "take 300ms". Measured kill strengths at this test's
+// 20ms interval over a 300ms window (expected ~15 wakes): poolRequeryInterval/8
+// produced 92 and poolRequeryInterval/64 — an effectively tight spin — produced
+// only 226, NOT the "thousands" an earlier version of this comment claimed,
+// because every wake still pays for a store query. A reviewer also measured that
+// poolRequeryInterval/4 SURVIVED a 4x cap, so the cap here is 2x expected: a
+// slow box can only fire FEWER times than expected, never more.
 func TestPoolRequeryBoundIsPacedAndDispatchesNothingWhenIdle(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
 	const repo = "owner/repo"
 	var wakes int64
+	const intervalMS, windowMS = 20, 300
 	restoreInterval, restoreObserver := poolRequeryInterval, poolRequeryObserver
-	poolRequeryInterval = 20 * time.Millisecond
+	poolRequeryInterval = intervalMS * time.Millisecond
 	poolRequeryObserver = func() { atomic.AddInt64(&wakes, 1) }
 	t.Cleanup(func() { poolRequeryInterval, poolRequeryObserver = restoreInterval, restoreObserver })
 
@@ -114,14 +142,20 @@ func TestPoolRequeryBoundIsPacedAndDispatchesNothingWhenIdle(t *testing.T) {
 	if !waitForCondition(t, 5*time.Second, adapter.stillBlocked) {
 		t.Fatalf("job-a never started delivering; delivered=%v", adapter.deliveredJobs())
 	}
-	time.Sleep(300 * time.Millisecond)
+	time.Sleep(windowMS * time.Millisecond)
 
 	got := atomic.LoadInt64(&wakes)
 	if got == 0 {
 		t.Fatalf("bound never fired while a job ran with an empty queue; the pass is still parked on a completion only")
 	}
-	if maxPaced := int64(300 / 20 * 4); got > maxPaced {
-		t.Fatalf("bound fired %d times in 300ms at a 20ms interval, want <= %d (re-query is spinning, not paced)", got, maxPaced)
+	// Expected wakes ≈ window/interval = 15. The cap is 2x that, tightened from
+	// 4x after a reviewer measured that a 4x over-fire (poolRequeryInterval/4 —
+	// 500ms in production) SURVIVED the looser bound, so the check could not see
+	// a real pacing regression. 2x kills interval/4 (~60 wakes) while staying
+	// safe on a slow box, where the timer can only fire FEWER times than
+	// expected, never more.
+	if maxPaced := int64(windowMS / intervalMS * 2); got > maxPaced {
+		t.Fatalf("bound fired %d times in %dms at a %dms interval, want <= %d (re-query is over-firing, not paced)", got, windowMS, intervalMS, maxPaced)
 	}
 	// Waking early must not manufacture dispatches: A is the only job, and it is
 	// still the only delivery.

--- a/internal/cli/pool_requery_bound_test.go
+++ b/internal/cli/pool_requery_bound_test.go
@@ -1,0 +1,139 @@
+package cli
+
+import (
+	"context"
+	"io"
+	"path/filepath"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/gitmoot/gitmoot/internal/runtime"
+	"github.com/gitmoot/gitmoot/internal/workflow"
+)
+
+// TestPoolPassSeesJobEnqueuedWhileAnotherRuns is the production-path proof for
+// the bounded re-query.
+//
+// Scenario, driven through the REAL single-repo supervisor wiring
+// (startTrackedWedgeLoop -> startSingleRepoWorkerLoop ->
+// runDaemonWorkerTickTracked) with the POOL scheduler: job A occupies the shared
+// repo checkout and hangs inside its adapter. Only AFTER A is genuinely in
+// flight is job B enqueued, with its own worktree so its checkout key differs
+// and nothing but the scheduler can hold it.
+//
+// DESIRED: B starts and completes while A still hangs.
+//
+// FAILS WITHOUT THE FIX: the live pool pass had dispatched nothing on its last
+// look and parked on `reap(<-done)`, which only wakes on a COMPLETION, so B was
+// invisible for A's remaining lifetime. A replacement pass cannot cover for it
+// either — the parked pass still holds poolRuns[repo], so tryBeginPool refuses.
+// Mutation proof: replace the select in runQueuedJobsForRepoPoolTracked with the
+// old `reap(<-done)` and this test times out with job-b still queued.
+//
+// This test deliberately enters through the loop rather than calling the
+// selector: a test that called selectRunnableQueuedJobsSeeded (or a pool helper)
+// directly would pass on unfixed code, because the defect is not in selection —
+// it is that nobody re-queries. The barrier scheduler already has this coverage
+// in TestWedgedInlineJobE2E; the pool path had none.
+func TestPoolPassSeesJobEnqueuedWhileAnotherRuns(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	const repo = "owner/repo"
+	store := daemonWorkerStore(t)
+	seedDaemonWorkerRepo(t, store, repo, t.TempDir())
+	seedDaemonWorkerAgent(t, store, "audit", runtime.ShellRuntime, "unused", []string{"ask"}, repo)
+
+	adapter := newWedgeBlockingAdapter("job-a")
+	// Job A: no worktree -> the shared "repo:owner/repo" checkout key.
+	enqueueDaemonWorkerJob(t, store, workflow.JobRequest{ID: "job-a", Agent: "audit", Action: "ask", Repo: repo, Branch: "main", PullRequest: 1})
+	_, errCh := startTrackedWedgeLoop(t, ctx, store, adapter, 2, true, io.Discard)
+
+	if !waitForCondition(t, 5*time.Second, adapter.stillBlocked) {
+		t.Fatalf("job-a never started delivering; delivered=%v", adapter.deliveredJobs())
+	}
+	// The pass has now dispatched A, found nothing else, and is waiting. Enqueue
+	// B only at this point, so its arrival is strictly after the wait began.
+	enqueueDaemonWorkerJob(t, store, workflow.JobRequest{ID: "job-b", Agent: "audit", Action: "ask", Repo: repo, Branch: "main", PullRequest: 2, WorktreePath: filepath.Join(t.TempDir(), "wt-job-b")})
+
+	// Bounded wait: comfortably past poolRequeryInterval, far short of "until A
+	// finishes" (A never finishes on its own in this test).
+	if got := waitForJobState(t, store, "job-b", string(workflow.JobSucceeded), 15*time.Second); got != string(workflow.JobSucceeded) {
+		t.Fatalf("job-b state = %q while job-a hangs, want succeeded within the re-query bound (a live pool pass must not sleep through a new arrival)", got)
+	}
+	if !adapter.stillBlocked() {
+		t.Fatalf("job-a finished before job-b was claimed; the scenario did not exercise the blind wait")
+	}
+	if got := waitForJobState(t, store, "job-a", string(workflow.JobRunning), 2*time.Second); got != string(workflow.JobRunning) {
+		t.Fatalf("job-a state = %q while blocked, want running", got)
+	}
+
+	// The slow job is never abandoned by the earlier wake.
+	close(adapter.release)
+	if got := waitForJobState(t, store, "job-a", string(workflow.JobSucceeded), 10*time.Second); got != string(workflow.JobSucceeded) {
+		t.Fatalf("job-a state = %q after release, want succeeded", got)
+	}
+
+	cancel()
+	select {
+	case <-errCh:
+	case <-time.After(5 * time.Second):
+		t.Fatal("worker loop did not stop after context cancellation")
+	}
+}
+
+// TestPoolRequeryBoundIsPacedAndDispatchesNothingWhenIdle is the negative half:
+// the bound must not become a spin, and waking early must not invent work.
+//
+// With one job hung and NOTHING else queued, the pass has no progress available.
+// It must wake at the BOUND — not in a tight loop — and dispatch nothing. The
+// observer count is the discriminator a wall-clock assertion cannot give: a busy
+// loop and a paced one both "take 300ms", but a busy loop wakes thousands of
+// times. The upper bound is deliberately loose (a slow CI box wakes fewer times,
+// never more) while still being orders of magnitude below a spin.
+func TestPoolRequeryBoundIsPacedAndDispatchesNothingWhenIdle(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	const repo = "owner/repo"
+	var wakes int64
+	restoreInterval, restoreObserver := poolRequeryInterval, poolRequeryObserver
+	poolRequeryInterval = 20 * time.Millisecond
+	poolRequeryObserver = func() { atomic.AddInt64(&wakes, 1) }
+	t.Cleanup(func() { poolRequeryInterval, poolRequeryObserver = restoreInterval, restoreObserver })
+
+	store := daemonWorkerStore(t)
+	seedDaemonWorkerRepo(t, store, repo, t.TempDir())
+	seedDaemonWorkerAgent(t, store, "audit", runtime.ShellRuntime, "unused", []string{"ask"}, repo)
+
+	adapter := newWedgeBlockingAdapter("job-a")
+	enqueueDaemonWorkerJob(t, store, workflow.JobRequest{ID: "job-a", Agent: "audit", Action: "ask", Repo: repo, Branch: "main", PullRequest: 1})
+	_, _ = startTrackedWedgeLoop(t, ctx, store, adapter, 2, true, io.Discard)
+
+	if !waitForCondition(t, 5*time.Second, adapter.stillBlocked) {
+		t.Fatalf("job-a never started delivering; delivered=%v", adapter.deliveredJobs())
+	}
+	time.Sleep(300 * time.Millisecond)
+
+	got := atomic.LoadInt64(&wakes)
+	if got == 0 {
+		t.Fatalf("bound never fired while a job ran with an empty queue; the pass is still parked on a completion only")
+	}
+	if maxPaced := int64(300 / 20 * 4); got > maxPaced {
+		t.Fatalf("bound fired %d times in 300ms at a 20ms interval, want <= %d (re-query is spinning, not paced)", got, maxPaced)
+	}
+	// Waking early must not manufacture dispatches: A is the only job, and it is
+	// still the only delivery.
+	if delivered := adapter.deliveredJobs(); len(delivered) != 1 || delivered[0] != "job-a" {
+		t.Fatalf("delivered = %v, want only job-a (an idle re-query must dispatch nothing)", delivered)
+	}
+	if !adapter.stillBlocked() {
+		t.Fatalf("job-a finished on its own; the idle-wait scenario was not exercised")
+	}
+
+	close(adapter.release)
+	if got := waitForJobState(t, store, "job-a", string(workflow.JobSucceeded), 10*time.Second); got != string(workflow.JobSucceeded) {
+		t.Fatalf("job-a state = %q after release, want succeeded (the empty-queue path must be unchanged)", got)
+	}
+}

--- a/internal/cli/wedged_inline_job_e2e_test.go
+++ b/internal/cli/wedged_inline_job_e2e_test.go
@@ -26,6 +26,12 @@ type wedgeBlockingAdapter struct {
 	delivered []string
 	blocked   bool
 	output    string
+	// ignoreCtx makes the blocking job deaf to context cancellation, so it stays
+	// in flight while the scheduler pass DRAINS. Default false keeps every
+	// existing test byte-identical; only a test that needs to observe the pass's
+	// post-cancellation behaviour sets it, because a ctx-obeying job returns
+	// immediately and leaves no drain window to observe.
+	ignoreCtx bool
 }
 
 func newWedgeBlockingAdapter(blockJob string) *wedgeBlockingAdapter {
@@ -53,13 +59,17 @@ func (a *wedgeBlockingAdapter) Deliver(ctx context.Context, _ runtime.Agent, job
 	}
 	a.mu.Unlock()
 	if blocking {
-		select {
-		case <-a.release:
-		case <-ctx.Done():
-			a.mu.Lock()
-			a.blocked = false
-			a.mu.Unlock()
-			return runtime.Result{}, ctx.Err()
+		if a.ignoreCtx {
+			<-a.release
+		} else {
+			select {
+			case <-a.release:
+			case <-ctx.Done():
+				a.mu.Lock()
+				a.blocked = false
+				a.mu.Unlock()
+				return runtime.Result{}, ctx.Err()
+			}
 		}
 		a.mu.Lock()
 		a.blocked = false


### PR DESCRIPTION
Closes #1830. **#1553's observability half is a SEPARATE defect and this PR does not close it** — the wait is now bounded, but a withheld job still records only `queued`, `tryBeginPool` still refuses silently, and nothing in the journal explains a delay.

Admitted under DRAIN by workflow ruling 112729 (Option A), on the grounds that this throttles the reviewer — the scarcest resource in the queue drain exists to finish — and silently cancels an owner capacity decision.

## The change

`runQueuedJobsForRepoPoolTracked` ended its loop body with a blind receive whose comment stated the false premise:

```go
if dispatched == 0 {
        // No progress is possible until a running worker frees a resource; block
        // for one, then re-query (which may now include newly-queued jobs).
        reap(<-done)
}
```

A job enqueued for that repo AFTER the pass parked *is* progress that is possible, and the pass cannot see it. The `running == 0` early return above means the pass cannot return while anything runs, so `poolRuns[repo]` stays set and `tryBeginPool` refuses a replacement pass. Now it waits on a completion **or** a 2-second bound and lets the top of the loop re-query.

**The bound is 2 seconds**, named as `poolRequeryInterval`. Rationale in the code comment: it converts a queued job's worst-case invisibility from "however long the longest running job takes" (measured: 22m42s, 27m40s, 40m47s, 71m21s) into a stated bound, and costs at most one `listPendingQueuedJobs` per 2s per repo that has work **in flight and nothing dispatchable**. The empty-queue path never reaches the seam — `running == 0 && dispatched == 0` returns above it. A `var` rather than a `const` so tests can shorten it; production never reassigns it.

**Single-flight preserved.** No second concurrent pass is introduced and no second selector exists: the same dispatcher goroutine simply looks again sooner, so two jobs can never be dispatched onto one checkout key. `tryBeginPool` and the barrier's `poolRunning` deferral are untouched.

**Scope:** this seam only. No refactor of the pool, no change to pool isolation, no change to the empty-queue or single-job paths.

## Tests, and why they enter the production path

`internal/cli/pool_requery_bound_test.go`:

- **`TestPoolPassSeesJobEnqueuedWhileAnotherRuns`** drives the real single-repo supervisor wiring (`startTrackedWedgeLoop` → `startSingleRepoWorkerLoop` → `runDaemonWorkerTickTracked`) with the **pool** scheduler. Job A hangs holding the shared checkout; job B is enqueued only after A is confirmed in flight, with its own worktree so its key differs and nothing but the scheduler can hold it. A test that called `selectRunnableQueuedJobsSeeded` or a pool helper directly would pass on unfixed code — the defect is not in selection, it is that nobody re-queries. The barrier scheduler already had this coverage (`TestWedgedInlineJobE2E`); the pool path had none.
- **`TestPoolRequeryBoundIsPacedAndDispatchesNothingWhenIdle`** is the negative half: with one job hung and nothing else queued, the bound must fire (a completion-only park would never fire it), must fire at the BOUND rather than in a tight loop, and must dispatch nothing. The wake counter is the discriminator a wall-clock assertion cannot give — a spinning loop and a paced one both "take 300ms", but a spin wakes thousands of times.

### Mutation proof, against a stated green baseline

Green baseline first (`-run 'TestPoolPassSees…|TestPoolRequeryBound…|TestWedgedInlineJobE2E|TestRunQueuedJobsPoolHonorsCheckoutSafety|TestTrackedDispatch|TestTrackedBarrierDefersToLivePoolPass|TestTrackedLoopShutdownDrainsInFlightJobs'`):

```
ok  	github.com/gitmoot/gitmoot/internal/cli	5.122s
```

Then a **semantic reversion** of the production path — the `select` replaced by the old `reap(<-done)`, everything else identical:

```
--- FAIL: TestPoolPassSeesJobEnqueuedWhileAnotherRuns (15.34s)
    pool_requery_bound_test.go:63: job-b state = "queued" while job-a hangs, want succeeded within the re-query bound (a live pool pass must not sleep through a new arrival)
--- FAIL: TestPoolRequeryBoundIsPacedAndDispatchesNothingWhenIdle (0.46s)
    pool_requery_bound_test.go:121: bound never fired while a job ran with an empty queue; the pass is still parked on a completion only
FAIL	github.com/gitmoot/gitmoot/internal/cli	15.859s
```

Both mutants killed, by the assertion each was aimed at.

## Gate

- `go build ./...`, `go vet ./...` — clean (`-buildvcs=false` in a worktree; #1800).
- `go test ./...` — one pre-existing failure class only: `TestSandboxExecKernelE2E`, `TestSandboxExecReadOnlyInputE2E`, `TestSandboxProbeSupported`, `TestClaudeProduceHookAutoReadLandlockE2E`. **Baselined on a pristine `origin/main` worktree on this box: 4 of 4 fail identically before any change** (Landlock probe writes outside its allowed roots — kernel/environment, not this diff). I do not assert "environmental" without that control.
- `go test -race -run 'TestPool|TestTracked|TestWedged|TestRunQueuedJobs' ./internal/cli/` — `ok 45.110s`.

## What this makes possible that was not possible before

A pass can now dispatch **mid-flight**, where it provably could not while parked. Anything relying on "no new dispatch occurs while a pass is blocked" is affected in principle, so: dispatch and `reap` both run on the same dispatcher goroutine and `inflightCheckouts` / `inflightRuntimes` remain dispatcher-owned, so the earlier wake adds no new interleaving and no new lock ordering — a pass already dispatched several jobs per pass before it ever blocked. Worktree cleanup and the host-cap accounting in `reap` are reached on the same paths as before. What genuinely changes is timing: a job may now start while another runs where it previously could not, which is the intended behaviour and is exactly what the same-repo serialization tests (`TestRunQueuedJobsPoolHonorsCheckoutSafety`, `TestTrackedDispatchPreservesSameRepoSerialization`) still constrain — both remain green.

## Deploy notes

Daemon-only change; no schema, no config surface. After merge, rebuild and restart `gitmoot-daemon` at idle (and `gitmoot-dashboard-web`, which runs its own copy of the binary). No migration, no re-enable step. **OWNER holds merge authority — not merging.**

— GITMOOT-COC