### PR TITLE
docs(agents): switch the committed workload mode to THROUGHPUT

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -404,7 +404,7 @@ Under ultracode, orchestrate via the Workflow tool with opus sub-agents
 
 ## Workload mode
 
-**Current mode: DRAIN.**
+**Current mode: THROUGHPUT.**
 
 A mode switch is a merged PR that changes the line above. It takes effect at
 that PR's `mergedAt` time. At the next check-in, the coordinator must:


### PR DESCRIPTION
Switches the committed workload-mode marker for `gitmoot/*` from DRAIN to THROUGHPUT.

## Authority

Owner instruction relayed as workflow directive **115599** (`gitmoot/worktree-lifecycle`), under owner merge policy row **115499**. One line changed; nothing else in the file.

## Why this is a PR and not a note

`AGENTS.md` defines the switch mechanism itself: *"A mode switch is a merged PR that changes the line above. It takes effect at that PR's `mergedAt` time."* The marker-note mechanism is uncommitted local text — reading it as policy already cost two coordinators a wrong mode call in this campaign, so this is the only valid switch.

`STEADY` is deliberately **not** introduced: it does not exist in the committed file, and inventing it is what produced that misreading.

## What THROUGHPUT changes

- Removes the two-implementer / one-reviewer occupancy cap; independent implementation lanes and reviews of **different** PRs may run in parallel.
- Does **not** change the one-reviewer-per-corrected-head rule (`AGENTS.md`, "use exactly one independent reviewer per corrected head. Parallel review lanes mean different PRs, not multiple reviewers on one head"). No panels or fanout without a durable owner row for that specific incident.
- Correctness, exact-head review, CI, and org merge authority are unchanged.

## Runtime gate

The `[daemon] workers = 1` requirement is scoped to a **DRAIN** mode-switch PR ("A DRAIN mode-switch PR is not merge-ready until…"), so it does not gate a switch *out* of drain. The live config already reads `workers = 32` under the owner's 2026-09-02 instruction, i.e. the runtime has been provisioned above drain for two days and this PR removes a policy line the configuration stopped matching.

## Follow-through required by the file

At the first check-in after `mergedAt`, the coordinator re-reads the marker from `origin/main:AGENTS.md` (never a worktree) and comments the exact `[workload-mode-transition]` record on this PR with `effective_commit` as the 40-character SHA.

## Deploy notes

Docs-only. No code, no binary, no service restart.

Baseline: `2dd03fd8c5d43c79e2c0374b02e0c323708b3a23`.