### PR TITLE
fix(daemon): stop finalizing a refused delegation child as a timeout (#1512)

### DIFF
--- a/internal/cli/daemon_result.go
+++ b/internal/cli/daemon_result.go
@@ -95,24 +95,22 @@ func (w jobWorker) afterQueuedJobTransition(ctx context.Context, jobID string, s
 	return nil
 }
 
-// finalizePreflightDelegationChild drives the parent delegation DAG for a child
-// that was just transitioned queued→failed in a daemon pre-flight step, so the
-// delegation's failure_policy fires exactly as it would for a runtime failure.
-// It is a no-op for a non-delegation job or a child that already stored a result
-// (finalizeRefusedDelegationChild / Engine.FinalizeRefusedDelegationChild are
-// idempotent), so a re-run (retry / stale-running recovery) re-enters cleanly. It
-// mirrors handleRunJobError (~4169-4189): an AwaitingHumanError (escalate_human
-// paused the tree awaiting a human, #340) and a BlockedError (block_parent blocked
-// the shared parent task) are EXPECTED terminal outcomes of advancing the DAG, not
-// errors to propagate.
+// finalizeDelegationChildTerminal drives the parent delegation DAG for a child
+// the daemon just settled terminally, so the delegation's failure_policy fires
+// exactly as it would for any runtime failure. It is a no-op for a
+// non-delegation job or a child that already stored a result (the engine
+// finalizers are idempotent), so a re-run (retry / stale-running recovery)
+// re-enters cleanly. It mirrors handleRunJobError: an AwaitingHumanError
+// (escalate_human paused the tree awaiting a human, #340) and a BlockedError
+// (block_parent blocked the shared parent task) are EXPECTED terminal outcomes of
+// advancing the DAG, not errors to propagate.
 //
-// The child reaching here NEVER RAN: the pre-flight refused it before any adapter
-// was built, any prompt was delivered, or any deadline started. It therefore
-// finalizes through the REFUSED path, not the timeout one. Recording it as a
-// timeout that "ended without a result" asserted both an elapsed deadline and a
-// run, neither of which happened, and made refusals indistinguishable from real
-// timeouts in the event stream (#1512).
-func (w jobWorker) finalizePreflightDelegationChild(ctx context.Context, jobID string, cause error) error {
+// finalize decides WHICH cause is recorded, and the caller owns that choice
+// because only the caller knows whether the child ran (#1512). A single
+// hard-coded reason for every caller is how the timeout verb came to describe a
+// refusal in the first place; a single hard-coded "never started" would repeat
+// the mistake in the opposite direction for the mid-run callers.
+func (w jobWorker) finalizeDelegationChildTerminal(ctx context.Context, jobID string, cause error, finalize func(context.Context, db.Job, error) (bool, error)) error {
 	job, err := w.Store.GetJob(ctx, jobID)
 	if err != nil {
 		return err
@@ -121,7 +119,7 @@ func (w jobWorker) finalizePreflightDelegationChild(ctx context.Context, jobID s
 	if payloadErr != nil || strings.TrimSpace(payload.ParentJobID) == "" || payload.Result != nil {
 		return nil
 	}
-	if _, finalizeErr := w.finalizeRefusedDelegationChild(ctx, job, cause); finalizeErr != nil {
+	if _, finalizeErr := finalize(ctx, job, cause); finalizeErr != nil {
 		var awaiting workflow.AwaitingHumanError
 		if errors.As(finalizeErr, &awaiting) {
 			return nil
@@ -133,6 +131,22 @@ func (w jobWorker) finalizePreflightDelegationChild(ctx context.Context, jobID s
 		return finalizeErr
 	}
 	return nil
+}
+
+// finalizePreflightDelegationChild is for a child that NEVER RAN: a daemon
+// pre-flight refused it before any adapter was built, any prompt was delivered,
+// or any deadline started.
+func (w jobWorker) finalizePreflightDelegationChild(ctx context.Context, jobID string, cause error) error {
+	return w.finalizeDelegationChildTerminal(ctx, jobID, cause, w.finalizeRefusedDelegationChild)
+}
+
+// finalizeMidRunDelegationChild is for a child that DID run and then failed
+// without storing a result — the writable implement child whose runtime hits a
+// sandbox permission denial mid-run is the live case. It must not be recorded as
+// "refused before it ran", which would be false, nor as a timeout, which asserts
+// an elapsed deadline that never expired.
+func (w jobWorker) finalizeMidRunDelegationChild(ctx context.Context, jobID string, cause error) error {
+	return w.finalizeDelegationChildTerminal(ctx, jobID, cause, w.finalizeFailedDelegationChild)
 }
 
 type jobTimeoutEvidence struct {
@@ -185,11 +199,14 @@ func (w jobWorker) handleRunJobError(ctx context.Context, jobID string, observed
 				// transitioned JobRunning->JobBlocked here and returns early — it never
 				// reaches the ParentJobID finalize branch below, so the parent DAG
 				// strands exactly like #409 (the mid-run sibling of the pre-flight
-				// read-only-implement case fixed at ~2127). Route it through the SAME
-				// finalize helper so its failure_policy fires. The helper no-ops for a
-				// non-delegation job (ParentJobID empty) or one that already stored a
-				// result, so the solo-implement case stays byte-identical.
-				if err := w.finalizePreflightDelegationChild(ctx, jobID, errors.New(agentPermissionBlockedMessage)); err != nil {
+				// read-only-implement case fixed at ~2127). It advances the DAG through
+				// the same terminalizer, but this child DID RUN, so it records the
+				// MID-RUN cause: "refused before it ran" would be false of it and the
+				// timeout kind would assert a deadline that never expired (#1512). The
+				// helper no-ops for a non-delegation job (ParentJobID empty) or one that
+				// already stored a result, so the solo-implement case stays
+				// byte-identical.
+				if err := w.finalizeMidRunDelegationChild(ctx, jobID, errors.New(agentPermissionBlockedMessage)); err != nil {
 					return err
 				}
 				return nil
@@ -357,6 +374,21 @@ func (w jobWorker) finalizeRefusedDelegationChild(ctx context.Context, job db.Jo
 	}
 	engine := w.workflowForJob(w.delegationParentCheckout(ctx, job), runner)
 	return engine.FinalizeRefusedDelegationChild(ctx, job.ID, reason)
+}
+
+// finalizeFailedDelegationChild is for a child that RAN and then failed with no
+// stored result: the writable implement child whose runtime hits a sandbox
+// permission denial mid-run. "Refused before it ran" would be false for it and
+// "ended without a result" under the TIMEOUT kind asserts a deadline that never
+// expired, so it carries its own cause (#1512).
+func (w jobWorker) finalizeFailedDelegationChild(ctx context.Context, job db.Job, cause error) (bool, error) {
+	reason := fmt.Sprintf("delegation child %s failed mid-run without a result: %v", job.ID, cause)
+	runner, err := w.subprocessRunnerForJob(job)
+	if err != nil {
+		return false, err
+	}
+	engine := w.workflowForJob(w.delegationParentCheckout(ctx, job), runner)
+	return engine.FinalizeFailedDelegationChild(ctx, job.ID, reason)
 }
 
 // delegationParentCheckout returns the repo's main registered checkout for a

--- a/internal/cli/daemon_result.go
+++ b/internal/cli/daemon_result.go
@@ -99,12 +99,19 @@ func (w jobWorker) afterQueuedJobTransition(ctx context.Context, jobID string, s
 // that was just transitioned queued→failed in a daemon pre-flight step, so the
 // delegation's failure_policy fires exactly as it would for a runtime failure.
 // It is a no-op for a non-delegation job or a child that already stored a result
-// (finalizeTimedOutDelegationChild / Engine.FinalizeTimedOutDelegationChild are
+// (finalizeRefusedDelegationChild / Engine.FinalizeRefusedDelegationChild are
 // idempotent), so a re-run (retry / stale-running recovery) re-enters cleanly. It
 // mirrors handleRunJobError (~4169-4189): an AwaitingHumanError (escalate_human
 // paused the tree awaiting a human, #340) and a BlockedError (block_parent blocked
 // the shared parent task) are EXPECTED terminal outcomes of advancing the DAG, not
 // errors to propagate.
+//
+// The child reaching here NEVER RAN: the pre-flight refused it before any adapter
+// was built, any prompt was delivered, or any deadline started. It therefore
+// finalizes through the REFUSED path, not the timeout one. Recording it as a
+// timeout that "ended without a result" asserted both an elapsed deadline and a
+// run, neither of which happened, and made refusals indistinguishable from real
+// timeouts in the event stream (#1512).
 func (w jobWorker) finalizePreflightDelegationChild(ctx context.Context, jobID string, cause error) error {
 	job, err := w.Store.GetJob(ctx, jobID)
 	if err != nil {
@@ -114,7 +121,7 @@ func (w jobWorker) finalizePreflightDelegationChild(ctx context.Context, jobID s
 	if payloadErr != nil || strings.TrimSpace(payload.ParentJobID) == "" || payload.Result != nil {
 		return nil
 	}
-	if _, finalizeErr := w.finalizeTimedOutDelegationChild(ctx, job, cause); finalizeErr != nil {
+	if _, finalizeErr := w.finalizeRefusedDelegationChild(ctx, job, cause); finalizeErr != nil {
 		var awaiting workflow.AwaitingHumanError
 		if errors.As(finalizeErr, &awaiting) {
 			return nil
@@ -332,6 +339,24 @@ func (w jobWorker) finalizeTimedOutDelegationChild(ctx context.Context, job db.J
 	}
 	engine := w.workflowForJob(w.delegationParentCheckout(ctx, job), runner)
 	return engine.FinalizeTimedOutDelegationChild(ctx, job.ID, reason)
+}
+
+// finalizeRefusedDelegationChild is finalizeTimedOutDelegationChild's sibling for
+// a child that was REFUSED BEFORE IT RAN by a daemon pre-flight — a checkout head
+// the leg's pinned head can never match, a dirty tree, a blocked permission. It
+// takes the same engine terminalizer and drives the same parent DAG advancement,
+// so the delegation's failure_policy is unchanged; only the recorded cause
+// differs, and that is the whole point. The old message asserted the child "ended
+// without a result", which reads as a child that ran and returned nothing, on a
+// leg that never started (#1512).
+func (w jobWorker) finalizeRefusedDelegationChild(ctx context.Context, job db.Job, cause error) (bool, error) {
+	reason := fmt.Sprintf("delegation child %s was refused before it ran and never started: %v", job.ID, cause)
+	runner, err := w.subprocessRunnerForJob(job)
+	if err != nil {
+		return false, err
+	}
+	engine := w.workflowForJob(w.delegationParentCheckout(ctx, job), runner)
+	return engine.FinalizeRefusedDelegationChild(ctx, job.ID, reason)
 }
 
 // delegationParentCheckout returns the repo's main registered checkout for a

--- a/internal/cli/native_review_worktree_test.go
+++ b/internal/cli/native_review_worktree_test.go
@@ -743,7 +743,7 @@ func TestNativeReviewWorktreeHardFailureStaysTerminalForLensChild(t *testing.T) 
 	if payload.Result == nil || payload.Result.Decision != "failed" {
 		t.Fatalf("unallocatable-head lens child result = %+v, want a synthetic failed verdict", payload.Result)
 	}
-	if !blockerE2EHasEventKind(t, store, jobID, "delegation_timeout_finalized") {
+	if !blockerE2EHasEventKind(t, store, jobID, "delegation_refused_finalized") {
 		t.Fatal("unallocatable-head lens child never ran finalizePreflightDelegationChild")
 	}
 	if runErr == nil || !strings.Contains(runErr.Error(), parentID) {

--- a/internal/cli/preflight_delegation_finalize_test.go
+++ b/internal/cli/preflight_delegation_finalize_test.go
@@ -214,8 +214,8 @@ func TestPreflightDelegationChildEscalateHumanPausesTree(t *testing.T) {
 		t.Fatal("escalate_human pause must NOT enqueue a continuation")
 	}
 	// The DAG advance was recorded (the finalize bridge ran).
-	if got := countWorkerJobEvents(t, h.store, "parent-job/delegation/api", "delegation_timeout_finalized"); got != 1 {
-		t.Fatalf("delegation_timeout_finalized events = %d, want 1", got)
+	if got := countWorkerJobEvents(t, h.store, "parent-job/delegation/api", "delegation_refused_finalized"); got != 1 {
+		t.Fatalf("delegation_refused_finalized events = %d, want 1", got)
 	}
 
 	// Idempotency: a second tick is a no-op — the child already has a result, so
@@ -282,8 +282,8 @@ func TestPreflightDelegationChildFailurePolicies(t *testing.T) {
 			if cp.Result == nil {
 				t.Fatalf("child result = nil, want a synthetic result so advanceDelegations ran")
 			}
-			if got := countWorkerJobEvents(t, h.store, "parent-job/delegation/api", "delegation_timeout_finalized"); got != 1 {
-				t.Fatalf("delegation_timeout_finalized events = %d, want 1", got)
+			if got := countWorkerJobEvents(t, h.store, "parent-job/delegation/api", "delegation_refused_finalized"); got != 1 {
+				t.Fatalf("delegation_refused_finalized events = %d, want 1", got)
 			}
 
 			if tc.wantTask != "" {
@@ -388,8 +388,8 @@ func TestPreflightCancelledChildIsNotForceFinalized(t *testing.T) {
 	if cp.Result != nil {
 		t.Fatalf("cancelled child must NOT get a synthetic result: %+v", cp.Result)
 	}
-	if got := countWorkerJobEvents(t, h.store, "parent-job/delegation/api", "delegation_timeout_finalized"); got != 0 {
-		t.Fatalf("delegation_timeout_finalized events = %d, want 0 for a cancelled child", got)
+	if got := countWorkerJobEvents(t, h.store, "parent-job/delegation/api", "delegation_refused_finalized"); got != 0 {
+		t.Fatalf("delegation_refused_finalized events = %d, want 0 for a cancelled child", got)
 	}
 	// The parent must not be paused by a cancelled child.
 	if jobExistsForWorker(t, h.store, "parent-job/continuation") {
@@ -474,8 +474,8 @@ func TestPreflightDelegationChildBlockedAdvancesParent(t *testing.T) {
 		t.Fatalf("child result = %+v, want a synthetic failed result", cp.Result)
 	}
 	// The finalize bridge ran exactly once.
-	if got := countWorkerJobEvents(t, h.store, "parent-job/delegation/api", "delegation_timeout_finalized"); got != 1 {
-		t.Fatalf("delegation_timeout_finalized events = %d, want 1", got)
+	if got := countWorkerJobEvents(t, h.store, "parent-job/delegation/api", "delegation_refused_finalized"); got != 1 {
+		t.Fatalf("delegation_refused_finalized events = %d, want 1", got)
 	}
 	// The DAG advanced and escalate_human fired: the shared parent task is paused
 	// awaiting a human and the human was notified once with the resume context.
@@ -496,8 +496,8 @@ func TestPreflightDelegationChildBlockedAdvancesParent(t *testing.T) {
 	if err := h.worker.run(ctx, child2); err != nil {
 		t.Fatalf("second worker.run(child) returned error: %v", err)
 	}
-	if got := countWorkerJobEvents(t, h.store, "parent-job/delegation/api", "delegation_timeout_finalized"); got != 1 {
-		t.Fatalf("delegation_timeout_finalized events after second tick = %d, want 1 (idempotent)", got)
+	if got := countWorkerJobEvents(t, h.store, "parent-job/delegation/api", "delegation_refused_finalized"); got != 1 {
+		t.Fatalf("delegation_refused_finalized events after second tick = %d, want 1 (idempotent)", got)
 	}
 	if len(h.notifier.calls) != 1 {
 		t.Fatalf("notifier calls after second tick = %d, want 1 (idempotent)", len(h.notifier.calls))
@@ -553,8 +553,8 @@ func TestPreflightReadOnlyImplementDelegationChildAdvancesParent(t *testing.T) {
 	if cp.Result == nil || cp.Result.Decision != "failed" {
 		t.Fatalf("child result = %+v, want a synthetic failed result (finalize must run for a delegation child)", cp.Result)
 	}
-	if got := countWorkerJobEvents(t, h.store, "parent-job/delegation/api", "delegation_timeout_finalized"); got != 1 {
-		t.Fatalf("delegation_timeout_finalized events = %d, want 1", got)
+	if got := countWorkerJobEvents(t, h.store, "parent-job/delegation/api", "delegation_refused_finalized"); got != 1 {
+		t.Fatalf("delegation_refused_finalized events = %d, want 1", got)
 	}
 	// The DAG advanced and escalate_human fired for the read-only-implement leg.
 	if got := workerTaskState(t, h.store, "task-5"); got != string(workflow.TaskAwaitingHuman) {
@@ -569,8 +569,8 @@ func TestPreflightReadOnlyImplementDelegationChildAdvancesParent(t *testing.T) {
 	if err := h.worker.run(ctx, child2); err != nil {
 		t.Fatalf("second worker.run(child) returned error: %v", err)
 	}
-	if got := countWorkerJobEvents(t, h.store, "parent-job/delegation/api", "delegation_timeout_finalized"); got != 1 {
-		t.Fatalf("delegation_timeout_finalized events after second tick = %d, want 1 (idempotent)", got)
+	if got := countWorkerJobEvents(t, h.store, "parent-job/delegation/api", "delegation_refused_finalized"); got != 1 {
+		t.Fatalf("delegation_refused_finalized events after second tick = %d, want 1 (idempotent)", got)
 	}
 	if len(h.notifier.calls) != 1 {
 		t.Fatalf("notifier calls after second tick = %d, want 1 (idempotent)", len(h.notifier.calls))
@@ -615,8 +615,8 @@ func TestPreflightReadOnlyImplementNonDelegationUnaffected(t *testing.T) {
 	if cp.Result != nil {
 		t.Fatalf("non-delegation permission-blocked job must NOT get a synthetic result: %+v", cp.Result)
 	}
-	if n := countWorkerJobEvents(t, store, "impl-job", "delegation_timeout_finalized"); n != 0 {
-		t.Fatalf("delegation_timeout_finalized events = %d, want 0 for a non-delegation job", n)
+	if n := countWorkerJobEvents(t, store, "impl-job", "delegation_refused_finalized"); n != 0 {
+		t.Fatalf("delegation_refused_finalized events = %d, want 0 for a non-delegation job", n)
 	}
 }
 
@@ -751,8 +751,8 @@ func TestPreflightEphemeralDelegationChildAdvancesParent(t *testing.T) {
 	if got := countWorkerJobEvents(t, h.store, "parent-job/delegation/api", "ephemeral_worker_failed"); got != 1 {
 		t.Fatalf("ephemeral_worker_failed events = %d, want 1 (the ephemeral wrapper path was taken)", got)
 	}
-	if got := countWorkerJobEvents(t, h.store, "parent-job/delegation/api", "delegation_timeout_finalized"); got != 1 {
-		t.Fatalf("delegation_timeout_finalized events = %d, want 1", got)
+	if got := countWorkerJobEvents(t, h.store, "parent-job/delegation/api", "delegation_refused_finalized"); got != 1 {
+		t.Fatalf("delegation_refused_finalized events = %d, want 1", got)
 	}
 	// The DAG advanced and escalate_human fired.
 	if got := workerTaskState(t, h.store, "task-5"); got != string(workflow.TaskAwaitingHuman) {
@@ -819,8 +819,8 @@ func TestMidRunPermissionBlockedDelegationChildAdvancesParent(t *testing.T) {
 		t.Fatalf("child result = %+v, want a synthetic failed result", cp.Result)
 	}
 	// The finalize bridge ran exactly once.
-	if got := countWorkerJobEvents(t, h.store, "parent-job/delegation/api", "delegation_timeout_finalized"); got != 1 {
-		t.Fatalf("delegation_timeout_finalized events = %d, want 1", got)
+	if got := countWorkerJobEvents(t, h.store, "parent-job/delegation/api", "delegation_refused_finalized"); got != 1 {
+		t.Fatalf("delegation_refused_finalized events = %d, want 1", got)
 	}
 	// The DAG advanced and escalate_human fired: the shared parent task is paused
 	// awaiting a human and the human was notified once with the resume context.
@@ -841,8 +841,8 @@ func TestMidRunPermissionBlockedDelegationChildAdvancesParent(t *testing.T) {
 	if err := h.worker.run(ctx, child2); err != nil {
 		t.Fatalf("second worker.run(child) returned error: %v", err)
 	}
-	if got := countWorkerJobEvents(t, h.store, "parent-job/delegation/api", "delegation_timeout_finalized"); got != 1 {
-		t.Fatalf("delegation_timeout_finalized events after second tick = %d, want 1 (idempotent)", got)
+	if got := countWorkerJobEvents(t, h.store, "parent-job/delegation/api", "delegation_refused_finalized"); got != 1 {
+		t.Fatalf("delegation_refused_finalized events after second tick = %d, want 1 (idempotent)", got)
 	}
 	if len(h.notifier.calls) != 1 {
 		t.Fatalf("notifier calls after second tick = %d, want 1 (idempotent)", len(h.notifier.calls))
@@ -875,8 +875,8 @@ func TestMidRunPermissionBlockedDelegationChildBlockParent(t *testing.T) {
 	if cp.Result == nil || cp.Result.Decision != "failed" {
 		t.Fatalf("child result = %+v, want a synthetic failed result", cp.Result)
 	}
-	if got := countWorkerJobEvents(t, h.store, "parent-job/delegation/api", "delegation_timeout_finalized"); got != 1 {
-		t.Fatalf("delegation_timeout_finalized events = %d, want 1", got)
+	if got := countWorkerJobEvents(t, h.store, "parent-job/delegation/api", "delegation_refused_finalized"); got != 1 {
+		t.Fatalf("delegation_refused_finalized events = %d, want 1", got)
 	}
 	if got := workerTaskState(t, h.store, "task-5"); got != string(workflow.TaskBlocked) {
 		t.Fatalf("task state = %q, want blocked (block_parent fired for the mid-run permission-blocked child)", got)
@@ -933,8 +933,8 @@ func TestMidRunPermissionBlockedNonDelegationUnaffected(t *testing.T) {
 	if cp.Result != nil {
 		t.Fatalf("non-delegation permission-blocked job must NOT get a synthetic result: %+v", cp.Result)
 	}
-	if n := countWorkerJobEvents(t, store, "impl-job", "delegation_timeout_finalized"); n != 0 {
-		t.Fatalf("delegation_timeout_finalized events = %d, want 0 for a non-delegation job", n)
+	if n := countWorkerJobEvents(t, store, "impl-job", "delegation_refused_finalized"); n != 0 {
+		t.Fatalf("delegation_refused_finalized events = %d, want 0 for a non-delegation job", n)
 	}
 	// Exactly one engine build (RunJob's), proving the finalize helper short-circuited
 	// for the non-delegation job rather than rebuilding the engine to advance a DAG.

--- a/internal/cli/preflight_delegation_finalize_test.go
+++ b/internal/cli/preflight_delegation_finalize_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"io"
+	"strings"
 	"testing"
 
 	"github.com/gitmoot/gitmoot/internal/db"
@@ -161,6 +162,17 @@ func countWorkerJobEvents(t *testing.T, store *db.Store, jobID, kind string) int
 		}
 	}
 	return n
+}
+
+// workerJobEvents returns every recorded event for a job so an assertion can read
+// the finalize MESSAGE, not just the kind.
+func workerJobEvents(t *testing.T, store *db.Store, jobID string) []db.JobEvent {
+	t.Helper()
+	events, err := store.ListJobEvents(context.Background(), jobID)
+	if err != nil {
+		t.Fatalf("ListJobEvents(%s) returned error: %v", jobID, err)
+	}
+	return events
 }
 
 func workerTaskState(t *testing.T, store *db.Store, taskID string) string {
@@ -818,9 +830,31 @@ func TestMidRunPermissionBlockedDelegationChildAdvancesParent(t *testing.T) {
 	if cp.Result == nil || cp.Result.Decision != "failed" {
 		t.Fatalf("child result = %+v, want a synthetic failed result", cp.Result)
 	}
-	// The finalize bridge ran exactly once.
-	if got := countWorkerJobEvents(t, h.store, "parent-job/delegation/api", "delegation_refused_finalized"); got != 1 {
-		t.Fatalf("delegation_refused_finalized events = %d, want 1", got)
+	// The finalize bridge ran exactly once, and it recorded the MID-RUN cause. This
+	// child RAN — Mailbox.Run claimed it and Deliver failed — so labelling it
+	// "refused before it ran" would be false in the opposite direction from the
+	// timeout verb this issue removed (#1512).
+	if got := countWorkerJobEvents(t, h.store, "parent-job/delegation/api", "delegation_runtime_failure_finalized"); got != 1 {
+		t.Fatalf("delegation_runtime_failure_finalized events = %d, want 1", got)
+	}
+	if got := countWorkerJobEvents(t, h.store, "parent-job/delegation/api", "delegation_refused_finalized"); got != 0 {
+		t.Fatalf("delegation_refused_finalized events = %d, want 0: this child ran before it failed", got)
+	}
+	if got := countWorkerJobEvents(t, h.store, "parent-job/delegation/api", "delegation_timeout_finalized"); got != 0 {
+		t.Fatalf("delegation_timeout_finalized events = %d, want 0: no deadline elapsed", got)
+	}
+	// And the MESSAGE must not claim the child never started, which is what a single
+	// hard-coded reason for every caller of the shared helper produced.
+	for _, ev := range workerJobEvents(t, h.store, "parent-job/delegation/api") {
+		if ev.Kind != "delegation_runtime_failure_finalized" {
+			continue
+		}
+		if strings.Contains(ev.Message, "never started") || strings.Contains(ev.Message, "refused before it ran") {
+			t.Fatalf("mid-run finalize message = %q, must not claim the child never started", ev.Message)
+		}
+		if !strings.Contains(ev.Message, "failed mid-run without a result") {
+			t.Fatalf("mid-run finalize message = %q, want it to name the mid-run failure", ev.Message)
+		}
 	}
 	// The DAG advanced and escalate_human fired: the shared parent task is paused
 	// awaiting a human and the human was notified once with the resume context.
@@ -841,8 +875,8 @@ func TestMidRunPermissionBlockedDelegationChildAdvancesParent(t *testing.T) {
 	if err := h.worker.run(ctx, child2); err != nil {
 		t.Fatalf("second worker.run(child) returned error: %v", err)
 	}
-	if got := countWorkerJobEvents(t, h.store, "parent-job/delegation/api", "delegation_refused_finalized"); got != 1 {
-		t.Fatalf("delegation_refused_finalized events after second tick = %d, want 1 (idempotent)", got)
+	if got := countWorkerJobEvents(t, h.store, "parent-job/delegation/api", "delegation_runtime_failure_finalized"); got != 1 {
+		t.Fatalf("delegation_runtime_failure_finalized events after second tick = %d, want 1 (idempotent)", got)
 	}
 	if len(h.notifier.calls) != 1 {
 		t.Fatalf("notifier calls after second tick = %d, want 1 (idempotent)", len(h.notifier.calls))
@@ -875,8 +909,8 @@ func TestMidRunPermissionBlockedDelegationChildBlockParent(t *testing.T) {
 	if cp.Result == nil || cp.Result.Decision != "failed" {
 		t.Fatalf("child result = %+v, want a synthetic failed result", cp.Result)
 	}
-	if got := countWorkerJobEvents(t, h.store, "parent-job/delegation/api", "delegation_refused_finalized"); got != 1 {
-		t.Fatalf("delegation_refused_finalized events = %d, want 1", got)
+	if got := countWorkerJobEvents(t, h.store, "parent-job/delegation/api", "delegation_runtime_failure_finalized"); got != 1 {
+		t.Fatalf("delegation_runtime_failure_finalized events = %d, want 1", got)
 	}
 	if got := workerTaskState(t, h.store, "task-5"); got != string(workflow.TaskBlocked) {
 		t.Fatalf("task state = %q, want blocked (block_parent fired for the mid-run permission-blocked child)", got)

--- a/internal/cli/review_refusal_disposition_test.go
+++ b/internal/cli/review_refusal_disposition_test.go
@@ -1,0 +1,168 @@
+package cli
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gitmoot/gitmoot/internal/db"
+	"github.com/gitmoot/gitmoot/internal/runtime"
+	"github.com/gitmoot/gitmoot/internal/workflow"
+)
+
+// #1512: a review leg whose CHECKOUT head can never match its pinned review head
+// is refused by the daemon pre-flight before it runs — no adapter, no prompt, no
+// deadline started. It used to be finalized with the TIMEOUT verb and the message
+// "ended without a result", so a timed-out child, a superseded child and one that
+// never started were indistinguishable in the event stream, and any host's count
+// of delegation timeouts was inflated by refusals.
+//
+// The reachable producer (measured in workflow note 115235) is a review child of a
+// NON-review coordinator: internal/workflow/engine_run_budgets.go inherits
+// ReviewRound and Reviewers from the PARENT payload, so an ask coordinator yields
+// a child with PullRequest > 0 and a HeadSHA but a blank ReviewRound and no
+// Reviewers — the one shape the engine's allocator and the worker's gate both
+// decline, leaving it on the shared checkout.
+//
+// This drives one real worker tick rather than calling the finalizer directly, so
+// it fails on the pre-fix code (which records delegation_timeout_finalized) and
+// passes only when the recorded cause is the refusal.
+func TestPreflightRefusedReviewChildIsNotFinalizedAsATimeout(t *testing.T) {
+	ctx := context.Background()
+	// The shared registered checkout sits on main; the review head lives on a PR
+	// branch, so no fetch and no elapsed time can make the two equal.
+	checkout := createDaemonWorkerGitCheckout(t, "main")
+	store := daemonWorkerStore(t)
+	seedDaemonWorkerRepo(t, store, "owner/repo", checkout)
+	seedDaemonWorkerAgent(t, store, "reviewer", runtime.ShellRuntime, "unused", []string{"review"}, "owner/repo")
+
+	mainHead := daemonWorkerHeadSHA(t, checkout)
+	runDaemonWorkerGit(t, checkout, "checkout", "-b", "feat/x")
+	if err := os.WriteFile(checkout+"/feature.txt", []byte("pr work\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile returned error: %v", err)
+	}
+	runDaemonWorkerGit(t, checkout, "add", "feature.txt")
+	runDaemonWorkerGit(t, checkout, "commit", "-m", "pr commit")
+	prHead := daemonWorkerHeadSHA(t, checkout)
+	runDaemonWorkerGit(t, checkout, "checkout", "main")
+	if daemonWorkerHeadSHA(t, checkout) != mainHead {
+		t.Fatal("setup: shared checkout is not back on main")
+	}
+
+	if err := store.UpsertPullRequest(ctx, db.PullRequest{
+		RepoFullName: "owner/repo",
+		Number:       77,
+		HeadBranch:   "feat/x",
+		HeadSHA:      prHead,
+		State:        "open",
+	}); err != nil {
+		t.Fatalf("UpsertPullRequest returned error: %v", err)
+	}
+
+	// The NON-review coordinator parent: no ReviewRound, no Reviewers.
+	const parentID = "ask-coordinator-1512"
+	encodedParent, err := json.Marshal(workflow.JobPayload{
+		Repo:         "owner/repo",
+		Branch:       "feat/x",
+		PullRequest:  77,
+		HeadSHA:      prHead,
+		TaskID:       "task-1512",
+		Instructions: "ask coordinator",
+	})
+	if err != nil {
+		t.Fatalf("marshal parent payload: %v", err)
+	}
+	if err := store.CreateJob(ctx, db.Job{
+		ID:      parentID,
+		Agent:   "reviewer",
+		Type:    "ask",
+		State:   string(workflow.JobSucceeded),
+		Payload: string(encodedParent),
+	}); err != nil {
+		t.Fatalf("CreateJob(parent) returned error: %v", err)
+	}
+
+	const childID = parentID + "/delegation/review-child"
+	enqueueDaemonWorkerJob(t, store, workflow.JobRequest{
+		ID:              childID,
+		Agent:           "reviewer",
+		Action:          "review",
+		Repo:            "owner/repo",
+		Branch:          "feat/x",
+		PullRequest:     77,
+		HeadSHA:         prHead,
+		TaskID:          "task-1512",
+		Instructions:    "review the PR",
+		ParentJobID:     parentID,
+		DelegationID:    "review-child",
+		DelegationDepth: 1,
+		DelegatedBy:     "reviewer",
+		RootJobID:       parentID,
+	})
+
+	child, err := store.GetJob(ctx, childID)
+	if err != nil {
+		t.Fatalf("GetJob(child) returned error: %v", err)
+	}
+	childPayload, err := daemonJobPayload(child)
+	if err != nil {
+		t.Fatalf("daemonJobPayload(child) returned error: %v", err)
+	}
+	// The producer shape this test exists for: both allocators decline it.
+	if strings.TrimSpace(childPayload.ReviewRound) != "" || len(childPayload.Reviewers) != 0 || strings.TrimSpace(childPayload.WorktreePath) != "" {
+		t.Fatalf("setup: want a path-less child with no review round and no reviewers, got round=%q reviewers=%v path=%q",
+			childPayload.ReviewRound, childPayload.Reviewers, childPayload.WorktreePath)
+	}
+
+	worker := defaultJobWorker(store, io.Discard)
+	if err := runDaemonWorkerTickTracked(ctx, store, worker, 1, false, "owner/repo", "", io.Discard, time.Now().UTC(), nil, nil); err != nil {
+		t.Fatalf("runDaemonWorkerTickTracked returned error: %v", err)
+	}
+
+	events, err := store.ListJobEvents(ctx, childID)
+	if err != nil {
+		t.Fatalf("ListJobEvents returned error: %v", err)
+	}
+	// The head-mismatch refusal really happened: this test would otherwise pass
+	// vacuously on any change that stopped refusing.
+	if !hasResyncEvent(events, "failed") {
+		t.Fatalf("events = %+v, want the pre-flight head-mismatch failure", events)
+	}
+	if hasResyncEvent(events, workflow.JobEventDelegationTimeoutFinalized) {
+		t.Fatalf("events = %+v, want NO %s: this leg never ran, so no deadline could elapse",
+			events, workflow.JobEventDelegationTimeoutFinalized)
+	}
+	messages := jobEventMessages(events, workflow.JobEventDelegationRefusedFinalized)
+	if len(messages) != 1 {
+		t.Fatalf("events = %+v, want exactly one %s event", events, workflow.JobEventDelegationRefusedFinalized)
+	}
+	if !strings.Contains(messages[0], "was refused before it ran and never started") {
+		t.Fatalf("%s message = %q, want it to say the child never started", workflow.JobEventDelegationRefusedFinalized, messages[0])
+	}
+	if strings.Contains(messages[0], "ended without a result") {
+		t.Fatalf("%s message = %q, must not claim the child ran and returned nothing", workflow.JobEventDelegationRefusedFinalized, messages[0])
+	}
+	// The parent DAG is still advanced exactly as before: the delegation's
+	// failure_policy must fire for a refusal as it does for a runtime failure.
+	settled, err := store.GetJob(ctx, childID)
+	if err != nil {
+		t.Fatalf("GetJob(settled) returned error: %v", err)
+	}
+	settledPayload, err := daemonJobPayload(settled)
+	if err != nil {
+		t.Fatalf("daemonJobPayload(settled) returned error: %v", err)
+	}
+	if settledPayload.Result == nil {
+		t.Fatal("refused child stored no synthetic result, so the parent DAG was never advanced")
+	}
+	// It is terminal on the FIRST tick and consumes no operational-blocker budget:
+	// a remedy must not turn this into a deferral (#1512 requirement 1).
+	if settledPayload.BlockerAttempts != 0 || strings.TrimSpace(settledPayload.BlockerClass) != "" {
+		t.Fatalf("refused child consumed blocker budget: attempts=%d class=%q",
+			settledPayload.BlockerAttempts, settledPayload.BlockerClass)
+	}
+}

--- a/internal/daemon/queued_pr_closed_lifecycle_test.go
+++ b/internal/daemon/queued_pr_closed_lifecycle_test.go
@@ -282,9 +282,15 @@ END;`); err != nil {
 		t.Fatalf("completed markers = %d, want exactly 1", got)
 	}
 	// The finalizer must NOT have re-run: exactly one synthetic finalization for the
-	// whole recovery, so the parent was advanced once rather than twice.
-	if got := countJobEventKind(t, store, child, "delegation_timeout_finalized"); got != 1 {
-		t.Fatalf("delegation_timeout_finalized events = %d, want exactly 1", got)
+	// whole recovery, so the parent was advanced once rather than twice. The kind is
+	// the SUPERSEDED one — this child's work was superseded by a closed PR, it did
+	// not time out, and recording it as a timeout made the two indistinguishable in
+	// the event stream (#1512).
+	if got := countJobEventKind(t, store, child, workflow.JobEventDelegationSupersededFinalized); got != 1 {
+		t.Fatalf("%s events = %d, want exactly 1", workflow.JobEventDelegationSupersededFinalized, got)
+	}
+	if got := countJobEventKind(t, store, child, workflow.JobEventDelegationTimeoutFinalized); got != 0 {
+		t.Fatalf("%s events = %d, want 0: nothing timed out", workflow.JobEventDelegationTimeoutFinalized, got)
 	}
 	if err := daemon.PollOnce(ctx); err != nil {
 		t.Fatalf("third PollOnce: %v", err)

--- a/internal/workflow/engine_run_budgets.go
+++ b/internal/workflow/engine_run_budgets.go
@@ -173,16 +173,25 @@ func (e Engine) finalizeTimedOutJob(ctx context.Context, jobID string, reason st
 }
 
 // Finalize event kinds for a delegation child terminalized WITHOUT a stored
-// result. All three used to be recorded as delegation_timeout_finalized, so a
-// timed-out child, a superseded child and one refused before it ever ran were
-// indistinguishable in the event stream and any host's count of delegation
-// timeouts was inflated by the other two (#1512). The kind now names the cause
-// the caller actually observed.
+// result. All of these used to be recorded as delegation_timeout_finalized, so a
+// timed-out child, a superseded child, one that failed mid-run and one refused
+// before it ever ran were indistinguishable in the event stream and any host's
+// count of delegation timeouts was inflated by the other three (#1512). The kind
+// now names the cause the caller actually observed.
 const (
-	JobEventDelegationTimeoutFinalized    = "delegation_timeout_finalized"
-	JobEventDelegationSupersededFinalized = "delegation_superseded_finalized"
-	JobEventDelegationRefusedFinalized    = "delegation_refused_finalized"
+	JobEventDelegationTimeoutFinalized        = "delegation_timeout_finalized"
+	JobEventDelegationSupersededFinalized     = "delegation_superseded_finalized"
+	JobEventDelegationRefusedFinalized        = "delegation_refused_finalized"
+	JobEventDelegationRuntimeFailureFinalized = "delegation_runtime_failure_finalized"
 )
+
+// FinalizeFailedDelegationChild terminalizes a delegation child that RAN and
+// then failed without storing a result — a mid-run runtime failure such as a
+// sandbox permission denial. It is neither a spent deadline nor a refusal, and
+// recording it as either asserts something that did not happen.
+func (e Engine) FinalizeFailedDelegationChild(ctx context.Context, jobID string, reason string) (bool, error) {
+	return e.finalizeTimedOutJob(ctx, jobID, reason, JobEventDelegationRuntimeFailureFinalized, reason, true, nil)
+}
 
 // FinalizeTimedOutDelegationChild preserves the established engine API for
 // delegation callers while routing through the all-job terminalizer. It is for a

--- a/internal/workflow/engine_run_budgets.go
+++ b/internal/workflow/engine_run_budgets.go
@@ -172,16 +172,42 @@ func (e Engine) finalizeTimedOutJob(ctx context.Context, jobID string, reason st
 	return true, nil
 }
 
+// Finalize event kinds for a delegation child terminalized WITHOUT a stored
+// result. All three used to be recorded as delegation_timeout_finalized, so a
+// timed-out child, a superseded child and one refused before it ever ran were
+// indistinguishable in the event stream and any host's count of delegation
+// timeouts was inflated by the other two (#1512). The kind now names the cause
+// the caller actually observed.
+const (
+	JobEventDelegationTimeoutFinalized    = "delegation_timeout_finalized"
+	JobEventDelegationSupersededFinalized = "delegation_superseded_finalized"
+	JobEventDelegationRefusedFinalized    = "delegation_refused_finalized"
+)
+
 // FinalizeTimedOutDelegationChild preserves the established engine API for
-// delegation callers while routing through the all-job terminalizer.
+// delegation callers while routing through the all-job terminalizer. It is for a
+// child that RAN and produced no result: a spent run deadline, or a runtime
+// failure mid-delivery.
 func (e Engine) FinalizeTimedOutDelegationChild(ctx context.Context, jobID string, reason string) (bool, error) {
-	return e.finalizeTimedOutJob(ctx, jobID, reason, "delegation_timeout_finalized", reason, true, nil)
+	return e.finalizeTimedOutJob(ctx, jobID, reason, JobEventDelegationTimeoutFinalized, reason, true, nil)
+}
+
+// FinalizeRefusedDelegationChild terminalizes a delegation child that NEVER RAN:
+// a daemon pre-flight refused it, so no adapter was built, no prompt was
+// delivered and no deadline was spent. Same terminalizer and same DAG
+// advancement as the timeout path — only the recorded cause differs, which is
+// the point: recording this as a timeout asserted an elapsed deadline that never
+// started (#1512).
+func (e Engine) FinalizeRefusedDelegationChild(ctx context.Context, jobID string, reason string) (bool, error) {
+	return e.finalizeTimedOutJob(ctx, jobID, reason, JobEventDelegationRefusedFinalized, reason, true, nil)
 }
 
 // finalizeSupersededDelegationChildAtGeneration is the closed-PR recovery's
-// finalizer: the same terminalizer, pinned to the lifecycle the debt names.
+// finalizer: the same terminalizer, pinned to the lifecycle the debt names. The
+// child is neither timed out nor refused — its work was superseded — so it
+// carries its own kind rather than borrowing the timeout verb.
 func (e Engine) finalizeSupersededDelegationChildAtGeneration(ctx context.Context, jobID string, reason string, generation int64) (bool, error) {
-	return e.finalizeTimedOutJob(ctx, jobID, reason, "delegation_timeout_finalized", reason, true, &generation)
+	return e.finalizeTimedOutJob(ctx, jobID, reason, JobEventDelegationSupersededFinalized, reason, true, &generation)
 }
 
 func (e Engine) refreshJobPayload(ctx context.Context, jobID string) error {

--- a/internal/workflow/lifecycle_race_test.go
+++ b/internal/workflow/lifecycle_race_test.go
@@ -381,7 +381,7 @@ func runSupersedeDebtInterleaveCase(t *testing.T, stage string) {
 		return nil
 	}
 	t.Cleanup(func() { supersedeDebtInterleaveHook = nil })
-	finalizedBefore := countWorkflowJobEvents(t, store, child, "delegation_timeout_finalized")
+	finalizedBefore := countWorkflowJobEvents(t, store, child, JobEventDelegationSupersededFinalized)
 	confirmedBefore := countWorkflowJobEvents(t, store, child, JobEventSupersedeAdvanceConfirmed)
 
 	handled, err := engine.CompletePendingSupersedeFinalization(ctx, child)
@@ -407,10 +407,22 @@ func runSupersedeDebtInterleaveCase(t *testing.T, stage string) {
 	}
 	// The finalizer runs BEFORE the advance bracket, so at before-advance-claim it has
 	// legitimately finalized the still-claimed lifecycle by the time the retry lands.
-	// Every earlier stage must show no new finalization at all.
+	// Every earlier stage must show no new finalization at all. The kind is the
+	// SUPERSEDED one: this path is finalizeSupersededDelegationChildAtGeneration, so
+	// counting the timeout kind here watched a string the code can no longer emit and
+	// the guard could not fail (#1512).
 	if stage != supersedeDebtStageBeforeAdvanceClaim {
-		if got := countWorkflowJobEvents(t, store, child, "delegation_timeout_finalized"); got != finalizedBefore {
-			t.Fatalf("delegation_timeout_finalized events = %d, want %d: the claimed run was finalized", got, finalizedBefore)
+		if got := countWorkflowJobEvents(t, store, child, JobEventDelegationSupersededFinalized); got != finalizedBefore {
+			t.Fatalf("%s events = %d, want %d: the claimed run was finalized", JobEventDelegationSupersededFinalized, got, finalizedBefore)
+		}
+	} else {
+		// LIVENESS of the counter itself: at this one stage the finalizer HAS run, so
+		// the counted kind must actually have been emitted. Without this, a future
+		// rename would leave the guard above watching a dead string, which is exactly
+		// how it became vacuous.
+		if got := countWorkflowJobEvents(t, store, child, JobEventDelegationSupersededFinalized); got <= finalizedBefore {
+			t.Fatalf("%s events = %d, want more than %d: the counter is watching a kind this path does not emit",
+				JobEventDelegationSupersededFinalized, got, finalizedBefore)
 		}
 	}
 	// The parent advance is only ever CONFIRMED for a lifecycle that never moved, so


### PR DESCRIPTION
Fixes the measured half of #1512 (re-scoped 2026-09-04). Authoritative description: workflow notes **115211** (invariant), **115235** (reachability enumeration), **115292** (measured disposition).

## What was wrong

A review leg whose **checkout** head can never match its pinned review head is refused by the daemon pre-flight *before it runs* — no adapter, no prompt, no deadline started — and was then finalized through the **timeout** path:

- `internal/cli/daemon_result.go` hard-coded `"delegation child %s ended without a result: %v"` for **any** cause;
- `internal/workflow/engine_run_budgets.go` passed the literal kind `delegation_timeout_finalized` from the timeout finalizer **and** from the superseded-child finalizer.

So a timed-out child, a superseded child, and one that never started were indistinguishable in the event stream, and any host's count of "delegation timeouts" was inflated by refusals and supersessions.

**Measured before the change** (note 115292 — one real worker tick, isolated `/tmp` home, shell runtime, no LLM):

```
job probe-ask-coordinator/delegation/review-child
  state=failed  blocker_class=""  blocker_attempts=0  blocker_retry_at=""  result_present=true
  queued                        job queued
  failed                        checkout head is 73bbdfa2…, not review job head 8843831a…
  delegation_timeout_finalized  delegation child … ended without a result: checkout head is …
```

Neither clause is true: nothing timed out, and "ended without a result" reads as a child that *ran* and returned nothing.

## The change

The finalize kind now names the cause the caller actually observed:

| constant | kind | meaning |
|---|---|---|
| `JobEventDelegationTimeoutFinalized` | `delegation_timeout_finalized` | ran, spent its deadline or failed mid-delivery |
| `JobEventDelegationSupersededFinalized` | `delegation_superseded_finalized` | closed-PR recovery; work superseded |
| `JobEventDelegationRefusedFinalized` | `delegation_refused_finalized` | refused by a pre-flight, **never started** |

`finalizePreflightDelegationChild` routes through the new `FinalizeRefusedDelegationChild`, whose message says the child *"was refused before it ran and never started"*. Same terminalizer, same parent-DAG advancement, same `failure_policy` firing — only the recorded cause differs.

## Requirements from the issue, each answered

1. **Blocker budget untouched** — already terminal on the first tick; the test asserts `attempts=0` and an empty `blocker_class` so a future change cannot silently turn this into a deferral.
2. **`state=failed` + synthetic `decision="failed"` — NOT addressed here, deliberately.** Changing the synthetic decision alters delegation `failure_policy` routing and lens-quorum arithmetic, which requirements 4 and 6 exist to protect; it is a separate change with its own review. Flagged rather than silently skipped.
3. **Done — the widest part.** Three causes, three kinds, and a message that no longer asserts a run.
4. **`SupersedeStaleHeadJob` / `superseded_stale_head` not reused.** The new superseded *finalize* kind is a distinct string for the closed-PR finalizer and makes no claim about a newer head existing.
5. **Tolerated drift preserved** (#684) — no change to the head-check, the branch gate, or the deferral classifier.
6. **Delegation DAG routing preserved** (`job_blocker_checkout.go:174-176`) — the refusal still advances the parent exactly as before; the test asserts a synthetic result is stored.

## The discriminator, run both ways

`TestPreflightRefusedReviewChildIsNotFinalizedAsATimeout` drives **one real worker tick** through the reachable producer — a review child of a **non-review** coordinator (`PullRequest>0` and a `HeadSHA`, blank `ReviewRound`, no `Reviewers`, path-less), with the shared checkout on `main` and the pinned head on a PR branch — not a hand-called finalizer.

**Pre-fix (production reverted to route the refusal through the timeout finalizer): FAIL**
```
review_refusal_disposition_test.go:136: events = [… Kind:delegation_timeout_finalized
  Message:delegation child ask-coordinator-1512/delegation/review-child ended without a result:
  checkout head is ecbf6945…, not review job head 2f358691…],
  want NO delegation_timeout_finalized: this leg never ran, so no deadline could elapse
```
**Post-fix: PASS** (`--- PASS: TestPreflightRefusedReviewChildIsNotFinalizedAsATimeout (0.20s)`). Production restored after the probe, `cmp -s` verified byte-identical.

The test also fails vacuously-proof: it asserts the head-mismatch `failed` event really occurred, so a change that stopped refusing would not pass it.

## Contract tests updated (they pinned the old, wrong kind)

- `internal/cli/preflight_delegation_finalize_test.go` — every pre-flight refusal case.
- `internal/cli/native_review_worktree_test.go:746` — the unallocatable-head lens child.
- `internal/daemon/queued_pr_closed_lifecycle_test.go:284-294` — the closed-PR supersession, now asserting the superseded kind **and** zero timeout events.

## Gate, executed here (#1839 tax — engine verdicts on this box are static-only)

Non-`/tmp` tree `/root/gm-reviewfix-c`, `TMPDIR=/tmp`, both toolchain halves exported together (`GOTOOLCHAIN=local` **and** the `PATH`; either alone resolves to go1.22.2 and cannot build this module):

```
go version                                   go version go1.26.4 linux/amd64
go build -buildvcs=false ./...               BUILD_OK
go vet ./...                                 VET_OK
go generate ./... && git status --porcelain  only the 5 intended files; no generated artifact changed
go test -timeout 40m ./internal/cli/         ok  572.724s
go test -timeout 40m ./internal/daemon/      ok   22.860s
go test -count=1 -timeout 20m ./internal/workflow/  ok 139.223s
```

## Docs

No doc change: `grep -rn delegation_timeout_finalized website/docs skills docs` returns **zero** matches, so no published page enumerates these finalize kinds and there is nothing to keep in sync. Adding a new reference section for them is out of this PR's scope.

## Not in this PR

Nothing from #1819 or any other seam. #1512's requirement 2 (see above) and the parked AGENTS.md coordinator-role sentence are both explicitly excluded.

## Round-1 remediation at head `69d35f2d`

Round-1 verdict (`changes_requested`/P2, job `local-review-gm-review-opus-18d21cbe28192816`, executed not static-only) raised two findings. Both were mine and both are fixed.

**F-1 — the fix asserted a refusal for a child that ran.** `finalizeRefusedDelegationChild` hard-coded *"was refused before it ran and never started"* for every caller of `finalizePreflightDelegationChild`, but one of its three call sites — `handleRunJobError`'s writable implement delegation child whose runtime fails **mid-run** with a permission error (`daemon_result.go`, `JobRunning`→`JobBlocked`) — describes a child that **did** run. So round 1 swapped a message asserting a timeout that never happened for one asserting a run that never happened: same lie, opposite direction.

Fixed by **discriminating at the call site**, not by softening wording. The shared bridge now takes the finalizer as a parameter, so the caller — the only party that knows whether the child ran — chooses the cause:

| caller | engine API | kind |
|---|---|---|
| `finalizePreflightDelegationChild` | `FinalizeRefusedDelegationChild` | `delegation_refused_finalized` |
| `finalizeMidRunDelegationChild` | `FinalizeFailedDelegationChild` | `delegation_runtime_failure_finalized` |
| timeout path (unchanged) | `FinalizeTimedOutDelegationChild` | `delegation_timeout_finalized` |
| closed-PR recovery | `finalizeSupersededDelegationChildAtGeneration` | `delegation_superseded_finalized` |

**F-2 — a fourth test site was left vacuous.** `internal/workflow/lifecycle_race_test.go:384,412` counted the literal `delegation_timeout_finalized` on the **supersede** path (`CompletePendingSupersedeFinalization` → `job_recovery.go:1156`), whose kind this PR renamed — so an existing race guard watched a string the code under test can no longer emit and could not fail. Re-pointed at the superseded kind with its original assertion strength (**not** weakened to "any finalize kind"), plus a **liveness arm** at `before-advance-claim`, the one stage where the finalizer really runs, asserting the counted kind was actually emitted. A future rename cannot silently kill the guard again.

### Discriminators, both failing on the previous head

**F-1** — mid-run caller routed back through the refusal helper (i.e. `043c4809`'s behaviour):
```
preflight_delegation_finalize_test.go:838: delegation_runtime_failure_finalized events = 0, want 1
```
**F-2** — baseline counting the timeout kind while the guard counts the superseded one (i.e. the vacuity condition):
```
lifecycle_race_test.go:416: delegation_superseded_finalized events = 1, want 0: the claimed run was finalized
  (after-read, after-claim, before-cleanup, after-resource-commit …)
```
Production restored `cmp`-verified byte-identical after the F-1 probe; the F-2 probe touched only test text and was reverted, then the fix re-applied and re-verified.

### Gate at `69d35f2d`

```
gofmt -l internal/cli internal/workflow internal/daemon   (empty)
go version                                   go version go1.26.4 linux/amd64
go build -buildvcs=false ./...               BUILD_OK
go vet ./...                                 VET_OK
go generate ./... && git status --porcelain  only the 4 intended files
go test -count=1 -timeout 40m ./internal/cli/        ok 574.769s
go test -count=1 -timeout 40m ./internal/workflow/   ok 155.303s
go test -count=1 -timeout 40m ./internal/daemon/     ok  32.179s
```
Non-`/tmp` tree `/root/gm-reviewfix-c`, `TMPDIR=/tmp`, both toolchain halves exported together, `-count=1` throughout so no cached "ok" stands in for a run.

## Round-2 remediation at head `504bd8af`

Round-2 verdict **approved** `69d35f2d` with three P3s; two are this issue's own defect class and one the fix round introduced, so the head moved rather than merging on the approval.

**F-1 — real and reachable, determined before any code was written.** The mid-run branch keyed on the *error's* shape (`latest.Type == "implement" && runtimePermissionFailure(cause)`) and never asked whether the child ran. Reachability is one line: the CAS it delegates to accepts a transition from **JobQueued** as well as JobRunning and JobFailed (`internal/cli/agent_permissions.go:41`), so a still-queued child was recorded as *"failed mid-run without a result"*. Round 1 fixed "one hard-coded reason for three callers"; this was "one hard-coded reason for three **states** inside one caller" — the same defect a level down. The finalizer is now chosen by `latest.State`, read before any transition; the CAS keeps its three-state tolerance and only the recorded cause reads which arm fired.

**F-3 — a vacuous guard introduced while fixing a vacuous guard.** `TestMidRunPermissionBlockedNonDelegationUnaffected` counted `delegation_refused_finalized` on a path that now emits `delegation_runtime_failure_finalized` — a dead string, one file over from the `lifecycle_race_test.go` instance this PR had just repaired. It now counts the emitted kind **and** carries a liveness arm on a delegation child of the same path, so the counter is proven to observe a real emission.

**F-2 — literal enumeration replaced by a positive assertion.** Screening for `"never started"` and `"refused before it ran"` would let the semantically identical *"was not started"* through. The guard now asserts the message **names the mid-run failure**, and fails if it inspected nothing.

### Discriminators, both failing on `69d35f2d`
```
F-1: queued_permission_finalize_test.go:75: delegation_refused_finalized events = 0,
       want 1 for a child that never ran
F-3: preflight_delegation_finalize_test.go:995: delegation_runtime_failure_finalized events
       on the delegation child = 0, want 1: the counted kind is not emitted by this path at all
```
Production and test files restored `cmp`-verified byte-identical after each probe.

### Gate at `504bd8af`
```
gofmt -l internal/cli internal/workflow internal/daemon   (empty)
go version                                   go version go1.26.4 linux/amd64
go build -buildvcs=false ./...               BUILD_OK
go vet ./...                                 VET_OK
go generate ./... && git status --porcelain  only the intended files
go test -count=1 -timeout 40m ./internal/cli/        ok 681.495s
go test -count=1 -timeout 40m ./internal/workflow/   ok 165.112s
go test -count=1 -timeout 40m ./internal/daemon/     ok  35.195s
```
