### PR TITLE
fix(daemon): key the finalize cause on the transition's state, not the error (#1848)

### DIFF
--- a/internal/cli/agent_permissions.go
+++ b/internal/cli/agent_permissions.go
@@ -34,9 +34,15 @@ func readOnlyImplementationBlocked(jobType string, agent runtime.Agent) bool {
 // that read and this write; the state-only CAS below then accepts the NEWER run's `running` and
 // blocks it. Review reproduced exactly that: new run state = "blocked", want running. The
 // guarantee has to live in the WRITE, not in a preceding read.
-func markJobPermissionBlockedAtGeneration(ctx context.Context, store *db.Store, jobID string, atGeneration int64) (bool, error) {
+// The matched source state is returned alongside the outcome: the CAS is the only
+// party that knows WHICH `from` actually won, and a caller that DESCRIBES the
+// transition needs that fact. A pre-write read cannot serve — the very window this
+// anchored form exists to close (#1407) sits between the read and the write — so
+// "did this child ever run" is answered by the arm that matched, never by a
+// snapshot taken before it (#1848).
+func markJobPermissionBlockedAtGeneration(ctx context.Context, store *db.Store, jobID string, atGeneration int64) (bool, workflow.JobState, error) {
 	if store == nil {
-		return false, errors.New("job store is required")
+		return false, "", errors.New("job store is required")
 	}
 	for _, from := range []workflow.JobState{workflow.JobQueued, workflow.JobRunning, workflow.JobFailed} {
 		event := db.JobEvent{
@@ -47,13 +53,13 @@ func markJobPermissionBlockedAtGeneration(ctx context.Context, store *db.Store, 
 		if atGeneration >= 0 {
 			transitioned, err := store.TransitionJobStateWithEventAtGeneration(ctx, jobID, string(from), atGeneration, string(workflow.JobBlocked), event)
 			if err != nil {
-				return false, err
+				return false, "", err
 			}
 			if transitioned {
 				if err := store.AddJobEvent(ctx, db.JobEvent{JobID: jobID, Kind: "permission_blocked", Message: agentPermissionBlockedMessage}); err != nil {
-					return false, err
+					return false, "", err
 				}
-				return true, nil
+				return true, from, nil
 			}
 			continue
 		}
@@ -63,23 +69,26 @@ func markJobPermissionBlockedAtGeneration(ctx context.Context, store *db.Store, 
 			Message: agentPermissionBlockedMessage,
 		})
 		if err != nil {
-			return false, err
+			return false, "", err
 		}
 		if transitioned {
 			if err := store.AddJobEvent(ctx, db.JobEvent{JobID: jobID, Kind: "permission_blocked", Message: agentPermissionBlockedMessage}); err != nil {
-				return false, err
+				return false, "", err
 			}
-			return true, nil
+			return true, from, nil
 		}
 	}
-	return false, nil
+	return false, "", nil
 }
 
 // markJobPermissionBlocked derives the atomic-write anchor from the admitted
 // row. Callers must retain that row rather than re-read before writing: a queued
-// cancellation and retry can produce the same state at a newer generation.
+// cancellation and retry can produce the same state at a newer generation. It
+// drops the matched source state: its callers block a job, they do not describe
+// the transition afterwards.
 func markJobPermissionBlocked(ctx context.Context, store *db.Store, job db.Job) (bool, error) {
-	return markJobPermissionBlockedAtGeneration(ctx, store, job.ID, job.LifecycleGeneration)
+	transitioned, _, err := markJobPermissionBlockedAtGeneration(ctx, store, job.ID, job.LifecycleGeneration)
+	return transitioned, err
 }
 
 func runtimePermissionFailure(err error) bool {

--- a/internal/cli/daemon_result.go
+++ b/internal/cli/daemon_result.go
@@ -180,7 +180,7 @@ func (w jobWorker) handleRunJobError(ctx context.Context, jobID string, observed
 	if latest.Type == "implement" && runtimePermissionFailure(cause) {
 		payload, payloadErr := daemonJobPayload(latest)
 		if payloadErr != nil || payload.Result == nil {
-			transitioned, err := markJobPermissionBlockedAtGeneration(ctx, w.Store, jobID, observed.generation)
+			transitioned, blockedFrom, err := markJobPermissionBlockedAtGeneration(ctx, w.Store, jobID, observed.generation)
 			if err != nil {
 				return err
 			}
@@ -194,19 +194,27 @@ func (w jobWorker) handleRunJobError(ctx context.Context, jobID string, observed
 				// once here. The following finalizePreflightDelegationChild only attaches
 				// a synthetic result (savePayload, no transition), so it never re-emits.
 				emitDaemonTerminalEvent(ctx, w.eventSink(), w.Store, jobID, daemonTerminalPermissionGuard, string(workflow.JobBlocked), agentPermissionBlockedMessage)
-				// A WRITABLE implement DELEGATION child whose runtime fails MID-RUN
-				// with a permission error (read-only FS / sandbox denies write) is
-				// transitioned JobRunning->JobBlocked here and returns early — it never
-				// reaches the ParentJobID finalize branch below, so the parent DAG
-				// strands exactly like #409 (the mid-run sibling of the pre-flight
-				// read-only-implement case fixed at ~2127). It advances the DAG through
-				// the same terminalizer, but this child DID RUN, so it records the
-				// MID-RUN cause: "refused before it ran" would be false of it and the
-				// timeout kind would assert a deadline that never expired (#1512). The
-				// helper no-ops for a non-delegation job (ParentJobID empty) or one that
-				// already stored a result, so the solo-implement case stays
-				// byte-identical.
-				if err := w.finalizeMidRunDelegationChild(ctx, jobID, errors.New(agentPermissionBlockedMessage)); err != nil {
+				// A WRITABLE implement DELEGATION child whose runtime fails with a
+				// permission error (read-only FS / sandbox denies write) is transitioned
+				// to JobBlocked here and returns early — it never reaches the
+				// ParentJobID finalize branch below, so the parent DAG strands exactly
+				// like #409 (the mid-run sibling of the pre-flight read-only-implement
+				// case fixed at ~2127). It advances the DAG through the same
+				// terminalizer either way, but the RECORDED CAUSE comes from the
+				// TRANSITION'S MATCHED SOURCE STATE, never from the error's shape
+				// (#1848). The CAS accepts JobQueued, JobRunning or JobFailed
+				// (agent_permissions.go:47), so this branch is reached by a child that
+				// never started as well as by one that did; keying on the error labelled
+				// a never-claimed child "failed mid-run". The matched arm is the only
+				// witness of which happened — a pre-write read cannot be, because the
+				// #1407 window sits between that read and this write. Both helpers
+				// no-op for a non-delegation job (ParentJobID empty) or one that already
+				// stored a result, so the solo-implement case stays byte-identical.
+				finalize := w.finalizeMidRunDelegationChild
+				if blockedFrom == workflow.JobQueued {
+					finalize = w.finalizePreflightDelegationChild
+				}
+				if err := finalize(ctx, jobID, errors.New(agentPermissionBlockedMessage)); err != nil {
 					return err
 				}
 				return nil

--- a/internal/cli/preflight_delegation_finalize_test.go
+++ b/internal/cli/preflight_delegation_finalize_test.go
@@ -843,18 +843,23 @@ func TestMidRunPermissionBlockedDelegationChildAdvancesParent(t *testing.T) {
 	if got := countWorkerJobEvents(t, h.store, "parent-job/delegation/api", "delegation_timeout_finalized"); got != 0 {
 		t.Fatalf("delegation_timeout_finalized events = %d, want 0: no deadline elapsed", got)
 	}
-	// And the MESSAGE must not claim the child never started, which is what a single
-	// hard-coded reason for every caller of the shared helper produced.
+	// The MESSAGE must NAME the mid-run failure. Asserting the positive is the point:
+	// enumerating forbidden phrasings ("never started", "refused before it ran") let
+	// the semantically identical "was not started" through, so the guard passed while
+	// the claim it forbids was present in spirit. A message that names a mid-run
+	// failure cannot also be asserting the child never started (#1512).
+	found := 0
 	for _, ev := range workerJobEvents(t, h.store, "parent-job/delegation/api") {
 		if ev.Kind != "delegation_runtime_failure_finalized" {
 			continue
 		}
-		if strings.Contains(ev.Message, "never started") || strings.Contains(ev.Message, "refused before it ran") {
-			t.Fatalf("mid-run finalize message = %q, must not claim the child never started", ev.Message)
-		}
+		found++
 		if !strings.Contains(ev.Message, "failed mid-run without a result") {
-			t.Fatalf("mid-run finalize message = %q, want it to name the mid-run failure", ev.Message)
+			t.Fatalf("mid-run finalize message = %q, want it to name the mid-run failure this child actually had", ev.Message)
 		}
+	}
+	if found != 1 {
+		t.Fatalf("mid-run finalize messages inspected = %d, want 1: the loop above asserted nothing", found)
 	}
 	// The DAG advanced and escalate_human fired: the shared parent task is paused
 	// awaiting a human and the human was notified once with the resume context.
@@ -967,8 +972,27 @@ func TestMidRunPermissionBlockedNonDelegationUnaffected(t *testing.T) {
 	if cp.Result != nil {
 		t.Fatalf("non-delegation permission-blocked job must NOT get a synthetic result: %+v", cp.Result)
 	}
-	if n := countWorkerJobEvents(t, store, "impl-job", "delegation_refused_finalized"); n != 0 {
-		t.Fatalf("delegation_refused_finalized events = %d, want 0 for a non-delegation job", n)
+	// The kind counted here must be one this path CAN emit, or the guard cannot fail:
+	// the mid-run permission branch now records delegation_runtime_failure_finalized,
+	// so counting delegation_refused_finalized watched a dead string — the same
+	// vacuity this issue removed from lifecycle_race_test.go, reintroduced one file
+	// over (#1512).
+	if n := countWorkerJobEvents(t, store, "impl-job", "delegation_runtime_failure_finalized"); n != 0 {
+		t.Fatalf("delegation_runtime_failure_finalized events = %d, want 0 for a non-delegation job", n)
+	}
+	// LIVENESS of that counter: the identical assertion on a DELEGATION child of the
+	// same mid-run path must observe exactly one such event, so a rename that killed
+	// the guard above would fail here instead of passing silently.
+	live := newPreflightHarnessForAction(t, "escalate_human", "implement")
+	live.worker.CheckoutValidator = func(context.Context, db.Job, workflow.JobPayload, runtime.Agent) (string, error) {
+		return live.checkout, nil
+	}
+	live.worker.AdapterFactory = func(runtime.Agent, string) (workflow.DeliveryAdapter, error) {
+		return permissionErrorAdapter{}, nil
+	}
+	live.runChildTick(t)
+	if n := countWorkerJobEvents(t, live.store, "parent-job/delegation/api", "delegation_runtime_failure_finalized"); n != 1 {
+		t.Fatalf("delegation_runtime_failure_finalized events on the delegation child = %d, want 1: the counted kind is not emitted by this path at all", n)
 	}
 	// Exactly one engine build (RunJob's), proving the finalize helper short-circuited
 	// for the non-delegation job rather than rebuilding the engine to advance a DAG.

--- a/internal/cli/queued_permission_finalize_test.go
+++ b/internal/cli/queued_permission_finalize_test.go
@@ -1,0 +1,109 @@
+package cli
+
+import (
+	"context"
+	"errors"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/gitmoot/gitmoot/internal/db"
+	"github.com/gitmoot/gitmoot/internal/github"
+	"github.com/gitmoot/gitmoot/internal/runtime"
+	"github.com/gitmoot/gitmoot/internal/workflow"
+)
+
+// #1512 round-2 F-1: the mid-run permission branch in handleRunJobError keys on
+// the ERROR's shape (`latest.Type == "implement" && runtimePermissionFailure`),
+// not on whether the child ever ran — and it is reachable by a child that never
+// did, because markJobPermissionBlockedAtGeneration accepts a transition from
+// JobQueued as well as JobRunning and JobFailed (agent_permissions.go:41). A
+// still-QUEUED delegation child whose run errors with a permission failure was
+// therefore finalized as "failed mid-run without a result", which is the same
+// false claim as the timeout verb this issue removed, one level down: one
+// hard-coded cause for three observed states inside a single caller.
+//
+// The recorded cause must follow the child's observed state. This drives
+// handleRunJobError — the seam whose state-keying is the defect — with the row
+// still queued, which is precisely the precondition the branch failed to read.
+func TestQueuedPermissionBlockedDelegationChildIsRecordedAsRefused(t *testing.T) {
+	ctx := context.Background()
+	store := daemonWorkerStore(t)
+	checkout := t.TempDir()
+	seedDaemonWorkerRepo(t, store, "gitmoot/gitmoot", checkout)
+	seedDaemonWorkerAgent(t, store, "coord", runtime.ShellRuntime, "unused", []string{"ask"}, "gitmoot/gitmoot")
+	seedDaemonWorkerAgent(t, store, "api", runtime.ShellRuntime, "unused", []string{"implement"}, "gitmoot/gitmoot")
+
+	// A coordinator parent with a delegation child that is STILL QUEUED: no claim,
+	// no adapter, no delivery.
+	parent := db.Job{ID: "parent-job", Agent: "coord", Type: "ask", State: string(workflow.JobSucceeded), Payload: mustJobPayload(t, workflow.JobPayload{
+		Repo: "gitmoot/gitmoot", Branch: "feature", TaskID: "task-q", TaskTitle: "Coordinator", Sender: "coord",
+		Result: &workflow.AgentResult{Decision: "approved", Summary: "fan out", Delegations: []workflow.Delegation{{ID: "api", Agent: "api", Action: "implement", Prompt: "build it"}}},
+	})}
+	if err := store.CreateJobWithEvent(ctx, parent, db.JobEvent{Kind: string(workflow.JobSucceeded), Message: "seed"}); err != nil {
+		t.Fatalf("CreateJobWithEvent(parent) returned error: %v", err)
+	}
+	child := db.Job{ID: "parent-job/delegation/api", Agent: "api", Type: "implement", State: string(workflow.JobQueued), Payload: mustJobPayload(t, workflow.JobPayload{
+		Repo: "gitmoot/gitmoot", Branch: "feature", TaskID: "task-q", TaskTitle: "Child", Sender: "coord",
+		ParentJobID: "parent-job", DelegationID: "api", DelegationDepth: 1, DelegatedBy: "coord", RootJobID: "parent-job",
+	})}
+	if err := store.CreateJobWithEvent(ctx, child, db.JobEvent{Kind: string(workflow.JobQueued), Message: "seed"}); err != nil {
+		t.Fatalf("CreateJobWithEvent(child) returned error: %v", err)
+	}
+
+	worker := defaultJobWorker(store, io.Discard)
+	engine := daemonWorkflowEngine(store, github.NewClient(checkout), checkout, "")
+	worker.WorkflowFactory = func(string) workflow.Engine { return engine }
+
+	queued, err := store.GetJob(ctx, child.ID)
+	if err != nil {
+		t.Fatalf("GetJob(child) returned error: %v", err)
+	}
+	if queued.State != string(workflow.JobQueued) {
+		t.Fatalf("setup: child state = %q, want queued", queued.State)
+	}
+	cause := errors.New("write /workspace/file: read-only file system")
+	if !runtimePermissionFailure(cause) {
+		t.Fatal("setup: the cause must match runtimePermissionFailure to reach the branch under test")
+	}
+	if err := worker.handleRunJobError(ctx, child.ID, observedJobLifecycle(queued), cause); err != nil {
+		t.Fatalf("handleRunJobError returned error: %v", err)
+	}
+
+	// A child that never started is recorded as REFUSED, never as a mid-run failure.
+	if got := countWorkerJobEvents(t, store, child.ID, "delegation_refused_finalized"); got != 1 {
+		t.Fatalf("delegation_refused_finalized events = %d, want 1 for a child that never ran", got)
+	}
+	if got := countWorkerJobEvents(t, store, child.ID, "delegation_runtime_failure_finalized"); got != 0 {
+		t.Fatalf("delegation_runtime_failure_finalized events = %d, want 0: this child was never claimed", got)
+	}
+	if got := countWorkerJobEvents(t, store, child.ID, "delegation_timeout_finalized"); got != 0 {
+		t.Fatalf("delegation_timeout_finalized events = %d, want 0: no deadline elapsed", got)
+	}
+	// And the message names the refusal rather than a run that did not happen.
+	found := 0
+	for _, ev := range workerJobEvents(t, store, child.ID) {
+		if ev.Kind != "delegation_refused_finalized" {
+			continue
+		}
+		found++
+		if !strings.Contains(ev.Message, "refused before it ran") {
+			t.Fatalf("refused finalize message = %q, want it to name the refusal", ev.Message)
+		}
+	}
+	if found != 1 {
+		t.Fatalf("refused finalize messages inspected = %d, want 1: the loop above asserted nothing", found)
+	}
+	// The parent DAG is still advanced: the disposition changed, not the routing.
+	settled, err := store.GetJob(ctx, child.ID)
+	if err != nil {
+		t.Fatalf("GetJob(settled) returned error: %v", err)
+	}
+	settledPayload, err := daemonJobPayload(settled)
+	if err != nil {
+		t.Fatalf("daemonJobPayload(settled) returned error: %v", err)
+	}
+	if settledPayload.Result == nil {
+		t.Fatal("the refused child stored no synthetic result, so the parent DAG was never advanced")
+	}
+}


### PR DESCRIPTION
Fixes #1848 — the three residuals from #1841's round-2 review (`local-review-gm-review-opus-18d220c3afb72b8e`, `approved`/P3 at `69d35f2d`), which merged as `8021b7c7` before they were fixed. All three are one class: **a guard keyed on a string or an error's shape rather than on the state it claims to describe.**

Base: `origin/main` at `8021b7c7`.

## 1 — the discrimination read the error, not the state (reachable)

`daemon_result.go` routed on `latest.Type == "implement" && runtimePermissionFailure(cause)` and then recorded *"failed mid-run without a result"*. But the CAS it delegates to accepts **three** source states (`internal/cli/agent_permissions.go`):

```go
for _, from := range []workflow.JobState{workflow.JobQueued, workflow.JobRunning, workflow.JobFailed} {
```

So a child still `queued` — never claimed, never run — transitioned to `blocked` through this path and was recorded as having failed mid-run.

`markJobPermissionBlockedAtGeneration` now **returns the source state that matched**, and the caller routes on it: `JobQueued` → refusal, `JobRunning`/`JobFailed` → mid-run failure (a job that reached `failed` had a run to fail). The matched arm is the only witness of which happened; a pre-write read cannot be, because the #1407 window sits between that read and this write — which is why the anchored form exists at all. The CAS keeps its three-state tolerance and the transition itself is unchanged; `markJobPermissionBlocked` drops the extra value for its two callers, which block a job rather than describe it.

**Round 1 of #1841 fixed one hard-coded reason for three CALLERS; this is one hard-coded reason for three STATES inside one caller. Same defect, one level down.** That is why a second round existed.

## 2 — the message guard enumerated spellings

The old guard screened `"never started"` and `"refused before it ran"`, so the semantically identical **"was not started"** passed it. Worse, `agentPermissionBlockedMessage` itself contains *"implementation was not started"*, so the forbidden claim was already inside the cause text the guard inspected. It now asserts the **positive** — the message names the mid-run failure — and fails if it inspected nothing. No spelling is added to any list; #1561 deleted that shape from production and it will not come back in a test.

## 3 — a guard counting a kind its path cannot emit

`TestMidRunPermissionBlockedNonDelegationUnaffected` counted `delegation_refused_finalized` on a path that emits `delegation_runtime_failure_finalized` — the third instance of the vacuity class in this PR family's history. It now counts the emitted kind **and** carries the liveness arm adopted for round 1's F-2: a delegation child of the same path must show exactly one such event, so a rename cannot orphan the guard silently.

## Fail-then-pass, all three, literal output

**1 — queued child, driven through the production seam** (`handleRunJobError` with the row still `queued`); pre-fix behaviour = ignore the matched state:
```
--- FAIL: TestQueuedPermissionBlockedDelegationChildIsRecordedAsRefused (0.17s)
    queued_permission_finalize_test.go:75: delegation_refused_finalized events = 0,
      want 1 for a child that never ran
```
The pre-fix arm was made **behavioural**, not a compile error: the first attempt left `blockedFrom` unused and the package failed to build, which proves nothing, so the probe kept the variable and discarded the routing instead.

**2 — side-by-side, same mutated message** (`"delegation child %s was not started: %v"`):
```
OLD literal guard  → ok      (0.209s)   the forbidden claim passes
NEW positive guard → FAIL               mid-run finalize message = "delegation child … was not started: …",
                                         want it to name the mid-run failure this child actually had
```
Control: the old guard also reports `ok` against the real *"failed mid-run"* message, so its `ok` above is indifference, not agreement.

**3 — liveness arm pointed at the pre-fix kind:**
```
--- FAIL: TestMidRunPermissionBlockedNonDelegationUnaffected
    preflight_delegation_finalize_test.go:995: delegation_runtime_failure_finalized events
      on the delegation child = 0, want 1: the counted kind is not emitted by this path at all
```
Production and test files were restored `cmp`-verified byte-identical after every probe (`RESTORED_BYTE_IDENTICAL`).

## Gate, executed here

Non-`/tmp` tree `/root/gm-reviewfix-c`, `GOTOOLCHAIN=go1.26.4` pinned with the toolchain `PATH`:

```
gofmt -l internal/cli internal/workflow internal/daemon   (empty)
go version                                   go version go1.26.4 linux/amd64
go build -buildvcs=false ./...               BUILD_OK
go vet ./...                                 VET_OK
go generate ./... && git status --porcelain  only the intended files
go test -count=1 -timeout 40m ./internal/cli/        ok 582.306s
go test -count=1 -timeout 40m ./internal/workflow/   ok 141.155s
go test -count=1 -timeout 40m ./internal/daemon/     ok  28.926s
```

## Notes

- No new event kinds; only which of the existing four a permission-blocked delegation child receives changes.
- No docs change: no published page enumerates these finalize kinds (`grep -rn delegation_timeout_finalized website/docs skills docs` → zero matches, re-checked at this base).
- Nothing from #1795, #1809, #1845 or any other lane.
