### PR TITLE
fix(daemon): route the permission-block label on the matched state (#1852)

### DIFF
--- a/internal/cli/agent_dispatch.go
+++ b/internal/cli/agent_dispatch.go
@@ -841,7 +841,9 @@ func enqueuePermissionBlockedLocalAgentJob(ctx context.Context, store *db.Store,
 	if err := store.AddJobEvent(ctx, db.JobEvent{JobID: job.ID, Kind: "route_selected", Message: routeSelectedMessage(request)}); err != nil {
 		return localAgentJobOutput{}, err
 	}
-	if _, err := markJobPermissionBlocked(ctx, store, job); err != nil {
+	// The matched source state is not consulted here: this site only blocks the job
+	// and reports State: blocked, it never describes the transition afterwards.
+	if _, _, err := markJobPermissionBlocked(ctx, store, job); err != nil {
 		return localAgentJobOutput{}, err
 	}
 	return localAgentJobOutput{

--- a/internal/cli/agent_permissions.go
+++ b/internal/cli/agent_permissions.go
@@ -83,12 +83,18 @@ func markJobPermissionBlockedAtGeneration(ctx context.Context, store *db.Store, 
 
 // markJobPermissionBlocked derives the atomic-write anchor from the admitted
 // row. Callers must retain that row rather than re-read before writing: a queued
-// cancellation and retry can produce the same state at a newer generation. It
-// drops the matched source state: its callers block a job, they do not describe
-// the transition afterwards.
-func markJobPermissionBlocked(ctx context.Context, store *db.Store, job db.Job) (bool, error) {
-	transitioned, _, err := markJobPermissionBlockedAtGeneration(ctx, store, job.ID, job.LifecycleGeneration)
-	return transitioned, err
+// cancellation and retry can produce the same state at a newer generation.
+//
+// It PASSES THROUGH the matched source state, because a caller that goes on to
+// DESCRIBE the transition needs it and the admitted row cannot supply it:
+// queued→running does not bump the generation (the bump fires only on a
+// transition TO queued, store_jobs.go's bumpLifecycleGenerationSQL), so a
+// concurrent claim leaves the row running at the SAME generation this CAS is
+// anchored to and the JobRunning arm matches. A caller keying its label on the
+// row it was handed would then record a child that DID run as "refused before it
+// ran and never started" — the #1848 defect at the sibling site (#1852).
+func markJobPermissionBlocked(ctx context.Context, store *db.Store, job db.Job) (bool, workflow.JobState, error) {
+	return markJobPermissionBlockedAtGeneration(ctx, store, job.ID, job.LifecycleGeneration)
 }
 
 func runtimePermissionFailure(err error) bool {

--- a/internal/cli/blocked_state_routing_test.go
+++ b/internal/cli/blocked_state_routing_test.go
@@ -1,0 +1,157 @@
+package cli
+
+import (
+	"context"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/gitmoot/gitmoot/internal/db"
+	"github.com/gitmoot/gitmoot/internal/github"
+	"github.com/gitmoot/gitmoot/internal/runtime"
+	"github.com/gitmoot/gitmoot/internal/workflow"
+)
+
+// #1852 finding 2: the pre-flight permission-block site keyed its finalize label
+// on the row it was HANDED, which cannot witness whether the child ran. The CAS
+// it calls is anchored to a generation, and queued→running does NOT bump the
+// generation — the bump fires only on a transition TO queued
+// (store_jobs.go's bumpLifecycleGenerationSQL) — so a concurrent claim leaves the
+// row RUNNING at the same generation, the CAS's JobRunning arm matches, and the
+// site recorded "refused before it ran and never started" for a child that did
+// run. This stages exactly that interleaving: the store row is running while the
+// caller holds the stale queued snapshot it was admitted with.
+func TestPreflightPermissionBlockRoutesOnMatchedStateNotTheHandedRow(t *testing.T) {
+	ctx := context.Background()
+	store := daemonWorkerStore(t)
+	checkout := t.TempDir()
+	seedDaemonWorkerRepo(t, store, "gitmoot/gitmoot", checkout)
+	seedDaemonWorkerAgent(t, store, "coord", runtime.ShellRuntime, "unused", []string{"ask"}, "gitmoot/gitmoot")
+	// A read-only implement agent: readOnlyImplementationBlocked is true for it, so
+	// run() takes the pre-flight permission-block branch.
+	seedDaemonWorkerAgentWithPolicy(t, store, "api", runtime.ShellRuntime, "unused", []string{"implement"}, "gitmoot/gitmoot", runtime.AutonomyPolicyAuto)
+
+	parent := db.Job{ID: "parent-job", Agent: "coord", Type: "ask", State: string(workflow.JobSucceeded), Payload: mustJobPayload(t, workflow.JobPayload{
+		Repo: "gitmoot/gitmoot", Branch: "feature", TaskID: "task-1852", TaskTitle: "Coordinator", Sender: "coord",
+		Result: &workflow.AgentResult{Decision: "approved", Summary: "fan out", Delegations: []workflow.Delegation{{ID: "api", Agent: "api", Action: "implement", Prompt: "build it"}}},
+	})}
+	if err := store.CreateJobWithEvent(ctx, parent, db.JobEvent{Kind: string(workflow.JobSucceeded), Message: "seed"}); err != nil {
+		t.Fatalf("CreateJobWithEvent(parent) returned error: %v", err)
+	}
+	child := db.Job{ID: "parent-job/delegation/api", Agent: "api", Type: "implement", State: string(workflow.JobQueued), Payload: mustJobPayload(t, workflow.JobPayload{
+		Repo: "gitmoot/gitmoot", Branch: "feature", TaskID: "task-1852", TaskTitle: "Child", Sender: "coord",
+		ParentJobID: "parent-job", DelegationID: "api", DelegationDepth: 1, DelegatedBy: "coord", RootJobID: "parent-job",
+	})}
+	if err := store.CreateJobWithEvent(ctx, child, db.JobEvent{Kind: string(workflow.JobQueued), Message: "seed"}); err != nil {
+		t.Fatalf("CreateJobWithEvent(child) returned error: %v", err)
+	}
+
+	// The row the worker was admitted with: queued, at generation G.
+	admitted, err := store.GetJob(ctx, child.ID)
+	if err != nil {
+		t.Fatalf("GetJob(admitted) returned error: %v", err)
+	}
+	if admitted.State != string(workflow.JobQueued) {
+		t.Fatalf("setup: admitted state = %q, want queued", admitted.State)
+	}
+	// THE INTERLEAVING: something claims the job queued→running. No generation bump,
+	// so the CAS anchored to G still matches — on its JobRunning arm.
+	claimed, err := store.TransitionJobStateWithEvent(ctx, child.ID, string(workflow.JobQueued), string(workflow.JobRunning), db.JobEvent{
+		JobID: child.ID, Kind: string(workflow.JobRunning), Message: "claimed by a concurrent worker",
+	})
+	if err != nil || !claimed {
+		t.Fatalf("staging the concurrent claim: claimed=%v err=%v", claimed, err)
+	}
+	running, err := store.GetJob(ctx, child.ID)
+	if err != nil {
+		t.Fatalf("GetJob(running) returned error: %v", err)
+	}
+	if running.State != string(workflow.JobRunning) {
+		t.Fatalf("setup: state after the claim = %q, want running", running.State)
+	}
+	if running.LifecycleGeneration != admitted.LifecycleGeneration {
+		t.Fatalf("setup: generation moved %d -> %d; this test's premise is that queued->running does NOT bump it",
+			admitted.LifecycleGeneration, running.LifecycleGeneration)
+	}
+
+	worker := defaultJobWorker(store, io.Discard)
+	engine := daemonWorkflowEngine(store, github.NewClient(checkout), checkout, "")
+	worker.WorkflowFactory = func(string) workflow.Engine { return engine }
+	// run() is handed the STALE queued row, exactly as the admitted worker holds it.
+	if err := worker.run(ctx, admitted); err != nil {
+		t.Fatalf("worker.run(stale queued row) returned error: %v", err)
+	}
+
+	// The child was claimed, so the recorded cause must be the mid-run one. Labelling
+	// it "refused before it ran" is the mirror image of the #1848 defect.
+	if got := countWorkerJobEvents(t, store, child.ID, "delegation_runtime_failure_finalized"); got != 1 {
+		t.Fatalf("delegation_runtime_failure_finalized events = %d, want 1: the CAS matched JobRunning, so this child ran", got)
+	}
+	if got := countWorkerJobEvents(t, store, child.ID, "delegation_refused_finalized"); got != 0 {
+		t.Fatalf("delegation_refused_finalized events = %d, want 0: this child was claimed before the block", got)
+	}
+	found := 0
+	for _, ev := range workerJobEvents(t, store, child.ID) {
+		if ev.Kind != "delegation_runtime_failure_finalized" {
+			continue
+		}
+		found++
+		if !strings.Contains(ev.Message, "failed mid-run without a result") {
+			t.Fatalf("finalize message = %q, want it to name the mid-run failure", ev.Message)
+		}
+	}
+	if found != 1 {
+		t.Fatalf("finalize messages inspected = %d, want 1", found)
+	}
+	// The parent DAG still advances: only the recorded cause changed.
+	settled, err := store.GetJob(ctx, child.ID)
+	if err != nil {
+		t.Fatalf("GetJob(settled) returned error: %v", err)
+	}
+	settledPayload, err := daemonJobPayload(settled)
+	if err != nil {
+		t.Fatalf("daemonJobPayload(settled) returned error: %v", err)
+	}
+	if settledPayload.Result == nil {
+		t.Fatal("the blocked child stored no synthetic result, so the parent DAG was never advanced")
+	}
+}
+
+// #1852 finding 3: the routing tested one arm by equality and let every other
+// state default to the mid-run label, so appending a fourth `from` to the CAS
+// would silently acquire "failed mid-run without a result". The mapper is now
+// exhaustive over the CAS's three arms and REFUSES anything else, so a new arm
+// fails loudly here instead of quietly mislabelling.
+func TestPermissionBlockFinalizerRefusesAnUnenumeratedState(t *testing.T) {
+	worker := defaultJobWorker(daemonWorkerStore(t), io.Discard)
+
+	for _, tc := range []struct {
+		state workflow.JobState
+		want  string
+	}{
+		{workflow.JobQueued, "refused"},
+		{workflow.JobRunning, "midrun"},
+		{workflow.JobFailed, "midrun"},
+	} {
+		finalize, err := worker.permissionBlockFinalizerFor(tc.state)
+		if err != nil {
+			t.Fatalf("permissionBlockFinalizerFor(%q) returned error: %v", tc.state, err)
+		}
+		if finalize == nil {
+			t.Fatalf("permissionBlockFinalizerFor(%q) returned a nil finalizer", tc.state)
+		}
+	}
+
+	// A state the CAS does not accept today. If someone adds it there, this is where
+	// the omission surfaces.
+	finalize, err := worker.permissionBlockFinalizerFor(workflow.JobCancelled)
+	if err == nil {
+		t.Fatalf("permissionBlockFinalizerFor(%q) returned a finalizer with no error; an unenumerated state must not inherit a label", workflow.JobCancelled)
+	}
+	if finalize != nil {
+		t.Fatal("permissionBlockFinalizerFor returned both a finalizer and an error")
+	}
+	if !strings.Contains(err.Error(), string(workflow.JobCancelled)) {
+		t.Fatalf("error = %v, want it to name the unexpected state", err)
+	}
+}

--- a/internal/cli/daemon_advance_blocked_test.go
+++ b/internal/cli/daemon_advance_blocked_test.go
@@ -948,7 +948,7 @@ func TestPermissionBlockDoesNotBlockANewerRun(t *testing.T) {
 		t.Fatalf("admitted generation = %d, observed generation = %d", admitted.LifecycleGeneration, observed.generation)
 	}
 
-	if _, err := markJobPermissionBlocked(ctx, store, admitted); err != nil {
+	if _, _, err := markJobPermissionBlocked(ctx, store, admitted); err != nil {
 		t.Fatalf("markJobPermissionBlocked returned error: %v", err)
 	}
 	after, err := store.GetJob(ctx, "perm-aba")

--- a/internal/cli/daemon_result.go
+++ b/internal/cli/daemon_result.go
@@ -149,6 +149,27 @@ func (w jobWorker) finalizeMidRunDelegationChild(ctx context.Context, jobID stri
 	return w.finalizeDelegationChildTerminal(ctx, jobID, cause, w.finalizeFailedDelegationChild)
 }
 
+// permissionBlockFinalizerFor maps the source state a permission-block CAS
+// actually matched to the finalizer that describes it truthfully. It is an
+// EXHAUSTIVE switch over the three arms markJobPermissionBlockedAtGeneration
+// accepts, with a default that REFUSES rather than guessing: the previous form
+// tested JobQueued by equality and let every other state fall through to the
+// mid-run label, so appending a fourth `from` to that CAS would have silently
+// acquired "failed mid-run without a result" — the same defect one iteration
+// later (#1852). A new arm now fails loudly here instead.
+func (w jobWorker) permissionBlockFinalizerFor(blockedFrom workflow.JobState) (func(context.Context, string, error) error, error) {
+	switch blockedFrom {
+	case workflow.JobQueued:
+		// Never claimed: no adapter, no prompt, no deadline started.
+		return w.finalizePreflightDelegationChild, nil
+	case workflow.JobRunning, workflow.JobFailed:
+		// It ran. A row that reached failed had a run to fail.
+		return w.finalizeMidRunDelegationChild, nil
+	default:
+		return nil, fmt.Errorf("permission block matched unexpected source state %q: no finalizer describes it, and guessing one would record a cause that did not happen", blockedFrom)
+	}
+}
+
 type jobTimeoutEvidence struct {
 	Deadline time.Time
 	Started  time.Time
@@ -210,9 +231,9 @@ func (w jobWorker) handleRunJobError(ctx context.Context, jobID string, observed
 				// #1407 window sits between that read and this write. Both helpers
 				// no-op for a non-delegation job (ParentJobID empty) or one that already
 				// stored a result, so the solo-implement case stays byte-identical.
-				finalize := w.finalizeMidRunDelegationChild
-				if blockedFrom == workflow.JobQueued {
-					finalize = w.finalizePreflightDelegationChild
+				finalize, finalizeErr := w.permissionBlockFinalizerFor(blockedFrom)
+				if finalizeErr != nil {
+					return finalizeErr
 				}
 				if err := finalize(ctx, jobID, errors.New(agentPermissionBlockedMessage)); err != nil {
 					return err

--- a/internal/cli/daemon_worker.go
+++ b/internal/cli/daemon_worker.go
@@ -391,7 +391,7 @@ func (w jobWorker) run(ctx context.Context, job db.Job) error {
 		return nil
 	}
 	if readOnlyImplementationBlocked(job.Type, agent) {
-		transitioned, err := markJobPermissionBlocked(ctx, w.Store, job)
+		transitioned, blockedFrom, err := markJobPermissionBlocked(ctx, w.Store, job)
 		if err != nil {
 			return err
 		}
@@ -416,10 +416,19 @@ func (w jobWorker) run(ctx context.Context, job db.Job) error {
 		// BEFORE finishQueuedJob, via markJobPermissionBlocked (a direct transition)
 		// — and blockTaskForPermissionBlockedJob only blocks the task, it never
 		// advances the parent DAG. So without this the parent strands exactly like
-		// #409. Route the delegation child through the SAME finalize helper so its
-		// failure_policy fires. Gated strictly on a delegation child (ParentJobID set,
-		// Result nil), so a NON-delegation permission-blocked job is byte-identical.
-		if err := w.finalizePreflightDelegationChild(ctx, job.ID, errors.New(agentPermissionBlockedMessage)); err != nil {
+		// #409. Route the delegation child through the finalize helper its MATCHED
+		// SOURCE STATE selects, so its failure_policy fires with a truthful cause.
+		// The admitted row cannot be that witness: queued→running does not bump the
+		// generation this CAS is anchored to, so a concurrent claim makes the
+		// JobRunning arm match and a label keyed on the handed-in row would call a
+		// child that DID run "refused before it ran" (#1852). Gated strictly on a
+		// delegation child (ParentJobID set, Result nil), so a NON-delegation
+		// permission-blocked job is byte-identical.
+		finalize, finalizeErr := w.permissionBlockFinalizerFor(blockedFrom)
+		if finalizeErr != nil {
+			return finalizeErr
+		}
+		if err := finalize(ctx, job.ID, errors.New(agentPermissionBlockedMessage)); err != nil {
 			return err
 		}
 		return nil

--- a/internal/cli/preflight_delegation_finalize_test.go
+++ b/internal/cli/preflight_delegation_finalize_test.go
@@ -972,13 +972,17 @@ func TestMidRunPermissionBlockedNonDelegationUnaffected(t *testing.T) {
 	if cp.Result != nil {
 		t.Fatalf("non-delegation permission-blocked job must NOT get a synthetic result: %+v", cp.Result)
 	}
-	// The kind counted here must be one this path CAN emit, or the guard cannot fail:
-	// the mid-run permission branch now records delegation_runtime_failure_finalized,
-	// so counting delegation_refused_finalized watched a dead string — the same
-	// vacuity this issue removed from lifecycle_race_test.go, reintroduced one file
-	// over (#1512).
-	if n := countWorkerJobEvents(t, store, "impl-job", "delegation_runtime_failure_finalized"); n != 0 {
-		t.Fatalf("delegation_runtime_failure_finalized events = %d, want 0 for a non-delegation job", n)
+	// BOTH kinds must be zero, not just whichever one this path happens to emit
+	// today. Counting only the emitted kind was a swap, not coverage: since
+	// daemon_result.go can now legitimately route a permission-blocked child to the
+	// REFUSED kind as well, a regression leaking either kind onto a NON-delegation
+	// job would go uncounted here (#1852). Counting the emitted kind is what makes
+	// the guard able to fail at all — the previous form watched a dead string
+	// (#1512) — and counting both is what makes it cover the path.
+	for _, kind := range []string{"delegation_runtime_failure_finalized", "delegation_refused_finalized"} {
+		if n := countWorkerJobEvents(t, store, "impl-job", kind); n != 0 {
+			t.Fatalf("%s events = %d, want 0 for a non-delegation job", kind, n)
+		}
 	}
 	// LIVENESS of that counter: the identical assertion on a DELEGATION child of the
 	// same mid-run path must observe exactly one such event, so a rename that killed


### PR DESCRIPTION
Fixes #1852 — the three residuals from #1849's review (`local-review-gm-review-opus-18d22dbbed9e7c5b`, `approved`/P3), which merged as `04b8a311` before they were fixed, plus a correction to a claim #1849 left in `main`.

Base: `origin/main` at `04b8a311`.

## F2 — the label's witness (the one with live consequences)

The **pre-flight** permission-block site keyed its finalize label on the row it was *handed*. That row cannot witness whether the child ran:

- `markJobPermissionBlockedAtGeneration`'s CAS is anchored to a generation and accepts `JobQueued`, `JobRunning`, `JobFailed`.
- `queued→running` does **not** bump the generation. `internal/db/store_jobs.go`'s `bumpLifecycleGenerationSQL` fires only on a transition **to** `queued` — deliberately, so a `queued→queued` write cannot invalidate an in-flight advancement's anchor.
- So a concurrent claim leaves the row `running` at the *same* generation, the CAS's `JobRunning` arm matches, and `daemon_worker.go` recorded *"refused before it ran and never started"* for a child that **did** run — the mirror image of #1848 at the sibling site.

`markJobPermissionBlocked` now passes the matched source state through, and that site routes on it. **This is a defect in the label's witness, not in the anchor** — the anchor does exactly what #1407 built it for. `agent_dispatch.go`'s caller discards the value with a comment saying why (it blocks a job; it never describes the transition afterwards).

I have **not** observed the race in the wild and am not presenting a static argument as a measurement. The claim is about what the anchor *cannot distinguish*, which the SQL decides rather than a schedule.

## F3 — a silent default becomes an exhaustive switch

The routing tested `JobQueued` by equality and let everything else fall through to the mid-run label, so appending a fourth `from` to the CAS would silently acquire *"failed mid-run without a result"*. `permissionBlockFinalizerFor` is now exhaustive over the three accepted arms with a default that **refuses** to label, naming the unexpected state in its error.

## F4 — coverage restored instead of swapped

The non-delegation guard counted only the kind that path emits today. Since a permission-blocked child can now legitimately route to the **refused** kind, a leak of *that* kind was uncounted. It asserts **both** kinds are zero, restoring the property the assertion had before #1849 traded it away.

## F1 — a story fix, no code

#1849's commit body and the comment at `preflight_delegation_finalize_test.go` claimed the forbidden-list guard let `"was not started"` through and that removing it closed a hole. **That was false.** Merged main at `8021b7c7:855` already carried the sound positive assertion `!strings.Contains(ev.Message, "failed mid-run without a result")`; the enumeration beside it was **dead weight**. Dropping it is still right — the real permission message legitimately contains "was not started" — but the rationale overstated what was broken, and the overstatement is in `main`. The comment and this PR's body say what was actually wrong.

Root cause of my error, recorded because it will recur: the probe compared the new guard against a **reconstruction** of the old one, and the reconstruction was missing the very line that made main sound. Every mutation arm in this PR therefore runs against the real blob via `git show 04b8a311:<path>`.

## Discriminators — one behavioural, and two honest negatives

**F2 — fails on the real base blobs.** Production replaced with `git show 04b8a311:` for `daemon_result.go`, `agent_permissions.go`, `daemon_worker.go`, `agent_dispatch.go` (and the base's own `daemon_advance_blocked_test.go`, whose signature differs):
```
--- FAIL: TestPreflightPermissionBlockRoutesOnMatchedStateNotTheHandedRow (0.26s)
    blocked_state_routing_test.go:88: delegation_runtime_failure_finalized events = 0,
      want 1: the CAS matched JobRunning, so this child ran
```
The test stages the interleaving directly: child transitioned `queued→running`, asserts the generation did **not** move, then hands `run()` the stale queued row. All files restored `cmp`-verified byte-identical (`ALL_RESTORED_BYTE_IDENTICAL`).

**F3 — no behavioural arm exists, and I will not claim one.** Its guard exercises `permissionBlockFinalizerFor`, which does not exist at `04b8a311`, so on base the test **fails to compile** — and a build failure proves nothing about behaviour (the same trap I hit in #1849 and reported). What it does prove, on this head, is that an unenumerated state (`JobCancelled`) is refused rather than silently labelled. It is forward-looking hardening; today's three-arm behaviour was already correct, as the reviewer said.

**F4 — no discriminator is achievable, measured not assumed.** I removed the non-delegation short-circuit to make the path leak a kind, then ran both assertion forms against the identical leak:
```
ARM A (old, single-kind): FAIL at :1002  WorkflowFactory builds = 2, want 1
ARM B (new, both-kinds):  FAIL at :1004  WorkflowFactory builds = 2, want 1
```
Both trip the pre-existing `factoryBuilds == 1` check *first*, so the counts never decide — exactly what the reviewer said when calling F4 "a robustness nit, not a hole". The change is coverage hardening with no reachable failure of its own. Production restored `cmp`-verified byte-identical.

## Gate, executed here

Non-`/tmp` tree `/root/gm-reviewfix-c`, `GOTOOLCHAIN=go1.26.4` pinned with the toolchain `PATH`:

```
gofmt -l internal/cli internal/workflow internal/daemon   (empty)
go version                                   go version go1.26.4 linux/amd64
go build -buildvcs=false ./...               BUILD_OK
go vet ./...                                 VET_OK
go generate ./... && git status --porcelain  only the intended files
go test -count=1 -timeout 40m ./internal/cli/        ok 506.541s
go test -count=1 -timeout 40m ./internal/workflow/   ok 117.206s
go test -count=1 -timeout 40m ./internal/daemon/     ok  22.421s
```

Nothing from #1795, #1809, #1845 or any other lane. No new event kinds.
