### PR TITLE
fix(runtime): stop labelling kimi failures as auth from output text (#1857)

### DIFF
--- a/docs/adapters.md
+++ b/docs/adapters.md
@@ -106,6 +106,18 @@ kimi -S <session-id> -p '<job-prompt>' --output-format stream-json
 Kimi runs against a logged-in Kimi CLI. Run `kimi login`, then restart the
 Gitmoot daemon so it inherits the session.
 
+Gitmoot does NOT classify kimi auth failures from the child's output (#1857).
+A failed kimi job reports the CLI's own text and exit cause verbatim, with no
+gitmoot-added "authentication required" label — in either direction, so a
+genuine authorization rejection is unlabelled too. Kimi relays its TOOLS'
+output through the same stdout/stderr it reports itself on, and the previous
+substring test ("login", "authenticate", "unauthorized", "authentication")
+therefore labelled a read-only sandbox denial as an auth failure because the
+GitHub CLI printed `To log in, run: gh auth login` inside it, sending the
+operator to re-login a session that was never the problem. Kimi's stream-json
+envelope carries no error or auth field and the adapter sees no exit code, so
+there is nothing of kimi's own to classify from.
+
 omp (oh-my-pi) startup and every later job run the SAME argument vector — one
 builder, so no flag can appear on one path and go missing on the other:
 

--- a/internal/runtime/adapter_test.go
+++ b/internal/runtime/adapter_test.go
@@ -2412,7 +2412,13 @@ func TestKimiHealthRunsFreshSession(t *testing.T) {
 	runner.want(t, 0, "kimi", "-p", KimiLiveCheckPrompt, "--output-format", "stream-json")
 }
 
-func TestKimiHealthClassifiesAuthFailure(t *testing.T) {
+// TestKimiHealthSurfacesTheChildsOwnFailureText is the post-#1857 contract for
+// what used to be TestKimiHealthClassifiesAuthFailure: gitmoot adds NO auth
+// label of its own, and the kimi CLI's own words survive intact. Kimi relays
+// its tools' output through the same streams it reports itself on, so a
+// gitmoot-added label derived from that text was labelling whichever program
+// happened to speak last.
+func TestKimiHealthSurfacesTheChildsOwnFailureText(t *testing.T) {
 	runner := &fakeRunner{
 		results: []subprocess.Result{{Stderr: "Please run `kimi login` to authenticate."}},
 		errs:    []error{errors.New("exit 1")},
@@ -2425,9 +2431,15 @@ func TestKimiHealthClassifiesAuthFailure(t *testing.T) {
 		t.Fatal("Health accepted auth failure")
 	}
 	errText := err.Error()
-	for _, want := range []string{"Kimi Code authentication required", "kimi login", "restart the Gitmoot daemon"} {
-		if !strings.Contains(errText, want) {
-			t.Fatalf("error missing %q:\n%s", want, errText)
+	if !strings.Contains(errText, "Please run `kimi login` to authenticate.") {
+		t.Fatalf("error dropped the CLI's own text:\n%s", errText)
+	}
+	if !strings.Contains(errText, "exit 1") {
+		t.Fatalf("error dropped the child's own cause:\n%s", errText)
+	}
+	for _, forbidden := range []string{"Kimi Code authentication required", "restart the Gitmoot daemon so it inherits the session"} {
+		if strings.Contains(errText, forbidden) {
+			t.Fatalf("error carries gitmoot's own auth label %q:\n%s", forbidden, errText)
 		}
 	}
 }

--- a/internal/runtime/kimi.go
+++ b/internal/runtime/kimi.go
@@ -12,8 +12,7 @@ import (
 )
 
 const (
-	KimiLiveCheckPrompt  = "Gitmoot Kimi live check. Return OK only."
-	KimiAuthSetupMessage = "Kimi Code background jobs need a logged-in Kimi CLI. Run: kimi login, then restart the Gitmoot daemon so it inherits the session."
+	KimiLiveCheckPrompt = "Gitmoot Kimi live check. Return OK only."
 
 	// kimiMaxArgvPromptBytes is the conservative per-argument size ceiling for
 	// the kimi prompt. Linux caps any SINGLE execve argument at MAX_ARG_STRLEN
@@ -115,7 +114,7 @@ func (a KimiAdapter) Start(ctx context.Context, request StartRequest) (StartResu
 	args = append(args, "-p", promptArg, "--output-format", "stream-json")
 	result, err := a.runner().Run(ctx, a.Dir, "kimi", args...)
 	if err != nil {
-		return StartResult{Raw: result.Stdout + result.Stderr}, kimiCommandError(result, err)
+		return StartResult{Raw: result.Stdout + result.Stderr}, commandError(result, err)
 	}
 	content, sessionID, _, parseErr := parseKimiStreamJSON(result.Stdout)
 	if parseErr != nil {
@@ -164,7 +163,7 @@ func (a KimiAdapter) Deliver(ctx context.Context, agent Agent, job Job) (Result,
 	// The fresh per-job kimi session never reports its id, so SessionID stays
 	// empty; the exit/stderr diagnostics still apply.
 	if err != nil {
-		return Result{Raw: result.Stdout + result.Stderr, SessionDiag: newSessionDiag(result, err, "")}, kimiCommandError(result, err)
+		return Result{Raw: result.Stdout + result.Stderr, SessionDiag: newSessionDiag(result, err, "")}, commandError(result, err)
 	}
 	content, _, usage, parseErr := parseKimiStreamJSON(result.Stdout)
 	if parseErr != nil {
@@ -289,18 +288,34 @@ func isKimiRuntime(runtimeName string) bool {
 	return runtimeName == KimiRuntime
 }
 
-func kimiCommandError(result subprocess.Result, err error) error {
-	base := commandError(result, err)
-	if !isKimiAuthFailure(result) {
-		return base
-	}
-	return fmt.Errorf("Kimi Code authentication required. %s: %w", KimiAuthSetupMessage, base)
-}
-
-func isKimiAuthFailure(result subprocess.Result) bool {
-	text := strings.ToLower(strings.Join([]string{result.Stdout, result.Stderr}, "\n"))
-	return strings.Contains(text, "login") ||
-		strings.Contains(text, "authenticate") ||
-		strings.Contains(text, "unauthorized") ||
-		strings.Contains(text, "authentication")
-}
+// KIMI HAS NO POST-HOC AUTH CLASSIFIER, DELIBERATELY (#1857).
+//
+// kimiCommandError used to wrap any failure whose combined stdout+stderr
+// contained "login", "authenticate", "unauthorized" or "authentication" as
+// "Kimi Code authentication required ... Run: kimi login". Kimi relays its
+// TOOLS' output through those same streams, so the test measured OTHER
+// programs' vocabulary: the measured instance (#1857) was a read-only sandbox
+// denial whose 80,440-char failure text carried the GitHub CLI's own "To log
+// in, run: gh auth login", and gitmoot labelled the sandbox denial an auth
+// failure and sent the operator to re-login a session that was never the
+// problem.
+//
+// Kimi's own machinery offers nothing to classify from: the stream-json
+// envelope (ExtractKimiStreamEvent, transcript_extract.go) carries only
+// role/type/content/session_id/usage/tool_calls, with no error or auth field,
+// and subprocess.Result carries no exit code, so no auth-reserved status is
+// available either. So a failed kimi child now surfaces its own cause
+// UNWRAPPED through commandError, and gitmoot no longer claims to detect kimi
+// auth from text in either direction: a genuine authorization rejection is
+// unlabelled too, which is the deliberate cost of not reporting another
+// program's words as kimi's.
+//
+// The obvious replacement - refuse before running when kimi's stored
+// credential is unusable - is NOT here, and deliberately: kimi has TWO auth
+// sources (credentials/kimi-code.json and the selected provider's api_key/env/
+// oauth key in config.toml, which gitmoot's own read-only staging already
+// treats as credential material in narrowKimiConfigDetailed), and which one
+// actually authenticates is unmeasured. On the host that produced #1857 the
+// token pair is blank while the selected provider's oauth key is populated, so
+// a preflight keyed on the token pair would refuse exactly the sandbox-denied
+// jobs this change stops mislabelling.

--- a/internal/runtime/kimi_auth_signal_test.go
+++ b/internal/runtime/kimi_auth_signal_test.go
@@ -1,0 +1,79 @@
+package runtime
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/gitmoot/gitmoot/internal/subprocess"
+)
+
+// TestKimiDeliverNeverLabelsAFailureAsAuth pins #1857's fix: kimi no longer
+// classifies auth from the child's TEXT, in either direction.
+//
+// Arm 1 is the measured defect. Kimi relays its TOOLS' output through the same
+// stdout/stderr it reports its own failures on, so the pre-fix substring test
+// (isKimiAuthFailure at d3fd2877:internal/runtime/kimi.go:300-306, matching
+// "login"/"authenticate"/"unauthorized"/"authentication" anywhere in
+// stdout+stderr) labelled a read-only sandbox denial as a kimi auth failure
+// because the GitHub CLI printed "To log in, run: gh auth login" inside it. The
+// operator was then told to re-login a session that was never the problem.
+//
+// Arm 2 is the DELIBERATE loss and the contract, not a regret: a genuine kimi
+// authorization rejection is now ALSO returned unwrapped. After this change
+// gitmoot does not claim to detect kimi auth from text at all - kimi's
+// stream-json envelope carries no error or auth field and subprocess.Result
+// carries no exit code, so there is nothing kimi's own machinery offers to
+// classify from, and a test of another program's vocabulary is worse than no
+// test. Both arms assert the SAME contract: whatever the child printed, the
+// error is the child's own cause with no auth wrapper and no login remedy.
+func TestKimiDeliverNeverLabelsAFailureAsAuth(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		stdout string
+		stderr string
+	}{
+		{
+			name:   "another tool's login text is not kimi auth",
+			stdout: "running gh pr view\nTo log in, run: gh auth login\n",
+			stderr: "bwrap: Permission denied\nopen /repo/.git: Permission denied\n",
+		},
+		{
+			name:   "a genuine kimi authorization rejection is also unwrapped",
+			stdout: "",
+			stderr: "kimi: request failed: 401 unauthorized: authentication required\n",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			runner := &fakeRunner{
+				results: []subprocess.Result{{Stdout: tc.stdout, Stderr: tc.stderr}},
+				errs:    []error{errors.New("exit status 1")},
+			}
+			adapter := KimiAdapter{Runner: runner}
+			agent := Agent{Name: "kimi", Role: "implementer", Runtime: KimiRuntime, RuntimeRef: FreshRefForJob("job-1")}
+			_, err := adapter.Deliver(context.Background(), agent, Job{Prompt: "work"})
+			if err == nil {
+				t.Fatal("Deliver returned nil error for a failed child")
+			}
+			got := err.Error()
+			for _, forbidden := range []string{"Kimi Code authentication required", "restart the Gitmoot daemon so it inherits the session"} {
+				if strings.Contains(got, forbidden) {
+					t.Fatalf("error carries gitmoot's own auth label %q: %q", forbidden, got)
+				}
+			}
+			if !strings.Contains(got, "exit status 1") {
+				t.Fatalf("error dropped the child's own cause: %q", got)
+			}
+			// commandError prefers stderr, falling back to stdout, so the
+			// surviving detail is the child's real first-hand text.
+			detail := strings.TrimSpace(tc.stderr)
+			if detail == "" {
+				detail = strings.TrimSpace(tc.stdout)
+			}
+			if !strings.Contains(got, strings.SplitN(detail, "\n", 2)[0]) {
+				t.Fatalf("error dropped the child's own output: %q, want it to carry %q", got, detail)
+			}
+		})
+	}
+}

--- a/website/docs/reference/runtime-adapters.md
+++ b/website/docs/reference/runtime-adapters.md
@@ -26,6 +26,14 @@ agent template and rendered job prompt before handing work to an adapter.
   the limit. Normal-size prompts are passed verbatim as before, unchanged. (The
   Claude and Codex adapters pass the prompt as an argv argument too, but their
   CLIs can also read it from stdin, so they have a native escape hatch.)
+  **Auth failures are not classified from output (#1857):** a failed kimi job
+  reports the CLI's own text and exit cause verbatim, with no gitmoot-added
+  "authentication required" label, and a genuine authorization rejection is
+  unlabelled too. Kimi relays its tools' output through the same streams it
+  reports itself on, so the previous substring test labelled a read-only
+  sandbox denial as an auth failure when the GitHub CLI printed `To log in,
+  run: gh auth login` inside it. Kimi's stream-json envelope carries no error
+  or auth field, so there is nothing of kimi's own to classify from.
 - **omp** is the oh-my-pi CLI (v17.2.4), a multi-provider *routing harness*
   rather than one vendor's CLI. Select it with `gitmoot agent start <name>
   --runtime omp`. It advertises `review`, `implement`, and `ask` — **not**


### PR DESCRIPTION
Fixes #1857.

## The defect

`isKimiAuthFailure` (`d3fd2877:internal/runtime/kimi.go:300-306`) substring-tested the child's **combined stdout+stderr** for `login`, `authenticate`, `unauthorized` or `authentication`, and `kimiCommandError` wrapped any match as `Kimi Code authentication required ... Run: kimi login`.

Kimi relays its **tools'** output through those same streams, so the test measured other programs' vocabulary rather than kimi's. The measured instance (#1857) was a read-only sandbox denial whose 80,440-char failure text carried the GitHub CLI's own `To log in, run: gh auth login`; gitmoot labelled the sandbox denial an auth failure and sent the operator to re-login a session that was never the problem.

## What ships

- `isKimiAuthFailure` deleted.
- `kimiCommandError` deleted rather than kept as a pass-through: both call sites (`Start`, `Deliver`) now call `commandError` directly, which is what "return the base error unwrapped, always" is in code.
- `KimiAuthSetupMessage` deleted with them — after the wrapper goes, it has no production consumer.
- Docs updated in **both** trees (`docs/adapters.md`, `website/docs/reference/runtime-adapters.md`).

**Deliberate loss, worded as the contract and not as a regret:** gitmoot no longer claims to detect kimi auth from text *in either direction*, so a genuine authorization rejection is now unlabelled too. Kimi's stream-json envelope (`ExtractKimiStreamEvent`) carries only role/type/content/session_id/usage/tool_calls — no error or auth field — and `subprocess.Result` carries no exit code, so nothing of kimi's own is available to classify from. A test of another process's words is worse than no test.

## Why there is no preflight replacement

The obvious replacement — refuse before running when the stored credential is unusable — is **not** here, deliberately. Kimi has **two** auth sources:

- `<profile>/credentials/kimi-code.json`, and
- the selected provider's `api_key` / `env` / `[.oauth] key` in `<profile>/config.toml`, which gitmoot's own read-only staging already treats as credential material (`narrowKimiConfigDetailed`, `readonly_seat_config_narrow.go:501-525`; measured on a live host per `daemon_worker.go:2023-2027`).

Measured read-only on the host that produced #1857, no values printed or copied: `credentials/kimi-code.json` is 136 bytes and **valid JSON** with `access_token` and `refresh_token` empty strings and `expires_at` 0, while `config.toml`'s selected provider `[providers."managed:kimi-code"]` has `api_key = ""` but a **non-empty** `[providers."managed:kimi-code".oauth] key`.

Two consequences, both load-bearing:

1. The file is **structurally intact and its token values are empty** — those are the same observation described two ways, and neither "the file is fine" nor "the file is destroyed" is the right summary. A validity check that treats structural presence as usable would read this host as healthy.
2. A preflight keyed on the token pair alone would refuse **every** kimi dispatch on this host, including exactly the sandbox-denied jobs this change stops mislabelling, and would offer `kimi login` as the remedy for a host that may well be logged in. Which source actually authenticates — the config oauth key, the credentials file, or a refresh of one from the other — is **unmeasured**, so no preflight predicate is defensible yet. It is recorded, not built.

## Tests

`internal/runtime/kimi_auth_signal_test.go` — `TestKimiDeliverNeverLabelsAFailureAsAuth`, two arms with `want` actually asserted:

- **arm 1**, the defect: stdout carrying `To log in, run: gh auth login` with stderr `bwrap: Permission denied` → returned **unwrapped**, no auth label, no login remedy, child's own cause and first-hand text preserved.
- **arm 2**, the deliberate loss: `401 unauthorized: authentication required` → **also** unwrapped, and the test says so as the contract.

`TestKimiHealthClassifiesAuthFailure` (which pinned the removed behaviour) is replaced by `TestKimiHealthSurfacesTheChildsOwnFailureText`: the CLI's own words and exit cause survive; gitmoot's label must be absent.

**Discriminator, run both ways against the real base blob** (`git show d3fd2877:internal/runtime/kimi.go` swapped into the tree, production restored `cmp`-verified byte-identical afterwards):

```
=== PRE-FIX, all three arms ===
--- FAIL: TestKimiHealthSurfacesTheChildsOwnFailureText (0.00s)
--- FAIL: TestKimiDeliverNeverLabelsAFailureAsAuth (0.00s)
    --- FAIL: .../another_tool's_login_text_is_not_kimi_auth (0.00s)
    --- FAIL: .../a_genuine_kimi_authorization_rejection_is_also_unwrapped (0.00s)
PRODUCTION_RESTORED_BYTE_IDENTICAL
```

Arm 1's pre-fix message is the defect in one line:

```
error claims a kimi auth failure: "Kimi Code authentication required. Kimi Code
background jobs need a logged-in Kimi CLI. Run: kimi login, ...: bwrap:
Permission denied\nopen /repo/.git: Permission denied: exit status 1"
```

## Gate

`GOTOOLCHAIN=go1.26.4` pinned, non-`/tmp` tree (`/root/gm-reviewfix-c`), `-count=1`:

```
go version go1.26.4 linux/amd64
BUILD_OK          (go build -buildvcs=false ./...)
VET_OK            (go vet ./...)
GENERATE_CLEAN    (go generate ./... left only this PR's own files modified)
ok  internal/runtime   0.191s
ok  internal/workflow  78.468s
ok  internal/daemon    11.935s
FAIL internal/cli      346.276s  -- TestApplyReviewPolicyEmptyHomeIsOff
```

`TestApplyReviewPolicyEmptyHomeIsOff` (`review_risk_test.go:166`, "empty home must resolve blocking severity to P3") is **pre-existing and not this PR's**: it fails identically with this PR's changes stashed, i.e. on `d3fd2877` in the same tree. It touches no file this PR changes. Reported separately rather than fixed here.

## Deploy notes

Runtime-adapter behaviour only; no migration, no config change, no new event kinds. Operators lose gitmoot's synthesized kimi auth message: a failed kimi job now shows the kimi CLI's own text and exit cause. Both doc trees updated in this PR; the website is published manually.
