### PR TITLE
fix(runtime): stop nesting a sandbox inside a codex read-only seat (#1812)

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -734,6 +734,43 @@ export TMPDIR=<seat cache>/tmp GOCACHE=<seat cache>/gocache GOMODCACHE=<seat cac
 - Quote `go version` output in any note making a baseline claim. It is the check
   that works without knowing which binary you got.
 
+### Codex reviews report zero executed checks (`bwrap: setting up uid map`)
+
+A codex read-only seat used to fail EVERY command before running it, so its
+reviews came back static-only with an executed-check count of zero. Codex's own
+sandbox is bwrap, which needs a user namespace that gitmoot's Landlock domain
+denies, so two sandboxes were fighting.
+
+Measured on this box, one command with only the domain differing:
+
+```
+bwrap --dev-bind / / --unshare-user -- /bin/true
+  outside the Landlock domain        -> rc=0
+  inside the domain                  -> rc=1  bwrap: setting up uid map: Permission denied
+  inside + /proc writable            -> rc=1  bwrap: Failed to make / slave
+  inside + /proc + /dev writable     -> rc=1  bwrap: Failed to make / slave
+plain /bin/true inside the domain    -> rc=0
+```
+
+So the domain executes fine and NESTING was the cause; granting more only moved
+the error from the uid map to mount propagation, which is why widening grants
+could not settle it.
+
+A codex seat therefore now runs with its own sandbox OFF and relies on the
+Landlock domain, which is the boundary gitmoot builds and tests. End to end in
+that seat, same grants either way:
+
+- before: `bwrap: setting up uid map: Permission denied`, nothing executed
+- after: `/bin/bash -lc 'echo PROBE_RAN' … succeeded in 0ms: PROBE_RAN`
+- writing outside the granted roots is still refused - `sh: cannot create
+  /root/…: Permission denied`, and no file appears on the host
+
+If a codex seat still reports zero executed checks, the seat's own state
+directory is the usual cause: `CODEX_HOME` must be WRITABLE (it is staged
+inside the seat's cache root). A read-only `CODEX_HOME` fails earlier and
+differently, with `failed to initialize in-process app-server client:
+Permission denied`.
+
 ### A review reporting it could not read prior verdicts
 
 The seat is given a RENDERED, REPO-SCOPED list of prior verdicts inside its own

--- a/internal/runtime/adapter.go
+++ b/internal/runtime/adapter.go
@@ -941,14 +941,42 @@ func effectiveEffort(agent Agent, job Job) string {
 
 func codexSandboxArgs(agent Agent, workdir string) ([]string, PermissionPolicyApplication) {
 	if agent.ReadOnlySeat {
-		args := []string{"--sandbox", "workspace-write"}
-		for _, path := range agent.WritablePaths {
-			if path = strings.TrimSpace(path); path != "" {
-				args = append(args, "--add-dir", path)
-			}
-		}
-		args = append(args, "-c", "sandbox_workspace_write.network_access=true")
-		return args, PermissionPolicyWidened
+		// #1812: A READ-ONLY SEAT MUST NOT NEST A SECOND SANDBOX.
+		//
+		// The seat already runs inside gitmoot's Landlock domain, and codex's
+		// own sandbox is bwrap, which needs a user namespace the domain denies.
+		// Measured on this box, one command with only the domain differing:
+		//
+		//	bwrap --dev-bind / / --unshare-user -- /bin/true
+		//	  outside the domain            -> rc=0
+		//	  inside the domain             -> rc=1, "setting up uid map: Permission denied"
+		//	  inside + /proc writable       -> rc=1, "Failed to make / slave"
+		//	  inside + /proc + /dev writable-> rc=1, "Failed to make / slave"
+		//	plain /bin/true inside the domain -> rc=0
+		//
+		// So the domain itself executes fine and NESTING is the isolated cause.
+		// The grant escalation is also a dead end: /proc write clears the uid
+		// map only to fail on mount propagation, which is why #1812 concluded
+		// grants cannot settle it. Every codex command in such a seat failed
+		// BEFORE running, giving reviews an executed-check count of zero.
+		//
+		// Codex's own help names this exact situation for this exact flag:
+		// "Intended solely for running in environments that are externally
+		// sandboxed". That is what the seat is.
+		//
+		// THE BOUNDARY IS NOT WEAKENED, because it was never codex's: the
+		// Landlock ruleset is unchanged, still read-only outside the seat's
+		// single writable cache root, and it is the boundary gitmoot builds and
+		// tests. Turning codex's sandbox off removes a nested mechanism that
+		// could not start; it grants the seat nothing. --add-dir and the
+		// network toggle are dropped with it because they only ever configured
+		// that sandbox.
+		//
+		// Declared WIDENED, unchanged from the nesting form: this reports what
+		// gitmoot puts on argv relative to the stored autonomy policy, and it
+		// must not claim credit for confinement the runtime is no longer asked
+		// to perform.
+		return []string{"--dangerously-bypass-approvals-and-sandbox"}, PermissionPolicyWidened
 	}
 	switch NormalizeStoredAutonomyPolicy(agent.AutonomyPolicy) {
 	case AutonomyPolicyReadOnly:

--- a/internal/runtime/adapter_test.go
+++ b/internal/runtime/adapter_test.go
@@ -364,7 +364,21 @@ func TestCodexStartCommandAppliesAutonomyPolicy(t *testing.T) {
 	}
 }
 
-func TestCodexDeliverReadOnlySeatCanRunToolsAndNetwork(t *testing.T) {
+// TestCodexDeliverReadOnlySeatDoesNotNestASandbox is #1812's guard, pinned at
+// the PRODUCTION argv path (Deliver -> codexDeliverArgs), not at the helper.
+//
+// A read-only seat already runs inside gitmoot's Landlock domain, and codex's
+// own sandbox is bwrap, which needs a user namespace that domain denies.
+// Measured: `bwrap --dev-bind / / --unshare-user -- /bin/true` returns rc=0
+// outside the domain and rc=1 "setting up uid map: Permission denied" inside,
+// while a plain command inside returns rc=0 - so nesting, not the domain, is
+// the cause. Every codex command in such a seat therefore failed BEFORE
+// running, and reviews came back with an executed-check count of zero.
+//
+// The assertion is deliberately two-sided: the bypass flag must be present AND
+// no sandbox-selecting flag may reappear. Asserting only the former would pass
+// if a future change emitted both.
+func TestCodexDeliverReadOnlySeatDoesNotNestASandbox(t *testing.T) {
 	runner := &fakeRunner{results: []subprocess.Result{{Stdout: "ok"}}}
 	adapter := CodexAdapter{Runner: runner}
 	agent := Agent{
@@ -375,7 +389,20 @@ func TestCodexDeliverReadOnlySeatCanRunToolsAndNetwork(t *testing.T) {
 	if _, err := adapter.Deliver(context.Background(), agent, Job{Prompt: "review"}); err != nil {
 		t.Fatalf("Deliver returned error: %v", err)
 	}
-	runner.want(t, 0, "codex", "exec", "--sandbox", "workspace-write", "--add-dir", "/cache/tools", "-c", "sandbox_workspace_write.network_access=true", "--json", "resume", "--last", "--", "review")
+	runner.want(t, 0, "codex", "exec", "--dangerously-bypass-approvals-and-sandbox", "--json", "resume", "--last", "--", "review")
+
+	// The nesting-prone policy must not return by any route, including beside
+	// the bypass flag.
+	argv := runner.calls[0]
+	for i, arg := range argv {
+		switch arg {
+		case "--sandbox", "-s":
+			t.Fatalf("read-only seat argv selects a codex sandbox at %d (%v): bwrap cannot start inside the Landlock domain", i, argv)
+		}
+		if strings.HasPrefix(arg, "--sandbox=") || strings.HasPrefix(arg, "sandbox_workspace_write.") {
+			t.Fatalf("read-only seat argv configures a codex sandbox at %d (%v)", i, argv)
+		}
+	}
 }
 
 // TestCodexDeliverNonSeatSandboxUnchanged proves a NON-seat read-only job keeps

--- a/website/docs/operations/troubleshooting.md
+++ b/website/docs/operations/troubleshooting.md
@@ -649,6 +649,43 @@ export TMPDIR=<seat cache>/tmp GOCACHE=<seat cache>/gocache GOMODCACHE=<seat cac
 - Quote `go version` output in any note making a baseline claim. It is the check
   that works without knowing which binary you got.
 
+### Codex reviews report zero executed checks (`bwrap: setting up uid map`)
+
+A codex read-only seat used to fail EVERY command before running it, so its
+reviews came back static-only with an executed-check count of zero. Codex's own
+sandbox is bwrap, which needs a user namespace that gitmoot's Landlock domain
+denies, so two sandboxes were fighting.
+
+Measured on this box, one command with only the domain differing:
+
+```
+bwrap --dev-bind / / --unshare-user -- /bin/true
+  outside the Landlock domain        -> rc=0
+  inside the domain                  -> rc=1  bwrap: setting up uid map: Permission denied
+  inside + /proc writable            -> rc=1  bwrap: Failed to make / slave
+  inside + /proc + /dev writable     -> rc=1  bwrap: Failed to make / slave
+plain /bin/true inside the domain    -> rc=0
+```
+
+So the domain executes fine and NESTING was the cause; granting more only moved
+the error from the uid map to mount propagation, which is why widening grants
+could not settle it.
+
+A codex seat therefore now runs with its own sandbox OFF and relies on the
+Landlock domain, which is the boundary gitmoot builds and tests. End to end in
+that seat, same grants either way:
+
+- before: `bwrap: setting up uid map: Permission denied`, nothing executed
+- after: `/bin/bash -lc 'echo PROBE_RAN' … succeeded in 0ms: PROBE_RAN`
+- writing outside the granted roots is still refused - `sh: cannot create
+  /root/…: Permission denied`, and no file appears on the host
+
+If a codex seat still reports zero executed checks, the seat's own state
+directory is the usual cause: `CODEX_HOME` must be WRITABLE (it is staged
+inside the seat's cache root). A read-only `CODEX_HOME` fails earlier and
+differently, with `failed to initialize in-process app-server client:
+Permission denied`.
+
 ### A review reporting it could not read prior verdicts
 
 The seat is given a RENDERED, REPO-SCOPED list of prior verdicts inside its own


### PR DESCRIPTION
Closes #1812.

## The defect

A codex read-only seat failed **every** command before running it, so its reviews returned an executed-check count of zero. Codex's own sandbox is bwrap, which needs a user namespace gitmoot's Landlock domain denies — two sandboxes fighting.

Measured, one command with only the domain differing:

| arm | result |
|---|---|
| `bwrap --dev-bind / / --unshare-user -- /bin/true` **outside** the domain | rc=0 |
| same **inside** the domain | rc=1 `setting up uid map: Permission denied` |
| inside + `/proc` writable | rc=1 `Failed to make / slave` |
| inside + `/proc` + `/dev` writable | rc=1 `Failed to make / slave` |
| plain `/bin/true` inside the domain | rc=0 |

The domain executes fine, so **nesting is the isolated cause**, and escalating grants only moves the error from the uid map to mount propagation — which is why #1812 concluded grants cannot settle it.

## The fix (option 1: stop nesting)

A `ReadOnlySeat` codex dispatch now selects `--dangerously-bypass-approvals-and-sandbox` instead of `workspace-write`. Codex's own help names this case for this flag: *"Intended solely for running in environments that are externally sandboxed."* `--add-dir` and the network toggle go with it — they only configured the sandbox that no longer runs.

**The boundary is not weakened, because it was never codex's.** No new grant: `/proc` stays read-only, `/dev` ungranted, Landlock untouched and still enforced.

End to end in a production-shaped seat, same grants either way:

- **before:** `bwrap: setting up uid map: Permission denied`, nothing executed
- **after:** `/bin/bash -lc 'echo PROBE_RAN' … succeeded in 0ms: PROBE_RAN`
- **escape attempt:** `sh: cannot create /root/…: Permission denied`, and no file on the host

## Verification

Guard pinned at the **production argv path** (`Deliver` → `codexDeliverArgs`), not a helper, and two-sided: the bypass flag must be present **and** no sandbox-selecting flag may reappear — asserting only the former would pass if a future change emitted both.

Mutants, each compiled, `cmp`-proven to change the file, tree restored byte-identical: restore `workspace-write` → **killed**; emit bypass **and** `--sandbox` together → **killed**.

Gate: gofmt clean; vet rc=0; `go generate` idempotent by `cmp`; `go test ./...` → 40 packages ok with **one pre-existing failure unrelated to this change** — `TestApplyReviewPolicyEmptyHomeIsOff` fails identically on pristine `origin/main` (`2752a4d9`) in a tree containing none of my paths. Reported separately, not fixed here.

## One harness error of mine

My first end-to-end probe failed in **both** arms with `failed to initialize in-process app-server client: Permission denied`, which read as the fix not working. Cause was the probe: I had granted `CODEX_HOME` read-only, while a real seat stages it **writable** inside the cache root. Documented in troubleshooting, since it fails earlier and differently from the nesting error.

Not merging.