### PR TITLE
fix(daemon): report a kimi credential that goes blank mid-run (#1856)

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -450,6 +450,29 @@ Fixes:
   that seat credential beside the ambient one, and doctor FAILS (non-zero exit)
   when it is expired with no refresh token, since every read-only seat job on
   that runtime will fail until the account is re-logged in.
+- A kimi credential that goes blank mid-session is REPORTED, not repaired
+  (#1856). Kimi's credential (`~/.kimi-code/credentials/kimi-code.json`) has
+  been observed blanked IN PLACE after a failed refresh: still-valid JSON, 136
+  bytes, with `access_token` and `refresh_token` empty strings and `expires_at`
+  0, while `scope` and `token_type` stay populated. Gitmoot writes that file
+  NOWHERE — the only writer is the vendor CLI — so it cannot make the write
+  atomic, and a safety net whose failure mode is "gitmoot corrupted the owner's
+  credential" would be worse than the defect. Instead the two paths that run a
+  kimi child against the LIVE profile — a non-seat delivery, and `gitmoot agent
+  doctor`'s health check — read the credential immediately before and after the
+  child and report a degradation: the delivery records one
+  `kimi_credential_degraded` job event (on success and failure alike, because
+  the measured case ran to success), and doctor prints the same observation on
+  stderr since a command has no job row. It fires only on a credential that
+  demonstrably carried a token before and demonstrably carries none after, so a
+  host that is simply logged out stays silent, and a reading gitmoot cannot
+  interpret (unreadable file, unmeasured schema) is never treated as evidence in
+  either direction. Read it with `gitmoot job events <job-id>`. **Attribution is
+  inferred, not confirmed**: the event records that a kimi child ran while the
+  file changed, never that this child wrote it. A read-only seat is deliberately
+  NOT observed — it reads a staged clone inside its own writable cache root,
+  which the child may legitimately rewrite, and gitmoot never grants a seat read
+  or write access to the live profile.
 - A Claude `produce` stage does NOT run against the operator profile. The daemon
   copies `.credentials.json` and `settings.json` from the configured account
   (`CLAUDE_CONFIG_DIR`, else `~/.claude`) into a job-private profile, points the

--- a/internal/cli/agent.go
+++ b/internal/cli/agent.go
@@ -2478,9 +2478,22 @@ func runAgentDoctor(args []string, stdout, stderr io.Writer) int {
 		fmt.Fprintf(stdout, "agent %s ok\n", rtAgent.Name)
 		return 0
 	}
-	if err := adapter.Health(context.Background(), rtAgent); err != nil {
+	// #1856 report-only detector, caller 1 of 2: runAgentDoctor's Health path runs
+	// the runtime CLI through the PLAIN runner with no seat sandbox and no staged
+	// profile, so a kimi child here reads the LIVE profile. Bracket it.
+	//
+	// `agent doctor` is a command, not a job, so there is no job row to attach an
+	// event to and the observation is reported on stderr beside the health result.
+	// The daemon's non-seat delivery path records the same observation as a job
+	// event; this one names the command instead.
+	credentialBefore, credentialObserved := observeKimiDoctorCredential(rtAgent)
+	healthErr := adapter.Health(context.Background(), rtAgent)
+	if degraded := kimiCredentialDegradationSinceDoctor(rtAgent, credentialBefore, credentialObserved); degraded != "" {
+		fmt.Fprintf(stderr, "agent %s %s (observed across `gitmoot agent doctor`)\n", rtAgent.Name, degraded)
+	}
+	if healthErr != nil {
 		_ = persistAgentHealth(*home, name, "failed")
-		fmt.Fprintf(stderr, "agent %s health failed: %v\n", rtAgent.Name, err)
+		fmt.Fprintf(stderr, "agent %s health failed: %v\n", rtAgent.Name, healthErr)
 		return 1
 	}
 	if err := persistAgentHealth(*home, name, "ok"); err != nil {
@@ -2489,6 +2502,30 @@ func runAgentDoctor(args []string, stdout, stderr io.Writer) int {
 	}
 	fmt.Fprintf(stdout, "agent %s ok\n", rtAgent.Name)
 	return 0
+}
+
+// observeKimiDoctorCredential reads the live kimi credential a doctor Health
+// check is about to exercise. Non-kimi runtimes and an unresolvable profile
+// return observed=false, so nothing is claimed about them.
+func observeKimiDoctorCredential(agent runtime.Agent) (runtime.KimiCredentialObservation, bool) {
+	if agent.Runtime != runtime.KimiRuntime {
+		return runtime.KimiCredentialObservation{}, false
+	}
+	dir, err := resolveRuntimeConfigDir(runtime.KimiRuntime, agent.RuntimeConfigDir)
+	if err != nil {
+		return runtime.KimiCredentialObservation{}, false
+	}
+	return runtime.ObserveKimiCredential(dir)
+}
+
+// kimiCredentialDegradationSinceDoctor re-reads the same credential after the
+// check and reports only a degradation.
+func kimiCredentialDegradationSinceDoctor(agent runtime.Agent, before runtime.KimiCredentialObservation, observed bool) string {
+	if !observed {
+		return ""
+	}
+	after, ok := observeKimiDoctorCredential(agent)
+	return runtime.KimiCredentialDegradation(before, after, ok)
 }
 
 func persistAgentHealth(home, name, status string) error {

--- a/internal/cli/agent_dispatch.go
+++ b/internal/cli/agent_dispatch.go
@@ -649,6 +649,15 @@ func dispatchLocalAgentJob(ctx context.Context, store *db.Store, request localAg
 		// the daemon worker: it must never replace the foreground job's outcome.
 		_ = quotaHooks.recordRuntimeOutcome(ctx, job, payload, effectiveAgent, runErr, time.Now().UTC())
 	}
+	// #1856: the two LOCAL CLI child-delivery boundaries. They are the arms of
+	// this one if/else - an ask delivers through mailbox.Run and never reaches
+	// engine.RunJob - so bracketing only the else arm would leave foreground and
+	// task-scoped asks, the largest non-seat CLI population, unobserved.
+	//
+	// effectiveAgent is deliberately the observed value rather than `agent`: a
+	// per-job runtime override can make them differ, and the observation must
+	// describe the child that actually ran.
+	credentialBefore, credentialObserved := observeNonSeatKimiCredential(effectiveAgent)
 	if request.Action == "ask" {
 		// Wire the home-aware registry defaults so a foreground ask with no
 		// agent/job model or effort pin honors the runtime's defaults too.
@@ -656,9 +665,11 @@ func dispatchLocalAgentJob(ctx context.Context, store *db.Store, request localAg
 		mailbox := workflow.NewMailbox(store, workflow.UnavailableDeliveryWorktreeResolver("foreground ask delivery"))
 		mailbox.RuntimeDefaultModel = runtimeDefaultModelResolver(request.Home)
 		mailbox.RuntimeDefaultEffort = runtimeDefaultEffortResolver(request.Home)
-		if _, err := mailbox.Run(runCtx, job.ID, effectiveAgent, adapter); err != nil {
-			recordRuntimeOutcome(err)
-			return localAgentJobOutput{}, foregroundAskTimeoutError(runCtx, jobTimeout, err)
+		_, runErr := mailbox.Run(runCtx, job.ID, effectiveAgent, adapter)
+		recordKimiCredentialDegradation(ctx, store, io.Discard, job.ID, effectiveAgent, credentialBefore, credentialObserved)
+		if runErr != nil {
+			recordRuntimeOutcome(runErr)
+			return localAgentJobOutput{}, foregroundAskTimeoutError(runCtx, jobTimeout, runErr)
 		}
 		recordRuntimeOutcome(nil)
 		if err := store.AddJobEvent(ctx, db.JobEvent{JobID: job.ID, Kind: "advance_completed", Message: "workflow advancement completed"}); err != nil {
@@ -670,13 +681,15 @@ func dispatchLocalAgentJob(ctx context.Context, store *db.Store, request localAg
 			workflowHome = paths.Home
 		}
 		engine := daemonWorkflowEngineForRunner(store, newAgentDispatchGitHubClient(checkoutPath), checkoutPath, workflowHome, localDispatchJobRunner(request), nil)
-		if _, err := engine.RunJob(runCtx, job.ID, effectiveAgent, adapter); err != nil {
-			if out, ok, _ := recoverAdvanceErrorOutput(ctx, store, job.ID, request, err); ok {
+		_, runErr := engine.RunJob(runCtx, job.ID, effectiveAgent, adapter)
+		recordKimiCredentialDegradation(ctx, store, io.Discard, job.ID, effectiveAgent, credentialBefore, credentialObserved)
+		if runErr != nil {
+			if out, ok, _ := recoverAdvanceErrorOutput(ctx, store, job.ID, request, runErr); ok {
 				recordRuntimeOutcome(nil)
 				return out, nil
 			}
-			recordRuntimeOutcome(err)
-			return localAgentJobOutput{}, err
+			recordRuntimeOutcome(runErr)
+			return localAgentJobOutput{}, runErr
 		}
 		recordRuntimeOutcome(nil)
 	}

--- a/internal/cli/daemon_worker.go
+++ b/internal/cli/daemon_worker.go
@@ -887,9 +887,9 @@ func (w jobWorker) run(ctx context.Context, job db.Job) error {
 	// runtime CLI against the operator's live profile (a read-only seat reads a
 	// staged clone instead, which the child may legitimately rewrite - so seats
 	// are excluded here rather than filtered later).
-	credentialBefore, credentialObserved := w.observeNonSeatKimiCredential(agent)
+	credentialBefore, credentialObserved := observeNonSeatKimiCredential(agent)
 	_, err = engine.RunJob(runCtx, job.ID, agent, adapter)
-	w.recordKimiCredentialDegradation(ctx, job.ID, agent, credentialBefore, credentialObserved)
+	recordKimiCredentialDegradation(ctx, w.Store, w.Stdout, job.ID, agent, credentialBefore, credentialObserved)
 	stopKillPending()
 	stopProgress()
 	if readOnlyState != nil {
@@ -3177,7 +3177,12 @@ func (w jobWorker) runWithTempWorker(ctx context.Context, job db.Job, payload wo
 		adapter = w.observePermissionPolicyEffects(adapter, delegatedJob.ID, checkout)
 	}
 	engine := w.workflowForJob(checkout, jobRunner)
+	// #1856: the DELEGATED-job delivery route. A delegation child whose action is
+	// neither ask nor review is non-seat (engine_delegation.go only sets
+	// ReadOnlySeat for those two), so a kimi child here reads the LIVE profile.
+	delegatedCredentialBefore, delegatedCredentialObserved := observeNonSeatKimiCredential(started.Agent)
 	_, err = engine.RunJob(runCtx, delegatedJob.ID, started.Agent, adapter)
+	recordKimiCredentialDegradation(ctx, w.Store, w.Stdout, delegatedJob.ID, started.Agent, delegatedCredentialBefore, delegatedCredentialObserved)
 	stopKillPending()
 	if err != nil {
 		if quotaErr := w.quotaRoleUnavailableHooks().recordRuntimeOutcome(ctx, delegatedJob, payload, started.Agent, err, time.Now().UTC()); quotaErr != nil {
@@ -4326,6 +4331,13 @@ func (w jobWorker) defaultCommenter(_ string) github.Client {
 	return github.NewClient("")
 }
 
+// kimiCredentialDegradedEvent names the #1856 report-only observation: the LIVE
+// kimi credential was usable before a non-seat delivery and is not after it.
+// Attribution is INFERRED - the event records that a kimi child ran while the
+// file changed, never that this child wrote it, because gitmoot writes this file
+// nowhere and the only writer is the vendor CLI.
+const kimiCredentialDegradedEvent = "kimi_credential_degraded"
+
 // observeNonSeatKimiCredential reads the LIVE kimi credential a non-seat
 // delivery is about to exercise (#1856).
 //
@@ -4334,7 +4346,12 @@ func (w jobWorker) defaultCommenter(_ string) github.Client {
 // operator's profile and its events would be indistinguishable from real ones.
 // It also observes nothing for other runtimes - claude's credential has its own
 // staging-side machinery (#1808) and codex was never reported for this.
-func (w jobWorker) observeNonSeatKimiCredential(agent runtime.Agent) (runtime.KimiCredentialObservation, bool) {
+//
+// Callers pass the agent DELIVERY actually runs with (the daemon's resolved
+// agent, the dispatch path's effectiveAgent), never the registered row: a
+// per-job runtime override can make those differ, and the observation must
+// describe the child that ran.
+func observeNonSeatKimiCredential(agent runtime.Agent) (runtime.KimiCredentialObservation, bool) {
 	if agent.Runtime != runtime.KimiRuntime || agent.ReadOnlySeat {
 		return runtime.KimiCredentialObservation{}, false
 	}
@@ -4345,26 +4362,44 @@ func (w jobWorker) observeNonSeatKimiCredential(agent runtime.Agent) (runtime.Ki
 	return runtime.ObserveKimiCredential(dir)
 }
 
-// recordKimiCredentialDegradation re-reads the credential after the run and
-// records ONE job event when it got worse, on success and failure alike - a
-// blanking during a run that SUCCEEDS is the measured #1856 shape.
+// recordKimiCredentialDegradation re-reads the credential after the child and
+// records AT MOST ONE job event when it got worse, on success and failure alike
+// - a blanking during a run that SUCCEEDS is the measured #1856 shape.
+//
+// The one-event-per-job bound is enforced HERE rather than left to the call
+// sites' shape. The two CLI dispatch boundaries are mutually exclusive arms of
+// one if/else (agent_dispatch.go's ask arm delivers through mailbox.Run, the
+// else arm through engine.RunJob) so today they cannot double-fire, but a reader
+// should not have to re-derive that from the control flow, and a retried job
+// re-entering delivery must not append a second copy of the same observation.
+// This mirrors recordReadOnlySeatCredentialDiagnosis's existing convention.
 //
 // Report-only: it never writes the credential, and a recording failure is
 // swallowed to a line on stdout rather than affecting the job's outcome.
-func (w jobWorker) recordKimiCredentialDegradation(ctx context.Context, jobID string, agent runtime.Agent, before runtime.KimiCredentialObservation, observed bool) {
-	if !observed {
+func recordKimiCredentialDegradation(ctx context.Context, store *db.Store, stdout io.Writer, jobID string, agent runtime.Agent, before runtime.KimiCredentialObservation, observed bool) {
+	if !observed || store == nil {
 		return
 	}
-	after, ok := w.observeNonSeatKimiCredential(agent)
+	after, ok := observeNonSeatKimiCredential(agent)
 	degraded := runtime.KimiCredentialDegradation(before, after, ok)
 	if degraded == "" {
 		return
 	}
-	if err := w.Store.AddJobEvent(ctx, db.JobEvent{
+	events, err := store.ListJobEvents(ctx, jobID)
+	if err != nil {
+		writeLine(stdout, "job %s kimi credential degradation lookup failed: %v", jobID, err)
+		return
+	}
+	for _, event := range events {
+		if event.Kind == kimiCredentialDegradedEvent {
+			return
+		}
+	}
+	if err := store.AddJobEvent(ctx, db.JobEvent{
 		JobID:   jobID,
 		Kind:    kimiCredentialDegradedEvent,
 		Message: degraded,
 	}); err != nil {
-		writeLine(w.Stdout, "job %s kimi credential degradation record failed: %v", jobID, err)
+		writeLine(stdout, "job %s kimi credential degradation record failed: %v", jobID, err)
 	}
 }

--- a/internal/cli/daemon_worker.go
+++ b/internal/cli/daemon_worker.go
@@ -883,7 +883,13 @@ func (w jobWorker) run(ctx context.Context, job db.Job) error {
 		}
 	}
 	nativeReviewDeliveryStarted = true
+	// #1856 report-only detector, caller 2 of 2: a NON-SEAT delivery runs the
+	// runtime CLI against the operator's live profile (a read-only seat reads a
+	// staged clone instead, which the child may legitimately rewrite - so seats
+	// are excluded here rather than filtered later).
+	credentialBefore, credentialObserved := w.observeNonSeatKimiCredential(agent)
 	_, err = engine.RunJob(runCtx, job.ID, agent, adapter)
+	w.recordKimiCredentialDegradation(ctx, job.ID, agent, credentialBefore, credentialObserved)
 	stopKillPending()
 	stopProgress()
 	if readOnlyState != nil {
@@ -4318,4 +4324,47 @@ func (w jobWorker) workflowHome() string {
 
 func (w jobWorker) defaultCommenter(_ string) github.Client {
 	return github.NewClient("")
+}
+
+// observeNonSeatKimiCredential reads the LIVE kimi credential a non-seat
+// delivery is about to exercise (#1856).
+//
+// It observes nothing for a read-only seat: that child reads a staged clone
+// inside its own writable cache root, so a change there says nothing about the
+// operator's profile and its events would be indistinguishable from real ones.
+// It also observes nothing for other runtimes - claude's credential has its own
+// staging-side machinery (#1808) and codex was never reported for this.
+func (w jobWorker) observeNonSeatKimiCredential(agent runtime.Agent) (runtime.KimiCredentialObservation, bool) {
+	if agent.Runtime != runtime.KimiRuntime || agent.ReadOnlySeat {
+		return runtime.KimiCredentialObservation{}, false
+	}
+	dir, err := resolveRuntimeConfigDir(runtime.KimiRuntime, agent.RuntimeConfigDir)
+	if err != nil {
+		return runtime.KimiCredentialObservation{}, false
+	}
+	return runtime.ObserveKimiCredential(dir)
+}
+
+// recordKimiCredentialDegradation re-reads the credential after the run and
+// records ONE job event when it got worse, on success and failure alike - a
+// blanking during a run that SUCCEEDS is the measured #1856 shape.
+//
+// Report-only: it never writes the credential, and a recording failure is
+// swallowed to a line on stdout rather than affecting the job's outcome.
+func (w jobWorker) recordKimiCredentialDegradation(ctx context.Context, jobID string, agent runtime.Agent, before runtime.KimiCredentialObservation, observed bool) {
+	if !observed {
+		return
+	}
+	after, ok := w.observeNonSeatKimiCredential(agent)
+	degraded := runtime.KimiCredentialDegradation(before, after, ok)
+	if degraded == "" {
+		return
+	}
+	if err := w.Store.AddJobEvent(ctx, db.JobEvent{
+		JobID:   jobID,
+		Kind:    kimiCredentialDegradedEvent,
+		Message: degraded,
+	}); err != nil {
+		writeLine(w.Stdout, "job %s kimi credential degradation record failed: %v", jobID, err)
+	}
 }

--- a/internal/cli/kimi_credential_detector_test.go
+++ b/internal/cli/kimi_credential_detector_test.go
@@ -1,0 +1,187 @@
+package cli
+
+import (
+	"context"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/gitmoot/gitmoot/internal/db"
+	"github.com/gitmoot/gitmoot/internal/runtime"
+)
+
+// #1856 caller tests. Every fixture is a COPY under t.TempDir() pointed at
+// through agent.RuntimeConfigDir: the live profile is never read and never
+// written by these tests, and no kimi binary runs.
+const (
+	kimiDetectorLiveCredential    = `{"access_token":"tok","refresh_token":"ref","expires_at":1788000000,"scope":"coding","token_type":"Bearer"}`
+	kimiDetectorBlankedCredential = `{"access_token":"","refresh_token":"","expires_at":0,"scope":"coding","token_type":"Bearer"}`
+)
+
+func writeKimiDetectorCredential(t *testing.T, profileDir, body string) string {
+	t.Helper()
+	path := filepath.Join(profileDir, runtime.KimiCredentialRelPath)
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		t.Fatalf("MkdirAll returned error: %v", err)
+	}
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatalf("WriteFile returned error: %v", err)
+	}
+	return path
+}
+
+func kimiDetectorEvents(t *testing.T, store *db.Store, jobID string) []db.JobEvent {
+	t.Helper()
+	events, err := store.ListJobEvents(context.Background(), jobID)
+	if err != nil {
+		t.Fatalf("ListJobEvents returned error: %v", err)
+	}
+	var out []db.JobEvent
+	for _, event := range events {
+		if event.Kind == kimiCredentialDegradedEvent {
+			out = append(out, event)
+		}
+	}
+	return out
+}
+
+// TestNonSeatKimiDeliveryRecordsCredentialDegradation is the instrument's
+// reason to exist: the credential carried a token before the run and none
+// after, and the run SUCCEEDED. #1856's own measured window contains a kimi job
+// that succeeded at 13:59:50Z shortly before the blanking, so an instrument
+// that only reported on failures would miss the shape it was built for.
+func TestNonSeatKimiDeliveryRecordsCredentialDegradation(t *testing.T) {
+	store := daemonWorkerStore(t)
+	worker := defaultJobWorker(store, io.Discard)
+	profile := t.TempDir()
+	path := writeKimiDetectorCredential(t, profile, kimiDetectorLiveCredential)
+	agent := runtime.Agent{Name: "kimi-impl", Runtime: runtime.KimiRuntime, RuntimeConfigDir: profile}
+
+	before, observed := worker.observeNonSeatKimiCredential(agent)
+	if !observed || !before.HasToken() {
+		t.Fatalf("pre-run observation = %+v observed = %v, want a token", before, observed)
+	}
+	// The vendor CLI blanking its own credential in place - the measured #1856
+	// shape, reproduced without running kimi.
+	writeKimiDetectorCredential(t, profile, kimiDetectorBlankedCredential)
+
+	worker.recordKimiCredentialDegradation(context.Background(), "job-kimi-1", agent, before, observed)
+
+	events := kimiDetectorEvents(t, store, "job-kimi-1")
+	if len(events) != 1 {
+		t.Fatalf("%s events = %d, want exactly 1", kimiCredentialDegradedEvent, len(events))
+	}
+	message := events[0].Message
+	for _, want := range []string{path, "token/", "blank_token/", "INFERRED"} {
+		if !strings.Contains(message, want) {
+			t.Fatalf("event message %q is missing %q", message, want)
+		}
+	}
+	// Report-only: the observation names the file, never its contents.
+	if strings.Contains(message, "tok") && !strings.Contains(message, "kimi-code.json") {
+		t.Fatalf("event message may not carry credential contents: %q", message)
+	}
+}
+
+// TestReadOnlySeatKimiDeliveryIsNotObserved pins the POPULATION as a property
+// of the code. A seat reads a staged clone inside its own writable cache root,
+// so a change there says nothing about the operator's profile; observing it
+// would emit events indistinguishable from real ones.
+func TestReadOnlySeatKimiDeliveryIsNotObserved(t *testing.T) {
+	store := daemonWorkerStore(t)
+	worker := defaultJobWorker(store, io.Discard)
+	profile := t.TempDir()
+	writeKimiDetectorCredential(t, profile, kimiDetectorLiveCredential)
+
+	for _, tc := range []struct {
+		name  string
+		agent runtime.Agent
+	}{
+		{"read-only seat", runtime.Agent{Name: "kimi-seat", Runtime: runtime.KimiRuntime, RuntimeConfigDir: profile, ReadOnlySeat: true}},
+		{"another runtime", runtime.Agent{Name: "claude", Runtime: runtime.ClaudeRuntime, RuntimeConfigDir: profile}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			before, observed := worker.observeNonSeatKimiCredential(tc.agent)
+			if observed {
+				t.Fatalf("observation = %+v, want none for %s", before, tc.name)
+			}
+			writeKimiDetectorCredential(t, profile, kimiDetectorBlankedCredential)
+			jobID := "job-" + tc.name
+			worker.recordKimiCredentialDegradation(context.Background(), jobID, tc.agent, before, observed)
+			if events := kimiDetectorEvents(t, store, jobID); len(events) != 0 {
+				t.Fatalf("%s events = %d, want 0 for %s", kimiCredentialDegradedEvent, len(events), tc.name)
+			}
+			writeKimiDetectorCredential(t, profile, kimiDetectorLiveCredential)
+		})
+	}
+}
+
+// TestNonSeatKimiDeliveryStaysSilentWithoutADegradation keeps the instrument
+// quiet on the cases that are not the defect: an unchanged credential, and a
+// host that was already logged out before the run.
+func TestNonSeatKimiDeliveryStaysSilentWithoutADegradation(t *testing.T) {
+	store := daemonWorkerStore(t)
+	worker := defaultJobWorker(store, io.Discard)
+
+	for _, tc := range []struct {
+		name   string
+		before string
+		after  string
+	}{
+		{"unchanged token", kimiDetectorLiveCredential, kimiDetectorLiveCredential},
+		{"already blank", kimiDetectorBlankedCredential, kimiDetectorBlankedCredential},
+		{"login during the run", kimiDetectorBlankedCredential, kimiDetectorLiveCredential},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			profile := t.TempDir()
+			writeKimiDetectorCredential(t, profile, tc.before)
+			agent := runtime.Agent{Name: "kimi-impl", Runtime: runtime.KimiRuntime, RuntimeConfigDir: profile}
+			observation, observed := worker.observeNonSeatKimiCredential(agent)
+			if !observed {
+				t.Fatal("expected an observation for a non-seat kimi agent")
+			}
+			writeKimiDetectorCredential(t, profile, tc.after)
+			jobID := "job-silent-" + tc.name
+			worker.recordKimiCredentialDegradation(context.Background(), jobID, agent, observation, observed)
+			if events := kimiDetectorEvents(t, store, jobID); len(events) != 0 {
+				t.Fatalf("%s events = %d, want 0", kimiCredentialDegradedEvent, len(events))
+			}
+		})
+	}
+}
+
+// TestAgentDoctorObservesTheLiveKimiCredential covers caller 1: `gitmoot agent
+// doctor` runs the runtime CLI through the plain runner with no seat sandbox, so
+// its child reads the LIVE profile. Doctor is a command rather than a job, so
+// the observation is reported on stderr and there is no job row to attach.
+func TestAgentDoctorObservesTheLiveKimiCredential(t *testing.T) {
+	profile := t.TempDir()
+	path := writeKimiDetectorCredential(t, profile, kimiDetectorLiveCredential)
+	agent := runtime.Agent{Name: "gm-review-kimi", Runtime: runtime.KimiRuntime, RuntimeConfigDir: profile}
+
+	before, observed := observeKimiDoctorCredential(agent)
+	if !observed || !before.HasToken() {
+		t.Fatalf("pre-check observation = %+v observed = %v, want a token", before, observed)
+	}
+	writeKimiDetectorCredential(t, profile, kimiDetectorBlankedCredential)
+	degraded := kimiCredentialDegradationSinceDoctor(agent, before, observed)
+	if degraded == "" {
+		t.Fatal("a blanked credential across the doctor check must be reported")
+	}
+	for _, want := range []string{path, "blank_token/", "INFERRED"} {
+		if !strings.Contains(degraded, want) {
+			t.Fatalf("report %q is missing %q", degraded, want)
+		}
+	}
+	// A non-kimi agent is not observed at all, so doctor's other runtimes keep
+	// their byte-identical output.
+	claude := runtime.Agent{Name: "claude", Runtime: runtime.ClaudeRuntime, RuntimeConfigDir: profile}
+	if _, ok := observeKimiDoctorCredential(claude); ok {
+		t.Fatal("observeKimiDoctorCredential must not observe a non-kimi runtime")
+	}
+	if report := kimiCredentialDegradationSinceDoctor(claude, before, false); report != "" {
+		t.Fatalf("unobserved agent produced a report: %q", report)
+	}
+}

--- a/internal/cli/kimi_credential_detector_test.go
+++ b/internal/cli/kimi_credential_detector_test.go
@@ -54,12 +54,11 @@ func kimiDetectorEvents(t *testing.T, store *db.Store, jobID string) []db.JobEve
 // that only reported on failures would miss the shape it was built for.
 func TestNonSeatKimiDeliveryRecordsCredentialDegradation(t *testing.T) {
 	store := daemonWorkerStore(t)
-	worker := defaultJobWorker(store, io.Discard)
 	profile := t.TempDir()
 	path := writeKimiDetectorCredential(t, profile, kimiDetectorLiveCredential)
 	agent := runtime.Agent{Name: "kimi-impl", Runtime: runtime.KimiRuntime, RuntimeConfigDir: profile}
 
-	before, observed := worker.observeNonSeatKimiCredential(agent)
+	before, observed := observeNonSeatKimiCredential(agent)
 	if !observed || !before.HasToken() {
 		t.Fatalf("pre-run observation = %+v observed = %v, want a token", before, observed)
 	}
@@ -67,7 +66,7 @@ func TestNonSeatKimiDeliveryRecordsCredentialDegradation(t *testing.T) {
 	// shape, reproduced without running kimi.
 	writeKimiDetectorCredential(t, profile, kimiDetectorBlankedCredential)
 
-	worker.recordKimiCredentialDegradation(context.Background(), "job-kimi-1", agent, before, observed)
+	recordKimiCredentialDegradation(context.Background(), store, io.Discard, "job-kimi-1", agent, before, observed)
 
 	events := kimiDetectorEvents(t, store, "job-kimi-1")
 	if len(events) != 1 {
@@ -85,13 +84,64 @@ func TestNonSeatKimiDeliveryRecordsCredentialDegradation(t *testing.T) {
 	}
 }
 
+// TestKimiCredentialDegradationIsRecordedAtMostOncePerJob pins the bound the
+// #1856 ruling states explicitly. The two CLI dispatch boundaries are mutually
+// exclusive arms of one if/else, so they cannot double-fire today - but the
+// bound is enforced in the recorder rather than left to that control flow, so a
+// retried job re-entering delivery cannot append a second copy of the same
+// observation and a future caller cannot reintroduce the duplicate.
+func TestKimiCredentialDegradationIsRecordedAtMostOncePerJob(t *testing.T) {
+	store := daemonWorkerStore(t)
+	profile := t.TempDir()
+	writeKimiDetectorCredential(t, profile, kimiDetectorLiveCredential)
+	agent := runtime.Agent{Name: "kimi-impl", Runtime: runtime.KimiRuntime, RuntimeConfigDir: profile}
+
+	before, observed := observeNonSeatKimiCredential(agent)
+	if !observed || !before.HasToken() {
+		t.Fatalf("pre-run observation = %+v observed = %v, want a token", before, observed)
+	}
+	writeKimiDetectorCredential(t, profile, kimiDetectorBlankedCredential)
+	for range 3 {
+		recordKimiCredentialDegradation(context.Background(), store, io.Discard, "job-once", agent, before, observed)
+	}
+	if events := kimiDetectorEvents(t, store, "job-once"); len(events) != 1 {
+		t.Fatalf("%s events = %d after three recordings, want exactly 1", kimiCredentialDegradedEvent, len(events))
+	}
+}
+
+// TestDelegatedKimiDeliveryRecordsCredentialDegradation covers the SECOND
+// bracketed delivery route (daemon_worker.go's delegated-job path). A
+// delegation child whose action is neither ask nor review is never given a
+// read-only seat (engine_delegation.go sets ReadOnlySeat only for those two),
+// so its kimi child reads the LIVE profile and belongs to the observed
+// population. The route runs through the SAME recorder, so this test pins the
+// route's coverage rather than re-testing the predicate.
+func TestDelegatedKimiDeliveryRecordsCredentialDegradation(t *testing.T) {
+	store := daemonWorkerStore(t)
+	profile := t.TempDir()
+	writeKimiDetectorCredential(t, profile, kimiDetectorLiveCredential)
+	// A delegation child's own agent, as the delegated path passes it
+	// (started.Agent): an implement action, so no seat.
+	delegated := runtime.Agent{Name: "kimi-delegate", Runtime: runtime.KimiRuntime, RuntimeConfigDir: profile}
+
+	before, observed := observeNonSeatKimiCredential(delegated)
+	if !observed || !before.HasToken() {
+		t.Fatalf("pre-run observation = %+v observed = %v, want a token", before, observed)
+	}
+	writeKimiDetectorCredential(t, profile, kimiDetectorBlankedCredential)
+	recordKimiCredentialDegradation(context.Background(), store, io.Discard, "delegated-kimi-1", delegated, before, observed)
+
+	if events := kimiDetectorEvents(t, store, "delegated-kimi-1"); len(events) != 1 {
+		t.Fatalf("%s events = %d, want exactly 1 for the delegated route", kimiCredentialDegradedEvent, len(events))
+	}
+}
+
 // TestReadOnlySeatKimiDeliveryIsNotObserved pins the POPULATION as a property
 // of the code. A seat reads a staged clone inside its own writable cache root,
 // so a change there says nothing about the operator's profile; observing it
 // would emit events indistinguishable from real ones.
 func TestReadOnlySeatKimiDeliveryIsNotObserved(t *testing.T) {
 	store := daemonWorkerStore(t)
-	worker := defaultJobWorker(store, io.Discard)
 	profile := t.TempDir()
 	writeKimiDetectorCredential(t, profile, kimiDetectorLiveCredential)
 
@@ -103,13 +153,13 @@ func TestReadOnlySeatKimiDeliveryIsNotObserved(t *testing.T) {
 		{"another runtime", runtime.Agent{Name: "claude", Runtime: runtime.ClaudeRuntime, RuntimeConfigDir: profile}},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			before, observed := worker.observeNonSeatKimiCredential(tc.agent)
+			before, observed := observeNonSeatKimiCredential(tc.agent)
 			if observed {
 				t.Fatalf("observation = %+v, want none for %s", before, tc.name)
 			}
 			writeKimiDetectorCredential(t, profile, kimiDetectorBlankedCredential)
 			jobID := "job-" + tc.name
-			worker.recordKimiCredentialDegradation(context.Background(), jobID, tc.agent, before, observed)
+			recordKimiCredentialDegradation(context.Background(), store, io.Discard, jobID, tc.agent, before, observed)
 			if events := kimiDetectorEvents(t, store, jobID); len(events) != 0 {
 				t.Fatalf("%s events = %d, want 0 for %s", kimiCredentialDegradedEvent, len(events), tc.name)
 			}
@@ -123,7 +173,6 @@ func TestReadOnlySeatKimiDeliveryIsNotObserved(t *testing.T) {
 // host that was already logged out before the run.
 func TestNonSeatKimiDeliveryStaysSilentWithoutADegradation(t *testing.T) {
 	store := daemonWorkerStore(t)
-	worker := defaultJobWorker(store, io.Discard)
 
 	for _, tc := range []struct {
 		name   string
@@ -138,13 +187,13 @@ func TestNonSeatKimiDeliveryStaysSilentWithoutADegradation(t *testing.T) {
 			profile := t.TempDir()
 			writeKimiDetectorCredential(t, profile, tc.before)
 			agent := runtime.Agent{Name: "kimi-impl", Runtime: runtime.KimiRuntime, RuntimeConfigDir: profile}
-			observation, observed := worker.observeNonSeatKimiCredential(agent)
+			observation, observed := observeNonSeatKimiCredential(agent)
 			if !observed {
 				t.Fatal("expected an observation for a non-seat kimi agent")
 			}
 			writeKimiDetectorCredential(t, profile, tc.after)
 			jobID := "job-silent-" + tc.name
-			worker.recordKimiCredentialDegradation(context.Background(), jobID, agent, observation, observed)
+			recordKimiCredentialDegradation(context.Background(), store, io.Discard, jobID, agent, observation, observed)
 			if events := kimiDetectorEvents(t, store, jobID); len(events) != 0 {
 				t.Fatalf("%s events = %d, want 0", kimiCredentialDegradedEvent, len(events))
 			}

--- a/internal/cli/kimi_credential_detector_test.go
+++ b/internal/cli/kimi_credential_detector_test.go
@@ -9,6 +9,8 @@ import (
 	"testing"
 
 	"github.com/gitmoot/gitmoot/internal/db"
+	"github.com/gitmoot/gitmoot/internal/github"
+	"github.com/gitmoot/gitmoot/internal/github/githubtest"
 	"github.com/gitmoot/gitmoot/internal/runtime"
 )
 
@@ -232,5 +234,156 @@ func TestAgentDoctorObservesTheLiveKimiCredential(t *testing.T) {
 	}
 	if report := kimiCredentialDegradationSinceDoctor(claude, before, false); report != "" {
 		t.Fatalf("unobserved agent produced a report: %q", report)
+	}
+}
+
+// dispatchArmCredentialProfile redirects HOME to a throwaway profile and writes
+// a live-looking credential into it.
+//
+// The HOME redirect is load-bearing rather than cosmetic: db.Agent carries no
+// RuntimeConfigDir and runtimeAgent sets none, so effectiveAgent.RuntimeConfigDir
+// is EMPTY on the dispatch path and observeNonSeatKimiCredential falls back to
+// $HOME/.kimi-code. Without t.Setenv("HOME", ...) these tests would read the
+// operator's real profile, which is the one thing #1856's work must never do.
+func dispatchArmCredentialProfile(t *testing.T) string {
+	t.Helper()
+	fakeHome := t.TempDir()
+	t.Setenv("HOME", fakeHome)
+	profile := filepath.Join(fakeHome, ".kimi-code")
+	writeKimiDetectorCredential(t, profile, kimiDetectorLiveCredential)
+	return filepath.Join(profile, runtime.KimiCredentialRelPath)
+}
+
+// dispatchArmKimiAdapter returns a fake adapter that blanks the credential IN
+// PLACE while it "delivers" - the measured #1856 shape, reproduced without a
+// kimi binary through the package-level adapter seam five other test files
+// already use (localAgentDispatchRuntimeAdapterFor).
+func dispatchArmKimiAdapter(t *testing.T, credentialPath string) *cliWorkerFakeAdapter {
+	t.Helper()
+	adapter := &cliWorkerFakeAdapter{output: `{"gitmoot_result":{"decision":"approved","summary":"done","findings":[],"changes_made":[],"tests_run":[],"needs":[],"delegations":[]}}`}
+	adapter.onDeliver = func() {
+		if err := os.WriteFile(credentialPath, []byte(kimiDetectorBlankedCredential), 0o600); err != nil {
+			t.Errorf("blanking the fixture credential returned error: %v", err)
+		}
+	}
+	previousAdapter := localAgentDispatchRuntimeAdapterFor
+	localAgentDispatchRuntimeAdapterFor = func(string, runtime.Agent, string) (runtime.Adapter, error) { return adapter, nil }
+	t.Cleanup(func() { localAgentDispatchRuntimeAdapterFor = previousAdapter })
+	previousPreflight := localRuntimeContractPreflight
+	localRuntimeContractPreflight = func(context.Context, runtime.Agent) runtime.RuntimeContractResult {
+		return runtime.RuntimeContractResult{Runtime: runtime.KimiRuntime, Version: "fake", State: runtime.RuntimeContractUnknown, Instrument: "test"}
+	}
+	t.Cleanup(func() { localRuntimeContractPreflight = previousPreflight })
+	return adapter
+}
+
+// TestCLIDispatchArmsObserveCredentialBlanking is the behavioural arm my first
+// PR body wrongly called impossible: it drives dispatchLocalAgentJob end to end
+// on BOTH local child-delivery boundaries and asserts the event.
+//
+// The two arms are separate cases because they are separate code paths, not one
+// path with a flag: an ask delivers through mailbox.Run (agent_dispatch.go's
+// then-branch) and never reaches engine.RunJob (the else branch). Deleting
+// either recorder call fails exactly one of these cases, which is what makes the
+// PR's coverage claim self-checking instead of an argument from symmetry.
+func TestCLIDispatchArmsObserveCredentialBlanking(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		action     string
+		capability string
+	}{
+		{"ask arm delivers through mailbox.Run", "ask", "ask"},
+		{"else arm delivers through engine.RunJob", "implement", "implement"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+			store, home := blockerE2EHome(t)
+			checkout := readonlyWorktreeGitCheckout(t, "owner/repo")
+			seedDaemonWorkerRepo(t, store, "owner/repo", checkout)
+			seedDaemonWorkerAgent(t, store, "kimi-responder", runtime.KimiRuntime, "fresh", []string{tc.capability}, "owner/repo")
+			credentialPath := dispatchArmCredentialProfile(t)
+			dispatchArmKimiAdapter(t, credentialPath)
+
+			out, err := dispatchLocalAgentJob(ctx, store, localAgentDispatchRequest{
+				RepoFlag:     "owner/repo",
+				Agent:        "kimi-responder",
+				Action:       tc.action,
+				Instructions: "work",
+				Home:         home,
+			})
+			if err != nil {
+				t.Fatalf("dispatchLocalAgentJob returned error: %v", err)
+			}
+			events := kimiDetectorEvents(t, store, out.JobID)
+			if len(events) != 1 {
+				t.Fatalf("%s events = %d, want exactly 1 on the %s arm", kimiCredentialDegradedEvent, len(events), tc.action)
+			}
+			message := events[0].Message
+			for _, want := range []string{credentialPath, "token/", "blank_token/", "INFERRED"} {
+				if !strings.Contains(message, want) {
+					t.Fatalf("event message %q is missing %q", message, want)
+				}
+			}
+			if strings.Contains(message, "tok") && !strings.Contains(message, "kimi-code.json") {
+				t.Fatalf("event message may not carry credential contents: %q", message)
+			}
+		})
+	}
+}
+
+// TestForegroundReviewKimiDispatchIsSeatExcluded is an EXCLUSION test and is
+// labelled as one deliberately: it asserts ZERO events, so it would still pass
+// if a bracket were deleted, and it must never be read as coverage of one.
+//
+// What it does prove, at the real CLI dispatch route rather than in the unit
+// table, is the truth table for this file:
+//
+//	Action "ask"       -> arm 1 (mailbox.Run), non-seat  -> observed
+//	Action "implement" -> arm 2 (engine.RunJob), non-seat -> observed
+//	Action "review"    -> arm 2, but a read-only SEAT     -> NOT observed
+//
+// A foreground review allocates a read-only worktree, so effectiveAgent
+// carries ReadOnlySeat=true and the observer declines. The next person to
+// extend this file will reach for "review" as the obvious else-arm case (a
+// coordinator's probe did exactly that and measured zero events); this test
+// records why that is the exclusion rather than the bracket.
+func TestForegroundReviewKimiDispatchIsSeatExcluded(t *testing.T) {
+	ctx := context.Background()
+	store, home := blockerE2EHome(t)
+	checkout := readonlyWorktreeGitCheckout(t, "owner/repo")
+	seedDaemonWorkerRepo(t, store, "owner/repo", checkout)
+	seedDaemonWorkerAgent(t, store, "kimi-reviewer", runtime.KimiRuntime, "fresh", []string{"review"}, "owner/repo")
+	seedDaemonWorkerAgent(t, store, "lead", runtime.ShellRuntime, "unused", []string{"implement"}, "owner/repo")
+	credentialPath := dispatchArmCredentialProfile(t)
+	dispatchArmKimiAdapter(t, credentialPath)
+	previousGitHubFactory := newAgentDispatchGitHubClient
+	newAgentDispatchGitHubClient = func(string) github.Client { return githubtest.NoopClient{} }
+	t.Cleanup(func() { newAgentDispatchGitHubClient = previousGitHubFactory })
+
+	out, err := dispatchLocalAgentJob(ctx, store, localAgentDispatchRequest{
+		RepoFlag: "owner/repo", Agent: "kimi-reviewer", LeadAgent: "lead",
+		Action: "review", Instructions: "review the head", PullRequest: 7,
+		Branch: "main", HeadSHA: readonlyWorktreeHead(t, checkout), Home: home,
+	})
+	if err != nil {
+		t.Fatalf("dispatchLocalAgentJob returned error: %v", err)
+	}
+	events, err := store.ListJobEvents(ctx, out.JobID)
+	if err != nil {
+		t.Fatalf("ListJobEvents returned error: %v", err)
+	}
+	seat := false
+	for _, event := range events {
+		if event.Kind == "readonly_worktree_allocated" {
+			seat = true
+		}
+		if event.Kind == kimiCredentialDegradedEvent {
+			t.Fatalf("a read-only seat dispatch must not be observed: %s", event.Message)
+		}
+	}
+	// Without this the test could pass by never having taken the seat path at
+	// all, which would make its zero-event assertion vacuous.
+	if !seat {
+		t.Fatal("expected a readonly_worktree_allocated event: the review dispatch did not take the seat path, so the exclusion was not exercised")
 	}
 }

--- a/internal/cli/readonly_seat_credential.go
+++ b/internal/cli/readonly_seat_credential.go
@@ -207,6 +207,13 @@ func readOnlySeatRuntimeAuthEnvForPaths(paths config.Paths, runtimeName string, 
 
 const readOnlySeatCredentialExpiredEvent = "readonly_seat_credential_expired"
 
+// kimiCredentialDegradedEvent names the #1856 report-only observation: the LIVE
+// kimi credential was usable before a non-seat delivery and is not after it.
+// Attribution is INFERRED - the event records that a kimi child ran while the
+// file changed, never that this child wrote it, because gitmoot writes this
+// file nowhere and the only writer is the vendor CLI.
+const kimiCredentialDegradedEvent = "kimi_credential_degraded"
+
 func (w jobWorker) recordReadOnlySeatCredentialDiagnosis(ctx context.Context, jobID, diagnosis string) error {
 	events, err := w.Store.ListJobEvents(ctx, jobID)
 	if err != nil {

--- a/internal/cli/readonly_seat_credential.go
+++ b/internal/cli/readonly_seat_credential.go
@@ -207,13 +207,6 @@ func readOnlySeatRuntimeAuthEnvForPaths(paths config.Paths, runtimeName string, 
 
 const readOnlySeatCredentialExpiredEvent = "readonly_seat_credential_expired"
 
-// kimiCredentialDegradedEvent names the #1856 report-only observation: the LIVE
-// kimi credential was usable before a non-seat delivery and is not after it.
-// Attribution is INFERRED - the event records that a kimi child ran while the
-// file changed, never that this child wrote it, because gitmoot writes this
-// file nowhere and the only writer is the vendor CLI.
-const kimiCredentialDegradedEvent = "kimi_credential_degraded"
-
 func (w jobWorker) recordReadOnlySeatCredentialDiagnosis(ctx context.Context, jobID, diagnosis string) error {
 	events, err := w.Store.ListJobEvents(ctx, jobID)
 	if err != nil {

--- a/internal/runtime/kimi_credential.go
+++ b/internal/runtime/kimi_credential.go
@@ -1,0 +1,171 @@
+package runtime
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// #1856's report-only detector: observe the credential a kimi child reads,
+// before and after it runs, and report a DEGRADATION.
+//
+// The defect: <profile>/credentials/kimi-code.json was blanked in place - 136
+// bytes of still-valid JSON whose access_token and refresh_token became empty
+// strings and expires_at 0, while scope and token_type stayed populated
+// (measured read-only, 2026-09-04; see #1856 issuecomment-5546404156).
+// Structural presence is therefore NOT usability: a predicate that asks only
+// "does the file parse" reads that host as healthy, which is why the one below
+// reads token VALUES.
+//
+// Gitmoot writes this file NOWHERE - the only writer is the vendor CLI - so the
+// atomic-write fix the issue originally asked for is unimplementable in this
+// tree, and a safety net whose failure mode is "gitmoot corrupted the owner's
+// credential" is worse than the defect. What gitmoot can do at zero risk is
+// WATCH, confirming or refuting the mechanism from traffic that already exists
+// rather than provoking a fresh failure.
+//
+// This file is a PURE HELPER: it reads the path it is given and nothing else,
+// it never writes, and it decides no policy. The CALLERS choose which
+// invocations to bracket, which is what makes the observed population a
+// property of the code rather than of a comment. It is deliberately NOT called
+// from KimiAdapter.Deliver: that would also cover read-only seats, whose
+// profile is a throwaway clone the child may legitimately rewrite, and those
+// events would be indistinguishable from real ones.
+const (
+	KimiCredentialAbsent      = "absent"
+	KimiCredentialEmptyFile   = "empty_file"
+	KimiCredentialUnparseable = "unparseable"
+	KimiCredentialBlankToken  = "blank_token"
+	KimiCredentialToken       = "token"
+	KimiCredentialUnknown     = "unknown_schema"
+)
+
+// KimiCredentialRelPath is the credential kimi reads inside its profile
+// directory. It matches the read-only seat staging policy's own constant for
+// the same file.
+var KimiCredentialRelPath = filepath.Join("credentials", "kimi-code.json")
+
+// KimiCredentialObservation is one reading of the credential: never its
+// contents, only where it is, how big it is, and which state it is in.
+type KimiCredentialObservation struct {
+	Path  string
+	Size  int64
+	State string
+}
+
+// String renders the observation for an event message. It carries no secret:
+// State is a classification and Size is a byte count.
+func (o KimiCredentialObservation) String() string {
+	return fmt.Sprintf("%s/%dB", o.State, o.Size)
+}
+
+// HasToken reports POSITIVE evidence that this reading carried a token gitmoot
+// could see. An unreadable file and an unmeasured schema are NOT positive
+// evidence, so they answer false here.
+func (o KimiCredentialObservation) HasToken() bool {
+	return o.State == KimiCredentialToken
+}
+
+// Unusable reports POSITIVE evidence that this reading carried no usable token.
+// The two readings gitmoot cannot interpret - an unreadable file and a schema it
+// has not measured - answer false, so an uninterpretable reading never becomes
+// evidence in either direction.
+//
+// HasToken and Unusable are deliberately NOT complements: between them sits the
+// "gitmoot cannot tell" region, and the whole #1856 lesson is that guessing
+// inside that region is how a detector starts reporting things it did not see.
+func (o KimiCredentialObservation) Unusable() bool {
+	switch o.State {
+	case KimiCredentialAbsent, KimiCredentialEmptyFile, KimiCredentialUnparseable, KimiCredentialBlankToken:
+		return true
+	default:
+		return false
+	}
+}
+
+// ObserveKimiCredential reads the credential's state inside profileDir. It
+// never writes, and it never returns the token - only path, size and state.
+// ok=false means there was no path to read, which is not an observation.
+func ObserveKimiCredential(profileDir string) (KimiCredentialObservation, bool) {
+	profileDir = strings.TrimSpace(profileDir)
+	if profileDir == "" {
+		return KimiCredentialObservation{}, false
+	}
+	observation := KimiCredentialObservation{Path: filepath.Join(profileDir, KimiCredentialRelPath)}
+	info, err := os.Stat(observation.Path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			observation.State = KimiCredentialAbsent
+			return observation, true
+		}
+		observation.State = KimiCredentialUnknown
+		return observation, true
+	}
+	observation.Size = info.Size()
+	raw, err := os.ReadFile(observation.Path)
+	if err != nil {
+		observation.State = KimiCredentialUnknown
+		return observation, true
+	}
+	observation.State = ClassifyKimiCredential(raw)
+	return observation, true
+}
+
+// ClassifyKimiCredential names what the credential bytes are, keying on the
+// TOKEN VALUES rather than on the file's structure.
+//
+// KimiCredentialBlankToken is reported only when a known token field is present
+// and every known field is empty - the measured #1856 shape. A file that parses
+// but carries neither field is KimiCredentialUnknown, because an unmeasured
+// schema is not evidence about a host.
+func ClassifyKimiCredential(raw []byte) string {
+	if strings.TrimSpace(string(raw)) == "" {
+		return KimiCredentialEmptyFile
+	}
+	var fields map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &fields); err != nil {
+		return KimiCredentialUnparseable
+	}
+	known := false
+	for _, name := range []string{"access_token", "refresh_token"} {
+		value, ok := fields[name]
+		if !ok {
+			continue
+		}
+		known = true
+		var token string
+		if err := json.Unmarshal(value, &token); err != nil {
+			return KimiCredentialUnknown
+		}
+		if strings.TrimSpace(token) != "" {
+			return KimiCredentialToken
+		}
+	}
+	if !known {
+		return KimiCredentialUnknown
+	}
+	return KimiCredentialBlankToken
+}
+
+// KimiCredentialDegradation returns the message for a credential that DEMONSTRABLY
+// carried a token before an invocation and DEMONSTRABLY carries none after it, or
+// "" when nothing observable got worse.
+//
+// Both sides require positive evidence, and that asymmetry is the point: a
+// reading gitmoot cannot interpret on EITHER side reports nothing, rather than
+// being counted as "had a token" (which would invent a degradation) or as "lost
+// it" (which would invent a cause). It reports ONE TRANSITION, not the
+// credential's standing state, so a host that is simply logged out does not emit
+// an event on every job, and a login during the run emits nothing at all.
+//
+// Attribution is INFERRED - the message says a kimi child ran while the file
+// changed, which is not proof that this child wrote it.
+func KimiCredentialDegradation(before, after KimiCredentialObservation, observed bool) string {
+	if !observed || !before.HasToken() || !after.Unusable() {
+		return ""
+	}
+	return fmt.Sprintf("kimi credential %s degraded while a kimi child ran: %s -> %s; gitmoot never writes this file, so the writer is the kimi CLI (INFERRED from the observation window, not confirmed)",
+		after.Path, before, after)
+}

--- a/internal/runtime/kimi_credential_test.go
+++ b/internal/runtime/kimi_credential_test.go
@@ -1,0 +1,124 @@
+package runtime
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// kimiBlankedCredential is the MEASURED #1856 shape: still-valid JSON, both
+// token values empty, expires_at 0, while scope and token_type stay populated.
+// It is the fixture that makes "structural presence is not usability"
+// falsifiable - a predicate keyed on key presence or parseability calls this
+// healthy.
+const kimiBlankedCredential = `{"access_token":"","refresh_token":"","expires_at":0,"scope":"coding","token_type":"Bearer","expires_in":0}`
+
+const kimiLiveCredential = `{"access_token":"tok-live","refresh_token":"ref-live","expires_at":1788000000,"scope":"coding","token_type":"Bearer","expires_in":3600}`
+
+func TestClassifyKimiCredentialReadsTokenValuesNotStructure(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		raw  string
+		want string
+	}{
+		{"blanked in place is not usable", kimiBlankedCredential, KimiCredentialBlankToken},
+		{"a populated token pair is usable", kimiLiveCredential, KimiCredentialToken},
+		{"a refresh token alone still counts", `{"access_token":"","refresh_token":"ref-only"}`, KimiCredentialToken},
+		{"whitespace only", "  \n\t", KimiCredentialEmptyFile},
+		{"not json", "{oops", KimiCredentialUnparseable},
+		{"parses but names no token field", `{"scope":"coding"}`, KimiCredentialUnknown},
+		{"token field of an unmeasured type", `{"access_token":{"nested":true}}`, KimiCredentialUnknown},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := ClassifyKimiCredential([]byte(tc.raw)); got != tc.want {
+				t.Fatalf("ClassifyKimiCredential = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestObserveKimiCredentialNeverWritesAndReportsSizeAndState(t *testing.T) {
+	dir := t.TempDir()
+	if observation, ok := ObserveKimiCredential(dir); !ok || observation.State != KimiCredentialAbsent {
+		t.Fatalf("absent credential: observation = %+v ok = %v, want state %q", observation, ok, KimiCredentialAbsent)
+	}
+	if _, ok := ObserveKimiCredential("  "); ok {
+		t.Fatal("an empty profile dir must not produce an observation")
+	}
+	path := filepath.Join(dir, KimiCredentialRelPath)
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		t.Fatalf("MkdirAll returned error: %v", err)
+	}
+	if err := os.WriteFile(path, []byte(kimiLiveCredential), 0o600); err != nil {
+		t.Fatalf("WriteFile returned error: %v", err)
+	}
+	before, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("Stat returned error: %v", err)
+	}
+	observation, ok := ObserveKimiCredential(dir)
+	if !ok || observation.State != KimiCredentialToken {
+		t.Fatalf("live credential: observation = %+v ok = %v, want state %q", observation, ok, KimiCredentialToken)
+	}
+	if observation.Size != int64(len(kimiLiveCredential)) {
+		t.Fatalf("observation.Size = %d, want %d", observation.Size, len(kimiLiveCredential))
+	}
+	if observation.Path != path {
+		t.Fatalf("observation.Path = %q, want %q", observation.Path, path)
+	}
+	// Report-only: reading must not touch the file at all.
+	after, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("Stat returned error: %v", err)
+	}
+	if !after.ModTime().Equal(before.ModTime()) || after.Size() != before.Size() {
+		t.Fatalf("observation mutated the credential: %v/%d -> %v/%d", before.ModTime(), before.Size(), after.ModTime(), after.Size())
+	}
+	// And it must never carry the token into the record.
+	if strings.Contains(observation.String(), "tok-live") {
+		t.Fatalf("observation leaked the token: %q", observation.String())
+	}
+}
+
+// TestKimiCredentialDegradationReportsOneTransitionOnly pins the predicate that
+// keeps this instrument quiet: it fires on usable -> unusable and on nothing
+// else, so a host that is simply logged out does not emit on every job, and a
+// reading gitmoot cannot interpret never becomes evidence.
+func TestKimiCredentialDegradationReportsOneTransitionOnly(t *testing.T) {
+	obs := func(state string, size int64) KimiCredentialObservation {
+		return KimiCredentialObservation{Path: "/p/credentials/kimi-code.json", Size: size, State: state}
+	}
+	for _, tc := range []struct {
+		name     string
+		before   KimiCredentialObservation
+		after    KimiCredentialObservation
+		observed bool
+		want     bool
+	}{
+		{"token blanked in place is the #1856 shape", obs(KimiCredentialToken, 210), obs(KimiCredentialBlankToken, 136), true, true},
+		{"token to absent", obs(KimiCredentialToken, 210), obs(KimiCredentialAbsent, 0), true, true},
+		{"token to unparseable", obs(KimiCredentialToken, 210), obs(KimiCredentialUnparseable, 12), true, true},
+		{"already blank stays silent", obs(KimiCredentialBlankToken, 136), obs(KimiCredentialBlankToken, 136), true, false},
+		{"unchanged token stays silent", obs(KimiCredentialToken, 210), obs(KimiCredentialToken, 210), true, false},
+		{"a login during the run stays silent", obs(KimiCredentialBlankToken, 136), obs(KimiCredentialToken, 210), true, false},
+		{"an unmeasured schema before is not evidence", obs(KimiCredentialUnknown, 90), obs(KimiCredentialBlankToken, 136), true, false},
+		{"an unmeasured schema after is not evidence", obs(KimiCredentialToken, 210), obs(KimiCredentialUnknown, 90), true, false},
+		{"no observation, no report", obs(KimiCredentialToken, 210), obs(KimiCredentialBlankToken, 136), false, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got := KimiCredentialDegradation(tc.before, tc.after, tc.observed)
+			if (got != "") != tc.want {
+				t.Fatalf("KimiCredentialDegradation = %q, want reported = %v", got, tc.want)
+			}
+			if !tc.want {
+				return
+			}
+			for _, want := range []string{tc.after.Path, tc.before.String(), tc.after.String(), "INFERRED"} {
+				if !strings.Contains(got, want) {
+					t.Fatalf("message %q is missing %q", got, want)
+				}
+			}
+		})
+	}
+}

--- a/website/docs/operations/troubleshooting.md
+++ b/website/docs/operations/troubleshooting.md
@@ -320,6 +320,29 @@ beside the ambient one, and doctor FAILS (non-zero exit) when it is expired with
 no refresh token, since every read-only seat job on that runtime will fail until
 the account is re-logged in.
 
+A kimi credential that goes blank mid-session is REPORTED, not repaired (#1856).
+Kimi's credential (`~/.kimi-code/credentials/kimi-code.json`) has been observed
+blanked IN PLACE after a failed refresh: still-valid JSON, 136 bytes, with
+`access_token` and `refresh_token` empty strings and `expires_at` 0, while
+`scope` and `token_type` stay populated. Gitmoot writes that file NOWHERE — the
+only writer is the vendor CLI — so it cannot make the write atomic, and a safety
+net whose failure mode is "gitmoot corrupted the owner's credential" would be
+worse than the defect. Instead the two paths that run a kimi child against the
+LIVE profile — a non-seat delivery, and `gitmoot agent doctor`'s health check —
+read the credential immediately before and after the child and report a
+degradation: the delivery records one `kimi_credential_degraded` job event (on
+success and failure alike, because the measured case ran to success), and doctor
+prints the same observation on stderr since a command has no job row. It fires
+only on a credential that demonstrably carried a token before and demonstrably
+carries none after, so a host that is simply logged out stays silent, and a
+reading gitmoot cannot interpret (unreadable file, unmeasured schema) is never
+treated as evidence in either direction. Read it with `gitmoot job events
+<job-id>`. **Attribution is inferred, not confirmed**: the event records that a
+kimi child ran while the file changed, never that this child wrote it. A
+read-only seat is deliberately NOT observed — it reads a staged clone inside its
+own writable cache root, which the child may legitimately rewrite, and gitmoot
+never grants a seat read or write access to the live profile.
+
 A Claude `produce` stage does NOT run against the operator profile. The daemon
 copies `.credentials.json` and `settings.json` from the configured account
 (`CLAUDE_CONFIG_DIR`, else `~/.claude`) into a job-private profile, points the


### PR DESCRIPTION
Fixes #1856.

## What the issue asked for, and why that exact fix is unimplementable here

The filed requirement was that a failed refresh leave the prior credential byte-identical, "with the write done to a temp file and renamed only on success". **Gitmoot writes `credentials/kimi-code.json` nowhere.** Every non-test reference reads or copies it (`daemon_worker.go:2014/2015/2018/2019`, `:2673`, `readonly_seat_credential.go:323`). The only writer is the vendor CLI, so gitmoot cannot make that write atomic, and a safety net whose failure mode is *"gitmoot corrupted the owner's credential"* would be worse than the defect.

## The authorized narrow guard measured EMPTY against its own symptom

Restricting protection to "dispatches that already stage" cannot help, because a staged seat child has **no access to the live profile at all**: `readOnlyRuntimeSandboxGrants` sets `grants.writes = []string{grants.cacheRoot}` (`daemon_worker.go:1853`) and `grants.reads` receives only the checkout plus `reviewGitMetadataPaths` (`:1856-1861`); `prepareReadOnlyRuntimeState` reads `~/.kimi-code` **in the gitmoot process** and copies (`:2061-2110`). The guard is therefore dropped rather than shipped inert. The full class discovery — grant sets, the two-job window, the mtime, the 2.4-second correlation, the reachability enumeration — is recorded in [#1856 issuecomment-5546404156](https://github.com/gitmoot/gitmoot/issues/1856#issuecomment-5546404156) rather than restated here.

## Coverage — which boundaries are observed, and which are not

Stated explicitly because an instrument that observes one route while the body says "non-seat deliveries" is a claim wider than its measurement.

**Observed — all four child-delivery boundaries where a kimi child can read the LIVE profile:**

| Boundary | Route |
|---|---|
| `daemon_worker.go` `engine.RunJob` (job path) | daemon delivery |
| `daemon_worker.go` `engine.RunJob` (delegated path) | delegation child whose action is neither ask nor review — never seat-wrapped |
| `agent_dispatch.go` `mailbox.Run` | **foreground / task-scoped ask** — this arm never reaches `engine.RunJob` |
| `agent_dispatch.go` `engine.RunJob` | every other local CLI dispatch |

The two dispatch sites are the arms of a single `if/else`, so they cannot double-fire; both observe `effectiveAgent` (not the registered agent), because a per-job runtime override can make those differ and the observation must describe the child that ran. The before-reading is taken **once above the branch**, so one-event-per-job follows from the control flow as well as from the recorder's own dedupe.

The dispatch callers pass `io.Discard` as the recorder's log sink, deliberately: on the foreground CLI path a *recording* failure would otherwise print a diagnostic into the operator's job output, and report-only means the instrument must never alter what a job shows or returns. The observation itself still lands in the job's event stream through the same `AddJobEvent`; only the recorder's own failure line is dropped. The daemon callers pass `w.Stdout`, where a daemon-log line is the right place for it.

**Not observed, with the reason for each:**

- **`KimiAdapter.Start`** (`kimi.go:115`). `wrapReadOnlySandboxAdapter` wraps a `workflow.DeliveryAdapter`, which is Deliver-only, so no seat wrapper exists on the Start path at all — but no path sets `ReadOnlySeat` on a Start agent either, so this is **latent, not live**: every Start site passes a registered/temp/ephemeral agent. Left alone rather than widened on a latent gap.
- **`internal/doctor/checker.go:132`** (`kimi --version` under `gitmoot doctor`). A live-profile invocation, but `--version` has no reason to refresh a token; listed for completeness rather than because it is suspected.
- **Read-only seats, deliberately** — a seat reads a staged clone in its own writable cache root, and gitmoot grants a seat neither read nor write on the live profile.

## What ships: the report-only detector

A pure helper in `internal/runtime/kimi_credential.go` reads a credential's path, size and state and decides no policy. The **callers** choose the population, which makes it a property of the code rather than of a comment:

1. **Non-seat delivery** (`daemon_worker.go`, bracketing `engine.RunJob`) records one `kimi_credential_degraded` job event.
2. **`gitmoot agent doctor`'s health check** (`agent.go`) prints the same observation on stderr — a command has no job row to attach to.

Both report **on success and failure alike**: `SessionDiag`/`FailureDiagnostics` are failure-only (`mailbox.go:1681`, `daemon_result.go:490`), and the measured #1856 window contains a kimi job that **succeeded** at 13:59:50Z shortly before the blanking, so a failure-only instrument would miss the shape it exists for.

Deliberately **not** placed inside `KimiAdapter.Deliver`: that would also cover read-only seats, whose profile is a throwaway clone the child may legitimately rewrite, and those events would be indistinguishable from real ones.

### The predicate

- Reads **token values** (`access_token`, `refresh_token`), not key presence. Structural presence is not usability, and this host is the proof: 136 bytes of valid JSON with both tokens empty would read *healthy* under a parse-only check.
- Requires **positive evidence on both sides** — `HasToken()` before, `Unusable()` after. These are deliberately not complements: between them sits a "gitmoot cannot tell" region (unreadable file, unmeasured schema), and a reading in it is never evidence in either direction.
- Reports **one transition**, not a standing state: an already-blank host, an unchanged credential, and a login during the run all stay silent.

### Attribution

**INFERRED, never confirmed.** The event records that a kimi child ran while the file changed — not that this child wrote it. On the observed instance, two `persistAgentHealth(..., "failed")` arms are reachable for a kimi agent (`agent.go:2436`, Validate-failed with no child; and the post-Health arm), and this PR does not assert which fired. The detector is the instrument that can settle it from real traffic — the experiment the forbidden live-profile probe would have run.

## Report-only means report-only

No new write path to the credential, no probe, no HOME override, nothing written under `/root/.kimi-code`, no snapshot-and-restore. The staging path (`readOnlyRuntimeSandboxGrants`, `prepareReadOnlyRuntimeState`) is untouched. Tests fixture a **copy** under `t.TempDir()` and point the helper at it through `RuntimeConfigDir`; no test reads the live profile and no kimi binary runs.

## Tests — 16 helper subtests plus 4 caller tests

`internal/runtime/kimi_credential_test.go`: classification table including the measured blanked-in-place fixture; an observation test that asserts the read **mutates nothing** (mtime and size unchanged) and leaks no token; and a 9-row transition table.

`internal/cli/kimi_credential_detector_test.go`: a successful non-seat run whose credential goes blank records exactly one event carrying path, both states and `INFERRED`; the delegated route recorded through the same recorder; **at most one event per job** across three recordings; a read-only seat and a non-kimi runtime record **zero**; three silence cases; and the doctor path reported on its own.

### Both CLI dispatch arms are covered behaviourally — and an earlier version of this body was wrong about that

An earlier revision of this section said a behavioural test of either dispatch arm "would need a real `kimi` binary". **That was factually incorrect**, and correcting it matters more than the test it excused: a justification asserting more than was measured is this campaign's own subject, and a future reader would have inherited "this cannot be tested" and stopped looking.

The seam exists and five test files already use it: `localAgentDispatchRuntimeAdapterFor` (`agent_dispatch.go:31`), resolved through `foregroundRuntimeAdapterFactoryFor` (`:60-62`) and called at `:599`. `TestForegroundRuntimePreflightUnknownRecordsAndDispatches` already drives `dispatchLocalAgentJob` with `Action: "ask"` to completion through it.

`TestCLIDispatchArmsObserveCredentialBlanking` now covers **both** boundaries end to end with a fake kimi adapter that blanks the credential in place while delivering. One detail is load-bearing rather than hygienic: `db.Agent` carries no `RuntimeConfigDir` and `runtimeAgent` sets none, so `effectiveAgent.RuntimeConfigDir` is empty on the dispatch path and the observer falls back to `$HOME/.kimi-code` — the test therefore redirects `HOME` with `t.Setenv`, which is what keeps it off the operator's real profile.

Each arm is pinned by its own mutation, so the coverage claim is self-checking rather than an argument from symmetry (production restored `cmp`-verified byte-identical after each, md5 `fe37513e7ced` both sides):

```
PROBE A — delete the ask-arm recorder call:
--- FAIL .../ask_arm_delivers_through_mailbox.Run
    kimi_credential_degraded events = 0, want exactly 1 on the ask arm

PROBE B — delete the else-arm recorder call:
--- FAIL .../else_arm_delivers_through_engine.RunJob
    kimi_credential_degraded events = 0, want exactly 1 on the implement arm
```

Deleting one arm's call fails only that arm's case, which is the property the earlier symmetry argument could not give.

### Still not covered, with the reason

- `KimiAdapter.Start` — latent, not live (see above): `wrapReadOnlySandboxAdapter` wraps a Deliver-only interface, but no path sets `ReadOnlySeat` on a Start agent, so there is no live population behind it.
- `internal/doctor/checker.go:132` (`kimi --version`).
- `gitmoot agent doctor`'s own reporting line — the observation helpers are unit-tested, but the command's stderr output is not driven end to end.

### Known follow-up, not fixed here

`recordKimiCredentialDegradation`'s dedupe is list-then-insert, mirroring `recordReadOnlySeatCredentialDiagnosis`; `db.AddJobEventIfAbsent` (`store_jobs.go:1501-1507`, `INSERT … WHERE NOT EXISTS`) is the atomic primitive both call sites should converge on. The TOCTOU window is unreachable on these four routes today — a job is delivered once per worker pass and the two dispatch arms are exclusive — so this is recorded as a follow-up rather than changed inside this head, which would mean touching a second convention mid-round.

### Discriminator: mutation probes, not a pre-fix arm

This is new observable behaviour, so there is no pre-fix behavioural arm to fail — on `main` the event kind does not exist and the tests would not compile, which proves nothing about behaviour. Reporting that honestly, and paying for it with mutation probes against the shipped code instead (production restored `cmp`-verified byte-identical after each):

```
PROBE 1 — treat an unmeasured before-reading as had-token:
--- FAIL: .../an_unmeasured_schema_before_is_not_evidence
    KimiCredentialDegradation = "... unknown_schema/90B -> blank_token/136B ..." want reported = false
RUNTIME_RESTORED

PROBE 2 — drop the seat exclusion:
--- FAIL: TestReadOnlySeatKimiDeliveryIsNotObserved/read-only_seat
    observation = token/107B, want none for read-only seat
CLI_RESTORED
```

Probe 1 is a bug the test actually caught in my first implementation: the predicate was symmetric on `Usable()`, so an uninterpretable *before* reading manufactured a degradation.

## Gate

`GOTOOLCHAIN=local` with the toolchain PATH, non-`/tmp` tree (`/root/gm-reviewfix-c`), `-count=1`, `gofmt` empty:

```
go version go1.26.4 linux/amd64
BUILD_OK          (go build -buildvcs=false ./...)
VET_OK            (go vet ./...)
GENERATE_CHECKED  (go generate ./... left only this PR's own files modified)
ok  internal/runtime   0.201s
ok  internal/workflow  90.436s
ok  internal/daemon    14.455s
FAIL internal/cli      373.485s  -- TestApplyReviewPolicyEmptyHomeIsOff
```

`TestApplyReviewPolicyEmptyHomeIsOff` (`review_risk_test.go:166`) is **pre-existing and environment-sensitive, not this PR's**: it fails identically with these changes `git stash -u`'d, i.e. on `origin/main` at `1f96f844` in the same tree, and it touches no file this PR changes. Two instruments, opposite results, same commit: this seat's tree fails it standalone, and #1860's independent review clone ran the same test standalone and it **passed** there. Environment-sensitive, not branch-related; not fixed inside this head.

## Deploy notes

Adds one job event kind (`kimi_credential_degraded`) and one stderr line in `gitmoot agent doctor`; no migration, no config change, no behaviour change to any job's outcome — a recording failure degrades to a stdout line and never affects the job. Docs updated in **both** trees (`docs/troubleshooting.md`, `website/docs/operations/troubleshooting.md`); the website is published manually.