### PR TITLE
fix(merge-gate): stop superseding the reviewed head of a behind PR (#1865)

### DIFF
--- a/docs/local-workflow.md
+++ b/docs/local-workflow.md
@@ -609,9 +609,18 @@ If a job is not eligible, Gitmoot keeps the old queue/wait behavior.
    a transient deferral while one exists, leaves the task in `ready_to_merge`,
    and re-evaluates on the next daemon tick. No blocked state or merge-gate error
    is emitted for this retry-later condition. If a parallel PR became behind the
-   base branch because another PR merged first, Gitmoot asks GitHub to update the
-   PR branch with the expected head SHA and leaves the merge gate pending so the
-   daemon can reload the new head and checks on a later poll tick.
+   base branch because another PR merged first, what happens next depends on the
+   base branch's protection. Where GitHub **requires** an up-to-date head,
+   Gitmoot asks GitHub to update the PR branch with the expected head SHA and
+   leaves the merge gate pending so the daemon can reload the new head and
+   checks on a later poll tick. Where the base does **not** require it, the
+   reviewed head is merged as it stands and no update is requested: the update
+   creates a merge commit that supersedes the very head the approving verdict is
+   bound to, so the next poll would find an unreviewed head and dispatch a fresh
+   review round. A **diverged** branch is never merged this way — it can
+   conflict — and an *undetermined* protection read (an unprotected branch and a
+   token that cannot read protection are indistinguishable) fails closed onto
+   the update-and-retry path.
 
    When review independence cannot be verified, the decline names the observed
    cause: no implement job for the task, task-identity mismatch, a matching job

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -632,6 +632,14 @@ Fixes:
   visibly unjudged, so an unevaluated head stops reading as an approved one. A
   later gate evaluation replaces it with the specific pending, failure, or
   success verdict for that same head.
+- A PR that is merely **behind** its base is merged on its reviewed head, and no
+  branch update is requested, unless the base branch requires an up-to-date head.
+  If you expected a `pull request branch update from main requested` pending
+  verdict and do not see one, that is why. Confirm what the gate saw with
+  `gh api repos/<owner>/<repo>/branches/<base>/protection --jq
+  '.required_status_checks.strict'`: `true` keeps the update-and-retry path, and
+  a 404 or a permission error is *undetermined* and also keeps it. Only an
+  explicit `false` skips the update. Diverged branches always take the update.
 - Gitmoot publishes it only while it owns the merge decision. With
   `[merge_gate] auto_merge = false`, with `GITMOOT_DISABLE_NATIVE_MERGE_GATE=1`,
   or once a task reaches `awaiting_human_merge`, `dismissed`, `superseded`,

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -3649,6 +3649,12 @@ func (f *fakeGitHub) MergePullRequest(context.Context, github.MergePullRequestIn
 	return github.MergeResult{}, errors.New("not implemented")
 }
 
+func (f *fakeGitHub) BaseRequiresUpToDateHead(context.Context, github.Repository, string) (bool, bool, error) {
+	// Undetermined: the merge gate fails closed on this, which is the
+	// pre-#1865 update-then-retry behaviour these daemon tests assert.
+	return false, false, nil
+}
+
 func (f *fakeGitHub) UpdatePullRequestBranch(context.Context, github.UpdatePullRequestBranchInput) (github.UpdatePullRequestBranchResult, error) {
 	return github.UpdatePullRequestBranchResult{}, errors.New("not implemented")
 }

--- a/internal/github/base_uptodate_test.go
+++ b/internal/github/base_uptodate_test.go
@@ -58,6 +58,14 @@ func TestBaseRequiresUpToDateHead(t *testing.T) {
 			{"empty stdout", subprocess.Result{Stdout: ""}, nil},
 			{"null stdout", subprocess.Result{Stdout: "null\n"}, nil},
 			{"unfiltered json", subprocess.Result{Stdout: "{\"strict\":true}\n"}, nil},
+			// #1870 round-2 finding (P3): every case above pairs its error with
+			// empty or non-determinate stdout, so the stdout switch alone could
+			// satisfy them and the explicit error check survived deletion. These
+			// two pair a gh FAILURE with determinate-looking output, so only the
+			// error check can make them fail closed - gh writes partial or stale
+			// stdout alongside a non-zero exit often enough to matter.
+			{"error with determinate true stdout", subprocess.Result{Stdout: "true\n", Stderr: "HTTP 403: Resource not accessible by integration"}, errors.New("exit status 1")},
+			{"error with determinate false stdout", subprocess.Result{Stdout: "false\n", Stderr: "HTTP 502: Bad Gateway"}, errors.New("exit status 1")},
 		}
 		for _, tc := range cases {
 			t.Run(tc.name, func(t *testing.T) {

--- a/internal/github/base_uptodate_test.go
+++ b/internal/github/base_uptodate_test.go
@@ -1,0 +1,108 @@
+package github
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/gitmoot/gitmoot/internal/subprocess"
+)
+
+// #1870 review finding 2 (P3): every other test reaches
+// BaseRequiresUpToDateHead through the MergeGateGitHub interface fake, so the
+// real client's gh-output handling - the jq filter and the swallow to
+// UNDETERMINED - had no direct coverage. These drive GhClient itself, reusing
+// the fakeRunner harness already used by sibling methods in this package.
+func TestBaseRequiresUpToDateHead(t *testing.T) {
+	repo := Repository{Owner: "o", Name: "r"}
+
+	t.Run("strict true is required and known", func(t *testing.T) {
+		runner := &fakeRunner{results: []subprocess.Result{{Stdout: "true\n"}}}
+		client := GhClient{Runner: runner}
+		required, known, err := client.BaseRequiresUpToDateHead(context.Background(), repo, "main")
+		if err != nil {
+			t.Fatalf("returned error: %v", err)
+		}
+		if !required || !known {
+			t.Fatalf("required=%v known=%v, want true/true", required, known)
+		}
+		args := strings.Join(runner.calls[0], " ")
+		if !strings.Contains(args, "repos/o/r/branches/main/protection") {
+			t.Fatalf("call args = %q, want the protection endpoint for the base branch", args)
+		}
+		if !strings.Contains(args, ".required_status_checks.strict") {
+			t.Fatalf("call args = %q, want the strict jq filter", args)
+		}
+	})
+
+	t.Run("strict false is known and not required", func(t *testing.T) {
+		runner := &fakeRunner{results: []subprocess.Result{{Stdout: "false\n"}}}
+		client := GhClient{Runner: runner}
+		required, known, err := client.BaseRequiresUpToDateHead(context.Background(), repo, "main")
+		if err != nil || required || !known {
+			t.Fatalf("required=%v known=%v err=%v, want false/true/nil", required, known, err)
+		}
+	})
+
+	// The merge gate merges a behind head only on known && !required, so any
+	// answer that is not a clean "false" MUST come back undetermined.
+	t.Run("undetermined answers never read as not-required", func(t *testing.T) {
+		cases := []struct {
+			name   string
+			result subprocess.Result
+			err    error
+		}{
+			{"404 unprotected branch", subprocess.Result{Stderr: "HTTP 404: Branch not protected"}, errors.New("exit status 1")},
+			{"permission failure", subprocess.Result{Stderr: "HTTP 403: Resource not accessible by integration"}, errors.New("exit status 1")},
+			{"empty stdout", subprocess.Result{Stdout: ""}, nil},
+			{"null stdout", subprocess.Result{Stdout: "null\n"}, nil},
+			{"unfiltered json", subprocess.Result{Stdout: "{\"strict\":true}\n"}, nil},
+		}
+		for _, tc := range cases {
+			t.Run(tc.name, func(t *testing.T) {
+				runner := &fakeRunner{results: []subprocess.Result{tc.result}}
+				if tc.err != nil {
+					runner.errs = []error{tc.err}
+				}
+				client := GhClient{Runner: runner, MaxRetries: 0}
+				required, known, err := client.BaseRequiresUpToDateHead(context.Background(), repo, "main")
+				if err != nil {
+					t.Fatalf("returned error: %v", err)
+				}
+				if known {
+					t.Fatalf("known = true for %q, want undetermined so the gate fails closed", tc.name)
+				}
+				if required {
+					t.Fatalf("required = true with known=false for %q", tc.name)
+				}
+			})
+		}
+	})
+
+	t.Run("missing repo or branch asks nothing", func(t *testing.T) {
+		for _, tc := range []struct {
+			name   string
+			repo   Repository
+			branch string
+		}{
+			{"no repo", Repository{}, "main"},
+			{"no branch", repo, "   "},
+		} {
+			t.Run(tc.name, func(t *testing.T) {
+				runner := &fakeRunner{}
+				client := GhClient{Runner: runner}
+				_, known, err := client.BaseRequiresUpToDateHead(context.Background(), tc.repo, tc.branch)
+				if err != nil {
+					t.Fatalf("returned error: %v", err)
+				}
+				if known {
+					t.Fatalf("known = true, want undetermined")
+				}
+				if len(runner.calls) != 0 {
+					t.Fatalf("calls = %v, want no gh invocation", runner.calls)
+				}
+			})
+		}
+	})
+}

--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -49,6 +49,7 @@ type Client interface {
 	GetUserPermission(ctx context.Context, repo Repository, username string) (UserPermission, error)
 	MergePullRequest(ctx context.Context, input MergePullRequestInput) (MergeResult, error)
 	UpdatePullRequestBranch(ctx context.Context, input UpdatePullRequestBranchInput) (UpdatePullRequestBranchResult, error)
+	BaseRequiresUpToDateHead(ctx context.Context, repo Repository, branch string) (required bool, known bool, err error)
 	GetCombinedStatus(ctx context.Context, repo Repository, ref string) (CombinedStatus, error)
 	ListCheckRunsForRef(ctx context.Context, repo Repository, ref string) ([]PullRequestCheck, error)
 	CompareCommits(ctx context.Context, repo Repository, base string, head string) (CompareResult, error)
@@ -1057,6 +1058,43 @@ func (c *GhClient) MergePullRequest(ctx context.Context, input MergePullRequestI
 		return MergeResult{Message: fmt.Sprintf("pull request merge is pending; current state is %q", pr.State)}, nil
 	}
 	return MergeResult{SHA: pr.MergeSHA, Merged: true}, nil
+}
+
+// BaseRequiresUpToDateHead reports whether branch protection on branch demands
+// that a pull request head be up to date with the base before merging, and
+// whether that could be DETERMINED at all.
+//
+// #1865: the merge gate used to request a branch update for every behind head
+// at verdict-advancement time, which created a merge commit and superseded the
+// head the verdict was bound to within seconds - buying a fresh paid review per
+// occurrence. Skipping that update is only safe where GitHub does not require
+// an up-to-date head, so the gate has to be able to ask.
+//
+// known=false means UNDETERMINED, not "not required": an unprotected branch
+// returns 404, but so does a token without the permission to read protection.
+// Callers must fail closed on known=false and keep requesting the update.
+func (c *GhClient) BaseRequiresUpToDateHead(ctx context.Context, repo Repository, branch string) (required bool, known bool, err error) {
+	branch = strings.TrimSpace(branch)
+	if strings.TrimSpace(repo.FullName()) == "" || branch == "" {
+		return false, false, nil
+	}
+	result, err := c.run(ctx, false, "api",
+		fmt.Sprintf("repos/%s/branches/%s/protection", repo.FullName(), branch),
+		"--jq", ".required_status_checks.strict // false")
+	if err != nil {
+		// 404 on an unprotected branch, or a permission failure. Both are
+		// UNDETERMINED here; the distinction needs a scope probe this call has
+		// no business making.
+		return false, false, nil
+	}
+	switch strings.TrimSpace(result.Stdout) {
+	case "true":
+		return true, true, nil
+	case "false":
+		return false, true, nil
+	default:
+		return false, false, nil
+	}
 }
 
 func (c *GhClient) UpdatePullRequestBranch(ctx context.Context, input UpdatePullRequestBranchInput) (UpdatePullRequestBranchResult, error) {

--- a/internal/github/githubtest/noop.go
+++ b/internal/github/githubtest/noop.go
@@ -99,6 +99,12 @@ func (NoopClient) MergePullRequest(context.Context, github.MergePullRequestInput
 	return github.MergeResult{}, errors.ErrUnsupported
 }
 
+// BaseRequiresUpToDateHead reports UNDETERMINED, which makes the merge gate
+// fail closed and keep its pre-#1865 branch-update behaviour.
+func (NoopClient) BaseRequiresUpToDateHead(context.Context, github.Repository, string) (bool, bool, error) {
+	return false, false, nil
+}
+
 func (NoopClient) UpdatePullRequestBranch(context.Context, github.UpdatePullRequestBranchInput) (github.UpdatePullRequestBranchResult, error) {
 	return github.UpdatePullRequestBranchResult{}, errors.ErrUnsupported
 }

--- a/internal/workflow/merge_gate.go
+++ b/internal/workflow/merge_gate.go
@@ -59,6 +59,7 @@ type MergeGateGitHub interface {
 	CreateCommitStatus(ctx context.Context, input github.CommitStatusInput) (github.CommitStatus, error)
 	PostIssueComment(ctx context.Context, repo github.Repository, issueNumber int64, body string) (github.IssueComment, error)
 	UpdatePullRequestBranch(ctx context.Context, input github.UpdatePullRequestBranchInput) (github.UpdatePullRequestBranchResult, error)
+	BaseRequiresUpToDateHead(ctx context.Context, repo github.Repository, branch string) (required bool, known bool, err error)
 	MergePullRequest(ctx context.Context, input github.MergePullRequestInput) (github.MergeResult, error)
 }
 
@@ -1500,6 +1501,14 @@ func (g PolicyMergeGate) ensureBranchFresh(ctx context.Context, repo github.Repo
 	}
 	status := strings.ToLower(strings.TrimSpace(compare.Status))
 	if compare.BehindBy > 0 || status == "behind" || status == "diverged" {
+		if status != "diverged" && g.baseAllowsBehindMerge(ctx, repo, base) {
+			// #1865: merely behind, and GitHub does not require an up-to-date
+			// head here. Requesting the update at this point would create a
+			// merge commit and supersede the head the verdict is bound to
+			// within seconds, buying a fresh paid review round. Merge the
+			// reviewed head instead.
+			return MergeDecision{}, false, nil
+		}
 		_, err := g.GitHub.UpdatePullRequestBranch(ctx, github.UpdatePullRequestBranchInput{
 			Repo:            repo,
 			Number:          int64(request.PullRequest),
@@ -1531,6 +1540,23 @@ func (g PolicyMergeGate) ensureBranchFresh(ctx context.Context, repo github.Repo
 		return decision, true, err
 	}
 	return MergeDecision{}, false, nil
+}
+
+// baseAllowsBehindMerge reports whether a head that is merely BEHIND base may be
+// merged without first requesting a branch update (#1865).
+//
+// It FAILS CLOSED: an undetermined protection read keeps the pre-#1865
+// behaviour of updating the branch and retrying, because an unprotected branch
+// and a token that cannot read protection are indistinguishable from here.
+func (g PolicyMergeGate) baseAllowsBehindMerge(ctx context.Context, repo github.Repository, base string) bool {
+	if g.GitHub == nil {
+		return false
+	}
+	required, known, err := g.GitHub.BaseRequiresUpToDateHead(ctx, repo, base)
+	if err != nil || !known {
+		return false
+	}
+	return !required
 }
 
 func (g PolicyMergeGate) postMergeConflictComment(ctx context.Context, repo github.Repository, request MergeRequest, pr github.PullRequest, reason string) error {

--- a/internal/workflow/merge_gate_behind_merge_test.go
+++ b/internal/workflow/merge_gate_behind_merge_test.go
@@ -180,3 +180,56 @@ func TestMergeGateMergesUpToDateBranchUnchanged(t *testing.T) {
 		})
 	}
 }
+
+// #1870 review finding 1 (P2): `compare.BehindBy > 0` in the guard at
+// merge_gate.go:1503 was a SURVIVING mutant - deleting it left the whole
+// internal/workflow suite green, so nothing pinned the numeric behind-check and
+// a later edit could delete it unnoticed. Without that term a compare response
+// carrying BehindBy > 0 under an unexpected status string falls through to
+// `return MergeDecision{}, false, nil`: merged with NO protection read and NO
+// update, which is worse than the pre-#1865 behaviour.
+//
+// These cases pass ONLY while the numeric check is present.
+func TestMergeGateTreatsNumericBehindAsBehindWhateverTheStatusString(t *testing.T) {
+	// "" and "unknown" are the DISCRIMINATING cases: they kill the mutant.
+	// "BEHIND" does NOT - the guard lowercases the status, so that arm matches
+	// the string check with or without the numeric term. It is kept as coverage
+	// of the case-folding, not as part of the kill.
+	for _, status := range []string{"", "unknown", "BEHIND"} {
+		t.Run("status="+status, func(t *testing.T) {
+			t.Run("protection allows behind merges", func(t *testing.T) {
+				gh := behindMergeGateClient(github.CompareResult{Status: status, BehindBy: 3})
+				gh.strictKnown = true
+				gh.strictBase = false
+
+				decision := evaluateBehindMergeGate(t, gh)
+
+				// The numeric term is what routes this into the behind branch at
+				// all. Drop it and protection is never consulted.
+				if gh.strictCalls == 0 {
+					t.Fatal("BehindBy > 0 must route through the behind branch and consult protection")
+				}
+				if !decision.Merged || len(gh.updates) != 0 {
+					t.Fatalf("decision = %+v updates = %+v", decision, gh.updates)
+				}
+				if len(gh.merges) != 1 || gh.merges[0].MatchHeadCommit != "head123" {
+					t.Fatalf("merge must stay fenced to the reviewed head: %+v", gh.merges)
+				}
+			})
+
+			t.Run("protection undetermined still updates", func(t *testing.T) {
+				gh := behindMergeGateClient(github.CompareResult{Status: status, BehindBy: 3})
+				gh.strictKnown = false
+
+				decision := evaluateBehindMergeGate(t, gh)
+
+				if decision.Merged {
+					t.Fatalf("numeric-behind head must not merge on an undetermined read: %+v", decision)
+				}
+				if len(gh.updates) != 1 || gh.updates[0].ExpectedHeadSHA != "head123" {
+					t.Fatalf("update inputs = %+v", gh.updates)
+				}
+			})
+		})
+	}
+}

--- a/internal/workflow/merge_gate_behind_merge_test.go
+++ b/internal/workflow/merge_gate_behind_merge_test.go
@@ -1,0 +1,182 @@
+package workflow
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/gitmoot/gitmoot/internal/db"
+	"github.com/gitmoot/gitmoot/internal/github"
+)
+
+// #1865: the gate used to request a branch update for EVERY behind head at
+// verdict-advancement time. The update creates a merge commit and supersedes
+// the head the verdict is bound to within seconds, so the next poll finds an
+// unreviewed head and dispatches a fresh paid review. Six occurrences were
+// measured in 114 minutes on 2026-09-04 (notes 117997, 118011, 118013).
+//
+// Every case below drives the PRODUCTION advancement path - PolicyMergeGate
+// .Evaluate - not ensureBranchFresh in isolation, so a routing change that
+// leaves real verdict advancement on the old path fails these tests.
+
+func behindMergeGateStore(t *testing.T) *db.Store {
+	t.Helper()
+	store := openEngineStore(t)
+	insertIndependentMergeGateReview(t, store, db.Job{ID: "review-job", Agent: "audit", Type: "review"}, JobPayload{
+		Repo:        "gitmoot/gitmoot",
+		PullRequest: 9,
+		HeadSHA:     "head123",
+		TaskID:      "task-9",
+		ReviewRound: "review-1",
+		Result:      &AgentResult{Decision: "approved", Summary: "ready"},
+	})
+	return store
+}
+
+func behindMergeGateClient(compare github.CompareResult) *fakeMergeGateGitHub {
+	mergeable := true
+	return &fakeMergeGateGitHub{
+		pr:          github.PullRequest{Number: 9, HeadRef: "task-9", BaseRef: "main", HeadSHA: "head123", Mergeable: &mergeable},
+		status:      github.CombinedStatus{State: "success"},
+		compare:     compare,
+		mergeResult: github.MergeResult{Merged: true, SHA: "merge123"},
+	}
+}
+
+func evaluateBehindMergeGate(t *testing.T, gh *fakeMergeGateGitHub) MergeDecision {
+	t.Helper()
+	gate := PolicyMergeGate{AutoMerge: true, Store: behindMergeGateStore(t), GitHub: gh, Git: &fakeMergeGateGit{clean: true}}
+	decision, err := gate.Evaluate(context.Background(), MergeRequest{Repo: "gitmoot/gitmoot", PullRequest: 9, TaskID: "task-9"})
+	if err != nil {
+		t.Fatalf("Evaluate returned error: %v", err)
+	}
+	return decision
+}
+
+// Acceptance 1: the verdict's own head is what merges. No update is requested,
+// so nothing supersedes the reviewed head.
+func TestMergeGateMergesBehindHeadWhenBaseAllowsIt(t *testing.T) {
+	gh := behindMergeGateClient(github.CompareResult{Status: "behind", BehindBy: 1})
+	gh.strictKnown = true
+	gh.strictBase = false
+
+	decision := evaluateBehindMergeGate(t, gh)
+
+	if !decision.Merged {
+		t.Fatalf("behind head must merge on its own verdict: decision = %+v", decision)
+	}
+	if len(gh.updates) != 0 {
+		t.Fatalf("no branch update may be requested: updates = %+v", gh.updates)
+	}
+	if len(gh.merges) != 1 {
+		t.Fatalf("merge inputs = %+v", gh.merges)
+	}
+	// The merge is fenced to the REVIEWED head; that is what makes this a fix
+	// rather than a suppression of the pending decision.
+	if gh.merges[0].MatchHeadCommit != "head123" {
+		t.Fatalf("merge must be fenced to the reviewed head: %+v", gh.merges[0])
+	}
+	if gh.strictCalls == 0 {
+		t.Fatal("protection must actually be consulted, not assumed")
+	}
+	if len(gh.strictBranches) == 0 || gh.strictBranches[0] != "main" {
+		t.Fatalf("protection must be read for the BASE branch: %v", gh.strictBranches)
+	}
+}
+
+// Acceptance 1, other arm: where GitHub does require an up-to-date head, the
+// update is still the only way to merge, so the pre-#1865 path must survive.
+func TestMergeGateStillUpdatesWhenBaseRequiresUpToDateHead(t *testing.T) {
+	gh := behindMergeGateClient(github.CompareResult{Status: "behind", BehindBy: 1})
+	gh.strictKnown = true
+	gh.strictBase = true
+
+	decision := evaluateBehindMergeGate(t, gh)
+
+	if decision.Merged || !strings.Contains(decision.Reason.Render(), "branch update") {
+		t.Fatalf("strict base must still take the update path: decision = %+v", decision)
+	}
+	if len(gh.updates) != 1 || gh.updates[0].ExpectedHeadSHA != "head123" {
+		t.Fatalf("update inputs = %+v", gh.updates)
+	}
+	if len(gh.merges) != 0 {
+		t.Fatalf("merge inputs = %+v", gh.merges)
+	}
+}
+
+// The guard fails CLOSED. An unprotected branch and a token that cannot read
+// protection are indistinguishable, so an undetermined answer keeps the old
+// behaviour instead of merging a head GitHub may refuse.
+func TestMergeGateFailsClosedWhenProtectionIsUndetermined(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		set  func(*fakeMergeGateGitHub)
+	}{
+		{"unknown", func(f *fakeMergeGateGitHub) { f.strictKnown = false }},
+		{"error", func(f *fakeMergeGateGitHub) { f.strictErr = errors.New("permission denied") }},
+		{"known false but errored", func(f *fakeMergeGateGitHub) {
+			f.strictKnown = true
+			f.strictErr = errors.New("boom")
+		}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			gh := behindMergeGateClient(github.CompareResult{Status: "behind", BehindBy: 1})
+			tc.set(gh)
+
+			decision := evaluateBehindMergeGate(t, gh)
+
+			if decision.Merged {
+				t.Fatalf("undetermined protection must not merge a behind head: %+v", decision)
+			}
+			if len(gh.updates) != 1 {
+				t.Fatalf("update inputs = %+v", gh.updates)
+			}
+		})
+	}
+}
+
+// A diverged branch is not merely behind: merging it can conflict, so the
+// update stays mandatory there even when protection allows behind merges.
+func TestMergeGateStillUpdatesDivergedBranch(t *testing.T) {
+	gh := behindMergeGateClient(github.CompareResult{Status: "diverged", BehindBy: 1, AheadBy: 1})
+	gh.strictKnown = true
+	gh.strictBase = false
+
+	decision := evaluateBehindMergeGate(t, gh)
+
+	if decision.Merged {
+		t.Fatalf("diverged branch must not merge without an update: %+v", decision)
+	}
+	if len(gh.updates) != 1 {
+		t.Fatalf("update inputs = %+v", gh.updates)
+	}
+	if gh.strictCalls != 0 {
+		t.Fatalf("diverged must not even consult protection: calls = %d", gh.strictCalls)
+	}
+}
+
+// Acceptance 3: the success case. A branch already up to date advances exactly
+// as before - the new guard must not reject valid input, and must not spend an
+// API call it does not need.
+func TestMergeGateMergesUpToDateBranchUnchanged(t *testing.T) {
+	for _, status := range []string{"identical", "ahead", ""} {
+		t.Run("status="+status, func(t *testing.T) {
+			gh := behindMergeGateClient(github.CompareResult{Status: status})
+			gh.strictKnown = true
+			gh.strictBase = true // must be irrelevant when not behind
+
+			decision := evaluateBehindMergeGate(t, gh)
+
+			if !decision.Merged {
+				t.Fatalf("up-to-date branch must merge: %+v", decision)
+			}
+			if len(gh.updates) != 0 {
+				t.Fatalf("updates = %+v", gh.updates)
+			}
+			if gh.strictCalls != 0 {
+				t.Fatalf("protection must not be read when the head is not behind: calls = %d", gh.strictCalls)
+			}
+		})
+	}
+}

--- a/internal/workflow/merge_gate_test.go
+++ b/internal/workflow/merge_gate_test.go
@@ -5169,6 +5169,11 @@ type fakeMergeGateGitHub struct {
 	prCheckCalls   int
 	checkRefs      []string
 	noChecks       bool
+	strictBase     bool
+	strictKnown    bool
+	strictErr      error
+	strictCalls    int
+	strictBranches []string
 }
 
 func (f *fakeMergeGateGitHub) GetPullRequest(context.Context, github.Repository, int64) (github.PullRequest, error) {
@@ -5215,6 +5220,15 @@ func (f *fakeMergeGateGitHub) CreateCommitStatus(_ context.Context, input github
 func (f *fakeMergeGateGitHub) PostIssueComment(_ context.Context, _ github.Repository, _ int64, body string) (github.IssueComment, error) {
 	f.comments = append(f.comments, body)
 	return github.IssueComment{Body: body}, nil
+}
+
+func (f *fakeMergeGateGitHub) BaseRequiresUpToDateHead(_ context.Context, _ github.Repository, branch string) (bool, bool, error) {
+	f.strictCalls++
+	f.strictBranches = append(f.strictBranches, branch)
+	if f.strictErr != nil {
+		return false, false, f.strictErr
+	}
+	return f.strictBase, f.strictKnown, nil
 }
 
 func (f *fakeMergeGateGitHub) UpdatePullRequestBranch(_ context.Context, input github.UpdatePullRequestBranchInput) (github.UpdatePullRequestBranchResult, error) {

--- a/website/docs/operations/troubleshooting.md
+++ b/website/docs/operations/troubleshooting.md
@@ -472,6 +472,29 @@ this head` and leaves any real gate verdict untouched. A `blocked` or
 cleared and Gitmoot can still resolve it when the task resumes. A draft pull
 request keeps the marker until it is undrafted.
 
+## No Branch Update For A PR That Is Behind Main
+
+Symptom: a pull request is behind its base and Gitmoot merges it anyway, with no
+`pull request branch update from main requested` pending verdict.
+
+Likely cause: this is the intended behaviour. Requesting the update creates a
+merge commit that supersedes the head the approving verdict is bound to, so the
+next poll would find an unreviewed head and dispatch a fresh review round.
+Gitmoot skips the update where GitHub does not require an up-to-date head and
+merges the reviewed head instead.
+
+Check:
+
+```sh
+gh api repos/owner/repo/branches/<base>/protection --jq '.required_status_checks.strict'
+```
+
+Fix: nothing to do in the common case. `true` keeps the update-and-retry path.
+A 404 or a permission error is *undetermined* — indistinguishable from an
+unprotected branch — and also keeps it, so the guard fails closed. Only an
+explicit `false` skips the update, and a **diverged** branch always takes the
+update because merging it can conflict.
+
 ## Live Docs Or LLM Context Stale
 
 Symptom: `gitmoot.io/docs` or `/llms.txt` does not show current source docs.


### PR DESCRIPTION
Closes #1865.

## The defect

`PolicyMergeGate.ensureBranchFresh` requested a branch update for **every** behind head at verdict-advancement time. The update creates a merge commit and replaces the head the approving verdict is bound to within **2-3 seconds**, so the next poll finds an unreviewed head and dispatches a **fresh paid review round**.

Six occurrences measured in 114 minutes on 2026-09-04, each derived from the review job's own payload rather than clock proximity (notes 117997, 118001, 118011, 118013, 118020):

| PR | approval event | branch update | lag |
|---|---|---|---|
| 1851 | 19:34:14 | 19:34:17 | 3s |
| 1860 | 20:35:42 | 20:35:45 | 3s |
| 1850 | 20:40:45 | 20:40:48 | 3s |
| 1861 | 20:38:39 | 20:38:41 | 2s |
| 1866 | 21:01:52 | 21:01:55 | 3s |
| 1783 | 21:28:02 | 21:28:05 | 3s |

Cost measured, not inferred: PR 1851's two `merge_gate_approval_evidence` events belong to **distinct review jobs** (`...18d230cb0a20e457` at `556540df`, then `...18d2364d267bade6` at `6cc31937`) — a second full review dispatched against the merge the gate itself created. `6cc31937` has two parents: 1851's approved head plus a main commit.

**Why this ranks above the #1834 wedge** (per the assigning directive): #1865 costs a fresh paid review on every occurrence, while a wedged head costs stored evidence and no re-review. #1865 is also *upstream* of the wedge — #1850's `f3e27328`, the head whose `changes_requested` wedged `review-pr-1850-3f3a1026`, was created by this very mechanism at gate row 983, 20:40:48.

## The decision, and why

Acceptance 1 offered two arms. I took **"the update is not requested at verdict-advancement time"** rather than "the verdict survives the update", because the update is not needed at all where GitHub does not require an up-to-date head: `main` on this repo is unprotected (`404 Branch not protected`), and tonight's squashes merged behind heads without one. Making a superseded verdict survive would instead mean carrying approval evidence forward across a head the reviewer never saw — a wider blast radius for a mechanism that can simply be skipped.

`ensureBranchFresh` is reached from exactly one caller (`Evaluate`, line 361), which returns early on any pending or missed gate, so this path is only reachable *after* an exact-head review is clean and CI is green. No same-tick poll requests the update independently.

## Fails closed, deliberately

- **Undetermined protection read → keep the old path.** An unprotected branch returns 404 and so does a token that cannot read protection; the two are indistinguishable from the gate, so `known=false` never means "not required".
- **Diverged → keep the old path**, and protection is not even consulted: merging a diverged branch can conflict.
- **Not behind → unchanged**, and no API call is spent.

## Accepted failure mode

On a non-strict base, a behind branch now merges as a squash onto a newer base, so the merged content differs from any tree that was tested. That is already the status quo for every non-strict repo and for every hand merge; the alternative costs a full model review per occurrence.

## Verification

- New `internal/workflow/merge_gate_behind_merge_test.go` drives **`PolicyMergeGate.Evaluate`** — the production advancement path — never `ensureBranchFresh` in isolation.
- **Four mutants, all killed**, baseline green before each and tree restored byte-identical after: drop the diverged exclusion → `TestMergeGateStillUpdatesDivergedBranch` fails; ignore `known` → `TestMergeGateFailsClosedWhenProtectionIsUndetermined` **and** the pre-existing `TestPolicyMergeGateUpdatesStaleBranchAndStaysPending` fail; invert the protection answer → two tests fail; **routing mutant** (guard computed, early return replaced by `_ = base`) → `TestMergeGateMergesBehindHeadWhenBaseAllowsIt` fails. That last one is acceptance 2: a change leaving real advancement on the old path does not pass.
- **Acceptance 3, the success case:** `TestMergeGateMergesUpToDateBranchUnchanged` proves `identical`, `ahead` and empty status still merge and spend no protection call.
- **Acceptance 4, the #1787 control:** `TestPolicyMergeGateUpdatesStaleBranchAndStaysPending` is unmodified and green — its fake leaves protection undetermined, so it now also pins the fail-closed arm.
- Gate: `gofmt` clean, `go build ./...` rc=0, `go generate ./...` added no diff, `go vet ./...` clean, `go test -race ./internal/workflow ./internal/github/... ./internal/daemon` rc=0 with **zero data races**.

**One pre-existing failure, not mine:** `internal/cli` `TestApplyReviewPolicyEmptyHomeIsOff` fails **identically on pristine `origin/main` at 76d202a6** in a worktree containing none of my paths (`review_risk_test.go:166`). It reads this box's `/root/.gitmoot/config.toml`, which sets `blocking_severity = "P2"` while the test asserts the `P3` default — host-dependent, recorded in notes 117784 and 117811.

Source claims are based on `origin/main` at 76d202a6 in a clean worktree, not the dirty `/root/gitmoot` checkout.