### PR TITLE
fix(workflow): let an approval at the current head clear changes_requested (#1834)

### DIFF
--- a/internal/cli/agent_dispatch.go
+++ b/internal/cli/agent_dispatch.go
@@ -1014,8 +1014,17 @@ func prepareLocalReviewTask(ctx context.Context, store *db.Store, repo github.Re
 		Title:        firstNonEmpty(request.TaskTitle, fmt.Sprintf("Review PR #%d", request.PullRequest)),
 		State:        string(workflow.TaskReviewing),
 	}
+	// changes_requested joins the disposed states here for a DIFFERENT reason, so
+	// the two must not be read as one list: a disposed task refuses the dispatch,
+	// while a task with a live objection ACCEPTS it and keeps its state. Writing
+	// reviewing here would clear a changes_requested that no approval had answered
+	// yet, which is the same erasure #1834's one-way re-arm guard exists to
+	// prevent - and it made the branchless path disagree with the --branch path
+	// above, which returns before any state write. An approval only leaves
+	// changes_requested through the head-bound admission in the merge gate.
 	updated, err := store.UpsertTaskUnlessStates(ctx, task, []string{
 		string(workflow.TaskDismissed), string(workflow.TaskSuperseded), string(workflow.TaskStranded),
+		string(workflow.TaskChangesRequested),
 	})
 	if err != nil {
 		return localAgentDispatchRequest{}, err
@@ -1025,7 +1034,11 @@ func prepareLocalReviewTask(ctx context.Context, store *db.Store, repo github.Re
 		if loadErr != nil {
 			return localAgentDispatchRequest{}, loadErr
 		}
-		return localAgentDispatchRequest{}, disposedReviewTaskError(existing)
+		if existing.State != string(workflow.TaskChangesRequested) {
+			return localAgentDispatchRequest{}, disposedReviewTaskError(existing)
+		}
+		task.GoalID = firstNonEmpty(existing.GoalID, task.GoalID)
+		task.Title = firstNonEmpty(existing.Title, task.Title)
 	}
 	request.TaskID = task.ID
 	request.GoalID = task.GoalID

--- a/internal/cli/review_dispatch_changes_requested_test.go
+++ b/internal/cli/review_dispatch_changes_requested_test.go
@@ -1,0 +1,107 @@
+package cli
+
+import (
+	"context"
+	"testing"
+
+	"github.com/gitmoot/gitmoot/internal/db"
+	"github.com/gitmoot/gitmoot/internal/github"
+	"github.com/gitmoot/gitmoot/internal/workflow"
+)
+
+// #1834, the dispatch half. The branchless path wrote reviewing through
+// UpsertTaskUnlessStates, whose exclusion list named only the DISPOSED states, so
+// dispatching a review silently cleared a live changes_requested. The --branch
+// path above it returns before any state write, so the two disagreed - which is
+// why repeated manual review rounds never reset the wedged tasks and, worse, why
+// a dispatch could erase an objection no approval had answered.
+//
+// Leaving changes_requested is now the merge gate's head-bound admission alone.
+func TestReviewDispatchKeepsChangesRequested(t *testing.T) {
+	ctx := context.Background()
+	home := t.TempDir()
+	store := openCLIJobStore(t, home)
+	defer store.Close()
+
+	if err := store.UpsertTask(ctx, db.Task{
+		ID:           "review-pr-9-abcd1234",
+		RepoFullName: "owner/repo",
+		GoalID:       "local-review",
+		Title:        "Review PR #9",
+		State:        string(workflow.TaskChangesRequested),
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	request, err := prepareLocalReviewTask(ctx, store,
+		github.Repository{Owner: "owner", Name: "repo"},
+		localAgentDispatchRequest{
+			Home: home, PullRequest: 9, HeadSHA: "head-new", TaskID: "review-pr-9-abcd1234",
+		})
+	if err != nil {
+		t.Fatalf("dispatching a review against an objecting task must be allowed: %v", err)
+	}
+	if request.TaskID != "review-pr-9-abcd1234" {
+		t.Fatalf("request bound task %q, want the existing task", request.TaskID)
+	}
+	// The dispatch must still carry the identity fields the review job needs.
+	if request.GoalID == "" || request.TaskTitle == "" {
+		t.Fatalf("dispatch dropped task identity: goal=%q title=%q", request.GoalID, request.TaskTitle)
+	}
+	task, err := store.GetTask(ctx, "review-pr-9-abcd1234")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if task.State != string(workflow.TaskChangesRequested) {
+		t.Fatalf("task state = %q, want changes_requested: dispatching a review must not clear an objection no approval has answered (#1834)", task.State)
+	}
+}
+
+// The disposed states keep refusing. They share the exclusion list with
+// changes_requested but mean the opposite thing, and collapsing the two would
+// turn a refusal into a silent accept.
+func TestReviewDispatchStillRefusesDisposedTask(t *testing.T) {
+	ctx := context.Background()
+	home := t.TempDir()
+	store := openCLIJobStore(t, home)
+	defer store.Close()
+
+	for _, state := range []workflow.TaskState{workflow.TaskDismissed, workflow.TaskSuperseded, workflow.TaskStranded} {
+		taskID := "review-pr-9-" + string(state)
+		if err := store.UpsertTask(ctx, db.Task{
+			ID: taskID, RepoFullName: "owner/repo", GoalID: "local-review",
+			Title: "Review PR #9", State: string(state),
+		}); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := prepareLocalReviewTask(ctx, store,
+			github.Repository{Owner: "owner", Name: "repo"},
+			localAgentDispatchRequest{Home: home, PullRequest: 9, HeadSHA: "head-new", TaskID: taskID},
+		); err == nil {
+			t.Fatalf("dispatch against a %s task must be refused", state)
+		}
+	}
+}
+
+// A task that does not exist yet is still created in reviewing: the new
+// exclusion must not turn first dispatch into a no-op.
+func TestReviewDispatchCreatesReviewingTask(t *testing.T) {
+	ctx := context.Background()
+	home := t.TempDir()
+	store := openCLIJobStore(t, home)
+	defer store.Close()
+
+	request, err := prepareLocalReviewTask(ctx, store,
+		github.Repository{Owner: "owner", Name: "repo"},
+		localAgentDispatchRequest{Home: home, PullRequest: 9, HeadSHA: "head-new"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	task, err := store.GetTask(ctx, request.TaskID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if task.State != string(workflow.TaskReviewing) {
+		t.Fatalf("new review task state = %q, want reviewing", task.State)
+	}
+}

--- a/internal/daemon/held_approval_recovery_test.go
+++ b/internal/daemon/held_approval_recovery_test.go
@@ -1,0 +1,145 @@
+package daemon
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/gitmoot/gitmoot/internal/db"
+	"github.com/gitmoot/gitmoot/internal/github"
+	"github.com/gitmoot/gitmoot/internal/workflow"
+)
+
+// #1871 round-3 P1, at the production boundary. The fail-closed refusal added for
+// the round-2 P1 was correct but it SETTLED: it recorded a durable event and
+// returned nil, so the approval read as advanced and nothing ever re-drove it once
+// the daemon inserted the pull_requests row. A two-poll probe ended with the task
+// still changes_requested and zero gate requests.
+//
+// The recovery has two halves and this test drives both, because neither half
+// lives where the other does: the daemon poll makes the head OBSERVABLE
+// (recordPullRequest), and the cli worker's advance-retry RE-DRIVES the held
+// advancement. The engine's contract between them is that a transient hold
+// returns an ERROR - that is what leaves the advancement unreconciled and keeps
+// the job a retry candidate. If the hold ever goes back to returning nil, step 1
+// fails here.
+func TestHeldApprovalRecoversOnceThePullRequestRowIsObservable(t *testing.T) {
+	ctx := context.Background()
+	store := testStore(t)
+	repo := github.Repository{Owner: "gitmoot", Name: "gitmoot"}
+
+	if err := store.UpsertTask(ctx, db.Task{
+		ID:           "review-pr-9-3f3a1026",
+		RepoFullName: repo.FullName(),
+		GoalID:       "local-review",
+		Title:        "Review PR #9",
+		State:        string(workflow.TaskChangesRequested),
+	}); err != nil {
+		t.Fatalf("UpsertTask returned error: %v", err)
+	}
+	seed := func(id, agent, head, decision, state string) {
+		t.Helper()
+		payload, err := json.Marshal(workflow.JobPayload{
+			Repo: repo.FullName(), Branch: "task-9", PullRequest: 9, HeadSHA: head,
+			TaskID: "review-pr-9-3f3a1026",
+			Result: &workflow.AgentResult{Decision: decision, Summary: decision},
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := store.CreateJob(ctx, db.Job{
+			ID: id, Agent: agent, Type: "review", State: state, Payload: string(payload),
+		}); err != nil {
+			t.Fatalf("CreateJob(%s) returned error: %v", id, err)
+		}
+	}
+	implement, err := json.Marshal(workflow.JobPayload{
+		Repo: repo.FullName(), Branch: "task-9", PullRequest: 9, HeadSHA: "head-new",
+		TaskID: "review-pr-9-3f3a1026",
+		Result: &workflow.AgentResult{Decision: "implemented", Summary: "implemented"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := store.CreateJob(ctx, db.Job{
+		ID: "implement-job", Agent: "implementer", Type: "implement",
+		State: string(workflow.JobSucceeded), Payload: string(implement),
+	}); err != nil {
+		t.Fatal(err)
+	}
+	seed("review-old", "auditor", "head-old", "changes_requested", string(workflow.JobSucceeded))
+	seed("review-new", "auditor", "head-new", "approved", string(workflow.JobSucceeded))
+
+	pull := github.PullRequest{
+		Number: 9, Title: "Review PR #9", State: "open",
+		URL:     "https://github.com/gitmoot/gitmoot/pull/9",
+		HeadRef: "task-9", BaseRef: "main", HeadSHA: "head-new",
+	}
+	client := &fakeGitHub{
+		pulls:    []github.PullRequest{pull},
+		comments: map[int64][]github.IssueComment{pull.Number: {}},
+	}
+	gate := &fakeWorkflowMergeGate{decision: workflow.MergeDecision{Ready: true}}
+	engine := workflow.Engine{Store: store, MergeGate: gate}
+	daemon := Daemon{Repo: repo, Store: store, GitHub: client, Workflow: &engine}
+
+	// STEP 1: no pull_requests row yet. The approval must be HELD, and held in the
+	// retryable shape - an error, not a settled nil.
+	err = engine.AdvanceJob(ctx, "review-new")
+	if err == nil {
+		t.Fatal("AdvanceJob returned nil with no observable head: the hold must stay retryable, or nothing will re-drive it")
+	}
+	if !strings.Contains(err.Error(), "no observed pull request row") {
+		t.Fatalf("hold error = %v, want the missing pull request row named", err)
+	}
+	if len(gate.requests) != 0 {
+		t.Fatalf("gate requests = %d, want 0 while the head is unobservable", len(gate.requests))
+	}
+	assertHeldTaskState(t, store, workflow.TaskChangesRequested)
+
+	// STEP 2: the daemon poll observes the PR. It must make the head observable
+	// WITHOUT resetting the objection - this task holds no branch lock, so the
+	// lock-gated reset path is skipped while recordPullRequest still runs.
+	if err := daemon.PollOnce(ctx); err != nil {
+		t.Fatalf("PollOnce returned error: %v", err)
+	}
+	stored, err := store.GetPullRequest(ctx, repo.FullName(), 9)
+	if err != nil {
+		t.Fatalf("GetPullRequest after poll: %v", err)
+	}
+	if stored.HeadSHA != "head-new" {
+		t.Fatalf("stored head = %q, want head-new: the poll must make the current head observable", stored.HeadSHA)
+	}
+	assertHeldTaskState(t, store, workflow.TaskChangesRequested)
+
+	// STEP 3: the advance-retry re-drives the SAME approval, which is now admitted.
+	// This is the step that returned gate_requests=0 before the fix.
+	if err := engine.AdvanceJob(ctx, "review-new"); err != nil {
+		t.Fatalf("AdvanceJob after the row appeared: %v", err)
+	}
+	if len(gate.requests) == 0 {
+		t.Fatal("gate was never asked: the held approval was not recovered after the head became observable")
+	}
+	if got := gate.requests[len(gate.requests)-1].ExpectedTaskState; got != string(workflow.TaskChangesRequested) {
+		t.Fatalf("gate claimed %q, want changes_requested: the CAS must match the row it is fencing", got)
+	}
+	task, err := store.GetTask(ctx, "review-pr-9-3f3a1026")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if task.State == string(workflow.TaskChangesRequested) {
+		t.Fatal("task is still changes_requested after recovery")
+	}
+}
+
+func assertHeldTaskState(t *testing.T, store *db.Store, want workflow.TaskState) {
+	t.Helper()
+	task, err := store.GetTask(context.Background(), "review-pr-9-3f3a1026")
+	if err != nil {
+		t.Fatalf("GetTask returned error: %v", err)
+	}
+	if task.State != string(want) {
+		t.Fatalf("task state = %q, want %q", task.State, want)
+	}
+}

--- a/internal/workflow/changes_requested_wedge_test.go
+++ b/internal/workflow/changes_requested_wedge_test.go
@@ -1,0 +1,262 @@
+package workflow
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/gitmoot/gitmoot/internal/db"
+	"github.com/gitmoot/gitmoot/internal/github"
+)
+
+// #1834: once a task reached changes_requested, an approval at a LATER head could
+// never clear the merge gate. The approved arm handed runMergeGate a CONSTANT
+// TaskReviewing, so PolicyMergeGate's ClaimTaskState CAS compared "reviewing"
+// against a row reading "changes_requested" and refused forever, while the only
+// re-arm helper (setReviewingIfNotChangesRequested) is one-way by design and
+// correctly declines to erase a live objection. Four live tasks wedged.
+//
+// These tests drive the PRODUCTION entry point, Engine.AdvanceJob, against a
+// PolicyMergeGate backed by the real store, so the CAS actually executes. A gate
+// left nil short-circuits to setTaskState and would pin nothing.
+func wedgeEngine(t *testing.T, store *db.Store) (Engine, *fakeMergeGateGitHub) {
+	t.Helper()
+	mergeable := true
+	gh := &fakeMergeGateGitHub{
+		pr: github.PullRequest{
+			Number: 9, State: "open", HeadRef: "task-9", BaseRef: "main",
+			HeadSHA: "head-new", Mergeable: &mergeable,
+		},
+		status:      github.CombinedStatus{State: "success", Statuses: []github.CommitStatus{{Context: "ci", State: "success"}}},
+		checks:      []github.PullRequestCheck{{Name: "ci", Bucket: "pass", State: "SUCCESS"}},
+		mergeResult: github.MergeResult{Merged: true, SHA: "merge123"},
+	}
+	engine := testEngine(store)
+	engine.MergeGate = PolicyMergeGate{AutoMerge: true, Store: store, GitHub: gh, Git: &fakeMergeGateGit{clean: true}}
+	return engine, gh
+}
+
+// seedObservedPullRequest records what the forge last reported, which is where
+// the rule reads the current head from. The daemon poll, the PR lifecycle and the
+// merge gate all maintain this row in production.
+func seedObservedPullRequest(t *testing.T, store *db.Store, head string) {
+	t.Helper()
+	if err := store.UpsertPullRequest(context.Background(), db.PullRequest{
+		RepoFullName: "gitmoot/gitmoot",
+		Number:       9,
+		HeadBranch:   "task-9",
+		BaseBranch:   "main",
+		HeadSHA:      head,
+		State:        "open",
+	}); err != nil {
+		t.Fatalf("UpsertPullRequest returned error: %v", err)
+	}
+}
+
+// The merge gate refuses to merge without a durable implement row: it cannot
+// establish independence otherwise. Without this the gate parks in
+// awaiting_human_merge and the state CAS - the thing #1834 wedges on - never runs,
+// which would make every test below vacuous.
+func seedImplementAttribution(t *testing.T, store *db.Store) {
+	t.Helper()
+	insertCompletedJob(t, store, db.Job{ID: "implement-job", Agent: "implementer", Type: "implement"}, JobPayload{
+		Repo:        "gitmoot/gitmoot",
+		Branch:      "task-9",
+		PullRequest: 9,
+		HeadSHA:     "head-new",
+		TaskID:      "task-9",
+		Result:      &AgentResult{Decision: "implemented", Summary: "implemented"},
+	})
+}
+
+func seedWedgedTask(t *testing.T, store *db.Store) {
+	t.Helper()
+	if err := store.UpsertTask(context.Background(), db.Task{
+		ID:           "task-9",
+		RepoFullName: "gitmoot/gitmoot",
+		Branch:       "task-9",
+		State:        string(TaskChangesRequested),
+	}); err != nil {
+		t.Fatalf("UpsertTask returned error: %v", err)
+	}
+}
+
+func seedReviewJob(t *testing.T, store *db.Store, id, agent, head, decision string, state JobState) {
+	t.Helper()
+	payload := JobPayload{
+		Repo:        "gitmoot/gitmoot",
+		Branch:      "task-9",
+		PullRequest: 9,
+		HeadSHA:     head,
+		TaskID:      "task-9",
+	}
+	if decision != "" {
+		payload.Result = &AgentResult{Decision: decision, Summary: decision + " at " + head}
+	}
+	encoded, err := marshalPayload(payload)
+	if err != nil {
+		t.Fatalf("marshalPayload returned error: %v", err)
+	}
+	if err := store.CreateJobWithEvent(context.Background(), db.Job{
+		ID: id, Agent: agent, Type: "review", State: string(state), Payload: encoded,
+	}, db.JobEvent{Kind: string(state), Message: "fixture"}); err != nil {
+		t.Fatalf("CreateJobWithEvent returned error: %v", err)
+	}
+}
+
+func heldReason(t *testing.T, store *db.Store, jobID string) string {
+	t.Helper()
+	events, err := store.ListJobEvents(context.Background(), jobID)
+	if err != nil {
+		t.Fatalf("ListJobEvents returned error: %v", err)
+	}
+	for _, event := range events {
+		if event.Kind == "review_advance_held" {
+			return event.Message
+		}
+	}
+	return ""
+}
+
+// ACCEPTANCE 1: an approval bound to the CURRENT head admits the task out of
+// changes_requested. This is the wedge itself; before the fix the task stayed in
+// changes_requested forever and the PR could not merge.
+func TestApprovalAtCurrentHeadClearsChangesRequested(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	seedWedgedTask(t, store)
+	seedObservedPullRequest(t, store, "head-new")
+	seedImplementAttribution(t, store)
+	engine, gh := wedgeEngine(t, store)
+
+	seedReviewJob(t, store, "review-old", "auditor", "head-old", "changes_requested", JobSucceeded)
+	seedReviewJob(t, store, "review-new", "auditor", "head-new", "approved", JobSucceeded)
+
+	if err := engine.AdvanceJob(ctx, "review-new"); err != nil {
+		t.Fatalf("AdvanceJob returned error: %v; the wedge surfaces here as ErrMergeTaskStateChanged", err)
+	}
+	// The MERGE is the observable, not merely "the state changed": the wedge lives
+	// in ClaimTaskState inside executePullRequestMergeFenced, and every path that
+	// stops short of the merge leaves the task in some other state without ever
+	// exercising the CAS.
+	if len(gh.merges) != 1 {
+		t.Fatalf("merge calls = %d, want 1: an approval at the current head must clear changes_requested and merge (#1834); held=%q",
+			len(gh.merges), heldReason(t, store, "review-new"))
+	}
+	if state := taskState(t, store, "task-9"); state == string(TaskChangesRequested) {
+		t.Fatalf("task stayed in changes_requested after a merge")
+	}
+}
+
+func taskState(t *testing.T, store *db.Store, taskID string) string {
+	t.Helper()
+	task, err := store.GetTask(context.Background(), taskID)
+	if err != nil {
+		t.Fatalf("GetTask returned error: %v", err)
+	}
+	return task.State
+}
+
+// ACCEPTANCE 2: an approval at a SUPERSEDED head must not clear the objection -
+// a newer review job dates a newer head, so this approval reviewed an old tree.
+func TestApprovalAtSupersededHeadLeavesChangesRequested(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	seedWedgedTask(t, store)
+	seedObservedPullRequest(t, store, "head-new")
+	seedImplementAttribution(t, store)
+	engine, gh := wedgeEngine(t, store)
+
+	seedReviewJob(t, store, "review-stale", "auditor", "head-old", "approved", JobSucceeded)
+	// A re-review is already open at the newer head; it has not reported yet.
+	seedReviewJob(t, store, "review-pending", "auditor", "head-new", "", JobRunning)
+
+	if err := engine.AdvanceJob(ctx, "review-stale"); err != nil {
+		t.Fatalf("AdvanceJob returned error: %v", err)
+	}
+	assertTaskState(t, store, "task-9", TaskChangesRequested)
+	if len(gh.merges) != 0 {
+		t.Fatalf("merge calls = %d, want 0: a superseded approval must not merge", len(gh.merges))
+	}
+	reason := heldReason(t, store, "review-stale")
+	if !strings.Contains(reason, "superseded head") {
+		t.Fatalf("held reason = %q, want it to name the superseded head; a silent no-op is what hid #1834", reason)
+	}
+}
+
+// ACCEPTANCE 3: if the LATEST verdict at the current head is itself
+// changes_requested, an earlier approval at that same head must not clear it.
+func TestChangesRequestedAtCurrentHeadOutranksEarlierApproval(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	seedWedgedTask(t, store)
+	seedObservedPullRequest(t, store, "head-new")
+	seedImplementAttribution(t, store)
+	engine, _ := wedgeEngine(t, store)
+
+	seedReviewJob(t, store, "review-approve", "auditor", "head-new", "approved", JobSucceeded)
+	seedReviewJob(t, store, "review-reject", "auditor", "head-new", "changes_requested", JobSucceeded)
+
+	if err := engine.AdvanceJob(ctx, "review-approve"); err != nil {
+		t.Fatalf("AdvanceJob returned error: %v", err)
+	}
+	assertTaskState(t, store, "task-9", TaskChangesRequested)
+	if reason := heldReason(t, store, "review-approve"); !strings.Contains(reason, "requested changes") {
+		t.Fatalf("held reason = %q, want it to name the objection at the current head", reason)
+	}
+}
+
+// ACCEPTANCE 4: the ambiguous same-head case, ruled EXPLICITLY rather than left
+// to iteration order. Two DIFFERENT reviewers at the same head, one objecting and
+// one approving: the objection wins. An approval must never merge over a peer's
+// live objection; the objector re-reviews, or a new head supersedes them both.
+func TestSameHeadObjectionFromAnotherReviewerBeatsApproval(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	seedWedgedTask(t, store)
+	seedObservedPullRequest(t, store, "head-new")
+	seedImplementAttribution(t, store)
+	engine, _ := wedgeEngine(t, store)
+
+	seedReviewJob(t, store, "review-a", "reviewer-a", "head-new", "changes_requested", JobSucceeded)
+	seedReviewJob(t, store, "review-b", "reviewer-b", "head-new", "approved", JobSucceeded)
+
+	if err := engine.AdvanceJob(ctx, "review-b"); err != nil {
+		t.Fatalf("AdvanceJob returned error: %v", err)
+	}
+	assertTaskState(t, store, "task-9", TaskChangesRequested)
+	if reason := heldReason(t, store, "review-b"); !strings.Contains(reason, "requested changes") {
+		t.Fatalf("held reason = %q, want the same-head objection named", reason)
+	}
+}
+
+// A task that never objected keeps the pre-#1834 behaviour exactly: the gate is
+// claimed as reviewing. This is the guard against "fixing" the wedge by loosening
+// the claim for every task.
+func TestApprovalOnReviewingTaskStillClaimsReviewing(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	if err := store.UpsertTask(ctx, db.Task{
+		ID: "task-9", RepoFullName: "gitmoot/gitmoot", Branch: "task-9", State: string(TaskReviewing),
+	}); err != nil {
+		t.Fatalf("UpsertTask returned error: %v", err)
+	}
+	seedObservedPullRequest(t, store, "head-new")
+	seedImplementAttribution(t, store)
+	engine, _ := wedgeEngine(t, store)
+	seedReviewJob(t, store, "review-new", "auditor", "head-new", "approved", JobSucceeded)
+
+	if err := engine.AdvanceJob(ctx, "review-new"); err != nil {
+		t.Fatalf("AdvanceJob returned error: %v", err)
+	}
+	if got := heldReason(t, store, "review-new"); got != "" {
+		t.Fatalf("a reviewing task must not be held: %q", got)
+	}
+	task, err := store.GetTask(ctx, "task-9")
+	if err != nil {
+		t.Fatalf("GetTask returned error: %v", err)
+	}
+	if task.State == string(TaskReviewing) {
+		t.Fatal("task stayed in reviewing; the approval should have advanced it")
+	}
+}

--- a/internal/workflow/changes_requested_wedge_test.go
+++ b/internal/workflow/changes_requested_wedge_test.go
@@ -289,15 +289,26 @@ func TestApprovalWithoutAnObservedPullRequestRowIsRefused(t *testing.T) {
 			}
 			seedReviewJob(t, store, "review-new", "auditor", "head-new", "approved", JobSucceeded)
 
-			if err := engine.AdvanceJob(ctx, "review-new"); err != nil {
-				t.Fatalf("AdvanceJob returned error: %v", err)
+			// The hold must be RETRYABLE, not settled: AdvanceJob returns an error so
+			// the advancement stays unreconciled and the daemon's advance-retry
+			// re-drives it once the pull_requests row lands. Returning nil here would
+			// record the approval as advanced and nothing would ever re-drive it -
+			// measured as a recovery wedge in the #1871 round-3 review.
+			err := engine.AdvanceJob(ctx, "review-new")
+			if err == nil {
+				t.Fatal("AdvanceJob returned nil: an unconfirmable head must leave the advancement retryable, not settle it")
+			}
+			if !strings.Contains(err.Error(), "no observed pull request row") {
+				t.Fatalf("error = %v, want it to name the missing pull request row", err)
 			}
 			assertTaskState(t, store, "task-9", TaskChangesRequested)
 			if len(gh.merges) != 0 {
 				t.Fatalf("merge calls = %d, want 0: an unconfirmed current head must never admit an approval", len(gh.merges))
 			}
-			if reason := heldReason(t, store, "review-new"); !strings.Contains(reason, "no observed pull request row") {
-				t.Fatalf("held reason = %q, want it to name the missing pull request row", reason)
+			// And it must NOT write a durable held event on this path: it is re-entered
+			// every tick, and a row per tick is what grew job_events to ~1.8M once.
+			if reason := heldReason(t, store, "review-new"); reason != "" {
+				t.Fatalf("retryable hold wrote a review_advance_held event (%q); the deduped advance_retry marker carries it instead", reason)
 			}
 		})
 	}
@@ -315,8 +326,8 @@ func TestApprovalAdmittedOnceThePullRequestRowAppears(t *testing.T) {
 	seedReviewJob(t, store, "review-old", "auditor", "head-old", "changes_requested", JobSucceeded)
 	seedReviewJob(t, store, "review-new", "auditor", "head-new", "approved", JobSucceeded)
 
-	if err := engine.AdvanceJob(ctx, "review-new"); err != nil {
-		t.Fatalf("AdvanceJob (no row) returned error: %v", err)
+	if err := engine.AdvanceJob(ctx, "review-new"); err == nil {
+		t.Fatal("AdvanceJob (no row) returned nil; the hold must stay retryable")
 	}
 	if len(gh.merges) != 0 {
 		t.Fatalf("merged with no observed pull request row")

--- a/internal/workflow/changes_requested_wedge_test.go
+++ b/internal/workflow/changes_requested_wedge_test.go
@@ -260,3 +260,72 @@ func TestApprovalOnReviewingTaskStillClaimsReviewing(t *testing.T) {
 		t.Fatal("task stayed in reviewing; the approval should have advanced it")
 	}
 }
+
+// The missing-pull_requests-row branch, in BOTH directions (#1871 review P1/P3).
+// Every other test here seeds the observed row, so without these the refusal path
+// has no coverage - and the first version of it ADMITTED whenever some review had
+// objected at a different head, which carries no ordering at all and could merge
+// over a live objection.
+func TestApprovalWithoutAnObservedPullRequestRowIsRefused(t *testing.T) {
+	ctx := context.Background()
+	for _, tc := range []struct {
+		name            string
+		objectionAtHead string
+	}{
+		// The dangerous case: an objection elsewhere used to be read as "the tree
+		// moved on", which it is not - nothing orders the two heads.
+		{name: "objection at another head", objectionAtHead: "head-old"},
+		{name: "objection at this head", objectionAtHead: "head-new"},
+		{name: "no objection recorded", objectionAtHead: ""},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			store := openEngineStore(t)
+			seedWedgedTask(t, store)
+			seedImplementAttribution(t, store)
+			// Deliberately NO seedObservedPullRequest: the forge head is unknown.
+			engine, gh := wedgeEngine(t, store)
+			if tc.objectionAtHead != "" {
+				seedReviewJob(t, store, "review-objection", "auditor", tc.objectionAtHead, "changes_requested", JobSucceeded)
+			}
+			seedReviewJob(t, store, "review-new", "auditor", "head-new", "approved", JobSucceeded)
+
+			if err := engine.AdvanceJob(ctx, "review-new"); err != nil {
+				t.Fatalf("AdvanceJob returned error: %v", err)
+			}
+			assertTaskState(t, store, "task-9", TaskChangesRequested)
+			if len(gh.merges) != 0 {
+				t.Fatalf("merge calls = %d, want 0: an unconfirmed current head must never admit an approval", len(gh.merges))
+			}
+			if reason := heldReason(t, store, "review-new"); !strings.Contains(reason, "no observed pull request row") {
+				t.Fatalf("held reason = %q, want it to name the missing pull request row", reason)
+			}
+		})
+	}
+}
+
+// ...and once the row appears, the same approval is admitted. This is the pair to
+// the refusal above: it proves the refusal is about the MISSING EVIDENCE and not a
+// blanket block that would re-wedge every task.
+func TestApprovalAdmittedOnceThePullRequestRowAppears(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	seedWedgedTask(t, store)
+	seedImplementAttribution(t, store)
+	engine, gh := wedgeEngine(t, store)
+	seedReviewJob(t, store, "review-old", "auditor", "head-old", "changes_requested", JobSucceeded)
+	seedReviewJob(t, store, "review-new", "auditor", "head-new", "approved", JobSucceeded)
+
+	if err := engine.AdvanceJob(ctx, "review-new"); err != nil {
+		t.Fatalf("AdvanceJob (no row) returned error: %v", err)
+	}
+	if len(gh.merges) != 0 {
+		t.Fatalf("merged with no observed pull request row")
+	}
+	seedObservedPullRequest(t, store, "head-new")
+	if err := engine.AdvanceJob(ctx, "review-new"); err != nil {
+		t.Fatalf("AdvanceJob (row present) returned error: %v", err)
+	}
+	if len(gh.merges) != 1 {
+		t.Fatalf("merge calls = %d, want 1 once the current head is observable", len(gh.merges))
+	}
+}

--- a/internal/workflow/engine_routing_merge.go
+++ b/internal/workflow/engine_routing_merge.go
@@ -282,25 +282,29 @@ func (e Engine) setReviewingIfNotChangesRequested(ctx context.Context, ref taskR
 // by design and correctly refuses to erase a live objection, so nothing re-armed
 // it. The fix is not to erase the objection earlier but to let an approval that
 // is DEMONSTRABLY NEWER than it own the claim.
-func (e Engine) mergeGateExpectedTaskState(ctx context.Context, ref taskRef, payload JobPayload) (TaskState, bool, string, error) {
+// The third return is the refusal reason and the fourth says whether the hold is
+// TRANSIENT. A transient hold must be retried rather than settled: the caller
+// returns an error so the advancement stays unreconciled and the daemon's
+// advance-retry re-drives it. A terminal hold records a durable event and stops.
+func (e Engine) mergeGateExpectedTaskState(ctx context.Context, ref taskRef, payload JobPayload) (TaskState, bool, string, bool, error) {
 	if strings.TrimSpace(ref.ID) == "" {
-		return TaskReviewing, true, "", nil
+		return TaskReviewing, true, "", false, nil
 	}
 	task, err := e.Store.GetTask(ctx, ref.ID)
 	if err != nil && !errors.Is(err, sql.ErrNoRows) {
-		return "", false, "", err
+		return "", false, "", false, err
 	}
 	if err != nil || task.State != string(TaskChangesRequested) {
-		return TaskReviewing, true, "", nil
+		return TaskReviewing, true, "", false, nil
 	}
-	admitted, reason, err := e.approvalSupersedesChangesRequested(ctx, payload)
+	admitted, reason, retryable, err := e.approvalSupersedesChangesRequested(ctx, payload)
 	if err != nil {
-		return "", false, "", err
+		return "", false, "", false, err
 	}
 	if !admitted {
-		return "", false, reason, nil
+		return "", false, reason, retryable, nil
 	}
-	return TaskChangesRequested, true, "", nil
+	return TaskChangesRequested, true, "", false, nil
 }
 
 // approvalSupersedesChangesRequested answers whether THIS approving review is
@@ -323,16 +327,17 @@ func (e Engine) mergeGateExpectedTaskState(ctx context.Context, ref taskRef, pay
 // head requested changes, the objection stands even when a different reviewer
 // approved the same head. An approval must not merge over a peer's live
 // objection; the objector re-reviews, or a new head supersedes them both.
-func (e Engine) approvalSupersedesChangesRequested(ctx context.Context, payload JobPayload) (bool, string, error) {
+func (e Engine) approvalSupersedesChangesRequested(ctx context.Context, payload JobPayload) (bool, string, bool, error) {
 	approvingHead := strings.TrimSpace(payload.HeadSHA)
 	if approvingHead == "" {
-		return false, "the approving review carries no head SHA, so it cannot be bound to the current head", nil
+		// Terminal: a review row does not gain a head later.
+		return false, "the approving review carries no head SHA, so it cannot be bound to the current head", false, nil
 	}
 	currentHead := ""
 	if payload.PullRequest > 0 {
 		pr, err := e.Store.GetPullRequest(ctx, payload.Repo, int64(payload.PullRequest))
 		if err != nil && !errors.Is(err, sql.ErrNoRows) {
-			return false, "", err
+			return false, "", false, err
 		}
 		if err == nil {
 			currentHead = strings.TrimSpace(pr.HeadSHA)
@@ -348,18 +353,23 @@ func (e Engine) approvalSupersedesChangesRequested(ctx context.Context, payload 
 		// merge over a live, current objection whenever the row is missing - which
 		// the CLI dispatch path can reach on a PR the daemon never polled
 		// (#1871 review, P1). Refusing only leaves the task where it already is.
+		//
+		// TRANSIENT: the row appears as soon as the daemon polls the PR, so this
+		// hold must be RETRIED, not settled. Settling it silently is the recovery
+		// wedge the round-3 review measured - the approval was recorded as advanced
+		// and nothing re-drove it once the row landed (#1871 review round 3, P1).
 		return false, fmt.Sprintf(
 			"no observed pull request row records a current head for %s#%d, so this approval cannot be shown to be bound to it",
-			payload.Repo, payload.PullRequest), nil
+			payload.Repo, payload.PullRequest), true, nil
 	}
 	if approvingHead != currentHead {
 		return false, fmt.Sprintf(
 			"approval is bound to head %s but the pull request's current head is %s; an approval at a superseded head does not clear changes_requested",
-			approvingHead, currentHead), nil
+			approvingHead, currentHead), false, nil
 	}
 	jobs, err := e.Store.ListJobs(ctx)
 	if err != nil {
-		return false, "", err
+		return false, "", false, err
 	}
 	blockingSeverity := e.reviewBlockingSeverity(payload.Repo)
 	for _, job := range jobs {
@@ -368,7 +378,7 @@ func (e Engine) approvalSupersedesChangesRequested(ctx context.Context, payload 
 		}
 		jobPayload, err := unmarshalPayload(job.Payload)
 		if err != nil {
-			return false, "", err
+			return false, "", false, err
 		}
 		if !sameTask(payload, jobPayload) || jobPayload.Result == nil || ResultIsFanOut(jobPayload.Result) {
 			continue
@@ -382,10 +392,10 @@ func (e Engine) approvalSupersedesChangesRequested(ctx context.Context, payload 
 		if strings.TrimSpace(jobPayload.HeadSHA) == approvingHead {
 			return false, fmt.Sprintf(
 				"a review at head %s requested changes, so the objection stands even though this review approved the same head",
-				approvingHead), nil
+				approvingHead), false, nil
 		}
 	}
-	return true, "", nil
+	return true, "", false, nil
 }
 
 func (e Engine) latestReviewRound(ctx context.Context, current JobPayload) (string, error) {

--- a/internal/workflow/engine_routing_merge.go
+++ b/internal/workflow/engine_routing_merge.go
@@ -272,6 +272,118 @@ func (e Engine) setReviewingIfNotChangesRequested(ctx context.Context, ref taskR
 	return e.setTaskState(ctx, ref, TaskReviewing)
 }
 
+// mergeGateExpectedTaskState resolves the task state the merge gate must claim
+// before it merges, and reports whether the approval may proceed at all.
+//
+// It exists because the approved arm used to hand runMergeGate a CONSTANT
+// TaskReviewing. Once a task reached changes_requested that claim could never
+// match, so a later approval at a fresh head could not clear the gate and the
+// task wedged permanently (#1834) - setReviewingIfNotChangesRequested is one-way
+// by design and correctly refuses to erase a live objection, so nothing re-armed
+// it. The fix is not to erase the objection earlier but to let an approval that
+// is DEMONSTRABLY NEWER than it own the claim.
+func (e Engine) mergeGateExpectedTaskState(ctx context.Context, ref taskRef, payload JobPayload) (TaskState, bool, string, error) {
+	if strings.TrimSpace(ref.ID) == "" {
+		return TaskReviewing, true, "", nil
+	}
+	task, err := e.Store.GetTask(ctx, ref.ID)
+	if err != nil && !errors.Is(err, sql.ErrNoRows) {
+		return "", false, "", err
+	}
+	if err != nil || task.State != string(TaskChangesRequested) {
+		return TaskReviewing, true, "", nil
+	}
+	admitted, reason, err := e.approvalSupersedesChangesRequested(ctx, payload)
+	if err != nil {
+		return "", false, "", err
+	}
+	if !admitted {
+		return "", false, reason, nil
+	}
+	return TaskChangesRequested, true, "", nil
+}
+
+// approvalSupersedesChangesRequested answers whether THIS approving review is
+// bound to the task's current head and is unopposed there. It returns the reason
+// when it refuses, so the caller can record why an approval did not advance
+// rather than leaving a silent no-op - silence is what made #1834 invisible
+// until four tasks had wedged.
+//
+// THE CURRENT HEAD COMES FROM THE OBSERVED PULL REQUEST, not from guessing which
+// review row is newest. `tasks` has no head column, but `pull_requests.head_sha`
+// already records what the forge last reported and is maintained by the daemon
+// poll, the PR lifecycle and the merge gate - so this needs no migration and no
+// recency heuristic. Ordering review rows would have been unsound: ListJobs
+// orders BY ID, and created_at is an ISO string with SECOND granularity, so two
+// reviews dispatched in the same second cannot be separated at all. A tie-break
+// on job id is deterministic but arbitrary, which is precisely the "accident of
+// iteration order" this rule must not rest on.
+//
+// THE SAME-HEAD TIE IS RULED EXPLICITLY: if any succeeded review at the current
+// head requested changes, the objection stands even when a different reviewer
+// approved the same head. An approval must not merge over a peer's live
+// objection; the objector re-reviews, or a new head supersedes them both.
+func (e Engine) approvalSupersedesChangesRequested(ctx context.Context, payload JobPayload) (bool, string, error) {
+	approvingHead := strings.TrimSpace(payload.HeadSHA)
+	if approvingHead == "" {
+		return false, "the approving review carries no head SHA, so it cannot be bound to the current head", nil
+	}
+	currentHead := ""
+	if payload.PullRequest > 0 {
+		pr, err := e.Store.GetPullRequest(ctx, payload.Repo, int64(payload.PullRequest))
+		if err != nil && !errors.Is(err, sql.ErrNoRows) {
+			return false, "", err
+		}
+		if err == nil {
+			currentHead = strings.TrimSpace(pr.HeadSHA)
+		}
+	}
+	if currentHead != "" && approvingHead != currentHead {
+		return false, fmt.Sprintf(
+			"approval is bound to head %s but the pull request's current head is %s; an approval at a superseded head does not clear changes_requested",
+			approvingHead, currentHead), nil
+	}
+	jobs, err := e.Store.ListJobs(ctx)
+	if err != nil {
+		return false, "", err
+	}
+	blockingSeverity := e.reviewBlockingSeverity(payload.Repo)
+	objectionElsewhere := false
+	for _, job := range jobs {
+		if job.Type != "review" || job.State != "succeeded" {
+			continue
+		}
+		jobPayload, err := unmarshalPayload(job.Payload)
+		if err != nil {
+			return false, "", err
+		}
+		if !sameTask(payload, jobPayload) || jobPayload.Result == nil || ResultIsFanOut(jobPayload.Result) {
+			continue
+		}
+		if effectiveReviewDecisionForPayload(jobPayload, blockingSeverity) != "changes_requested" {
+			continue
+		}
+		head := strings.TrimSpace(jobPayload.HeadSHA)
+		if head == approvingHead {
+			return false, fmt.Sprintf(
+				"a review at head %s requested changes, so the objection stands even though this review approved the same head",
+				approvingHead), nil
+		}
+		if head != "" {
+			objectionElsewhere = true
+		}
+	}
+	if currentHead == "" && !objectionElsewhere {
+		// No observed pull request row AND no objection at another head: nothing
+		// here shows the tree moved past whatever set changes_requested, so admitting
+		// would be a guess. Refuse and say which fact is missing.
+		return false, fmt.Sprintf(
+			"no observed pull request row records a current head for %s#%d and no review objected at a different head, so this approval cannot be shown to supersede the objection",
+			payload.Repo, payload.PullRequest), nil
+	}
+	return true, "", nil
+}
+
 func (e Engine) latestReviewRound(ctx context.Context, current JobPayload) (string, error) {
 	jobs, err := e.Store.ListJobs(ctx)
 	if err != nil {

--- a/internal/workflow/engine_routing_merge.go
+++ b/internal/workflow/engine_routing_merge.go
@@ -338,7 +338,21 @@ func (e Engine) approvalSupersedesChangesRequested(ctx context.Context, payload 
 			currentHead = strings.TrimSpace(pr.HeadSHA)
 		}
 	}
-	if currentHead != "" && approvingHead != currentHead {
+	if currentHead == "" {
+		// The current head could not be confirmed, so there is NO evidence this
+		// approval is newer than the objection. An earlier draft admitted here when
+		// some review had objected at a different head, but "a different head"
+		// carries no ordering: this PR rejects job recency as unsound precisely
+		// because ListJobs orders by id and created_at is second-granularity, and
+		// the same argument disqualifies it here. Admitting would let an approval
+		// merge over a live, current objection whenever the row is missing - which
+		// the CLI dispatch path can reach on a PR the daemon never polled
+		// (#1871 review, P1). Refusing only leaves the task where it already is.
+		return false, fmt.Sprintf(
+			"no observed pull request row records a current head for %s#%d, so this approval cannot be shown to be bound to it",
+			payload.Repo, payload.PullRequest), nil
+	}
+	if approvingHead != currentHead {
 		return false, fmt.Sprintf(
 			"approval is bound to head %s but the pull request's current head is %s; an approval at a superseded head does not clear changes_requested",
 			approvingHead, currentHead), nil
@@ -348,7 +362,6 @@ func (e Engine) approvalSupersedesChangesRequested(ctx context.Context, payload 
 		return false, "", err
 	}
 	blockingSeverity := e.reviewBlockingSeverity(payload.Repo)
-	objectionElsewhere := false
 	for _, job := range jobs {
 		if job.Type != "review" || job.State != "succeeded" {
 			continue
@@ -363,23 +376,14 @@ func (e Engine) approvalSupersedesChangesRequested(ctx context.Context, payload 
 		if effectiveReviewDecisionForPayload(jobPayload, blockingSeverity) != "changes_requested" {
 			continue
 		}
-		head := strings.TrimSpace(jobPayload.HeadSHA)
-		if head == approvingHead {
+		// Only an objection AT THE CURRENT HEAD can block: by here the approving
+		// head IS the current head, and an objection at any other head is one the
+		// current head supersedes. No ordering is needed or attempted.
+		if strings.TrimSpace(jobPayload.HeadSHA) == approvingHead {
 			return false, fmt.Sprintf(
 				"a review at head %s requested changes, so the objection stands even though this review approved the same head",
 				approvingHead), nil
 		}
-		if head != "" {
-			objectionElsewhere = true
-		}
-	}
-	if currentHead == "" && !objectionElsewhere {
-		// No observed pull request row AND no objection at another head: nothing
-		// here shows the tree moved past whatever set changes_requested, so admitting
-		// would be a guess. Refuse and say which fact is missing.
-		return false, fmt.Sprintf(
-			"no observed pull request row records a current head for %s#%d and no review objected at a different head, so this approval cannot be shown to supersede the objection",
-			payload.Repo, payload.PullRequest), nil
 	}
 	return true, "", nil
 }

--- a/internal/workflow/engine_run_budgets.go
+++ b/internal/workflow/engine_run_budgets.go
@@ -816,11 +816,29 @@ func (e Engine) AdvanceJob(ctx context.Context, jobID string) (retErr error) {
 			// be claimed as changes_requested, and only when this approval is bound
 			// to the current head and unopposed there; otherwise the objection
 			// stands and the approval is recorded rather than silently dropped.
-			expectedState, proceed, held, err := e.mergeGateExpectedTaskState(ctx, ref, payload)
+			expectedState, proceed, held, retryable, err := e.mergeGateExpectedTaskState(ctx, ref, payload)
 			if err != nil {
 				return err
 			}
 			if !proceed {
+				if retryable {
+					// A TRANSIENT hold - the current head is not observable YET. Returning
+					// an error leaves the advancement unreconciled, so the daemon's
+					// advance-retry re-drives this approval once the daemon poll inserts
+					// the pull_requests row. Recording an event and returning nil would
+					// SETTLE it, and nothing would ever re-drive it: the approval reads as
+					// advanced while the task stays wedged (#1871 review round 3, P1,
+					// measured with a two-poll probe that ended gate_requests=0).
+					//
+					// No job event is written here on purpose. This path is re-entered on
+					// every tick until the row appears, and recordAdvanceRetryOnce already
+					// dedups the advance_retry marker that carries this message - appending
+					// a row per tick is what grew job_events to ~1.8M rows once before.
+					return fmt.Errorf("review approval held: %s", held)
+				}
+				// TERMINAL: a superseded head or a live objection at the current head.
+				// Nothing will change without a new review or a new head, so settle it
+				// with a durable reason instead of retrying forever.
 				return e.Store.AddJobEvent(ctx, db.JobEvent{
 					JobID:   job.ID,
 					Kind:    "review_advance_held",

--- a/internal/workflow/engine_run_budgets.go
+++ b/internal/workflow/engine_run_budgets.go
@@ -811,7 +811,23 @@ func (e Engine) AdvanceJob(ctx context.Context, jobID string) (retErr error) {
 			if !ready {
 				return e.setReviewingIfNotChangesRequested(ctx, ref)
 			}
-			_, err = e.runMergeGate(ctx, reviewer, payload, ref, TaskReviewing)
+			// #1834: the expectation handed to the gate must be the task's ACTUAL
+			// state, not a constant. A task that reached changes_requested can only
+			// be claimed as changes_requested, and only when this approval is bound
+			// to the current head and unopposed there; otherwise the objection
+			// stands and the approval is recorded rather than silently dropped.
+			expectedState, proceed, held, err := e.mergeGateExpectedTaskState(ctx, ref, payload)
+			if err != nil {
+				return err
+			}
+			if !proceed {
+				return e.Store.AddJobEvent(ctx, db.JobEvent{
+					JobID:   job.ID,
+					Kind:    "review_advance_held",
+					Message: held,
+				})
+			}
+			_, err = e.runMergeGate(ctx, reviewer, payload, ref, expectedState)
 			return err
 		}
 	}


### PR DESCRIPTION
Closes #1834.

## The wedge

Once a task reached `changes_requested`, an approval at a later head could never clear the merge gate. The approved arm handed `runMergeGate` a **constant** `TaskReviewing`; `PolicyMergeGate` turns that into `ClaimTaskState(taskID, "reviewing")` inside `executePullRequestMergeFenced`, which can never match a row reading `changes_requested`. Every later approval failed with `ErrMergeTaskStateChanged`, and `setReviewingIfNotChangesRequested` is one-way **by design** and correctly refuses to erase a live objection, so nothing re-armed it.

## The fix

The objection is not erased earlier. An approval that is demonstrably newer is allowed to own the claim:

- the arm computes the expected state from the task's **actual** state, and passes `changes_requested` only when the approval is bound to the current head and is unopposed there;
- a refusal records a `review_advance_held` job event naming the reason, because the silence is what kept this invisible until four tasks had wedged.

**The current head comes from `pull_requests.head_sha`, not from guessing which review row is newest.** Deriving it from review payloads was tried first and is unsound: `ListJobs` orders BY ID and `jobs.created_at` is second-granularity, so two reviews dispatched in the same second cannot be ordered, and a job-id tie-break is deterministic but arbitrary. It measurably picked the wrong head and failed two of these tests. `pull_requests` is maintained by the daemon poll, the PR lifecycle and the merge gate — no migration, and it records what the forge reported.

**The same-head tie is ruled explicitly:** a succeeded objection at the current head beats an approval at that head, including from a different reviewer.

**The manual-dispatch path is fixed with it.** The branchless path wrote `reviewing` through `UpsertTaskUnlessStates` whose exclusion list named only the disposed states, so dispatching a review silently cleared a live objection — while the `--branch` path returns before any state write. That asymmetry is why repeated manual rounds never reset the wedged tasks.

Constraints honoured: no `setTaskState` call is added on the routing side, the one-way guard's contract is unchanged, and no branch lock is taken or designed around.

## Evidence

Tests drive `Engine.AdvanceJob` against a `PolicyMergeGate` backed by the real store so the CAS executes, and assert the **merge happened** rather than that the state merely changed — the gate parks in `awaiting_human_merge` without reaching the CAS, and the first version of this test passed with the defect fully restored.

Mutants, all against a **compiling** tree, all restored byte-identical:

| mutant | tests failed |
|---|---|
| restore the constant `TaskReviewing` | 1 |
| disable the superseded-head check | 1 |
| ignore a same-head objection | 2 |
| make admission never refuse | 3 |
| let dispatch erase the objection | 1 (internal/cli) |

Gate: `go version go1.26.4 linux/amd64`, `GOTOOLCHAIN=go1.26.4`; gofmt clean, `go build ./...` OK, `go vet ./...` OK, `go generate ./...` a byte-identical no-op, `go test ./...` 39 packages ok with one failure — `TestApplyReviewPolicyEmptyHomeIsOff`, which is **pre-existing and host-dependent** (it asserts an empty home resolves to defaults but falls through to the operator's real `~/.gitmoot`; it passes with `HOME` set to an empty temp dir and this branch touches none of its files).