### PR TITLE
refactor(test): tag the e2e/live suite and add the CI lane that runs it (#1760)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,12 @@ name: CI
 #     run everything.
 #   - BUILD / VET / TEST: build, generated-contract check, vet, and plain
 #     `go test ./...` stay together with the partition-script self-test as the
-#     non-race gate.
+#     non-race gate. Since #1760 step 3 this lane runs the UNTAGGED tests only:
+#     36 e2e/live files carry `//go:build e2e` and are invisible without it.
+#   - E2E: the same `go test ./...` WITH `-tags e2e`, which is the only lane that
+#     compiles those 36 files. Tagging them without this job would have stopped
+#     them running forever, silently, and a green suite is exactly what that
+#     failure looks like.
 #   - RACE BUILD: five package jobs compile one -race test binary each. Every
 #     package's full current test list is partitioned and asserted to appear
 #     exactly once before its binary + shard plan are uploaded.
@@ -109,6 +114,31 @@ jobs:
       - name: Test
         run: go test -timeout 25m ./...
 
+  e2e:
+    name: e2e (tagged)
+    needs: changes
+    # Skipped on dep-only PRs for the same reason as the race lanes (#754).
+    if: needs.changes.outputs.code == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      # THE ONLY LANE THAT COMPILES THE TAGGED FILES. `./...` rather than the
+      # three packages that hold them today, because a package list would silently
+      # stop covering a tagged file added to a fourth package later — the same
+      # silent-stop this job exists to prevent, one level up. The cost is that the
+      # untagged tests run here a second time; that is the price of a lane that
+      # cannot drift, and it runs concurrently with build-test rather than after.
+      - name: Test (e2e tag)
+        run: go test -tags e2e -timeout 30m ./...
+
   race-build:
     name: race build (internal/${{ matrix.package }})
     needs: changes
@@ -148,7 +178,13 @@ jobs:
           bundle="$RUNNER_TEMP/race-$PACKAGE"
           mkdir -p "$bundle/partitions"
 
-          go test -c -race -o "$bundle/$PACKAGE.test" "./internal/$PACKAGE/"
+          # -tags e2e is REQUIRED here, not optional: without it this compile
+          # silently drops the 33 tagged internal/cli files (plus 2 in workflow
+          # and 1 in daemon) from the race binary, and the shard plan derived
+          # from `-test.list` would shrink to match with nothing failing. That is
+          # the same silent-stop as tagging with no runner, one layer down. Race
+          # coverage is therefore byte-for-byte what it was before the tag.
+          go test -c -race -tags e2e -o "$bundle/$PACKAGE.test" "./internal/$PACKAGE/"
           # `go tool -n` resolves the matching test2json executable even when
           # the Go distribution materializes it in the build cache on demand.
           cp "$(go tool -n test2json)" "$bundle/test2json"

--- a/internal/cli/agent_template_roundtrip_e2e_test.go
+++ b/internal/cli/agent_template_roundtrip_e2e_test.go
@@ -1,3 +1,5 @@
+//go:build e2e
+
 package cli
 
 import (

--- a/internal/cli/blocker_defer_e2e_support_test.go
+++ b/internal/cli/blocker_defer_e2e_support_test.go
@@ -1,0 +1,80 @@
+package cli
+
+import (
+	"context"
+	"github.com/gitmoot/gitmoot/internal/config"
+	"github.com/gitmoot/gitmoot/internal/db"
+	"github.com/gitmoot/gitmoot/internal/db/dbtest"
+	"github.com/gitmoot/gitmoot/internal/runtime"
+	"github.com/gitmoot/gitmoot/internal/workflow"
+	"io"
+	"strings"
+	"testing"
+)
+
+// Test helpers shared with UNTAGGED tests, kept out of the e2e build tag
+// (#1760 step 3). Tagging the e2e file beside this one removes it from the
+// default build; these symbols are used by tests that are not e2e, so they
+// would have stopped compiling. Types are moved WITH their methods.
+
+// blockerE2EHome initializes an isolated gitmoot home (no GITMOOT_HOME / live
+// home reads) and opens its store.
+func blockerE2EHome(t *testing.T) (*db.Store, string) {
+	t.Helper()
+	home := t.TempDir()
+	paths := config.PathsForHome(home)
+	if err := config.Initialize(paths); err != nil {
+		t.Fatalf("Initialize returned error: %v", err)
+	}
+	store, err := dbtest.Open(t, paths.Database)
+	if err != nil {
+		t.Fatalf("Open returned error: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := store.Close(); err != nil {
+			t.Fatalf("Close returned error: %v", err)
+		}
+	})
+	return store, home
+}
+
+// blockerE2EWorker builds a jobWorker on the isolated home with only the
+// checkout resolution stubbed (checkout state is not under test); the adapter is
+// the REAL ShellAdapter built by the default factory from the agent's runtime.
+func blockerE2EWorker(store *db.Store, home string, checkout string) jobWorker {
+	worker := defaultJobWorker(store, io.Discard, home)
+	worker.CheckoutValidator = func(_ context.Context, _ db.Job, payload workflow.JobPayload, _ runtime.Agent) (string, error) {
+		if isolated := strings.TrimSpace(payload.WorktreePath); payload.ReadOnlySeat && isolated != "" {
+			return isolated, nil
+		}
+		return checkout, nil
+	}
+	return worker
+}
+
+func blockerE2EJobPayload(t *testing.T, store *db.Store, jobID string) (db.Job, workflow.JobPayload) {
+	t.Helper()
+	job, err := store.GetJob(context.Background(), jobID)
+	if err != nil {
+		t.Fatalf("GetJob returned error: %v", err)
+	}
+	payload, err := daemonJobPayload(job)
+	if err != nil {
+		t.Fatalf("parse payload: %v", err)
+	}
+	return job, payload
+}
+
+func blockerE2EHasEventKind(t *testing.T, store *db.Store, jobID string, kind string) bool {
+	t.Helper()
+	events, err := store.ListJobEvents(context.Background(), jobID)
+	if err != nil {
+		t.Fatalf("ListJobEvents returned error: %v", err)
+	}
+	for _, event := range events {
+		if event.Kind == kind {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/cli/blocker_defer_e2e_test.go
+++ b/internal/cli/blocker_defer_e2e_test.go
@@ -1,19 +1,17 @@
+//go:build e2e
+
 package cli
 
 import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 	"time"
 
-	"github.com/gitmoot/gitmoot/internal/config"
-	"github.com/gitmoot/gitmoot/internal/db"
-	"github.com/gitmoot/gitmoot/internal/db/dbtest"
 	"github.com/gitmoot/gitmoot/internal/events"
 	"github.com/gitmoot/gitmoot/internal/runtime"
 	"github.com/gitmoot/gitmoot/internal/workflow"
@@ -31,41 +29,6 @@ import (
 // the first dispatch terminally fails the job — the `queued` assertion and the
 // second-attempt success assertion below flip RED.
 
-// blockerE2EHome initializes an isolated gitmoot home (no GITMOOT_HOME / live
-// home reads) and opens its store.
-func blockerE2EHome(t *testing.T) (*db.Store, string) {
-	t.Helper()
-	home := t.TempDir()
-	paths := config.PathsForHome(home)
-	if err := config.Initialize(paths); err != nil {
-		t.Fatalf("Initialize returned error: %v", err)
-	}
-	store, err := dbtest.Open(t, paths.Database)
-	if err != nil {
-		t.Fatalf("Open returned error: %v", err)
-	}
-	t.Cleanup(func() {
-		if err := store.Close(); err != nil {
-			t.Fatalf("Close returned error: %v", err)
-		}
-	})
-	return store, home
-}
-
-// blockerE2EWorker builds a jobWorker on the isolated home with only the
-// checkout resolution stubbed (checkout state is not under test); the adapter is
-// the REAL ShellAdapter built by the default factory from the agent's runtime.
-func blockerE2EWorker(store *db.Store, home string, checkout string) jobWorker {
-	worker := defaultJobWorker(store, io.Discard, home)
-	worker.CheckoutValidator = func(_ context.Context, _ db.Job, payload workflow.JobPayload, _ runtime.Agent) (string, error) {
-		if isolated := strings.TrimSpace(payload.WorktreePath); payload.ReadOnlySeat && isolated != "" {
-			return isolated, nil
-		}
-		return checkout, nil
-	}
-	return worker
-}
-
 func blockerE2EDeliveryCount(t *testing.T, countFile string) int {
 	t.Helper()
 	data, err := os.ReadFile(countFile)
@@ -76,33 +39,6 @@ func blockerE2EDeliveryCount(t *testing.T, countFile string) int {
 		t.Fatalf("read count file: %v", err)
 	}
 	return strings.Count(string(data), "x")
-}
-
-func blockerE2EJobPayload(t *testing.T, store *db.Store, jobID string) (db.Job, workflow.JobPayload) {
-	t.Helper()
-	job, err := store.GetJob(context.Background(), jobID)
-	if err != nil {
-		t.Fatalf("GetJob returned error: %v", err)
-	}
-	payload, err := daemonJobPayload(job)
-	if err != nil {
-		t.Fatalf("parse payload: %v", err)
-	}
-	return job, payload
-}
-
-func blockerE2EHasEventKind(t *testing.T, store *db.Store, jobID string, kind string) bool {
-	t.Helper()
-	events, err := store.ListJobEvents(context.Background(), jobID)
-	if err != nil {
-		t.Fatalf("ListJobEvents returned error: %v", err)
-	}
-	for _, event := range events {
-		if event.Kind == kind {
-			return true
-		}
-	}
-	return false
 }
 
 const blockerE2EApprovedResult = `{"gitmoot_result":{"decision":"approved","summary":"second attempt succeeded","findings":[],"changes_made":[],"tests_run":[],"needs":[],"delegations":[]}}`

--- a/internal/cli/blocker_slices_e2e_test.go
+++ b/internal/cli/blocker_slices_e2e_test.go
@@ -1,3 +1,5 @@
+//go:build e2e
+
 package cli
 
 import (

--- a/internal/cli/daemon_conditional_e2e_test.go
+++ b/internal/cli/daemon_conditional_e2e_test.go
@@ -1,3 +1,5 @@
+//go:build e2e
+
 package cli
 
 import (

--- a/internal/cli/daemon_flock_singleton_e2e_test.go
+++ b/internal/cli/daemon_flock_singleton_e2e_test.go
@@ -1,9 +1,10 @@
+//go:build e2e
+
 package cli
 
 import (
 	"bytes"
 	"errors"
-	"fmt"
 	"os"
 	"os/exec"
 	"strconv"
@@ -13,33 +14,6 @@ import (
 
 	"github.com/gitmoot/gitmoot/internal/config"
 )
-
-// daemonRunChildHomeEnv, when set, flips the re-exec'd test binary into a REAL
-// `gitmoot daemon run --home <value>` process (see TestMain). flock(2) is
-// process-scoped — two goroutines cannot exercise it — so the #556 singleton
-// E2E must launch genuine child processes, and re-exec'ing the already-built
-// test binary is how it gets them without shelling out to `go build`.
-const daemonRunChildHomeEnv = "GITMOOT_TEST_DAEMON_RUN_CHILD_HOME"
-
-func TestMain(m *testing.M) {
-	if len(os.Args) > 1 && os.Args[1] == "sandbox-exec" {
-		// Review jobs wrap every runtime through the current executable. Under
-		// go test that executable is cli.test, so dispatch the hidden shim before
-		// m.Run instead of recursively starting the package suite.
-		os.Exit(Run(os.Args[1:], os.Stdout, os.Stderr))
-	}
-	if home := os.Getenv(daemonRunChildHomeEnv); home != "" {
-		os.Exit(Run([]string{"daemon", "run", "--home", home}, os.Stdout, os.Stderr))
-	}
-	code := m.Run()
-	if err := cleanupSharedGitmootTestBinary(); err != nil {
-		fmt.Fprintf(os.Stderr, "clean shared gitmoot test binary: %v\n", err)
-		if code == 0 {
-			code = 1
-		}
-	}
-	os.Exit(code)
-}
 
 // daemonRunProc is one real `daemon run` child process launched by the E2E.
 // stdout/stderr buffers must only be read AFTER done has delivered (cmd.Wait

--- a/internal/cli/daemon_start_visibility_e2e_test.go
+++ b/internal/cli/daemon_start_visibility_e2e_test.go
@@ -1,3 +1,5 @@
+//go:build e2e
+
 package cli
 
 import (

--- a/internal/cli/daemon_worker_loop_escalate_e2e_test.go
+++ b/internal/cli/daemon_worker_loop_escalate_e2e_test.go
@@ -1,3 +1,5 @@
+//go:build e2e
+
 package cli
 
 import (

--- a/internal/cli/effective_runtime_e2e_test.go
+++ b/internal/cli/effective_runtime_e2e_test.go
@@ -1,3 +1,5 @@
+//go:build e2e
+
 package cli
 
 import (

--- a/internal/cli/execbackend_e2e_support_test.go
+++ b/internal/cli/execbackend_e2e_support_test.go
@@ -1,0 +1,38 @@
+package cli
+
+import (
+	"context"
+	"errors"
+	"github.com/gitmoot/gitmoot/internal/subprocess"
+	"io"
+)
+
+// Test helpers shared with UNTAGGED tests, kept out of the e2e build tag
+// (#1760 step 3). Tagging the e2e file beside this one removes it from the
+// default build; these symbols are used by tests that are not e2e, so they
+// would have stopped compiling. Types are moved WITH their methods.
+
+type p2ProbeSubprocessRunner struct {
+	calls int
+}
+
+func (r *p2ProbeSubprocessRunner) Run(context.Context, string, string, ...string) (subprocess.Result, error) {
+	r.calls++
+	return subprocess.Result{}, errP2ProbeSubprocessReached
+}
+
+func (r *p2ProbeSubprocessRunner) RunEnv(ctx context.Context, dir string, _ []string, command string, args ...string) (subprocess.Result, error) {
+	return r.Run(ctx, dir, command, args...)
+}
+
+func (r *p2ProbeSubprocessRunner) RunExactEnv(ctx context.Context, dir string, _ []string, _, _ io.Writer, command string, args ...string) error {
+	_, err := r.Run(ctx, dir, command, args...)
+	return err
+}
+
+func (r *p2ProbeSubprocessRunner) LookPath(string) (string, error) {
+	r.calls++
+	return "", errP2ProbeSubprocessReached
+}
+
+var errP2ProbeSubprocessReached = errors.New("p2-probe subprocess runner reached")

--- a/internal/cli/execbackend_e2e_test.go
+++ b/internal/cli/execbackend_e2e_test.go
@@ -1,3 +1,5 @@
+//go:build e2e
+
 package cli
 
 import (
@@ -48,31 +50,6 @@ var execBackendLocalEventKindBaseline = []string{
 	"advance_started",
 	"delegation_worktree_removed",
 	"advance_completed",
-}
-
-var errP2ProbeSubprocessReached = errors.New("p2-probe subprocess runner reached")
-
-type p2ProbeSubprocessRunner struct {
-	calls int
-}
-
-func (r *p2ProbeSubprocessRunner) Run(context.Context, string, string, ...string) (subprocess.Result, error) {
-	r.calls++
-	return subprocess.Result{}, errP2ProbeSubprocessReached
-}
-
-func (r *p2ProbeSubprocessRunner) RunEnv(ctx context.Context, dir string, _ []string, command string, args ...string) (subprocess.Result, error) {
-	return r.Run(ctx, dir, command, args...)
-}
-
-func (r *p2ProbeSubprocessRunner) RunExactEnv(ctx context.Context, dir string, _ []string, _, _ io.Writer, command string, args ...string) error {
-	_, err := r.Run(ctx, dir, command, args...)
-	return err
-}
-
-func (r *p2ProbeSubprocessRunner) LookPath(string) (string, error) {
-	r.calls++
-	return "", errP2ProbeSubprocessReached
 }
 
 // execBackendDispatchAsk enqueues a background shell ask and returns its job id.

--- a/internal/cli/execbackend_lifecycle_e2e_support_test.go
+++ b/internal/cli/execbackend_lifecycle_e2e_support_test.go
@@ -1,0 +1,20 @@
+package cli
+
+import (
+	"github.com/gitmoot/gitmoot/internal/config"
+	"testing"
+)
+
+// Test helpers shared with UNTAGGED tests, kept out of the e2e build tag
+// (#1760 step 3). Tagging the e2e file beside this one removes it from the
+// default build; these symbols are used by tests that are not e2e, so they
+// would have stopped compiling. Types are moved WITH their methods.
+
+func executionBackendConfigForTest(t *testing.T, worker jobWorker) config.RemoteExecConfig {
+	t.Helper()
+	cfg, err := worker.executionBackendConfig()
+	if err != nil {
+		t.Fatal(err)
+	}
+	return cfg
+}

--- a/internal/cli/execbackend_lifecycle_e2e_test.go
+++ b/internal/cli/execbackend_lifecycle_e2e_test.go
@@ -1,3 +1,5 @@
+//go:build e2e
+
 package cli
 
 import (
@@ -301,15 +303,6 @@ func TestRuntimeContractPreflightUsesConfiguredExecutionIdentityOnlyForLifecycle
 			}
 		})
 	}
-}
-
-func executionBackendConfigForTest(t *testing.T, worker jobWorker) config.RemoteExecConfig {
-	t.Helper()
-	cfg, err := worker.executionBackendConfig()
-	if err != nil {
-		t.Fatal(err)
-	}
-	return cfg
 }
 
 func configuredLocalTestIdentity(t *testing.T) (uint32, uint32) {

--- a/internal/cli/heartbeat_loop_e2e_support_test.go
+++ b/internal/cli/heartbeat_loop_e2e_support_test.go
@@ -1,0 +1,40 @@
+package cli
+
+import (
+	"github.com/gitmoot/gitmoot/internal/config"
+	"github.com/gitmoot/gitmoot/internal/db"
+	"github.com/gitmoot/gitmoot/internal/db/dbtest"
+	"testing"
+)
+
+// Test helpers shared with UNTAGGED tests, kept out of the e2e build tag
+// (#1760 step 3). Tagging the e2e file beside this one removes it from the
+// default build; these symbols are used by tests that are not e2e, so they
+// would have stopped compiling. Types are moved WITH their methods.
+
+// heartbeatLoopE2EHome builds an isolated home with an Initialized config + an
+// open Store on that home's DB, so the write-side CLI (`agent heartbeat add`,
+// which edits the config file), the production heartbeat enqueuer
+// (newHeartbeatEnqueuer(store, home)), and the daemon worker tick all share the
+// SAME config + store — exactly as the live daemon wires them. Never touches a
+// real home.
+func heartbeatLoopE2EHome(t *testing.T) (string, config.Paths, *db.Store) {
+	t.Helper()
+	home := t.TempDir()
+	paths := config.PathsForHome(home)
+	if err := config.Initialize(paths); err != nil {
+		t.Fatalf("Initialize: %v", err)
+	}
+	store, err := dbtest.Open(t, paths.Database)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	t.Cleanup(func() { store.Close() })
+	return home, paths, store
+}
+
+// heartbeatShellResultScript is the SHELL-runtime session body the worker runs as
+// `sh -c <script> gitmoot <prompt>`. It ignores its input and echoes a valid
+// gitmoot_result with decision "approved" so the ask job runs to a TERMINAL
+// succeeded state with NO LLM and NO network — fully deterministic offline.
+const heartbeatShellResultScript = `printf '%s' '{"gitmoot_result":{"decision":"approved","summary":"heartbeat ran","findings":[],"changes_made":[],"tests_run":[],"needs":[],"delegations":[]}}'`

--- a/internal/cli/heartbeat_loop_e2e_test.go
+++ b/internal/cli/heartbeat_loop_e2e_test.go
@@ -1,3 +1,5 @@
+//go:build e2e
+
 package cli
 
 import (
@@ -14,33 +16,6 @@ import (
 	"github.com/gitmoot/gitmoot/internal/runtime"
 	"github.com/gitmoot/gitmoot/internal/workflow"
 )
-
-// heartbeatLoopE2EHome builds an isolated home with an Initialized config + an
-// open Store on that home's DB, so the write-side CLI (`agent heartbeat add`,
-// which edits the config file), the production heartbeat enqueuer
-// (newHeartbeatEnqueuer(store, home)), and the daemon worker tick all share the
-// SAME config + store — exactly as the live daemon wires them. Never touches a
-// real home.
-func heartbeatLoopE2EHome(t *testing.T) (string, config.Paths, *db.Store) {
-	t.Helper()
-	home := t.TempDir()
-	paths := config.PathsForHome(home)
-	if err := config.Initialize(paths); err != nil {
-		t.Fatalf("Initialize: %v", err)
-	}
-	store, err := dbtest.Open(t, paths.Database)
-	if err != nil {
-		t.Fatalf("Open: %v", err)
-	}
-	t.Cleanup(func() { store.Close() })
-	return home, paths, store
-}
-
-// heartbeatShellResultScript is the SHELL-runtime session body the worker runs as
-// `sh -c <script> gitmoot <prompt>`. It ignores its input and echoes a valid
-// gitmoot_result with decision "approved" so the ask job runs to a TERMINAL
-// succeeded state with NO LLM and NO network — fully deterministic offline.
-const heartbeatShellResultScript = `printf '%s' '{"gitmoot_result":{"decision":"approved","summary":"heartbeat ran","findings":[],"changes_made":[],"tests_run":[],"needs":[],"delegations":[]}}'`
 
 // countHeartbeatJobs returns every persisted job whose id carries the
 // heartbeatJobID prefix, i.e. jobs the heartbeat scan actually enqueued (not the

--- a/internal/cli/job_answer_e2e_test.go
+++ b/internal/cli/job_answer_e2e_test.go
@@ -1,3 +1,5 @@
+//go:build e2e
+
 package cli
 
 import (

--- a/internal/cli/memory_lifecycle_e2e_test.go
+++ b/internal/cli/memory_lifecycle_e2e_test.go
@@ -1,3 +1,5 @@
+//go:build e2e
+
 package cli
 
 import (

--- a/internal/cli/pipeline_agent_stage_e2e_test.go
+++ b/internal/cli/pipeline_agent_stage_e2e_test.go
@@ -1,3 +1,5 @@
+//go:build e2e
+
 package cli
 
 import (

--- a/internal/cli/pipeline_auto_merge_e2e_test.go
+++ b/internal/cli/pipeline_auto_merge_e2e_test.go
@@ -1,3 +1,5 @@
+//go:build e2e
+
 package cli
 
 import (

--- a/internal/cli/pipeline_bundle_e2e_test.go
+++ b/internal/cli/pipeline_bundle_e2e_test.go
@@ -1,3 +1,5 @@
+//go:build e2e
+
 package cli
 
 import (

--- a/internal/cli/pipeline_implement_stage_e2e_test.go
+++ b/internal/cli/pipeline_implement_stage_e2e_test.go
@@ -1,3 +1,5 @@
+//go:build e2e
+
 package cli
 
 import (

--- a/internal/cli/pipeline_lifecycle_e2e_test.go
+++ b/internal/cli/pipeline_lifecycle_e2e_test.go
@@ -1,3 +1,5 @@
+//go:build e2e
+
 package cli
 
 import (

--- a/internal/cli/pipeline_remote_roundtrip_e2e_test.go
+++ b/internal/cli/pipeline_remote_roundtrip_e2e_test.go
@@ -1,3 +1,5 @@
+//go:build e2e
+
 package cli
 
 import (

--- a/internal/cli/pipeline_run_e2e_support_test.go
+++ b/internal/cli/pipeline_run_e2e_support_test.go
@@ -1,0 +1,46 @@
+package cli
+
+import (
+	"strings"
+)
+
+// Test helpers shared with UNTAGGED tests, kept out of the e2e build tag
+// (#1760 step 3). Tagging the e2e file beside this one removes it from the
+// default build; these symbols are used by tests that are not e2e, so they
+// would have stopped compiling. Types are moved WITH their methods.
+
+// pipelineStageResultCmd is a shell command that ignores its input and echoes a
+// valid gitmoot_result with the given decision (and, for a block, the given
+// needs). It is the SHELL-runtime session body a stage job runs as
+// `sh -c <cmd> gitmoot <prompt>`, so the whole pipeline chain runs with NO LLM and
+// NO network — fully deterministic offline (the #446/#533 shell-runtime idiom).
+func pipelineStageResultCmd(decision, summary string, needs []string) string {
+	return pipelineStageResultCmdWithSeverity(decision, summary, needs, "")
+}
+
+func pipelineStageResultCmdWithSeverity(decision, summary string, needs []string, severity string) string {
+	needsJSON := "[]"
+	if len(needs) > 0 {
+		quoted := make([]string, 0, len(needs))
+		for _, n := range needs {
+			quoted = append(quoted, `"`+n+`"`)
+		}
+		needsJSON = "[" + strings.Join(quoted, ",") + "]"
+	}
+	severityJSON := ""
+	if severity != "" {
+		severityJSON = `,"severity":"` + severity + `"`
+	}
+	return `printf '%s' '{"gitmoot_result":{"decision":"` + decision + `"` + severityJSON + `,"summary":"` + summary +
+		`","findings":[],"changes_made":[],"tests_run":[],"needs":` + needsJSON + `,"delegations":[]}}'`
+}
+
+// pipelineE2EStage renders one stage block with the shell cmd as a literal YAML
+// block scalar (so the JSON-bearing single-quoted command survives YAML parsing).
+func pipelineE2EStage(id, cmd, needs string) string {
+	block := "  - id: " + id + "\n    cmd: |\n      " + cmd + "\n"
+	if needs != "" {
+		block += "    needs: [" + needs + "]\n"
+	}
+	return block
+}

--- a/internal/cli/pipeline_run_e2e_test.go
+++ b/internal/cli/pipeline_run_e2e_test.go
@@ -1,3 +1,5 @@
+//go:build e2e
+
 package cli
 
 import (
@@ -11,32 +13,6 @@ import (
 	"github.com/gitmoot/gitmoot/internal/pipeline"
 	"github.com/gitmoot/gitmoot/internal/runtime"
 )
-
-// pipelineStageResultCmd is a shell command that ignores its input and echoes a
-// valid gitmoot_result with the given decision (and, for a block, the given
-// needs). It is the SHELL-runtime session body a stage job runs as
-// `sh -c <cmd> gitmoot <prompt>`, so the whole pipeline chain runs with NO LLM and
-// NO network — fully deterministic offline (the #446/#533 shell-runtime idiom).
-func pipelineStageResultCmd(decision, summary string, needs []string) string {
-	return pipelineStageResultCmdWithSeverity(decision, summary, needs, "")
-}
-
-func pipelineStageResultCmdWithSeverity(decision, summary string, needs []string, severity string) string {
-	needsJSON := "[]"
-	if len(needs) > 0 {
-		quoted := make([]string, 0, len(needs))
-		for _, n := range needs {
-			quoted = append(quoted, `"`+n+`"`)
-		}
-		needsJSON = "[" + strings.Join(quoted, ",") + "]"
-	}
-	severityJSON := ""
-	if severity != "" {
-		severityJSON = `,"severity":"` + severity + `"`
-	}
-	return `printf '%s' '{"gitmoot_result":{"decision":"` + decision + `"` + severityJSON + `,"summary":"` + summary +
-		`","findings":[],"changes_made":[],"tests_run":[],"needs":` + needsJSON + `,"delegations":[]}}'`
-}
 
 // TestPipelineBlockedParkE2E is the full-chain, NO-LLM, deterministic blocked-park
 // E2E (#681). It drives the REAL chain a daemon iteration runs, end to end:
@@ -306,14 +282,4 @@ stages:
 	if count != 1 {
 		t.Fatalf("advance_skipped_no_pr count = %d, want 1; events=%+v", count, events)
 	}
-}
-
-// pipelineE2EStage renders one stage block with the shell cmd as a literal YAML
-// block scalar (so the JSON-bearing single-quoted command survives YAML parsing).
-func pipelineE2EStage(id, cmd, needs string) string {
-	block := "  - id: " + id + "\n    cmd: |\n      " + cmd + "\n"
-	if needs != "" {
-		block += "    needs: [" + needs + "]\n"
-	}
-	return block
 }

--- a/internal/cli/pipeline_service_e2e_support_test.go
+++ b/internal/cli/pipeline_service_e2e_support_test.go
@@ -1,0 +1,45 @@
+package cli
+
+import (
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+// Test helpers shared with UNTAGGED tests, kept out of the e2e build tag
+// (#1760 step 3). Tagging the e2e file beside this one removes it from the
+// default build; these symbols are used by tests that are not e2e, so they
+// would have stopped compiling. Types are moved WITH their methods.
+
+func serviceRequest(t *testing.T, method, url, token, body string) *http.Response {
+	t.Helper()
+	request, err := http.NewRequest(method, url, strings.NewReader(body))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if token != "" {
+		request.Header.Set("Authorization", "Bearer "+token)
+	}
+	request.Header.Set("Content-Type", "application/json")
+	response, err := http.DefaultClient.Do(request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return response
+}
+
+func readResponse(t *testing.T, response *http.Response) string {
+	t.Helper()
+	return string(readResponseBytes(t, response))
+}
+
+func readResponseBytes(t *testing.T, response *http.Response) []byte {
+	t.Helper()
+	defer response.Body.Close()
+	body, err := io.ReadAll(response.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return body
+}

--- a/internal/cli/pipeline_service_e2e_test.go
+++ b/internal/cli/pipeline_service_e2e_test.go
@@ -1,3 +1,5 @@
+//go:build e2e
+
 package cli
 
 import (
@@ -436,38 +438,6 @@ func TestPipelineRemoveRefusesActiveServiceRun(t *testing.T) {
 	if _, ok, err := store.GetPipeline(ctx, "active-service"); err != nil || !ok {
 		t.Fatalf("active service pipeline was removed: ok=%v err=%v", ok, err)
 	}
-}
-
-func serviceRequest(t *testing.T, method, url, token, body string) *http.Response {
-	t.Helper()
-	request, err := http.NewRequest(method, url, strings.NewReader(body))
-	if err != nil {
-		t.Fatal(err)
-	}
-	if token != "" {
-		request.Header.Set("Authorization", "Bearer "+token)
-	}
-	request.Header.Set("Content-Type", "application/json")
-	response, err := http.DefaultClient.Do(request)
-	if err != nil {
-		t.Fatal(err)
-	}
-	return response
-}
-
-func readResponse(t *testing.T, response *http.Response) string {
-	t.Helper()
-	return string(readResponseBytes(t, response))
-}
-
-func readResponseBytes(t *testing.T, response *http.Response) []byte {
-	t.Helper()
-	defer response.Body.Close()
-	body, err := io.ReadAll(response.Body)
-	if err != nil {
-		t.Fatal(err)
-	}
-	return body
 }
 
 func decodeResponse(t *testing.T, response *http.Response, target any) {

--- a/internal/cli/pipeline_service_retry_e2e_test.go
+++ b/internal/cli/pipeline_service_retry_e2e_test.go
@@ -1,3 +1,5 @@
+//go:build e2e
+
 package cli
 
 import (

--- a/internal/cli/pipeline_shell_upstream_context_e2e_support_test.go
+++ b/internal/cli/pipeline_shell_upstream_context_e2e_support_test.go
@@ -1,0 +1,26 @@
+package cli
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// Test helpers shared with UNTAGGED tests, kept out of the e2e build tag
+// (#1760 step 3). Tagging the e2e file beside this one removes it from the
+// default build; these symbols are used by tests that are not e2e, so they
+// would have stopped compiling. Types are moved WITH their methods.
+
+func pipelineShellResultCommand(t *testing.T, decision, summary string) string {
+	t.Helper()
+	raw, err := json.Marshal(map[string]any{
+		"gitmoot_result": map[string]any{
+			"decision": decision, "summary": summary,
+			"findings": []any{}, "changes_made": []any{}, "tests_run": []any{},
+			"needs": []any{}, "delegations": []any{},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return `printf '%s' ` + posixQuote(string(raw))
+}

--- a/internal/cli/pipeline_shell_upstream_context_e2e_test.go
+++ b/internal/cli/pipeline_shell_upstream_context_e2e_test.go
@@ -1,3 +1,5 @@
+//go:build e2e
+
 package cli
 
 import (
@@ -155,21 +157,6 @@ func runPipelineShellUpstreamContextE2E(t *testing.T, name, sourceSummary string
 	}
 	t.Fatalf("pipeline %s did not settle", name)
 	return "", nil
-}
-
-func pipelineShellResultCommand(t *testing.T, decision, summary string) string {
-	t.Helper()
-	raw, err := json.Marshal(map[string]any{
-		"gitmoot_result": map[string]any{
-			"decision": decision, "summary": summary,
-			"findings": []any{}, "changes_made": []any{}, "tests_run": []any{},
-			"needs": []any{}, "delegations": []any{},
-		},
-	})
-	if err != nil {
-		t.Fatal(err)
-	}
-	return `printf '%s' ` + posixQuote(string(raw))
 }
 
 func jsonString(t *testing.T, value string) string {

--- a/internal/cli/plan_mode_dispatch_e2e_test.go
+++ b/internal/cli/plan_mode_dispatch_e2e_test.go
@@ -1,3 +1,5 @@
+//go:build e2e
+
 package cli
 
 import (

--- a/internal/cli/readonly_worktree_concurrency_e2e_support_test.go
+++ b/internal/cli/readonly_worktree_concurrency_e2e_support_test.go
@@ -1,0 +1,30 @@
+package cli
+
+import (
+	"context"
+	"github.com/gitmoot/gitmoot/internal/db"
+	"testing"
+)
+
+// Test helpers shared with UNTAGGED tests, kept out of the e2e build tag
+// (#1760 step 3). Tagging the e2e file beside this one removes it from the
+// default build; these symbols are used by tests that are not e2e, so they
+// would have stopped compiling. Types are moved WITH their methods.
+
+// terminalJobDecision returns a terminal job and its parsed gitmoot_result decision.
+func terminalJobDecision(t *testing.T, ctx context.Context, store *db.Store, jobID string) (db.Job, string) {
+	t.Helper()
+	job, err := store.GetJob(ctx, jobID)
+	if err != nil {
+		t.Fatalf("GetJob(%s): %v", jobID, err)
+	}
+	payload, err := daemonJobPayload(job)
+	if err != nil {
+		t.Fatalf("payload(%s): %v", jobID, err)
+	}
+	decision := ""
+	if payload.Result != nil {
+		decision = payload.Result.Decision
+	}
+	return job, decision
+}

--- a/internal/cli/readonly_worktree_concurrency_e2e_test.go
+++ b/internal/cli/readonly_worktree_concurrency_e2e_test.go
@@ -1,3 +1,5 @@
+//go:build e2e
+
 package cli
 
 import (
@@ -208,24 +210,6 @@ func drivePoolConcurrently(t *testing.T, ctx context.Context, worker jobWorker, 
 	close(stop)
 	<-done
 	return bothRunning
-}
-
-// terminalJobDecision returns a terminal job and its parsed gitmoot_result decision.
-func terminalJobDecision(t *testing.T, ctx context.Context, store *db.Store, jobID string) (db.Job, string) {
-	t.Helper()
-	job, err := store.GetJob(ctx, jobID)
-	if err != nil {
-		t.Fatalf("GetJob(%s): %v", jobID, err)
-	}
-	payload, err := daemonJobPayload(job)
-	if err != nil {
-		t.Fatalf("payload(%s): %v", jobID, err)
-	}
-	decision := ""
-	if payload.Result != nil {
-		decision = payload.Result.Decision
-	}
-	return job, decision
 }
 
 // TestReadOnlyWorktreeConcurrentAsksE2E is the primary #739 proof: two BACKGROUND

--- a/internal/cli/reliability_batch_e2e_test.go
+++ b/internal/cli/reliability_batch_e2e_test.go
@@ -1,3 +1,5 @@
+//go:build e2e
+
 package cli
 
 import (

--- a/internal/cli/runtime_override_e2e_support_test.go
+++ b/internal/cli/runtime_override_e2e_support_test.go
@@ -1,0 +1,37 @@
+package cli
+
+import (
+	"context"
+	"github.com/gitmoot/gitmoot/internal/db"
+	"github.com/gitmoot/gitmoot/internal/runtime"
+	"testing"
+)
+
+// Test helpers shared with UNTAGGED tests, kept out of the e2e build tag
+// (#1760 step 3). Tagging the e2e file beside this one removes it from the
+// default build; these symbols are used by tests that are not e2e, so they
+// would have stopped compiling. Types are moved WITH their methods.
+
+func runtimeOverrideE2EHome(t *testing.T) (string, *db.Store, string) {
+	t.Helper()
+	home, _, store := heartbeatLoopE2EHome(t)
+	checkout := createDaemonWorkerGitCheckout(t, "main")
+	seedDaemonWorkerRepo(t, store, "owner/repo", checkout)
+	// Default runtime codex with a stored model: the override must use neither.
+	if err := store.UpsertAgent(context.Background(), db.Agent{
+		Name:           "maintainer",
+		Role:           "worker",
+		Runtime:        runtime.CodexRuntime,
+		RuntimeRef:     runtimeOverrideCodexRef,
+		RepoScope:      "owner/repo",
+		Capabilities:   []string{"ask"},
+		AutonomyPolicy: runtime.AutonomyPolicyAuto,
+		Model:          "gpt-5.5-codex",
+		HealthStatus:   "ok",
+	}); err != nil {
+		t.Fatalf("UpsertAgent: %v", err)
+	}
+	return home, store, checkout
+}
+
+const runtimeOverrideCodexRef = "codex-session-never-invoked"

--- a/internal/cli/runtime_override_e2e_test.go
+++ b/internal/cli/runtime_override_e2e_test.go
@@ -1,3 +1,5 @@
+//go:build e2e
+
 package cli
 
 import (
@@ -42,30 +44,6 @@ import (
 // The foreground test drives the CLI dispatch path; the daemon test drives
 // enqueue-with-override -> the REAL worker tick, proving background jobs
 // honor the override identically.
-
-const runtimeOverrideCodexRef = "codex-session-never-invoked"
-
-func runtimeOverrideE2EHome(t *testing.T) (string, *db.Store, string) {
-	t.Helper()
-	home, _, store := heartbeatLoopE2EHome(t)
-	checkout := createDaemonWorkerGitCheckout(t, "main")
-	seedDaemonWorkerRepo(t, store, "owner/repo", checkout)
-	// Default runtime codex with a stored model: the override must use neither.
-	if err := store.UpsertAgent(context.Background(), db.Agent{
-		Name:           "maintainer",
-		Role:           "worker",
-		Runtime:        runtime.CodexRuntime,
-		RuntimeRef:     runtimeOverrideCodexRef,
-		RepoScope:      "owner/repo",
-		Capabilities:   []string{"ask"},
-		AutonomyPolicy: runtime.AutonomyPolicyAuto,
-		Model:          "gpt-5.5-codex",
-		HealthStatus:   "ok",
-	}); err != nil {
-		t.Fatalf("UpsertAgent: %v", err)
-	}
-	return home, store, checkout
-}
 
 // runtimeOverrideShellScript is the shell-runtime session body run as
 // `sh -c <script> gitmoot <prompt>`: it records that the SHELL adapter really

--- a/internal/cli/runtime_preflight_e2e_test.go
+++ b/internal/cli/runtime_preflight_e2e_test.go
@@ -1,3 +1,5 @@
+//go:build e2e
+
 package cli
 
 import (

--- a/internal/cli/sandbox_live_test.go
+++ b/internal/cli/sandbox_live_test.go
@@ -1,3 +1,5 @@
+//go:build e2e
+
 package cli
 
 import (

--- a/internal/cli/session_job_e2e_test.go
+++ b/internal/cli/session_job_e2e_test.go
@@ -1,3 +1,5 @@
+//go:build e2e
+
 package cli
 
 import (

--- a/internal/cli/task_dismiss_shell_e2e_test.go
+++ b/internal/cli/task_dismiss_shell_e2e_test.go
@@ -1,3 +1,5 @@
+//go:build e2e
+
 package cli
 
 import (

--- a/internal/cli/testmain_test.go
+++ b/internal/cli/testmain_test.go
@@ -1,0 +1,43 @@
+package cli
+
+import (
+	"fmt"
+	"os"
+	"testing"
+)
+
+// TestMain MUST stay in the default build (#1760 step 3). It is the package's
+// only TestMain and it does two things before m.Run that untagged tests depend
+// on: it dispatches the hidden `sandbox-exec` shim, and it re-execs as a real
+// `gitmoot daemon run` child when the env var below is set. Under `go test` the
+// current executable IS cli.test, so a test that re-execs itself without this
+// dispatch restarts the whole package suite recursively - measured as a
+// 38-minute hang in TestRuntimeCredentialCurationForegroundAndDaemonE2E when
+// this function briefly sat behind the e2e tag.
+
+// daemonRunChildHomeEnv, when set, flips the re-exec'd test binary into a REAL
+// `gitmoot daemon run --home <value>` process (see TestMain). flock(2) is
+// process-scoped — two goroutines cannot exercise it — so the #556 singleton
+// E2E must launch genuine child processes, and re-exec'ing the already-built
+// test binary is how it gets them without shelling out to `go build`.
+const daemonRunChildHomeEnv = "GITMOOT_TEST_DAEMON_RUN_CHILD_HOME"
+
+func TestMain(m *testing.M) {
+	if len(os.Args) > 1 && os.Args[1] == "sandbox-exec" {
+		// Review jobs wrap every runtime through the current executable. Under
+		// go test that executable is cli.test, so dispatch the hidden shim before
+		// m.Run instead of recursively starting the package suite.
+		os.Exit(Run(os.Args[1:], os.Stdout, os.Stderr))
+	}
+	if home := os.Getenv(daemonRunChildHomeEnv); home != "" {
+		os.Exit(Run([]string{"daemon", "run", "--home", home}, os.Stdout, os.Stderr))
+	}
+	code := m.Run()
+	if err := cleanupSharedGitmootTestBinary(); err != nil {
+		fmt.Fprintf(os.Stderr, "clean shared gitmoot test binary: %v\n", err)
+		if code == 0 {
+			code = 1
+		}
+	}
+	os.Exit(code)
+}

--- a/internal/cli/warm_reload_e2e_test.go
+++ b/internal/cli/warm_reload_e2e_test.go
@@ -1,3 +1,5 @@
+//go:build e2e
+
 package cli
 
 import (

--- a/internal/cli/wedged_inline_job_e2e_support_test.go
+++ b/internal/cli/wedged_inline_job_e2e_support_test.go
@@ -1,0 +1,128 @@
+package cli
+
+import (
+	"context"
+	"github.com/gitmoot/gitmoot/internal/db"
+	"github.com/gitmoot/gitmoot/internal/runtime"
+	"sync"
+	"testing"
+	"time"
+)
+
+// Test helpers shared with UNTAGGED tests, kept out of the e2e build tag
+// (#1760 step 3). Types are moved WITH their methods.
+
+// wedgeBlockingAdapter is a delivery adapter whose Deliver BLOCKS for the job
+// named in blockJob until release is closed (or the job's ctx is cancelled),
+// standing in for a hung/very-long runtime subprocess. Every other job returns a
+// successful ask result immediately. It records delivery order and lets the test
+// observe (a) that the blocking job is genuinely in flight and (b) whether a
+// second job was delivered WHILE the first one was still blocked.
+type wedgeBlockingAdapter struct {
+	mu        sync.Mutex
+	blockJob  string
+	release   chan struct{}
+	delivered []string
+	blocked   bool
+	output    string
+	// ignoreCtx makes the blocking job deaf to context cancellation, so it stays
+	// in flight while the scheduler pass DRAINS. Default false keeps every
+	// existing test byte-identical; only a test that needs to observe the pass's
+	// post-cancellation behaviour sets it, because a ctx-obeying job returns
+	// immediately and leaves no drain window to observe.
+	ignoreCtx bool
+}
+
+func newWedgeBlockingAdapter(blockJob string) *wedgeBlockingAdapter {
+	return &wedgeBlockingAdapter{
+		blockJob: blockJob,
+		release:  make(chan struct{}),
+		output:   poolSchedulerAskResult,
+	}
+}
+
+func (a *wedgeBlockingAdapter) Name() string { return "wedge-fake" }
+
+func (a *wedgeBlockingAdapter) Start(context.Context, runtime.StartRequest) (runtime.StartResult, error) {
+	return runtime.StartResult{RuntimeRef: "550e8400-e29b-41d4-a716-446655440000"}, nil
+}
+
+func (a *wedgeBlockingAdapter) Validate(context.Context, runtime.Agent) error { return nil }
+
+func (a *wedgeBlockingAdapter) Deliver(ctx context.Context, _ runtime.Agent, job runtime.Job) (runtime.Result, error) {
+	a.mu.Lock()
+	a.delivered = append(a.delivered, job.ID)
+	blocking := job.ID == a.blockJob
+	if blocking {
+		a.blocked = true
+	}
+	a.mu.Unlock()
+	if blocking {
+		if a.ignoreCtx {
+			<-a.release
+		} else {
+			select {
+			case <-a.release:
+			case <-ctx.Done():
+				a.mu.Lock()
+				a.blocked = false
+				a.mu.Unlock()
+				return runtime.Result{}, ctx.Err()
+			}
+		}
+		a.mu.Lock()
+		a.blocked = false
+		a.mu.Unlock()
+	}
+	return runtime.Result{Raw: a.output}, nil
+}
+
+func (a *wedgeBlockingAdapter) Health(context.Context, runtime.Agent) error { return nil }
+
+func (a *wedgeBlockingAdapter) Capabilities(context.Context) ([]string, error) { return nil, nil }
+
+func (a *wedgeBlockingAdapter) stillBlocked() bool {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	return a.blocked
+}
+
+func (a *wedgeBlockingAdapter) deliveredJobs() []string {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	out := make([]string, len(a.delivered))
+	copy(out, a.delivered)
+	return out
+}
+
+// waitForJobState polls the store until jobID reaches wantState or the deadline
+// elapses, returning the last observed state.
+func waitForJobState(t *testing.T, store *db.Store, jobID string, wantState string, deadline time.Duration) string {
+	t.Helper()
+	stop := time.Now().Add(deadline)
+	last := ""
+	for time.Now().Before(stop) {
+		job, err := store.GetJob(context.Background(), jobID)
+		if err == nil {
+			last = job.State
+			if last == wantState {
+				return last
+			}
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	return last
+}
+
+// waitForCondition polls fn until it returns true or the deadline elapses.
+func waitForCondition(t *testing.T, deadline time.Duration, fn func() bool) bool {
+	t.Helper()
+	stop := time.Now().Add(deadline)
+	for time.Now().Before(stop) {
+		if fn() {
+			return true
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	return fn()
+}

--- a/internal/cli/wedged_inline_job_e2e_test.go
+++ b/internal/cli/wedged_inline_job_e2e_test.go
@@ -1,3 +1,5 @@
+//go:build e2e
+
 package cli
 
 import (
@@ -8,125 +10,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/gitmoot/gitmoot/internal/db"
 	"github.com/gitmoot/gitmoot/internal/runtime"
 	"github.com/gitmoot/gitmoot/internal/workflow"
 )
-
-// wedgeBlockingAdapter is a delivery adapter whose Deliver BLOCKS for the job
-// named in blockJob until release is closed (or the job's ctx is cancelled),
-// standing in for a hung/very-long runtime subprocess. Every other job returns a
-// successful ask result immediately. It records delivery order and lets the test
-// observe (a) that the blocking job is genuinely in flight and (b) whether a
-// second job was delivered WHILE the first one was still blocked.
-type wedgeBlockingAdapter struct {
-	mu        sync.Mutex
-	blockJob  string
-	release   chan struct{}
-	delivered []string
-	blocked   bool
-	output    string
-	// ignoreCtx makes the blocking job deaf to context cancellation, so it stays
-	// in flight while the scheduler pass DRAINS. Default false keeps every
-	// existing test byte-identical; only a test that needs to observe the pass's
-	// post-cancellation behaviour sets it, because a ctx-obeying job returns
-	// immediately and leaves no drain window to observe.
-	ignoreCtx bool
-}
-
-func newWedgeBlockingAdapter(blockJob string) *wedgeBlockingAdapter {
-	return &wedgeBlockingAdapter{
-		blockJob: blockJob,
-		release:  make(chan struct{}),
-		output:   poolSchedulerAskResult,
-	}
-}
-
-func (a *wedgeBlockingAdapter) Name() string { return "wedge-fake" }
-
-func (a *wedgeBlockingAdapter) Start(context.Context, runtime.StartRequest) (runtime.StartResult, error) {
-	return runtime.StartResult{RuntimeRef: "550e8400-e29b-41d4-a716-446655440000"}, nil
-}
-
-func (a *wedgeBlockingAdapter) Validate(context.Context, runtime.Agent) error { return nil }
-
-func (a *wedgeBlockingAdapter) Deliver(ctx context.Context, _ runtime.Agent, job runtime.Job) (runtime.Result, error) {
-	a.mu.Lock()
-	a.delivered = append(a.delivered, job.ID)
-	blocking := job.ID == a.blockJob
-	if blocking {
-		a.blocked = true
-	}
-	a.mu.Unlock()
-	if blocking {
-		if a.ignoreCtx {
-			<-a.release
-		} else {
-			select {
-			case <-a.release:
-			case <-ctx.Done():
-				a.mu.Lock()
-				a.blocked = false
-				a.mu.Unlock()
-				return runtime.Result{}, ctx.Err()
-			}
-		}
-		a.mu.Lock()
-		a.blocked = false
-		a.mu.Unlock()
-	}
-	return runtime.Result{Raw: a.output}, nil
-}
-
-func (a *wedgeBlockingAdapter) Health(context.Context, runtime.Agent) error { return nil }
-
-func (a *wedgeBlockingAdapter) Capabilities(context.Context) ([]string, error) { return nil, nil }
-
-func (a *wedgeBlockingAdapter) stillBlocked() bool {
-	a.mu.Lock()
-	defer a.mu.Unlock()
-	return a.blocked
-}
-
-func (a *wedgeBlockingAdapter) deliveredJobs() []string {
-	a.mu.Lock()
-	defer a.mu.Unlock()
-	out := make([]string, len(a.delivered))
-	copy(out, a.delivered)
-	return out
-}
-
-// waitForJobState polls the store until jobID reaches wantState or the deadline
-// elapses, returning the last observed state.
-func waitForJobState(t *testing.T, store *db.Store, jobID string, wantState string, deadline time.Duration) string {
-	t.Helper()
-	stop := time.Now().Add(deadline)
-	last := ""
-	for time.Now().Before(stop) {
-		job, err := store.GetJob(context.Background(), jobID)
-		if err == nil {
-			last = job.State
-			if last == wantState {
-				return last
-			}
-		}
-		time.Sleep(5 * time.Millisecond)
-	}
-	return last
-}
-
-// waitForCondition polls fn until it returns true or the deadline elapses.
-func waitForCondition(t *testing.T, deadline time.Duration, fn func() bool) bool {
-	t.Helper()
-	stop := time.Now().Add(deadline)
-	for time.Now().Before(stop) {
-		if fn() {
-			return true
-		}
-		time.Sleep(5 * time.Millisecond)
-	}
-	return fn()
-}
 
 // TestWedgedInlineJobE2E is the #562 end-to-end reproduction and fix proof.
 //

--- a/internal/daemon/review_redispatch_1745_e2e_test.go
+++ b/internal/daemon/review_redispatch_1745_e2e_test.go
@@ -1,3 +1,5 @@
+//go:build e2e
+
 package daemon
 
 import (

--- a/internal/workflow/delegation_lock_release_617_e2e_support_test.go
+++ b/internal/workflow/delegation_lock_release_617_e2e_support_test.go
@@ -1,0 +1,79 @@
+package workflow
+
+import (
+	"context"
+	"fmt"
+	"github.com/gitmoot/gitmoot/internal/db"
+	"testing"
+)
+
+// Test helpers shared with UNTAGGED tests, kept out of the e2e build tag
+// (#1760 step 3). Tagging the e2e file beside this one removes it from the
+// default build; these symbols are used by tests that are not e2e, so they
+// would have stopped compiling. Types are moved WITH their methods.
+
+const burst617Repo = "jerryfane/noted"
+
+// fanOutEphemeralImplementBurst inserts a coordinator whose result declares n
+// ephemeral, workspace-write implement delegations (mirroring the issue's six-way
+// codex burst) and drives its AdvanceJob so the engine dispatches every leg —
+// allocating one gitmoot-delegation-* branch lock per leg. It returns the leg job
+// ids in dispatch order. Each leg is left queued, exactly as the daemon would see it
+// before running the worker.
+func fanOutEphemeralImplementBurst(t *testing.T, engine Engine, store *db.Store, coordinatorID string, n int) []string {
+	t.Helper()
+	ctx := context.Background()
+	seedAgent(t, store, "coord-617", []string{"ask"}, burst617Repo)
+
+	dels := make([]Delegation, 0, n)
+	for i := 0; i < n; i++ {
+		dels = append(dels, Delegation{
+			ID:        fmt.Sprintf("impl-%d-command", i),
+			Action:    "implement",
+			Prompt:    "implement a distinct small subcommand and open a PR",
+			Ephemeral: &EphemeralSpec{Runtime: "codex", AutonomyPolicy: "workspace-write"},
+		})
+	}
+	insertCompletedJob(t, store, db.Job{ID: coordinatorID, Agent: "coord-617", Type: "ask"}, JobPayload{
+		Repo:   burst617Repo,
+		Branch: "main",
+		Sender: "coord-617",
+		Result: &AgentResult{Decision: "approved", Summary: "fan out the burst", Delegations: dels},
+	})
+
+	if err := engine.AdvanceJob(ctx, coordinatorID); err != nil {
+		t.Fatalf("AdvanceJob(%s) fan-out returned error: %v", coordinatorID, err)
+	}
+
+	legIDs := make([]string, 0, n)
+	for _, d := range dels {
+		legID := coordinatorID + "/delegation/" + d.ID
+		if !jobExists(t, store, legID) {
+			t.Fatalf("ephemeral implement leg %s was not dispatched", legID)
+		}
+		legIDs = append(legIDs, legID)
+	}
+	return legIDs
+}
+
+func countBranchLocks(t *testing.T, store *db.Store, repo string) int {
+	t.Helper()
+	locks, err := store.ListBranchLocks(context.Background(), repo)
+	if err != nil {
+		t.Fatalf("ListBranchLocks(%s) returned error: %v", repo, err)
+	}
+	return len(locks)
+}
+
+func newBurst617Engine(t *testing.T) (Engine, *db.Store) {
+	t.Helper()
+	store := openEngineStore(t)
+	engine := testEngine(store)
+	engine.Home = t.TempDir()
+	engine.DelegationCheckout = t.TempDir()
+	// A fake worktree manager: AllocateDelegationWorktree still writes the REAL branch
+	// lock to the store (that is the entity #617 leaks); the on-disk worktree/branch
+	// are stubbed. existingBranches stays empty so allocation takes the create path.
+	engine.DelegationWorktrees = &fakeWorktreeManager{existingBranches: map[string]bool{}}
+	return engine, store
+}

--- a/internal/workflow/delegation_lock_release_617_e2e_test.go
+++ b/internal/workflow/delegation_lock_release_617_e2e_test.go
@@ -1,11 +1,10 @@
+//go:build e2e
+
 package workflow
 
 import (
 	"context"
-	"fmt"
 	"testing"
-
-	"github.com/gitmoot/gitmoot/internal/db"
 )
 
 // This file is the end-to-end proof for #617: an ephemeral implement delegation's
@@ -30,72 +29,6 @@ import (
 // cleanupImplementDelegationWorktree (internal/workflow/worktree.go) and the success
 // sub-test goes RED again — the locks are stranded after success exactly as #617
 // reported.
-
-const burst617Repo = "jerryfane/noted"
-
-// fanOutEphemeralImplementBurst inserts a coordinator whose result declares n
-// ephemeral, workspace-write implement delegations (mirroring the issue's six-way
-// codex burst) and drives its AdvanceJob so the engine dispatches every leg —
-// allocating one gitmoot-delegation-* branch lock per leg. It returns the leg job
-// ids in dispatch order. Each leg is left queued, exactly as the daemon would see it
-// before running the worker.
-func fanOutEphemeralImplementBurst(t *testing.T, engine Engine, store *db.Store, coordinatorID string, n int) []string {
-	t.Helper()
-	ctx := context.Background()
-	seedAgent(t, store, "coord-617", []string{"ask"}, burst617Repo)
-
-	dels := make([]Delegation, 0, n)
-	for i := 0; i < n; i++ {
-		dels = append(dels, Delegation{
-			ID:        fmt.Sprintf("impl-%d-command", i),
-			Action:    "implement",
-			Prompt:    "implement a distinct small subcommand and open a PR",
-			Ephemeral: &EphemeralSpec{Runtime: "codex", AutonomyPolicy: "workspace-write"},
-		})
-	}
-	insertCompletedJob(t, store, db.Job{ID: coordinatorID, Agent: "coord-617", Type: "ask"}, JobPayload{
-		Repo:   burst617Repo,
-		Branch: "main",
-		Sender: "coord-617",
-		Result: &AgentResult{Decision: "approved", Summary: "fan out the burst", Delegations: dels},
-	})
-
-	if err := engine.AdvanceJob(ctx, coordinatorID); err != nil {
-		t.Fatalf("AdvanceJob(%s) fan-out returned error: %v", coordinatorID, err)
-	}
-
-	legIDs := make([]string, 0, n)
-	for _, d := range dels {
-		legID := coordinatorID + "/delegation/" + d.ID
-		if !jobExists(t, store, legID) {
-			t.Fatalf("ephemeral implement leg %s was not dispatched", legID)
-		}
-		legIDs = append(legIDs, legID)
-	}
-	return legIDs
-}
-
-func countBranchLocks(t *testing.T, store *db.Store, repo string) int {
-	t.Helper()
-	locks, err := store.ListBranchLocks(context.Background(), repo)
-	if err != nil {
-		t.Fatalf("ListBranchLocks(%s) returned error: %v", repo, err)
-	}
-	return len(locks)
-}
-
-func newBurst617Engine(t *testing.T) (Engine, *db.Store) {
-	t.Helper()
-	store := openEngineStore(t)
-	engine := testEngine(store)
-	engine.Home = t.TempDir()
-	engine.DelegationCheckout = t.TempDir()
-	// A fake worktree manager: AllocateDelegationWorktree still writes the REAL branch
-	// lock to the store (that is the entity #617 leaks); the on-disk worktree/branch
-	// are stubbed. existingBranches stays empty so allocation takes the create path.
-	engine.DelegationWorktrees = &fakeWorktreeManager{existingBranches: map[string]bool{}}
-	return engine, store
-}
 
 // TestDelegationBranchLockReleasedOnSuccess_617_E2E is the primary reproduction and
 // the mutation target: a six-way ephemeral implement burst succeeds in full, and

--- a/internal/workflow/preset_delivery_e2e_test.go
+++ b/internal/workflow/preset_delivery_e2e_test.go
@@ -1,3 +1,5 @@
+//go:build e2e
+
 package workflow
 
 import (


### PR DESCRIPTION
refactor(test): tag the e2e/live suite and add the CI lane that runs it (#1760)

Step 3 of #1760. Steps 1 (#1791) and 2 (#1877) are done.

36 test files matching `_(e2e|integration|live)_test.go` now carry `//go:build
e2e`: 35 `_e2e_test.go` plus 1 `_live_test.go`, zero `_integration_test.go`, in
internal/cli (33), internal/workflow (2) and internal/daemon (1). The issue body
says 44 files in internal/cli; re-measured at 6f9552bd it is 36 across three
packages, so scoping this to internal/cli would have left three behind.

THE CI LANE SHIPS IN THE SAME COMMIT, because a tag with no runner stops the
tests forever and a green suite is exactly what that looks like:
  - build-test (unchanged command) now runs the UNTAGGED tests only.
  - a new `e2e (tagged)` job runs `go test -tags e2e ./...`. It uses ./... rather
    than the three packages that hold tagged files today, because a package list
    would silently stop covering a tagged file added to a fourth package later -
    the same silent-stop one level up.
  - race-build now compiles with `-tags e2e`. Without it that compile drops the
    36 files from the race binary AND from the shard plan derived by -test.list,
    with nothing failing. Measured: internal/workflow race list is 1017 untagged
    vs 1022 with the tag vs 1022 at base; internal/daemon 181 / 182 / 182. Race
    coverage is therefore what it was before the tag.

FOUR CATEGORIES OF SHARED TEST HELPER HAD TO MOVE OUT OF THE TAGGED FILES, or the
DEFAULT build stops compiling: 20 symbols across 11 files were referenced by
untagged tests, and types moved with their methods. They now live in
`*_support_test.go` siblings with no build tag.

THE ONE THAT MATTERED MOST WAS TestMain. internal/cli's only TestMain lived in
daemon_flock_singleton_e2e_test.go. It dispatches the hidden `sandbox-exec` shim
and the `daemon run` child re-exec BEFORE m.Run; under `go test` the current
executable IS cli.test, so without that dispatch a test which re-execs itself
restarts the whole package suite recursively. Measured, not reasoned:
TestRuntimeCredentialCurationForegroundAndDaemonE2E runs in 1.460s at base, HUNG
past a 360s timeout with TestMain behind the tag, and runs in 1.559s with TestMain
moved back to the default build. My enumeration of shared symbols had missed it
because the filter skipped every name starting with "Test" - the filter excluded
the one symbol that mattered.

TWO-ARM PROOF, since "the suite is green" is what a silently-skipped set looks
like:
  discovery, `go test -list`:      default 4622, with -tags e2e 4756, delta 134
    internal/cli 1892 / 2020, internal/workflow 1017 / 1022, internal/daemon
    181 / 182 - and 6f9552bd's default discovery is 4756, equal to the tagged arm
    here, so nothing was lost, only moved behind the tag.
  execution, `go test ./...`:      default 319s wall, 39 packages ok
  execution, `go test -tags e2e`:  398s wall, 39 packages ok
Both arms report the SAME single failure, TestApplyReviewPolicyEmptyHomeIsOff
(#1859, ambient ~/.gitmoot config), which also fails identically at 6f9552bd:
366s wall, 39 ok, same one failure. It is not fixed and not tagged away here.

test_binary_test.go stays UNTAGGED deliberately. sharedGitmootTestBinary has
three callers and only one is in the tagged set: pipeline_defaults_test.go is a
plain unit test and sandbox_produce_hook_linux_test.go is platform-constrained
(`//go:build linux`). Tagging the helper would have moved both out of the default
run, which is a bigger change than this step is allowed to make; the default run
therefore still pays the ./cmd/gitmoot build when an untagged caller needs it.

Composition with the existing platform constraints was checked and is not needed
yet: the four test files carrying `//go:build linux`/`unix` are disjoint from the
36, so no file needs `linux && e2e` today.

---

## Lane map after this PR

| lane | command | runs |
|---|---|---|
| build / vet / test | `go test -timeout 25m ./...` | untagged only (4622 tests) |
| e2e (tagged), new | `go test -tags e2e -timeout 30m ./...` | untagged + tagged (4756) |
| race build | `go test -c -race -tags e2e` | unchanged coverage vs base |
| race run | shards from the tagged binary's `-test.list` | unchanged |

Closes #1760 step 3 only; steps 4 and 5 remain open on the issue.
