### PR TITLE
fix(workflow): close delimiter-short envelopes and stop identical retries (#1507)

### DIFF
--- a/internal/workflow/mailbox.go
+++ b/internal/workflow/mailbox.go
@@ -486,6 +486,19 @@ type JobPayload struct {
 	CheckRetries     int          `json:"check_retries,omitempty"`
 	RawOutputs       []string     `json:"raw_outputs,omitempty"`
 	Result           *AgentResult `json:"result,omitempty"`
+	// ResultRepair names the engine repair the ACCEPTED parse required, or is
+	// absent for a clean parse (#1507). Today the only value is
+	// AgentResultRepairDelimiterBalance: the agent's bytes were JSON closers
+	// short and appending exactly the missing closers yielded a schema-valid
+	// result.
+	//
+	// It rides the ENGINE'S envelope record and never the agent-authored
+	// gitmoot_result object, so `result` keeps matching what the agent emitted
+	// and raw_outputs stays a usable audit trail. Omitempty is load-bearing: a
+	// clean parse must carry NO key, so "repaired" can never be inferred from a
+	// zero value. contract_version is untouched - a payload annotation is not a
+	// contract field.
+	ResultRepair string `json:"gitmoot_result_repair,omitempty"`
 	// ReviewStatusGrade records the evidence strength of an externally-driven
 	// review when it closes. Caller-supplied session inputs are always reported.
 	ReviewStatusGrade evidence.Grade `json:"review_status_grade,omitempty"`
@@ -1181,7 +1194,15 @@ func (m Mailbox) Run(ctx context.Context, jobID string, agent runtime.Agent, ada
 	}
 	payload.RawOutputs = append(payload.RawOutputs, firstRaw)
 
-	result, parseErr := extractAgentResultForAction(firstRaw, job.Type)
+	// #1507: a delimiter-short envelope is CLOSED and accepted here rather than
+	// re-asked. A clean parse always wins and carries no marker; the close is
+	// only tried after the clean path failed on the whole output.
+	result, resultRepair, parseErr := extractAgentResultForActionAllowingRepair(firstRaw, job.Type)
+	if parseErr == nil {
+		if err := m.recordResultRepair(ctx, job.ID, &payload, resultRepair); err != nil {
+			return AgentResult{}, err
+		}
+	}
 	if parseErr != nil {
 		// The agent may have delivered useful work but omitted the required
 		// gitmoot_result envelope. Re-ask with the repair prompt up to
@@ -1243,16 +1264,37 @@ func (m Mailbox) Run(ctx context.Context, jobID string, agent runtime.Agent, ada
 			if repairRefreshedRef != "" {
 				agent.RuntimeRef = repairRefreshedRef
 			}
+			// #1507 fix 2, BEFORE the parse: a re-ask whose bytes equal the prior
+			// attempt's cannot succeed where that attempt failed, so the loop stops
+			// with its remaining attempt UNSPENT rather than paying another
+			// round-trip. Measured: 51 of 63 retained malformed-envelope deaths on
+			// this host contained a byte-identical consecutive re-ask.
+			identicalRetry := RetryCannotDiffer(lastRaw, repairRaw)
 			payload.RawOutputs = append(payload.RawOutputs, repairRaw)
 			lastRaw = repairRaw
 			lastDiag = repairDiag
 
-			result, parseErr = extractAgentResultForAction(repairRaw, job.Type)
+			// #1507 fix 1's PLACEMENT, which the issue got wrong and the record
+			// settled: every one of the 18 measured recoverable outputs sits at a
+			// REPAIR attempt (indices 1 and 2), never the first delivery, so a close
+			// attempted only before the loop would have recovered NONE of them.
+			result, resultRepair, parseErr = extractAgentResultForActionAllowingRepair(repairRaw, job.Type)
 			if parseErr == nil {
+				// A clean parse here CLEARS a marker an earlier attempt set: the
+				// marker describes the accepted parse, not the job.
+				if err := m.recordResultRepair(ctx, job.ID, &payload, resultRepair); err != nil {
+					return AgentResult{}, err
+				}
 				break
 			}
 			if err := m.savePayload(ctx, job.ID, payload); err != nil {
 				return AgentResult{}, err
+			}
+			if identicalRetry {
+				if err := m.addEvent(ctx, job.ID, repairRetryIdenticalEvent, fmt.Sprintf("stopping after attempt %d of %d: the re-ask returned byte-identical output (%d bytes), so a further attempt cannot differ", attempt, maxRepairAttempts, len(repairRaw))); err != nil {
+					return AgentResult{}, err
+				}
+				break
 			}
 		}
 
@@ -2185,4 +2227,37 @@ func compactPipelineKeyAccess(values []PipelineKeyAccess) []PipelineKeyAccess {
 		out = append(out, value)
 	}
 	return out
+}
+
+// repairRetryIdenticalEvent records that the repair loop STOPPED EARLY because a
+// re-ask returned byte-identical output (#1507). The distinct kind is the point:
+// "a retry that cannot differ is not a retry", and an operator reading the
+// record must be able to tell an exhausted budget from a budget deliberately
+// left unspent.
+const repairRetryIdenticalEvent = "repair_retry_identical"
+
+// resultRepairedEvent records that the ACCEPTED envelope was closed by the
+// engine rather than terminated by the agent (#1507). It fires once, on the
+// attempt whose parse was accepted, and never for a clean parse.
+const resultRepairedEvent = "result_repaired"
+
+// recordResultRepair stamps the accepted parse's repair marker onto the engine's
+// envelope record and, when a repair was needed, records it as an event.
+//
+// A CLEAN parse CLEARS any marker a previous attempt set - that is the ranking
+// the marker exists for, applied where the engine chooses which parse to accept.
+// The clearing is silent by design: the event stream already carries the earlier
+// attempt's marker event, so the surviving record is "an attempt was repaired,
+// and the accepted one was not".
+func (m *Mailbox) recordResultRepair(ctx context.Context, jobID string, payload *JobPayload, repair string) error {
+	if payload == nil {
+		return nil
+	}
+	repair = strings.TrimSpace(repair)
+	if repair == "" {
+		payload.ResultRepair = ""
+		return nil
+	}
+	payload.ResultRepair = repair
+	return m.addEvent(ctx, jobID, resultRepairedEvent, fmt.Sprintf("accepted envelope repaired by %s: the agent's output was JSON closers short and the engine appended exactly the missing closers; the stored result is a repaired parse, not a clean one", repair))
 }

--- a/internal/workflow/repair_determinism_test.go
+++ b/internal/workflow/repair_determinism_test.go
@@ -1,0 +1,262 @@
+package workflow
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/gitmoot/gitmoot/internal/runtime"
+)
+
+// #1507 fixtures. truncatedReviewEnvelope is the MEASURED shape: a complete
+// gitmoot_result whose enclosing envelope is never closed - brace deficit 1,
+// bracket deficit 0, everything else well-formed. The instance that produced
+// the issue was 3794 bytes of approved review discarded for one character.
+const truncatedReviewEnvelope = `{"gitmoot_result":{"decision":"approved","summary":"one brace short","findings":[],"changes_made":[],"tests_run":["go test ./..."],"needs":[],"delegations":[]}`
+
+const cleanReviewEnvelope = `{"gitmoot_result":{"decision":"approved","summary":"terminated cleanly","findings":[],"changes_made":[],"tests_run":["go test ./..."],"needs":[],"delegations":[]}}`
+
+func repairTestMailbox(t *testing.T) (*Mailbox, context.Context, runtime.Agent) {
+	t.Helper()
+	store := openTestStore(t)
+	mailbox := &Mailbox{store: store, resolveDeliveryWorktree: ExcludedDeliveryWorktreeResolver("test_explicit_no_worktree")}
+	agent := runtime.Agent{Name: "audit", Runtime: runtime.ShellRuntime, RuntimeRef: "printf ok", RepoScope: "gitmoot/gitmoot", Role: "reviewer"}
+	return mailbox, context.Background(), agent
+}
+
+// repairTestStoredPayload returns the job's payload as STORED JSON.
+//
+// The marker is asserted against the serialized bytes rather than a typed field
+// on purpose: it keeps every arm below compilable against a tree WITHOUT this
+// fix, so the arms can be run as pre-fix discriminators and fail for
+// BEHAVIOURAL reasons instead of failing to build (a build failure measures
+// nothing about behaviour). The typed constants are exercised separately.
+func repairTestStoredPayload(t *testing.T, mailbox *Mailbox, ctx context.Context, jobID string) string {
+	t.Helper()
+	stored, err := mailbox.store.GetJob(ctx, jobID)
+	if err != nil {
+		t.Fatalf("GetJob returned error: %v", err)
+	}
+	return stored.Payload
+}
+
+const repairMarkerJSON = `"gitmoot_result_repair":"delimiter-balance"`
+
+const repairedEventKind = "result_repaired"
+
+const repairIdenticalEventKind = "repair_retry_identical"
+
+// ARM (i) - THE CONSTRUCTION ASSERTION. A first delivery that is delimiter-short
+// is closed and accepted, so the repair loop is NEVER ENTERED: zero repair_retry
+// events, one delivery, and the round-trip is not paid.
+//
+// The cross-attempt shape originally specified for this fix - attempt 1
+// repairable, attempt 2 clean - is UNREACHABLE by construction once the close is
+// accepted here, and it also occurs ZERO times in the measured record (0 of 63
+// retained malformed-envelope deaths had a delimiter-repairable FIRST output).
+// So this arm asserts the construction instead, and the clean-beats-repaired
+// ranking is asserted where it does occur, in the candidate arm below.
+func TestMailboxRunClosesDelimiterShortFirstOutputWithoutARepairAsk(t *testing.T) {
+	mailbox, ctx, agent := repairTestMailbox(t)
+	adapter := &fakeDelivery{outputs: []string{truncatedReviewEnvelope}}
+	if _, err := mailbox.Enqueue(ctx, JobRequest{ID: "job-1", Agent: "audit", Action: "review", Repo: "gitmoot/gitmoot"}); err != nil {
+		t.Fatalf("Enqueue returned error: %v", err)
+	}
+
+	result, err := mailbox.Run(ctx, "job-1", agent, adapter)
+	if err != nil {
+		t.Fatalf("Run returned error: %v", err)
+	}
+	if result.Summary != "one brace short" {
+		t.Fatalf("summary = %q, want the recovered verdict", result.Summary)
+	}
+	if len(adapter.prompts) != 1 {
+		t.Fatalf("deliveries = %d, want exactly 1: a repaired first output must not be re-asked", len(adapter.prompts))
+	}
+	events, err := mailbox.store.ListJobEvents(ctx, "job-1")
+	if err != nil {
+		t.Fatalf("ListJobEvents returned error: %v", err)
+	}
+	if hasEvent(events, "repair_retry") || hasEvent(events, "malformed_output") {
+		t.Fatalf("a closed envelope must not enter the repair loop: events = %+v", events)
+	}
+	if !hasEvent(events, repairedEventKind) {
+		t.Fatalf("events = %+v, want a %s event", events, repairedEventKind)
+	}
+	stored := repairTestStoredPayload(t, mailbox, ctx, "job-1")
+	if !strings.Contains(stored, repairMarkerJSON) {
+		t.Fatalf("stored payload carries no repair marker: %s", stored)
+	}
+	// The marker rides the ENGINE's envelope record, never the agent's object:
+	// the stored gitmoot_result must still be the agent's own bytes.
+	if strings.Contains(stored, `"summary":"one brace short","gitmoot_result_repair"`) {
+		t.Fatalf("marker leaked into the agent's object: %s", stored)
+	}
+}
+
+// ARM (ii) - THE REAL-WORLD SHAPE, 18 of 18. Every recoverable output in the
+// measured record sits at a REPAIR attempt (indices 1 and 2), never the first
+// delivery. The issue's own item 1 reads "before invoking the repair LLM"; built
+// that way it would have recovered NONE of the 18. So the close runs after every
+// delivery, repair deliveries included.
+func TestMailboxRunClosesDelimiterShortRepairOutput(t *testing.T) {
+	mailbox, ctx, agent := repairTestMailbox(t)
+	adapter := &fakeDelivery{outputs: []string{
+		"findings posted, no json",
+		truncatedReviewEnvelope,
+	}}
+	if _, err := mailbox.Enqueue(ctx, JobRequest{ID: "job-1", Agent: "audit", Action: "review", Repo: "gitmoot/gitmoot"}); err != nil {
+		t.Fatalf("Enqueue returned error: %v", err)
+	}
+
+	result, err := mailbox.Run(ctx, "job-1", agent, adapter)
+	if err != nil {
+		t.Fatalf("Run returned error: %v", err)
+	}
+	if result.Summary != "one brace short" {
+		t.Fatalf("summary = %q, want the recovered verdict", result.Summary)
+	}
+	if len(adapter.prompts) != 2 {
+		t.Fatalf("deliveries = %d, want 2 (first delivery plus one repair ask)", len(adapter.prompts))
+	}
+	events, err := mailbox.store.ListJobEvents(ctx, "job-1")
+	if err != nil {
+		t.Fatalf("ListJobEvents returned error: %v", err)
+	}
+	if !hasEvent(events, "malformed_output") || !hasEvent(events, "repair_retry") {
+		t.Fatalf("events = %+v, want the first delivery's malformed_output and one repair_retry", events)
+	}
+	if !hasEvent(events, repairedEventKind) {
+		t.Fatalf("events = %+v, want a %s event", events, repairedEventKind)
+	}
+	if stored := repairTestStoredPayload(t, mailbox, ctx, "job-1"); !strings.Contains(stored, repairMarkerJSON) {
+		t.Fatalf("stored payload carries no repair marker: %s", stored)
+	}
+}
+
+// ARM (iii) - CLEAN BEATS REPAIRED, which is what makes the marker RANKED rather
+// than labelled. One job in the measured record carried an attempt that already
+// parsed clean and still died, so this ordering has an instance.
+//
+// Both directions are asserted: a clean parse alongside a truncated one wins and
+// carries NO marker, and a clean parse at a later attempt CLEARS a marker an
+// earlier attempt set.
+func TestMailboxRunPrefersACleanParseOverADelimiterRepair(t *testing.T) {
+	t.Run("within one delivery", func(t *testing.T) {
+		mailbox, ctx, agent := repairTestMailbox(t)
+		adapter := &fakeDelivery{outputs: []string{truncatedReviewEnvelope + "\n" + cleanReviewEnvelope}}
+		if _, err := mailbox.Enqueue(ctx, JobRequest{ID: "job-1", Agent: "audit", Action: "review", Repo: "gitmoot/gitmoot"}); err != nil {
+			t.Fatalf("Enqueue returned error: %v", err)
+		}
+
+		result, err := mailbox.Run(ctx, "job-1", agent, adapter)
+		if err != nil {
+			t.Fatalf("Run returned error: %v", err)
+		}
+		if result.Summary != "terminated cleanly" {
+			t.Fatalf("summary = %q, want the CLEAN envelope to win", result.Summary)
+		}
+		if stored := repairTestStoredPayload(t, mailbox, ctx, "job-1"); strings.Contains(stored, "gitmoot_result_repair") {
+			t.Fatalf("a clean parse must carry no marker: %s", stored)
+		}
+		events, err := mailbox.store.ListJobEvents(ctx, "job-1")
+		if err != nil {
+			t.Fatalf("ListJobEvents returned error: %v", err)
+		}
+		if hasEvent(events, repairedEventKind) {
+			t.Fatalf("events = %+v, want no %s for a clean parse", events, repairedEventKind)
+		}
+	})
+
+	t.Run("a later clean attempt clears an earlier marker", func(t *testing.T) {
+		mailbox, ctx, agent := repairTestMailbox(t)
+		// Attempt 1 is unparseable, attempt 2 is delimiter-short but its result
+		// VIOLATES the review contract (no severity for changes_requested), so it
+		// is refused and the loop continues; attempt 3 parses clean.
+		adapter := &fakeDelivery{outputs: []string{
+			"no json here",
+			`{"gitmoot_result":{"decision":"changes_requested","summary":"missing severity","findings":[],"changes_made":[],"tests_run":[],"needs":[],"delegations":[]}`,
+			cleanReviewEnvelope,
+		}}
+		if _, err := mailbox.Enqueue(ctx, JobRequest{ID: "job-2", Agent: "audit", Action: "review", Repo: "gitmoot/gitmoot"}); err != nil {
+			t.Fatalf("Enqueue returned error: %v", err)
+		}
+
+		result, err := mailbox.Run(ctx, "job-2", agent, adapter)
+		if err != nil {
+			t.Fatalf("Run returned error: %v", err)
+		}
+		if result.Summary != "terminated cleanly" {
+			t.Fatalf("summary = %q, want the clean attempt's verdict", result.Summary)
+		}
+		if stored := repairTestStoredPayload(t, mailbox, ctx, "job-2"); strings.Contains(stored, "gitmoot_result_repair") {
+			t.Fatalf("the accepted parse was clean, so no marker may survive: %s", stored)
+		}
+	})
+}
+
+// ARM (iv) - A RETRY THAT CANNOT DIFFER IS NOT A RETRY. Measured: 51 of 63
+// retained malformed-envelope deaths contained a byte-identical consecutive
+// re-ask. The loop stops with its remaining attempt UNSPENT and says why, so an
+// operator can tell a deliberately-unspent budget from an exhausted one.
+func TestMailboxRunStopsRepairingWhenTheReAskIsByteIdentical(t *testing.T) {
+	mailbox, ctx, agent := repairTestMailbox(t)
+	// The measured shape: the re-ask returns the SAME bytes the previous
+	// delivery did, so the loop stops and the third output is never delivered.
+	adapter := &fakeDelivery{outputs: []string{
+		"no json here",
+		"no json here",
+		"this attempt must stay unspent",
+	}}
+	if _, err := mailbox.Enqueue(ctx, JobRequest{ID: "job-1", Agent: "audit", Action: "review", Repo: "gitmoot/gitmoot"}); err != nil {
+		t.Fatalf("Enqueue returned error: %v", err)
+	}
+
+	if _, err := mailbox.Run(ctx, "job-1", agent, adapter); err == nil {
+		t.Fatal("Run returned nil error for output that never parses")
+	}
+	// Deliveries: the first plus repair attempt 1. Attempt 2 was NOT spent - the
+	// loop's own budget is maxRepairAttempts=2, so a pre-#1507 run would deliver
+	// three times.
+	if len(adapter.prompts) != 2 {
+		t.Fatalf("deliveries = %d, want 2: the second repair attempt must stay unspent", len(adapter.prompts))
+	}
+	events, err := mailbox.store.ListJobEvents(ctx, "job-1")
+	if err != nil {
+		t.Fatalf("ListJobEvents returned error: %v", err)
+	}
+	if !hasEvent(events, repairIdenticalEventKind) {
+		t.Fatalf("events = %+v, want a %s event naming why the loop stopped", events, repairIdenticalEventKind)
+	}
+	for _, event := range events {
+		if event.Kind == repairIdenticalEventKind && !strings.Contains(event.Message, "cannot differ") {
+			t.Fatalf("%s message = %q, want it to name the reason", repairIdenticalEventKind, event.Message)
+		}
+	}
+}
+
+// TestExtractAgentResultNamesATruncation pins fix 3: the parse failure names the
+// cause. "missing valid gitmoot_result JSON object" told an operator nothing
+// about a 3.8 KB verdict that was one closing brace short.
+func TestExtractAgentResultNamesATruncation(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		output string
+		want   string
+	}{
+		{"one unclosed object", truncatedReviewEnvelope, "unterminated object: 1 unclosed '{' at EOF"},
+		{"unclosed array inside the envelope", `{"gitmoot_result":{"decision":"approved","summary":"s","findings":[`, "unterminated object: 2 unclosed '{' and 1 unclosed '[' at EOF"},
+		{"ends inside a string", `{"gitmoot_result":{"summary":"cut off here`, "unterminated string at EOF"},
+		{"balanced but envelope-less", `{"other":{"decision":"approved"}}`, "missing valid gitmoot_result JSON object"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := ExtractAgentResult(tc.output)
+			if err == nil {
+				t.Fatal("ExtractAgentResult returned nil error")
+			}
+			if !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("error = %q, want it to contain %q", err.Error(), tc.want)
+			}
+		})
+	}
+}

--- a/internal/workflow/repair_determinism_units_test.go
+++ b/internal/workflow/repair_determinism_units_test.go
@@ -1,0 +1,50 @@
+package workflow
+
+import "testing"
+
+// #1507 unit arms that reference the fix's own identifiers. They are kept apart
+// from the behavioural arms so those stay compilable against a tree without this
+// fix and can serve as pre-fix discriminators.
+
+func TestRetryCannotDiffer(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		previous string
+		next     string
+		want     bool
+	}{
+		{"identical non-empty", "same", "same", true},
+		{"different", "a", "b", false},
+		{"empty previous is not a repeat", "", "", false},
+		{"empty next differs", "a", "", false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := RetryCannotDiffer(tc.previous, tc.next); got != tc.want {
+				t.Fatalf("RetryCannotDiffer(%q, %q) = %v, want %v", tc.previous, tc.next, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestDelimiterCloseRefusesWhatItCannotJustify keeps the close narrow: it must
+// not invent content, and it must not turn a contract violation into a verdict.
+func TestDelimiterCloseRefusesWhatItCannotJustify(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		output string
+	}{
+		{"ends inside a string literal", `{"gitmoot_result":{"decision":"approved","summary":"cut`},
+		{"closing a truncation still violates the review contract", `{"gitmoot_result":{"decision":"changes_requested","summary":"no severity","findings":[],"changes_made":[],"tests_run":[],"needs":[],"delegations":[]}`},
+		{"more closers than openers", `{"gitmoot_result":{"decision":"approved"}}}`},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			_, repair, err := extractAgentResultForActionAllowingRepair(tc.output, "review")
+			if err == nil {
+				t.Fatalf("extractAgentResultForActionAllowingRepair accepted %q with repair %q", tc.output, repair)
+			}
+			if repair != "" {
+				t.Fatalf("repair = %q, want empty on a refusal", repair)
+			}
+		})
+	}
+}

--- a/internal/workflow/result.go
+++ b/internal/workflow/result.go
@@ -512,7 +512,10 @@ func ExtractAgentResult(output string) (AgentResult, error) {
 	if validationErr != nil {
 		return AgentResult{}, validationErr
 	}
-	return AgentResult{}, errors.New("missing valid gitmoot_result JSON object")
+	// #1507 fix 3: name the cause when the output is TRUNCATED rather than
+	// merely envelope-less. "missing valid gitmoot_result JSON object" told an
+	// operator nothing about a 3.8 KB verdict that was one closing brace short.
+	return AgentResult{}, unterminatedEnvelopeError(output)
 }
 
 // extractAgentResultForAction applies action-specific contract rules after the
@@ -1067,4 +1070,140 @@ func balancedJSONObject(input string) (string, bool) {
 		}
 	}
 	return "", false
+}
+
+// AgentResultRepairDelimiterBalance marks an envelope the ENGINE closed: the
+// agent's bytes were one or more JSON closers short of parsing, and appending
+// exactly the missing closers produced a schema-valid gitmoot_result (#1507).
+//
+// It is a marker on the engine's own envelope record, never a field inside the
+// agent-authored gitmoot_result object. The agent did not write those closers;
+// writing engine-derived data into the agent's object would blur the provenance
+// boundary this marker exists to preserve, and would mean the stored object no
+// longer matches raw_outputs - which is the audit trail the recovery relies on.
+// A clean parse carries NO marker, and contract_version is untouched because a
+// payload-side annotation is not a contract field.
+const AgentResultRepairDelimiterBalance = "delimiter-balance"
+
+// RetryCannotDiffer reports whether re-running a deterministic operation
+// produced output byte-identical to the previous attempt.
+//
+// "A RETRY THAT CANNOT DIFFER IS NOT A RETRY" (#1507). It is deliberately
+// general rather than welded to the result-parse path: any loop that re-runs an
+// operation hoping for a different answer can consult it, and the caller decides
+// what to do with the answer. Measured on this host's store, 51 of 63 retained
+// malformed-envelope job deaths (81%) contained a byte-identical consecutive
+// re-ask - each one a paid LLM round-trip that could not have succeeded.
+//
+// Empty previous output is NOT a match: there is nothing to have repeated.
+func RetryCannotDiffer(previous, next string) bool {
+	return previous != "" && previous == next
+}
+
+// jsonCloserDeficit returns the closers a truncated JSON document is missing,
+// in the order that would terminate it, plus whether the scan ended INSIDE a
+// string literal.
+//
+// A scan that ends mid-string is NOT repairable by appending closers: the value
+// itself is cut, so any completion the engine invents is content rather than
+// punctuation. The caller must refuse those.
+func jsonCloserDeficit(output string) (string, bool) {
+	inString := false
+	escaped := false
+	var stack []byte
+	for index := 0; index < len(output); index++ {
+		char := output[index]
+		if inString {
+			switch {
+			case escaped:
+				escaped = false
+			case char == '\\':
+				escaped = true
+			case char == '"':
+				inString = false
+			}
+			continue
+		}
+		switch char {
+		case '"':
+			inString = true
+		case '{':
+			stack = append(stack, '}')
+		case '[':
+			stack = append(stack, ']')
+		case '}', ']':
+			if len(stack) == 0 {
+				// More closers than openers: not a truncation, and appending
+				// anything would be guesswork on a malformed document.
+				return "", inString
+			}
+			stack = stack[:len(stack)-1]
+		}
+	}
+	if inString {
+		return "", true
+	}
+	closers := make([]byte, 0, len(stack))
+	for index := len(stack) - 1; index >= 0; index-- {
+		closers = append(closers, stack[index])
+	}
+	return string(closers), false
+}
+
+// unterminatedEnvelopeError names WHY the envelope did not parse when the cause
+// is a truncation, instead of the generic "missing valid gitmoot_result JSON
+// object" that told an operator nothing about a document that was one character
+// short (#1507).
+func unterminatedEnvelopeError(output string) error {
+	closers, midString := jsonCloserDeficit(strings.TrimSpace(output))
+	switch {
+	case midString:
+		return errors.New("unterminated string at EOF: the output ends inside a JSON string literal, so no closer can complete it")
+	case closers != "":
+		braces := strings.Count(closers, "}")
+		brackets := strings.Count(closers, "]")
+		switch {
+		case brackets == 0:
+			return fmt.Errorf("unterminated object: %d unclosed '{' at EOF", braces)
+		case braces == 0:
+			return fmt.Errorf("unterminated array: %d unclosed '[' at EOF", brackets)
+		default:
+			return fmt.Errorf("unterminated object: %d unclosed '{' and %d unclosed '[' at EOF", braces, brackets)
+		}
+	default:
+		return errors.New("missing valid gitmoot_result JSON object")
+	}
+}
+
+// extractAgentResultForActionAllowingRepair is the engine's parse seam for a
+// delivered output. It returns the repair marker that applies to the accepted
+// parse, or "" for a clean one.
+//
+// RANKING, which is the point rather than a detail: a CLEAN parse always wins.
+// The delimiter close is attempted ONLY after the clean path has failed on the
+// whole output, so an output carrying both a truncated envelope and a complete
+// one parses clean and carries no marker (one such job exists in the measured
+// record). A clean parse at any later attempt therefore also clears a marker set
+// by an earlier one - the marker describes the accepted parse, not the job.
+//
+// The close is refused unless it yields a SCHEMA-VALID result for this action:
+// balancing delimiters must not turn a contract violation into an accepted
+// verdict.
+func extractAgentResultForActionAllowingRepair(output, action string) (AgentResult, string, error) {
+	result, err := extractAgentResultForAction(output, action)
+	if err == nil {
+		return result, "", nil
+	}
+	closers, midString := jsonCloserDeficit(strings.TrimSpace(output))
+	if midString || closers == "" {
+		return AgentResult{}, "", err
+	}
+	repaired, repairErr := extractAgentResultForAction(strings.TrimSpace(output)+closers, action)
+	if repairErr != nil {
+		// The deficit was real but closing it did not produce a valid contract
+		// object. Report the ORIGINAL failure: the engine's speculative close is
+		// not a fact about the agent's output.
+		return AgentResult{}, "", err
+	}
+	return repaired, AgentResultRepairDelimiterBalance, nil
 }


### PR DESCRIPTION
Fixes #1507.

## What shipped, in the order the measurement argues for

**1. A retry that cannot differ is not a retry.** When a repair re-ask returns bytes identical to the previous delivery, the loop stops with its remaining attempt **unspent** and records `repair_retry_identical` naming why — so an operator can tell a deliberately-unspent budget from an exhausted one. `RetryCannotDiffer` is deliberately general rather than welded to this path, per the ruling's generalisation.

**2. A truncated envelope is closed and accepted** when appending exactly the missing JSON closers yields a **schema-valid** `gitmoot_result` for that action.

**3. The parse failure names a truncation** — `unterminated object: 1 unclosed '{' at EOF` instead of `missing valid gitmoot_result JSON object`.

## The issue's own item 1 was wrong about WHERE the close goes, and the record settled it

The issue reads *"before invoking the repair LLM"*. Built that way it would have recovered **zero** of the 18 measured recoverable cases, because **every** recoverable output sits at a repair attempt:

```
failures whose FIRST output was delimiter-repairable (not clean): 0
recoverable-attempt index histogram: {1: 13, 2: 18}   (18 recoverable jobs)
outputs per recoverable job: {3 outputs: 17, 5 outputs: 1}
```

So the close runs after **every** delivery, repair deliveries included, and fix 1's guard stops the loop before it spends an attempt that could not have differed.

## Population: three rules, three denominators, one conclusion

The issue's 39% is **the issue's** measurement (9 of 23). Two independent re-derivations on today's store, each with its exact rule, disagree with it on the denominator and agree with each other on the shape:

| rule (exact SQL) | jobs | retain `raw_outputs` | recoverable (any attempt) | share |
|---|---|---|---|---|
| `kind='failed' AND message LIKE '%missing valid gitmoot_result%'` | 36 | 35 | 18 | 51% |
| `kind='failed' AND (message LIKE '%repair output malformed%' OR message LIKE '%missing valid gitmoot_result%')` | 64 | 63 | 18 | 29% |
| `kind='malformed_output' AND message LIKE '%missing valid gitmoot_result%'` (includes jobs that later succeeded) | 147 | 146 | 21 | 14% |

The **numerator is stable** (18/18/21) and the share is entirely a function of which denominator you choose, so no single percentage is quoted as *the* figure here. What is rule-invariant, and is the stronger argument:

- **Retention is now ~100%** (35/36 and 63/64) against the issue's 23/66 — the issue's share is computed over a denominator that no longer describes the system, and nearly every one of these deaths now retains the bytes that could be recovered.
- **Zero** attempt-1 repairables under either failure rule.
- **Exactly one** job had an attempt that already parsed clean and died anyway — so the clean-beats-repaired ordering has a real instance.
- Date range of the widest population: 2026-05-25 → 2026-09-04.

## Provenance: marked, and ranked where the engine can rank it

An accepted close sets `gitmoot_result_repair: "delimiter-balance"` on the **engine's envelope record** (`JobPayload`), never inside the agent-authored `gitmoot_result` object — the agent did not write those closers, and writing engine-derived data into its object would break `raw_outputs` as an audit trail. A clean parse carries **no key** (`omitempty` is load-bearing: "repaired" must never be inferable from a zero value), and `contract_version` is untouched because a payload annotation is not a contract field.

**What consults the marker**, stated plainly because a marker nothing consults is decoration: candidate selection *within* a delivery — the close is attempted only after the clean path has failed on the whole output, so an output carrying both a truncated and a complete envelope parses clean with no marker — and a clean parse at any later attempt **clears** a marker an earlier one set.

**What does not, yet:** the merge gate. `parsed-clean > delimiter-repaired` belongs beside `recordApprovalEvidence`'s existing executed/static-only distinction (`internal/workflow/merge_gate.go:589-630`, #1839), which is outside this PR's authorized surface and inside another open PR's file set. Filed as a follow-up rather than reached for.

**Retired, with its reason:** the originally specified cross-attempt test — attempt 1 repairable, attempt 2 clean — is unreachable by construction once a repairable first output is accepted without a re-ask, and it occurs **zero** times in the record. Making it reachable would require paying a re-ask that is byte-identical 81% of the time, i.e. re-introducing this issue's own defect to satisfy a test.

## The close refuses what it cannot justify

- Output ending **inside a string literal** — the value itself is cut, so any completion is invented content, not punctuation.
- **More closers than openers** — not a truncation.
- A balance that would turn a **contract violation** into an accepted verdict (e.g. `changes_requested` with no severity): the original parse error is reported, because the engine's speculative close is not a fact about the agent's output.

## Tests — four arms, and honest about which discriminate

Behavioural arms live in `repair_determinism_test.go` and are written **without referencing this fix's own identifiers**, so they compile against a fix-less tree and fail for *behavioural* reasons rather than failing to build (a build failure measures nothing about behaviour). Identifier-level units are split into `repair_determinism_units_test.go`.

Pre-fix discriminator — `origin/main`'s `mailbox.go` + `result.go` swapped in, production restored `cmp`-verified byte-identical afterwards:

```
--- FAIL: TestMailboxRunClosesDelimiterShortFirstOutputWithoutARepairAsk
    Run returned error: missing valid gitmoot_result JSON object
--- FAIL: TestMailboxRunClosesDelimiterShortRepairOutput
    Run returned error: missing valid gitmoot_result JSON object
--- FAIL: TestMailboxRunStopsRepairingWhenTheReAskIsByteIdentical
    deliveries = 3, want 2: the second repair attempt must stay unspent
--- FAIL: TestExtractAgentResultNamesATruncation (3 of 4 subtests)
PRODUCTION_RESTORED_BYTE_IDENTICAL
```

`TestMailboxRunPrefersACleanParseOverADelimiterRepair` **passes pre-fix** and is reported as an invariant-preservation arm, not a fix arm: candidate scanning already preferred a complete envelope, and the arm exists so the close cannot later be moved ahead of it.

## Gate

`GOTOOLCHAIN=local` with the toolchain PATH, `-count=1`, non-`/tmp` tree, `gofmt` empty:

```
go version go1.26.4 linux/amd64
BUILD_OK          (go build -buildvcs=false ./...)
VET_OK            (go vet ./...)
GENERATE_CHECKED  (go generate ./... left only this PR's own files modified)
ok  internal/workflow  92.618s
ok  internal/daemon    14.084s
ok  internal/pipeline   5.963s
FAIL internal/cli      347.220s  -- TestApplyReviewPolicyEmptyHomeIsOff
```

That failure is pre-existing and **environment-sensitive, not branch-related**: it fails standalone in this tree at a pristine `origin/main` worktree with none of these changes, while an independent review clone of an earlier PR ran the same test standalone and it **passed**. It touches no file this PR changes.

## Deploy notes

Adds two job event kinds (`result_repaired`, `repair_retry_identical`) and one payload key (`gitmoot_result_repair`, absent on clean parses). No migration, no config change, no contract-version bump. Behaviour change: a delimiter-short envelope now succeeds where it previously failed, and a byte-identical repair re-ask now ends the loop early — both strictly reduce paid LLM round-trips.
