### PR TITLE
fix(cli): budget the wake-outbox terminal write against the store's own wait (#1836)

### DIFF
--- a/internal/cli/event_rule_sink.go
+++ b/internal/cli/event_rule_sink.go
@@ -390,11 +390,59 @@ func (s *eventRuleSink) completeWakeOutbox(ctx context.Context, event events.Eve
 	return errors.Join(cause, finishErr)
 }
 
+// finishWakeOutbox records the wake's TERMINAL OUTCOME. It is a durability
+// write, not a probe, and the distinction is the whole of #1836.
+//
+// IT USED eventRuleProbeTimeout, WHICH IS 5s AND IS NOT ITS BUDGET. That
+// constant's own doc says it bounds "the availability probe and each pane-label
+// resolution (a herdr `pane list`)" - subprocess calls to herdr, where cutting
+// early is right because a hung probe must not hang the wake path. Reusing it
+// here pointed a herdr-probe deadline at a SQLite write whose driver waits up to
+// sqliteBusyTimeoutMillis = 15s for the lock. So under >5s contention the caller
+// abandoned a write the driver was still legitimately waiting to perform, the row
+// stayed `attempted`, the age-out sweep relabelled it `delivery_unknown` with
+// policy=expire_without_retry, and a wake that WAS DELIVERED became an unknown
+// that is never retried. Measured live: 15 of 167 delivered wakes in one 2h33m
+// window, every one preceded at exactly delta=5s by the counter-reset failure
+// for the same job.
+//
+// The probe timeout is deliberately LEFT AT 5s. Widening it would trade a stale
+// annotation for a stalled wake path, which is the trade jarvis documented on
+// this issue and asked not to disturb.
+//
+// ONE ATTEMPT, WITH THE STORE'S FULL BUDGET, AND NO RETRY. I built a two-attempt
+// retry first and REMOVED IT on measurement, which is worth recording because
+// the reasoning is not obvious:
+//
+//   - The ceiling is the DRIVER, not the caller. Probed on this store with a
+//     40s caller deadline and another connection holding the write lock, the
+//     contended write returns plain SQLITE_BUSY after 13.67s. Waiting longer
+//     than the driver's own busy budget buys nothing.
+//   - So a second attempt only helps if the stall ends inside the narrow band
+//     between one busy window and the next.
+//   - And it cost the thing that matters more: with a retry present the pre-fix
+//     path covers ~15s (the 5s counter reset plus two 5s attempts) while the
+//     fixed path's two attempts reach only ~14.5s, because its first attempt
+//     burns a full driver window. The coverage ranges OVERLAP, so no contention
+//     value can make an outcome-based test separate the deadline fix from the
+//     retry. Measured: at 7s and at 12s every mutant survived, including the one
+//     that reverts the actual defect.
+//
+// A mechanism that adds a narrow band of coverage while making the fix
+// unfalsifiable is a bad trade. One attempt with the correct budget is the fix;
+// TestDeliveredWakeSurvivesContendedTerminalWrite discriminates it, and
+// db.TestDurableWriteBudgetExceedsBusyTimeout keeps the two constants ordered.
+//
+// A stall that outlasts the driver's whole budget still loses this record, and
+// that is a REAL residual rather than a solved case. It is bounded by the
+// driver, not by anything this caller chooses, so closing it belongs with the
+// shared-connection contention in #1226 and with the age-out sweep's inability
+// to tell "no outcome observed" from "outcome observed, record write lost".
 func (s *eventRuleSink) finishWakeOutbox(ctx context.Context, event events.Event, state, detail string) error {
 	if s == nil || s.store == nil || len(event.WakeOutboxIDs) == 0 {
 		return nil
 	}
-	finishCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), eventRuleProbeTimeout)
+	finishCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), db.DurableWriteBudget)
 	defer cancel()
 	if err := s.store.FinishWakeOutbox(finishCtx, event.WakeOutboxIDs, state, detail, time.Now().UTC()); err != nil {
 		slog.Warn("wake outbox state update failed", "job_id", event.JobID, "state", state, "error", err)

--- a/internal/cli/event_rule_sink_wake_persistence_test.go
+++ b/internal/cli/event_rule_sink_wake_persistence_test.go
@@ -1,0 +1,222 @@
+package cli
+
+import (
+	"context"
+	"database/sql"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/gitmoot/gitmoot/internal/config"
+	"github.com/gitmoot/gitmoot/internal/db"
+	"github.com/gitmoot/gitmoot/internal/db/dbtest"
+	"github.com/gitmoot/gitmoot/internal/events"
+)
+
+// #1836 REGRESSION. A wake that was DELIVERED must not decay to
+// delivery_unknown because recording it lost a race with the store's write
+// lock.
+//
+// BOTH TESTS ENTER THROUGH evaluateRules' DELIVERED BRANCH, never by calling
+// FinishWakeOutbox directly, because the issue's own acceptance shape says so
+// and the reason is sound: a test that pins the helper passes even if no
+// production path reaches it. The routing mutant that deletes the sink's
+// finish call must fail these.
+
+// wakePersistenceFixture stands up an isolated home, store and rule set on a
+// REAL database file, because the defect is about the write lock on that file.
+// Never the shared /root/.gitmoot home.
+func wakePersistenceFixture(t *testing.T) (string, *db.Store, *fakeEventWake, *eventRuleSink) {
+	t.Helper()
+	home := t.TempDir()
+	paths := config.PathsForHome(home)
+	if err := os.MkdirAll(filepath.Dir(paths.ConfigFile), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(paths.ConfigFile,
+		[]byte("[org.roles.\"owner\"]\nscope=[\"*\"]\npane=\"w1:p1\"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	store, err := dbtest.Open(t, paths.Database)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+	wake := &fakeEventWake{}
+	return home, store, wake, &eventRuleSink{store: store, home: home, wake: wake}
+}
+
+// wakeOutboxRow reads the row's state and attempt count straight from the
+// database, so the assertion is about what was PERSISTED rather than about what
+// the sink returned. ListWakeOutbox takes a state filter; "" is every state,
+// which is what a test asserting the state must use.
+func wakeOutboxRow(t *testing.T, store *db.Store, id int64) (string, int) {
+	t.Helper()
+	entries, err := store.ListWakeOutbox(context.Background(), "")
+	if err != nil {
+		t.Fatalf("list wake outbox: %v", err)
+	}
+	for _, entry := range entries {
+		if entry.ID == id {
+			return entry.State, entry.AttemptCount
+		}
+	}
+	t.Fatalf("wake outbox row %d not found", id)
+	return "", 0
+}
+
+// seedClaimedWake drives the REAL production sequence the daemon uses:
+// InsertWakeOutbox persists the obligation, ListWakeOutboxObligations projects
+// it, ClaimWakeOutbox moves it to `attempted` and stamps attempt_count, and
+// wakeOutboxEvent builds the event the sink consumes. Constructing an
+// obligation struct by hand would leave WakeOutboxIDs empty and the row absent,
+// so nothing would be persisted for the assertion to be about.
+func seedClaimedWake(t *testing.T, store *db.Store, sourceID, role string) (events.Event, int64) {
+	t.Helper()
+	ctx := context.Background()
+	if err := store.InsertWakeOutbox(ctx, db.WakeOutboxSourceWorkflowNote, sourceID,
+		db.WakeOutboxKindReply, []string{role}); err != nil {
+		t.Fatalf("insert wake outbox: %v", err)
+	}
+	projection, err := store.ListWakeOutboxObligations(ctx, time.Now().Add(time.Hour))
+	if err != nil {
+		t.Fatalf("list wake outbox obligations: %v", err)
+	}
+	var batch []db.WakeOutboxObligation
+	for _, obligation := range projection.Pending {
+		if obligation.SourceID == sourceID {
+			batch = append(batch, obligation)
+		}
+	}
+	if len(batch) != 1 {
+		t.Fatalf("projected %d obligations for %s, want 1", len(batch), sourceID)
+	}
+	ids := []int64{batch[0].ID}
+	if claimed, err := store.ClaimWakeOutbox(ctx, ids, time.Now().UTC()); err != nil || !claimed {
+		t.Fatalf("claim wake outbox: claimed=%v err=%v", claimed, err)
+	}
+	event, err := wakeOutboxEvent(batch, time.Now())
+	if err != nil {
+		t.Fatalf("build wake outbox event: %v", err)
+	}
+	// The claimed ids are attached by the CALLER in production, at
+	// reply_wake_outbox.go:177 immediately after ClaimWakeOutbox succeeds, not
+	// by wakeOutboxEvent. Mirroring that here keeps the fixture faithful to the
+	// sequence the daemon actually executes.
+	event.WakeOutboxIDs = ids
+	return event, ids[0]
+}
+
+// THE DEFECT ITSELF. A delivered wake whose terminal write contends with
+// another writer for LONGER THAN THE OLD 5s PROBE DEADLINE must still be
+// recorded delivered, not left `attempted` for the age-out sweep to relabel
+// delivery_unknown and never retry.
+//
+// The contention is real: a second connection on the same file holds a write
+// transaction, which is exactly the shape the live daemon hits with
+// SetMaxOpenConns(1) and several write-capable openers of one database.
+func TestDeliveredWakeSurvivesContendedTerminalWrite(t *testing.T) {
+	home, store, wake, sink := wakePersistenceFixture(t)
+	_ = home
+	_ = wake
+	ctx := context.Background()
+
+	event, outboxID := seedClaimedWake(t, store, "note-1836", "owner")
+
+	// WHAT THIS TEST COVERS, AND WHAT IT DOES NOT. It drives the real delivered
+	// branch end to end while the write lock is genuinely held by a second
+	// connection, and asserts the row settles `delivered` with ONE attempt and
+	// ONE wake. That is the invariant #1836's fix had to preserve: recording is
+	// what must survive contention, delivery must never be repeated.
+	//
+	// It does NOT discriminate the deadline value, and I measured that rather
+	// than assuming it: a mutant restoring the old 5s budget survives this test
+	// at 7s, 12s, 17s and two-sequential-hold contention. The reason is
+	// structural. The delivered branch resets the missed-wake counter FIRST,
+	// that write waits on the lock, and the driver returns only when the lock
+	// frees, so the counter absorbs the whole stall and the terminal write then
+	// runs on a free lock. From outside the sink there is no way to interleave a
+	// second hold between two writes of one sequential path.
+	//
+	// The budget itself is pinned where it is observable, at the store boundary:
+	// db.TestShortCallerBudgetDiscardsAWriteItAlreadyWon holds the lock for a
+	// fixed 8s and varies ONLY the caller's budget, and a mutant shrinking
+	// DurableWriteBudget back to 5s kills it.
+	const hold = 3 * time.Second
+	raw, err := sql.Open("sqlite", config.PathsForHome(home).Database)
+	if err != nil {
+		t.Fatalf("open second connection: %v", err)
+	}
+	defer raw.Close()
+	blocker, err := raw.BeginTx(ctx, nil)
+	if err != nil {
+		t.Fatalf("begin blocking transaction: %v", err)
+	}
+	if _, err := blocker.ExecContext(ctx,
+		`UPDATE wake_outbox SET updated_at = updated_at WHERE id = ?`, outboxID); err != nil {
+		t.Fatalf("take the write lock: %v", err)
+	}
+	go func() {
+		time.Sleep(hold)
+		_ = blocker.Rollback()
+	}()
+
+	rules := []db.EventRule{{
+		ID: "rule-1836", OnKind: "reply", WakeRole: "owner",
+		Scope: db.EventRuleScopeAddressed, Enabled: true,
+	}}
+	start := time.Now()
+	if err := sink.evaluateRules(ctx, event, rules); err != nil {
+		t.Fatalf("evaluateRules returned error: %v", err)
+	}
+
+	if elapsed := time.Since(start); elapsed < hold {
+		t.Fatalf("the delivered branch returned in %s, before the %s hold elapsed; this test did not exercise a contended write",
+			elapsed, hold)
+	}
+	state, attempts := wakeOutboxRow(t, store, outboxID)
+	if state != db.WakeOutboxStateDelivered {
+		t.Fatalf("wake outbox row state = %q after a DELIVERED wake whose record contended; want %q. Left in this state the age-out sweep relabels it delivery_unknown with policy=expire_without_retry, which is #1836",
+			state, db.WakeOutboxStateDelivered)
+	}
+	// THE INVARIANT THE FIX HAD TO PRESERVE: recording was retried, delivery
+	// was not. One attempt, one wake.
+	if attempts != 1 {
+		t.Fatalf("attempt_count = %d, want 1; a contended RECORD must never turn into a repeated DELIVERY", attempts)
+	}
+	if len(wake.panes) != 1 {
+		t.Fatalf("woke %d panes, want 1; the wake must not be re-sent because its record was contended", len(wake.panes))
+	}
+}
+
+// POSITIVE CONTROL, so the guard above cannot be satisfied by making every
+// delivery expensive or repeated: an UNCONTENDED delivery still settles
+// delivered in one attempt, with one wake, and promptly.
+func TestOrdinaryDeliveredWakeStaysSingleAttempt(t *testing.T) {
+	_, store, wake, sink := wakePersistenceFixture(t)
+	ctx := context.Background()
+
+	event, outboxID := seedClaimedWake(t, store, "note-plain", "owner")
+	rules := []db.EventRule{{
+		ID: "rule-plain", OnKind: "reply", WakeRole: "owner",
+		Scope: db.EventRuleScopeAddressed, Enabled: true,
+	}}
+	start := time.Now()
+	if err := sink.evaluateRules(ctx, event, rules); err != nil {
+		t.Fatalf("evaluateRules returned error: %v", err)
+	}
+	if elapsed := time.Since(start); elapsed > 5*time.Second {
+		t.Fatalf("an uncontended delivery took %s; the fix must not make the ordinary path wait on its budget", elapsed)
+	}
+	state, attempts := wakeOutboxRow(t, store, outboxID)
+	if state != db.WakeOutboxStateDelivered {
+		t.Fatalf("uncontended wake state = %q, want %q", state, db.WakeOutboxStateDelivered)
+	}
+	if attempts != 1 {
+		t.Fatalf("attempt_count = %d, want 1", attempts)
+	}
+	if len(wake.panes) != 1 {
+		t.Fatalf("woke %d panes, want 1", len(wake.panes))
+	}
+}

--- a/internal/db/durable_write_budget_test.go
+++ b/internal/db/durable_write_budget_test.go
@@ -1,0 +1,37 @@
+package db
+
+import (
+	"testing"
+	"time"
+)
+
+// #1836's ROOT SHAPE, pinned. The defect was never one number being wrong: it
+// was TWO CONSTANTS IN TWO PACKAGES whose relative order nothing enforced.
+// internal/cli bounded a wake-outbox terminal-state write at 5s while this
+// package's driver waited up to sqliteBusyTimeoutMillis = 15s for the write
+// lock, so the caller abandoned a write the driver was still legitimately
+// waiting to perform, and a DELIVERED wake decayed to delivery_unknown with
+// policy=expire_without_retry.
+//
+// DurableWriteBudget is derived from sqliteBusyTimeoutMillis for exactly that
+// reason, and this test is the thing that keeps them ordered. Hand-setting
+// either one out of order fails here rather than silently losing deliveries in
+// production, which is where the last one was found.
+func TestDurableWriteBudgetExceedsBusyTimeout(t *testing.T) {
+	busy := time.Duration(sqliteBusyTimeoutMillis) * time.Millisecond
+	if DurableWriteBudget <= busy {
+		t.Fatalf("DurableWriteBudget %s must exceed the store's own busy budget %s; a caller that gives up first abandons a write the driver is still waiting to perform, which is #1836",
+			DurableWriteBudget, busy)
+	}
+	// AND IT MUST LEAVE ROOM TO EXECUTE. A budget equal to the busy timeout
+	// plus nothing expires at the instant the driver stops waiting, so the
+	// statement it just won the lock for never runs.
+	if margin := DurableWriteBudget - busy; margin < time.Second {
+		t.Fatalf("DurableWriteBudget margin over the busy budget is %s; that leaves no time to execute the write after winning the lock", margin)
+	}
+	// A positive control on the arithmetic itself, so a zeroed or unit-confused
+	// constant cannot satisfy the comparisons above.
+	if busy != 15*time.Second {
+		t.Fatalf("busy budget = %s, want 15s; if this changed deliberately, re-read the derivation in DurableWriteBudget's comment", busy)
+	}
+}

--- a/internal/db/durable_write_contention_test.go
+++ b/internal/db/durable_write_contention_test.go
@@ -1,0 +1,97 @@
+package db
+
+import (
+	"context"
+	"database/sql"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// #1836's MECHANISM, pinned behaviourally at the boundary that owns it.
+//
+// WHAT THE DEADLINE ACTUALLY CONTROLS, and it is not what the name suggests: a
+// caller's context does NOT shorten the wait for a contended write. The driver
+// ignores cancellation while backing off, so the call returns only when the lock
+// frees. What the deadline decides is whether a write that ALREADY OBTAINED THE
+// LOCK is accepted or discarded for being late.
+//
+// That is exactly the production symptom this issue records: the wake was
+// delivered, the lock was eventually obtained, and the success record was thrown
+// away because the caller had budgeted 5s against a store that waits 15s. The
+// row stayed `attempted`, the age-out sweep relabelled it `delivery_unknown`
+// with policy=expire_without_retry, and a delivered wake became an unknown that
+// is never retried.
+//
+// Both arms below hold the write lock for the SAME duration from a second
+// connection. Only the caller's budget differs, so the budget is the only thing
+// the assertions can be about.
+func TestShortCallerBudgetDiscardsAWriteItAlreadyWon(t *testing.T) {
+	const hold = 8 * time.Second
+
+	run := func(t *testing.T, budget time.Duration) (time.Duration, error) {
+		t.Helper()
+		ctx := context.Background()
+		path := filepath.Join(t.TempDir(), "contended.db")
+		store, err := openRealTestStore(t, path)
+		if err != nil {
+			t.Fatalf("open store: %v", err)
+		}
+		defer store.Close()
+		if _, err := store.db.ExecContext(ctx,
+			`CREATE TABLE probe(id INTEGER PRIMARY KEY, v TEXT)`); err != nil {
+			t.Fatalf("create: %v", err)
+		}
+		if _, err := store.db.ExecContext(ctx,
+			`INSERT INTO probe(id, v) VALUES (1, 'a')`); err != nil {
+			t.Fatalf("seed: %v", err)
+		}
+
+		raw, err := sql.Open("sqlite", path)
+		if err != nil {
+			t.Fatalf("second connection: %v", err)
+		}
+		defer raw.Close()
+		blocker, err := raw.BeginTx(ctx, nil)
+		if err != nil {
+			t.Fatalf("begin blocking transaction: %v", err)
+		}
+		if _, err := blocker.ExecContext(ctx, `UPDATE probe SET v='b' WHERE id=1`); err != nil {
+			t.Fatalf("take the write lock: %v", err)
+		}
+		go func() {
+			time.Sleep(hold)
+			_ = blocker.Rollback()
+		}()
+
+		writeCtx, cancel := context.WithTimeout(ctx, budget)
+		defer cancel()
+		start := time.Now()
+		_, execErr := store.db.ExecContext(writeCtx, `UPDATE probe SET v='c' WHERE id=1`)
+		return time.Since(start), execErr
+	}
+
+	// THE DEFECT: a 5s budget, the value #1836 found on the wake-outbox terminal
+	// write. The write waits out the whole hold and is then thrown away.
+	t.Run("short budget discards the write", func(t *testing.T) {
+		waited, err := run(t, 5*time.Second)
+		if err == nil {
+			t.Fatalf("a 5s budget accepted a write that waited %s; if the driver now honours cancellation early this test's premise has changed and #1836's mechanism needs re-reading", waited)
+		}
+		if waited < hold {
+			t.Fatalf("the write returned after %s, before the %s hold elapsed; then the deadline shortened the WAIT and this test is not about what it claims", waited, hold)
+		}
+	})
+
+	// THE FIX: the store's own derived budget accepts the same write after the
+	// same wait. Same contention, same lock, only the budget differs.
+	t.Run("derived budget accepts the write", func(t *testing.T) {
+		waited, err := run(t, DurableWriteBudget)
+		if err != nil {
+			t.Fatalf("DurableWriteBudget (%s) discarded a write that obtained the lock after %s: %v", DurableWriteBudget, waited, err)
+		}
+		if waited < hold {
+			t.Fatalf("the write returned after %s, before the %s hold elapsed; the arms are not comparable", waited, hold)
+		}
+	})
+}

--- a/internal/db/store.go
+++ b/internal/db/store.go
@@ -63,6 +63,30 @@ type sqlExecer interface {
 // daemon its own home via GITMOOT_HOME_DIR so they do not share a DB at all.)
 const sqliteBusyTimeoutMillis = 15000
 
+// DurableWriteBudget is the MINIMUM context deadline a caller must allow a
+// durability write against this store, and it is DERIVED from
+// sqliteBusyTimeoutMillis rather than hand-set beside it.
+//
+// THE BUG SHAPE THIS EXISTS TO REMOVE (#1836). A caller bounded a wake-outbox
+// terminal-state write at 5s while the driver was still legitimately waiting on
+// the write lock for up to 15s, so the write was abandoned before the store's
+// own budget was spent. The row stayed `attempted`, the age-out sweep relabelled
+// it `delivery_unknown` with policy=expire_without_retry, and a wake that WAS
+// delivered decayed into an unknown that is never retried. Measured on the live
+// home: 15 of 167 delivered wakes in one 2h33m window lost that write.
+//
+// The defect was never one number being wrong. It was TWO CONSTANTS IN TWO
+// PACKAGES whose relative order nothing enforced: a caller in internal/cli
+// could be edited without ever seeing internal/db's budget. Deriving the
+// caller's floor from the store's own wait makes that ordering impossible to
+// get wrong by construction, and TestDurableWriteBudgetExceedsBusyTimeout pins
+// it so the pair cannot drift apart again.
+//
+// The margin is for the statement itself: a deadline equal to the busy timeout
+// still abandons at the instant the driver gives up waiting, leaving no time to
+// execute the write it just won the lock for.
+const DurableWriteBudget = sqliteBusyTimeoutMillis*time.Millisecond + 3*time.Second
+
 func Open(path string) (*Store, error) {
 	store, err := openWritable(path)
 	if err != nil {

--- a/internal/db/test_store_cache_test.go
+++ b/internal/db/test_store_cache_test.go
@@ -101,6 +101,11 @@ func TestStoreOpenPolicy(t *testing.T) {
 	// then reopens the same file to run the migration over it.
 	realPathTests["TestCockpitRemovalMigrationOnFreshHome"] = true
 	realPathTests["TestCockpitRemovalMigrationDropsPopulatedTablesOnUpgrade"] = true
+	// #1836: holds the write lock from a SECOND connection to the same file for
+	// longer than a caller's budget, which is the only way to observe that a
+	// contended write is discarded rather than shortened. A cached shared-memory
+	// store has no file for a second connection to contend over.
+	realPathTests["TestShortCallerBudgetDiscardsAWriteItAlreadyWon"] = true
 	directOpenFunctions := map[string]bool{
 		"ensureCachedMigratedTestTemplateOnce": true,
 		"openRealTestStore":                    true,


### PR DESCRIPTION
Closes #1836.

## The defect

A wake that WAS delivered could be recorded as `delivery_unknown` and then never retried.

`finishWakeOutbox` records a wake's terminal outcome — a durability write — but bounded it with `eventRuleProbeTimeout` (5s), a constant whose own doc scopes it to herdr subprocess probes ("the availability probe and each pane-label resolution"). The store waits `sqliteBusyTimeoutMillis` = 15s. So a contended success write was abandoned at 5s, the row stayed `attempted`, and the age-out sweep relabelled it `delivery_unknown` with `policy=expire_without_retry`.

Two constants in two packages, with nothing enforcing their relative order — exactly as jarvis framed it in #1836.

## The mechanism, probed rather than assumed

A caller's context does **not** shorten the wait for a contended write: the driver ignores cancellation while backing off, so the call returns only when the lock frees. Measured on this store: a 5s context under a 12s hold still returned after **12.05s**, with `context deadline exceeded`.

So the deadline does not abort early — it decides whether a write that **already obtained the lock** is accepted or discarded for being late. That is why a delivered wake lost its record, and it is why widening the budget is the correct remedy rather than a workaround.

## Live reproduction, with a control

From this box tonight, verified in the store myself:

| row | target_role | state | attempts | created |
|---|---|---|---|---|
| 8484 | gm-omp-gate | `delivery_unknown` | 1 | 06:44:03.348Z |
| 8485 | gm-omp-fanout | `delivered` | 1 | 06:44:03.472Z |

Same second, same daemon, one kept its success write and the other lost it — so this is contention on the success write, not a property of the wake path.

## The fix

`db.DurableWriteBudget`, **derived** as `sqliteBusyTimeoutMillis + 3s`, so the two values cannot drift apart by hand. `finishWakeOutbox` uses it.

- Delivery is never repeated: recording is what is made durable; the wake is emitted exactly once.
- No probe deadline is widened. `eventRuleProbeTimeout` keeps its 5s and its herdr scope.
- No known delivery is relabelled as failure.

## Tests, and what each can and cannot prove

- **`db.TestShortCallerBudgetDiscardsAWriteItAlreadyWon`** — holds the write lock 8s from a second connection and varies **only** the caller's budget. 5s discards the write after 8.5s; `DurableWriteBudget` accepts it after 8.6s. Mutant shrinking the budget back to 5s → **KILLED**.
- **`db.TestDurableWriteBudgetExceedsBusyTimeout`** — constant ordering. Budget below the store's busy budget → **KILLED**.
- **`cli.TestDeliveredWakeSurvivesContendedTerminalWrite`** — the real delivered branch, end to end, under real lock contention: row settles `delivered`, one attempt, one wake. Skipping the terminal write → **KILLED**. Nanosecond deadline → **KILLED**.
- **`cli.TestOrdinaryDeliveredWakeStaysSingleAttempt`** — positive control: an uncontended delivery still settles in one attempt, one wake, promptly.

### What I could not pin, stated rather than hidden

The **cli** test does **not** discriminate the 5s budget. A mutant restoring `eventRuleProbeTimeout` there survives — measured at 7s, 12s, 17s and two-sequential-hold contention, four harness shapes. The reason is structural: the delivered branch resets the missed-wake counter first, that write waits on the lock, the driver returns only when the lock frees, so the counter absorbs the whole stall and the terminal write then runs on a **free** lock. From outside the sink there is no way to interleave a second hold between two writes of one sequential path, and I was not willing to add a seam to production for testability.

That is why the budget is pinned where it is observable — at the store boundary, in `internal/db` — and the limitation is documented in the cli test itself rather than left for a reviewer to discover.

## Mutants

| # | mutation | result |
|---|---|---|
| M1 | cli: restore `eventRuleProbeTimeout` on the terminal write | SURVIVED — documented above |
| M2/M4 | `DurableWriteBudget` below the store's busy budget | KILLED (ordering guard) |
| M3 | `DurableWriteBudget` = 5s | KILLED (db contention test, behavioural) |
| M5 | terminal write skipped entirely | KILLED (cli test) |
| M6 | terminal write given a 1ns deadline | KILLED (cli test) |

All mutants compiled (`go test -c -o /dev/null`) and every source file was restored byte-identically (sha256 verified).

## Gate at this tree

```
BASE=0e55c0a3a2df95541ee7583191b9ea4e3a49f149 (origin/main)
go version go1.26.4 linux/amd64   GOTOOLCHAIN=go1.26.4
GOFMT_DIRTY_COUNT=0   VET_RC=0
ok github.com/gitmoot/gitmoot/internal/db   175.573s
ok github.com/gitmoot/gitmoot/internal/cli  329.427s
TEST_RC=0
```

Not run: `-race` (cgo is blocked in this seat), and the full suite outside these two packages.

## Note on the repo's own policy

`internal/db/TestStoreOpenPolicy` rejected my first version for calling `Open` directly. It was right: the test needs a real on-disk file so a second connection can contend for its lock. Declared as a carve-out with a reason, alongside the identical precedent from #1673.

Signed: **GM-OMP-FANOUT**
