### PR TITLE
fix(style): make IsTerminal a terminal check, not a char-device check (#1838)

### DIFF
--- a/internal/cli/dashboard_test.go
+++ b/internal/cli/dashboard_test.go
@@ -166,18 +166,17 @@ func TestDashboardWatchRejectsInvalidCombos(t *testing.T) {
 // the wrong guard, which is precisely the class that round claimed to close
 // (#1787 review F1).
 //
-// Reaching the interval guard needs a stdout that satisfies IsTerminal. /dev/null
-// is a character device, so it does - the same weakness filed as #1838, used
-// here deliberately and named so nobody reads it as an accident.
+// Reaching the interval guard needs a stdout that satisfies IsTerminal. This
+// case USED TO open /dev/null for that, relying on the #1838 weakness it names.
+// With that weakness fixed, /dev/null no longer passes and the old version
+// would have SILENTLY SKIPPED - still green, testing nothing. It now uses a
+// genuine terminal instead, so it exercises the same production ordering
+// without depending on a defect.
 func TestDashboardWatchRejectsANonPositiveInterval(t *testing.T) {
 	home := dashboardTestHome(t)
-	devNull, err := os.OpenFile(os.DevNull, os.O_WRONLY, 0)
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer devNull.Close()
-	if !style.IsTerminal(devNull) {
-		t.Skip("this host does not report /dev/null as a character device, so the terminal guard cannot be passed here")
+	tty := openTerminalForTest(t)
+	if !style.IsTerminal(tty) {
+		t.Fatal("openTerminalForTest did not return a terminal, so the terminal guard cannot be passed here")
 	}
 	original := runDashboardWatchFn
 	t.Cleanup(func() { runDashboardWatchFn = original })
@@ -187,7 +186,7 @@ func TestDashboardWatchRejectsANonPositiveInterval(t *testing.T) {
 		return 0
 	}
 	var stderr bytes.Buffer
-	code := Run([]string{"dashboard", "--home", home, "--watch", "--interval", "0s"}, devNull, &stderr)
+	code := Run([]string{"dashboard", "--home", home, "--watch", "--interval", "0s"}, tty, &stderr)
 	if started != 0 {
 		t.Fatal("the watch loop started with a non-positive interval")
 	}

--- a/internal/cli/dashboard_watch_terminal_test.go
+++ b/internal/cli/dashboard_watch_terminal_test.go
@@ -1,0 +1,133 @@
+package cli
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"strings"
+	"testing"
+	"time"
+)
+
+// openTerminalForTest returns a REAL terminal for tests that must pass the
+// --watch terminal guard. /dev/ptmx is a pty master, so TCGETS succeeds on it
+// and no pty helper dependency is needed.
+//
+// #1838: tests used to open /dev/null for this, which worked only because the
+// guard was a character-device check. Anything relying on that would now skip
+// silently rather than fail, which is why this helper exists in one place.
+func openTerminalForTest(t *testing.T) *os.File {
+	t.Helper()
+	file, err := os.OpenFile("/dev/ptmx", os.O_RDWR, 0)
+	if err != nil {
+		t.Skipf("cannot open /dev/ptmx on this host, so no genuine terminal is available: %v", err)
+	}
+	t.Cleanup(func() { _ = file.Close() })
+	return file
+}
+
+// THE #1838 FAILING CONTROL, driven through the production dashboard entry
+// path: `gitmoot dashboard --watch >/dev/null` must refuse with exit 2 rather
+// than entering the loop. Before the fix this passed the guard - /dev/null is a
+// character device - and the watch loop ran until interrupted against a sink
+// nobody could see, which is why the original report measured exit=124 from a
+// timeout kill rather than a refusal.
+func TestDashboardWatchRefusesDevNull(t *testing.T) {
+	home := dashboardTestHome(t)
+	devNull, err := os.OpenFile(os.DevNull, os.O_WRONLY, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = devNull.Close() })
+
+	original := runDashboardWatchFn
+	t.Cleanup(func() { runDashboardWatchFn = original })
+	started := 0
+	runDashboardWatchFn = func(io.Writer, string, bool, time.Duration) int {
+		started++
+		return 0
+	}
+
+	var stderr bytes.Buffer
+	code := Run([]string{"dashboard", "--home", home, "--watch"}, devNull, &stderr)
+
+	// The loop assertion is the one that matters: exit 2 with a started loop
+	// would still hang in production.
+	if started != 0 {
+		t.Fatalf("the watch loop started against %s; it ran %d time(s)", os.DevNull, started)
+	}
+	if code != 2 {
+		t.Fatalf("Run = %d, want 2; stderr=%q", code, stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "dashboard --watch requires a terminal") {
+		t.Fatalf("stderr = %q, want the TERMINAL guard's own message", stderr.String())
+	}
+}
+
+// THE POSITIVE CONTROL, and it is the half a tightened bound usually breaks: a
+// genuine terminal must still reach the watch loop. Without this, a guard that
+// refused every writer would pass the case above.
+func TestDashboardWatchAcceptsARealTerminal(t *testing.T) {
+	home := dashboardTestHome(t)
+	tty := openTerminalForTest(t)
+
+	original := runDashboardWatchFn
+	t.Cleanup(func() { runDashboardWatchFn = original })
+	started := 0
+	var seenInterval time.Duration
+	runDashboardWatchFn = func(_ io.Writer, _ string, _ bool, interval time.Duration) int {
+		started++
+		seenInterval = interval
+		return 0
+	}
+
+	var stderr bytes.Buffer
+	code := Run([]string{"dashboard", "--home", home, "--watch", "--interval", "3s"}, tty, &stderr)
+
+	if started != 1 {
+		t.Fatalf("the watch loop ran %d time(s) on a genuine terminal, want 1; stderr=%q", started, stderr.String())
+	}
+	if code != 0 {
+		t.Fatalf("Run = %d, want 0; stderr=%q", code, stderr.String())
+	}
+	if seenInterval != 3*time.Second {
+		t.Fatalf("interval = %s, want 3s: the guard must not disturb the flags it gates", seenInterval)
+	}
+}
+
+// A pipe is the ordinary non-terminal case and must keep being refused - the
+// fix narrows what counts as a terminal and must not widen it anywhere.
+func TestDashboardWatchRefusesAPipe(t *testing.T) {
+	home := dashboardTestHome(t)
+	reader, writer, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		_ = writer.Close()
+		_ = reader.Close()
+	})
+	// Drain so a full pipe buffer can never be mistaken for the hang under test.
+	go func() { _, _ = io.Copy(io.Discard, reader) }()
+
+	original := runDashboardWatchFn
+	t.Cleanup(func() { runDashboardWatchFn = original })
+	started := 0
+	runDashboardWatchFn = func(io.Writer, string, bool, time.Duration) int {
+		started++
+		return 0
+	}
+
+	var stderr bytes.Buffer
+	code := Run([]string{"dashboard", "--home", home, "--watch"}, writer, &stderr)
+
+	if started != 0 {
+		t.Fatalf("the watch loop started against a pipe; it ran %d time(s)", started)
+	}
+	if code != 2 {
+		t.Fatalf("Run = %d, want 2; stderr=%q", code, stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "dashboard --watch requires a terminal") {
+		t.Fatalf("stderr = %q, want the TERMINAL guard's own message", stderr.String())
+	}
+}

--- a/internal/cli/style/is_terminal_test.go
+++ b/internal/cli/style/is_terminal_test.go
@@ -1,0 +1,67 @@
+package style
+
+import (
+	"bytes"
+	"os"
+	"testing"
+)
+
+// #1838: IsTerminal used to be a character-device check, so /dev/null passed
+// it and `dashboard --watch >/dev/null` looped forever against a sink nobody
+// could see. These cases pin the discriminator itself: every path below is a
+// CHARACTER DEVICE, so a char-device check cannot tell them apart and the old
+// implementation returned true for all three.
+func TestIsTerminalRejectsCharacterDevicesThatAreNotTerminals(t *testing.T) {
+	for _, path := range []string{os.DevNull, "/dev/zero"} {
+		t.Run(path, func(t *testing.T) {
+			file, err := os.OpenFile(path, os.O_RDWR, 0)
+			if err != nil {
+				t.Skipf("cannot open %s on this host: %v", path, err)
+			}
+			t.Cleanup(func() { _ = file.Close() })
+
+			info, err := file.Stat()
+			if err != nil {
+				t.Fatalf("Stat: %v", err)
+			}
+			// State the premise as an assertion rather than a comment: if this
+			// host does not report a character device here, the case is not
+			// testing what it claims to.
+			if info.Mode()&os.ModeCharDevice == 0 {
+				t.Fatalf("%s is not a character device on this host, so it cannot discriminate the two checks", path)
+			}
+			if IsTerminal(file) {
+				t.Fatalf("IsTerminal(%s) = true, want false: a character device is not a terminal", path)
+			}
+		})
+	}
+}
+
+// The positive control. Without it the guard could reject every writer and
+// still pass the cases above - every bound in this campaign had a version that
+// rejected valid input. /dev/ptmx is a real terminal (TCGETS succeeds on the
+// master), so this needs no pty helper and no skip on Linux CI.
+func TestIsTerminalAcceptsARealTerminal(t *testing.T) {
+	file, err := os.OpenFile("/dev/ptmx", os.O_RDWR, 0)
+	if err != nil {
+		t.Skipf("cannot open /dev/ptmx on this host: %v", err)
+	}
+	t.Cleanup(func() { _ = file.Close() })
+
+	if !IsTerminal(file) {
+		t.Fatal("IsTerminal(/dev/ptmx) = false, want true: the guard must still accept a genuine terminal")
+	}
+}
+
+// A writer with no file descriptor at all - the ordinary pipe/buffer case that
+// callers rely on to take the non-interactive branch.
+func TestIsTerminalRejectsWritersWithoutADescriptor(t *testing.T) {
+	if IsTerminal(&bytes.Buffer{}) {
+		t.Fatal("IsTerminal(*bytes.Buffer) = true, want false")
+	}
+	// A Stat()-only writer is exactly what the old char-device implementation
+	// accepted; it has no descriptor, so an ioctl cannot be performed on it.
+	if IsTerminal(charDevice{}) {
+		t.Fatal("IsTerminal(charDevice{}) = true, want false: Stat() alone cannot prove a terminal")
+	}
+}

--- a/internal/cli/style/style.go
+++ b/internal/cli/style/style.go
@@ -11,6 +11,8 @@ import (
 	"os"
 	"runtime"
 	"strings"
+
+	"github.com/charmbracelet/x/term"
 )
 
 const (
@@ -95,11 +97,23 @@ func windowsVTCapable(lookup func(string) (string, bool)) bool {
 	return false
 }
 
-// IsTerminal reports whether w is a character device (a real terminal),
-// independent of the NO_COLOR / TERM color conventions. Use it to gate
-// terminal-only features such as a refreshing watch loop.
+// IsTerminal reports whether w is a real interactive terminal, independent of
+// the NO_COLOR / TERM color conventions. Use it to gate terminal-only features
+// such as a refreshing watch loop.
+//
+// #1838: this used to be a CHARACTER-DEVICE check, which /dev/null, /dev/zero
+// and /dev/full all satisfy - so `dashboard --watch >/dev/null` passed the
+// guard and looped forever against a sink nobody could see. The property the
+// callers want is "a human is watching", and the instrument for that is an
+// ioctl against the fd (TCGETS), which term.IsTerminal performs.
 func IsTerminal(w io.Writer) bool {
-	return isCharDevice(w)
+	fder, ok := w.(interface {
+		Fd() uintptr
+	})
+	if !ok {
+		return false
+	}
+	return term.IsTerminal(fder.Fd())
 }
 
 func isCharDevice(w io.Writer) bool {


### PR DESCRIPTION
Closes #1838.

## The defect

`gitmoot dashboard --watch >/dev/null` hung forever instead of being refused. The guard is `style.IsTerminal`, which was a **character-device** check — and `/dev/null`, `/dev/zero` and `/dev/full` all satisfy that, so the watch loop started against a sink nobody could see.

The property the callers want is "a human is watching an interactive terminal". Its instrument is an ioctl (`TCGETS`) against the fd, which `term.IsTerminal` performs and `/dev/null` fails. `github.com/charmbracelet/x/term` is already a **direct** dependency, imported by `internal/cli/auth.go`, so this adds none.

## Measured on real binaries, both sides, at this base

| binary | command | result |
|---|---|---|
| pristine `0e55c0a3` | `dashboard --watch >/dev/null` under `timeout 10` | **exit=124**, stderr empty |
| this PR | same | **exit=2**, `dashboard --watch requires a terminal` |

The probe that the fix rests on, run before any code was written — all three are character devices, so the old check could not tell them apart:

| path | char device | `term.IsTerminal` |
|---|---|---|
| `/dev/null` | true | **false** |
| `/dev/zero` | true | **false** |
| `/dev/ptmx` | true | **true** |

That last row is why the positive control needs no pty dependency and no `t.Skip`.

## Callers enumerated before changing semantics

The issue and the assignment both require this. There are exactly three, plus one name collision:

1. **`dashboard.go:190`** — the subject.
2. **`auth.go:20`** — gates an interactive password prompt against reading stdin. Behaviour change: with `/dev/null` as stdin it used to call `term.ReadPassword` on a non-terminal; it now takes the read path and yields an empty secret. Its only test stubs `authReadSecret` wholesale, so nothing depended on the old semantics.
3. **`style.go:78`** — the **color** path, via `isCharDevice`, deliberately **unchanged**. ANSI written to `/dev/null` is harmless, and widening that check is a different behaviour change than this issue asks for. Named so the omission reads as a decision, not an oversight.
4. `internal/workflow/finalize_test.go:78` `TestEngineFinalizeContinuationIsTerminal` — unrelated name collision about continuation state.

## A fixture was pinning the defect

`TestDashboardWatchRejectsANonPositiveInterval` opened `/dev/null` **specifically to get past the terminal guard**, with a comment naming #1838 as the weakness it exploited and a `t.Skip` if `/dev/null` were ever not a char device. With the predicate fixed that case would have **skipped silently** — green while testing nothing. It now opens a genuine terminal, and its local variable is no longer called `devNull` while holding a tty.

## Verification

Tests drive the **production entry path** (`Run`), never the predicate alone; `runDashboardWatchFn` is used only to observe whether the loop started.

- `TestDashboardWatchRefusesDevNull` — the failing control: exit 2, terminal message, loop proven unstarted.
- `TestDashboardWatchAcceptsARealTerminal` — the positive control: loop runs exactly once, exit 0, and the `3s` interval arrives intact, so the guard does not disturb the flags it gates.
- `TestDashboardWatchRefusesAPipe` — with a drain goroutine, so a full pipe buffer can never be mistaken for the hang under test.
- Predicate units in `internal/cli/style/is_terminal_test.go`, each **asserting its own premise** (that the path really is a character device on this host) so a case cannot quietly stop discriminating.

**Three mutants, all killed by named tests:** restoring the char-device semantics kills the `/dev/null` and `/dev/zero` cases *and* `TestDashboardWatchRefusesDevNull`; refusing every writer kills all three positive controls; falling back to char-device for fd-less writers kills `TestIsTerminalRejectsWritersWithoutADescriptor`.

**An instrument error of mine, reported:** my first two mutants deleted the `term` call and left its import unused, so both failed to *compile* while my detector scored them as kills with an empty failure list — testing the compiler, not the guard. Re-run consuming the values, verified compiling, then read the failures. Tree restored byte-identical after each.

**Gate:** `gofmt` clean; `go build ./...` rc=0; `go generate ./...` no diff; `go vet ./...` clean; full suite 39 packages ok; `go test -race ./internal/cli ./internal/cli/style` with **zero data races**.

**One pre-existing failure, re-measured at this base rather than carried forward:** `internal/cli` `TestApplyReviewPolicyEmptyHomeIsOff` (`review_risk_test.go:166`) fails identically on pristine `0e55c0a3` in a worktree with none of my paths. It reads this box's `/root/.gitmoot/config.toml`, which sets `blocking_severity = "P2"` while the test asserts the `P3` default — host-dependent, not fixed here per owner rule 117411. It is also the only failure in the race run.