### PR TITLE
fix(doctor): distinguish a runtime that is installed from one that is serving (#1558)

### DIFF
--- a/internal/cli/doctor_runtime_serving.go
+++ b/internal/cli/doctor_runtime_serving.go
@@ -1,0 +1,197 @@
+package cli
+
+import (
+	"context"
+	"strings"
+	"time"
+
+	"github.com/gitmoot/gitmoot/internal/config"
+	"github.com/gitmoot/gitmoot/internal/db"
+	"github.com/gitmoot/gitmoot/internal/doctor"
+	"github.com/gitmoot/gitmoot/internal/workflow"
+)
+
+// runtimeServingStatus resolves, in the CLI layer that owns store access, which
+// runtimes the ENGINE is currently holding off a provider refusal (#1558).
+//
+// THE PREDICATE, and it is the whole design: a runtime is reported as not
+// serving iff a NON-TERMINAL job attributed to it carries a runtime_quota or
+// runtime_auth blocker class AND the BlockerRetryAt the classifier wrote is
+// still in the FUTURE. That field is the engine's own forward-looking "I am
+// still waiting this out", so doctor reports what the engine believes rather
+// than a second opinion derived from a clock.
+//
+// The alternative - "the newest 403 within N minutes" - was rejected on
+// measurement, not taste: it asserts the provider is refusing NOW from a
+// timestamp that only says it refused THEN. On this host's store 12 jobs
+// succeeded on a runtime AFTER carrying a runtime_quota block, and 4 more after
+// runtime_auth; a newest-wins rule would report every one of those runtimes as
+// dead. Replacing a false green with a false red is the same defect with the
+// sign flipped, and the false green is what #1558 was filed for.
+//
+// FOUR NEGATIVES, each a case this must NOT report:
+//   - a hold whose RetryAt has PASSED: the engine will retry it, and the
+//     provider may well serve it;
+//   - a job that reached a terminal state: its block is history, and a later
+//     success on that runtime is the common case;
+//   - a hold with NO RetryAt: absent is not "unknown therefore bad". Measured,
+//     42 of 55 succeeded checkout_contention rows carry no retry time, so
+//     absence is the COMMON case on at least one path;
+//   - a job whose runtime cannot be attributed: excluded, never guessed.
+//
+// Store failures omit the whole check rather than manufacturing a verdict,
+// matching stuckJobsStatus's convention.
+// The clock is a parameter so the four negatives are testable at a fixed
+// instant; runtimeServingStatus is the production entry point and passes the
+// real one.
+func runtimeServingStatus(paths config.Paths) *doctor.RuntimeServingStatus {
+	return runtimeServingStatusAt(paths, time.Now().UTC())
+}
+
+func runtimeServingStatusAt(paths config.Paths, now time.Time) *doctor.RuntimeServingStatus {
+	if strings.TrimSpace(paths.Database) == "" {
+		return nil
+	}
+	store, err := db.OpenReadOnly(paths.Database)
+	if err != nil {
+		return nil
+	}
+	defer store.Close()
+	ctx := context.Background()
+	jobs, err := store.ListJobs(ctx)
+	if err != nil {
+		return nil
+	}
+	registered := registeredAgentRuntimes(ctx, store)
+	status := &doctor.RuntimeServingStatus{}
+	seen := make(map[string]struct{})
+	for _, job := range jobs {
+		if workflow.IsFinalJobState(job.State) {
+			// Final means the block is history. `blocked` is deliberately NOT
+			// excluded here: it is settled but not final (#632's split), and a
+			// blocked job holding a future retry is exactly the live hold this
+			// check exists to report.
+			continue
+		}
+		payload, err := jobListPayload(job)
+		if err != nil {
+			continue
+		}
+		class := strings.TrimSpace(payload.BlockerClass)
+		if class != string(blockerClassRuntimeQuota) && class != string(blockerClassRuntimeAuth) {
+			continue
+		}
+		retryAt, ok := parseBlockerRetryAt(payload.BlockerRetryAt)
+		if !ok || !retryAt.After(now) {
+			// No hold, or a hold the engine has already aged out.
+			continue
+		}
+		runtimeName := blockedJobRuntime(ctx, store, job, payload, registered)
+		if runtimeName == "" {
+			// Unattributable: excluded rather than guessed. Three rows of 284 on
+			// this host - small, which is exactly why the rule has to be written
+			// down: nobody would notice three wrong rows.
+			continue
+		}
+		key := runtimeName + "\x00" + class
+		if _, duplicate := seen[key]; duplicate {
+			continue
+		}
+		seen[key] = struct{}{}
+		status.Blocks = append(status.Blocks, doctor.RuntimeServingBlock{
+			Runtime: runtimeName,
+			Class:   class,
+			JobID:   job.ID,
+			Detail:  firstLineTrimmed(payload.BlockerSuggestedAction),
+			RetryAt: retryAt,
+		})
+	}
+	return status
+}
+
+// parseBlockerRetryAt reads the classifier's forward-looking hold. An absent or
+// unparseable value is NOT a hold: ok=false, so the caller reports nothing.
+func parseBlockerRetryAt(value string) (time.Time, bool) {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return time.Time{}, false
+	}
+	parsed, err := time.Parse(time.RFC3339Nano, value)
+	if err != nil {
+		return time.Time{}, false
+	}
+	return parsed, true
+}
+
+// registeredAgentRuntimes indexes each registered agent's default runtime, the
+// third and last resolution source.
+func registeredAgentRuntimes(ctx context.Context, store *db.Store) map[string]string {
+	agents, err := store.ListAgents(ctx)
+	if err != nil {
+		return nil
+	}
+	byName := make(map[string]string, len(agents))
+	for _, agent := range agents {
+		byName[agent.Name] = strings.TrimSpace(agent.Runtime)
+	}
+	return byName
+}
+
+// blockedJobRuntime attributes a blocked job to the runtime its child would have
+// used, in PRIORITY ORDER, and returns "" when none of the sources can answer.
+//
+// It extends the dashboard's existing resolveJobRuntime (agent registry, then an
+// ephemeral worker's own spec) rather than duplicating it: the payload's
+// EffectiveRuntime wins when present, and the job's own effective_runtime EVENT
+// is consulted before falling back to that shared resolver.
+//
+// No single source covers the population, which is why all three are needed and
+// why the residue is excluded. Measured over the 284 runtime_quota /
+// runtime_auth rows on this host: 107 carry payload.effective_runtime, 101 have
+// an effective_runtime event, 281 have an agent row that still exists, and 3 are
+// attributable by none of them.
+func blockedJobRuntime(ctx context.Context, store *db.Store, job db.Job, payload workflow.JobPayload, registered map[string]string) string {
+	if name := strings.TrimSpace(payload.EffectiveRuntime); name != "" {
+		return name
+	}
+	if name := effectiveRuntimeFromEvents(ctx, store, job.ID); name != "" {
+		return name
+	}
+	return resolveJobRuntime(job, payload, registered)
+}
+
+// effectiveRuntimeFromEvents recovers the runtime from the job's own
+// effective_runtime event, whose message names it. The event is the only source
+// for jobs dispatched before the payload field existed.
+func effectiveRuntimeFromEvents(ctx context.Context, store *db.Store, jobID string) string {
+	events, err := store.ListJobEvents(ctx, jobID)
+	if err != nil {
+		return ""
+	}
+	for index := len(events) - 1; index >= 0; index-- {
+		if events[index].Kind != "effective_runtime" {
+			continue
+		}
+		return runtimeNameFromEffectiveRuntimeMessage(events[index].Message)
+	}
+	return ""
+}
+
+// runtimeNameFromEffectiveRuntimeMessage extracts the runtime from the event's
+// own wording ("job runs on runtime kimi (agent default kimi); ..."). It returns
+// "" rather than a guess when the wording does not match, so a message format
+// change degrades to "unattributable" - which this check excludes - instead of
+// to a wrong runtime.
+func runtimeNameFromEffectiveRuntimeMessage(message string) string {
+	const marker = "runs on runtime "
+	index := strings.Index(message, marker)
+	if index < 0 {
+		return ""
+	}
+	rest := strings.TrimSpace(message[index+len(marker):])
+	if rest == "" {
+		return ""
+	}
+	name, _, _ := strings.Cut(rest, " ")
+	return strings.TrimSpace(strings.Trim(name, ";,"))
+}

--- a/internal/cli/doctor_runtime_serving_test.go
+++ b/internal/cli/doctor_runtime_serving_test.go
@@ -1,0 +1,256 @@
+package cli
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gitmoot/gitmoot/internal/config"
+	"github.com/gitmoot/gitmoot/internal/db"
+	"github.com/gitmoot/gitmoot/internal/doctor"
+	"github.com/gitmoot/gitmoot/internal/workflow"
+)
+
+// #1558. The POSITIVE is one line; the four NEGATIVES are the suite, because a
+// health verdict that reads a stale row and calls it current would replace a
+// false green with a false red - the same defect with the sign flipped.
+var servingNow = time.Date(2026, 9, 5, 12, 0, 0, 0, time.UTC)
+
+type servingJobSpec struct {
+	id               string
+	agent            string
+	state            workflow.JobState
+	blockerClass     string
+	retryAt          string
+	effectiveRuntime string
+	effectiveEvent   string
+}
+
+func seedServingJob(t *testing.T, store *db.Store, spec servingJobSpec) {
+	t.Helper()
+	payload := workflow.JobPayload{
+		Repo:             "owner/repo",
+		BlockerClass:     spec.blockerClass,
+		BlockerRetryAt:   spec.retryAt,
+		EffectiveRuntime: spec.effectiveRuntime,
+	}
+	encoded, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatalf("Marshal returned error: %v", err)
+	}
+	job := db.Job{ID: spec.id, Agent: spec.agent, Type: "review", State: string(spec.state), Payload: string(encoded)}
+	if err := store.CreateJob(context.Background(), job); err != nil {
+		t.Fatalf("CreateJob(%s) returned error: %v", spec.id, err)
+	}
+	if spec.effectiveEvent != "" {
+		if err := store.AddJobEvent(context.Background(), db.JobEvent{
+			JobID:   spec.id,
+			Kind:    "effective_runtime",
+			Message: "job runs on runtime " + spec.effectiveEvent + " (agent default " + spec.effectiveEvent + "); session lock runtime:" + spec.effectiveEvent,
+		}); err != nil {
+			t.Fatalf("AddJobEvent(%s) returned error: %v", spec.id, err)
+		}
+	}
+}
+
+func servingStatusForStore(t *testing.T, seed func(*testing.T, *db.Store)) *doctor.RuntimeServingStatus {
+	t.Helper()
+	home := t.TempDir()
+	paths := config.PathsForHome(home)
+	if err := config.Initialize(paths); err != nil {
+		t.Fatalf("Initialize returned error: %v", err)
+	}
+	store, err := db.Open(paths.Database)
+	if err != nil {
+		t.Fatalf("Open returned error: %v", err)
+	}
+	seed(t, store)
+	if err := store.Close(); err != nil {
+		t.Fatalf("Close returned error: %v", err)
+	}
+	return runtimeServingStatusAt(paths, servingNow)
+}
+
+// THE POSITIVE: an installed, contract-valid runtime whose engine-recorded hold
+// has NOT expired is reported as not serving, and the row names the evidence.
+func TestRuntimeServingReportsALiveProviderHold(t *testing.T) {
+	status := servingStatusForStore(t, func(t *testing.T, store *db.Store) {
+		seedDaemonWorkerAgent(t, store, "gm-review-kimi", "kimi", "fresh", []string{"review"}, "owner/repo")
+		seedServingJob(t, store, servingJobSpec{
+			id: "held-1", agent: "gm-review-kimi", state: workflow.JobQueued,
+			blockerClass: "runtime_quota",
+			retryAt:      servingNow.Add(30 * time.Minute).Format(time.RFC3339Nano),
+		})
+	})
+	if status == nil || len(status.Blocks) != 1 {
+		t.Fatalf("status = %+v, want exactly one block", status)
+	}
+	block := status.Blocks[0]
+	if block.Runtime != "kimi" || block.Class != "runtime_quota" || block.JobID != "held-1" {
+		t.Fatalf("block = %+v, want kimi/runtime_quota/held-1", block)
+	}
+	check := doctor.CheckRuntimeServing(*status)
+	if check.OK {
+		t.Fatal("CheckRuntimeServing reported OK while a hold is live")
+	}
+	if check.State != "warn" {
+		t.Fatalf("check.State = %q, want warn: the runtime is installed and contract-valid, the provider is refusing", check.State)
+	}
+	for _, want := range []string{"kimi", "runtime_quota", "held-1", "NOT serving"} {
+		if !strings.Contains(check.Detail, want) {
+			t.Fatalf("detail %q is missing %q", check.Detail, want)
+		}
+	}
+}
+
+// THE FOUR NEGATIVES. Each is a state the store contains in bulk on a real host
+// and none of them may degrade a runtime.
+func TestRuntimeServingStaysSilentOnEveryNonHold(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		seed func(*testing.T, *db.Store)
+	}{
+		{
+			// Measured: 12 jobs on this host succeeded on a runtime AFTER carrying
+			// a runtime_quota block, and 4 more after runtime_auth. A newest-wins
+			// rule would call every one of those runtimes dead.
+			name: "a job that reached a terminal state",
+			seed: func(t *testing.T, store *db.Store) {
+				seedDaemonWorkerAgent(t, store, "gm-review-kimi", "kimi", "fresh", []string{"review"}, "owner/repo")
+				seedServingJob(t, store, servingJobSpec{
+					id: "done-1", agent: "gm-review-kimi", state: workflow.JobSucceeded,
+					blockerClass: "runtime_quota",
+					retryAt:      servingNow.Add(30 * time.Minute).Format(time.RFC3339Nano),
+				})
+			},
+		},
+		{
+			name: "a hold whose retry time has already passed",
+			seed: func(t *testing.T, store *db.Store) {
+				seedDaemonWorkerAgent(t, store, "gm-review-kimi", "kimi", "fresh", []string{"review"}, "owner/repo")
+				seedServingJob(t, store, servingJobSpec{
+					id: "aged-1", agent: "gm-review-kimi", state: workflow.JobQueued,
+					blockerClass: "runtime_auth",
+					retryAt:      servingNow.Add(-time.Minute).Format(time.RFC3339Nano),
+				})
+			},
+		},
+		{
+			// Measured: 42 of 55 succeeded checkout_contention rows carry no retry
+			// time, so absence is the COMMON case on at least one path and must
+			// never mean "unknown therefore bad".
+			name: "a blocker row with no retry time",
+			seed: func(t *testing.T, store *db.Store) {
+				seedDaemonWorkerAgent(t, store, "gm-review-kimi", "kimi", "fresh", []string{"review"}, "owner/repo")
+				seedServingJob(t, store, servingJobSpec{
+					id: "noretry-1", agent: "gm-review-kimi", state: workflow.JobQueued,
+					blockerClass: "runtime_quota",
+				})
+			},
+		},
+		{
+			// Measured: 3 of 284 blocked rows are attributable by none of the three
+			// sources. Small is exactly why the rule is written down - nobody would
+			// notice three wrong rows, which is what makes guessing them attractive.
+			name: "a hold whose runtime cannot be attributed",
+			seed: func(t *testing.T, store *db.Store) {
+				seedServingJob(t, store, servingJobSpec{
+					id: "orphan-1", agent: "agent-that-no-longer-exists", state: workflow.JobQueued,
+					blockerClass: "runtime_quota",
+					retryAt:      servingNow.Add(30 * time.Minute).Format(time.RFC3339Nano),
+				})
+			},
+		},
+		{
+			name: "a blocker class that is not a provider refusal",
+			seed: func(t *testing.T, store *db.Store) {
+				seedDaemonWorkerAgent(t, store, "gm-review-kimi", "kimi", "fresh", []string{"review"}, "owner/repo")
+				seedServingJob(t, store, servingJobSpec{
+					id: "contention-1", agent: "gm-review-kimi", state: workflow.JobQueued,
+					blockerClass: "checkout_contention",
+					retryAt:      servingNow.Add(30 * time.Minute).Format(time.RFC3339Nano),
+				})
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			status := servingStatusForStore(t, tc.seed)
+			if status == nil {
+				t.Fatal("status = nil, want an empty status rather than an omitted check")
+			}
+			if len(status.Blocks) != 0 {
+				t.Fatalf("blocks = %+v, want none", status.Blocks)
+			}
+			if check := doctor.CheckRuntimeServing(*status); !check.OK {
+				t.Fatalf("check = %+v, want OK: %s", check, tc.name)
+			}
+		})
+	}
+}
+
+// THE ATTRIBUTION ORDER. No single source covers the population - measured, 107
+// of 284 blocked rows carry payload.effective_runtime and 101 have the event -
+// so all three are needed, and the priority must be observable rather than
+// implied.
+func TestRuntimeServingResolvesTheRuntimeInPriorityOrder(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		spec servingJobSpec
+		want string
+	}{
+		{
+			name: "payload effective_runtime wins over the agent default",
+			spec: servingJobSpec{id: "p-1", agent: "gm-review-kimi", effectiveRuntime: "codex", effectiveEvent: "claude"},
+			want: "codex",
+		},
+		{
+			name: "the effective_runtime event is used when the payload has none",
+			spec: servingJobSpec{id: "e-1", agent: "gm-review-kimi", effectiveEvent: "claude"},
+			want: "claude",
+		},
+		{
+			name: "the agent's registered runtime is the last resort",
+			spec: servingJobSpec{id: "a-1", agent: "gm-review-kimi"},
+			want: "kimi",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			spec := tc.spec
+			spec.state = workflow.JobQueued
+			spec.blockerClass = "runtime_quota"
+			spec.retryAt = servingNow.Add(time.Hour).Format(time.RFC3339Nano)
+			status := servingStatusForStore(t, func(t *testing.T, store *db.Store) {
+				seedDaemonWorkerAgent(t, store, "gm-review-kimi", "kimi", "fresh", []string{"review"}, "owner/repo")
+				seedServingJob(t, store, spec)
+			})
+			if status == nil || len(status.Blocks) != 1 {
+				t.Fatalf("status = %+v, want one block", status)
+			}
+			if status.Blocks[0].Runtime != tc.want {
+				t.Fatalf("runtime = %q, want %q", status.Blocks[0].Runtime, tc.want)
+			}
+		})
+	}
+}
+
+// A message whose wording no longer matches must degrade to UNATTRIBUTABLE -
+// which the check excludes - rather than to a wrong runtime.
+func TestEffectiveRuntimeMessageParsingRefusesAGuess(t *testing.T) {
+	for _, tc := range []struct {
+		message string
+		want    string
+	}{
+		{"job runs on runtime kimi (agent default kimi); session lock runtime:kimi", "kimi"},
+		{"job runs on runtime codex", "codex"},
+		{"job runs on runtime claude; extra", "claude"},
+		{"selected review via agent_review: explicit agent review", ""},
+		{"", ""},
+		{"job runs on runtime ", ""},
+	} {
+		if got := runtimeNameFromEffectiveRuntimeMessage(tc.message); got != tc.want {
+			t.Fatalf("runtimeNameFromEffectiveRuntimeMessage(%q) = %q, want %q", tc.message, got, tc.want)
+		}
+	}
+}

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -159,6 +159,7 @@ func runDoctor(args []string, stdout, stderr io.Writer) int {
 	paths, pathsErr := pathsFromFlag(*home)
 	buildStatus := daemonBuildStatus(paths)
 	stuckStatus := stuckJobsStatus(paths)
+	servingStatus := runtimeServingStatus(paths)
 	logStatus := daemonLogStatus(paths)
 	probeRunner, authState, authSource, authErr := runtimeJobRunnerWithAuth(*home, runtime.ClaudeRuntime, nil)
 	contractResults := make([]runtime.RuntimeContractResult, 0, len(runtime.BuiltinRuntimeRegistry().All()))
@@ -176,6 +177,7 @@ func runDoctor(args []string, stdout, stderr io.Writer) int {
 		SkipDaemonAuth:    true,
 		Build:             &buildStatus,
 		StuckJobs:         stuckStatus,
+		RuntimeServing:    servingStatus,
 		LogStatus:         &logStatus,
 		RuntimeContracts:  contractResults,
 	}

--- a/internal/doctor/checker.go
+++ b/internal/doctor/checker.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -102,6 +103,11 @@ type Checker struct {
 	// StuckJobs is supplied by the CLI, which owns store access and process
 	// probing. Nil omits the check for callers such as the dashboard.
 	StuckJobs *StuckJobsStatus
+	// RuntimeServing is supplied by the CLI, which owns store access, and names
+	// the runtimes the engine is currently holding off a provider refusal
+	// (#1558). Nil omits the check: a dashboard that cannot resolve holds must
+	// not imply every runtime is serving.
+	RuntimeServing *RuntimeServingStatus
 	// LogStatus is supplied by the one-shot CLI. Nil omits the check for callers
 	// such as the continuously refreshed terminal dashboard.
 	LogStatus *DaemonLogStatus
@@ -146,6 +152,9 @@ func (c Checker) GlobalChecks(ctx context.Context) []Check {
 	}
 	if c.StuckJobs != nil {
 		checks = append(checks, CheckStuckJobs(*c.StuckJobs))
+	}
+	if c.RuntimeServing != nil {
+		checks = append(checks, CheckRuntimeServing(*c.RuntimeServing))
 	}
 	if c.LogStatus != nil {
 		// Preserve the existing doctor surface unless staleness is positively
@@ -577,4 +586,78 @@ func firstLine(values ...string) string {
 		}
 	}
 	return ""
+}
+
+// RuntimeServingBlock is one runtime the ENGINE is currently holding off a
+// provider refusal (#1558). It is inert data: the CLI resolves it from the
+// store and doctor renders it, so this package keeps its store independence.
+type RuntimeServingBlock struct {
+	// Runtime is the runtime the blocked job would have run on, resolved by the
+	// caller. A job whose runtime cannot be attributed is NOT reported at all.
+	Runtime string
+	// Class is the blocker class the classifier recorded (runtime_quota or
+	// runtime_auth).
+	Class string
+	// JobID and Detail name the evidence so the row is actionable rather than
+	// merely red.
+	JobID  string
+	Detail string
+	// RetryAt is the engine's own forward-looking hold: the moment it intends to
+	// retry. The caller reports a block ONLY while this is in the future, so the
+	// verdict is the engine's current belief rather than a guess from a clock.
+	RetryAt time.Time
+}
+
+// RuntimeServingStatus records the provider-refusal holds the engine is sitting
+// on right now.
+type RuntimeServingStatus struct {
+	Blocks []RuntimeServingBlock
+}
+
+// CheckRuntimeServing distinguishes "installed and contract-valid" from
+// "serving" (#1558).
+//
+// The false green this replaces: `doctor` reported kimi `ok 0.29.2 / contract
+// ok` while the daemon had, eleven minutes earlier, deferred two review jobs on
+// `provider.api_error: 403 You've reached your usage limit for this billing
+// cycle`. Capability present, service unavailable - the same shape AGENTS.md
+// already records for CLAUDE_CODE_OAUTH_TOKEN, one layer out. It cost a real
+// decision: kimi went on a review panel on doctor's word and its legs deferred
+// indefinitely.
+//
+// WHAT THIS CHECK DELIBERATELY IS NOT: a second opinion about the provider. It
+// reports only what the ENGINE currently believes, keyed on the forward-looking
+// BlockerRetryAt the classifier wrote when it deferred the job. A verdict
+// derived from "the store says 403 sometime" would be a stale row read as
+// current - and replacing a false green with a false red is the same defect with
+// the sign flipped. The caller therefore filters to holds that have not expired,
+// and every state it cannot interpret is neutral.
+//
+// It is a WARNING, not a failure: the runtime is installed and its contract is
+// valid, the provider is refusing today, and the operator's decision is which
+// runtime to put on a panel rather than whether the box is broken.
+func CheckRuntimeServing(status RuntimeServingStatus) Check {
+	check := Check{
+		Name:   "runtime serving",
+		OK:     true,
+		Detail: "no runtime is held on a provider refusal the engine is still waiting out",
+	}
+	if len(status.Blocks) == 0 {
+		return check
+	}
+	details := make([]string, 0, len(status.Blocks))
+	for _, block := range status.Blocks {
+		detail := fmt.Sprintf("%s: %s until %s (job %s)", block.Runtime, block.Class,
+			block.RetryAt.UTC().Format(time.RFC3339), block.JobID)
+		if strings.TrimSpace(block.Detail) != "" {
+			detail += ": " + strings.TrimSpace(block.Detail)
+		}
+		details = append(details, detail)
+	}
+	sort.Strings(details)
+	check.OK = false
+	check.State = "warn"
+	check.Detail = fmt.Sprintf("%d runtime(s) installed and contract-valid but NOT serving - the engine is holding a provider refusal: %s",
+		len(status.Blocks), strings.Join(details, "; "))
+	return check
 }

--- a/skills/gitmoot/references/CLI.md
+++ b/skills/gitmoot/references/CLI.md
@@ -46,6 +46,19 @@ It also reports the SQLite auto-vacuum mode. New homes use bounded incremental
 reclaim automatically. A legacy home remains a non-blocking warning until an
 operator deliberately converts it during an idle maintenance window:
 
+A runtime that is installed and contract-valid is not necessarily SERVING, and
+`doctor` reports the difference (#1558). When the engine is currently holding a
+job off a provider refusal - a `runtime_quota` or `runtime_auth` blocker whose
+recorded retry time is still in the future - the `runtime serving` check warns
+and names the runtime, the blocker class, the retry time and the job id. The
+verdict is the engine's own forward-looking hold, not a second opinion about the
+provider: a hold whose retry time has passed, a job that reached a terminal
+state, a blocker row carrying no retry time, and a job whose runtime cannot be
+attributed are all neutral, so a stale row can never be read as a current
+refusal. It is a warning rather than a failure because the binary and its
+contract are fine; what the operator needs is to not put that runtime on a
+review panel today.
+
 ```sh
 sqlite3 "$HOME/.gitmoot/gitmoot.db" \
   'PRAGMA auto_vacuum=INCREMENTAL; VACUUM;'

--- a/website/docs/reference/cli.md
+++ b/website/docs/reference/cli.md
@@ -31,6 +31,19 @@ job whose directly recorded runtime PID is confirmably dead is a
 required `stuck jobs` failure; legacy jobs with no recorded PID and hosts where
 process identity cannot be verified are neutral and produce no ghost-job
 finding.
+A runtime that is installed and contract-valid is not necessarily SERVING, and
+`doctor` reports the difference (#1558). When the engine is currently holding a
+job off a provider refusal - a `runtime_quota` or `runtime_auth` blocker whose
+recorded retry time is still in the future - the `runtime serving` check warns
+and names the runtime, the blocker class, the retry time and the job id. The
+verdict is the engine's own forward-looking hold, not a second opinion about the
+provider: a hold whose retry time has passed, a job that reached a terminal
+state, a blocker row carrying no retry time, and a job whose runtime cannot be
+attributed are all neutral, so a stale row can never be read as a current
+refusal. It is a warning rather than a failure because the binary and its
+contract are fine; what the operator needs is to not put that runtime on a
+review panel today.
+
 Doctor validates `[remote_exec]` through the same configuration loader used by
 job dispatch. An absent section passes because remote execution is opt-in; an
 invalid backend, identity pair, numeric identity, or local root is a required


### PR DESCRIPTION
Fixes #1558 asks 1 and 2. Ask 3 is filed separately as #1887 — see Scope below.

## The false green

`doctor` reported kimi `ok 0.29.2 / contract ok` while the daemon had, eleven minutes earlier, deferred two review jobs on `provider.api_error: 403 You've reached your usage limit for this billing cycle`. Capability present, service unavailable — the same shape `AGENTS.md` already records for `CLAUDE_CODE_OAUTH_TOKEN` (*"auth ok is set-not-valid, a false green"*), one layer out. It cost a real decision: kimi went on a review panel on doctor's word and its legs deferred indefinitely while native fanout kept enqueuing more that would also defer.

## What ships

A `runtime serving` check that **warns** — not fails — when the engine is currently holding a job off a provider refusal, naming the runtime, the blocker class, the retry time and the job id. Warn is the right level because the binary and its contract are genuinely fine; what the operator needs is to not put that runtime on a panel today.

The store stays behind the CLI: `internal/doctor` receives inert data through a `RuntimeServingStatus` struct, exactly as `CheckStuckJobs`/`StuckJobsStatus` already does, so no store handle is plumbed into that package.

## The predicate, and why it is not a staleness window

**Degraded iff** a non-final job attributed to that runtime carries a `runtime_quota` or `runtime_auth` blocker class **and** the `BlockerRetryAt` the classifier wrote (`internal/cli/job_blocker.go:485-487`) is still in the future.

That field is the engine's own forward-looking *"I am still waiting this out"*, so doctor reports what the engine believes rather than a second opinion derived from a clock. The obvious alternative — "the newest 403 within N minutes" — was rejected **on measurement**: it asserts the provider is refusing *now* from a timestamp that only says it refused *then*.

`blocked` is deliberately not excluded: it is settled but not final (#632's documented split), and a blocked job holding a future retry is exactly the live hold this check exists to report.

## Four negatives, each measured in bulk on a live store

Replacing a false green with a false red is the same defect with the sign flipped, so the negatives are the suite rather than an afterthought:

| state | must not degrade | why, measured read-only |
|---|---|---|
| hold's retry time has passed | ✓ | the engine will retry it; the provider may well serve it |
| job reached a terminal state | ✓ | **12** jobs succeeded on a runtime *after* carrying a `runtime_quota` block, plus **4** after `runtime_auth` — a newest-wins rule calls all those runtimes dead |
| blocker row carries no retry time | ✓ | **42 of 55** succeeded `checkout_contention` rows have none, so absence is the *common* case on at least one path and can never mean unknown-therefore-bad |
| runtime cannot be attributed | ✓ | **3 of 284** blocked rows. Small is exactly why the rule is written down: nobody would notice three wrong rows, which is what makes guessing them attractive |

A blocker class that is not a provider refusal (e.g. `checkout_contention`) is also neutral and has its own case.

## Runtime attribution: three sources, priority order, residue excluded

No single source covers the population. Measured over the 284 `runtime_quota` + `runtime_auth` rows on this host: **107** carry `payload.effective_runtime`, **101** have an `effective_runtime` event, **281** have an agent row that still exists, and **3** are attributable by none.

So resolution runs payload → event → agent's registered runtime, reusing the dashboard's existing `resolveJobRuntime` for the last step rather than duplicating it. A message whose wording no longer matches the `effective_runtime` event format degrades to **unattributable** — which the check excludes — instead of to a wrong runtime, and that refusal has its own test.

## Scope: why ask 3 is a separate issue (#1887)

Ask 3 (surface deferral state in `job list` / `job watch`) edits the renderers, and **#1553's remedy edits the same renderers for a different cause** — a job withheld because an implement holds the repo also displays as bare `queued`. A change surfacing only the blocker half would leave #1553's half invisible while looking, to the next reader, like the gap had been closed. Both causes belong on one pass through that surface. The data is already persisted, so #1887 is a display gap rather than plumbing.

## Tests — 11 cases

`internal/cli/doctor_runtime_serving_test.go` at a fixed instant so every negative is testable:

- the positive: a live hold is reported, `State == "warn"`, detail names runtime/class/job;
- the four negatives above plus the non-provider blocker class;
- attribution priority, all three sources, each asserted separately;
- `effective_runtime` message parsing refusing a guess on unrecognised wording.

**No pre-fix behavioural arm exists and I am not manufacturing one:** the check is new, so on `main` the `runtime serving` row simply does not exist — a test asserting its absence would pass for the wrong reason, and one referencing the new symbols would only fail to compile, which measures nothing (#1852's lesson). What the suite defends instead is the *predicate*: each negative fails if the corresponding filter is removed, which is the property that keeps this from becoming a false red.

## Gate

`GOTOOLCHAIN=local` with the toolchain PATH, `-count=1`, non-`/tmp` tree, `gofmt` empty:

```
go version go1.26.4 linux/amd64
BUILD_OK          (go build -buildvcs=false ./...)
VET_OK            (go vet ./...)
GENERATE_CHECKED  (go generate ./... left only this PR's own files modified)
ok  internal/doctor    0.007s
ok  internal/workflow  106.315s
FAIL internal/cli      444.574s  -- TestApplyReviewPolicyEmptyHomeIsOff
```

That failure is pre-existing and **environment-sensitive, not branch-related**, and it is now measured four ways on one commit: this tree fails it standalone, a pristine `origin/main` worktree fails it standalone, and two independent review clones ran it standalone and **passed**. It touches no file this PR changes.

## Deploy notes

Adds one doctor check (`runtime serving`, warn-level) and one CLI collector; no migration, no config change, no new event kinds, no behaviour change to dispatch or delivery. Docs updated in both trees (`website/docs/reference/cli.md`, `skills/gitmoot/references/CLI.md`); the website is published manually.
