### PR TITLE
fix(daemon): name the inputs behind every task-resolution refusal (#1909)

### DIFF
--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -2525,9 +2525,20 @@ func pullRequestListedAsMerged(pull github.PullRequest) bool {
 // request has no managed task".
 func (d Daemon) lookupPolledPullRequestTask(ctx context.Context, pull github.PullRequest) (db.Task, error) {
 	if !d.pullRequestHeadIsLocal(pull) {
+		// #1909: a refusal that names only the branch is undiagnosable — three
+		// reproductions on gitmoot/gitmoot#1783 could not say WHICH input
+		// mismatched, because the ack text carries pull.HeadRef and nothing else.
+		// Log every value the decision was made on, at the one site that makes it.
+		d.logf("task resolution refused for %s#%d: reason=fork_head repo=%q head_repo=%q head_ref=%q",
+			d.Repo.FullName(), pull.Number, d.Repo.FullName(), pull.HeadRepoFullName, pull.HeadRef)
 		return db.Task{}, sql.ErrNoRows
 	}
-	return d.lookupPullRequestTask(ctx, d.Repo.FullName(), pull.HeadRef)
+	task, err := d.lookupPullRequestTask(ctx, d.Repo.FullName(), pull.HeadRef)
+	if errors.Is(err, sql.ErrNoRows) {
+		d.logf("task resolution refused for %s#%d: reason=no_task_for_branch repo=%q head_repo=%q head_ref=%q",
+			d.Repo.FullName(), pull.Number, d.Repo.FullName(), pull.HeadRepoFullName, pull.HeadRef)
+	}
+	return task, err
 }
 
 func (d Daemon) lookupPullRequestTask(ctx context.Context, repoFullName string, branch string) (db.Task, error) {
@@ -2543,6 +2554,11 @@ func (d Daemon) lookupPullRequestTask(ctx context.Context, repoFullName string, 
 		return db.Task{}, err
 	}
 	if task.RepoFullName != "" && task.RepoFullName != repoFullName {
+		// The branch string resolved a task BY ID, but that task belongs to another
+		// repository. Distinguishable from "no such task" only when both values are
+		// logged (#1909).
+		d.logf("task resolution refused for %s: reason=task_repo_mismatch lookup_repo=%q task=%q task_repo=%q",
+			branch, repoFullName, task.ID, task.RepoFullName)
 		return db.Task{}, sql.ErrNoRows
 	}
 	return task, nil

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -2524,22 +2524,34 @@ func pullRequestListedAsMerged(pull github.PullRequest) bool {
 // head reports sql.ErrNoRows, which every caller already handles as "this pull
 // request has no managed task".
 func (d Daemon) lookupPolledPullRequestTask(ctx context.Context, pull github.PullRequest) (db.Task, error) {
+	repo := d.Repo.FullName()
 	if !d.pullRequestHeadIsLocal(pull) {
 		// #1909: a refusal that names only the branch is undiagnosable — three
 		// reproductions on gitmoot/gitmoot#1783 could not say WHICH input
 		// mismatched, because the ack text carries pull.HeadRef and nothing else.
 		// Log every value the decision was made on, at the one site that makes it.
 		d.logf("task resolution refused for %s#%d: reason=fork_head repo=%q head_repo=%q head_ref=%q",
-			d.Repo.FullName(), pull.Number, d.Repo.FullName(), pull.HeadRepoFullName, pull.HeadRef)
+			repo, pull.Number, repo, pull.HeadRepoFullName, pull.HeadRef)
 		return db.Task{}, sql.ErrNoRows
 	}
-	task, err := d.lookupPullRequestTask(ctx, d.Repo.FullName(), pull.HeadRef)
-	if errors.Is(err, sql.ErrNoRows) {
+	task, err := d.lookupPullRequestTask(ctx, repo, pull.HeadRef)
+	// The repo-mismatch arm below already logged the values it decided on. Adding
+	// no_task_for_branch on top would give ONE refusal TWO contradictory reason
+	// tags — the exact ambiguity #1909 exists to remove — so log this reason only
+	// when the inner resolver refused for want of a task row.
+	if errors.Is(err, sql.ErrNoRows) && !errors.Is(err, errTaskRepoMismatch) {
 		d.logf("task resolution refused for %s#%d: reason=no_task_for_branch repo=%q head_repo=%q head_ref=%q",
-			d.Repo.FullName(), pull.Number, d.Repo.FullName(), pull.HeadRepoFullName, pull.HeadRef)
+			repo, pull.Number, repo, pull.HeadRepoFullName, pull.HeadRef)
 	}
 	return task, err
 }
+
+// errTaskRepoMismatch marks the refusal arm where the branch string resolved a
+// task BY ID whose task belongs to another repository. It always accompanies
+// sql.ErrNoRows, so every caller's "this pull request has no managed task"
+// branch is unchanged; it exists only so the resolver above can tell that arm
+// apart from an absent task row and emit exactly one reason per refusal.
+var errTaskRepoMismatch = errors.New("task belongs to another repository")
 
 func (d Daemon) lookupPullRequestTask(ctx context.Context, repoFullName string, branch string) (db.Task, error) {
 	task, err := d.Store.GetTaskByRepoBranch(ctx, repoFullName, branch)
@@ -2559,7 +2571,7 @@ func (d Daemon) lookupPullRequestTask(ctx context.Context, repoFullName string, 
 		// logged (#1909).
 		d.logf("task resolution refused for %s: reason=task_repo_mismatch lookup_repo=%q task=%q task_repo=%q",
 			branch, repoFullName, task.ID, task.RepoFullName)
-		return db.Task{}, sql.ErrNoRows
+		return db.Task{}, fmt.Errorf("%w: %w", errTaskRepoMismatch, sql.ErrNoRows)
 	}
 	return task, nil
 }

--- a/internal/daemon/resolver_refusal_log_test.go
+++ b/internal/daemon/resolver_refusal_log_test.go
@@ -157,6 +157,54 @@ func TestLookupPullRequestTaskLogsTaskRepoMismatchInputs(t *testing.T) {
 	}
 }
 
+// The composed path, which the direct-call test above cannot reach: a polled PR
+// whose HeadRef happens to equal ANOTHER repository's task ID. lookupPullRequestTask's
+// id fallback (db.Store.GetTask is a global lookup, not repo-scoped) refuses with
+// the repo-mismatch reason, and the polled resolver used to add no_task_for_branch
+// on top - one event, two contradictory reason tags, which is the ambiguity #1909
+// exists to remove. Exactly one refusal line must survive, and it must be the arm
+// that actually decided.
+func TestLookupPolledPullRequestTaskLogsOneReasonWhenTaskBelongsToAnotherRepo(t *testing.T) {
+	ctx := context.Background()
+	store, daemon, logs := newResolverLogDaemon(t)
+	if err := store.UpsertTask(ctx, db.Task{
+		ID:           "task-elsewhere",
+		RepoFullName: "other/repo",
+		GoalID:       "goal-1",
+		Title:        "Task in another repository",
+		State:        "pr_open",
+		Branch:       "some-branch",
+	}); err != nil {
+		t.Fatalf("UpsertTask returned error: %v", err)
+	}
+
+	_, err := daemon.lookupPolledPullRequestTask(ctx, github.PullRequest{
+		Number:           42,
+		HeadRef:          "task-elsewhere",
+		HeadRepoFullName: "gitmoot/gitmoot",
+	})
+	// Resolution behaviour is unchanged: every caller reads this as "no managed
+	// task", so the reason marker must not become visible as a different error.
+	if !errors.Is(err, sql.ErrNoRows) {
+		t.Fatalf("error = %v, want sql.ErrNoRows through the polled resolver", err)
+	}
+
+	line := onlyRefusalLog(t, *logs)
+	for _, want := range []string{
+		"reason=task_repo_mismatch",
+		`lookup_repo="gitmoot/gitmoot"`,
+		`task="task-elsewhere"`,
+		`task_repo="other/repo"`,
+	} {
+		if !strings.Contains(line, want) {
+			t.Fatalf("composed refusal log = %q, want it to contain %q", line, want)
+		}
+	}
+	if strings.Contains(line, "reason=no_task_for_branch") {
+		t.Fatalf("composed refusal log = %q, want the deciding arm's reason only", line)
+	}
+}
+
 // Successful resolution must stay silent: a log line per resolved PR per poll
 // would bury the refusals this change exists to surface.
 func TestLookupPolledPullRequestTaskLogsNothingOnSuccess(t *testing.T) {

--- a/internal/daemon/resolver_refusal_log_test.go
+++ b/internal/daemon/resolver_refusal_log_test.go
@@ -269,13 +269,14 @@ func TestLookupPolledPullRequestTaskLogsNothingOnSuccess(t *testing.T) {
 	if task.ID != "task-ok" {
 		t.Fatalf("task = %+v, want task-ok", task)
 	}
-	// Same metadata independence as onlyRefusalLog: a renamed refusal line
-	// must still fail this test, while "reason=" inside rendered input data must
-	// not. Resolver diagnostics must also stay behind the injected sink.
+	// The contract is SILENCE, not merely the absence of a reason tag. Round 4's
+	// review defeated the tag-only form with a compiling production mutant that
+	// logged "task resolution succeeded for %s#%d" after a successful lookup: no
+	// reason= tag, test still green, and an operator handed a diagnostic for a
+	// path that decided nothing. Assert the sink is EMPTY, which also keeps the
+	// process-logger escape closed.
 	logs.assertSingleSink(t)
-	for _, entry := range logs.entries {
-		if strings.Contains(entry.format, "reason=") {
-			t.Fatalf("logs = %q, want no reason-bearing Logf call on successful resolution", logs.entries)
-		}
+	if len(logs.entries) != 0 {
+		t.Fatalf("Logf calls = %d (%+v), want successful resolution to log nothing", len(logs.entries), logs.entries)
 	}
 }

--- a/internal/daemon/resolver_refusal_log_test.go
+++ b/internal/daemon/resolver_refusal_log_test.go
@@ -36,18 +36,24 @@ func newResolverLogDaemon(t *testing.T) (*db.Store, Daemon, *[]string) {
 	return store, daemon, logs
 }
 
+// onlyRefusalLog counts REASON-BEARING lines, not lines carrying a particular
+// prose prefix. #1910's round-2 review built a production mutant that emitted a
+// second reason=no_task_for_branch line under the wording "task resolution
+// rejected"; a prose-matching helper kept this whole file green while an
+// operator saw two contradictory reasons again. The property is "exactly one
+// reason per refusal", so the reason tag is the only thing to match on.
 func onlyRefusalLog(t *testing.T, logs []string) string {
 	t.Helper()
-	refusals := []string{}
+	reasons := []string{}
 	for _, line := range logs {
-		if strings.Contains(line, "task resolution refused") {
-			refusals = append(refusals, line)
+		if strings.Contains(line, "reason=") {
+			reasons = append(reasons, line)
 		}
 	}
-	if len(refusals) != 1 {
-		t.Fatalf("refusal log lines = %d (%q), want exactly 1", len(refusals), refusals)
+	if len(reasons) != 1 {
+		t.Fatalf("reason-bearing log lines = %d (%q), want exactly 1", len(reasons), reasons)
 	}
-	return refusals[0]
+	return reasons[0]
 }
 
 // A fork head that merely collides with a local branch name must log the head
@@ -232,9 +238,11 @@ func TestLookupPolledPullRequestTaskLogsNothingOnSuccess(t *testing.T) {
 	if task.ID != "task-ok" {
 		t.Fatalf("task = %+v, want task-ok", task)
 	}
+	// Same prose-independence as onlyRefusalLog: a renamed refusal line must
+	// still fail this test.
 	for _, line := range *logs {
-		if strings.Contains(line, "task resolution refused") {
-			t.Fatalf("logs = %q, want no refusal line on successful resolution", *logs)
+		if strings.Contains(line, "reason=") {
+			t.Fatalf("logs = %q, want no reason-bearing line on successful resolution", *logs)
 		}
 	}
 }

--- a/internal/daemon/resolver_refusal_log_test.go
+++ b/internal/daemon/resolver_refusal_log_test.go
@@ -1,0 +1,192 @@
+package daemon
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/gitmoot/gitmoot/internal/db"
+	"github.com/gitmoot/gitmoot/internal/github"
+)
+
+// A task-resolution refusal used to name only the branch (#1909). Three
+// reproductions against a real PR still could not say WHICH input mismatched,
+// because the operator-visible text carried pull.HeadRef and nothing else - so
+// the fork-head guard, an absent task row, and a task belonging to another
+// repository were indistinguishable in the field.
+//
+// These tests pin the DIAGNOSTIC content of each refusal arm: the reason tag and
+// the values the decision was actually made on. A refusal that stops naming its
+// inputs fails here even though resolution behaviour is unchanged.
+
+func newResolverLogDaemon(t *testing.T) (*db.Store, Daemon, *[]string) {
+	t.Helper()
+	store := testStore(t)
+	logs := &[]string{}
+	daemon := Daemon{
+		Repo:  github.Repository{Owner: "gitmoot", Name: "gitmoot"},
+		Store: store,
+		Logf: func(format string, args ...any) {
+			*logs = append(*logs, fmt.Sprintf(format, args...))
+		},
+	}
+	return store, daemon, logs
+}
+
+func onlyRefusalLog(t *testing.T, logs []string) string {
+	t.Helper()
+	refusals := []string{}
+	for _, line := range logs {
+		if strings.Contains(line, "task resolution refused") {
+			refusals = append(refusals, line)
+		}
+	}
+	if len(refusals) != 1 {
+		t.Fatalf("refusal log lines = %d (%q), want exactly 1", len(refusals), refusals)
+	}
+	return refusals[0]
+}
+
+// A fork head that merely collides with a local branch name must log the head
+// repository it was rejected for - the value that distinguishes this arm from an
+// absent task row.
+func TestLookupPolledPullRequestTaskLogsForkHeadRefusalInputs(t *testing.T) {
+	ctx := context.Background()
+	store, daemon, logs := newResolverLogDaemon(t)
+	if err := store.UpsertTask(ctx, db.Task{
+		ID:           "task-local",
+		RepoFullName: "gitmoot/gitmoot",
+		GoalID:       "goal-1",
+		Title:        "Local task",
+		State:        "pr_open",
+		Branch:       "shared-branch-name",
+	}); err != nil {
+		t.Fatalf("UpsertTask returned error: %v", err)
+	}
+
+	_, err := daemon.lookupPolledPullRequestTask(ctx, github.PullRequest{
+		Number:           99,
+		HeadRef:          "shared-branch-name",
+		HeadRepoFullName: "outsider/gitmoot",
+	})
+	if !errors.Is(err, sql.ErrNoRows) {
+		t.Fatalf("error = %v, want sql.ErrNoRows for a fork head", err)
+	}
+
+	line := onlyRefusalLog(t, *logs)
+	for _, want := range []string{
+		"reason=fork_head",
+		`head_repo="outsider/gitmoot"`,
+		`repo="gitmoot/gitmoot"`,
+		`head_ref="shared-branch-name"`,
+		"gitmoot/gitmoot#99",
+	} {
+		if !strings.Contains(line, want) {
+			t.Fatalf("fork-head refusal log = %q, want it to contain %q", line, want)
+		}
+	}
+}
+
+// A local head with no task row must log a DIFFERENT reason than the fork arm,
+// so an operator can tell "not mine" from "not registered" without reading code.
+func TestLookupPolledPullRequestTaskLogsMissingTaskRefusalInputs(t *testing.T) {
+	ctx := context.Background()
+	_, daemon, logs := newResolverLogDaemon(t)
+
+	_, err := daemon.lookupPolledPullRequestTask(ctx, github.PullRequest{
+		Number:           7,
+		HeadRef:          "feat/unregistered",
+		HeadRepoFullName: "gitmoot/gitmoot",
+	})
+	if !errors.Is(err, sql.ErrNoRows) {
+		t.Fatalf("error = %v, want sql.ErrNoRows for an unregistered branch", err)
+	}
+
+	line := onlyRefusalLog(t, *logs)
+	for _, want := range []string{
+		"reason=no_task_for_branch",
+		`repo="gitmoot/gitmoot"`,
+		`head_repo="gitmoot/gitmoot"`,
+		`head_ref="feat/unregistered"`,
+		"gitmoot/gitmoot#7",
+	} {
+		if !strings.Contains(line, want) {
+			t.Fatalf("missing-task refusal log = %q, want it to contain %q", line, want)
+		}
+	}
+	if strings.Contains(line, "reason=fork_head") {
+		t.Fatalf("missing-task refusal log = %q, want a reason distinct from the fork-head arm", line)
+	}
+}
+
+// The third arm: the branch string resolves a task BY ID, but that task belongs
+// to another repository. Both repositories must appear, since the mismatch is
+// the whole content of the refusal.
+func TestLookupPullRequestTaskLogsTaskRepoMismatchInputs(t *testing.T) {
+	ctx := context.Background()
+	store, daemon, logs := newResolverLogDaemon(t)
+	if err := store.UpsertTask(ctx, db.Task{
+		ID:           "task-elsewhere",
+		RepoFullName: "other/repo",
+		GoalID:       "goal-1",
+		Title:        "Task in another repository",
+		State:        "pr_open",
+		Branch:       "some-branch",
+	}); err != nil {
+		t.Fatalf("UpsertTask returned error: %v", err)
+	}
+
+	_, err := daemon.lookupPullRequestTask(ctx, "gitmoot/gitmoot", "task-elsewhere")
+	if !errors.Is(err, sql.ErrNoRows) {
+		t.Fatalf("error = %v, want sql.ErrNoRows when the task belongs to another repository", err)
+	}
+
+	line := onlyRefusalLog(t, *logs)
+	for _, want := range []string{
+		"reason=task_repo_mismatch",
+		`lookup_repo="gitmoot/gitmoot"`,
+		`task="task-elsewhere"`,
+		`task_repo="other/repo"`,
+	} {
+		if !strings.Contains(line, want) {
+			t.Fatalf("task-repo-mismatch refusal log = %q, want it to contain %q", line, want)
+		}
+	}
+}
+
+// Successful resolution must stay silent: a log line per resolved PR per poll
+// would bury the refusals this change exists to surface.
+func TestLookupPolledPullRequestTaskLogsNothingOnSuccess(t *testing.T) {
+	ctx := context.Background()
+	store, daemon, logs := newResolverLogDaemon(t)
+	if err := store.UpsertTask(ctx, db.Task{
+		ID:           "task-ok",
+		RepoFullName: "gitmoot/gitmoot",
+		GoalID:       "goal-1",
+		Title:        "Resolvable task",
+		State:        "pr_open",
+		Branch:       "feat/registered",
+	}); err != nil {
+		t.Fatalf("UpsertTask returned error: %v", err)
+	}
+
+	task, err := daemon.lookupPolledPullRequestTask(ctx, github.PullRequest{
+		Number:           11,
+		HeadRef:          "feat/registered",
+		HeadRepoFullName: "gitmoot/gitmoot",
+	})
+	if err != nil {
+		t.Fatalf("lookupPolledPullRequestTask returned error: %v", err)
+	}
+	if task.ID != "task-ok" {
+		t.Fatalf("task = %+v, want task-ok", task)
+	}
+	for _, line := range *logs {
+		if strings.Contains(line, "task resolution refused") {
+			t.Fatalf("logs = %q, want no refusal line on successful resolution", *logs)
+		}
+	}
+}

--- a/internal/daemon/resolver_refusal_log_test.go
+++ b/internal/daemon/resolver_refusal_log_test.go
@@ -36,22 +36,27 @@ func newResolverLogDaemon(t *testing.T) (*db.Store, Daemon, *[]string) {
 	return store, daemon, logs
 }
 
-// onlyRefusalLog counts REASON-BEARING lines, not lines carrying a particular
-// prose prefix. #1910's round-2 review built a production mutant that emitted a
-// second reason=no_task_for_branch line under the wording "task resolution
-// rejected"; a prose-matching helper kept this whole file green while an
-// operator saw two contradictory reasons again. The property is "exactly one
-// reason per refusal", so the reason tag is the only thing to match on.
+// onlyRefusalLog counts reason= TAG OCCURRENCES across every captured line, not
+// lines carrying a prose prefix and not reason-bearing lines. Two review rounds
+// on #1910 each defeated a weaker rule with a compiling production mutant:
+// round 2 renamed the prose ("task resolution rejected") past a prefix match,
+// and round 3 merged both reasons onto ONE line
+// ("reason=task_repo_mismatch reason=fork_head") past a per-line count. An
+// operator reading two reasons for one refusal cannot tell which input decided
+// it, and that is true whether they sit on one line or two - so the property is
+// one reason tag per refusal, and the tag is what gets counted.
 func onlyRefusalLog(t *testing.T, logs []string) string {
 	t.Helper()
 	reasons := []string{}
+	tags := 0
 	for _, line := range logs {
-		if strings.Contains(line, "reason=") {
+		if count := strings.Count(line, "reason="); count > 0 {
 			reasons = append(reasons, line)
+			tags += count
 		}
 	}
-	if len(reasons) != 1 {
-		t.Fatalf("reason-bearing log lines = %d (%q), want exactly 1", len(reasons), reasons)
+	if tags != 1 {
+		t.Fatalf("reason= tags = %d across %d line(s) (%q), want exactly 1", tags, len(reasons), reasons)
 	}
 	return reasons[0]
 }

--- a/internal/daemon/resolver_refusal_log_test.go
+++ b/internal/daemon/resolver_refusal_log_test.go
@@ -1,10 +1,12 @@
 package daemon
 
 import (
+	"bytes"
 	"context"
 	"database/sql"
 	"errors"
 	"fmt"
+	"log"
 	"strings"
 	"testing"
 
@@ -22,41 +24,65 @@ import (
 // the values the decision was actually made on. A refusal that stops naming its
 // inputs fails here even though resolution behaviour is unchanged.
 
-func newResolverLogDaemon(t *testing.T) (*db.Store, Daemon, *[]string) {
+type resolverLogEntry struct {
+	format   string
+	rendered string
+}
+
+type resolverLogCapture struct {
+	entries     []resolverLogEntry
+	processLogs bytes.Buffer
+}
+
+func newResolverLogDaemon(t *testing.T) (*db.Store, Daemon, *resolverLogCapture) {
 	t.Helper()
 	store := testStore(t)
-	logs := &[]string{}
+	logs := &resolverLogCapture{}
+	previousLogWriter := log.Writer()
+	log.SetOutput(&logs.processLogs)
+	t.Cleanup(func() {
+		log.SetOutput(previousLogWriter)
+	})
 	daemon := Daemon{
 		Repo:  github.Repository{Owner: "gitmoot", Name: "gitmoot"},
 		Store: store,
 		Logf: func(format string, args ...any) {
-			*logs = append(*logs, fmt.Sprintf(format, args...))
+			logs.entries = append(logs.entries, resolverLogEntry{
+				format:   format,
+				rendered: fmt.Sprintf(format, args...),
+			})
 		},
 	}
 	return store, daemon, logs
 }
 
-// onlyRefusalLog counts reason= TAG OCCURRENCES across every captured line, not
-// lines carrying a prose prefix and not reason-bearing lines. Two review rounds
-// on #1910 each defeated a weaker rule with a compiling production mutant:
-// round 2 renamed the prose ("task resolution rejected") past a prefix match,
-// and round 3 merged both reasons onto ONE line
-// ("reason=task_repo_mismatch reason=fork_head") past a per-line count. An
-// operator reading two reasons for one refusal cannot tell which input decided
-// it, and that is true whether they sit on one line or two - so the property is
-// one reason tag per refusal, and the tag is what gets counted.
-func onlyRefusalLog(t *testing.T, logs []string) string {
+func (logs *resolverLogCapture) assertSingleSink(t *testing.T) {
 	t.Helper()
+	if logs.processLogs.Len() != 0 {
+		t.Fatalf("resolver wrote outside Daemon.Logf: %q", logs.processLogs.String())
+	}
+}
+
+// onlyRefusalLog counts reason= tags in the Logf FORMAT, not the rendered
+// diagnostic. Four review rounds on #1910 each defeated a weaker rule: prose
+// renaming bypassed a prefix match; two reasons on one rendered line bypassed a
+// per-line count; and valid input containing "reason=" looked like a second tag
+// when rendered data was counted. Capturing the format separately distinguishes
+// schema from data. Capturing the process logger as well prevents a second
+// operator-visible sink from bypassing the assertion.
+func onlyRefusalLog(t *testing.T, logs *resolverLogCapture) string {
+	t.Helper()
+	logs.assertSingleSink(t)
 	reasons := []string{}
 	tags := 0
-	for _, line := range logs {
-		if count := strings.Count(line, "reason="); count > 0 {
-			reasons = append(reasons, line)
+	for _, entry := range logs.entries {
+		if count := strings.Count(entry.format, "reason="); count > 0 {
+			reasons = append(reasons, entry.rendered)
 			tags += count
 		}
 	}
 	if tags != 1 {
-		t.Fatalf("reason= tags = %d across %d line(s) (%q), want exactly 1", tags, len(reasons), reasons)
+		t.Fatalf("reason= tags = %d across %d Logf call(s) (%q), want exactly 1", tags, len(reasons), reasons)
 	}
 	return reasons[0]
 }
@@ -87,7 +113,7 @@ func TestLookupPolledPullRequestTaskLogsForkHeadRefusalInputs(t *testing.T) {
 		t.Fatalf("error = %v, want sql.ErrNoRows for a fork head", err)
 	}
 
-	line := onlyRefusalLog(t, *logs)
+	line := onlyRefusalLog(t, logs)
 	for _, want := range []string{
 		"reason=fork_head",
 		`head_repo="outsider/gitmoot"`,
@@ -109,19 +135,19 @@ func TestLookupPolledPullRequestTaskLogsMissingTaskRefusalInputs(t *testing.T) {
 
 	_, err := daemon.lookupPolledPullRequestTask(ctx, github.PullRequest{
 		Number:           7,
-		HeadRef:          "feat/unregistered",
+		HeadRef:          "feat/reason=embedded",
 		HeadRepoFullName: "gitmoot/gitmoot",
 	})
 	if !errors.Is(err, sql.ErrNoRows) {
 		t.Fatalf("error = %v, want sql.ErrNoRows for an unregistered branch", err)
 	}
 
-	line := onlyRefusalLog(t, *logs)
+	line := onlyRefusalLog(t, logs)
 	for _, want := range []string{
 		"reason=no_task_for_branch",
 		`repo="gitmoot/gitmoot"`,
 		`head_repo="gitmoot/gitmoot"`,
-		`head_ref="feat/unregistered"`,
+		`head_ref="feat/reason=embedded"`,
 		"gitmoot/gitmoot#7",
 	} {
 		if !strings.Contains(line, want) {
@@ -155,7 +181,7 @@ func TestLookupPullRequestTaskLogsTaskRepoMismatchInputs(t *testing.T) {
 		t.Fatalf("error = %v, want sql.ErrNoRows when the task belongs to another repository", err)
 	}
 
-	line := onlyRefusalLog(t, *logs)
+	line := onlyRefusalLog(t, logs)
 	for _, want := range []string{
 		"reason=task_repo_mismatch",
 		`lookup_repo="gitmoot/gitmoot"`,
@@ -200,7 +226,7 @@ func TestLookupPolledPullRequestTaskLogsOneReasonWhenTaskBelongsToAnotherRepo(t 
 		t.Fatalf("error = %v, want sql.ErrNoRows through the polled resolver", err)
 	}
 
-	line := onlyRefusalLog(t, *logs)
+	line := onlyRefusalLog(t, logs)
 	for _, want := range []string{
 		"reason=task_repo_mismatch",
 		`lookup_repo="gitmoot/gitmoot"`,
@@ -243,11 +269,13 @@ func TestLookupPolledPullRequestTaskLogsNothingOnSuccess(t *testing.T) {
 	if task.ID != "task-ok" {
 		t.Fatalf("task = %+v, want task-ok", task)
 	}
-	// Same prose-independence as onlyRefusalLog: a renamed refusal line must
-	// still fail this test.
-	for _, line := range *logs {
-		if strings.Contains(line, "reason=") {
-			t.Fatalf("logs = %q, want no reason-bearing line on successful resolution", *logs)
+	// Same metadata independence as onlyRefusalLog: a renamed refusal line
+	// must still fail this test, while "reason=" inside rendered input data must
+	// not. Resolver diagnostics must also stay behind the injected sink.
+	logs.assertSingleSink(t)
+	for _, entry := range logs.entries {
+		if strings.Contains(entry.format, "reason=") {
+			t.Fatalf("logs = %q, want no reason-bearing Logf call on successful resolution", logs.entries)
 		}
 	}
 }


### PR DESCRIPTION
Closes #1909 (diagnostics half - resolution behaviour is unchanged).

## Why

A task-resolution refusal named only the branch. Three reproductions against #1783 still could not say **which input mismatched**, because the operator-visible text carried `pull.HeadRef` and nothing else:

| comment | command | reply |
|---|---|---|
| 5552283779 | `/gitmoot merge` | ``branch `docs/exact-head-and-steady-mode` is not registered as a task`` |
| 5552331086 | `/gitmoot merge` (controlled retry) | identical |
| 5552344194 | `/gitmoot status` | ``task `pr-1783-comment-5552344194` not registered`` |

Every readable input was correct - unique task row on that branch predating the refusal by six minutes, hex-identical branch/repo strings, `isCrossRepository: false`, no branch lock, daemon verified as `dev-0e55c0a3` on the same database. The investigation stalled because **three distinct arms return the same bare `sql.ErrNoRows`**, and the log said nothing.

The third arm was found by reading the resolver rather than from the incident: `lookupPullRequestTask` also tries the branch string as a **task id**, and a hit belonging to another repository is rejected with the same bare no-rows.

## What changes

Each refusal arm logs the values it decided on, at the one resolver every polled-PR consumer calls:

- `reason=fork_head` - with `repo`, `head_repo`, `head_ref`
- `reason=no_task_for_branch` - with `repo`, `head_repo`, `head_ref`
- `reason=task_repo_mismatch` - with `lookup_repo`, `task`, `task_repo`

No control-flow change: the same inputs still resolve, and still refuse, exactly as before.

## Verification

- `go build ./...` - OK. `go vet ./internal/daemon/` - OK.
- `go test ./internal/daemon/` - ok, 8.2s. `go test -race -timeout 20m ./internal/daemon/` - ok, 29.5s.
- 4 new tests in `resolver_refusal_log_test.go` pass.
- **The guard was mutated, not assumed.** Reverting only the production file (`git stash` of `daemon.go`, tests untouched) fails all three refusal tests with `refusal log lines = 0 ([]), want exactly 1`; restoring it returns the file byte-identical (`cmp` clean) and they pass. A semantic reversion, so the tests exercise the production path rather than a compile error.
- The fourth test asserts **silence on success**, so this cannot degrade into a log line per resolved PR per poll - the failure mode that would make an operator turn the logging off.

Local `GOFLAGS=-buildvcs=false` was needed because `go` could not read VCS status in the throwaway worktree; CI stamps normally.

## Not in this PR

The underlying resolution failure on #1783 is still unexplained - that is #1909's other half, and it needs these fields from a live refusal to name the mismatching value. #1783 itself was merged by hand under directive 120937 with the bypass recorded on the PR (comment 5552407387) and in workflow note 120949.
