### PR TITLE
docs(agents): name the read-only seat toolchain boundary (#1915)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,6 +30,32 @@ export GOCACHE=/tmp/gitmoot-go-build-cache
 mkdir -p "$GOCACHE"
 ```
 
+**Inside a read-only review seat, both exports above are wrong** — a seat that
+follows them gets `exit 126` and a denied cache, which read as broken
+infrastructure rather than the documented boundary they are:
+
+- **Never invoke `/root/.local/toolchains/go1.26.4/bin/go`.** The daemon stages a
+  copy it owns and points the seat at it via injected `GOROOT` and `PATH`
+  (`internal/cli/toolchain_seat.go`); granting the operator's own installation was
+  rejected as escape-class (symlink redirect out of containment, and an
+  unclosable TOCTOU on a path the daemon does not own). Execution denial on that
+  path is **expected and is never a finding** — probe with plain `go version` and
+  `go env GOROOT`, which should report a `GOROOT` under `<home>/.gitmoot/toolchains/`.
+- **Never use the shared `/tmp/gitmoot-go-build-cache`.** It is not writable from a
+  seat; use a seat-owned `GOCACHE` under `$TMPDIR`. Note the cost: each building
+  seat then populates its own cache instead of sharing one, so seat builds are
+  coupled to the dispatch disk floor.
+- **Set `CGO_ENABLED=0`.** The sandbox denies `/usr/include/stdc-predef.h`, so any
+  default-cgo `build`/`vet`/`test` fails on a C header.
+- **`-race` is unreachable in a seat**, because race requires cgo. It is covered by
+  CI's race shards only, and its absence from a seat verdict is not a regression.
+
+When a seat's plain `go` really does return 126, staging did not happen and the
+reason is on the daemon's stderr rather than in the job's events — see
+`docs/troubleshooting.md`, "`Permission denied`, exit 126, running Go", which
+enumerates the staging refusals (unpinned source, system-package prefix, symlink
+in the source set, free space below the 4 GiB floor).
+
 Run from the repo root and make these pass before committing — they mirror the CI
 gate in `.github/workflows/ci.yml`:
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,16 +45,24 @@ infrastructure rather than the documented boundary they are:
   seat; use a seat-owned `GOCACHE` under `$TMPDIR`. Note the cost: each building
   seat then populates its own cache instead of sharing one, so seat builds are
   coupled to the dispatch disk floor.
-- **Set `CGO_ENABLED=0`.** The sandbox denies `/usr/include/stdc-predef.h`, so any
-  default-cgo `build`/`vet`/`test` fails on a C header.
-- **`-race` is unreachable in a seat**, because race requires cgo. It is covered by
-  CI's race shards only, and its absence from a seat verdict is not a regression.
+- **Set `CGO_ENABLED=0`.** The sandbox denies `/usr/include/stdc-predef.h`, so
+  anything that actually reaches `runtime/cgo` fails on a C header — which
+  includes the repo-wide gate and `./cmd/gitmoot`. A pure-Go package still builds
+  and tests with default cgo, so a passing single-package run proves nothing about
+  the gate.
+- **`-race` is unreachable in a seat**, because race requires cgo (`go: -race
+  requires cgo; enable cgo by setting CGO_ENABLED=1`). It is covered by CI's race
+  shards only, and its absence from a seat verdict is not a regression.
 
-When a seat's plain `go` really does return 126, staging did not happen and the
-reason is on the daemon's stderr rather than in the job's events — see
-`docs/troubleshooting.md`, "`Permission denied`, exit 126, running Go", which
-enumerates the staging refusals (unpinned source, system-package prefix, symlink
-in the source set, free space below the 4 GiB floor).
+When a seat's plain `go` returns 126, staging did not happen — but **only some of
+those cases say why.** `stageSeatToolchain` deliberately stays SILENT when no `go`
+is on the daemon's `PATH`, when the toolchain sits under a system-package prefix,
+or when the source is not a pinned installation (`ErrNotPinned`): the seat is left
+exactly as it was, with no diagnostic. Other staging failures do print
+`gitmoot: read-only seat toolchain:` on the daemon's stderr, never in the job's
+events. See `docs/troubleshooting.md`, "`Permission denied`, exit 126, running
+Go", for the refusal list (unpinned source, system-package prefix, symlink in the
+source set, free space below the 4 GiB floor).
 
 Run from the repo root and make these pass before committing — they mirror the CI
 gate in `.github/workflows/ci.yml`:

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -759,10 +759,15 @@ What to expect:
   seat's own cache root.** Both `/tmp` and the workspace return `EACCES` on
   `mkdir`, and "a writable dir" reads as satisfied by `/tmp` when it is not.
 
-If a seat still gets exit 126 running `go`, staging did not happen. **The reason is
-on the daemon's stderr, not in the job's events** - deliberately, because a fact
-about the host must not change a job's event stream. Look for
-`gitmoot: read-only seat toolchain:`. The causes, all of which leave the seat
+If a seat still gets exit 126 running `go`, staging did not happen. **Some of those
+cases print the reason on the daemon's stderr, not in the job's events** -
+deliberately, because a fact about the host must not change a job's event stream.
+Look for `gitmoot: read-only seat toolchain:`. **The first three causes below are
+SILENT by design**: no `go` on the daemon's `PATH`, a system-package prefix, and a
+source that is not a pinned installation all leave the seat as it was and emit
+nothing at all, so an absent log line does not mean staging succeeded. Only the
+remaining staging failures - free space below the floor, a symlink in the source
+set, and other copy errors - carry a diagnostic. All of them leave the seat
 exactly as it was before this feature existed rather than failing the launch:
 
 - **No pinned toolchain on the daemon's `PATH`.** A toolchain under `/opt`,


### PR DESCRIPTION
Closes the fourth ask on #1915 — the documentation half, which is the root of today's exit-126 false-alarm chain.

## The defect

`AGENTS.md`'s host-pinning block tells every agent to `export PATH=/root/.local/toolchains/go1.26.4/bin:$PATH` and `export GOCACHE=/tmp/gitmoot-go-build-cache`. Inside a **read-only review seat** both are wrong:

- The operator path is denied **by design**. #1879 refuses to grant a seat the operator's own installation (symlink redirect out of containment, unclosable TOCTOU on a path the daemon does not own) and stages a daemon-owned copy instead, injecting `GOROOT`/`PATH` — `internal/cli/toolchain_seat.go`.
- The shared `GOCACHE` is not writable from a seat.

So an agent that follows the repo's own documented setup gets `exit 126` plus a denied cache, and both read as broken infrastructure. **That is not hypothetical:** a review seat stopped on exactly this and reported a *"failed #1879 deployment probe"* — its brief had been written from this document. The staged copy was working the whole time (`go version go1.26.4`, `GOROOT=/root/.gitmoot/toolchains/go1.26.4-d9cf614354030113`).

## The change

Documentation only, one block in `AGENTS.md`:

- never invoke the operator path; probe with plain `go version` / `go env GOROOT`, and treat 126 there as expected rather than a finding
- use a seat-owned `GOCACHE`, with the cost stated: each building seat populates its own cache instead of sharing one, coupling seat builds to the dispatch disk floor
- `CGO_ENABLED=0` is required — the sandbox denies `/usr/include/stdc-predef.h`
- `-race` is therefore unreachable in a seat and is covered by CI's race shards only, so its absence from a seat verdict is not a regression

Plus a pointer to `docs/troubleshooting.md`, "`Permission denied`, exit 126, running Go", which already enumerates the staging refusals — this block deliberately does not duplicate them.

## Verification

No code paths touched, so the gate is unchanged; `AGENTS.md` is not compiled or tested. The claims were checked against source rather than memory: `internal/cli/toolchain_seat.go` at `200eab78` for the copy-not-grant rationale and the injected env, and the `-race`/cgo and `GOCACHE` failures against a real seat's executed evidence (job `local-review-g7-review-18d27b329e79e0f7`: `CGO_ENABLED=0` build/vet/test pass, default-cgo variants fail on the denied header, shared `GOCACHE` permission denied, `-race` rejected as requiring cgo).

Not verified: nothing in this PR is executable.

## Deploy notes

None. Documentation only; no binary, no restart.

Kept deliberately separate from the #1910 resolver-log test correction per directive 121388 — one is prose about the environment, the other is a regression test that must be proven against an evasive mutant.
