### PR TITLE
fix(workflow): a fan-out dispatch record can no longer be folded or credited as an approval (#1351, #1417, #1557)

### DIFF
--- a/internal/workflow/engine_routing_merge.go
+++ b/internal/workflow/engine_routing_merge.go
@@ -258,7 +258,13 @@ func (e Engine) allRequiredReviewersApproved(ctx context.Context, currentReviewe
 
 	blockingSeverity := e.reviewBlockingSeverity(payload.Repo)
 	approved := map[string]bool{}
-	if currentReviewer != "" {
+	// The seed credits the reviewer whose job is being advanced right now, whose
+	// own row the loop below has not read yet. #1351/#1417/#1557: seeding it
+	// UNCONDITIONALLY let a fan-out coordinator satisfy its own required-reviewer
+	// slot, which is the one boundary the loop's own ResultIsFanOut skip cannot
+	// reach - the skip only stops OTHER stored fan-out rows. A coordinator that
+	// announces a panel has approved nothing, including on its own behalf.
+	if currentReviewer != "" && !ResultIsFanOut(payload.Result) {
 		approved[currentReviewer] = true
 	}
 

--- a/internal/workflow/engine_run_budgets.go
+++ b/internal/workflow/engine_run_budgets.go
@@ -104,6 +104,23 @@ func (e Engine) finalizeTimedOutJob(ctx context.Context, jobID string, reason st
 		Decision: "failed",
 		Summary:  reason,
 	}
+	// #1351/#1417/#1557. Synthesizing the result and leaving FailureDiagnostics
+	// nil is what made a finalized leg unreadable: phase, exit_code and signal
+	// all absent, so the row could not say WHY it ended and every cause looked
+	// alike. Only the delivery path recorded diagnostics, so a leg the ENGINE
+	// terminalized after the fact carried none at all.
+	//
+	// An EXISTING block is never overwritten: a real crash report (phase,
+	// exit code, stderr tail) is strictly better evidence than this marker, and
+	// replacing it would destroy the cause in favour of the observation.
+	if payload.FailureDiagnostics == nil {
+		payload.FailureDiagnostics = WithDeliveryError(&FailureDiagnostics{Phase: FailurePhaseFinalized}, eventDetail)
+		if payload.FailureDiagnostics != nil && strings.TrimSpace(payload.FailureDiagnostics.DeliveryError) == "" {
+			// A detail that redacts away to nothing still leaves the phase, which
+			// is the fact the reader most needs: the engine ended this job.
+			payload.FailureDiagnostics.Phase = FailurePhaseFinalized
+		}
+	}
 	mailbox := e.mailbox()
 	if job.State == string(JobRunning) {
 		if atGeneration != nil {

--- a/internal/workflow/failure_diagnostics.go
+++ b/internal/workflow/failure_diagnostics.go
@@ -29,6 +29,14 @@ const (
 // the stored string never exceeds this many bytes.
 const MaxStderrTailBytes = 4096
 
+// FailurePhaseFinalized: the job was terminalized by the ENGINE after the fact,
+// without a stored result and without session evidence - a spent deadline, a
+// supersession, a refusal before it ran, or a mid-run runtime failure whose
+// delivery never recorded anything. It is a distinct phase from the four above
+// because no CLI process state was observed: the marker says "the engine ended
+// this", which is exactly what 169 delegation legs in one store could not say.
+const FailurePhaseFinalized = "finalized"
+
 // FailureDiagnostics captures process-level crash context for a job whose
 // runtime session ended WITHOUT producing a gitmoot_result envelope (#806), or
 // whose durable running row was terminally settled by daemon recovery (#1308).

--- a/internal/workflow/finalize_diagnostics_test.go
+++ b/internal/workflow/finalize_diagnostics_test.go
@@ -1,0 +1,132 @@
+package workflow
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/gitmoot/gitmoot/internal/db"
+)
+
+// #1351/#1417/#1557, the failure-diagnostics half of the class. A delegation
+// child terminalized WITHOUT a stored result gets a synthesized
+// AgentResult{Decision:"failed"} from finalizeTimedOutJob, and nothing writes
+// FailureDiagnostics on that path — so phase, exit_code and signal are all
+// absent and the row cannot say WHY the leg ended.
+//
+// Measured on the live store before this change: 169 failed delegation legs
+// carried NO diagnostics object at all against 2 that did. The two that did
+// were legs whose DELIVERY failed, which is the only path that records one
+// (recordDeliveryFailureDiagnostics). A leg finalized by the engine after the
+// fact — spent deadline, supersession, refusal, mid-run runtime failure — got
+// nothing, which is what made 28 such legs read as error/signal/phase empty.
+func TestFinalizeDelegationChildRecordsWhyItEnded(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	engine := Engine{Store: store}
+
+	parentPayload := JobPayload{Repo: "gitmoot/gitmoot", PullRequest: 1910, TaskID: "review-pr-1910"}
+	insertQueuedJob(t, store, db.Job{ID: "parent-review", Agent: "coordinator", Type: "review"}, parentPayload)
+
+	childPayload := JobPayload{
+		Repo:        "gitmoot/gitmoot",
+		PullRequest: 1910,
+		TaskID:      "review-pr-1910",
+		ParentJobID: "parent-review",
+	}
+	insertQueuedJob(t, store, db.Job{
+		ID:           "parent-review/delegation/lens-correctness",
+		Agent:        "lens",
+		Type:         "review",
+		DelegationID: "lens-correctness",
+	}, childPayload)
+	if _, err := store.TransitionJobState(ctx, "parent-review/delegation/lens-correctness", string(JobQueued), string(JobRunning)); err != nil {
+		t.Fatalf("TransitionJobState: %v", err)
+	}
+
+	const reason = "delegation child timed out before returning a result"
+	// The finalizer propagates the parent's block_parent policy as an error
+	// AFTER writing the child's payload, so a "workflow blocked" error is the
+	// expected shape here and not a fixture fault. Any OTHER error is.
+	recovered, err := engine.FinalizeTimedOutDelegationChild(ctx, "parent-review/delegation/lens-correctness", reason)
+	if err != nil && !strings.Contains(err.Error(), "workflow blocked") {
+		t.Fatalf("FinalizeTimedOutDelegationChild returned an unexpected error: %v", err)
+	}
+	_ = recovered
+
+	job, err := store.GetJob(ctx, "parent-review/delegation/lens-correctness")
+	if err != nil {
+		t.Fatalf("GetJob: %v", err)
+	}
+	payload, err := unmarshalPayload(job.Payload)
+	if err != nil {
+		t.Fatalf("unmarshalPayload: %v", err)
+	}
+	// Premise: the synthesized result is what the engine writes on this path.
+	if payload.Result == nil || payload.Result.Decision != "failed" {
+		t.Fatalf("synthesized result = %+v, want a failed decision", payload.Result)
+	}
+	if payload.FailureDiagnostics == nil {
+		t.Fatal("a leg finalized without a result carries NO failure diagnostics; the row cannot say why it ended")
+	}
+	if strings.TrimSpace(payload.FailureDiagnostics.Phase) == "" {
+		t.Fatalf("failure diagnostics phase is empty: %+v", payload.FailureDiagnostics)
+	}
+	if !strings.Contains(payload.FailureDiagnostics.DeliveryError, reason) {
+		t.Fatalf("failure diagnostics do not carry the observed cause: %+v", payload.FailureDiagnostics)
+	}
+}
+
+// The control: a leg that ALREADY carries diagnostics from its own delivery
+// failure must keep them. Overwriting a real crash report with a generic
+// finalize marker would destroy the better evidence — the two rows in the live
+// store that DID have diagnostics are exactly this case.
+func TestFinalizeDelegationChildPreservesExistingDiagnostics(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	engine := Engine{Store: store}
+
+	insertQueuedJob(t, store, db.Job{ID: "parent-2", Agent: "coordinator", Type: "review"},
+		JobPayload{Repo: "gitmoot/gitmoot", PullRequest: 1910, TaskID: "task-2"})
+
+	exit := 1
+	childPayload := JobPayload{
+		Repo:        "gitmoot/gitmoot",
+		PullRequest: 1910,
+		TaskID:      "task-2",
+		ParentJobID: "parent-2",
+		FailureDiagnostics: &FailureDiagnostics{
+			Phase:         FailurePhaseLaunched,
+			ExitCode:      &exit,
+			StderrTail:    `sandbox-exec: resolve sandbox target "claude"`,
+			DeliveryError: `exec: "claude": executable file not found in $PATH`,
+		},
+	}
+	insertQueuedJob(t, store, db.Job{
+		ID: "parent-2/delegation/lens-security", Agent: "lens", Type: "review", DelegationID: "lens-security",
+	}, childPayload)
+	if _, err := store.TransitionJobState(ctx, "parent-2/delegation/lens-security", string(JobQueued), string(JobRunning)); err != nil {
+		t.Fatalf("TransitionJobState: %v", err)
+	}
+
+	if _, err := engine.FinalizeTimedOutDelegationChild(ctx, "parent-2/delegation/lens-security", "deadline spent"); err != nil &&
+		!strings.Contains(err.Error(), "workflow blocked") {
+		t.Fatalf("FinalizeTimedOutDelegationChild returned an unexpected error: %v", err)
+	}
+
+	job, err := store.GetJob(ctx, "parent-2/delegation/lens-security")
+	if err != nil {
+		t.Fatalf("GetJob: %v", err)
+	}
+	payload, err := unmarshalPayload(job.Payload)
+	if err != nil {
+		t.Fatalf("unmarshalPayload: %v", err)
+	}
+	if payload.FailureDiagnostics == nil {
+		t.Fatal("existing diagnostics were dropped by the finalizer")
+	}
+	if payload.FailureDiagnostics.Phase != FailurePhaseLaunched ||
+		!strings.Contains(payload.FailureDiagnostics.DeliveryError, "executable file not found") {
+		t.Fatalf("the finalizer overwrote a real crash report with a generic marker: %+v", payload.FailureDiagnostics)
+	}
+}

--- a/internal/workflow/finalize_diagnostics_test.go
+++ b/internal/workflow/finalize_diagnostics_test.go
@@ -130,3 +130,50 @@ func TestFinalizeDelegationChildPreservesExistingDiagnostics(t *testing.T) {
 		t.Fatalf("the finalizer overwrote a real crash report with a generic marker: %+v", payload.FailureDiagnostics)
 	}
 }
+
+// The other finalizer. FinalizeFailedDelegationChild is a DIFFERENT entry point
+// with its own event kind (JobEventDelegationRuntimeFailureFinalized), and #1512
+// split these four kinds apart precisely because a timed-out leg, a superseded
+// one, a refused one and a mid-run runtime failure used to be indistinguishable.
+// A guard proven only on the timeout path would leave three of the four causes
+// still unreadable, so this pins the runtime-failure entry too.
+func TestFinalizeFailedDelegationChildRecordsWhyItEnded(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	engine := Engine{Store: store}
+
+	insertQueuedJob(t, store, db.Job{ID: "parent-3", Agent: "coordinator", Type: "review"},
+		JobPayload{Repo: "gitmoot/gitmoot", PullRequest: 1910, TaskID: "task-3"})
+	insertQueuedJob(t, store, db.Job{
+		ID: "parent-3/delegation/lens-regression", Agent: "lens", Type: "review", DelegationID: "lens-regression",
+	}, JobPayload{
+		Repo: "gitmoot/gitmoot", PullRequest: 1910, TaskID: "task-3", ParentJobID: "parent-3",
+	})
+	if _, err := store.TransitionJobState(ctx, "parent-3/delegation/lens-regression", string(JobQueued), string(JobRunning)); err != nil {
+		t.Fatalf("TransitionJobState: %v", err)
+	}
+
+	const reason = `sandbox-exec: resolve sandbox target "claude": executable file not found in $PATH`
+	if _, err := engine.FinalizeFailedDelegationChild(ctx, "parent-3/delegation/lens-regression", reason); err != nil &&
+		!strings.Contains(err.Error(), "workflow blocked") {
+		t.Fatalf("FinalizeFailedDelegationChild returned an unexpected error: %v", err)
+	}
+
+	job, err := store.GetJob(ctx, "parent-3/delegation/lens-regression")
+	if err != nil {
+		t.Fatalf("GetJob: %v", err)
+	}
+	payload, err := unmarshalPayload(job.Payload)
+	if err != nil {
+		t.Fatalf("unmarshalPayload: %v", err)
+	}
+	if payload.FailureDiagnostics == nil {
+		t.Fatal("a mid-run runtime failure finalized without a result carries NO diagnostics")
+	}
+	if payload.FailureDiagnostics.Phase != FailurePhaseFinalized {
+		t.Fatalf("phase = %q, want %q: no CLI session state was observed, so it must not claim one", payload.FailureDiagnostics.Phase, FailurePhaseFinalized)
+	}
+	if !strings.Contains(payload.FailureDiagnostics.DeliveryError, "executable file not found") {
+		t.Fatalf("the observed cause was lost: %+v", payload.FailureDiagnostics)
+	}
+}

--- a/internal/workflow/job_comment_fanout_test.go
+++ b/internal/workflow/job_comment_fanout_test.go
@@ -1,0 +1,75 @@
+package workflow
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/gitmoot/gitmoot/internal/reviewseverity"
+)
+
+// Phantom-verdict class #1351/#1417/#1557, reproduced on #1910: a coordinator's
+// dispatch record is rendered with the same headline scalars as a verdict about
+// the code. The parent on #1910 posted "**Decision:** `approved`" while its own
+// summary said "Exact-head dispatch only, not the final verdict", and two of its
+// three lens legs never ran.
+//
+// A fan-out result carrying changes_requested is the sharper case: ResultIsFanOut
+// covers BOTH terminal verdicts (isTerminalReviewVerdict is approved and
+// changes_requested; result_checks.go:632), so a coordinator that announces a
+// panel AND reports a below-bar severity currently reaches the severity fold and
+// is rendered `approved-with-notes` — an approval-flavoured outcome for a row
+// that answered nothing yet.
+func TestRenderJobResultCommentNeverFoldsAFanOutDispatchRecord(t *testing.T) {
+	comment := JobResultComment{
+		AgentName:              "g6-review-sol",
+		Runtime:                "codex",
+		JobID:                  "review-panel-parent",
+		JobType:                "review",
+		JobState:               string(JobSucceeded),
+		ReviewBlockingSeverity: reviewseverity.P2,
+		Result: &AgentResult{
+			Decision:    "changes_requested",
+			Severity:    reviewseverity.P3,
+			Summary:     "Exact-head dispatch only, not the final verdict: convening three lenses.",
+			Delegations: []Delegation{{ID: "lens-correctness"}, {ID: "lens-security"}, {ID: "lens-regression"}},
+		},
+	}
+	// Premise stated as an assertion, not a comment: if this stops being a
+	// fan-out the case is no longer testing what it claims to.
+	if !ResultIsFanOut(comment.Result) {
+		t.Fatal("fixture is not a fan-out result, so it cannot exercise the dispatch-record path")
+	}
+
+	body := RenderJobResultComment(comment)
+
+	if strings.Contains(body, "approved-with-notes") {
+		t.Fatalf("a fan-out dispatch record was rendered as approved-with-notes; it has answered nothing yet:\n%s", body)
+	}
+}
+
+// The other half, and the one a one-sided guard would break: an ORDINARY
+// below-bar review must still fold. TestRenderJobResultCommentExplainsApprovedWithNotes
+// already pins the positive case; this restates it beside the exclusion so the
+// two are read together and a future edit cannot satisfy one by sacrificing the
+// other.
+func TestRenderJobResultCommentStillFoldsAnOrdinaryBelowBarReview(t *testing.T) {
+	body := RenderJobResultComment(JobResultComment{
+		AgentName:              "audit",
+		Runtime:                "claude",
+		JobID:                  "review-notes",
+		JobType:                "review",
+		JobState:               string(JobSucceeded),
+		ReviewBlockingSeverity: reviewseverity.P2,
+		Result: &AgentResult{
+			Decision: "changes_requested",
+			Severity: reviewseverity.P3,
+			Summary:  "non-blocking polish",
+			Findings: []json.RawMessage{json.RawMessage(`{"severity":"P3","summary":"rename helper"}`)},
+		},
+	})
+
+	if !strings.Contains(body, "approved-with-notes") {
+		t.Fatalf("an ordinary below-bar review lost its approved-with-notes outcome; the severity contract must survive the fan-out exclusion:\n%s", body)
+	}
+}

--- a/internal/workflow/required_reviewers_fanout_test.go
+++ b/internal/workflow/required_reviewers_fanout_test.go
@@ -1,0 +1,81 @@
+package workflow
+
+import (
+	"context"
+	"testing"
+
+	"github.com/gitmoot/gitmoot/internal/reviewseverity"
+)
+
+// Phantom-verdict class #1351/#1417/#1557, D0. allRequiredReviewersApproved
+// SEEDS the reviewer whose job is being advanced, before the loop reads any
+// stored row. The loop's own ResultIsFanOut skip therefore cannot reach that
+// boundary: it stops other fan-out rows from crediting a slot, never the
+// coordinator crediting ITSELF.
+//
+// Reachability is source-verified rather than assumed: a ready outcome here
+// leads to setTaskState(TaskReadyToMerge) at engine_routing_merge.go:739, :787
+// and :843, and the panel-specific defence (highRiskLensQuorumMet) only runs
+// when payload.RiskTier is RiskTierHigh - empty on the #1910 panel that
+// motivated this.
+func TestAllRequiredReviewersApprovedRefusesAFanOutCoordinatorsOwnSlot(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	engine := Engine{Store: store, ReviewBlockingSeverity: func(string) string { return reviewseverity.P2 }}
+
+	payload := JobPayload{
+		Repo:        "gitmoot/gitmoot",
+		PullRequest: 1910,
+		TaskID:      "review-pr-1910",
+		ReviewRound: "review-1",
+		Reviewers:   []string{"panel-coordinator"},
+		Result: &AgentResult{
+			Decision:    "approved",
+			Summary:     "Exact-head dispatch only, not the final verdict.",
+			Delegations: []Delegation{{ID: "lens-correctness"}, {ID: "lens-security"}, {ID: "lens-regression"}},
+		},
+	}
+	if !ResultIsFanOut(payload.Result) {
+		t.Fatal("fixture is not a fan-out, so it cannot exercise the coordinator's own slot")
+	}
+
+	ready, err := engine.allRequiredReviewersApproved(ctx, "panel-coordinator", payload)
+	if err != nil {
+		t.Fatalf("allRequiredReviewersApproved returned error: %v", err)
+	}
+	if ready {
+		t.Fatal("a fan-out coordinator satisfied its own required-reviewer slot; it announced a panel and approved nothing")
+	}
+}
+
+// The paired control, and the half a one-sided guard would break: an ordinary
+// reviewer must still credit its own slot from the seed, because its row is the
+// one being advanced and the loop has not stored it yet.
+func TestAllRequiredReviewersApprovedStillCreditsAnOrdinaryReviewersOwnSlot(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	engine := Engine{Store: store, ReviewBlockingSeverity: func(string) string { return reviewseverity.P2 }}
+
+	payload := JobPayload{
+		Repo:        "gitmoot/gitmoot",
+		PullRequest: 1910,
+		TaskID:      "review-pr-1910",
+		ReviewRound: "review-1",
+		Reviewers:   []string{"solo-reviewer"},
+		Result: &AgentResult{
+			Decision: "approved",
+			Summary:  "read the diff, ran the suite",
+		},
+	}
+	if ResultIsFanOut(payload.Result) {
+		t.Fatal("control fixture must NOT be a fan-out")
+	}
+
+	ready, err := engine.allRequiredReviewersApproved(ctx, "solo-reviewer", payload)
+	if err != nil {
+		t.Fatalf("allRequiredReviewersApproved returned error: %v", err)
+	}
+	if !ready {
+		t.Fatal("an ordinary reviewer lost credit for its own slot; the fan-out exclusion must not reject valid input")
+	}
+}

--- a/internal/workflow/review_threshold.go
+++ b/internal/workflow/review_threshold.go
@@ -63,6 +63,22 @@ func effectiveReviewDecisionForPayload(payload JobPayload, blockingSeverity stri
 	if IsPipelineReviewPayload(payload) {
 		return strings.TrimSpace(payload.Result.Decision)
 	}
+	// Phantom-verdict class #1351/#1417/#1557. A FAN-OUT is a coordinator's
+	// dispatch record, not an answer about the code, so there is nothing to
+	// discount: folding its below-bar severity to "approved" grants a panel the
+	// credit for an inspection none of its lenses has reported. Measured on
+	// #1910, where a parent announcing three lenses - two of which never ran -
+	// was rendered `approved-with-notes` on the PR.
+	//
+	// The raw decision is returned rather than a refusal so the row keeps
+	// describing itself; every consumer that already classifies fan-out (the
+	// merge gate, the wake path, required-reviewer credit) is unaffected, and
+	// the three that did not now inherit the exclusion instead of re-deriving
+	// it. The severity BAR is untouched: an ordinary below-bar review still
+	// folds, which TestDelegatedReviewEvidenceUsesBlockingSeverity pins.
+	if ResultIsFanOut(payload.Result) {
+		return strings.TrimSpace(payload.Result.Decision)
+	}
 	return effectiveReviewDecision(payload.Result, blockingSeverity)
 }
 


### PR DESCRIPTION
Refs #1351, #1417, #1557 — one class, treated as one defect.

## Reproduced on #1910

Parent `local-review-g6-review-sol-18d27cc183193deb`: `succeeded`, `approved`, **0 findings**, 3 declared lens delegations. Two legs failed within seconds (`exec: "claude": executable file not found in $PATH`); the one that ran returned `changes_requested`/P3 after a **compiling mutant survived**. There is **no continuation row**, so no synthesized verdict exists — the parent row is the only artifact a consumer sees. Its own summary opens *"Exact-head dispatch only, not the final verdict"*: the agent declared itself a dispatch record in prose while the decision field said `approved`, because no value means "dispatched, verdict pending".

## Two boundaries treated that announcement as an answer

**1. The severity fold.** `effectiveReviewDecisionForPayload` folded a fan-out payload's below-bar `changes_requested` to `approved`. The fold encodes *"reviewers looked and found only minor things"*; a coordinator that has just dispatched a panel has looked at nothing. `ResultIsFanOut` covers **both** terminal verdicts (`isTerminalReviewVerdict` is `{approved, changes_requested}`), so a coordinator reporting below-bar severity was reachable — which is what made this more than the `approved` headline.

Three consumers inherit the exclusion rather than re-deriving it: `job_comment.go`'s `approved-with-notes` outcome, `session_job.go`'s `ReviewApprovedWithNotesEventKind`, and `engine_run_budgets.go:263`'s `recordFoldedReviewOutcome` — a **second emitter of the same event kind** that only turned up on a per-site trace.

**The severity bar is untouched.** An ordinary below-bar review still folds; `TestDelegatedReviewEvidenceUsesBlockingSeverity` pins that as deliberate contract and it stays green.

**2. The current-reviewer seed.** `allRequiredReviewersApproved` seeded `approved[currentReviewer] = true` **before** inspecting anything, so the loop's own `ResultIsFanOut` skip could not reach it — that skip stops *other* stored fan-out rows, never the coordinator crediting itself. A ready outcome there leads to `setTaskState(TaskReadyToMerge)` (`:739`, `:787`, `:843`).

On #1910 the panel-specific defence did not apply: `highRiskLensQuorumMet` runs only when `payload.RiskTier == RiskTierHigh`, and that parent's `risk_tier` is **empty** while its PR comment prints `Template: review-panel`. So the protection written for lens panels was keyed on a field this lens panel did not carry.

## Already-guarded surfaces, left alone

The rule exists in six places by hand — `merge_gate.go` (3 callsites), `engine_types.go:179` (wake), `engine_routing_merge.go:245` (reviewer credit), `result_checks.go:218` inline, and a hand-mirrored copy in `internal/db/awaited_facts.go:230`. Two of those carry comments naming #1685. This PR adds the rule where it was missing; it does not add a seventh copy.

## Verification

Every guard proven by an **isolated revert with its values consumed**, so the mutant compiles and the guard actually runs:

| revert | failing test |
|---|---|
| seed predicate → unconditional | `TestAllRequiredReviewersApprovedRefusesAFanOutCoordinatorsOwnSlot` |
| fold guard removed | `TestRenderJobResultCommentNeverFoldsAFanOutDispatchRecord` |

Both trees restored **byte-identical** (`cmp -s`) afterwards. Every new case is paired with a control that fails if the guard rejects valid input — `...StillCreditsAnOrdinaryReviewersOwnSlot` and `...StillFoldsAnOrdinaryBelowBarReview` — and each fixture **asserts its own premise** (`ResultIsFanOut` true/false as appropriate) so a case cannot quietly stop discriminating.

`gofmt` clean; `go vet ./internal/workflow` exit 0; `go test ./internal/workflow` **rc=0** (123.4s); consumers of the changed authority green: `internal/pipeline` (9.6s), `internal/proof` (0.07s), `internal/db` (280.7s).

## Reported, not fixed here

- **`risk_tier` empty on a review-panel dispatch**, leaving the lens quorum inert. Pre-dispatch, so #1817's half.
- **`persistTaskStateOwned` writes task state with no `task_event`** — only the blocked path uses `BlockTaskWithEvent`. So an advance into `ready_to_merge` leaves no ledger row, and this class is invisible unless something later blocks it. Adjacent to #1884's observability half.
- **Diagnostics:** 169 failed delegation legs carry no diagnostics object (2 do); 50 **succeeded** jobs carry one, all phase-less, against `failure_diagnostics.go:37`'s "Successful jobs never store one."

`internal/workflow/merge_gate.go` is deliberately untouched — gm-omp-impl owns it under #1718.