### PR TITLE
fix(cli): stop the empty-home review-policy test reading the live home (#1924)

### DIFF
--- a/internal/cli/review_risk_test.go
+++ b/internal/cli/review_risk_test.go
@@ -154,6 +154,10 @@ func TestApplyReviewPolicyInvalidRepoSeverityOverridesPermissiveGlobal(t *testin
 }
 
 func TestApplyReviewPolicyEmptyHomeIsOff(t *testing.T) {
+	// applyReviewPolicy("") resolves config.DefaultPaths() from $HOME, so without
+	// this the assertions below read the operator's live ~/.gitmoot/config.toml
+	// and a host with [review] set turns the whole package red (#1924).
+	t.Setenv("HOME", t.TempDir())
 	var engine workflow.Engine
 	applyReviewPolicy(&engine, "")
 	if engine.RiskTiersEnabled {


### PR DESCRIPTION
Fixes #1924.

## What was wrong

`go test ./internal/cli/` was **red on pristine `main` (9ce2453f)** on this host while CI was green:

```
--- FAIL: TestApplyReviewPolicyEmptyHomeIsOff (0.00s)
    review_risk_test.go:166: empty home must resolve blocking severity to P3
```

`applyReviewPolicy(&engine, "")` makes `resolveConfigFile("")` (`internal/cli/event_sink.go:157-165`) fall back to `config.DefaultPaths()` — the operator live `~/.gitmoot/config.toml`. This box config sets `[review] blocking_severity = "P2"`, so the `DefaultBlocking` (P3) assertion failed. CI passed only because its home has no `[review]` section: the test was green by coincidence, not by isolation. It also read `/root/.gitmoot`, which `AGENTS.md` forbids for tests.

## Fix

One `t.Setenv("HOME", t.TempDir())`, matching the convention already used by every sibling empty-home test in the package: `permission_policy_config_test.go:13,32,52`, `merge_gate_policy_test.go:134`, `daemon_home_shape_test.go:150`, `build_skew_test.go:319`. **Production code unchanged** — the `DefaultPaths()` fallback for an empty home is deliberate for CLI runs without `--home`.

## Class enumeration

Grepped every `config.DefaultPaths()` and empty-home call site under `internal/` and `cmd/` (13 matches, 11 files). `TestApplyReviewPolicyEmptyHomeIsOff`, added by #1693, is the **only** empty-home test missing the guard, so this is a one-site class.

## Verification (same commit, same binary, `-run` match count 1)

|arm|before|after|
|---|---|---|
|`HOME=/root` (live config, `P2`)|`FAIL`|`--- PASS` / `ok 0.040s`|
|`HOME=/tmp/nohome-probe` (no config)|`ok 0.013s`|`ok 0.033s`|

`go vet ./internal/cli/` clean. **Mutant:** repointing the isolation at `t.Setenv("HOME", "/root")` returns the package to `FAIL`, so the guard is load-bearing. Being a test-only change, that mutant necessarily targets the test isolation itself — it proves the assertion still discriminates, not anything about production behavior.

## Deploy notes

Test-only; no binary behavior change, no deploy or daemon restart needed.