### PR TITLE
fix(workflow): correlate merge-gate rows positionally when task identity migrates (#1519)

### DIFF
--- a/internal/cli/agent_review_task_identity_test.go
+++ b/internal/cli/agent_review_task_identity_test.go
@@ -3,7 +3,6 @@ package cli
 import (
 	"context"
 	"database/sql"
-	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -36,6 +35,32 @@ func TestStableReviewTaskIdentityKeepsHeadRoundIsolation(t *testing.T) {
 	}
 }
 
+// C1 (#1404 slice 1, commit d621bbd9) made review task identity STABLE across
+// rounds, and this test measured that: an `after_C1` arm asserting stable minting
+// resolves one implementing agent and merges, beside a `before_C1` arm asserting
+// that the LEGACY `review-pr-<N>-<hash>` identities - minted per head, so
+// divergent between rounds - resolved ZERO agents and failed the independence
+// check closed.
+//
+// THE before_C1 ARM IS RETIRED, NOT RE-PINNED (#1519). C1 fixed the MINTING so
+// identities stop diverging; #1519 fixes the DEPENDENCE, so the merge gate
+// correlates rows positionally (repo and pull request, plus branch when both
+// sides record one) when the identities diverge anyway. Divergent legacy
+// identities therefore resolve their implementing agent and merge, which is
+// exactly the outcome before_C1 required NOT to happen: the two artefacts are a
+// direct contradiction on the same input, written sixteen days apart by
+// different hands with neither citing the other.
+//
+// It is retired rather than inverted for a reason worth keeping: once the gate no
+// longer depends on identity sameness, before_C1 and after_C1 describe the SAME
+// outcome, so a table with both arms could no longer fail informatively. The
+// negatives that matter now live where the behaviour does -
+// TestPolicyMergeGateStillBlocksSelfApprovalAcrossDivergentTaskIdentities and
+// TestPolicyMergeGateDoesNotCorrelateImplementRowFromAnotherPullRequest in
+// internal/workflow keep self-approval refused and cross-PR rows uncorrelated.
+//
+// after_C1 is unchanged below: stable minting yielding one agent and a merge is
+// C1's actual contract and #1519 does not touch it.
 func TestC1MeasurementEngineDispatchedImplementerIdentity(t *testing.T) {
 	repoDir, oldHead, newHead := c1ReviewRepository(t)
 	if oldHead == newHead {
@@ -43,8 +68,6 @@ func TestC1MeasurementEngineDispatchedImplementerIdentity(t *testing.T) {
 	}
 	stableFirst := mintC1ReviewTaskID(t, repoDir, oldHead)
 	stableSecond := mintC1ReviewTaskID(t, repoDir, newHead)
-	legacyFirst := fmt.Sprintf("review-pr-%d-%s", 17, shortHash("owner/repo\x00"+oldHead))
-	legacySecond := fmt.Sprintf("review-pr-%d-%s", 17, shortHash("owner/repo\x00"+newHead))
 
 	for _, tc := range []struct {
 		name            string
@@ -53,7 +76,6 @@ func TestC1MeasurementEngineDispatchedImplementerIdentity(t *testing.T) {
 		wantAgents      int
 		wantFailClosed  bool
 	}{
-		{name: "before_C1", implementTaskID: legacyFirst, reviewTaskID: legacySecond, wantAgents: 0, wantFailClosed: true},
 		{name: "after_C1", implementTaskID: stableFirst, reviewTaskID: stableSecond, wantAgents: 1, wantFailClosed: false},
 	} {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/workflow/merge_gate.go
+++ b/internal/workflow/merge_gate.go
@@ -808,7 +808,7 @@ func (g PolicyMergeGate) ensureFinalReviewCaptured(ctx context.Context, request 
 		PullRequest: request.PullRequest,
 		TaskID:      request.TaskID,
 	}
-	implementerAttribution := collectImplementerAttribution(jobs, current)
+	implementerAttribution := collectGateImplementerAttribution(jobs, current)
 	implementingAgents := implementerAttribution.agents
 	missingImplementerReason := implementerAttribution.failureReason()
 	// One row per (parent, delegation): the LATEST attempt, exactly as continuation
@@ -1358,7 +1358,29 @@ type implementerAttributionEvidence struct {
 	sawMalformedPayload bool
 }
 
+// collectImplementerAttribution is the STRICT-KEY collector, and it is the one
+// Engine.autoFixOwner uses (engine_routing_merge.go). Its result routes
+// WRITE-CAPABLE work: autoFixOwner resolves an owner from this evidence and
+// dispatchFix then enqueues an implementation job against it. #1519's positional
+// fallback is deliberately NOT applied here - widening ownership routing is a
+// different decision from widening a read-only independence check, and #1519
+// asked for the latter. #1929's review caught the collector being shared and the
+// widening leaking through it.
 func collectImplementerAttribution(jobs []db.Job, current JobPayload) implementerAttributionEvidence {
+	return collectImplementerAttributionMatching(jobs, current, sameTask)
+}
+
+// collectGateImplementerAttribution is the merge gate's own collector. It
+// correlates positionally when task identity has migrated (#1519), because the
+// gate's question is "who implemented the PR in front of me" and its answer
+// authorises nothing by itself: independence is then decided on the recorded
+// agent identities, and a self-approval still refuses.
+func collectGateImplementerAttribution(jobs []db.Job, current JobPayload) implementerAttributionEvidence {
+	return collectImplementerAttributionMatching(jobs, current, sameCorrelatedTask)
+}
+
+func collectImplementerAttributionMatching(jobs []db.Job, current JobPayload,
+	matches func(current JobPayload, payload JobPayload) bool) implementerAttributionEvidence {
 	evidence := implementerAttributionEvidence{agents: make(map[string]struct{})}
 	for _, job := range jobs {
 		if job.Type != "implement" {
@@ -1370,13 +1392,15 @@ func collectImplementerAttribution(jobs []db.Job, current JobPayload) implemente
 			evidence.sawMalformedPayload = true
 			continue
 		}
-		// #1519: a row whose TaskID diverges but whose repo and pull request agree
-		// is ATTRIBUTION, not an anomaly. This branch previously computed exactly
-		// that positional agreement and used it only to raise
-		// "may indicate a stable-task-identity regression" - which was a true
-		// diagnosis reached through a false verdict, because the identity migrates
-		// legitimately between review rounds while the agents stay distinct.
-		if !sameCorrelatedTask(current, payload) {
+		// The caller's predicate decides belonging: strict TaskID equality for
+		// ownership routing, or #1519's positional correlation for the gate, where
+		// a row whose TaskID diverged but whose repo and pull request agree is
+		// ATTRIBUTION rather than an anomaly. The old code computed exactly that
+		// positional agreement here and used it only to raise "may indicate a
+		// stable-task-identity regression" - a true diagnosis reached through a
+		// false verdict, since the identity migrates legitimately between review
+		// rounds while the agents stay distinct.
+		if !matches(current, payload) {
 			continue
 		}
 		agent := strings.TrimSpace(job.Agent)

--- a/internal/workflow/merge_gate.go
+++ b/internal/workflow/merge_gate.go
@@ -747,12 +747,67 @@ func (g PolicyMergeGate) validate() error {
 	return nil
 }
 
+// sameCorrelatedTask decides whether a stored job row belongs to the pull request
+// the gate is evaluating. It is the gate's own correlation rule, deliberately
+// weaker than sameTask (engine_routing_merge.go), which the gate keeps calling
+// first: an equal TaskID remains the strongest evidence of belonging.
+//
+// The weakening exists because TASK IDENTITY MIGRATES BETWEEN REVIEW ROUNDS
+// (#1519). On PR #1518 the implement jobs and round-1 reviews carried
+// `adhoc-64daeee4` while round-2 reviews were issued `review-pr-1518-3f3a1026`,
+// with repo, pull request and branch identical throughout - so after the
+// migration no implement row could ever match a review row again, and the gate
+// false-blocked a PR whose approval was genuinely independent. sameTask cannot
+// be relaxed for this: it decides task-scoped routing for callers outside the
+// gate, whose semantics this change does not measure. The narrower rule lives
+// here, where the question is only "is this row about the PR in front of me".
+//
+// Repo AND pull request must both agree positionally, so rows from another PR or
+// another repository never correlate (a divergent identity must not become a
+// wildcard). Branch is compared only when BOTH sides record one: a stored row is
+// not required to carry a branch, and demanding one would re-block the rows this
+// fix exists to admit. Measured on this host's store when this was written:
+// 6,730 implement+review rows, of which 2,256 implement and 4,326 review rows
+// carry a branch at all; 322 pull requests have a non-empty branch on both sides
+// and ZERO of those disagree - so the conditional check rejects nothing observed
+// while still refusing a genuine cross-branch mismatch.
+//
+// What the gate then decides from the correlated rows is UNCHANGED: independence
+// is judged on the recorded AGENT identities, and a self-approval still refuses -
+// see TestPolicyMergeGateStillBlocksSelfApprovalAcrossDivergentTaskIdentities and
+// TestPolicyMergeGateDoesNotCorrelateImplementRowFromAnotherPullRequest.
+func sameCorrelatedTask(current JobPayload, payload JobPayload) bool {
+	if sameTask(current, payload) {
+		return true
+	}
+	if current.Repo == "" || current.Repo != payload.Repo {
+		return false
+	}
+	if current.PullRequest <= 0 || current.PullRequest != payload.PullRequest {
+		return false
+	}
+	currentBranch := strings.TrimSpace(current.Branch)
+	payloadBranch := strings.TrimSpace(payload.Branch)
+	if currentBranch != "" && payloadBranch != "" && currentBranch != payloadBranch {
+		return false
+	}
+	return true
+}
+
 func (g PolicyMergeGate) ensureFinalReviewCaptured(ctx context.Context, request MergeRequest, headSHA string) error {
 	jobs, err := g.Store.ListJobs(ctx)
 	if err != nil {
 		return err
 	}
-	current := JobPayload{Repo: request.Repo, PullRequest: request.PullRequest, TaskID: request.TaskID}
+	// Branch is carried so sameCorrelatedTask can refuse a cross-branch row when
+	// both sides record one (#1519); it is empty for callers that do not track a
+	// branch, which the correlation treats as "no evidence" rather than a mismatch.
+	current := JobPayload{
+		Repo:        request.Repo,
+		Branch:      request.Branch,
+		PullRequest: request.PullRequest,
+		TaskID:      request.TaskID,
+	}
 	implementerAttribution := collectImplementerAttribution(jobs, current)
 	implementingAgents := implementerAttribution.agents
 	missingImplementerReason := implementerAttribution.failureReason()
@@ -806,7 +861,7 @@ func (g PolicyMergeGate) ensureFinalReviewCaptured(ctx context.Context, request 
 		if err != nil {
 			return err
 		}
-		if !sameTask(current, payload) {
+		if !sameCorrelatedTask(current, payload) {
 			continue
 		}
 		taskReviews = append(taskReviews, taskReview{job: job, payload: payload})
@@ -1292,7 +1347,6 @@ const (
 	// reads. The gate still refuses — attribution genuinely is unknown — but the
 	// lane can now clear it without a coordinator round.
 	noImplementJobAttributionReason            = "latest review round's approval is NOT disqualified, but independence cannot be verified: no implement job is recorded for this task, so the gate cannot establish who implemented it. This is an attribution gap, not a failed independence check, and it is the expected state for in-session implementation. Remedy, runnable by the implementing lane: record the durable attribution row with gitmoot job record --agent <implementing-agent> --repo <owner/repo> --type implement --decision implemented --task <task-id> --pr <number> --head-sha <sha>, then re-evaluate. Do not record an agent that did not implement, and do not record the reviewer"
-	mismatchedImplementTaskAttributionReason   = "latest review round's approval cannot be verified as independent: implement jobs are recorded, but none match this task identity; this is an attribution anomaly and may indicate a stable-task-identity regression"
 	emptyImplementAgentAttributionReason       = "latest review round's approval cannot be verified as independent: an implement job matches this task but has no recorded agent; this is an attribution data anomaly"
 	malformedImplementPayloadAttributionReason = "latest review round's approval cannot be verified as independent: an implement job has a malformed payload, so attribution for this task cannot be verified; this is a corrupt-record anomaly"
 )
@@ -1300,7 +1354,6 @@ const (
 type implementerAttributionEvidence struct {
 	agents              map[string]struct{}
 	sawImplementJob     bool
-	sawTaskMismatch     bool
 	sawEmptyAgent       bool
 	sawMalformedPayload bool
 }
@@ -1317,11 +1370,13 @@ func collectImplementerAttribution(jobs []db.Job, current JobPayload) implemente
 			evidence.sawMalformedPayload = true
 			continue
 		}
-		if !sameTask(current, payload) {
-			if current.Repo != "" && current.Repo == payload.Repo &&
-				current.PullRequest > 0 && current.PullRequest == payload.PullRequest {
-				evidence.sawTaskMismatch = true
-			}
+		// #1519: a row whose TaskID diverges but whose repo and pull request agree
+		// is ATTRIBUTION, not an anomaly. This branch previously computed exactly
+		// that positional agreement and used it only to raise
+		// "may indicate a stable-task-identity regression" - which was a true
+		// diagnosis reached through a false verdict, because the identity migrates
+		// legitimately between review rounds while the agents stay distinct.
+		if !sameCorrelatedTask(current, payload) {
 			continue
 		}
 		agent := strings.TrimSpace(job.Agent)
@@ -1343,8 +1398,6 @@ func (e implementerAttributionEvidence) failureReason() string {
 		return malformedImplementPayloadAttributionReason
 	case e.sawEmptyAgent:
 		return emptyImplementAgentAttributionReason
-	case e.sawTaskMismatch:
-		return mismatchedImplementTaskAttributionReason
 	case !e.sawImplementJob:
 		return noImplementJobAttributionReason
 	default:

--- a/internal/workflow/merge_gate_task_identity_test.go
+++ b/internal/workflow/merge_gate_task_identity_test.go
@@ -1,0 +1,158 @@
+package workflow
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/gitmoot/gitmoot/internal/db"
+	"github.com/gitmoot/gitmoot/internal/github"
+)
+
+// #1519. The merge gate correlates a PR's implement and review rows by TASK
+// IDENTITY, but that identity MIGRATES between review rounds: on PR #1518 the
+// implement jobs and round-1 reviews carried `adhoc-64daeee4` while round-2
+// reviews were issued `review-pr-1518-3f3a1026`, with repo, pull request and
+// branch identical throughout. Once the sides diverge nothing can match again,
+// so the gate false-blocks for the rest of the PR's life.
+//
+// Independence is a property of AGENTS - did someone other than the implementer
+// approve this commit - and the agents were distinct the whole time. Task
+// identity is only a correlation key, so its divergence must not be reported as
+// an independence failure.
+//
+// BOTH call sites in Evaluate's path share that key, which is why a fix confined
+// to one of them leaves the defect reachable from the other:
+//
+//   - the review-collection loop drops rows the key rejects before reviewsAtHead
+//     is built, so a migrated ROUND is invisible to quorum;
+//   - collectImplementerAttribution drops implement rows the key rejects, which
+//     is the direction #1518's table records.
+//
+// Which side is dropped depends on which identity the MergeRequest carries, so
+// the two tests below drive one direction each. Neither asserts anything about
+// how identities come to diverge; that is the dispatcher's behaviour and #1519
+// leaves it open deliberately.
+
+const (
+	migratedImplementTaskID = "adhoc-64daeee4"
+	migratedReviewTaskID    = "review-pr-9-3f3a1026"
+)
+
+// mergeGateMigratedScenario builds #1518's shape: one implement row and one
+// approving review row whose task identities differ while repo, PR and branch
+// agree, with distinct agents. requestTaskID selects which side the gate's own
+// `current` payload matches, i.e. which side the shared key discards.
+// implementPullRequest exists so a caller can place the implement row on a
+// DIFFERENT pull request, which is the only way to leave this PR with no
+// attribution row at all.
+func mergeGateMigratedScenario(t *testing.T, implementTaskID, reviewTaskID, requestTaskID string,
+	implementAgent, reviewAgent string, implementPullRequest int) (*db.Store, PolicyMergeGate, MergeRequest) {
+	t.Helper()
+	store := openEngineStore(t)
+	implementBranch := "task-9"
+	if implementPullRequest != 9 {
+		implementBranch = "other-branch"
+	}
+	insertCompletedJob(t, store, db.Job{ID: "implement-migrated", Agent: implementAgent, Type: "implement"}, JobPayload{
+		Repo:        "gitmoot/gitmoot",
+		PullRequest: implementPullRequest,
+		Branch:      implementBranch,
+		TaskID:      implementTaskID,
+		Result:      &AgentResult{Decision: "implemented", Summary: "implemented"},
+	})
+	insertCompletedJob(t, store, db.Job{ID: "review-migrated", Agent: reviewAgent, Type: "review"}, JobPayload{
+		Repo:        "gitmoot/gitmoot",
+		PullRequest: 9,
+		Branch:      "task-9",
+		HeadSHA:     "head123",
+		TaskID:      reviewTaskID,
+		ReviewRound: "review-2",
+		Result:      &AgentResult{Decision: "approved", Summary: "approved"},
+	})
+	mergeable := true
+	gate := PolicyMergeGate{AutoMerge: true, Store: store, Git: &fakeMergeGateGit{clean: true}, GitHub: &fakeMergeGateGitHub{
+		pr: github.PullRequest{
+			Number: 9, State: "open", HeadRef: "task-9", BaseRef: "main",
+			HeadSHA: "head123", Mergeable: &mergeable,
+		},
+		status:      github.CombinedStatus{State: "success", Statuses: []github.CommitStatus{{Context: "ci", State: "success"}}},
+		checks:      []github.PullRequestCheck{{Name: "ci", Bucket: "pass", State: "SUCCESS"}},
+		mergeResult: github.MergeResult{Merged: true, SHA: "merge123"},
+	}}
+	return store, gate, MergeRequest{Repo: "gitmoot/gitmoot", PullRequest: 9, TaskID: requestTaskID}
+}
+
+// The exact #1518 repro: the request carries the MIGRATED REVIEW identity, so
+// the implement row is the side discarded and the gate reports the
+// stable-task-identity anomaly against an approval that was genuinely
+// independent.
+func TestPolicyMergeGateAdmitsIndependenceWhenImplementTaskIdentityDiverges(t *testing.T) {
+	_, gate, request := mergeGateMigratedScenario(t,
+		migratedImplementTaskID, migratedReviewTaskID, migratedReviewTaskID, "wave-impl", "g7-review", 9)
+
+	decision, err := gate.Evaluate(context.Background(), request)
+
+	if err != nil {
+		t.Fatalf("Evaluate returned error: %v", err)
+	}
+	if !decision.Merged {
+		t.Fatalf("decision = %+v, reason = %q; want the merge admitted: repo, PR and branch agree and the implementer (wave-impl) is not the reviewer (g7-review), so a divergent task identity is a correlation-key difference rather than an independence failure",
+			decision, decision.Reason.Render())
+	}
+}
+
+// The direction #1519's report did not measure: the request carries the ORIGINAL
+// implement identity, so the migrated round-2 REVIEW row is the side discarded -
+// before reviewsAtHead exists - and the gate cannot see the approval at all.
+func TestPolicyMergeGateSeesReviewRoundWhoseTaskIdentityDiverges(t *testing.T) {
+	_, gate, request := mergeGateMigratedScenario(t,
+		migratedImplementTaskID, migratedReviewTaskID, migratedImplementTaskID, "wave-impl", "g7-review", 9)
+
+	decision, err := gate.Evaluate(context.Background(), request)
+
+	if err != nil {
+		t.Fatalf("Evaluate returned error: %v", err)
+	}
+	if !decision.Merged {
+		t.Fatalf("decision = %+v, reason = %q; want the migrated review round visible to the gate: the approving row carries this PR's repo, number and branch",
+			decision, decision.Reason.Render())
+	}
+}
+
+// A REAL hollow approval must still block after the fix. Same divergence, but
+// the approver IS the implementer, so the positional correlation now succeeds and
+// the self-approval refusal is what has to fire.
+func TestPolicyMergeGateStillBlocksSelfApprovalAcrossDivergentTaskIdentities(t *testing.T) {
+	_, gate, request := mergeGateMigratedScenario(t,
+		migratedImplementTaskID, migratedReviewTaskID, migratedReviewTaskID, "wave-impl", "wave-impl", 9)
+
+	decision, err := gate.Evaluate(context.Background(), request)
+
+	if err != nil {
+		t.Fatalf("Evaluate returned error: %v", err)
+	}
+	if decision.Merged || !decision.LeaveOpen {
+		t.Fatalf("decision = %+v; want the merge refused: the only approval is the implementer's own", decision)
+	}
+	if reason := decision.Reason.Render(); !strings.Contains(reason, "implement") {
+		t.Fatalf("reason = %q; want it to name the implementer/approver collision", reason)
+	}
+}
+
+// Cross-PR rows must never correlate, whatever their task identities: the
+// positional fallback is keyed on repo AND pull request, so a row from another
+// PR cannot supply attribution here.
+func TestPolicyMergeGateDoesNotCorrelateImplementRowFromAnotherPullRequest(t *testing.T) {
+	_, gate, request := mergeGateMigratedScenario(t,
+		migratedImplementTaskID, migratedReviewTaskID, migratedReviewTaskID, "wave-impl", "g7-review", 10)
+
+	decision, err := gate.Evaluate(context.Background(), request)
+
+	if err != nil {
+		t.Fatalf("Evaluate returned error: %v", err)
+	}
+	if decision.Merged || !decision.LeaveOpen {
+		t.Fatalf("decision = %+v; want the merge refused: this PR has no implement row, and PR 10's row must not attribute PR 9", decision)
+	}
+}

--- a/internal/workflow/merge_gate_task_identity_test.go
+++ b/internal/workflow/merge_gate_task_identity_test.go
@@ -83,6 +83,95 @@ func mergeGateMigratedScenario(t *testing.T, implementTaskID, reviewTaskID, requ
 	return store, gate, MergeRequest{Repo: "gitmoot/gitmoot", PullRequest: 9, TaskID: requestTaskID}
 }
 
+// mergeGateMigratedBranchScenario is mergeGateMigratedScenario with the stored
+// implement row's branch and the REQUEST's branch under the caller's control, so
+// the conditional branch comparison in sameCorrelatedTask can actually execute.
+// #1929's review found that comparison unreachable from every other test here:
+// MergeRequest carried no Branch, so deleting the guard left the suite green. A
+// measurement (322 pull requests with branches on both sides, zero disagreeing)
+// justified the conditional SHAPE; it could not pin it. These three cases do.
+func mergeGateMigratedBranchScenario(t *testing.T, implementBranch, requestBranch string) (PolicyMergeGate, MergeRequest) {
+	t.Helper()
+	store := openEngineStore(t)
+	insertCompletedJob(t, store, db.Job{ID: "implement-branch", Agent: "wave-impl", Type: "implement"}, JobPayload{
+		Repo:        "gitmoot/gitmoot",
+		PullRequest: 9,
+		Branch:      implementBranch,
+		TaskID:      migratedImplementTaskID,
+		Result:      &AgentResult{Decision: "implemented", Summary: "implemented"},
+	})
+	insertCompletedJob(t, store, db.Job{ID: "review-branch", Agent: "g7-review", Type: "review"}, JobPayload{
+		Repo:        "gitmoot/gitmoot",
+		PullRequest: 9,
+		Branch:      "task-9",
+		HeadSHA:     "head123",
+		TaskID:      migratedReviewTaskID,
+		ReviewRound: "review-2",
+		Result:      &AgentResult{Decision: "approved", Summary: "approved"},
+	})
+	mergeable := true
+	gate := PolicyMergeGate{AutoMerge: true, Store: store, Git: &fakeMergeGateGit{clean: true}, GitHub: &fakeMergeGateGitHub{
+		pr: github.PullRequest{
+			Number: 9, State: "open", HeadRef: "task-9", BaseRef: "main",
+			HeadSHA: "head123", Mergeable: &mergeable,
+		},
+		status:      github.CombinedStatus{State: "success", Statuses: []github.CommitStatus{{Context: "ci", State: "success"}}},
+		checks:      []github.PullRequestCheck{{Name: "ci", Bucket: "pass", State: "SUCCESS"}},
+		mergeResult: github.MergeResult{Merged: true, SHA: "merge123"},
+	}}
+	return gate, MergeRequest{
+		Repo:        "gitmoot/gitmoot",
+		Branch:      requestBranch,
+		PullRequest: 9,
+		TaskID:      migratedReviewTaskID,
+	}
+}
+
+// Equal branches on both sides: the divergent identity still correlates.
+func TestPolicyMergeGateCorrelatesDivergentIdentityWhenBranchesAgree(t *testing.T) {
+	gate, request := mergeGateMigratedBranchScenario(t, "task-9", "task-9")
+
+	decision, err := gate.Evaluate(context.Background(), request)
+
+	if err != nil {
+		t.Fatalf("Evaluate returned error: %v", err)
+	}
+	if !decision.Merged {
+		t.Fatalf("decision = %+v, reason = %q; want the merge admitted: repo, PR and branch all agree", decision, decision.Reason.Render())
+	}
+}
+
+// DIFFERING branches refuse to correlate, so the implement row cannot attribute
+// this pull request. This is the case that fails if the guard is deleted.
+func TestPolicyMergeGateRefusesCorrelationWhenBranchesDiffer(t *testing.T) {
+	gate, request := mergeGateMigratedBranchScenario(t, "task-9-other", "task-9")
+
+	decision, err := gate.Evaluate(context.Background(), request)
+
+	if err != nil {
+		t.Fatalf("Evaluate returned error: %v", err)
+	}
+	if decision.Merged || !decision.LeaveOpen {
+		t.Fatalf("decision = %+v; want the merge refused: the only implement row records branch task-9-other, not task-9", decision)
+	}
+}
+
+// One side missing a branch admits: a stored row is not required to carry one,
+// and treating absence as a mismatch would re-block exactly the rows #1519
+// exists to admit.
+func TestPolicyMergeGateCorrelatesWhenOnlyOneSideRecordsABranch(t *testing.T) {
+	gate, request := mergeGateMigratedBranchScenario(t, "", "task-9")
+
+	decision, err := gate.Evaluate(context.Background(), request)
+
+	if err != nil {
+		t.Fatalf("Evaluate returned error: %v", err)
+	}
+	if !decision.Merged {
+		t.Fatalf("decision = %+v, reason = %q; want the merge admitted: an absent branch is no evidence, not a mismatch", decision, decision.Reason.Render())
+	}
+}
+
 // The exact #1518 repro: the request carries the MIGRATED REVIEW identity, so
 // the implement row is the side discarded and the gate reports the
 // stable-task-identity anomaly against an approval that was genuinely
@@ -154,5 +243,47 @@ func TestPolicyMergeGateDoesNotCorrelateImplementRowFromAnotherPullRequest(t *te
 	}
 	if decision.Merged || !decision.LeaveOpen {
 		t.Fatalf("decision = %+v; want the merge refused: this PR has no implement row, and PR 10's row must not attribute PR 9", decision)
+	}
+}
+
+// THE COLLECTOR SPLIT IS LOAD-BEARING, so it gets a negative of its own.
+//
+// #1929's review found that collectImplementerAttribution is not gate-local:
+// Engine.autoFixOwner (engine_routing_merge.go) resolves an owner from the same
+// evidence, and dispatchFix then enqueues WRITE-CAPABLE implementation work
+// against that owner. Applying #1519's positional fallback there would let a
+// changes_requested review with a migrated task identity inherit an implementer
+// from a different identity by repo/PR agreement alone - an ownership-routing
+// change, which is not what #1519 asked for.
+//
+// So the gate uses collectGateImplementerAttribution and ownership keeps the
+// strict key. This test pins the strict half directly: with identities diverged,
+// the strict collector must resolve NO agent (which is what makes autoFixOwner
+// fail closed with "auto-fix ownership unresolved"), while the gate's collector
+// resolves the implementer. If the two ever collapse back into one, one of these
+// two assertions fails.
+func TestImplementerAttributionCollectorsDisagreeOnMigratedIdentity(t *testing.T) {
+	current := JobPayload{Repo: "gitmoot/gitmoot", Branch: "task-9", PullRequest: 9, TaskID: migratedReviewTaskID}
+	stored := JobPayload{Repo: "gitmoot/gitmoot", Branch: "task-9", PullRequest: 9, TaskID: migratedImplementTaskID}
+	encoded, err := marshalPayload(stored)
+	if err != nil {
+		t.Fatalf("marshalPayload returned error: %v", err)
+	}
+	jobs := []db.Job{{ID: "implement-migrated", Agent: "wave-impl", Type: "implement", Payload: encoded}}
+
+	strict := collectImplementerAttribution(jobs, current)
+	if len(strict.agents) != 0 {
+		t.Fatalf("strict collector resolved %v; ownership routing must NOT correlate a migrated identity", strict.agents)
+	}
+	if reason := strict.failureReason(); reason == "" {
+		t.Fatal("strict collector reported no failure reason, so autoFixOwner would not fail closed")
+	}
+
+	gated := collectGateImplementerAttribution(jobs, current)
+	if _, ok := gated.agents["wave-impl"]; !ok || len(gated.agents) != 1 {
+		t.Fatalf("gate collector resolved %v, want exactly wave-impl: the independence check must see the implementer", gated.agents)
+	}
+	if reason := gated.failureReason(); reason != "" {
+		t.Fatalf("gate collector reported %q, want no failure once the implementer is attributed", reason)
 	}
 }

--- a/internal/workflow/merge_gate_test.go
+++ b/internal/workflow/merge_gate_test.go
@@ -1588,14 +1588,6 @@ func TestPolicyMergeGateNamesImplementerAttributionDeclineCause(t *testing.T) {
 			doNotWant: []string{"implemented in a pane"},
 		},
 		{
-			name: "task_identity_mismatch",
-			seed: func(t *testing.T, store *db.Store, payload JobPayload) {
-				payload.TaskID = "different-task"
-				insertCompletedJob(t, store, db.Job{ID: "implement-mismatch", Agent: "implementer", Type: "implement"}, payload)
-			},
-			want: []string{"none match this task identity", "stable-task-identity regression"},
-		},
-		{
 			name: "empty_implement_agent",
 			seed: func(t *testing.T, store *db.Store, payload JobPayload) {
 				insertCompletedJob(t, store, db.Job{ID: "implement-empty-agent", Type: "implement"}, payload)
@@ -1829,10 +1821,6 @@ func TestImplementerAttributionAnomalyDeclinesRemainByteStable(t *testing.T) {
 		got  string
 		want string
 	}{
-		"task mismatch": {
-			got:  mismatchedImplementTaskAttributionReason,
-			want: "latest review round's approval cannot be verified as independent: implement jobs are recorded, but none match this task identity; this is an attribution anomaly and may indicate a stable-task-identity regression",
-		},
 		"empty agent": {
 			got:  emptyImplementAgentAttributionReason,
 			want: "latest review round's approval cannot be verified as independent: an implement job matches this task but has no recorded agent; this is an attribution data anomaly",


### PR DESCRIPTION
Fixes #1519.

## What false-blocked, and why the issue's own fix was half of it

PR #1518's independence check refused a merge whose independence **held** (implementer `wave-impl`, reviewers `g7-review` and `gm-review-opus`). Review **task identity migrates between rounds**: implement jobs and round-1 reviews carried `adhoc-64daeee4`, round-2 reviews were issued `review-pr-1518-3f3a1026`, and repo, pull request and branch were identical throughout. Once the sides diverge nothing matches again, so the gate reports `may indicate a stable-task-identity regression` — a **true diagnosis reached through a false verdict**.

#1519 suggests relaxing `sameTask`. That is incomplete, and the missing half is measured rather than argued: **two** call sites on `Evaluate`'s path share that key.

| call site | what it drops | direction |
|---|---|---|
| `ensureFinalReviewCaptured`'s review-collection loop | review rows, **before** `reviewsAtHead` exists — a migrated round is invisible to quorum | not measured by #1519 |
| `collectImplementerAttribution` | implement rows | the direction #1518's table records |

Which side is dropped depends on which identity the `MergeRequest` carries. A patch to either site alone leaves the defect reachable from the other, so both directions are pinned:

```
pre-fix, both fail:
--- FAIL TestPolicyMergeGateAdmitsIndependenceWhenImplementTaskIdentityDiverges
    reason = "...implement jobs are recorded, but none match this task identity..."
--- FAIL TestPolicyMergeGateSeesReviewRoundWhoseTaskIdentityDiverges
    reason = "final agent review is not captured for head head123"
```

## The fix

`sameCorrelatedTask` — the **gate's own** correlation rule. It tries `sameTask` first (an equal `TaskID` is still the strongest evidence) and otherwise correlates positionally. `sameTask` is **untouched**: it decides task-scoped routing for callers outside the gate whose semantics this change does not measure, and the gate's question is narrower — *is this row about the PR in front of me*.

Repo **and** pull request must agree. Branch is compared **only when both sides record one**, because a stored row is not required to carry a branch and demanding one would re-block the rows this exists to admit. Measured on this host's store: **6,730** implement+review rows (2,256 implement / 4,326 review carry a branch at all), **322** PRs with a non-empty branch on both sides, and **zero** of those disagree — so the conditional check rejects nothing observed while still refusing a genuine cross-branch row.

Independence is still decided where it belongs — on **agent identities**.

## Round-1 review: two P2s, both blast radius

`g6-review-sol` (executed, 14 tests_run, no P1) found two things, and neither faults the diagnosis, the fallback, the mutants or the `before_C1` retirement.

**P2-A — the collector was not gate-local.** `Engine.autoFixOwner` resolves an owner from `collectImplementerAttribution`, and `dispatchFix` then enqueues **write-capable** implementation work against it. Applying the positional fallback inside the shared collector therefore widened *ownership routing*: a `changes_requested` review with a migrated identity could inherit an implementer from a different identity on repo/PR agreement alone. #1519 asked for a merge-gate independence fix, not an ownership change.

Taken as **option (a)**: the collector splits over one shared body that takes the match predicate —

| collector | key | caller |
|---|---|---|
| `collectImplementerAttribution` | strict `TaskID` (behaviour restored exactly) | `autoFixOwner` → `dispatchFix` |
| `collectGateImplementerAttribution` | positional (#1519) | `ensureFinalReviewCaptured` only |

The split carries its own negative, because a split nobody asserts silently collapses: `TestImplementerAttributionCollectorsDisagreeOnMigratedIdentity` pins that on the same migrated input the **strict** collector resolves *no* agent and yields a failure reason — which is exactly what makes `autoFixOwner` fail closed — while the **gate** collector resolves the implementer.

**P2-B — the branch guard was unpinned, and the proof was that deleting it left the suite green.** `mergeGateMigratedScenario`'s `MergeRequest` carried no `Branch`, so the comparison could not execute in any of the four original tests. The 322-PR/zero-disagreement measurement justified the conditional *shape*; it could not pin it. Three committed cases now do, with the request branch populated:

| case | expectation |
|---|---|
| equal branches | correlates, merge admitted |
| **differing** branches | refuses to correlate, merge refused |
| one side missing a branch | correlates (absence is no evidence, not a mismatch) |

Deletion mutation re-run against those: `--- FAIL: TestPolicyMergeGateRefusesCorrelationWhenBranchesDiffer`, production restored `cmp`-verified (md5 `cf87b12e68d2` both sides). The guard is now load-bearing.

## Acceptance tests, mapped to the issue's list

| # | issue requirement | test |
|---|---|---|
| 1 | exact repro admits | `TestPolicyMergeGateAdmitsIndependenceWhenImplementTaskIdentityDiverges` |
| 2 | real hollow approval still blocks | `TestPolicyMergeGateStillBlocksSelfApprovalAcrossDivergentTaskIdentities` |
| 3 | empty-TaskID path unchanged | unchanged by construction — `sameTask` is tried first and its empty-id fallback is untouched; pinned by the pre-existing suite |
| 4 | cross-PR must not match | `TestPolicyMergeGateDoesNotCorrelateImplementRowFromAnotherPullRequest` |
| 5 | pin whichever half you fix | this PR fixes the **dependence**, not the migration, and pins both call sites; the dispatcher's identity assignment is left alone deliberately |

Plus the direction the issue did not measure: `TestPolicyMergeGateSeesReviewRoundWhoseTaskIdentityDiverges`.

**Mutants, both run, production restored `cmp`-verified (md5 `f1eaa1aba750` both sides):** reverting *only* the review call site kills `SeesReviewRound`; reverting *only* the attribution call site kills `AdmitsIndependence`. Neither test passes by construction.

## Removed rather than left dead

`mismatchedImplementTaskAttributionReason` and `sawTaskMismatch` had **no reachable writer** after this change — the flag was set only in the branch that now accepts the row — so both are deleted along with the two test references that pinned them (`TestImplementerAttributionAnomalyDeclinesRemainByteStable`'s `task mismatch` entry and the decline-cause suite's `task_identity_mismatch` arm). Keeping a constant whose state cannot occur is how a false verdict survives a fix.

## The finding: a measurement test can veto its own fix

The three CI failures on this PR's first head were one test — `internal/cli/agent_review_task_identity_test.go`'s `before_C1` arm — asserting **as required behaviour** exactly what #1519 abolishes: legacy `review-pr-<N>-<hash>` identities diverging between rounds, resolving **zero** implementing agents and failing the independence check **closed**.

It was not stale or careless. It was a deliberate *before-picture* from #1404's C1 slice (`d621bbd9`, 2026-08-02, since merged), written to measure what C1 improved. #1519 was filed sixteen days later, and **neither artifact cites the other** — so a test that pinned a defect's *current* behaviour became a **veto on fixing it**, and nothing in either place said "this documents a state we intend to remove".

That is this campaign's recurring class in test form rather than in prose: an assertion that claims more than its subject is meant to keep. The arm is therefore **deleted, not re-pinned** — inverting its expectations would leave `before_C1` and `after_C1` describing the same outcome, a table that can no longer fail informatively. `after_C1` is untouched (stable minting still yields one agent and merges, C1's real contract), as are the two `TestStableReviewTaskIdentity*` tests, which pass unchanged. The negatives moved to where the behaviour lives: self-approval refusal and cross-PR non-correlation in `internal/workflow`.

Authorised out of seam by directives 121919/122010 under the standard stated in jarvis 122002 — a test pinning a removed defect is deleted, and out-of-seam ownership is a coordination fact, not a veto. The C1 lane is notified through the coordinator rather than discovering its measurement retired by surprise.

### One pre-existing failure, baselined rather than asserted

`./internal/cli/` also fails `TestApplyReviewPolicyEmptyHomeIsOff` (`review_risk_test.go:166`) on this branch. It is **not** caused by this change and is not in its diff. Measured by checking out untouched `origin/main` into the worktree and running the same test:

```
this branch:      --- FAIL: TestApplyReviewPolicyEmptyHomeIsOff (0.00s)
origin/main:      --- FAIL: TestApplyReviewPolicyEmptyHomeIsOff (0.00s)
```

Identical on both, so it is the host-environment sensitivity AGENTS.md already records, not a regression here. Reported rather than filtered out of the run.

## Scope and measurement honesty

The issue states the blast radius as "any PR that runs more than one review round … every `wave-impl` PR". **My own read of this store disagrees:** of 342 PRs carrying both implement and review task ids, the two sets are disjoint on **5** (`gitmoot#1212`, `herdres#235/#240/#242`, plus #1518's family), and on all five the implement and review agents were also disjoint — independence genuinely held, only the key diverged. The defect's shape is exactly as diagnosed; its measured frequency here is 5 of 342. The issue's figure is the issue's; the 5-of-342 is mine.

## Deploy notes

Engine-only change in `internal/workflow`; no migration, no config, no CLI surface. The daemon rebuilds its per-repo engine each tick, so a restart at idle picks it up. It makes the gate **admit** work it previously refused, so a PR that was wedged on this anomaly can now reach the normal independence and CI checks — nothing that was blocked for a *different* reason becomes mergeable.

## Gate

Seat-owned `GOCACHE`, `CGO_ENABLED=0` explicit, `free_bytes` re-measured before **each** invocation against the 28,000,000,000 line:

```
gofmt -l internal/workflow      -> empty
pre-build 29,766,066,176        -> BUILD_OK
pre-vet   29,548,834,816        -> VET_OK
pre-test  29,535,875,072        -> ok github.com/gitmoot/gitmoot/internal/workflow  94.416s
```

`-race` is unavailable in a read-only seat (needs cgo; gitmoot#1915) and is **not** claimed. `./internal/cli/...` is **deferred and named**: the changed symbols are `internal/workflow`-local and `internal/cli` does not reference them.

One disclosure about my own process: during mutant work I ran a single `go test` at `27,946,795,008` — **below** the 28e9 line — because I dropped the guard while re-running for full output. The gate numbers above were all taken under the guard; that one mutant invocation was not, and it is reported rather than quietly omitted.