### PR TITLE
fix(db): refuse a findings-ledger observation with no explicit severity (#1928)

### DIFF
--- a/internal/db/review_findings.go
+++ b/internal/db/review_findings.go
@@ -9,6 +9,8 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/gitmoot/gitmoot/internal/reviewseverity"
 )
 
 // The #1822 findings ledger. One row per (finding, head) OBSERVATION, never one
@@ -116,6 +118,14 @@ var (
 	// ErrFindingObservedAt rejects a malformed caller timestamp.
 	ErrFindingObservedAt       = errors.New("observed_at must be RFC3339 when supplied")
 	ErrFindingUnknownContinues = errors.New("continues_uid does not name an existing finding")
+	// ErrFindingSeverity rejects a row no severity policy could ever disposition
+	// (#1928). Three rows for jerryfane/joltra#831 persisted with severity "",
+	// and an empty severity is NOT P3: it is an obligation that fails closed
+	// forever, because reviewseverity.Blocks treats an unrankable value as
+	// blocking. Defaulting it here would be worse than refusing - it would
+	// silently downgrade an unknown-severity defect to the least severe class at
+	// the one boundary that still knows the value was missing.
+	ErrFindingSeverity = errors.New("finding observation requires an explicit severity of P0, P1, P2 or P3")
 )
 
 var (
@@ -185,6 +195,15 @@ func (s *Store) RecordReviewFindingObservation(ctx context.Context, obs ReviewFi
 	repo := strings.TrimSpace(obs.Repo)
 	if repo == "" {
 		return "", errors.New("finding observation requires a repo")
+	}
+	// SEVERITY IS VALIDATED AT THE WRITE BOUNDARY, alongside head and state,
+	// because this is the last point that can tell a missing severity from a
+	// chosen one. Legacy empty-severity rows already in the ledger are NOT
+	// touched and NOT auto-dismissed: they stay fail-closed obligations until a
+	// reviewer observes them explicitly.
+	severity := strings.TrimSpace(obs.Severity)
+	if !reviewseverity.Valid(severity) {
+		return "", fmt.Errorf("%w: got %q", ErrFindingSeverity, obs.Severity)
 	}
 	switch obs.State {
 	case FindingOpen, FindingAnswered, FindingSuperseded:
@@ -339,7 +358,7 @@ func (s *Store) RecordReviewFindingObservation(ctx context.Context, obs ReviewFi
 	evidence_locator, rationale, source_job, withdraw_reason)
 VALUES (?, ?, ?, ?, COALESCE(NULLIF(?, ''), strftime('%Y-%m-%dT%H:%M:%fZ','now')), ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 		uid, repo, obs.PullRequest, head, strings.TrimSpace(obs.ObservedAt), obs.ObserverJob, string(obs.State),
-		obs.Severity, obs.RoundLabel, labelAbsent, obs.Title, obs.Detail, obs.File, obs.Line,
+		severity, obs.RoundLabel, labelAbsent, obs.Title, obs.Detail, obs.File, obs.Line,
 		string(keys), string(obs.EvidenceKind), string(cmds), obs.ExecutedCount,
 		obs.EvidenceLocator, obs.Rationale, obs.SourceJob, obs.WithdrawReason); err != nil {
 		// The key is (finding_uid, head_sha, observer_job), so this fires only for a

--- a/internal/db/review_findings_schema_test.go
+++ b/internal/db/review_findings_schema_test.go
@@ -58,7 +58,7 @@ func TestReviewFindingListReportsCorruptRelevanceKeys(t *testing.T) {
 	head := strings.Repeat("a", 40)
 	if _, err := store.RecordReviewFindingObservation(ctx, ReviewFindingObservation{
 		Repo: "owner/repo", PullRequest: 7, HeadSHA: head, ObserverJob: "review-1",
-		State: FindingOpen, Title: "t", File: "internal/run.go",
+		State: FindingOpen, Severity: "P2", Title: "t", File: "internal/run.go",
 		EvidenceKind: EvidenceExecuted, ExecutedCommands: []string{"probe"}, ExecutedCount: 1,
 	}); err != nil {
 		t.Fatalf("seed: %v", err)

--- a/internal/db/review_findings_severity_test.go
+++ b/internal/db/review_findings_severity_test.go
@@ -1,0 +1,112 @@
+package db
+
+import (
+	"context"
+	"errors"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestRecordReviewFindingObservationRefusesUnrankableSeverity is issue #1928's
+// acceptance criteria 1, 2 and 5 through the PRODUCTION write path.
+//
+// MEASURED DEFECT: three persisted rows for jerryfane/joltra#831 carry
+// severity "" (#831-f1..f3 at head 6360ab56, observer
+// local-review-joltra-sol-review-18d2814edd22159c). An empty severity is not
+// P3, and no severity policy can disposition it later - the row is an
+// obligation that can only ever fail closed. Every other caller-asserted field
+// on this boundary (head, state, observed_at, evidence) is already refused when
+// it cannot be trusted; severity was the one that was not.
+//
+// A DEFAULT WOULD BE WORSE THAN A REFUSAL. This boundary is the last point that
+// can still tell a missing severity from a chosen one, so defaulting to P3 here
+// would silently downgrade an unknown-severity defect at exactly the moment the
+// information still exists.
+func TestRecordReviewFindingObservationRefusesUnrankableSeverity(t *testing.T) {
+	ctx := context.Background()
+	store, err := openCachedTestStore(t, filepath.Join(t.TempDir(), "gitmoot.db"))
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	head := strings.Repeat("a", 40)
+	base := func(severity string, observer string) ReviewFindingObservation {
+		return ReviewFindingObservation{
+			Repo: "owner/repo", PullRequest: 831, HeadSHA: head, ObserverJob: observer,
+			State: FindingOpen, Severity: severity, Title: "t", Detail: "d",
+			File: "internal/db/review_findings.go", EvidenceKind: EvidenceExecuted,
+			ExecutedCommands: []string{"go test ./internal/db/"}, ExecutedCount: 1,
+		}
+	}
+
+	// The reproduction: the exact shape that produced the joltra#831 rows.
+	for _, severity := range []string{"", "   ", "p1", "P4", "critical", "unknown"} {
+		uid, err := store.RecordReviewFindingObservation(ctx, base(severity, "review-refused"))
+		if !errors.Is(err, ErrFindingSeverity) {
+			t.Errorf("severity %q was accepted or misreported: uid=%q err=%v; the ledger would hold a row no severity policy can disposition", severity, uid, err)
+		}
+		if uid != "" {
+			t.Errorf("severity %q minted uid %q; a refused observation must not consume identity", severity, uid)
+		}
+		// The caller must be able to act on it: the error names the value it got.
+		if err != nil && !strings.Contains(err.Error(), "severity") {
+			t.Errorf("refusal for %q does not name severity: %v", severity, err)
+		}
+	}
+
+	// PASSING CONTROL, so a green test cannot mean "the boundary refuses
+	// everything": every canonical severity is still accepted, and surrounding
+	// whitespace normalises rather than failing.
+	for i, severity := range []string{"P0", "P1", "P2", "P3", " P2 "} {
+		uid, err := store.RecordReviewFindingObservation(ctx, base(severity, "review-accepted-"+severity))
+		if err != nil {
+			t.Fatalf("canonical severity %q was refused: %v", severity, err)
+		}
+		if uid == "" {
+			t.Fatalf("canonical severity %q minted no uid", severity)
+		}
+		var stored string
+		if err := store.db.QueryRowContext(ctx, `SELECT severity FROM review_finding_observations WHERE finding_uid = ?`, uid).Scan(&stored); err != nil {
+			t.Fatalf("read back %q: %v", uid, err)
+		}
+		if stored != strings.TrimSpace(severity) {
+			t.Errorf("row %d stored severity %q, want %q", i, stored, strings.TrimSpace(severity))
+		}
+	}
+}
+
+// TestLegacyEmptySeverityRowsStayFailClosedObligations is acceptance criterion 4.
+//
+// The rows already in the ledger must NOT be repaired, defaulted or dismissed by
+// this change: a legacy empty-severity finding stays an obligation until a
+// reviewer observes it explicitly. The insert goes straight to SQL because the
+// Go boundary now refuses this shape - which is the point: the only way such a
+// row can exist is from before the refusal, so that is how the fixture is built.
+func TestLegacyEmptySeverityRowsStayFailClosedObligations(t *testing.T) {
+	ctx := context.Background()
+	store, err := openCachedTestStore(t, filepath.Join(t.TempDir(), "gitmoot.db"))
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	head := strings.Repeat("b", 40)
+	if _, err := store.db.ExecContext(ctx, `INSERT INTO review_finding_observations(
+		finding_uid, repo, pull_request, head_sha, observer_job, state, severity, evidence_kind)
+		VALUES ('owner/repo#831-f1', 'owner/repo', 831, ?, 'legacy-review', 'open', '', 'EXECUTED')`, head); err != nil {
+		t.Fatalf("seed legacy row: %v", err)
+	}
+
+	observations, err := store.ListReviewFindingObservations(ctx, "owner/repo", 831)
+	if err != nil {
+		t.Fatalf("list observations: %v", err)
+	}
+	if len(observations) != 1 {
+		t.Fatalf("legacy row count = %d, want 1: a legacy row must remain readable rather than be filtered out of existence", len(observations))
+	}
+	legacy := observations[0]
+	if legacy.Severity != "" {
+		t.Errorf("legacy severity was rewritten to %q; this change must not repair existing rows", legacy.Severity)
+	}
+	if legacy.State != FindingOpen {
+		t.Errorf("legacy state = %q, want open: an empty severity must never auto-dismiss the obligation", legacy.State)
+	}
+}

--- a/internal/workflow/findings_ledger_remediation_test.go
+++ b/internal/workflow/findings_ledger_remediation_test.go
@@ -38,7 +38,8 @@ func TestLedgerQuotedObservationCannotSilenceAnOpenFinding(t *testing.T) {
 	headA, headB, headC := strings.Repeat("a", 40), strings.Repeat("b", 40), strings.Repeat("c", 40)
 	uid := seedOpenFinding(t, store, headA)
 	if _, err := store.RecordReviewFindingObservation(ctx, db.ReviewFindingObservation{
-		Repo: "owner/repo", PullRequest: 7, HeadSHA: headB, ObserverJob: "review-2",
+		Severity: "P2",
+		Repo:     "owner/repo", PullRequest: 7, HeadSHA: headB, ObserverJob: "review-2",
 		ContinuesUID: uid, State: db.FindingOpen, Title: "the defect", File: "internal/run.go",
 		EvidenceKind: db.EvidenceQuoted, SourceJob: "review-1",
 	}); err != nil {
@@ -62,7 +63,8 @@ func TestLedgerExecutedObservationDischargesAtThatHead(t *testing.T) {
 	headA, headB := strings.Repeat("a", 40), strings.Repeat("b", 40)
 	uid := seedOpenFinding(t, store, headA)
 	if _, err := store.RecordReviewFindingObservation(ctx, db.ReviewFindingObservation{
-		Repo: "owner/repo", PullRequest: 7, HeadSHA: headB, ObserverJob: "review-2",
+		Severity: "P2",
+		Repo:     "owner/repo", PullRequest: 7, HeadSHA: headB, ObserverJob: "review-2",
 		ContinuesUID: uid, State: db.FindingAnswered, Title: "the defect", File: "internal/run.go",
 		EvidenceKind: db.EvidenceExecuted, ExecutedCommands: []string{"go test ./internal/ -> ok"}, ExecutedCount: 1,
 	}); err != nil {
@@ -130,7 +132,8 @@ func TestLedgerStaticDischargeIsReArmedWhenItsLocatorIsGone(t *testing.T) {
 	headA, headB := strings.Repeat("a", 40), strings.Repeat("b", 40)
 	uid := seedOpenFinding(t, store, headA)
 	if _, err := store.RecordReviewFindingObservation(ctx, db.ReviewFindingObservation{
-		Repo: "owner/repo", PullRequest: 7, HeadSHA: headA, ObserverJob: "review-2",
+		Severity: "P2",
+		Repo:     "owner/repo", PullRequest: 7, HeadSHA: headA, ObserverJob: "review-2",
 		ContinuesUID: uid, State: db.FindingAnswered, Title: "the defect", File: "internal/run.go",
 		EvidenceKind: db.EvidenceStatic, EvidenceLocator: "internal/gone.go:9999",
 		Rationale: "the guard now lives here",
@@ -171,7 +174,8 @@ func TestLedgerRefusesASymbolRelevanceKey(t *testing.T) {
 	ctx := context.Background()
 	store := openEngineStore(t)
 	_, err := store.RecordReviewFindingObservation(ctx, db.ReviewFindingObservation{
-		Repo: "owner/repo", PullRequest: 7, HeadSHA: strings.Repeat("a", 40), ObserverJob: "review-1",
+		Severity: "P2",
+		Repo:     "owner/repo", PullRequest: 7, HeadSHA: strings.Repeat("a", 40), ObserverJob: "review-1",
 		State: db.FindingOpen, Title: "t", File: "internal/run.go",
 		RelevanceKeys: []string{"EnsureLedgerObligationsObserved()"},
 		EvidenceKind:  db.EvidenceExecuted, ExecutedCommands: []string{"probe"}, ExecutedCount: 1,
@@ -188,7 +192,8 @@ func TestLedgerRefusesAReasonlessWithdrawal(t *testing.T) {
 	ctx := context.Background()
 	store := openEngineStore(t)
 	_, err := store.RecordReviewFindingObservation(ctx, db.ReviewFindingObservation{
-		Repo: "owner/repo", PullRequest: 7, HeadSHA: strings.Repeat("a", 40), ObserverJob: "review-1",
+		Severity: "P2",
+		Repo:     "owner/repo", PullRequest: 7, HeadSHA: strings.Repeat("a", 40), ObserverJob: "review-1",
 		State: db.FindingWithdrawn, Title: "t", File: "internal/run.go",
 		EvidenceKind: db.EvidenceStatic, EvidenceLocator: "a", Rationale: "n",
 	})
@@ -206,7 +211,8 @@ func TestLedgerFoldIgnoresACallerSuppliedFutureTimestamp(t *testing.T) {
 	headA, headB := strings.Repeat("a", 40), strings.Repeat("b", 40)
 	uid := seedOpenFinding(t, store, headA)
 	if _, err := store.RecordReviewFindingObservation(ctx, db.ReviewFindingObservation{
-		Repo: "owner/repo", PullRequest: 7, HeadSHA: headA, ObserverJob: "review-2",
+		Severity: "P2",
+		Repo:     "owner/repo", PullRequest: 7, HeadSHA: headA, ObserverJob: "review-2",
 		ContinuesUID: uid, State: db.FindingAnswered, Title: "t", File: "internal/run.go",
 		ObservedAt:   "9999-01-01T00:00:00Z",
 		EvidenceKind: db.EvidenceExecuted, ExecutedCommands: []string{"go test -> ok"}, ExecutedCount: 1,
@@ -214,7 +220,8 @@ func TestLedgerFoldIgnoresACallerSuppliedFutureTimestamp(t *testing.T) {
 		t.Fatalf("a valid RFC3339 stamp must be accepted: %v", err)
 	}
 	if _, err := store.RecordReviewFindingObservation(ctx, db.ReviewFindingObservation{
-		Repo: "owner/repo", PullRequest: 7, HeadSHA: headA, ObserverJob: "review-3",
+		Severity: "P2",
+		Repo:     "owner/repo", PullRequest: 7, HeadSHA: headA, ObserverJob: "review-3",
 		ContinuesUID: uid, State: db.FindingOpen, Title: "t", File: "internal/run.go",
 		EvidenceKind: db.EvidenceExecuted, ExecutedCommands: []string{"go test -> FAIL"}, ExecutedCount: 1,
 	}); err != nil {
@@ -224,7 +231,8 @@ func TestLedgerFoldIgnoresACallerSuppliedFutureTimestamp(t *testing.T) {
 		t.Fatal("the future-stamped answer won the fold, so a reopened finding read as answered")
 	}
 	_, bad := store.RecordReviewFindingObservation(ctx, db.ReviewFindingObservation{
-		Repo: "owner/repo", PullRequest: 7, HeadSHA: headB, ObserverJob: "review-4",
+		Severity: "P2",
+		Repo:     "owner/repo", PullRequest: 7, HeadSHA: headB, ObserverJob: "review-4",
 		State: db.FindingOpen, Title: "t", File: "internal/run.go", ObservedAt: "not-a-time",
 		EvidenceKind: db.EvidenceExecuted, ExecutedCommands: []string{"probe"}, ExecutedCount: 1,
 	})
@@ -242,7 +250,8 @@ func TestLedgerAdmitsASecondReviewerAtTheSameHead(t *testing.T) {
 	head := strings.Repeat("a", 40)
 	uid := seedOpenFinding(t, store, head)
 	second := db.ReviewFindingObservation{
-		Repo: "owner/repo", PullRequest: 7, HeadSHA: head, ObserverJob: "reviewer-b",
+		Severity: "P2",
+		Repo:     "owner/repo", PullRequest: 7, HeadSHA: head, ObserverJob: "reviewer-b",
 		ContinuesUID: uid, State: db.FindingOpen, Title: "still broken", File: "internal/run.go",
 		EvidenceKind: db.EvidenceExecuted, ExecutedCommands: []string{"go test -> FAIL"}, ExecutedCount: 1,
 	}
@@ -267,7 +276,8 @@ func TestLedgerQuotedMentionDoesNotReopenAnAnsweredFinding(t *testing.T) {
 	headA, headB, headC := strings.Repeat("a", 40), strings.Repeat("b", 40), strings.Repeat("c", 40)
 	uid := seedOpenFinding(t, store, headA)
 	if _, err := store.RecordReviewFindingObservation(ctx, db.ReviewFindingObservation{
-		Repo: "owner/repo", PullRequest: 7, HeadSHA: headA, ObserverJob: "review-2",
+		Severity: "P2",
+		Repo:     "owner/repo", PullRequest: 7, HeadSHA: headA, ObserverJob: "review-2",
 		ContinuesUID: uid, State: db.FindingAnswered, Title: "the defect", File: "internal/run.go",
 		EvidenceKind: db.EvidenceExecuted, ExecutedCommands: []string{"go test -> ok"}, ExecutedCount: 1,
 	}); err != nil {
@@ -276,7 +286,8 @@ func TestLedgerQuotedMentionDoesNotReopenAnAnsweredFinding(t *testing.T) {
 	// A later round merely QUOTES it for context. Nothing was re-checked and
 	// nothing was re-broken.
 	if _, err := store.RecordReviewFindingObservation(ctx, db.ReviewFindingObservation{
-		Repo: "owner/repo", PullRequest: 7, HeadSHA: headB, ObserverJob: "review-3",
+		Severity: "P2",
+		Repo:     "owner/repo", PullRequest: 7, HeadSHA: headB, ObserverJob: "review-3",
 		ContinuesUID: uid, State: db.FindingOpen, Title: "the defect", File: "internal/run.go",
 		EvidenceKind: db.EvidenceQuoted, SourceJob: "review-2",
 	}); err != nil {
@@ -300,7 +311,8 @@ func TestLedgerRefusesSymbolKeysAndAcceptsRealPaths(t *testing.T) {
 	head := strings.Repeat("a", 40)
 	record := func(key string) error {
 		_, err := store.RecordReviewFindingObservation(ctx, db.ReviewFindingObservation{
-			Repo: "owner/repo", PullRequest: 7, HeadSHA: head, ObserverJob: "review-" + key,
+			Severity: "P2",
+			Repo:     "owner/repo", PullRequest: 7, HeadSHA: head, ObserverJob: "review-" + key,
 			State: db.FindingOpen, Title: "t", File: "internal/run.go",
 			RelevanceKeys: []string{key},
 			EvidenceKind:  db.EvidenceExecuted, ExecutedCommands: []string{"probe"}, ExecutedCount: 1,
@@ -379,7 +391,8 @@ func TestLedgerScopeDegradesWhenLocatorResolverIsAbsent(t *testing.T) {
 	h1, h2 := strings.Repeat("a", 40), strings.Repeat("b", 40)
 	uid := seedOpenFinding(t, store, h1)
 	if _, err := store.RecordReviewFindingObservation(ctx, db.ReviewFindingObservation{
-		Repo: "owner/repo", PullRequest: 7, HeadSHA: h1, ObserverJob: "review-2",
+		Severity: "P2",
+		Repo:     "owner/repo", PullRequest: 7, HeadSHA: h1, ObserverJob: "review-2",
 		ContinuesUID: uid, State: db.FindingAnswered, Title: "the defect", File: "internal/run.go",
 		EvidenceKind: db.EvidenceStatic, EvidenceLocator: "internal/run.go:42",
 		Rationale: "the guard lives here",

--- a/internal/workflow/findings_ledger_test.go
+++ b/internal/workflow/findings_ledger_test.go
@@ -148,7 +148,8 @@ func TestLedgerRefusesAnEvidenceFreeDischarge(t *testing.T) {
 	store := ledgerStore(t)
 
 	staticNoRationale := db.ReviewFindingObservation{
-		Repo: "owner/repo", PullRequest: 7, HeadSHA: headA, State: db.FindingOpen,
+		Severity: "P2",
+		Repo:     "owner/repo", PullRequest: 7, HeadSHA: headA, State: db.FindingOpen,
 		EvidenceKind: db.EvidenceStatic, EvidenceLocator: "internal/workflow/run.go:1977",
 	}
 	if _, err := store.RecordReviewFindingObservation(ctx, staticNoRationale); !errors.Is(err, db.ErrFindingDischarge) {
@@ -163,7 +164,8 @@ func TestLedgerRefusesAnEvidenceFreeDischarge(t *testing.T) {
 
 	// QUOTED establishes nothing, so it cannot discharge.
 	quoted := db.ReviewFindingObservation{
-		Repo: "owner/repo", PullRequest: 7, HeadSHA: headA, State: db.FindingAnswered,
+		Severity: "P2",
+		Repo:     "owner/repo", PullRequest: 7, HeadSHA: headA, State: db.FindingAnswered,
 		EvidenceKind: db.EvidenceQuoted, SourceJob: "local-implement-1",
 	}
 	if _, err := store.RecordReviewFindingObservation(ctx, quoted); !errors.Is(err, db.ErrFindingQuotedDischarge) {

--- a/internal/workflow/findings_ledger_writer.go
+++ b/internal/workflow/findings_ledger_writer.go
@@ -327,6 +327,9 @@ func (e Engine) ledgerObligationBrief(ctx context.Context, repo string, pullRequ
 	b.WriteString("finding, emit a finding object citing its uid as \"continues_uid\" - typing its old label is naming,\n")
 	b.WriteString("not reference, and mints a NEW finding instead. Set \"state\": \"answered\" only if you CHECKED it at\n")
 	b.WriteString("this head, and say what you ran; \"withdrawn\" requires \"withdraw_reason\" and is refused without one.\n")
+	b.WriteString("EVERY finding you emit needs an explicit \"severity\" of P0, P1, P2 or P3. A finding with none is\n")
+	b.WriteString("REFUSED rather than stored, because a row with no severity is an obligation no severity policy\n")
+	b.WriteString("can ever disposition, and it is not the same thing as P3 (#1928).\n")
 	for _, obligation := range pending {
 		label := obligation.RoundLabel
 		if strings.TrimSpace(label) == "" {
@@ -334,6 +337,13 @@ func (e Engine) ledgerObligationBrief(ctx context.Context, repo string, pullRequ
 		}
 		b.WriteString(fmt.Sprintf("  uid=%s  was=%s  severity=%s  reason=%s  title=%s\n",
 			obligation.FindingUID, label, obligation.Severity, obligation.Reason, obligation.Title))
+		if strings.TrimSpace(obligation.Severity) == "" {
+			// A LEGACY EMPTY-SEVERITY ROW MUST NOT PRINT AS "severity=". The
+			// reviewer reads this line to decide how to answer; a blank there
+			// reads as "unset, therefore minor", which is the inference #1928
+			// exists to stop. It is named for what it is instead.
+			b.WriteString("    (that row predates the severity requirement and carries none; treat it as unranked and blocking until you observe it)\n")
+		}
 	}
 	return b.String()
 }

--- a/internal/workflow/findings_ledger_writer_test.go
+++ b/internal/workflow/findings_ledger_writer_test.go
@@ -119,7 +119,8 @@ func TestLedgerObligationBriefNamesEveryUIDAReviewerMustCite(t *testing.T) {
 	}
 	// And once observed here, the brief stops asking.
 	if _, err := store.RecordReviewFindingObservation(ctx, db.ReviewFindingObservation{
-		Repo: "gitmoot/gitmoot", PullRequest: 1850, HeadSHA: headB, ObserverJob: "review-2",
+		Severity: "P2",
+		Repo:     "gitmoot/gitmoot", PullRequest: 1850, HeadSHA: headB, ObserverJob: "review-2",
 		ContinuesUID: uid, State: db.FindingAnswered, Title: "unfixed defect", File: "internal/run.go",
 		EvidenceKind: db.EvidenceExecuted, ExecutedCommands: []string{"go test -> ok"}, ExecutedCount: 1,
 	}); err != nil {


### PR DESCRIPTION
Closes #1928. Assigned scope: directive 122090 ("reject missing/invalid severity at the production ledger write boundary; never silently default it to P3; keep legacy empty-severity rows fail-closed").

## The defect, measured

Three persisted rows for `jerryfane/joltra#831` (`#831-f1..f3`, head `6360ab56`, observer `local-review-joltra-sol-review-18d2814edd22159c`) carry `severity = \x27\x27`. An empty severity **is not P3**: `reviewseverity.Blocks` treats an unrankable value as blocking, so such a row is an obligation that can only ever fail closed and that no severity policy can disposition.

This is not hypothetical or historical. `gitmoot/gitmoot#1903` carries the same shape today: `#1903-f1` through `#1903-f5` are all `open` with empty severity.

## The fix

`RecordReviewFindingObservation` is the production write boundary, and it already refuses an untrustworthy `head_sha`, `state`, `observed_at` and evidence claim. Severity was the one caller-asserted field it did not check. It now requires a canonical `P0/P1/P2/P3` and returns `ErrFindingSeverity` naming the value it got.

**A default would be worse than a refusal.** This boundary is the last point that can still tell a *missing* severity from a *chosen* one, so defaulting to P3 here would silently downgrade an unknown-severity defect at exactly the moment the information still exists.

Refusals are already durable at the caller: `RecordReviewFindingsToLedger` records a per-finding skip event naming the store error, so a refused finding is auditable rather than lost silently. The reviewer brief now states the requirement up front, and a legacy empty-severity obligation prints an explicit \"unranked and blocking\" line rather than a bare `severity=` - a blank there reads as \"unset, therefore minor\", which is the inference this issue exists to stop.

## Acceptance criteria

1. **Unranked severity cannot be persisted** - `TestRecordReviewFindingObservationRefusesUnrankableSeverity` covers empty, whitespace, `p1` (wrong case), `P4`, `critical`, `unknown`.
2. **Concrete error, no silent P3** - `ErrFindingSeverity` names the received value; the refusal mints no uid, so a refused observation does not consume finding identity.
3. **Valid severities unchanged** - the same test asserts `P0/P1/P2/P3` still insert and read back identically, with surrounding whitespace normalised. This passing control is deliberate: without it a green test could mean \"the boundary refuses everything\".
4. **Legacy rows stay fail-closed** - `TestLegacyEmptySeverityRowsStayFailClosedObligations` seeds a legacy row via raw SQL (the Go boundary now refuses that shape, so that is the only way one can exist) and asserts it stays readable, keeps its empty severity unrepaired, and stays `open`. `LedgerObligationsAtHead` keys on state, never severity, so it remains an obligation.
5. **Regression exercises the production path and fails pre-fix** - verified by mutation rather than assertion: disabling the guard reproduces the exact joltra shape, minting `owner/repo#831-f1` with an empty severity and failing all six arms.

## Test fixtures

13 fixtures relied on persisting an empty severity. Several were **refusal** tests - a symbol relevance key, a reasonless withdrawal, an evidence-free discharge - so without an explicit severity they would have gone green on the *severity* refusal instead of the one they name. That is a test passing for the wrong reason, not a fixture detail.

## Verification

- `go build ./...`, `go vet ./...` clean.
- `go test ./internal/db/` and `go test ./internal/workflow/` both green.
- Mutation control as described in criterion 5.

## Deploy notes

Engine code, not config. No daemon restart is required and none was performed; #1928 explicitly says not to restart the daemon. Behaviour change to note: a reviewer emitting a finding with no severity now gets that finding refused with a recorded skip event instead of stored unranked.

## Out of scope

Branch protection on `jerryfane/joltra` (repository configuration, named in the issue as a separate owner action), and post-merge reconciliation of findings after an out-of-band merge, which the issue defers to #1906.