### PR TITLE
fix(doctor): read herdr's version, not its commit hash (#1736)

### DIFF
--- a/internal/doctor/herdr.go
+++ b/internal/doctor/herdr.go
@@ -63,16 +63,28 @@ type semVersion struct {
 	prerelease          []string
 }
 
+// parseHerdrVersion extracts the version from `herdr --version` output.
+//
+// IT SCANS FOR THE FIRST SEMVER FIELD RATHER THAN TAKING THE LAST (#1736, and
+// #1664 which reported the same defect first). herdr prints
+// "herdr 0.8.2 (4c745b97)", so the LAST field is the commit hash: the check
+// reported `malformed "herdr 0.8.2 (4c745b97)"` and failed a >=0.7.5 floor that
+// 0.8.2 plainly satisfies. Because this check is REQUIRED that made
+// `gitmoot doctor` exit 1 permanently - measured on this host - and a
+// permanently red required check is worse than cosmetic: it hides a genuine
+// failure of any other required check behind noise an operator learns to ignore.
+//
+// A leading "v" is deliberately NOT accepted. The existing contract pins
+// "herdr v0.7.5" as malformed, that is not the defect being fixed, and quietly
+// widening what counts as a version is how a parser stops being a check.
 func parseHerdrVersion(output string) (string, error) {
 	fields := strings.Fields(strings.TrimSpace(output))
-	if len(fields) == 0 {
-		return "", fmt.Errorf("malformed `herdr --version` output")
+	for _, field := range fields {
+		if _, err := parseStrictSemVer(field); err == nil {
+			return field, nil
+		}
 	}
-	version := fields[len(fields)-1]
-	if _, err := parseStrictSemVer(version); err != nil {
-		return "", fmt.Errorf("malformed `herdr --version` output %q", strings.TrimSpace(output))
-	}
-	return version, nil
+	return "", fmt.Errorf("malformed `herdr --version` output %q", strings.TrimSpace(output))
 }
 
 func parseStrictSemVer(value string) (semVersion, error) {

--- a/internal/doctor/herdr_test.go
+++ b/internal/doctor/herdr_test.go
@@ -22,6 +22,13 @@ func TestCheckHerdrVersionBoundaries(t *testing.T) {
 		{name: "newer", output: "herdr version 1.0.0\n", wantOK: true},
 		{name: "minimum prerelease", output: "herdr 0.7.5-rc.1\n", wantOK: false},
 		{name: "malformed", output: "herdr v0.7.5\n", wantOK: false},
+		// #1736/#1664: herdr prints a trailing commit hash, and taking the LAST
+		// field parsed that hash as the version - so a satisfied floor reported
+		// `malformed "herdr 0.8.2 (4c745b97)"` and made a REQUIRED check
+		// permanently red, masking any other required failure behind it.
+		{name: "trailing commit hash", output: "herdr 0.8.2 (4c745b97)\n", wantOK: true},
+		{name: "trailing hash below floor", output: "herdr 0.7.4 (4c745b97)\n", wantOK: false},
+		{name: "no version anywhere", output: "herdr unknown build\n", wantOK: false},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {


### PR DESCRIPTION
Closes #1736. #1664 reported the same defect first and is a duplicate of it — no new issue filed, per the directive not to duplicate an existing version-parse issue.

## The defect

`herdr --version` prints `herdr 0.8.2 (4c745b97)`. `parseHerdrVersion` took the **last** field, so it parsed the commit hash as the version and reported:

```
herdr  fail  org requires herdr >=0.7.5; upgrade herdr (0.7.0-0.7.4 have delivery bugs); malformed `herdr --version` output "herdr 0.8.2 (4c745b97)"
```

The installed herdr is newer than the floor. No upgrade was ever warranted.

## Why it is more than cosmetic

The herdr check is **required**, so `gitmoot doctor` exited 1 permanently. Measured on this host before the fix:

```
failed required checks: stuck jobs, herdr
exit=1
```

A permanently red required check hides a genuine failure of any *other* required check behind noise an operator learns to ignore. After the fix, same host, same command:

```
herdr        ok    herdr 0.8.2 (org requires >=0.7.5)
failed required checks: stuck jobs
```

The real failure is now alone and visible.

## The fix

Scan for the **first** strict-SemVer field rather than taking the last, so a trailing hash, build suffix or date cannot displace the version.

A leading `v` is deliberately **still refused**. The existing boundary table pins `herdr v0.7.5` as malformed, that is not this defect, and quietly widening what counts as a version is how a parser stops being a check.

## Regressions

Added to the existing boundary table, so they run beside the cases that already pin the floor:

- `herdr 0.8.2 (4c745b97)` → **ok** (the reported shape).
- `herdr 0.7.4 (4c745b97)` → **fail**, so the fix cannot pass by accepting everything: the same trailing-hash shape below the floor is still refused.
- `herdr unknown build` → **fail**, no version anywhere.
- The pre-existing `herdr v0.7.5` → **fail**, unchanged.

**Mutation-verified:** restoring the last-field read fails the trailing-hash case and nothing else, so the guard is load-bearing and narrowly aimed.

## Verification

- `go build ./...`, `go vet ./internal/doctor/`, `go test ./internal/doctor/` green.
- Live before/after on this host as quoted above.

## Deploy notes

Engine code. Deploying this changes `gitmoot doctor`'s exit code from a permanent 1 to whatever the *other* required checks actually say — which is the point, and worth knowing before anything keys on that exit code.