### PR TITLE
fix(workflow): make the findings ledger tell the truth in both directions, and refuse a finding that articulates nothing (#1932, #1936, #1968)

### DIFF
--- a/internal/db/review_findings.go
+++ b/internal/db/review_findings.go
@@ -187,6 +187,14 @@ func pathLikeRelevanceKey(key string) bool {
 // RecordReviewFindingObservation validates at the STORE BOUNDARY and inserts.
 // Every rejection here is a refusal, never a warning: a warning on a write path
 // is indistinguishable from success to the caller that ignores it.
+// IsStructuralFindingLocator reports whether value is a locator this store will
+// accept for a STATIC discharge: a repo-relative path, optionally with a line.
+// Exported because the WRITER must be able to ask before it builds a row - it
+// previously guessed, and a prose citation cost the whole observation.
+func IsStructuralFindingLocator(value string) bool {
+	return locatorPattern.MatchString(strings.TrimSpace(value))
+}
+
 func (s *Store) RecordReviewFindingObservation(ctx context.Context, obs ReviewFindingObservation) (string, error) {
 	head := strings.TrimSpace(obs.HeadSHA)
 	if !headSHAPattern.MatchString(head) {

--- a/internal/db/review_findings.go
+++ b/internal/db/review_findings.go
@@ -126,6 +126,36 @@ var (
 	// silently downgrade an unknown-severity defect to the least severe class at
 	// the one boundary that still knows the value was missing.
 	ErrFindingSeverity = errors.New("finding observation requires an explicit severity of P0, P1, P2 or P3")
+	// ErrFindingNoConcern rejects a row that articulates nothing (#1968). It is
+	// the content sibling of ErrFindingSeverity: a severity says how much a defect
+	// matters, and prose says what the defect IS. A row with neither a title, a
+	// detail nor a rationale identifies no defect that can be evaluated
+	// independently, yet it occupies the same ledger as real ones and, with
+	// [review] blocking_severity = "P2", holds a merge on a concern nobody can
+	// read.
+	//
+	// Measured on this box's store on 2026-09-07: 77 of 571 recorded findings
+	// carried an empty title AND detail AND rationale, and 73 of those had already
+	// been withdrawn BY HAND, one written reason at a time, with reviewers saying
+	// things like "provides no title, detail, or articulated concern... should not
+	// have become an obligation". Manual withdrawal is the correct verdict reached
+	// after the row is already an obligation.
+	//
+	// A FILE OR A LOCATOR IS NOT A CONCERN, deliberately: the withdrawn rows all
+	// carried one. "internal/cli/style/style.go:78" names where to look and says
+	// nothing about what is wrong there, and several distinct uids pointed at one
+	// such bare locator.
+	//
+	// REFUSING DOES NOT DROP A BLOCK, which is the property that makes refusal
+	// safe for a P0 (PHOBOS's condition on this slice). The merge gate blocks on
+	// the review's VERDICT - effectiveReviewDecisionForPayload reads
+	// Result.Decision and Result.Severity - not on ledger rows, so a
+	// changes_requested P0 review whose every finding was refused still refuses
+	// the head. Measured by probe: the gate returned "review at evaluated head has
+	// blocking result from reviewer" against a zero-row ledger. What refusal costs
+	// is the itemised, dischargeable obligation, which is exactly what a row with
+	// no prose could never have provided anyway.
+	ErrFindingNoConcern = errors.New("finding observation requires an articulated concern: a title, a detail or a rationale")
 )
 
 var (
@@ -266,6 +296,54 @@ func (s *Store) RecordReviewFindingObservation(ctx context.Context, obs ReviewFi
 	}
 	if obs.EvidenceKind == EvidenceQuoted && obs.State != FindingOpen {
 		return "", ErrFindingQuotedDischarge
+	}
+
+	// CONTENT IS VALIDATED AT THE WRITE BOUNDARY for the same reason severity is
+	// (#1968): this is the last point that still knows the row said nothing. The
+	// bar lives HERE rather than in the writer that produced today's rows,
+	// because the writer is one of several callers and a rule defined against an
+	// open set of callers decays as the set widens - the #1967 chokepoint
+	// argument again. The lens path, continuations and any future writer all
+	// reach the ledger through this function.
+	//
+	// IT RUNS LAST ON PURPOSE, so it is strictly ADDITIVE to the existing
+	// precedence. Placed before the evidence switch it preempted
+	// ErrFindingDischarge for a STATIC row missing its rationale, and
+	// TestLedgerRefusesAnEvidenceFreeDischarge caught that: both errors were
+	// true of that row, but a caller matching the discharge sentinel would have
+	// stopped seeing it. Here it can only refuse a row every older bar already
+	// admitted.
+	//
+	// IT APPLIES ONLY TO AN OBSERVATION THAT OPENS AN OBLIGATION, and that
+	// narrowing is not caution - my first version did not have it and was
+	// measurably wrong. gm-integrity asked whether this rule could contradict the
+	// #1965 continues_uid normalisation, so I measured instead of answering, and
+	// of the 77 no-prose rows on this box's ledger ZERO are open: 58 are
+	// withdrawn and 19 are ANSWERED. Those 19 are genuine discharges - P1, P2 and
+	// P3, EvidenceKind EXECUTED with executed_count 8 apiece, against real paths
+	// like internal/sandbox/exec_linux.go. A state-blind bar would have refused
+	// all 19 and left 19 real obligations, P1s among them, open forever. Removing
+	// noise by refusing real discharges is a worse ledger, not a better one.
+	//
+	// A DISCHARGE IS ALREADY GATED: EXECUTED needs a non-empty command list and a
+	// non-zero count, STATIC needs a structural locator AND a rationale, and
+	// withdrawn needs its written reason. Prose is the articulation an OPENING
+	// observation owes, because opening is the act that creates an obligation
+	// somebody else has to discharge.
+	//
+	// THE LIMIT OF THAT CLAIM, stated because gm-integrity asked for it rather
+	// than left for the next reader to over-read: those bars are about
+	// ARTICULATION, not FRESHNESS. Nothing here requires a discharge's commands
+	// to differ from the ones the finding was opened with, or to name the head
+	// being judged, so "already gated" does not mean "proved re-checked at this
+	// head". Measured on this box: of 99 open-to-answered pairs, 7 repeat the
+	// identical command list and 92 bring a different one, and 0 answer at the
+	// opening head - so the gap is real in this code and largely unexercised by
+	// the population. Whether an EXECUTED discharge should have to prove
+	// freshness is #1970's question, not this bar's.
+	if obs.State == FindingOpen && strings.TrimSpace(obs.Title) == "" &&
+		strings.TrimSpace(obs.Detail) == "" && strings.TrimSpace(obs.Rationale) == "" {
+		return "", fmt.Errorf("%w: file=%q line=%d", ErrFindingNoConcern, obs.File, obs.Line)
 	}
 
 	// KEYS ARE VALIDATED BEFORE THE TRANSACTION so a bad key costs no write lock.

--- a/internal/db/review_findings_no_concern_1968_test.go
+++ b/internal/db/review_findings_no_concern_1968_test.go
@@ -1,0 +1,162 @@
+package db
+
+import (
+	"context"
+	"errors"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// #1968. A finding with no articulated concern became a durable obligation.
+//
+// Measured on this box's PRE-CLEANUP store (the backup taken before PHOBOS's
+// approved withdrawal pass, so the denominator is the one the defect actually
+// produced): of 571 recorded findings, 77 carried an empty title AND detail AND
+// rationale, and 46 of those were OPEN. 7 P1, 21 P2, 17 P3, 1 with no severity.
+// 73 had to be withdrawn by hand, one written reason at a time.
+//
+// The bar lives at the store boundary rather than in the writer that produced
+// those rows, because the writer is one of several callers: the lens path,
+// continuations and any future writer all reach the ledger through here. A rule
+// defined against an open set of callers decays as the set widens.
+func TestRecordReviewFindingObservationRefusesAnOpeningRowThatArticulatesNothing(t *testing.T) {
+	ctx := context.Background()
+	store := openNoConcernTestStore(t)
+
+	_, err := store.RecordReviewFindingObservation(ctx, noConcernObservation(ReviewFindingObservation{
+		State:            FindingOpen,
+		EvidenceKind:     EvidenceExecuted,
+		ExecutedCommands: []string{"go test ./internal/db"},
+		ExecutedCount:    1,
+		File:             "internal/cli/style/style.go",
+		Line:             78,
+	}))
+	if !errors.Is(err, ErrFindingNoConcern) {
+		t.Fatalf("RecordReviewFindingObservation = %v, want ErrFindingNoConcern for a row whose only content is a locator", err)
+	}
+	if !strings.Contains(err.Error(), "internal/cli/style/style.go") {
+		t.Fatalf("refusal %q must name the locator it refused, so the producer can see which finding was rejected", err)
+	}
+}
+
+// THE CONTROL THAT CHANGED THE DESIGN, and it exists because gm-integrity asked
+// whether this rule could contradict the #1965 continues_uid normalisation
+// instead of only asking about line numbers.
+//
+// My first predicate was state-blind. Measured against the live ledger, ZERO of
+// the 77 no-prose rows are open: 58 are withdrawn and 19 are ANSWERED, and those
+// 19 are genuine discharges - P1, P2 and P3, EXECUTED with executed_count 8
+// apiece, against real paths like internal/sandbox/exec_linux.go. A state-blind
+// bar would have refused all 19 and left 19 real obligations, P1s among them,
+// open forever: removing noise by refusing real discharges is a worse ledger.
+//
+// It would also have killed gm-integrity's own case twice. Those six findings
+// were already lost once to an abbreviated uid; they move to answered at a new
+// head, so a state-blind bar would have refused the same verdict a second time
+// by a different mechanism.
+func TestRecordReviewFindingObservationStillAcceptsADischargeWithNoProse(t *testing.T) {
+	ctx := context.Background()
+	store := openNoConcernTestStore(t)
+
+	uid, err := store.RecordReviewFindingObservation(ctx, noConcernObservation(ReviewFindingObservation{
+		State:            FindingAnswered,
+		EvidenceKind:     EvidenceExecuted,
+		ExecutedCommands: []string{"go test -run TestSandboxExec ./internal/sandbox"},
+		ExecutedCount:    8,
+		File:             "internal/sandbox/exec_linux.go",
+	}))
+	if err != nil {
+		t.Fatalf("a discharge carrying executed evidence and no prose was refused: %v", err)
+	}
+	if strings.TrimSpace(uid) == "" {
+		t.Fatal("discharge recorded no uid")
+	}
+}
+
+// An opening row whose whole concern lives in the rationale is real: 7 such rows
+// were open on the pre-cleanup store. Refusing them would be the same error as
+// refusing the 19 discharges, one field over.
+func TestRecordReviewFindingObservationAcceptsAnOpeningRowWhoseConcernIsItsRationale(t *testing.T) {
+	ctx := context.Background()
+	store := openNoConcernTestStore(t)
+
+	if _, err := store.RecordReviewFindingObservation(ctx, noConcernObservation(ReviewFindingObservation{
+		State:            FindingOpen,
+		EvidenceKind:     EvidenceExecuted,
+		ExecutedCommands: []string{"go build ./..."},
+		ExecutedCount:    1,
+		Rationale:        "the build fails on a clean clone because the generated file is not committed",
+	})); err != nil {
+		t.Fatalf("an opening row whose concern is its rationale was refused: %v", err)
+	}
+}
+
+// PRECEDENCE. The content bar runs after every older bar, so it can only refuse
+// a row they all admitted. My first version ran it before the evidence switch
+// and preempted ErrFindingDischarge for a STATIC row missing its rationale:
+// both errors were true, but a caller matching the discharge sentinel would
+// have stopped seeing it. This pins the ordering rather than trusting it.
+func TestRecordReviewFindingObservationKeepsTheOlderRefusalsAheadOfTheContentBar(t *testing.T) {
+	ctx := context.Background()
+	store := openNoConcernTestStore(t)
+
+	for _, tc := range []struct {
+		name string
+		obs  ReviewFindingObservation
+		want error
+	}{
+		{
+			name: "a missing severity still reports the severity refusal",
+			obs: noConcernObservationWithSeverity(ReviewFindingObservation{
+				State: FindingOpen, EvidenceKind: EvidenceExecuted,
+				ExecutedCommands: []string{"go vet ./..."}, ExecutedCount: 1,
+			}, ""),
+			want: ErrFindingSeverity,
+		},
+		{
+			name: "an evidence-free EXECUTED claim still reports the evidence refusal",
+			obs: noConcernObservation(ReviewFindingObservation{
+				State: FindingOpen, EvidenceKind: EvidenceExecuted,
+			}),
+			want: ErrFindingEvidence,
+		},
+		{
+			name: "a STATIC row with no locator still reports the discharge refusal",
+			obs: noConcernObservation(ReviewFindingObservation{
+				State: FindingOpen, EvidenceKind: EvidenceStatic,
+			}),
+			want: ErrFindingDischarge,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := store.RecordReviewFindingObservation(ctx, tc.obs)
+			if !errors.Is(err, tc.want) {
+				t.Fatalf("error = %v, want %v; the content bar must not preempt an older, more specific refusal", err, tc.want)
+			}
+		})
+	}
+}
+
+func openNoConcernTestStore(t *testing.T) *Store {
+	t.Helper()
+	store, err := openCachedTestStore(t, filepath.Join(t.TempDir(), "no-concern.db"))
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	return store
+}
+
+// noConcernObservation fills the fields every observation needs so each test
+// varies exactly one thing.
+func noConcernObservation(obs ReviewFindingObservation) ReviewFindingObservation {
+	return noConcernObservationWithSeverity(obs, "P2")
+}
+
+func noConcernObservationWithSeverity(obs ReviewFindingObservation, severity string) ReviewFindingObservation {
+	obs.Repo = "gitmoot/gitmoot"
+	obs.PullRequest = 1968
+	obs.HeadSHA = strings.Repeat("ab12cd34ef", 4)
+	obs.Severity = severity
+	return obs
+}

--- a/internal/workflow/findings_ledger.go
+++ b/internal/workflow/findings_ledger.go
@@ -146,6 +146,25 @@ func dischargedAtHead(observations []db.ReviewFindingObservation, head string) m
 		if obs.EvidenceKind == db.EvidenceQuoted {
 			continue
 		}
+		// #1941 f4, P1. STATIC ROWS DO NOT SHORT-CIRCUIT HERE. This function ran
+		// BEFORE answeredIsMandatory and skipped any same-head non-QUOTED row, so
+		// a discharge recorded at the head being judged was accepted without its
+		// locator ever being resolved: a reviewer probe continued a mandatory P1
+		// citing does/not/exist.go, AdvanceJob persisted it STATIC/answered,
+		// EnsureLedgerObligationsObserved accepted it, and PathExistsAtHead ran
+		// ZERO times.
+		//
+		// STATIC is the ONLY kind whose locator existence is re-checked, so a
+		// STATIC row must reach answeredIsMandatory and be judged there - at the
+		// same head or a later one. EXECUTED rows keep the short-circuit: they
+		// carry executed commands and have no locator to resolve.
+		//
+		// The fix is the ORDER, not another writer-side compensation: the writer
+		// cannot know whether a path exists (it has no tree) and every attempt to
+		// compensate for that in the writer produced a new invention.
+		if obs.EvidenceKind == db.EvidenceStatic {
+			continue
+		}
 		seen[obs.FindingUID] = true
 	}
 	return seen

--- a/internal/workflow/findings_ledger_evidence_test.go
+++ b/internal/workflow/findings_ledger_evidence_test.go
@@ -65,7 +65,7 @@ func TestAdvanceJobRefusesToRecordStaticOnlyAsExecuted(t *testing.T) {
 				"grep -rn Foo internal/ -> 3 hits",
 				"go build -> COULD NOT RUN: permission denied",
 			},
-			Findings: []json.RawMessage{json.RawMessage(`{"id":"F1","severity":"P1","file":"internal/run.go","title":"prior defect","continues_uid":"` + uid + `","state":"answered"}`)},
+			Findings: []json.RawMessage{json.RawMessage(`{"id":"F1","severity":"P1","file":"internal/run.go","title":"prior defect","continues_uid":"` + uid + `","state":"answered","rationale":"read internal/run.go at this head and the guard is present"}`)},
 		},
 	})
 	if err := engine.AdvanceJob(ctx, "review-static"); err != nil {
@@ -160,7 +160,7 @@ func TestAdvanceJobStillRecordsExecutedForAnExecutedVerdict(t *testing.T) {
 			Decision: "approved", Summary: "executed re-review",
 			Evidence: EvidenceExecuted,
 			TestsRun: []string{"go test ./internal/ -> ok", "go vet ./internal/... -> clean"},
-			Findings: []json.RawMessage{json.RawMessage(`{"id":"F1","severity":"P1","file":"internal/run.go","title":"prior defect","continues_uid":"` + uid + `","state":"answered"}`)},
+			Findings: []json.RawMessage{json.RawMessage(`{"id":"F1","severity":"P1","file":"internal/run.go","title":"prior defect","continues_uid":"` + uid + `","state":"answered","rationale":"read internal/run.go at this head and the guard is present"}`)},
 		},
 	})
 	if err := engine.AdvanceJob(ctx, "review-exec"); err != nil {

--- a/internal/workflow/findings_ledger_refusal_1968_test.go
+++ b/internal/workflow/findings_ledger_refusal_1968_test.go
@@ -1,0 +1,59 @@
+package workflow
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/gitmoot/gitmoot/internal/db"
+)
+
+// #1968, THE PROPERTY THE WHOLE REFUSAL RESTS ON.
+//
+// PHOBOS's condition on this slice, after gm-integrity found a live P0 whose
+// only record was a review job nobody read: a P0 with no title must not be
+// silently dropped by the gate that refuses it. The refusal is safe only if it
+// costs the itemised obligation and NOT the merge block.
+//
+// It is safe, and this is why: the merge gate reads the review's VERDICT, not
+// the ledger. effectiveReviewDecisionForPayload takes Result.Decision and
+// Result.Severity, so a changes_requested P0 review whose every finding was
+// refused still refuses the head. This test exists because that is an invariant
+// of a DIFFERENT file than the one #1968 changes, so nothing else would notice
+// if it stopped holding, and the refusal would silently become a way to unblock
+// a head by saying nothing.
+func TestRefusedFindingsDoNotUnblockTheHeadTheyWereReportedAgainst(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	insertCompletedJob(t, store, db.Job{ID: "review-p0", Agent: "reviewer", Type: "review"}, JobPayload{
+		Repo:        "gitmoot/gitmoot",
+		PullRequest: 9,
+		HeadSHA:     "head123",
+		TaskID:      "task-9",
+		ReviewRound: "review-1",
+		Result: &AgentResult{
+			Decision: "changes_requested",
+			Summary:  "a blocking concern the reviewer never articulated",
+			Severity: "P0",
+		},
+	})
+
+	// The premise: the ledger is empty, exactly as it would be if every finding
+	// in that verdict had been refused for articulating nothing.
+	rows, err := store.ListReviewFindingObservations(ctx, "gitmoot/gitmoot", 9)
+	if err != nil {
+		t.Fatalf("ListReviewFindingObservations returned error: %v", err)
+	}
+	if len(rows) != 0 {
+		t.Fatalf("premise broken: ledger holds %d row(s), want 0", len(rows))
+	}
+
+	err = (PolicyMergeGate{Store: store}).ensureFinalReviewCaptured(ctx, MergeRequest{
+		Repo: "gitmoot/gitmoot", PullRequest: 9, TaskID: "task-9", Reviewer: "reviewer",
+		ReviewBlockingSeverity: "P2",
+	}, "head123")
+	var blocked mergeBlocked
+	if !errors.As(err, &blocked) {
+		t.Fatalf("gate returned %T %v, want mergeBlocked; if a zero-row ledger stops blocking, refusing a bare P0 finding becomes a way to merge a head by saying nothing", err, err)
+	}
+}

--- a/internal/workflow/findings_ledger_truthfulness_test.go
+++ b/internal/workflow/findings_ledger_truthfulness_test.go
@@ -1,0 +1,201 @@
+package workflow
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/gitmoot/gitmoot/internal/db"
+)
+
+// #1936, the FALSE-SUCCESS half. A finding that cites `evidence_locator` instead
+// of `file` used to fall through to QUOTED, which forces `open` - so a declared
+// `answered` became an open row while the summary event still read
+// "recorded 4 of 4 ... (0 skipped)". Measured consequence: the merge gate
+// refused a head whose reviewer had done the work and said so, and store-wide
+// ZERO STATIC rows had ever reached answered against 13 EXECUTED.
+//
+// Driven through AdvanceJob and asserted on the PERSISTED rows, because a test
+// that pins ledgerObservationFor is not a test of the path.
+func TestAdvanceJobAcceptsAPathShapedLocatorAsStaticEvidence(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	seedAgent(t, store, "g7-review", []string{"review"}, "gitmoot/gitmoot")
+	engine := testEngine(store)
+	head := strings.Repeat("c", 40)
+
+	insertCompletedJob(t, store, db.Job{ID: "review-locator", Agent: "g7-review", Type: "review"}, JobPayload{
+		Repo: "gitmoot/gitmoot", Branch: "task-locator", PullRequest: 1933, HeadSHA: head,
+		TaskID: "task-locator", ReviewRound: "review-1",
+		Result: &AgentResult{
+			Decision: "approved", Summary: "locator-only dispositions",
+			// static_only on purpose: this is the reading reviewer STATIC exists for.
+			Evidence: EvidenceStaticOnly,
+			Findings: []json.RawMessage{
+				// The #1936 shape, verbatim in structure: a declared answer whose
+				// only locator is a prose-tailed path.
+				json.RawMessage(`{"id":"L1","severity":"P2","state":"answered","evidence_locator":"internal/workflow/merge_gate.go: collectImplementerAttribution matching agent/role switch (~lines 1436-1449)","title":"attribution switch","detail":"read the switch at this head"}`),
+				// A reviewer that DECLARES quoted evidence and also declares an
+				// answer. QUOTED can never discharge, so the answer cannot stand -
+				// and that reversal must be audible rather than silent. (A finding
+				// with neither a locator nor execution takes a different path: the
+				// writer skips it loudly, which the bare-string case below pins.)
+				json.RawMessage(`{"id":"L2","severity":"P2","state":"answered","evidence_kind":"QUOTED","evidence_locator":"discussed in the review thread","title":"no citable path","detail":"nothing checkable"}`),
+			},
+		},
+	})
+
+	if err := engine.AdvanceJob(ctx, "review-locator"); err != nil {
+		t.Fatalf("AdvanceJob returned error: %v", err)
+	}
+
+	observations, err := store.ListReviewFindingObservations(ctx, "gitmoot/gitmoot", 1933)
+	if err != nil {
+		t.Fatalf("ListReviewFindingObservations returned error: %v", err)
+	}
+	byLabel := map[string]db.ReviewFindingObservation{}
+	for _, obs := range observations {
+		byLabel[obs.RoundLabel] = obs
+	}
+	if len(observations) != 2 {
+		t.Fatalf("ledger holds %d row(s) for a verdict reporting 2 findings", len(observations))
+	}
+
+	// L1: a path-shaped locator makes the disposition dischargeable.
+	l1 := byLabel["L1"]
+	if l1.EvidenceKind != db.EvidenceStatic {
+		t.Fatalf("[L1] evidence kind = %q, want STATIC: a path-shaped evidence_locator is checkable evidence", l1.EvidenceKind)
+	}
+	if l1.State != db.FindingAnswered {
+		t.Fatalf("[L1] state = %q, want answered: the reviewer's declared disposition was reversed", l1.State)
+	}
+	if l1.File != "internal/workflow/merge_gate.go" {
+		t.Fatalf("[L1] file = %q, want the leading path token from the locator", l1.File)
+	}
+	// The LOCATOR must be structurally checkable, because the store refuses a
+	// STATIC discharge whose locator is not `path` or `path:line` and
+	// answeredIsMandatory re-resolves it against the head. The reviewer's prose
+	// citation is preserved as the RATIONALE instead of being lost or destroying
+	// the row - both values came from the reviewer, and each lands where it is
+	// usable.
+	if !db.IsStructuralFindingLocator(l1.EvidenceLocator) {
+		t.Fatalf("[L1] evidence locator = %q, want a structurally checkable path the re-arm can resolve", l1.EvidenceLocator)
+	}
+	if !strings.Contains(l1.Rationale, "collectImplementerAttribution") {
+		t.Fatalf("[L1] rationale = %q, want the reviewer's prose citation preserved", l1.Rationale)
+	}
+	if l1.ExecutedCount != 0 {
+		t.Fatalf("[L1] executed count = %d, want 0: nothing was executed and STATIC must never imply it", l1.ExecutedCount)
+	}
+
+	// L2: unciteable prose still cannot discharge - the guard must not widen.
+	l2 := byLabel["L2"]
+	if l2.EvidenceKind != db.EvidenceQuoted {
+		t.Fatalf("[L2] evidence kind = %q, want QUOTED as declared", l2.EvidenceKind)
+	}
+	if l2.State != db.FindingOpen {
+		t.Fatalf("[L2] state = %q, want open", l2.State)
+	}
+
+	// AND THE REVERSAL IS AUDIBLE. Without this the fix would only move the
+	// silence, not remove it.
+	events, err := store.ListJobEvents(ctx, "review-locator")
+	if err != nil {
+		t.Fatalf("ListJobEvents returned error: %v", err)
+	}
+	var downgrade, summary string
+	for _, event := range events {
+		switch event.Kind {
+		case "findings_ledger_downgraded":
+			downgrade = event.Message
+		case "findings_ledger_recorded":
+			summary = event.Message
+		}
+	}
+	if downgrade == "" {
+		t.Fatal("no findings_ledger_downgraded event: a declared answer was reversed with no record of it")
+	}
+	if !strings.Contains(downgrade, "declared answered") || !strings.Contains(downgrade, "QUOTED") {
+		t.Fatalf("downgrade event = %q, want it to name the declared state and the cause", downgrade)
+	}
+	if !strings.Contains(summary, "1 downgraded") {
+		t.Fatalf("summary event = %q, want it to count the downgrade rather than report unqualified success", summary)
+	}
+}
+
+// The live joltra shape. Review job local-review-joltra-sol-review-18d2b773bd0c534b
+// returned six real findings and recorded ZERO: every finding arrived as one
+// prose string with the severity inline, so the store refused each for an empty
+// severity. The skip was loud, which is right; discarding values the reviewer
+// actually sent is not.
+func TestAdvanceJobReadsSeverityAndPathFromABareStringFinding(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	seedAgent(t, store, "joltra-sol-review", []string{"review"}, "gitmoot/gitmoot")
+	engine := testEngine(store)
+	head := strings.Repeat("d", 40)
+
+	insertCompletedJob(t, store, db.Job{ID: "review-bare", Agent: "joltra-sol-review", Type: "review"}, JobPayload{
+		Repo: "gitmoot/gitmoot", Branch: "task-bare", PullRequest: 1934, HeadSHA: head,
+		TaskID: "task-bare", ReviewRound: "review-1",
+		Result: &AgentResult{
+			Decision: "changes_requested", Severity: "P2", Summary: "prose findings",
+			Evidence: EvidenceStaticOnly,
+			Findings: []json.RawMessage{
+				// Structurally the joltra finding: severity token, then a path with a
+				// line, then prose.
+				json.RawMessage(`"P2 apps/web/src/views/LandingView.vue:365 - an explicit element root is not clipped to the viewport, so offscreen videos keep decoding."`),
+				// No severity token: the loud skip must survive, because a finding
+				// the writer cannot faithfully record must never be counted.
+				json.RawMessage(`"the hero column keeps four videos alive with no severity stated"`),
+			},
+		},
+	})
+
+	if err := engine.AdvanceJob(ctx, "review-bare"); err != nil {
+		t.Fatalf("AdvanceJob returned error: %v", err)
+	}
+
+	observations, err := store.ListReviewFindingObservations(ctx, "gitmoot/gitmoot", 1934)
+	if err != nil {
+		t.Fatalf("ListReviewFindingObservations returned error: %v", err)
+	}
+	if len(observations) != 1 {
+		t.Fatalf("ledger holds %d row(s); want exactly the one finding whose severity was stated", len(observations))
+	}
+	obs := observations[0]
+	if obs.Severity != "P2" {
+		t.Fatalf("severity = %q, want P2 read from the leading token", obs.Severity)
+	}
+	if obs.File != "apps/web/src/views/LandingView.vue" {
+		t.Fatalf("file = %q, want the path parsed from the prose", obs.File)
+	}
+	if obs.EvidenceKind != db.EvidenceStatic {
+		t.Fatalf("evidence kind = %q, want STATIC now that a locator exists", obs.EvidenceKind)
+	}
+	if strings.HasPrefix(obs.Title, "P2 ") {
+		t.Fatalf("title = %q, want the severity token consumed rather than left in the prose", obs.Title)
+	}
+
+	// The unparseable one stays a LOUD skip, and the summary must say so.
+	events, err := store.ListJobEvents(ctx, "review-bare")
+	if err != nil {
+		t.Fatalf("ListJobEvents returned error: %v", err)
+	}
+	var skip, summary string
+	for _, event := range events {
+		switch event.Kind {
+		case "findings_ledger_skipped":
+			skip = event.Message
+		case "findings_ledger_recorded":
+			summary = event.Message
+		}
+	}
+	if skip == "" {
+		t.Fatal("the severity-less finding was not recorded and left NO skip event; a silent drop is the defect this lane removes")
+	}
+	if !strings.Contains(summary, "recorded 1 of 2") || !strings.Contains(summary, "1 skipped") {
+		t.Fatalf("summary event = %q, want an honest 1 of 2 with 1 skipped", summary)
+	}
+}

--- a/internal/workflow/findings_ledger_truthfulness_test.go
+++ b/internal/workflow/findings_ledger_truthfulness_test.go
@@ -451,3 +451,52 @@ func TestAdvanceJobStillRecordsAFindingWhoseContentIsItsRationale(t *testing.T) 
 		t.Fatalf("evidence locator = %q, want path:line built from the declared file", obs.EvidenceLocator)
 	}
 }
+
+// THE REAL #1936 SHAPE, keyed as the actual verdict keyed it. Job
+// local-review-gm-review-opus-18d2a757546655c2 emitted `"locator"`, not
+// `"evidence_locator"`, so reading only the canonical key left the exact
+// instance the issue was filed about unread - my first head fixed #1936
+// against a schema no reviewer had sent. Copied from the stored payload.
+func TestAdvanceJobReadsTheLocatorKeyTheRealVerdictUsed(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	seedAgent(t, store, "gm-review-opus", []string{"review"}, "gitmoot/gitmoot")
+	engine := testEngine(store)
+	head := strings.Repeat("9", 40)
+
+	insertCompletedJob(t, store, db.Job{ID: "review-realkey", Agent: "gm-review-opus", Type: "review"}, JobPayload{
+		Repo: "gitmoot/gitmoot", Branch: "task-rk", PullRequest: 1946, HeadSHA: head,
+		TaskID: "task-rk", ReviewRound: "review-1",
+		Result: &AgentResult{
+			Decision: "approved", Summary: "three continuations",
+			Evidence: EvidenceStaticOnly,
+			Findings: []json.RawMessage{
+				json.RawMessage(`{"id":"K1","severity":"P2","state":"answered","locator":"internal/workflow/merge_gate.go: collectImplementerAttribution matching agent/role switch (~lines 1436-1449)","detail":"static read of the merge tree confirms the conditional-write fix survives"}`),
+			},
+		},
+	})
+
+	if err := engine.AdvanceJob(ctx, "review-realkey"); err != nil {
+		t.Fatalf("AdvanceJob returned error: %v", err)
+	}
+	observations, err := store.ListReviewFindingObservations(ctx, "gitmoot/gitmoot", 1946)
+	if err != nil {
+		t.Fatalf("ListReviewFindingObservations returned error: %v", err)
+	}
+	if len(observations) != 1 {
+		t.Fatalf("ledger holds %d row(s), want 1", len(observations))
+	}
+	obs := observations[0]
+	if obs.File != "internal/workflow/merge_gate.go" {
+		t.Fatalf("file = %q; the `locator` key was not read, so the real #1936 shape is still dropped", obs.File)
+	}
+	if obs.EvidenceKind != db.EvidenceStatic || obs.State != db.FindingAnswered {
+		t.Fatalf("row = kind %s / state %s, want STATIC/answered: the declared disposition must survive", obs.EvidenceKind, obs.State)
+	}
+	if obs.EvidenceLocator != "internal/workflow/merge_gate.go" {
+		t.Fatalf("evidence locator = %q, want the bare path the re-arm can resolve", obs.EvidenceLocator)
+	}
+	if !strings.Contains(obs.Rationale, "collectImplementerAttribution") {
+		t.Fatalf("rationale = %q, want the reviewer's prose citation preserved", obs.Rationale)
+	}
+}

--- a/internal/workflow/findings_ledger_truthfulness_test.go
+++ b/internal/workflow/findings_ledger_truthfulness_test.go
@@ -79,8 +79,17 @@ func TestAdvanceJobAcceptsAPathShapedLocatorAsStaticEvidence(t *testing.T) {
 	// citation is preserved as the RATIONALE instead of being lost or destroying
 	// the row - both values came from the reviewer, and each lands where it is
 	// usable.
-	if !db.IsStructuralFindingLocator(l1.EvidenceLocator) {
-		t.Fatalf("[L1] evidence locator = %q, want a structurally checkable path the re-arm can resolve", l1.EvidenceLocator)
+	// BEHAVIOURAL, not a helper call (#1941 review f3): the reviewer noted the
+	// previous version invoked db.IsStructuralFindingLocator directly, which pins
+	// a helper rather than the path. The store REFUSES a STATIC discharge whose
+	// locator is not path-shaped, so the row existing as STATIC/answered above
+	// already proves structural validity; what remains to assert is that the
+	// locator is the path and carries none of the prose.
+	if l1.EvidenceLocator != "internal/workflow/merge_gate.go" {
+		t.Fatalf("[L1] evidence locator = %q, want exactly the path the re-arm can resolve", l1.EvidenceLocator)
+	}
+	if strings.Contains(l1.EvidenceLocator, " ") {
+		t.Fatalf("[L1] evidence locator %q carries prose; the store would refuse it", l1.EvidenceLocator)
 	}
 	if !strings.Contains(l1.Rationale, "collectImplementerAttribution") {
 		t.Fatalf("[L1] rationale = %q, want the reviewer's prose citation preserved", l1.Rationale)
@@ -197,5 +206,248 @@ func TestAdvanceJobReadsSeverityAndPathFromABareStringFinding(t *testing.T) {
 	}
 	if !strings.Contains(summary, "recorded 1 of 2") || !strings.Contains(summary, "1 skipped") {
 		t.Fatalf("summary event = %q, want an honest 1 of 2 with 1 skipped", summary)
+	}
+}
+
+// #1941 review f2 and f3, reproduced as the reviewer measured them on the
+// production path. Each input is one it actually ran, and each arm pins a
+// behaviour my first head got wrong in the PERMISSIVE direction: the parser
+// rescued a severity and then recorded a row that said nothing, or invented a
+// locator out of prose.
+func TestAdvanceJobRefusesManufacturedBareStringFindings(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	seedAgent(t, store, "g7-review", []string{"review"}, "gitmoot/gitmoot")
+	engine := testEngine(store)
+	head := strings.Repeat("e", 40)
+
+	insertCompletedJob(t, store, db.Job{ID: "review-manufactured", Agent: "g7-review", Type: "review"}, JobPayload{
+		Repo: "gitmoot/gitmoot", Branch: "task-man", PullRequest: 1942, HeadSHA: head,
+		TaskID: "task-man", ReviewRound: "review-1",
+		Result: &AgentResult{
+			Decision: "changes_requested", Severity: "P2", Summary: "manufactured shapes",
+			Evidence: EvidenceStaticOnly,
+			Findings: []json.RawMessage{
+				// [M1] A severity token alone. Recorded as QUOTED with the token as
+				// its whole title before this change.
+				json.RawMessage(`"P2:"`),
+				// [M2] A version is not a path. Invented File/EvidenceLocator "v1.2"
+				// and recorded STATIC before this change.
+				json.RawMessage(`"P2 v1.2 is a version, not a repository file"`),
+				// [M3] An object carrying only id and severity: recorded with title
+				// and detail both empty.
+				json.RawMessage(`{"id":"M3","severity":"P2"}`),
+				// [M4] LOWERCASE severity, which is the fifth mutant's discriminator:
+				// with strings.ToUpper removed this records nothing at all.
+				json.RawMessage(`"p2 internal/workflow/findings_ledger_writer.go:226 - lowercase severities are real reviewer output"`),
+				// [M5] Colon-suffixed severity followed by a real path.
+				json.RawMessage(`"P2: internal/db/review_findings.go:247 - the discharge bar refuses a prose locator"`),
+			},
+		},
+	})
+
+	if err := engine.AdvanceJob(ctx, "review-manufactured"); err != nil {
+		t.Fatalf("AdvanceJob returned error: %v", err)
+	}
+
+	observations, err := store.ListReviewFindingObservations(ctx, "gitmoot/gitmoot", 1942)
+	if err != nil {
+		t.Fatalf("ListReviewFindingObservations returned error: %v", err)
+	}
+	byLabel := map[string]db.ReviewFindingObservation{}
+	for _, obs := range observations {
+		byLabel[obs.RoundLabel] = obs
+	}
+
+	// M1 and M3 say nothing, so they must not be rows at all. M2 says something,
+	// so it IS recorded - but with no invented locator.
+	if len(observations) != 3 {
+		var got []string
+		for _, obs := range observations {
+			got = append(got, obs.RoundLabel+"/"+string(obs.EvidenceKind)+"/"+obs.File)
+		}
+		t.Fatalf("ledger holds %d row(s) %v; want 3 - the two content-free findings must be skipped, not recorded", len(observations), got)
+	}
+
+	for _, obs := range observations {
+		if strings.TrimSpace(obs.Title) == "" && strings.TrimSpace(obs.Detail) == "" {
+			t.Fatalf("row %q was recorded with no title and no detail; that is the empty-row defect this lane closes", obs.RoundLabel)
+		}
+		if obs.File == "v1.2" || obs.EvidenceLocator == "v1.2" {
+			t.Fatalf("row %q invented a locator from prose: file=%q locator=%q", obs.RoundLabel, obs.File, obs.EvidenceLocator)
+		}
+	}
+
+	// M4 is the lowercase discriminator: it must be recorded, with its severity
+	// normalised and its real path read.
+	lower := byLabel[""]
+	found := false
+	for _, obs := range observations {
+		if strings.Contains(obs.Title, "lowercase severities") {
+			found = true
+			lower = obs
+		}
+	}
+	if !found {
+		t.Fatal("the lowercase-severity finding was not recorded; strings.ToUpper is the only thing that reads it")
+	}
+	if lower.Severity != "P2" {
+		t.Fatalf("lowercase severity recorded as %q, want normalised P2", lower.Severity)
+	}
+	if lower.File != "internal/workflow/findings_ledger_writer.go" {
+		t.Fatalf("lowercase finding file = %q, want the real path", lower.File)
+	}
+
+	// The skips must be LOUD and the summary must count them.
+	events, err := store.ListJobEvents(ctx, "review-manufactured")
+	if err != nil {
+		t.Fatalf("ListJobEvents returned error: %v", err)
+	}
+	skips, summary := 0, ""
+	for _, event := range events {
+		switch event.Kind {
+		case "findings_ledger_skipped":
+			skips++
+		case "findings_ledger_recorded":
+			summary = event.Message
+		}
+	}
+	if skips != 2 {
+		t.Fatalf("skip events = %d, want 2: a finding that cannot be recorded must fail loudly", skips)
+	}
+	if !strings.Contains(summary, "recorded 3 of 5") || !strings.Contains(summary, "2 skipped") {
+		t.Fatalf("summary = %q, want an honest 3 of 5 with 2 skipped", summary)
+	}
+}
+
+// #1941 review f1, THE P1, reproduced through the production path. A
+// path-shaped locator was promoted to File and STATIC, and the writer then
+// MANUFACTURED the rationale the store demands for a discharge - so a
+// continuation whose only content was a path I parsed myself persisted as
+// answered/STATIC and cleared its obligation. That is inventing evidence, the
+// permissive mirror of the defect this lane was opened to fix.
+//
+// A STATIC row now requires that the REVIEWER supplied something of its own.
+func TestAdvanceJobRefusesToDischargeOnAManufacturedRationale(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	seedAgent(t, store, "g7-review", []string{"review"}, "gitmoot/gitmoot")
+	engine := testEngine(store)
+	head := strings.Repeat("f", 40)
+
+	insertCompletedJob(t, store, db.Job{ID: "review-manufactured-rationale", Agent: "g7-review", Type: "review"}, JobPayload{
+		Repo: "gitmoot/gitmoot", Branch: "task-mr", PullRequest: 1944, HeadSHA: head,
+		TaskID: "task-mr", ReviewRound: "review-1",
+		Result: &AgentResult{
+			Decision: "approved", Summary: "content-free discharge attempt",
+			Evidence: EvidenceStaticOnly,
+			Findings: []json.RawMessage{
+				// [N1] The reviewer's own construction: a declared answer whose only
+				// content is a locator citing a path that does not exist. No title,
+				// no detail, no rationale, nothing executed.
+				json.RawMessage(`{"id":"N1","severity":"P1","state":"answered","evidence_locator":"does/not/exist.go"}`),
+				// [N2] The same locator WITH reviewer prose. This one is a legitimate
+				// static reading and must still be recorded as STATIC, so the guard
+				// cannot be satisfied by refusing everything.
+				json.RawMessage(`{"id":"N2","severity":"P1","state":"answered","evidence_locator":"does/not/exist.go","detail":"read the call site at this head and the guard is present"}`),
+			},
+		},
+	})
+
+	if err := engine.AdvanceJob(ctx, "review-manufactured-rationale"); err != nil {
+		t.Fatalf("AdvanceJob returned error: %v", err)
+	}
+
+	observations, err := store.ListReviewFindingObservations(ctx, "gitmoot/gitmoot", 1944)
+	if err != nil {
+		t.Fatalf("ListReviewFindingObservations returned error: %v", err)
+	}
+	byLabel := map[string]db.ReviewFindingObservation{}
+	for _, obs := range observations {
+		byLabel[obs.RoundLabel] = obs
+	}
+
+	// N1 carries NOTHING of the reviewer's own - no title, no detail, no
+	// rationale, nothing executed - so it is refused outright and never counted.
+	// That is stronger than recording it as QUOTED: it cannot discharge AND it
+	// cannot pad a "recorded n of n" line. What must never happen is the
+	// original behaviour, a STATIC row whose rationale this writer invented.
+	if n1, ok := byLabel["N1"]; ok {
+		t.Fatalf("N1 was recorded (kind=%s state=%s rationale=%q); a finding whose only content is a path the WRITER parsed must not become a row",
+			n1.EvidenceKind, n1.State, n1.Rationale)
+	}
+
+	// The positive control. Without it, refusing everything would pass.
+	n2 := byLabel["N2"]
+	if n2.EvidenceKind != db.EvidenceStatic {
+		t.Fatalf("N2 evidence kind = %q, want STATIC: a reviewer that supplied prose and a locator did the work STATIC exists for", n2.EvidenceKind)
+	}
+	if n2.State != db.FindingAnswered {
+		t.Fatalf("N2 state = %q, want answered", n2.State)
+	}
+
+	// And N1's reversal is audible rather than silent.
+	events, err := store.ListJobEvents(ctx, "review-manufactured-rationale")
+	if err != nil {
+		t.Fatalf("ListJobEvents returned error: %v", err)
+	}
+	skip, summary := "", ""
+	for _, event := range events {
+		switch event.Kind {
+		case "findings_ledger_skipped":
+			skip = event.Message
+		case "findings_ledger_recorded":
+			summary = event.Message
+		}
+	}
+	if skip == "" {
+		t.Fatal("N1 was refused with NO skip event; a silent drop is the other half of this lane's defect")
+	}
+	if !strings.Contains(summary, "recorded 1 of 2") || !strings.Contains(summary, "1 skipped") {
+		t.Fatalf("summary = %q, want an honest 1 of 2 with 1 skipped", summary)
+	}
+}
+
+// The control for the ENTRY check, and it exists because my own first
+// remediation would have broken it: refusing every finding with no title and no
+// detail newly rejected a legitimate one carrying a `file` and a `rationale`,
+// which is a real static reading with its evidence in the rationale field. A
+// guard that refuses valid input is the failure mode every bound in this
+// campaign has had a version of.
+func TestAdvanceJobStillRecordsAFindingWhoseContentIsItsRationale(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	seedAgent(t, store, "g7-review", []string{"review"}, "gitmoot/gitmoot")
+	engine := testEngine(store)
+	head := strings.Repeat("a", 40)
+
+	insertCompletedJob(t, store, db.Job{ID: "review-rationale-only", Agent: "g7-review", Type: "review"}, JobPayload{
+		Repo: "gitmoot/gitmoot", Branch: "task-ro", PullRequest: 1945, HeadSHA: head,
+		TaskID: "task-ro", ReviewRound: "review-1",
+		Result: &AgentResult{
+			Decision: "approved", Summary: "rationale carries the reading",
+			Evidence: EvidenceStaticOnly,
+			Findings: []json.RawMessage{
+				json.RawMessage(`{"id":"R1","severity":"P2","state":"answered","file":"internal/workflow/findings_ledger.go","line":198,"rationale":"read dischargedAtHead at this head: a same-head non-QUOTED row is treated as discharged"}`),
+			},
+		},
+	})
+
+	if err := engine.AdvanceJob(ctx, "review-rationale-only"); err != nil {
+		t.Fatalf("AdvanceJob returned error: %v", err)
+	}
+	observations, err := store.ListReviewFindingObservations(ctx, "gitmoot/gitmoot", 1945)
+	if err != nil {
+		t.Fatalf("ListReviewFindingObservations returned error: %v", err)
+	}
+	if len(observations) != 1 {
+		t.Fatalf("ledger holds %d row(s); a finding whose content is its rationale must still be recorded", len(observations))
+	}
+	obs := observations[0]
+	if obs.EvidenceKind != db.EvidenceStatic || obs.State != db.FindingAnswered {
+		t.Fatalf("row = kind %s / state %s, want STATIC/answered", obs.EvidenceKind, obs.State)
+	}
+	if obs.EvidenceLocator != "internal/workflow/findings_ledger.go:198" {
+		t.Fatalf("evidence locator = %q, want path:line built from the declared file", obs.EvidenceLocator)
 	}
 }

--- a/internal/workflow/findings_ledger_truthfulness_test.go
+++ b/internal/workflow/findings_ledger_truthfulness_test.go
@@ -35,7 +35,7 @@ func TestAdvanceJobAcceptsAPathShapedLocatorAsStaticEvidence(t *testing.T) {
 			Findings: []json.RawMessage{
 				// The #1936 shape, verbatim in structure: a declared answer whose
 				// only locator is a prose-tailed path.
-				json.RawMessage(`{"id":"L1","severity":"P2","state":"answered","evidence_locator":"internal/workflow/merge_gate.go: collectImplementerAttribution matching agent/role switch (~lines 1436-1449)","title":"attribution switch","detail":"read the switch at this head"}`),
+				json.RawMessage(`{"id":"L1","severity":"P2","state":"answered","evidence_locator":"internal/workflow/merge_gate.go: collectImplementerAttribution matching agent/role switch (~lines 1436-1449)","title":"attribution switch","detail":"read the switch at this head","rationale":"read the agent/role switch at this head; the conditional write is present"}`),
 				// A reviewer that DECLARES quoted evidence and also declares an
 				// answer. QUOTED can never discharge, so the answer cannot stand -
 				// and that reversal must be audible rather than silent. (A finding
@@ -91,8 +91,13 @@ func TestAdvanceJobAcceptsAPathShapedLocatorAsStaticEvidence(t *testing.T) {
 	if strings.Contains(l1.EvidenceLocator, " ") {
 		t.Fatalf("[L1] evidence locator %q carries prose; the store would refuse it", l1.EvidenceLocator)
 	}
-	if !strings.Contains(l1.Rationale, "collectImplementerAttribution") {
-		t.Fatalf("[L1] rationale = %q, want the reviewer's prose citation preserved", l1.Rationale)
+	// The rationale is the REVIEWER'S, verbatim - not the citation, not the
+	// title, not the detail, and not a sentence this writer authored (#1941 f5).
+	if l1.Rationale != "read the agent/role switch at this head; the conditional write is present" {
+		t.Fatalf("[L1] rationale = %q, want the reviewer's own rationale verbatim", l1.Rationale)
+	}
+	if strings.Contains(l1.Rationale, "~lines 1436-1449") {
+		t.Fatalf("[L1] the prose citation was promoted into the rationale: %q", l1.Rationale)
 	}
 	if l1.ExecutedCount != 0 {
 		t.Fatalf("[L1] executed count = %d, want 0: nothing was executed and STATIC must never imply it", l1.ExecutedCount)
@@ -180,8 +185,12 @@ func TestAdvanceJobReadsSeverityAndPathFromABareStringFinding(t *testing.T) {
 	if obs.File != "apps/web/src/views/LandingView.vue" {
 		t.Fatalf("file = %q, want the path parsed from the prose", obs.File)
 	}
-	if obs.EvidenceKind != db.EvidenceStatic {
-		t.Fatalf("evidence kind = %q, want STATIC now that a locator exists", obs.EvidenceKind)
+	// A BARE STRING CARRIES NO RATIONALE KEY, so it can never be STATIC under
+	// #1941 f5: a discharge needs an explicit reviewer rationale and prose
+	// cannot be promoted into one. It records fully, loudly and discharges
+	// nothing, which is the honest floor for a finding whose only form is text.
+	if obs.EvidenceKind != db.EvidenceQuoted {
+		t.Fatalf("evidence kind = %q, want QUOTED: a bare string supplies no rationale, so it cannot discharge", obs.EvidenceKind)
 	}
 	if strings.HasPrefix(obs.Title, "P2 ") {
 		t.Fatalf("title = %q, want the severity token consumed rather than left in the prose", obs.Title)
@@ -349,7 +358,7 @@ func TestAdvanceJobRefusesToDischargeOnAManufacturedRationale(t *testing.T) {
 				// [N2] The same locator WITH reviewer prose. This one is a legitimate
 				// static reading and must still be recorded as STATIC, so the guard
 				// cannot be satisfied by refusing everything.
-				json.RawMessage(`{"id":"N2","severity":"P1","state":"answered","evidence_locator":"does/not/exist.go","detail":"read the call site at this head and the guard is present"}`),
+				json.RawMessage(`{"id":"N2","severity":"P1","state":"answered","evidence_locator":"does/not/exist.go","detail":"read the call site at this head and the guard is present","rationale":"read the call site at this head and the guard is present"}`),
 			},
 		},
 	})
@@ -471,7 +480,7 @@ func TestAdvanceJobReadsTheLocatorKeyTheRealVerdictUsed(t *testing.T) {
 			Decision: "approved", Summary: "three continuations",
 			Evidence: EvidenceStaticOnly,
 			Findings: []json.RawMessage{
-				json.RawMessage(`{"id":"K1","severity":"P2","state":"answered","locator":"internal/workflow/merge_gate.go: collectImplementerAttribution matching agent/role switch (~lines 1436-1449)","detail":"static read of the merge tree confirms the conditional-write fix survives"}`),
+				json.RawMessage(`{"id":"K1","severity":"P2","state":"answered","locator":"internal/workflow/merge_gate.go: collectImplementerAttribution matching agent/role switch (~lines 1436-1449)","detail":"static read of the merge tree confirms the conditional-write fix survives","rationale":"static read of the merge tree at this head confirms the conditional-write fix survives"}`),
 			},
 		},
 	})
@@ -496,7 +505,177 @@ func TestAdvanceJobReadsTheLocatorKeyTheRealVerdictUsed(t *testing.T) {
 	if obs.EvidenceLocator != "internal/workflow/merge_gate.go" {
 		t.Fatalf("evidence locator = %q, want the bare path the re-arm can resolve", obs.EvidenceLocator)
 	}
-	if !strings.Contains(obs.Rationale, "collectImplementerAttribution") {
-		t.Fatalf("rationale = %q, want the reviewer's prose citation preserved", obs.Rationale)
+	if obs.Rationale != "static read of the merge tree at this head confirms the conditional-write fix survives" {
+		t.Fatalf("rationale = %q, want the reviewer's own rationale verbatim", obs.Rationale)
+	}
+}
+
+// #1941 f4, P1: THE SAME-HEAD DISCHARGE MUST NOT BYPASS LOCATOR RESOLUTION.
+// dischargedAtHead ran BEFORE answeredIsMandatory and skipped any same-head
+// non-QUOTED row, so a discharge recorded at the head being judged was accepted
+// without its locator ever being resolved. The reviewer's probe continued a
+// mandatory P1 citing does/not/exist.go, AdvanceJob persisted it STATIC/answered,
+// EnsureLedgerObligationsObserved accepted it, and PathExistsAtHead ran ZERO
+// times.
+//
+// The resolver's invocation count is OBSERVABLE here on purpose: "the obligation
+// was refused" could be true for other reasons, and the specific claim is that
+// the existence check now runs at the same head.
+//
+// KILLS: restoring the early same-head discharge (re-adding STATIC rows to
+// dischargedAtHead, value consumed so the mutant compiles).
+func TestSameHeadDischargeResolvesTheLocatorBeforeAccepting(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	seedAgent(t, store, "g7-review", []string{"review"}, "gitmoot/gitmoot")
+	head := strings.Repeat("7", 40)
+	uid := "gitmoot/gitmoot#1947-f1"
+
+	// A prior MANDATORY open finding, recorded at an earlier head.
+	if _, err := store.RecordReviewFindingObservation(ctx, db.ReviewFindingObservation{
+		Repo: "gitmoot/gitmoot", PullRequest: 1947, HeadSHA: strings.Repeat("6", 40),
+		ObserverJob: "seed-review", SourceJob: "seed-review", Severity: "P1",
+		State: db.FindingOpen, EvidenceKind: db.EvidenceQuoted,
+		Title: "prior defect", Detail: "the guard is missing",
+	}); err != nil {
+		t.Fatalf("seeding the prior finding: %v", err)
+	}
+	seeded, err := store.ListReviewFindingObservations(ctx, "gitmoot/gitmoot", 1947)
+	if err != nil || len(seeded) != 1 {
+		t.Fatalf("seed rows = %d err=%v", len(seeded), err)
+	}
+	priorUID := seeded[0].FindingUID
+	_ = uid
+
+	// A continuation AT THE HEAD BEING JUDGED, declaring an answer and citing a
+	// path that does not exist, with an explicit rationale so it clears the
+	// store's STATIC bar on its own terms.
+	engine := testEngine(store)
+	insertCompletedJob(t, store, db.Job{ID: "review-samehead", Agent: "g7-review", Type: "review"}, JobPayload{
+		Repo: "gitmoot/gitmoot", Branch: "task-sh", PullRequest: 1947, HeadSHA: head,
+		TaskID: "task-sh", ReviewRound: "review-2",
+		Result: &AgentResult{
+			Decision: "approved", Summary: "answering the prior finding",
+			Evidence: EvidenceStaticOnly,
+			Findings: []json.RawMessage{json.RawMessage(
+				`{"id":"S1","severity":"P1","state":"answered","continues_uid":"` + priorUID +
+					`","evidence_locator":"does/not/exist.go","rationale":"read does/not/exist.go at this head and the guard is present"}`)},
+		},
+	})
+	if err := engine.AdvanceJob(ctx, "review-samehead"); err != nil {
+		t.Fatalf("AdvanceJob returned error: %v", err)
+	}
+
+	// The row must exist and be STATIC/answered: this test is about the READER,
+	// so the writer's output has to be the shape the reviewer produced.
+	rows, err := store.ListReviewFindingObservations(ctx, "gitmoot/gitmoot", 1947)
+	if err != nil {
+		t.Fatalf("ListReviewFindingObservations returned error: %v", err)
+	}
+	answered := false
+	for _, obs := range rows {
+		if obs.State == db.FindingAnswered && obs.EvidenceKind == db.EvidenceStatic {
+			answered = true
+		}
+	}
+	if !answered {
+		t.Fatalf("no STATIC/answered row persisted at the judged head; rows=%d - the reader is not being exercised", len(rows))
+	}
+
+	// THE RESOLVER IS COUNTED. Zero invocations is the defect, regardless of the
+	// outcome that follows it.
+	calls := 0
+	missing := LedgerScope{PathExistsAtHead: func(_ context.Context, _ string, _ string) (bool, error) {
+		calls++
+		return false, nil
+	}}
+	err = EnsureLedgerObligationsObserved(ctx, store, "gitmoot/gitmoot", 1947, head, missing)
+	if calls == 0 {
+		t.Fatal("PathExistsAtHead was invoked ZERO times at the judged head: the same-head short-circuit is still bypassing locator resolution")
+	}
+	if err == nil {
+		t.Fatal("an answer citing a nonexistent locator discharged its obligation at the head being judged")
+	}
+
+	// POSITIVE CONTROL, so the guard is not satisfied by refusing everything: the
+	// same row with the path present legitimately answers at its own head.
+	present := LedgerScope{PathExistsAtHead: func(context.Context, string, string) (bool, error) { return true, nil }}
+	if err := EnsureLedgerObligationsObserved(ctx, store, "gitmoot/gitmoot", 1947, head, present); err != nil {
+		t.Fatalf("a same-head answer whose cited path EXISTS was refused: %v", err)
+	}
+}
+
+// #1941 f5's NEGATIVE CONTROL, and it is here because its absence let a mutant
+// survive: re-synthesizing the rationale from title/detail/generated text broke
+// nothing I had written, because every fixture that reached STATIC supplied a
+// rationale of its own. A guard whose violation no test can observe is not
+// guarded.
+//
+// The reviewer's own probe was exactly this shape: detail supplied, rationale
+// absent, detail read back as the persisted rationale, and the store's STATIC
+// bar satisfied by text the reviewer never wrote as a rationale.
+//
+// KILLS: restoring any promotion into Rationale - proseCitation, Title, Detail,
+// or the generated "reported by a review that declared no executed checks".
+func TestAdvanceJobNeverPromotesProseIntoTheRationale(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	seedAgent(t, store, "g7-review", []string{"review"}, "gitmoot/gitmoot")
+	engine := testEngine(store)
+	head := strings.Repeat("8", 40)
+
+	insertCompletedJob(t, store, db.Job{ID: "review-nopromote", Agent: "g7-review", Type: "review"}, JobPayload{
+		Repo: "gitmoot/gitmoot", Branch: "task-np", PullRequest: 1948, HeadSHA: head,
+		TaskID: "task-np", ReviewRound: "review-1",
+		Result: &AgentResult{
+			Decision: "approved", Summary: "detail but no rationale",
+			Evidence: EvidenceStaticOnly,
+			Findings: []json.RawMessage{
+				// [P1] A declared answer with a real file, a real detail and NO
+				// rationale. The detail must not become the rationale, so the row
+				// cannot be STATIC and cannot discharge.
+				json.RawMessage(`{"id":"P1","severity":"P1","state":"answered","file":"internal/workflow/findings_ledger.go","line":198,"title":"same-head ordering","detail":"read dischargedAtHead at this head"}`),
+				// [P2] The positive control: the identical finding WITH an explicit
+				// rationale is STATIC and answered, so the guard cannot be satisfied
+				// by refusing every static row.
+				json.RawMessage(`{"id":"P2","severity":"P1","state":"answered","file":"internal/workflow/findings_ledger.go","line":198,"title":"same-head ordering","detail":"read dischargedAtHead at this head","rationale":"resolved the ordering at this head: STATIC rows now reach answeredIsMandatory"}`),
+			},
+		},
+	})
+
+	if err := engine.AdvanceJob(ctx, "review-nopromote"); err != nil {
+		t.Fatalf("AdvanceJob returned error: %v", err)
+	}
+	observations, err := store.ListReviewFindingObservations(ctx, "gitmoot/gitmoot", 1948)
+	if err != nil {
+		t.Fatalf("ListReviewFindingObservations returned error: %v", err)
+	}
+	byLabel := map[string]db.ReviewFindingObservation{}
+	for _, obs := range observations {
+		byLabel[obs.RoundLabel] = obs
+	}
+
+	p1 := byLabel["P1"]
+	if p1.EvidenceKind == db.EvidenceStatic {
+		t.Fatalf("[P1] recorded STATIC with rationale %q; the reviewer supplied NO rationale, so this is prose promoted into a discharge claim", p1.Rationale)
+	}
+	if strings.TrimSpace(p1.Rationale) != "" {
+		t.Fatalf("[P1] rationale = %q, want empty: the writer must not author the reviewer's explanation", p1.Rationale)
+	}
+	if p1.State != db.FindingOpen {
+		t.Fatalf("[P1] state = %q, want open: a finding with no explicit rationale discharges nothing", p1.State)
+	}
+	// The detail itself must survive - refusing the discharge must not drop the
+	// reviewer's words, which is the other half of the invariant.
+	if p1.Detail != "read dischargedAtHead at this head" {
+		t.Fatalf("[P1] detail = %q, want the reviewer's detail preserved verbatim", p1.Detail)
+	}
+
+	p2 := byLabel["P2"]
+	if p2.EvidenceKind != db.EvidenceStatic || p2.State != db.FindingAnswered {
+		t.Fatalf("[P2] kind %s / state %s, want STATIC/answered: an explicit rationale is exactly what STATIC requires", p2.EvidenceKind, p2.State)
+	}
+	if p2.Rationale != "resolved the ordering at this head: STATIC rows now reach answeredIsMandatory" {
+		t.Fatalf("[P2] rationale = %q, want the reviewer's own sentence verbatim", p2.Rationale)
 	}
 }

--- a/internal/workflow/findings_ledger_truthfulness_test.go
+++ b/internal/workflow/findings_ledger_truthfulness_test.go
@@ -307,25 +307,45 @@ func TestAdvanceJobRefusesManufacturedBareStringFindings(t *testing.T) {
 		t.Fatalf("lowercase finding file = %q, want the real path", lower.File)
 	}
 
-	// The skips must be LOUD and the summary must count them.
+	// The refusals must be LOUD and the summary must count them.
+	//
+	// #1968 MOVED THE RULE AND SHARPENED THE EVENT. The predicate that lived here
+	// in the writer now lives at the store boundary, so these two findings are
+	// refused by RecordReviewFindingObservation rather than pre-filtered, and a
+	// content refusal is reported as findings_ledger_refused instead of sharing
+	// findings_ledger_skipped with transient store failures. This test keeps
+	// asserting what it always asserted - not recorded, loud, counted - and adds
+	// the two properties that make a refused P0 actionable: the event names the
+	// severity the reviewer claimed, and it quotes the reviewer's own bytes, so
+	// the concern is refused rather than discarded.
 	events, err := store.ListJobEvents(ctx, "review-manufactured")
 	if err != nil {
 		t.Fatalf("ListJobEvents returned error: %v", err)
 	}
-	skips, summary := 0, ""
+	refusals, summary := 0, ""
+	var refusalMessages []string
 	for _, event := range events {
 		switch event.Kind {
-		case "findings_ledger_skipped":
-			skips++
+		case "findings_ledger_refused":
+			refusals++
+			refusalMessages = append(refusalMessages, event.Message)
 		case "findings_ledger_recorded":
 			summary = event.Message
 		}
 	}
-	if skips != 2 {
-		t.Fatalf("skip events = %d, want 2: a finding that cannot be recorded must fail loudly", skips)
+	if refusals != 2 {
+		t.Fatalf("refusal events = %d, want 2: a finding that cannot be recorded must fail loudly", refusals)
 	}
-	if !strings.Contains(summary, "recorded 3 of 5") || !strings.Contains(summary, "2 skipped") {
-		t.Fatalf("summary = %q, want an honest 3 of 5 with 2 skipped", summary)
+	for _, message := range refusalMessages {
+		if !strings.Contains(message, "REFUSED") || !strings.Contains(message, "claimed severity") {
+			t.Fatalf("refusal event %q must say it was refused and at what claimed severity", message)
+		}
+		if !strings.Contains(message, "Reviewer's finding verbatim:") {
+			t.Fatalf("refusal event %q must quote the reviewer's finding back, or the concern is discarded rather than refused", message)
+		}
+	}
+	if !strings.Contains(summary, "recorded 3 of 5") || !strings.Contains(summary, "2 refused for articulating no concern") {
+		t.Fatalf("summary = %q, want an honest 3 of 5 with 2 refused", summary)
 	}
 }
 
@@ -400,20 +420,23 @@ func TestAdvanceJobRefusesToDischargeOnAManufacturedRationale(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ListJobEvents returned error: %v", err)
 	}
-	skip, summary := "", ""
+	// #1968: a content refusal now reports as findings_ledger_refused rather than
+	// sharing findings_ledger_skipped with transient store failures. The property
+	// under test is unchanged - the reversal is audible, never silent.
+	refusal, summary := "", ""
 	for _, event := range events {
 		switch event.Kind {
-		case "findings_ledger_skipped":
-			skip = event.Message
+		case "findings_ledger_refused":
+			refusal = event.Message
 		case "findings_ledger_recorded":
 			summary = event.Message
 		}
 	}
-	if skip == "" {
-		t.Fatal("N1 was refused with NO skip event; a silent drop is the other half of this lane's defect")
+	if refusal == "" {
+		t.Fatal("N1 was refused with NO refusal event; a silent drop is the other half of this lane's defect")
 	}
-	if !strings.Contains(summary, "recorded 1 of 2") || !strings.Contains(summary, "1 skipped") {
-		t.Fatalf("summary = %q, want an honest 1 of 2 with 1 skipped", summary)
+	if !strings.Contains(summary, "recorded 1 of 2") || !strings.Contains(summary, "1 refused for articulating no concern") {
+		t.Fatalf("summary = %q, want an honest 1 of 2 with 1 refused", summary)
 	}
 }
 

--- a/internal/workflow/findings_ledger_writer.go
+++ b/internal/workflow/findings_ledger_writer.go
@@ -44,13 +44,23 @@ type reviewFindingWire struct {
 	// Ledger fields. A reviewer that has read the brief can CONTINUE a prior
 	// finding by citing its uid; absent that, mint-by-default creates a new
 	// finding and the prior one stays unobserved, which is the fail-safe.
-	ContinuesUID   string   `json:"continues_uid"`
-	State          string   `json:"state"`
-	RelevanceKeys  []string `json:"relevance_keys"`
-	EvidenceKind   string   `json:"evidence_kind"`
-	Locator        string   `json:"evidence_locator"`
-	Rationale      string   `json:"rationale"`
-	WithdrawReason string   `json:"withdraw_reason"`
+	ContinuesUID  string   `json:"continues_uid"`
+	State         string   `json:"state"`
+	RelevanceKeys []string `json:"relevance_keys"`
+	EvidenceKind  string   `json:"evidence_kind"`
+	Locator       string   `json:"evidence_locator"`
+	// LocatorAlias is the SAME field under the key the real verdict used, and it
+	// is measured rather than guessed: the #1936 instance
+	// (local-review-gm-review-opus-18d2a757546655c2) emitted
+	// `"locator":"internal/workflow/merge_gate.go: collectImplementerAttribution
+	// ... (~lines 1436-1449)"`, not `evidence_locator`. Reading only the
+	// canonical key left the very shape that issue was filed about unread - so
+	// the first head "fixed" #1936 against a schema no reviewer had sent. Same
+	// rule as every other alternate key here: read what reviewers actually
+	// write, invent nothing.
+	LocatorAlias   string `json:"locator"`
+	Rationale      string `json:"rationale"`
+	WithdrawReason string `json:"withdraw_reason"`
 	// Evidence is the REFUTATION-LENS finding shape (risk.go): a lens emits
 	// {lens,refuted,severity,confidence,evidence:"file:line - why"} and NO file
 	// field, so before this the key set came out EMPTY and such a finding could
@@ -238,7 +248,7 @@ func (e Engine) ledgerObservationWithDeclaredState(job db.Job, payload JobPayloa
 			// re-resolves the locator against the head via PathExistsAtHead and
 			// fails the discharge when it has vanished. A locator that is prose
 			// only yields "" here and still lands in QUOTED, now with an event.
-			pathFromLensEvidence(wire.Locator),
+			pathFromLensEvidence(wire.locator()),
 		),
 		Line:           int64(wire.Line),
 		RelevanceKeys:  wire.RelevanceKeys,
@@ -365,7 +375,7 @@ func (e Engine) ledgerObservationWithDeclaredState(job db.Job, payload JobPayloa
 		// is preserved as RATIONALE instead of destroying the row. Nothing is
 		// invented: both values came from the reviewer.
 		proseCitation := ""
-		if locator := strings.TrimSpace(wire.Locator); locator != "" {
+		if locator := strings.TrimSpace(wire.locator()); locator != "" {
 			if db.IsStructuralFindingLocator(locator) {
 				obs.EvidenceLocator = locator
 			} else {
@@ -614,4 +624,11 @@ func looksLikeRepoPath(path string) bool {
 		}
 	}
 	return true
+}
+
+// locator returns whichever key the reviewer used for its citation. The
+// canonical `evidence_locator` wins; `locator` is the alternate a real verdict
+// sent.
+func (w reviewFindingWire) locator() string {
+	return firstNonEmptyLedgerText(w.Locator, w.LocatorAlias)
 }

--- a/internal/workflow/findings_ledger_writer.go
+++ b/internal/workflow/findings_ledger_writer.go
@@ -227,8 +227,19 @@ func (e Engine) ledgerObservationWithDeclaredState(job db.Job, payload JobPayloa
 		// alternates. `evidence` is last for detail because it is also the lens
 		// shape parsed for a path below, so a lens finding keeps its locator and
 		// still contributes its prose instead of writing an empty row.
-		Title:  firstNonEmptyLedgerText(strings.TrimSpace(wire.Title), strings.TrimSpace(wire.Summary)),
-		Detail: firstNonEmptyLedgerText(strings.TrimSpace(wire.Detail), strings.TrimSpace(wire.Body), strings.TrimSpace(wire.Evidence)),
+		Title: firstNonEmptyLedgerText(strings.TrimSpace(wire.Title), strings.TrimSpace(wire.Summary)),
+		// The unparseable prose citation lands here, LAST, and never in the
+		// rationale (#1941 f5). It is reviewer text, so dropping it would be the
+		// #1932 defect again - but it describes WHERE the reviewer looked, not
+		// WHY an obligation is answered, so it cannot stand in for a rationale.
+		// When the reviewer also wrote a detail that wins, and the citation's
+		// only unique content, the path, is already captured in File.
+		Detail: firstNonEmptyLedgerText(
+			strings.TrimSpace(wire.Detail),
+			strings.TrimSpace(wire.Body),
+			strings.TrimSpace(wire.Evidence),
+			unstructuredLocatorText(wire.locator()),
+		),
 		File: firstNonEmptyLedgerText(
 			strings.TrimSpace(wire.File),
 			pathFromLensEvidence(wire.Evidence),
@@ -326,7 +337,7 @@ func (e Engine) ledgerObservationWithDeclaredState(job db.Job, payload JobPayloa
 		obs.EvidenceKind = db.EvidenceExecuted
 		obs.ExecutedCommands = commands
 		obs.ExecutedCount = int64(len(commands))
-	case obs.File != "":
+	case obs.File != "" && strings.TrimSpace(wire.Rationale) != "":
 		// DECLARED static_only, OR DECLARED NOTHING. It falls through to STATIC
 		// rather than to QUOTED, and that choice is measured rather than
 		// preferred. THREE THINGS POINT THE SAME WAY:
@@ -374,18 +385,18 @@ func (e Engine) ledgerObservationWithDeclaredState(job db.Job, payload JobPayloa
 		// So a structural locator replaces the derived one, and a prose citation
 		// is preserved as RATIONALE instead of destroying the row. Nothing is
 		// invented: both values came from the reviewer.
-		proseCitation := ""
-		if locator := strings.TrimSpace(wire.locator()); locator != "" {
-			if db.IsStructuralFindingLocator(locator) {
-				obs.EvidenceLocator = locator
-			} else {
-				proseCitation = locator
-			}
+		if locator := strings.TrimSpace(wire.locator()); locator != "" && db.IsStructuralFindingLocator(locator) {
+			obs.EvidenceLocator = locator
 		}
-		// The prose citation ranks above title/detail because it is what the
-		// reviewer offered as the thing it READ, which is exactly what a STATIC
-		// rationale is for. An explicit `rationale` still wins over both.
-		obs.Rationale = firstNonEmptyLedgerText(wire.Rationale, proseCitation, obs.Title, obs.Detail, "reported by a review that declared no executed checks")
+		// THE RATIONALE IS THE REVIEWER'S, VERBATIM, OR THERE IS NO STATIC ROW
+		// (#1941 f5). This used to fall back to the prose citation, then the
+		// title, then the detail, then a string this writer authored - and the
+		// store demands a rationale for a STATIC discharge, so those fallbacks
+		// were manufacturing the very assertion the bar exists to require. A
+		// rationale says WHY an obligation is answered; only the reviewer can
+		// say that. Generic finding prose is not that sentence, and neither is
+		// "reported by a review that declared no executed checks".
+		obs.Rationale = strings.TrimSpace(wire.Rationale)
 	default:
 		// No locator to cite and no declared execution: recordable for context
 		// and incapable of discharging anything, which is the honest floor.
@@ -393,9 +404,10 @@ func (e Engine) ledgerObservationWithDeclaredState(job db.Job, payload JobPayloa
 		obs.State = db.FindingOpen
 		obs.ExecutedCommands = commands
 	}
-	if obs.EvidenceKind == db.EvidenceStatic && strings.TrimSpace(obs.Rationale) == "" {
-		obs.Rationale = "reported by a static review with no executed checks"
-	}
+	// The second synthesis site, deleted for the same reason. A STATIC row is
+	// now only reachable WITH an explicit rationale, so there is nothing left to
+	// fill in; filling it in was what let the store's bar be satisfied by text
+	// the reviewer never wrote.
 	if obs.State == db.FindingWithdrawn && obs.WithdrawReason == "" {
 		// The store refuses a reasonless withdrawal; a review asking for one
 		// without saying why is downgraded to OPEN rather than rejected, because
@@ -611,19 +623,23 @@ func looksLikeRepoPath(path string) bool {
 	if path == "" {
 		return false
 	}
-	if strings.Contains(path, "/") {
-		return true
-	}
-	dot := strings.LastIndex(path, ".")
-	if dot <= 0 || dot == len(path)-1 {
-		return false
-	}
-	for _, r := range path[dot+1:] {
-		if !((r >= 'A' && r <= 'Z') || (r >= 'a' && r <= 'z')) {
-			return false
-		}
-	}
-	return true
+	// AN EXACT PARSE, NOT A DOTTED-TOKEN HEURISTIC (#1941 f6). Two rounds of
+	// tightening a heuristic failed the same way: "any dotted token" invented
+	// "v1.2", and "any dotted token with an alphabetic extension" invented
+	// "v1.beta". The class is prose that happens to contain a dot, and no
+	// extension rule decides it - a denylist of version spellings least of all.
+	//
+	// A repo-relative locator contains a DIRECTORY SEPARATOR. That is checkable
+	// rather than suggestive; it accepts every locator in the measured evidence
+	// (apps/web/src/views/LandingView.vue, internal/workflow/merge_gate.go) and
+	// rejects version labels and prose BY CONSTRUCTION rather than by
+	// recognising their spelling. Existence is still not claimed here - that is
+	// resolved under the head being judged.
+	//
+	// Cost, stated rather than hidden: a root-level file cited without a
+	// directory is refused. No observed verdict has done that, and refusing is
+	// the safe direction for a value that can authorise a discharge.
+	return strings.Contains(path, "/")
 }
 
 // locator returns whichever key the reviewer used for its citation. The
@@ -631,4 +647,15 @@ func looksLikeRepoPath(path string) bool {
 // sent.
 func (w reviewFindingWire) locator() string {
 	return firstNonEmptyLedgerText(w.Locator, w.LocatorAlias)
+}
+
+// unstructuredLocatorText returns the reviewer's citation when it is NOT a
+// structural locator, so prose is preserved as detail rather than vanishing.
+// A structural locator is already stored as the locator itself.
+func unstructuredLocatorText(locator string) string {
+	locator = strings.TrimSpace(locator)
+	if locator == "" || db.IsStructuralFindingLocator(locator) {
+		return ""
+	}
+	return locator
 }

--- a/internal/workflow/findings_ledger_writer.go
+++ b/internal/workflow/findings_ledger_writer.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/gitmoot/gitmoot/internal/db"
+	"github.com/gitmoot/gitmoot/internal/reviewseverity"
 )
 
 // THE PRODUCTION WRITER (#1850 review F1, P1, found by both verdicts).
@@ -56,6 +57,23 @@ type reviewFindingWire struct {
 	// never be re-armed by relevance once answered (#1850 round 2 F4).
 	Evidence string `json:"evidence"`
 	Lens     string `json:"lens"`
+	// ALTERNATE PROSE KEYS, MEASURED FROM REAL VERDICTS (#1928). Findings ride as
+	// free-form json.RawMessage, so a reviewer that names its prose differently
+	// silently loses it: the row is written with an EMPTY title or detail and the
+	// text survives only inside the job payload, where no ledger reader looks.
+	// Four instances in one evening, three distinct schemas, each dropping a
+	// different column:
+	//
+	//   #1930 round 1 emitted {title, body}            -> detail EMPTY
+	//   #1921 round 3 emitted {title, evidence}        -> detail EMPTY
+	//   #1930 round 3 emitted {summary, detail, location} -> title EMPTY, file EMPTY
+	//
+	// A row nobody can read cannot be dispositioned, which is exactly what the
+	// gate's obligation message needs it for. These keys are READ, never invented:
+	// each one is a field a real reviewer actually sent.
+	Body     string `json:"body"`
+	Summary  string `json:"summary"`
+	Location string `json:"location"`
 }
 
 // pathFromLensEvidence extracts the leading repo-relative path from a lens
@@ -95,7 +113,7 @@ func (e Engine) RecordReviewFindingsToLedger(ctx context.Context, job db.Job, pa
 	if head == "" || repo == "" || payload.PullRequest <= 0 || len(payload.Result.Findings) == 0 {
 		return nil
 	}
-	written, skipped := 0, 0
+	written, skipped, downgrades := 0, 0, 0
 	for index, raw := range payload.Result.Findings {
 		var wire reviewFindingWire
 		if err := json.Unmarshal(raw, &wire); err != nil {
@@ -108,9 +126,9 @@ func (e Engine) RecordReviewFindingsToLedger(ctx context.Context, job db.Job, pa
 				e.recordLedgerSkip(ctx, job.ID, index, fmt.Sprintf("finding is neither an object nor a string: %v", err))
 				continue
 			}
-			wire = reviewFindingWire{Title: text}
+			wire = wireFromBareFindingText(text)
 		}
-		obs, ok := e.ledgerObservationFor(job, payload, wire, head, repo)
+		obs, declared, ok := e.ledgerObservationWithDeclaredState(job, payload, wire, head, repo)
 		if !ok {
 			skipped++
 			e.recordLedgerSkip(ctx, job.ID, index, "finding carries no file and the review executed nothing, so no evidence kind is truthful")
@@ -122,6 +140,15 @@ func (e Engine) RecordReviewFindingsToLedger(ctx context.Context, job db.Job, pa
 			continue
 		}
 		written++
+		// #1936: A REVERSAL THE REVIEWER DID NOT ASK FOR IS NOW AUDIBLE. The row
+		// is recorded either way - dropping it would lose the observation - but a
+		// declared disposition that did not survive is named, with the reason, so
+		// the lane can supply a `file` or an execution instead of discovering the
+		// reversal from a gate refusal several steps later.
+		if downgraded, reason := ledgerStateDowngrade(declared, obs); downgraded {
+			e.recordLedgerDowngrade(ctx, job.ID, index, declared, obs.State, reason)
+			downgrades++
+		}
 	}
 	// THE SUMMARY EVENT IS BEST-EFFORT AND ITS FAILURE MUST NOT FAIL THE REVIEW.
 	// Returning it would hand AdvanceJob an error, and AdvanceJob's caller treats
@@ -140,8 +167,12 @@ func (e Engine) RecordReviewFindingsToLedger(ctx context.Context, job db.Job, pa
 	_ = e.Store.AddJobEvent(ctx, db.JobEvent{
 		JobID: job.ID,
 		Kind:  "findings_ledger_recorded",
-		Message: fmt.Sprintf("recorded %d of %d reported finding(s) to the #1822 ledger at head %s (%d skipped)",
-			written, len(payload.Result.Findings), head, skipped),
+		// THE COUNT NO LONGER OVERSTATES ITSELF (#1936). "recorded 4 of 4 ... (0
+		// skipped)" was true of the WRITE and false of the OUTCOME: three of those
+		// four rows had their declared disposition reversed. A summary that cannot
+		// distinguish those two facts is the false-success half of this defect.
+		Message: fmt.Sprintf("recorded %d of %d reported finding(s) to the #1822 ledger at head %s (%d skipped, %d downgraded)",
+			written, len(payload.Result.Findings), head, skipped, downgrades),
 	})
 	return nil
 }
@@ -149,23 +180,59 @@ func (e Engine) RecordReviewFindingsToLedger(ctx context.Context, job db.Job, pa
 // ledgerObservationFor builds the observation, choosing the evidence kind from
 // what the review ACTUALLY did rather than from what would be convenient.
 func (e Engine) ledgerObservationFor(job db.Job, payload JobPayload, wire reviewFindingWire, head string, repo string) (db.ReviewFindingObservation, bool) {
+	obs, _, ok := e.ledgerObservationWithDeclaredState(job, payload, wire, head, repo)
+	return obs, ok
+}
+
+// ledgerObservationWithDeclaredState additionally reports the state the REVIEWER
+// declared, so the caller can say when the recorded state is not the declared
+// one. #1936: a declared `answered` silently became `open` while the summary
+// event still read "recorded 4 of 4 ... (0 skipped)" - a false success beside a
+// silent reversal, which is the pair this lane exists to remove.
+func (e Engine) ledgerObservationWithDeclaredState(job db.Job, payload JobPayload, wire reviewFindingWire, head string, repo string) (db.ReviewFindingObservation, db.FindingState, bool) {
 	obs := db.ReviewFindingObservation{
-		Repo:           repo,
-		PullRequest:    int64(payload.PullRequest),
-		HeadSHA:        head,
-		ObserverJob:    job.ID,
-		Severity:       strings.TrimSpace(wire.Severity),
-		RoundLabel:     strings.TrimSpace(wire.ID),
-		Title:          strings.TrimSpace(wire.Title),
-		Detail:         strings.TrimSpace(wire.Detail),
-		File:           firstNonEmptyLedgerText(strings.TrimSpace(wire.File), pathFromLensEvidence(wire.Evidence)),
+		Repo:        repo,
+		PullRequest: int64(payload.PullRequest),
+		HeadSHA:     head,
+		ObserverJob: job.ID,
+		Severity:    strings.TrimSpace(wire.Severity),
+		RoundLabel:  strings.TrimSpace(wire.ID),
+		// PROSE IS TAKEN FROM WHICHEVER KEY THE REVIEWER USED (#1928). Order is
+		// specific-to-general: the canonical key wins, then the observed
+		// alternates. `evidence` is last for detail because it is also the lens
+		// shape parsed for a path below, so a lens finding keeps its locator and
+		// still contributes its prose instead of writing an empty row.
+		Title:  firstNonEmptyLedgerText(strings.TrimSpace(wire.Title), strings.TrimSpace(wire.Summary)),
+		Detail: firstNonEmptyLedgerText(strings.TrimSpace(wire.Detail), strings.TrimSpace(wire.Body), strings.TrimSpace(wire.Evidence)),
+		File: firstNonEmptyLedgerText(
+			strings.TrimSpace(wire.File),
+			pathFromLensEvidence(wire.Evidence),
+			pathFromLensEvidence(wire.Location),
+			// #1936: evidence_locator LAST. A reviewer that cites
+			// "internal/workflow/merge_gate.go: collectImplementerAttribution
+			// (~lines 1436-1449)" and no `file` used to fall through to QUOTED,
+			// which forced its declared `answered` to `open` - so three real
+			// dispositions became three open rows and the gate refused a head
+			// whose reviewer had done the work. Zero STATIC rows had ever reached
+			// answered in this store, against 13 EXECUTED, which is what that
+			// looks like from the outside.
+			//
+			// NO FILESYSTEM CHECK HERE, deliberately: the writer has no tree, which
+			// is the same reason the store boundary does not check either. A
+			// path-SHAPED leading token is enough, because answeredIsMandatory
+			// re-resolves the locator against the head via PathExistsAtHead and
+			// fails the discharge when it has vanished. A locator that is prose
+			// only yields "" here and still lands in QUOTED, now with an event.
+			pathFromLensEvidence(wire.Locator),
+		),
 		Line:           int64(wire.Line),
 		RelevanceKeys:  wire.RelevanceKeys,
 		ContinuesUID:   strings.TrimSpace(wire.ContinuesUID),
 		WithdrawReason: strings.TrimSpace(wire.WithdrawReason),
 		SourceJob:      job.ID,
 	}
-	switch db.FindingState(strings.ToLower(strings.TrimSpace(wire.State))) {
+	declared := db.FindingState(strings.ToLower(strings.TrimSpace(wire.State)))
+	switch declared {
 	case db.FindingAnswered:
 		obs.State = db.FindingAnswered
 	case db.FindingWithdrawn:
@@ -242,10 +309,31 @@ func (e Engine) ledgerObservationFor(job db.Job, payload JobPayload, wire review
 			// this way so the host:port lint has nothing to match on.
 			obs.EvidenceLocator = obs.File + ":" + strconv.Itoa(int(wire.Line))
 		}
-		if strings.TrimSpace(wire.Locator) != "" {
-			obs.EvidenceLocator = strings.TrimSpace(wire.Locator)
+		// THE REVIEWER'S LOCATOR IS ONLY USED AS THE LOCATOR WHEN IT IS
+		// STRUCTURALLY ONE (#1936). This override used to be unconditional, and
+		// the store requires a locator matching `path` or `path:line` for a STATIC
+		// discharge - so a reviewer that wrote a citation in prose
+		// ("internal/workflow/merge_gate.go: collectImplementerAttribution
+		// (~lines 1436-1449)") had its whole observation REFUSED, even when it
+		// had also supplied a usable `file`. Measured: that exact finding was
+		// rejected with ErrFindingDischarge while its rationale was non-empty,
+		// which is why the ledger held zero answered STATIC rows.
+		//
+		// So a structural locator replaces the derived one, and a prose citation
+		// is preserved as RATIONALE instead of destroying the row. Nothing is
+		// invented: both values came from the reviewer.
+		proseCitation := ""
+		if locator := strings.TrimSpace(wire.Locator); locator != "" {
+			if db.IsStructuralFindingLocator(locator) {
+				obs.EvidenceLocator = locator
+			} else {
+				proseCitation = locator
+			}
 		}
-		obs.Rationale = firstNonEmptyLedgerText(wire.Rationale, obs.Title, obs.Detail, "reported by a review that declared no executed checks")
+		// The prose citation ranks above title/detail because it is what the
+		// reviewer offered as the thing it READ, which is exactly what a STATIC
+		// rationale is for. An explicit `rationale` still wins over both.
+		obs.Rationale = firstNonEmptyLedgerText(wire.Rationale, proseCitation, obs.Title, obs.Detail, "reported by a review that declared no executed checks")
 	default:
 		// No locator to cite and no declared execution: recordable for context
 		// and incapable of discharging anything, which is the honest floor.
@@ -262,7 +350,7 @@ func (e Engine) ledgerObservationFor(job db.Job, payload JobPayload, wire review
 		// dropping the row entirely would lose the observation.
 		obs.State = db.FindingOpen
 	}
-	return obs, true
+	return obs, declared, true
 }
 
 func firstNonEmptyLedgerText(values ...string) string {
@@ -374,4 +462,76 @@ func (e Engine) ledgerObligationBrief(ctx context.Context, repo string, pullRequ
 // gate incapable of disagreeing (#1850 round 3 item 1).
 func (e Engine) ledgerScopeFor(repo string, pullRequest int, taskID string) LedgerScope {
 	return e.LedgerResolvers.ScopeFor(repo, pullRequest, taskID)
+}
+
+// ledgerStateDowngrade reports whether the recorded state differs from the one
+// the reviewer declared, and why. It never invents a downgrade for an omitted
+// state: silence means OPEN by design, so only a DECLARED disposition that did
+// not survive is a reversal worth naming.
+func ledgerStateDowngrade(declared db.FindingState, obs db.ReviewFindingObservation) (bool, string) {
+	switch declared {
+	case db.FindingAnswered, db.FindingWithdrawn, db.FindingSuperseded:
+	default:
+		return false, ""
+	}
+	if obs.State == declared {
+		return false, ""
+	}
+	switch {
+	case declared == db.FindingWithdrawn && strings.TrimSpace(obs.WithdrawReason) == "":
+		return true, "withdrawal carried no withdraw_reason"
+	case obs.EvidenceKind == db.EvidenceQuoted:
+		return true, "evidence QUOTED: no file or path-shaped evidence_locator, and the review declared no executed checks"
+	default:
+		return true, "recorded state differs from the declared one"
+	}
+}
+
+func (e Engine) recordLedgerDowngrade(ctx context.Context, jobID string, index int, declared db.FindingState, recorded db.FindingState, reason string) {
+	if e.Store == nil {
+		return
+	}
+	_ = e.Store.AddJobEvent(ctx, db.JobEvent{
+		JobID: jobID,
+		Kind:  "findings_ledger_downgraded",
+		Message: fmt.Sprintf("finding[%d] declared %s, recorded %s (%s)",
+			index, declared, recorded, reason),
+	})
+}
+
+// wireFromBareFindingText reads a finding an agent emitted as ONE PROSE STRING.
+//
+// MEASURED, not hypothesised: review job
+// local-review-joltra-sol-review-18d2b773bd0c534b returned six real findings
+// and the ledger recorded ZERO, six times over -
+// `requires an explicit severity of P0, P1, P2 or P3: got ""` - because every
+// finding arrived as "P2 apps/web/src/views/LandingView.vue:365 (mirrored at
+// ...) - prose". The severity and the locator were both PRESENT, inline, and
+// the writer read neither, so the store refused all six and a review that found
+// six defects left an empty ledger.
+//
+// That skip was LOUD, which is the correct half of the invariant, and it stays
+// loud for anything unparseable. What was wrong is that the writer discarded
+// values the reviewer actually sent. Only a LEADING severity token is read, and
+// only a path-shaped token after it - nothing is inferred from prose, because a
+// wrong locator re-arms the wrong finding.
+func wireFromBareFindingText(text string) reviewFindingWire {
+	wire := reviewFindingWire{Title: strings.TrimSpace(text)}
+	fields := strings.Fields(wire.Title)
+	if len(fields) == 0 {
+		return wire
+	}
+	severity := strings.ToUpper(strings.Trim(fields[0], ":,"))
+	if !reviewseverity.Valid(severity) {
+		return wire
+	}
+	wire.Severity = severity
+	rest := strings.TrimSpace(strings.TrimPrefix(wire.Title, fields[0]))
+	wire.Title = firstNonEmptyLedgerText(rest, wire.Title)
+	// The locator, when the next token is path-shaped. pathFromLensEvidence is
+	// the same parser the lens shape already uses, so one rule governs both.
+	if path := pathFromLensEvidence(rest); path != "" {
+		wire.File = path
+	}
+	return wire
 }

--- a/internal/workflow/findings_ledger_writer.go
+++ b/internal/workflow/findings_ledger_writer.go
@@ -3,6 +3,7 @@ package workflow
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strconv"
 	"strings"
@@ -123,7 +124,7 @@ func (e Engine) RecordReviewFindingsToLedger(ctx context.Context, job db.Job, pa
 	if head == "" || repo == "" || payload.PullRequest <= 0 || len(payload.Result.Findings) == 0 {
 		return nil
 	}
-	written, skipped, downgrades := 0, 0, 0
+	written, skipped, downgrades, refused := 0, 0, 0, 0
 	for index, raw := range payload.Result.Findings {
 		var wire reviewFindingWire
 		if err := json.Unmarshal(raw, &wire); err != nil {
@@ -138,21 +139,6 @@ func (e Engine) RecordReviewFindingsToLedger(ctx context.Context, job db.Job, pa
 			}
 			wire = wireFromBareFindingText(text)
 		}
-		// A SEVERITY TOKEN IS NOT A FINDING (#1941 review f2). "P2:" was recorded
-		// as a QUOTED row whose only title was the severity itself, and an object
-		// carrying nothing but {id, severity} was recorded with title and detail
-		// both empty. Both are the empty-row defect #1932 was filed against,
-		// reached from the permissive side: my parser rescued the severity and
-		// then had nothing left to record. The invariant's loud-failure half
-		// covers this, so it skips and is never counted.
-		if strings.TrimSpace(wire.Title) == "" && strings.TrimSpace(wire.Detail) == "" &&
-			strings.TrimSpace(wire.Body) == "" && strings.TrimSpace(wire.Summary) == "" &&
-			strings.TrimSpace(wire.Evidence) == "" && strings.TrimSpace(wire.Rationale) == "" {
-			skipped++
-			e.recordLedgerSkip(ctx, job.ID, index,
-				"finding carries no title, detail, body, summary or evidence, so the row would say nothing about what it observed")
-			continue
-		}
 		obs, declared, ok := e.ledgerObservationWithDeclaredState(job, payload, wire, head, repo)
 		if !ok {
 			skipped++
@@ -160,6 +146,24 @@ func (e Engine) RecordReviewFindingsToLedger(ctx context.Context, job db.Job, pa
 			continue
 		}
 		if _, err := e.Store.RecordReviewFindingObservation(ctx, obs); err != nil {
+			// A CONTENT REFUSAL IS NOT A STORE HICCUP, and reporting them the same
+			// way is what let 73 of these become obligations somebody withdrew by
+			// hand (#1968). It is the producer's contract violation, it is
+			// deterministic, and re-running the review changes nothing unless the
+			// reviewer says what it observed. So it gets its own event kind, it
+			// names the severity the reviewer claimed, and it QUOTES the finding
+			// back - the concern is refused, never discarded, which is the whole
+			// difference between this and a silent drop.
+			//
+			// It deliberately does NOT fail the review, and does not need to: the
+			// verdict still blocks the merge on its own severity, so a refused P0
+			// cannot let a head through. Failing here would throw away the other
+			// findings in the same result and the verdict with them.
+			if errors.Is(err, db.ErrFindingNoConcern) {
+				refused++
+				e.recordLedgerContentRefusal(ctx, job.ID, index, obs.Severity, raw)
+				continue
+			}
 			skipped++
 			e.recordLedgerSkip(ctx, job.ID, index, fmt.Sprintf("store refused the observation: %v", err))
 			continue
@@ -196,8 +200,8 @@ func (e Engine) RecordReviewFindingsToLedger(ctx context.Context, job db.Job, pa
 		// skipped)" was true of the WRITE and false of the OUTCOME: three of those
 		// four rows had their declared disposition reversed. A summary that cannot
 		// distinguish those two facts is the false-success half of this defect.
-		Message: fmt.Sprintf("recorded %d of %d reported finding(s) to the #1822 ledger at head %s (%d skipped, %d downgraded)",
-			written, len(payload.Result.Findings), head, skipped, downgrades),
+		Message: fmt.Sprintf("recorded %d of %d reported finding(s) to the #1822 ledger at head %s (%d skipped, %d downgraded, %d refused for articulating no concern)",
+			written, len(payload.Result.Findings), head, skipped, downgrades, refused),
 	})
 	return nil
 }
@@ -458,6 +462,45 @@ func (e Engine) ReviewObligationBrief(ctx context.Context, repo string, pullRequ
 	return e.ledgerObligationBrief(ctx, repo, pullRequest, head, taskID)
 }
 
+// recordLedgerContentRefusal records a finding the store refused for saying
+// nothing (#1968), and it is deliberately NOT recordLedgerSkip.
+//
+// PHOBOS's condition on this slice: a P0 with no title must not be silently
+// dropped by the gate that refuses it. So this event carries the three things a
+// reader needs to act without the row existing - which finding, at what claimed
+// severity, and the reviewer's own bytes - and it says what to do about it. The
+// raw JSON is bounded because a finding can carry a large evidence blob and a
+// job event is not a place to store one.
+func (e Engine) recordLedgerContentRefusal(ctx context.Context, jobID string, index int, severity string, raw json.RawMessage) {
+	if e.Store == nil {
+		return
+	}
+	claimed := strings.TrimSpace(severity)
+	if claimed == "" {
+		claimed = "(none)"
+	}
+	quoted := strings.TrimSpace(string(raw))
+	if len(quoted) > ledgerRefusalQuoteLimit {
+		quoted = quoted[:ledgerRefusalQuoteLimit] + "... (truncated)"
+	}
+	_ = e.Store.AddJobEvent(ctx, db.JobEvent{
+		JobID: jobID,
+		Kind:  "findings_ledger_refused",
+		Message: fmt.Sprintf(
+			"finding[%d] at claimed severity %s was REFUSED, not recorded: it carries no title, detail or rationale, "+
+				"so it names no defect that can be evaluated or discharged. The verdict's own severity still blocks the "+
+				"merge, so nothing is unblocked by this refusal. Restate the concern with a title and a detail. "+
+				"Reviewer's finding verbatim: %s",
+			index, claimed, quoted),
+	})
+}
+
+// ledgerRefusalQuoteLimit bounds the reviewer bytes echoed into the refusal
+// event. Long enough for any real finding object observed on this box (the
+// longest recorded title is 464 characters), short enough that an evidence blob
+// cannot turn an audit row into a payload.
+const ledgerRefusalQuoteLimit = 2000
+
 // ledgerObligationBrief renders the prior findings a round at this head must
 // observe, for inclusion in the review brief. THIS IS THE HALF THAT KEEPS THE
 // GATE FROM REJECTING VALID INPUT: an obligation can only be discharged by
@@ -503,6 +546,10 @@ func (e Engine) ledgerObligationBrief(ctx context.Context, repo string, pullRequ
 	b.WriteString("EVERY finding you emit needs an explicit \"severity\" of P0, P1, P2 or P3. A finding with none is\n")
 	b.WriteString("REFUSED rather than stored, because a row with no severity is an obligation no severity policy\n")
 	b.WriteString("can ever disposition, and it is not the same thing as P3 (#1928).\n")
+	b.WriteString("EVERY finding also needs an articulated concern: a \"title\", a \"detail\" or a \"rationale\". A file\n")
+	b.WriteString("and line alone is REFUSED rather than stored (#1968), because a bare locator says where to look\n")
+	b.WriteString("and nothing about what is wrong there, so no later round can evaluate or discharge it. Return\n")
+	b.WriteString("fewer findings rather than empty ones; a refusal is reported back against your job.\n")
 	for _, obligation := range pending {
 		label := obligation.RoundLabel
 		if strings.TrimSpace(label) == "" {

--- a/internal/workflow/findings_ledger_writer.go
+++ b/internal/workflow/findings_ledger_writer.go
@@ -89,7 +89,7 @@ func pathFromLensEvidence(evidence string) string {
 	head = strings.TrimSuffix(strings.TrimSpace(head), ",")
 	path, _, _ := strings.Cut(head, ":")
 	path = strings.TrimSpace(path)
-	if path == "" || !strings.Contains(path, "/") && !strings.Contains(path, ".") {
+	if !looksLikeRepoPath(path) {
 		return ""
 	}
 	return path
@@ -127,6 +127,21 @@ func (e Engine) RecordReviewFindingsToLedger(ctx context.Context, job db.Job, pa
 				continue
 			}
 			wire = wireFromBareFindingText(text)
+		}
+		// A SEVERITY TOKEN IS NOT A FINDING (#1941 review f2). "P2:" was recorded
+		// as a QUOTED row whose only title was the severity itself, and an object
+		// carrying nothing but {id, severity} was recorded with title and detail
+		// both empty. Both are the empty-row defect #1932 was filed against,
+		// reached from the permissive side: my parser rescued the severity and
+		// then had nothing left to record. The invariant's loud-failure half
+		// covers this, so it skips and is never counted.
+		if strings.TrimSpace(wire.Title) == "" && strings.TrimSpace(wire.Detail) == "" &&
+			strings.TrimSpace(wire.Body) == "" && strings.TrimSpace(wire.Summary) == "" &&
+			strings.TrimSpace(wire.Evidence) == "" && strings.TrimSpace(wire.Rationale) == "" {
+			skipped++
+			e.recordLedgerSkip(ctx, job.ID, index,
+				"finding carries no title, detail, body, summary or evidence, so the row would say nothing about what it observed")
+			continue
 		}
 		obs, declared, ok := e.ledgerObservationWithDeclaredState(job, payload, wire, head, repo)
 		if !ok {
@@ -231,6 +246,33 @@ func (e Engine) ledgerObservationWithDeclaredState(job db.Job, payload JobPayloa
 		WithdrawReason: strings.TrimSpace(wire.WithdrawReason),
 		SourceJob:      job.ID,
 	}
+	// #1941 review f1, P1. A STATIC row is DISCHARGEABLE, and the store demands a
+	// rationale for one - which this writer then manufactured
+	// ("reported by a review that declared no executed checks") even when the
+	// reviewer had supplied no title, no detail and no rationale. Combined with
+	// my locator promotion that produced a discharge built entirely out of a
+	// path I parsed myself, which is inventing evidence: the exact opposite of
+	// this lane's invariant, arriving from the permissive side.
+	//
+	// THE GUARD LIVES AT THE ENTRY, NOT HERE, AND A SURVIVING MUTANT IS WHY.
+	// My first remediation put a second condition on this STATIC branch
+	// requiring reviewer-supplied content. Mutating it away left every test
+	// green, and the reason is structural rather than a missing fixture:
+	// RecordReviewFindingsToLedger already refuses a finding carrying no title,
+	// detail, body, summary, evidence or rationale, and every one of those feeds
+	// obs.Title, obs.Detail or obs.Rationale - so nothing content-free can reach
+	// this branch at all. A condition that cannot fail is not a guard, so it is
+	// deleted rather than kept for reassurance. The entry check is the single
+	// place the invariant is enforced, and mutating IT fails two tests.
+	//
+	// AND A LIMIT I AM NAMING RATHER THAN IMPLYING I CLOSED: the reviewer also
+	// showed that a SAME-HEAD non-QUOTED observation never reaches
+	// answeredIsMandatory at all - dischargedAtHead (findings_ledger.go) marks it
+	// discharged and LedgerObligationsAtHead skips it - so PathExistsAtHead is
+	// not consulted for a discharge recorded at the head under review. I
+	// verified that in source. It predates this PR, affects file-based STATIC
+	// rows identically, and lives outside this lane's file boundary, so it is
+	// reported rather than patched here.
 	declared := db.FindingState(strings.ToLower(strings.TrimSpace(wire.State)))
 	switch declared {
 	case db.FindingAnswered:
@@ -526,12 +568,50 @@ func wireFromBareFindingText(text string) reviewFindingWire {
 		return wire
 	}
 	wire.Severity = severity
+	// NO FALLBACK TO THE WHOLE STRING (#1941 review f2). This used to read
+	// firstNonEmptyLedgerText(rest, wire.Title), so a bare "P2:" - nothing but a
+	// severity - kept the token itself as its title, passed the content check,
+	// and was recorded as a row whose only content was the severity it had just
+	// been parsed out of. An empty remainder means the finding said nothing, and
+	// saying nothing must skip loudly rather than round-trip through a title.
 	rest := strings.TrimSpace(strings.TrimPrefix(wire.Title, fields[0]))
-	wire.Title = firstNonEmptyLedgerText(rest, wire.Title)
+	wire.Title = rest
 	// The locator, when the next token is path-shaped. pathFromLensEvidence is
 	// the same parser the lens shape already uses, so one rule governs both.
 	if path := pathFromLensEvidence(rest); path != "" {
 		wire.File = path
 	}
 	return wire
+}
+
+// looksLikeRepoPath is the tightened rule (#1941 review f2). "any token
+// containing a dot" was too loose and INVENTED locators out of prose: a bare
+// "P2 v1.2 is a version, not a repository file" produced File and
+// EvidenceLocator "v1.2" and recorded a STATIC row - manufacture from nothing,
+// which is the defect this lane exists to remove, arriving from the permissive
+// side.
+//
+// A directory separator is accepted outright. Otherwise the token must carry an
+// ALPHABETIC extension - "exec_linux.go", "LandingView.vue" - because a numeric
+// or absent extension is what versions, line ranges and ordinary prose look
+// like. Nothing here proves the path EXISTS: that is answeredIsMandatory's job,
+// where a tree is available.
+func looksLikeRepoPath(path string) bool {
+	path = strings.TrimSpace(path)
+	if path == "" {
+		return false
+	}
+	if strings.Contains(path, "/") {
+		return true
+	}
+	dot := strings.LastIndex(path, ".")
+	if dot <= 0 || dot == len(path)-1 {
+		return false
+	}
+	for _, r := range path[dot+1:] {
+		if !((r >= 'A' && r <= 'Z') || (r >= 'a' && r <= 'z')) {
+			return false
+		}
+	}
+	return true
 }

--- a/internal/workflow/findings_ledger_writer_test.go
+++ b/internal/workflow/findings_ledger_writer_test.go
@@ -353,3 +353,121 @@ func TestAdvanceJobPreservesASupersededRoundsFindings(t *testing.T) {
 		t.Fatal("the stale round's observation discharged the obligation at the CURRENT head")
 	}
 }
+
+// TestAdvanceJobKeepsProseFromEveryObservedFindingSchema pins the defect measured
+// on 2026-09-05, THROUGH THE PRODUCTION PATH: AdvanceJob -> the writer -> the
+// store, then reads the persisted rows back.
+//
+// IT DELIBERATELY DOES NOT CALL ledgerObservationFor. An earlier version of this
+// test did, and a review made the point that decided this shape: a routing mutant
+// that leaves every real verdict on another path still passes a test that pins the
+// helper. The only way to defend the persisted row is to enter where production
+// enters and assert what production stored.
+//
+// EVERY FIXTURE IS A REAL VERDICT SHAPE recorded that evening, not an invented
+// one. Three reviewers used three schemas and each silently dropped a different
+// column, because the writer read only title/detail/file:
+//
+//	#1930 round 1  {title, body}                -> detail EMPTY
+//	#1921 round 3  {title, evidence}            -> detail EMPTY
+//	#1930 round 3  {summary, detail, location}   -> title and file EMPTY
+//
+// WHAT THIS IS NOT, stated because the first diagnosis was wrong and was ruled on
+// in directive 122197: it is NOT a gate bypass and not the #1928 severity defect.
+// reviewseverity.Blocks fails closed on an unknown severity and
+// LedgerObligationsAtHead keys on STATE rather than severity, so an empty column
+// never turned a blocking row into a passing one. The damage is auditability: the
+// gate names each obligation by uid, severity and title, so a row with an empty
+// title tells the next reviewer nothing about what it must answer, and the prose
+// survives only inside the job payload where no ledger reader looks.
+func TestAdvanceJobKeepsProseFromEveryObservedFindingSchema(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	seedAgent(t, store, "g7-review", []string{"review"}, "gitmoot/gitmoot")
+	engine := testEngine(store)
+	head := strings.Repeat("b", 40)
+
+	insertCompletedJob(t, store, db.Job{ID: "review-schemas", Agent: "g7-review", Type: "review"}, JobPayload{
+		Repo: "gitmoot/gitmoot", Branch: "task-schema", PullRequest: 1931, HeadSHA: head,
+		TaskID: "task-schema", ReviewRound: "review-1",
+		Result: &AgentResult{
+			Decision: "changes_requested", Severity: "P1", Summary: "three reviewer schemas",
+			Evidence: EvidenceExecuted,
+			TestsRun: []string{"go test ./internal/workflow/ -> ok"},
+			Findings: []json.RawMessage{
+				json.RawMessage(`{"id":"C1","severity":"P1","file":"internal/sandbox/exec_linux.go","line":274,"title":"canonical title","detail":"canonical detail"}`),
+				json.RawMessage(`{"id":"B1","severity":"P1","file":"internal/cli/review_phase_instrument.go","line":280,"title":"FIFO pairing loses identity","body":"The profiler discards translator tool IDs and pairs results with commands FIFO."}`),
+				json.RawMessage(`{"id":"E1","severity":"P1","title":"markers still let a profile buy a grant","evidence":"internal/sandbox/exec_linux.go:274 - isPackageInstallRoot only requires a node_modules segment and a regular package.json."}`),
+				json.RawMessage(`{"id":"S1","severity":"P2","location":"internal/db/dashboard_store.go:201","summary":"The trailing phase_profile event replaces blocked-review reasons.","detail":"ListDashboardBlockedJobs falls back to the newest event without filtering its kind."}`),
+			},
+		},
+	})
+
+	if err := engine.AdvanceJob(ctx, "review-schemas"); err != nil {
+		t.Fatalf("AdvanceJob returned error: %v", err)
+	}
+
+	observations, err := store.ListReviewFindingObservations(ctx, "gitmoot/gitmoot", 1931)
+	if err != nil {
+		t.Fatalf("ListReviewFindingObservations returned error: %v", err)
+	}
+	if len(observations) != 4 {
+		t.Fatalf("ledger holds %d row(s) for a verdict reporting 4 findings; the production writer is not on the advance path", len(observations))
+	}
+
+	// Keyed by round label, which the writer preserves for humans, so a failure
+	// names WHICH schema lost its prose rather than only that one did.
+	byLabel := map[string]db.ReviewFindingObservation{}
+	for _, obs := range observations {
+		byLabel[obs.RoundLabel] = obs
+	}
+	for _, want := range []struct {
+		label  string
+		title  string
+		detail string
+		file   string
+	}{
+		{
+			label:  "C1",
+			title:  "canonical title",
+			detail: "canonical detail",
+			file:   "internal/sandbox/exec_linux.go",
+		},
+		{
+			label:  "B1",
+			title:  "FIFO pairing loses identity",
+			detail: "The profiler discards translator tool IDs and pairs results with commands FIFO.",
+			file:   "internal/cli/review_phase_instrument.go",
+		},
+		{
+			label:  "E1",
+			title:  "markers still let a profile buy a grant",
+			detail: "internal/sandbox/exec_linux.go:274 - isPackageInstallRoot only requires a node_modules segment and a regular package.json.",
+			file:   "internal/sandbox/exec_linux.go",
+		},
+		{
+			label:  "S1",
+			title:  "The trailing phase_profile event replaces blocked-review reasons.",
+			detail: "ListDashboardBlockedJobs falls back to the newest event without filtering its kind.",
+			file:   "internal/db/dashboard_store.go",
+		},
+	} {
+		obs, ok := byLabel[want.label]
+		if !ok {
+			t.Errorf("no persisted row carries round label %q, so this reviewer's finding was not recorded at all", want.label)
+			continue
+		}
+		if obs.Title != want.title {
+			t.Errorf("[%s] persisted title = %q, want %q.\nThe reviewer's own words never reached the store, so the gate's obligation line names this finding with an empty title.", want.label, obs.Title, want.title)
+		}
+		if obs.Detail != want.detail {
+			t.Errorf("[%s] persisted detail = %q, want %q.\nThe prose exists only in the job payload, which no ledger reader consults, so nobody can disposition this row later.", want.label, obs.Detail, want.detail)
+		}
+		if obs.File != want.file {
+			t.Errorf("[%s] persisted file = %q, want %q.\nWithout a locator the ledger's relevance half cannot re-arm this finding when the cited path changes.", want.label, obs.File, want.file)
+		}
+		if obs.HeadSHA != head {
+			t.Errorf("[%s] persisted head = %q, want the review's exact head %q", want.label, obs.HeadSHA, head)
+		}
+	}
+}


### PR DESCRIPTION
Closes #1932. Closes #1936. One writer, failing in the two opposite directions.

## The invariant

A finding the writer cannot faithfully record must fail **loudly** and never be counted as recorded; reviewer prose the writer does not parse must never be **silently dropped**.

## #1932 — the silent-drop half

`reviewFindingWire` read prose from `title`, `detail`, `file` only. Three real reviewer schemas each lost a column:

| verdict | keys sent | column lost |
|---|---|---|
| #1930 round 1 | `title`, **`body`** | detail |
| #1921 round 3 | `title`, **`evidence`** | detail |
| #1930 round 3 | **`summary`**, `detail`, **`location`** | title, file |

Prose is now read specific-to-general across keys real reviewers actually sent: `title ← title, summary`; `detail ← detail, body, evidence`; `file ← file`, then a path parsed from `evidence`, `location`, or `evidence_locator`. **No key is invented.**

**And a live instance I measured myself rather than taking from the issue:** review job `local-review-joltra-sol-review-18d2b773bd0c534b` returned six findings and recorded **zero** — six `findings_ledger_skipped` events, `requires an explicit severity … got ""`, because each finding arrived as one prose string with the severity inline (`"P2 apps/web/src/views/LandingView.vue:365 — why"`). The skip was loud, which is the correct half; discarding values the reviewer *had* sent is not. A **leading** severity token and a following path-shaped token are now read from a bare string. Anything unparseable still skips loudly and is never counted.

## #1936 — the false-success half

A finding citing `evidence_locator` instead of `file` fell through to QUOTED, which forces `open`, so three declared `answered` dispositions became three open rows and the merge gate refused a head whose reviewer had done the work. Store-wide, **zero** STATIC rows had ever reached `answered` against 13 EXECUTED.

**Two causes, not the one the issue names:**

1. A path-shaped `evidence_locator` now yields a `file`, so the row reaches STATIC and the declared disposition survives. **No filesystem check in the writer** — it has no tree, which is exactly why the store boundary has none either; `answeredIsMandatory` re-resolves the locator against the head via `PathExistsAtHead` and fails a discharge whose path has vanished.
2. The locator override was **unconditional**, and the store requires `path` or `path:line` for a STATIC discharge — so a reviewer writing a prose citation had its **whole observation refused** (`ErrFindingDischarge`) even when it had also supplied a usable `file`. That is why I found the first fix insufficient: `L1` still failed. A prose citation is now preserved as the **rationale** instead of destroying the row. `db.IsStructuralFindingLocator` is exported so the writer asks the store's own rule rather than duplicating the regexp.

Reversals are now audible: `findings_ledger_downgraded` names the index, declared state, recorded state and cause, and the summary event counts downgrades rather than reporting `0 skipped` as success.

## Verification

Every arm enters through **`AdvanceJob`** and asserts rows read back with **`ListReviewFindingObservations`** — never `ledgerObservationFor`. **Four semantic reverts, each compiling with its values consumed** so the guard actually runs:

| revert | result |
|---|---|
| pre-fix prose mapping | `[B1] detail=""`, `[E1] detail=""`, `[S1] title=""`, `[S1] file=""` — the live empty columns, verbatim |
| locator-as-path read removed | `[L1] evidence kind = "QUOTED", want STATIC` |
| downgrade event disabled | `no findings_ledger_downgraded event: a declared answer was reversed with no record of it` |
| bare-string read removed | `ledger holds 0 row(s)` — the joltra outcome exactly |

`gofmt` clean; `go build ./...` exit 0; `go vet ./...` exit 0; `go test ./internal/workflow` **ok 182.8s**; `go test ./internal/db` **ok 384.9s**.

## Scope and disclosure

Four files: `findings_ledger_writer.go` + its tests, a new test file, and **8 lines in `internal/db/review_findings.go`** exporting `IsStructuralFindingLocator`. That last one is beyond "the writer plus its tests" and I am naming it rather than burying it: the alternative was copying `locatorPattern` into `workflow`, and two copies of a validation rule drift. It is not in the #1926/#1930 forbidden set — verified file-by-file, all zero.

**Also corrected two of my own errors during this work,** both caught by measurement: my worktree base was seven commits stale, so the severity rule my live evidence came from did not exist in it (rebased onto `6e15066d` before continuing); and my first rationale edit was clobbered by a later assignment on the same field, which the failing test surfaced.