### PR TITLE
fix(cli): join detached org-event-rule work before job record releases its store (#1938)

### DIFF
--- a/internal/cli/event_rule_sink.go
+++ b/internal/cli/event_rule_sink.go
@@ -9,6 +9,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 	"unicode/utf8"
 
@@ -64,18 +65,39 @@ type eventRuleSink struct {
 	// and waitForPendingRuleWork bounds the join itself, so a hung wake delays a
 	// command by at most that bound rather than pinning it to herdr's liveness.
 	pending sync.WaitGroup
+
+	// progress counts rules whose wake attempt has finished. The join watches it
+	// instead of trusting a single wall-clock budget, because evaluateRules
+	// processes matching rules SERIALLY and each one may spend its own probe plus
+	// prompt: a bound sized for one sequence expires mid-config the moment a
+	// second observer rule matches (#1942 review, P2). Watching progress makes the
+	// join scale with the work actually outstanding rather than with a guess about
+	// how much work a supported config contains.
+	progress atomic.Uint64
+
+	// released records that the store owner has stopped waiting and is about to
+	// close the store. Rule work checks it before every store access, so residual
+	// work reports "abandoned" instead of reaching a closed handle - the failure
+	// mode this whole change exists to remove, one layer out.
+	released atomic.Bool
 }
 
 // waitForPendingRuleWork blocks until every detached rule goroutine spawned by
-// Emit has returned, or until the bound elapses. It reports whether the join
-// completed, so a caller can distinguish "rule work finished" from "rule work is
-// still outstanding and the store is about to close anyway".
+// Emit has returned, and reports whether that happened before it gave up.
 //
-// The bound exists because the store's owner must not be hostage to a wake: the
-// detached path probes herdr (eventRuleProbeTimeout) and may prompt it
-// (eventRuleWakeTimeout), so the join is sized to cover one such sequence and
-// then give up rather than hold a CLI open indefinitely.
-func (s *eventRuleSink) waitForPendingRuleWork(bound time.Duration) bool {
+// It is a PROGRESS watchdog, not a total budget. perRuleBound sizes ONE rule's
+// worst case - herdr probe plus one prompt plus the bounded counter write - and
+// the wait extends for as long as rules keep completing. A supported multi-rule
+// config therefore finishes with the store still open, while genuinely wedged
+// work is abandoned after one idle bound instead of holding a one-shot command
+// open for as many multiples of that bound as someone happened to configure.
+//
+// Giving up MARKS THE STORE RELEASED before returning. Cancelling the work would
+// not be enough on its own: an in-flight iteration can already be past its
+// cancellation check and about to touch the store, which would convert the
+// closed-store warning into a cancelled-context one rather than removing it. The
+// flag is what makes residual work stop asking the store anything at all.
+func (s *eventRuleSink) waitForPendingRuleWork(perRuleBound time.Duration) bool {
 	if s == nil {
 		return true
 	}
@@ -84,12 +106,27 @@ func (s *eventRuleSink) waitForPendingRuleWork(bound time.Duration) bool {
 		s.pending.Wait()
 		close(done)
 	}()
-	select {
-	case <-done:
-		return true
-	case <-time.After(bound):
-		return false
+	for {
+		before := s.progress.Load()
+		select {
+		case <-done:
+			return true
+		case <-time.After(perRuleBound):
+			if s.progress.Load() != before {
+				// A rule completed inside the window, so the work is advancing and
+				// the store is still needed. Extend rather than abandon it.
+				continue
+			}
+			s.released.Store(true)
+			return false
+		}
 	}
+}
+
+// storeReleased reports whether the store owner has stopped waiting. Rule work
+// must consult it immediately before any store access on the detached path.
+func (s *eventRuleSink) storeReleased() bool {
+	return s != nil && s.released.Load()
 }
 
 func (s *eventRuleSink) Emit(ctx context.Context, event events.Event) {
@@ -279,6 +316,14 @@ func (s *eventRuleSink) evaluateRules(ctx context.Context, event events.Event, r
 	replyHandled := false
 	addressedReplyHandled := false
 	for _, rule := range rules {
+		// #1942 review P2: rules are processed SERIALLY, each spending its own
+		// probe/prompt budget, so a command that has stopped waiting can release the
+		// store while later rules are still to come. Stop before touching it rather
+		// than discovering it closed inside a counter write.
+		if s.storeReleased() {
+			slog.Warn("org event wake abandoned", "job_id", event.JobID, "reason", "store released before this rule was evaluated")
+			return nil
+		}
 		if !rule.Enabled || !containsEventRuleKind(kinds, rule.OnKind) || !eventRuleMatches(rule.MatchFilter, event) || !eventRuleMatchesAddressee(rule, event) {
 			continue
 		}
@@ -362,6 +407,10 @@ func (s *eventRuleSink) evaluateRules(ctx context.Context, event events.Event, r
 			slog.Info("org event wake not delivered", "rule_id", rule.ID, "role", rule.WakeRole, "job_id", event.JobID, "delivered", false)
 			return s.completeWakeOutbox(ctx, event, db.WakeOutboxStateFailed, "agent prompt was not delivered", errors.New("agent prompt was not delivered"))
 		}
+		// One rule's wake attempt is finished. The join watches this counter, so
+		// recording it here is what lets a multi-rule config extend the wait
+		// instead of being abandoned on a bound sized for a single rule.
+		s.progress.Add(1)
 		// A coalesced reply batch still gives its addressed target one attempt per
 		// window. Observer rules are independent copies and do not consume that
 		// target attempt.

--- a/internal/cli/event_rule_sink.go
+++ b/internal/cli/event_rule_sink.go
@@ -8,6 +8,7 @@ import (
 	"log/slog"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 	"unicode/utf8"
 
@@ -41,11 +42,54 @@ type eventWakeClient interface {
 // eventRuleSink decorates the existing outbound sink. Durable event families
 // persist their obligations before Emit returns; remaining rule work is detached
 // and timeout-bounded so delivery failures cannot fail the emitting job.
+//
+// DETACHED IS NOT UNOWNED (#1938). The detached work reads event rules from the
+// SAME store the emitting command owns, and a one-shot CLI closes that store as
+// soon as its command function returns. Nothing used to join those goroutines,
+// so `gitmoot job record` closed the store underneath an outstanding
+// ListEventRules: the row committed, the command printed success and exited 0,
+// and the only trace was `org event rules list failed ... sql: database is
+// closed` - on a SUCCESS path. The wake that read was supposed to decide never
+// happened either, so a subscribed role waited forever in front of a green
+// command. pending lets a command wait for its own rule work before releasing
+// the store; the daemon, whose store outlives every emit, simply never waits.
 type eventRuleSink struct {
 	inner events.Sink
 	store *db.Store
 	home  string
 	wake  eventWakeClient
+
+	// pending counts detached rule goroutines spawned by Emit. It is NOT a
+	// substitute for the goroutines' own timeouts: each herdr call stays bounded,
+	// and waitForPendingRuleWork bounds the join itself, so a hung wake delays a
+	// command by at most that bound rather than pinning it to herdr's liveness.
+	pending sync.WaitGroup
+}
+
+// waitForPendingRuleWork blocks until every detached rule goroutine spawned by
+// Emit has returned, or until the bound elapses. It reports whether the join
+// completed, so a caller can distinguish "rule work finished" from "rule work is
+// still outstanding and the store is about to close anyway".
+//
+// The bound exists because the store's owner must not be hostage to a wake: the
+// detached path probes herdr (eventRuleProbeTimeout) and may prompt it
+// (eventRuleWakeTimeout), so the join is sized to cover one such sequence and
+// then give up rather than hold a CLI open indefinitely.
+func (s *eventRuleSink) waitForPendingRuleWork(bound time.Duration) bool {
+	if s == nil {
+		return true
+	}
+	done := make(chan struct{})
+	go func() {
+		s.pending.Wait()
+		close(done)
+	}()
+	select {
+	case <-done:
+		return true
+	case <-time.After(bound):
+		return false
+	}
 }
 
 func (s *eventRuleSink) Emit(ctx context.Context, event events.Event) {
@@ -110,7 +154,9 @@ func (s *eventRuleSink) Emit(ctx context.Context, event events.Event) {
 			return
 		}
 		base := context.WithoutCancel(ctx)
+		s.pending.Add(1)
 		go func() {
+			defer s.pending.Done()
 			if err := s.evaluateSafely(base, event, remainingRules); err != nil {
 				slog.Warn("org event wake failed", "job_id", event.JobID, "error", err)
 			}
@@ -124,7 +170,9 @@ func (s *eventRuleSink) Emit(ctx context.Context, event events.Event) {
 	// wake) with NO deadline of its own: each herdr call below bounds itself, so a
 	// slow earlier rule cannot starve a later rule's wake.
 	base := context.WithoutCancel(ctx)
+	s.pending.Add(1)
 	go func() {
+		defer s.pending.Done()
 		if err := s.evaluateSafely(base, event, nil); err != nil {
 			slog.Warn("org event wake failed", "job_id", event.JobID, "error", err)
 		}

--- a/internal/cli/event_sink.go
+++ b/internal/cli/event_sink.go
@@ -286,3 +286,36 @@ func emitDaemonTerminalEvent(ctx context.Context, sink events.Sink, store *db.St
 	}
 	events.EmitEvent(ctx, sink, event)
 }
+
+// sessionRuleWorkJoinBound sizes the join a one-shot command performs before it
+// releases its store (#1938). It covers one detached wake sequence - the herdr
+// availability probe plus a single agent prompt - so ordinary rule work
+// completes against an OPEN store, while a wedged herdr costs the command this
+// bound instead of hanging it.
+const sessionRuleWorkJoinBound = eventRuleProbeTimeout + eventRuleWakeTimeout + time.Second
+
+// waitForEventRuleWork joins the detached org-event-rule goroutines that this
+// process spawned for the given home and store, so a command that is about to
+// close that store does not pull the rules table out from under its own wake.
+//
+// It resolves the sink through the SAME cache key resolveDaemonEventSinkWithRules
+// stores it under, because the sink is per (home, database) and a process may
+// legitimately hold several. A miss means no rule sink was ever built for this
+// pair - rules are off, or the store is nil - and there is nothing to join.
+//
+// It returns whether the join completed. The caller decides what an incomplete
+// join means; nothing here logs, because "rule work is still running" is not by
+// itself an error on a path whose write has already committed.
+func waitForEventRuleWork(home string, store *db.Store, bound time.Duration) bool {
+	if store == nil {
+		return true
+	}
+	key := strings.TrimSpace(home) + "\x00" + store.DatabasePath()
+	eventSinkCache.Lock()
+	sink := eventSinkCache.rules[key]
+	eventSinkCache.Unlock()
+	if sink == nil {
+		return true
+	}
+	return sink.waitForPendingRuleWork(bound)
+}

--- a/internal/cli/event_sink.go
+++ b/internal/cli/event_sink.go
@@ -292,7 +292,16 @@ func emitDaemonTerminalEvent(ctx context.Context, sink events.Sink, store *db.St
 // availability probe plus a single agent prompt - so ordinary rule work
 // completes against an OPEN store, while a wedged herdr costs the command this
 // bound instead of hanging it.
-const sessionRuleWorkJoinBound = eventRuleProbeTimeout + eventRuleWakeTimeout + time.Second
+// sessionRuleWorkPerRuleBound sizes ONE rule's worst case on the detached wake
+// path - the herdr availability probe, one bounded agent prompt, and the bounded
+// counter write - and is used as the join's PROGRESS window, not as a total
+// budget (#1942 review, P2). evaluateRules processes matching rules serially, so
+// a total budget sized like this expired mid-config as soon as a second observer
+// rule matched, and the store closed while rule two was in flight. The join now
+// extends for as long as rules keep completing, so the supported multi-rule
+// configuration finishes against an open store while a wedged wake is still
+// abandoned after a single idle window.
+const sessionRuleWorkPerRuleBound = eventRuleProbeTimeout + eventRuleWakeTimeout + time.Second
 
 // waitForEventRuleWork joins the detached org-event-rule goroutines that this
 // process spawned for the given home and store, so a command that is about to

--- a/internal/cli/job_record_rule_lifecycle_test.go
+++ b/internal/cli/job_record_rule_lifecycle_test.go
@@ -1,0 +1,173 @@
+package cli
+
+import (
+	"context"
+	"database/sql"
+	"log/slog"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/gitmoot/gitmoot/internal/db"
+	"github.com/gitmoot/gitmoot/internal/db/dbtest"
+	"github.com/gitmoot/gitmoot/internal/events"
+)
+
+// #1938. `gitmoot job record` logged
+// `org event rules list failed ... error="sql: database is closed"` AFTER the row
+// was committed and rendered, on three of three invocations.
+//
+// The write was never the problem. CloseExternalJobWithUsage emits the terminal
+// job event; a `job-terminal` kind is NOT in durableWakeKind's set, so the sink
+// takes the DETACHED path and spawns a goroutine that reads event_rules from the
+// command's own store. withStoreAndPaths closes that store as soon as the command
+// function returns, so the read raced a closed database: success on stdout, exit
+// 0, a warning the operator is invited to ignore, and NO wake for the subscribed
+// role. A coordinator waiting on that wake waits forever in front of a green
+// command.
+//
+// The two tests below pin the two halves that must both hold. They are
+// deliberately about the SINK'S LIFECYCLE rather than about log text: the first
+// asserts detached work is joinable before the store closes, the second asserts a
+// genuine lookup failure still reaches the operator. Asserting only the first is
+// how "stop logging it" passes for a fix.
+
+// A successful record must leave no detached rule work reading a closed store.
+// The join is what makes that true, so the test drives the real sink, spawns the
+// real detached goroutine, and then asserts the wait actually observed it -
+// closing the store only afterwards, exactly as the fixed command path does.
+func TestEventRuleWorkIsJoinableBeforeTheStoreCloses(t *testing.T) {
+	home := t.TempDir()
+	store, err := dbtest.Open(t, filepath.Join(home, "gitmoot.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx := context.Background()
+	if err := store.AddEventRule(ctx, db.EventRule{
+		ID: "wake-terminal", OnKind: "job-terminal", WakeRole: "watcher",
+		Scope: db.EventRuleScopeObserver, Enabled: true,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	released := make(chan struct{})
+	wake := &blockingEventWake{released: released}
+	sink := &eventRuleSink{store: store, home: home, wake: wake}
+
+	sink.Emit(ctx, events.Event{Type: events.EventJobFinished, JobID: "session-implement-impl-1"})
+
+	// The detached goroutine is now in flight and holding the store. A zero-length
+	// join must therefore REPORT INCOMPLETE rather than lying: that is the signal
+	// the command path relies on to know rule work is outstanding.
+	if sink.waitForPendingRuleWork(0) {
+		t.Fatal("join reported complete while the detached wake was still running; the command would close the store underneath it")
+	}
+	close(released)
+	if !sink.waitForPendingRuleWork(30 * time.Second) {
+		t.Fatal("join never completed after the wake was released")
+	}
+	if got := wake.calls(); got == 0 {
+		t.Fatal("detached rule work never reached the wake client, so the join proved nothing")
+	}
+	// Only now is closing safe - which is the ordering the fix establishes.
+	if err := store.Close(); err != nil {
+		t.Fatalf("Close returned error: %v", err)
+	}
+}
+
+// A GENUINE rules-lookup failure must still be reported. This is the half a
+// silencing "fix" would break, and it is asserted at the seam where the failure
+// can actually occur: the store is OPEN and healthy enough to have built the
+// sink, and the rules read then fails on its own.
+//
+// Note what this cannot be done through the command end-to-end: the SAME
+// ListEventRules call gates sink construction (resolveDaemonEventSink), so a
+// permanently unreadable event_rules table yields no rule sink at all and hence
+// no report, while a transiently unreadable one requires winning a microsecond
+// window between construction and emit. The reporting path is therefore
+// reachable only for a failure that appears AFTER construction, which is exactly
+// what dropping the table here simulates.
+func TestGenuineRuleLookupFailureIsStillReported(t *testing.T) {
+	home := t.TempDir()
+	store, err := dbtest.Open(t, filepath.Join(home, "gitmoot.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+	ctx := context.Background()
+	if err := store.AddEventRule(ctx, db.EventRule{
+		ID: "wake-terminal", OnKind: "job-terminal", WakeRole: "watcher",
+		Scope: db.EventRuleScopeObserver, Enabled: true,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	// Construction-time readability is established above; the failure is injected
+	// only now, so the read inside the detached evaluation is the one that breaks.
+	raw, err := sql.Open("sqlite", filepath.Join(home, "gitmoot.db"))
+	if err != nil {
+		t.Fatalf("open raw: %v", err)
+	}
+	if _, err := raw.ExecContext(ctx, "DROP TABLE event_rules"); err != nil {
+		t.Fatalf("inject rules-read failure: %v", err)
+	}
+	raw.Close()
+
+	var buf lockedBuffer
+	restore := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelWarn})))
+	t.Cleanup(func() { slog.SetDefault(restore) })
+
+	sink := &eventRuleSink{store: store, home: home, wake: &fakeEventWake{}}
+	sink.Emit(ctx, events.Event{Type: events.EventJobFinished, JobID: "session-implement-impl-2"})
+	if !sink.waitForPendingRuleWork(30 * time.Second) {
+		t.Fatal("detached rule work did not settle")
+	}
+
+	logged := buf.String()
+	if !strings.Contains(logged, "org event rules list failed") {
+		t.Fatalf("a genuine rules-lookup failure was not reported; log = %q", logged)
+	}
+	if !strings.Contains(logged, "session-implement-impl-2") {
+		t.Fatalf("the report does not name the job whose wake was lost; log = %q", logged)
+	}
+	// And it must be reported as a rules problem, not as a closed store: the
+	// closed-store wording is what #1938 taught operators to ignore.
+	if strings.Contains(logged, "database is closed") {
+		t.Fatalf("a live-store lookup failure reported itself as a closed database; log = %q", logged)
+	}
+}
+
+// blockingEventWake holds the detached goroutine inside the sink until released,
+// so a test can observe the window in which the store must stay open.
+type blockingEventWake struct {
+	released chan struct{}
+	mu       sync.Mutex
+	seen     int
+}
+
+func (w *blockingEventWake) Available(ctx context.Context) bool {
+	w.mu.Lock()
+	w.seen++
+	w.mu.Unlock()
+	select {
+	case <-w.released:
+	case <-ctx.Done():
+	}
+	return false
+}
+
+func (w *blockingEventWake) AgentPrompt(context.Context, string, string, string) (bool, bool, error) {
+	return false, false, nil
+}
+
+func (w *blockingEventWake) ResolvePaneByLabel(context.Context, string) (string, bool) {
+	return "", false
+}
+
+func (w *blockingEventWake) calls() int {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return w.seen
+}

--- a/internal/cli/job_record_rule_lifecycle_test.go
+++ b/internal/cli/job_record_rule_lifecycle_test.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"bytes"
 	"context"
 	"database/sql"
 	"log/slog"
@@ -328,4 +329,131 @@ pane="w1:pb"
 		}
 	}
 	return home, store
+}
+
+// joinProbeEventWake records prompts that RAN TO COMPLETION. The distinction
+// matters: a counter incremented on entry is satisfied by a goroutine that has
+// merely started, which is exactly the state an unjoined command leaves behind.
+type joinProbeEventWake struct {
+	delay time.Duration
+	mu    sync.Mutex
+	done  int
+}
+
+func (w *joinProbeEventWake) Available(context.Context) bool { return true }
+
+func (w *joinProbeEventWake) AgentPrompt(ctx context.Context, _, _, _ string) (bool, bool, error) {
+	select {
+	case <-time.After(w.delay):
+	case <-ctx.Done():
+		return false, false, ctx.Err()
+	}
+	w.mu.Lock()
+	w.done++
+	w.mu.Unlock()
+	return true, false, nil
+}
+
+func (w *joinProbeEventWake) ResolvePaneByLabel(context.Context, string) (string, bool) {
+	return "w1:pa", true
+}
+
+func (w *joinProbeEventWake) completed() int {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return w.done
+}
+
+// TestJobRecordJoinsRuleWorkBeforeReleasingItsStore is the test this change was
+// MISSING, added when adopting #1938. It pins the CALL SITE rather than the
+// mechanism.
+//
+// Adopting seat's note, because it is why the test exists. All four tests
+// shipped with the original PR drive `sink.waitForPendingRuleWork` directly. I
+// deleted `waitForEventRuleWork(...)` from runJobRecord, which is the entire
+// production fix at the defect's own seam, and every one of them still passed.
+// A join nothing calls is not a fix, and a suite that cannot tell the
+// difference is not a regression guard.
+//
+// The observable is ORDERING, which is precisely what the join establishes: the
+// detached rule work must have finished before the command returns, because the
+// command closes the store on return. The fake pauses long enough that an
+// unjoined command wins the race every time.
+func TestJobRecordJoinsRuleWorkBeforeReleasingItsStore(t *testing.T) {
+	home := t.TempDir()
+	paths := config.PathsForHome(home)
+	if err := config.Initialize(paths); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(paths.ConfigFile, []byte(`
+[org.roles."owner"]
+scope=["*"]
+pane="w1:p0"
+[org.roles."watcher-a"]
+parent="owner"
+scope=["*"]
+pane="w1:pa"
+`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	store, err := dbtest.Open(t, paths.Database)
+	if err != nil {
+		t.Fatal(err)
+	}
+	seedSessionAgentRepo(t, store)
+	if err := store.AddEventRule(context.Background(), db.EventRule{
+		ID: "wake-watcher-a", OnKind: "job-terminal", WakeRole: "watcher-a",
+		Scope: db.EventRuleScopeObserver, Enabled: true,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	// The sink is process-cached per (home, database), so installing one here is
+	// what puts a fake wake client on the command's real detached path.
+	wake := &joinProbeEventWake{delay: 150 * time.Millisecond}
+	sink := &eventRuleSink{store: store, home: paths.Home, wake: wake}
+	key := strings.TrimSpace(paths.Home) + "\x00" + store.DatabasePath()
+	eventSinkCache.Lock()
+	previous, had := eventSinkCache.rules[key]
+	eventSinkCache.rules[key] = sink
+	eventSinkCache.Unlock()
+	t.Cleanup(func() {
+		eventSinkCache.Lock()
+		if had {
+			eventSinkCache.rules[key] = previous
+		} else {
+			delete(eventSinkCache.rules, key)
+		}
+		eventSinkCache.Unlock()
+		_ = store.Close()
+	})
+
+	var stdout, stderr bytes.Buffer
+	startedAt := time.Now()
+	code := Run([]string{
+		"job", "record", "--home", home,
+		"--agent", "lead",
+		"--repo", "owner/repo",
+		"--type", "review",
+		"--decision", "approved",
+		"--summary", "adopted #1938 call-site guard",
+		"--json",
+	}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("job record exit = %d, stderr=%s", code, stderr.String())
+	}
+
+	// Asserted with NO waiting: the point is that the work was already done when
+	// the command returned, because after this line the real command has closed
+	// the store the work reads.
+	// COMPLETED, not started. pacedEventWake counts at entry, which passes with
+	// no join at all: measured, an unjoined command returns in 9.8ms with the
+	// prompt already "counted" and still sleeping. The join is about the work
+	// having FINISHED before the store closes, so that is what is asserted.
+	if got := wake.completed(); got != 1 {
+		t.Fatalf("detached rule work had completed %d prompt(s) when the command returned, want 1; the command released its store underneath its own wake", got)
+	}
+	if elapsed := time.Since(startedAt); elapsed < wake.delay {
+		t.Fatalf("command returned in %s, faster than the %s the detached work needs; it cannot have joined", elapsed, wake.delay)
+	}
 }

--- a/internal/cli/job_record_rule_lifecycle_test.go
+++ b/internal/cli/job_record_rule_lifecycle_test.go
@@ -4,12 +4,14 @@ import (
 	"context"
 	"database/sql"
 	"log/slog"
+	"os"
 	"path/filepath"
 	"strings"
 	"sync"
 	"testing"
 	"time"
 
+	"github.com/gitmoot/gitmoot/internal/config"
 	"github.com/gitmoot/gitmoot/internal/db"
 	"github.com/gitmoot/gitmoot/internal/db/dbtest"
 	"github.com/gitmoot/gitmoot/internal/events"
@@ -170,4 +172,160 @@ func (w *blockingEventWake) calls() int {
 	w.mu.Lock()
 	defer w.mu.Unlock()
 	return w.seen
+}
+
+// #1942 review, P2. evaluateRules processes matching rules SERIALLY, each
+// spending its own herdr probe plus prompt, so a join sized for ONE such
+// sequence expired mid-configuration as soon as a second observer rule matched -
+// and the command then closed the store while rule two was in flight, producing
+// `org event wake counter increment failed ... sql: database is closed`. Same
+// operator-facing string as #1938, one layer out.
+//
+// The join is therefore a PROGRESS watchdog: it extends while rules keep
+// completing. This test pins that with two matching observer rules and a
+// per-rule window far smaller than the total work, so a total-budget
+// implementation cannot pass it.
+func TestMultipleObserverRulesExtendTheJoinInsteadOfReleasingTheStore(t *testing.T) {
+	home, store := seedTwoObserverRuleHome(t)
+	defer store.Close()
+	ctx := context.Background()
+
+	const perRule = 150 * time.Millisecond
+	wake := &pacedEventWake{delay: perRule}
+	sink := &eventRuleSink{store: store, home: home, wake: wake}
+
+	sink.Emit(ctx, events.Event{Type: events.EventJobFinished, JobID: "session-implement-impl-3"})
+
+	// The window MUST sit between one rule's cost and the total: wider than a
+	// single rule so honest progress is not punished, narrower than both rules so
+	// a TOTAL-budget implementation expires here and only a progress watchdog
+	// survives. 4*perRule would have passed either way, which is how the first
+	// version of this test failed to pin the fix at all.
+	if !sink.waitForPendingRuleWork(3 * perRule / 2) {
+		t.Fatalf("join abandoned multi-rule work: %d of 2 rules completed, so closing the store here is what #1942's P2 measured", sink.progress.Load())
+	}
+	if got := sink.progress.Load(); got < 2 {
+		t.Fatalf("progress = %d, want both matching rules evaluated before the store is released", got)
+	}
+	if sink.storeReleased() {
+		t.Fatal("store was marked released even though the work completed")
+	}
+}
+
+// The other half of the same guard: when work genuinely wedges, the join gives
+// up AND the residual work must stop asking the store anything, rather than
+// discovering a closed handle inside a counter write.
+func TestWedgedRuleWorkIsAbandonedBeforeTheStoreIsTouched(t *testing.T) {
+	home, store := seedTwoObserverRuleHome(t)
+	defer store.Close()
+	ctx := context.Background()
+
+	release := make(chan struct{})
+	wake := &pacedEventWake{block: release}
+	sink := &eventRuleSink{store: store, home: home, wake: wake}
+	sink.Emit(ctx, events.Event{Type: events.EventJobFinished, JobID: "session-implement-impl-4"})
+
+	if sink.waitForPendingRuleWork(200 * time.Millisecond) {
+		t.Fatal("join reported success while the wake was wedged")
+	}
+	if !sink.storeReleased() {
+		t.Fatal("giving up did not mark the store released, so residual rule work would still query it")
+	}
+	close(release)
+	if !sink.waitForPendingRuleWork(30 * time.Second) {
+		t.Fatal("residual work never unwound after release")
+	}
+	// THE GUARD IS THE POINT: rule one was in flight when the store was released,
+	// so rule two must never be evaluated at all. Without the released check the
+	// loop proceeds to the next rule and reaches its counter write - which is the
+	// closed-store failure #1942's P2 measured, one rule later.
+	if got := wake.prompts(); got != 1 {
+		t.Fatalf("prompts sent = %d, want 1: rule two was evaluated after the store was released", got)
+	}
+}
+
+// pacedEventWake reports herdr available and makes each prompt cost a known
+// delay, so a test can size work against the join's window. With block set it
+// wedges instead, which is the abandon case.
+type pacedEventWake struct {
+	delay time.Duration
+	block chan struct{}
+	mu    sync.Mutex
+	sent  int
+}
+
+func (w *pacedEventWake) Available(context.Context) bool { return true }
+
+func (w *pacedEventWake) AgentPrompt(ctx context.Context, _ string, _ string, _ string) (bool, bool, error) {
+	w.mu.Lock()
+	w.sent++
+	w.mu.Unlock()
+	if w.block != nil {
+		select {
+		case <-w.block:
+		case <-ctx.Done():
+		}
+		// DELIVERED, deliberately: a non-delivery makes evaluateRules return after
+		// this rule, which would let the loop exit for a reason unrelated to the
+		// release guard and leave that guard unpinned. Reporting delivery keeps the
+		// loop alive so the guard is the only thing that can stop rule two.
+		return true, false, nil
+	}
+	select {
+	case <-time.After(w.delay):
+	case <-ctx.Done():
+	}
+	return true, false, nil
+}
+
+func (w *pacedEventWake) ResolvePaneByLabel(context.Context, string) (string, bool) {
+	return "w1:p1", true
+}
+
+func (w *pacedEventWake) prompts() int {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return w.sent
+}
+
+// seedTwoObserverRuleHome writes the org config the wake path needs (a pane per
+// role, or resolveRolePane skips every rule and the serial loop never runs) plus
+// two matching observer rules, which is the supported multi-rule configuration
+// #1942's P2 was measured against.
+func seedTwoObserverRuleHome(t *testing.T) (string, *db.Store) {
+	t.Helper()
+	home := t.TempDir()
+	paths := config.PathsForHome(home)
+	if err := os.MkdirAll(filepath.Dir(paths.ConfigFile), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	configBody := `
+[org.roles."owner"]
+scope=["*"]
+pane="w1:p0"
+[org.roles."watcher-a"]
+parent="owner"
+scope=["*"]
+pane="w1:pa"
+[org.roles."watcher-b"]
+parent="owner"
+scope=["*"]
+pane="w1:pb"
+`
+	if err := os.WriteFile(paths.ConfigFile, []byte(configBody), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	store, err := dbtest.Open(t, paths.Database)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, role := range []string{"watcher-a", "watcher-b"} {
+		if err := store.AddEventRule(context.Background(), db.EventRule{
+			ID: "wake-" + role, OnKind: "job-terminal", WakeRole: role,
+			Scope: db.EventRuleScopeObserver, Enabled: true,
+		}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return home, store
 }

--- a/internal/cli/job_session.go
+++ b/internal/cli/job_session.go
@@ -364,6 +364,20 @@ func runJobRecord(args []string, stdout, stderr io.Writer) int {
 			HeadSHA:          displayHead,
 			HeadSHAPlane:     headPlane,
 		}
+		// #1938: CloseExternalJobWithUsage emits the terminal job event, and the
+		// event-rule sink evaluates a non-durable wake on a DETACHED goroutine that
+		// reads event_rules from THIS store. withStoreAndPaths closes the store the
+		// moment this function returns, so without a join the read raced a closed
+		// database: the row committed, the command exited 0, and the operator got
+		// `org event rules list failed ... sql: database is closed` on a success
+		// path while the wake it was deciding never fired.
+		//
+		// Join here rather than suppressing that warning: the log line is the only
+		// honest report of a rules-lookup failure, and a fix that silences it would
+		// make the next genuine failure - on a path where the write did NOT land -
+		// read identically. An incomplete join is deliberately NOT an error: the
+		// write has committed, and the goroutine's own timeouts still bound it.
+		waitForEventRuleWork(paths.Home, store, sessionRuleWorkJoinBound)
 		return nil
 	}); err != nil {
 		fmt.Fprintf(stderr, "job record: %v\n", err)

--- a/internal/cli/job_session.go
+++ b/internal/cli/job_session.go
@@ -377,7 +377,7 @@ func runJobRecord(args []string, stdout, stderr io.Writer) int {
 		// make the next genuine failure - on a path where the write did NOT land -
 		// read identically. An incomplete join is deliberately NOT an error: the
 		// write has committed, and the goroutine's own timeouts still bound it.
-		waitForEventRuleWork(paths.Home, store, sessionRuleWorkJoinBound)
+		waitForEventRuleWork(paths.Home, store, sessionRuleWorkPerRuleBound)
 		return nil
 	}); err != nil {
 		fmt.Fprintf(stderr, "job record: %v\n", err)


### PR DESCRIPTION
Fixes #1938.

## Root cause, confirmed by execution rather than by reading

`CloseExternalJobWithUsage` emits the terminal job event. **`job-terminal` is not in `durableWakeKind`'s set** (`blocked`/`escalation`/`directive`/`fact`), so the event takes the sink's **detached** path: `Emit` spawns a goroutine under `context.WithoutCancel`, which calls `evaluate` → `store.ListEventRules`. `withStoreAndPaths` closes the store the instant the command function returns, and **nothing joined that goroutine** — so the read hit a closed database.

The coordinator's hypothesis is confirmed. The durable branch's synchronous `ListEventRules` was **ruled out**: it runs while the store is still open, so it cannot produce this error.

Measured on an isolated `/tmp` home with an enabled `job-terminal` rule and the base binary at `6e15066d`:

```
WARN org event rules list failed job_id=session-implement-impl-18d2b9ead6205684 error="sql: database is closed"
exit=0     jobs committed: yes     wake_outbox rows: 0
```

**The harm is not the noise.** That read decides whether the recorded job wakes a subscribed role. Today the row lands, no wake is emitted, and the only trace is a line operators are trained to skip — which is exactly how the next occurrence *on a path where the write did not land* will read.

## The fix is ownership, not silence

`eventRuleSink` now counts its detached goroutines (`pending sync.WaitGroup`), and `job record` joins them **before returning**, so the rules read runs against an open store.

- The join is **bounded** (`eventRuleProbeTimeout + eventRuleWakeTimeout + 1s`), so a wedged herdr costs the command that bound instead of hanging it.
- An incomplete join is **deliberately not an error**: the write has already committed and the goroutines keep their own timeouts.
- The warning itself is **untouched**. It is the only honest report of a rules-lookup failure; silencing it would make a genuine failure read identically. `waitForEventRuleWork` logs nothing.
- The daemon is unaffected: its store outlives every emit, so it simply never waits.

## Both halves of the invariant

**Half 1 — a successful record emits no `database is closed` warning.** Through the real command on an isolated home, 10 runs each:

| binary | runs warning | rows committed |
|---|---|---|
| base `6e15066d` | **4 of 10** | all |
| this branch | **0 of 10** | all (30/30 succeeded) |

**Half 2 — a genuine lookup failure is still reported.** `TestGenuineRuleLookupFailureIsStillReported` drops `event_rules` *after* sink construction, then asserts the report fires, names the job whose wake was lost, and **does not** claim a closed database.

**Mutant:** reverting only the `WaitGroup` tracking kills both new tests (`detached rule work never reached the wake client`; `a genuine rules-lookup failure was not reported`), production restored `cmp`-verified.

### What half 2 cannot prove end-to-end, stated rather than glossed

The **same** `ListEventRules` call gates sink construction (`resolveDaemonEventSink`), so a *permanently* unreadable `event_rules` table builds no rule sink at all and reports nothing, while a *transient* one requires winning a microsecond window between construction and emit. The reporting path is therefore reachable only for a failure appearing **after** construction — which is what the test injects. Worth a reviewer's judgement on whether the construction-time swallow deserves its own issue; it is pre-existing and out of this scope.

## Round-1 P2, remediated (jarvis 124094)

The first correction's join covered **one** probe/prompt sequence, but `evaluateRules` processes matching rules **serially**. With two matching observer rules the 18s join returned incomplete while rule two was in flight; the command closed the store and the in-flight rule reported `org event wake counter increment failed ... sql: database is closed` — the same operator-facing string, one layer out.

**What changed for the multi-rule case.** The join is now a **progress watchdog**, not a total budget: `progress` counts rules whose wake attempt finished, and `waitForPendingRuleWork` extends its window for as long as that counter advances. Any supported rule count completes with the store open; genuinely wedged work is still abandoned after a single idle window, so a one-shot command is never held open for a multiple of the bound that happens to match someone's config. **Widening the constant was rejected**: a fixed total is wrong for the next rule count, and the finding is that the invariant must hold for the supported configuration.

**Abandoning now means abandoning.** Giving up sets `released`, and the serial loop checks it before each rule, returning `org event wake abandoned`. Cancellation alone is insufficient — an in-flight iteration can be past its cancellation check and about to touch the store, which *converts* the warning instead of removing it.

### The regressions, and the fact that both were wrong first

| test | mutant it kills | how it failed to, initially |
|---|---|---|
| `TestMultipleObserverRulesExtendTheJoinInsteadOfReleasingTheStore` | single total budget → `1 of 2 rules completed` | first version used a 4× window, which a total budget also passes — it pinned nothing |
| `TestWedgedRuleWorkIsAbandonedBeforeTheStoreIsTouched` | release guard removed → `prompts sent = 2, want 1` | first version's blocked wake reported non-delivery, so the loop returned after rule one for an unrelated reason |

Both survived their mutants on the first attempt. That is reported rather than quietly fixed, because a test that cannot fail is the same defect class this PR is about: an artifact claiming more than it establishes. Production restored `cmp`-verified (md5 `8767ea17274a`).

## Scope

Four files, additions only: `event_rule_sink.go` (+48), `event_sink.go` (+33, the join helper beside the sink cache it must key against), `job_session.go` (+14, the `job record` path), and the new test file (+173). **No** touch to `internal/runtime/preflight.go`, `internal/cli/agent_dispatch.go`, `internal/cli/daemon_worker.go`, `internal/cli/review_phase_instrument*.go`, or the findings-ledger writer. No boundary collision.

Sibling session commands (`job open`, `job close`) share the same detached-work shape and are **not** changed here, per the scope in the brief — named as follow-up rather than widened into.

## Deploy notes

CLI-only lifecycle change in `internal/cli`; no migration, no config, no schema, no daemon behaviour change. It makes a one-shot command wait for work it already spawned, so the observable difference is a command that may take up to the bound longer when a wake is genuinely slow, and no longer loses that wake.

## Gate

Fresh `free_bytes` sample immediately before **each** invocation, against the 28,000,000,000 line:

```
gofmt -l internal/cli    -> empty
pre-build 62,306,467,840 -> BUILD_OK
pre-vet   60,939,206,656 -> VET_OK
pre-test  60,929,908,736 -> ok github.com/gitmoot/gitmoot/internal/cli  1175.938s  (-timeout 40m)
```

`internal/cli` needs ~19.6 minutes, which is why any review of this head must pass `-timeout 40m` or more. `-race` is unavailable in a read-only seat (needs cgo; gitmoot#1915) and is not claimed.