### PR TITLE
fix(workflow): block a headless objection before the external merge claim (#1933)

### DIFF
--- a/internal/workflow/merge_gate.go
+++ b/internal/workflow/merge_gate.go
@@ -987,8 +987,10 @@ func (g PolicyMergeGate) ensureFinalReviewCaptured(ctx context.Context, request 
 	//     distinct ways. sameCorrelatedTask already filtered by repo/PR/branch. Then:
 	//     a DELEGATION CHILD is headless by engine design and is judged through its
 	//     parent's fan-out evidence; an INTEGRATION-WORKTREE row has its head
-	//     cleared so it can validate an isolated tree; and a row with NEITHER head
-	//     NOR round is an unattributable delegation remnant, not a verdict. All
+	//     cleared so it can validate an isolated tree; and an ENGINE-INSERTED
+	//     roundless row is an unattributable delegation remnant. That last test is
+	//     on ORIGIN, never on roundlessness: an EXTERNALLY DRIVEN session review
+	//     legitimately carries neither head nor round and IS a real objection. All
 	//     three point the OPPOSITE way from everything else here - including any of
 	//     them would block every head forever, which no push could ever clear.
 	//   - LATEST: among survivors the newest row decides, by the same
@@ -1023,23 +1025,32 @@ func (g PolicyMergeGate) ensureFinalReviewCaptured(ctx context.Context, request 
 		if isDelegationChild(review.job) {
 			continue
 		}
-		// NOT APPLICABLE, THIRD SHAPE, and this one is a JUDGEMENT I am recording
-		// rather than burying. A row that records NEITHER a head NOR a review round
-		// matches no production path that produces a reviewer verdict: an
-		// engine-dispatched review carries a ReviewRound, and a CLI-dispatched
-		// `gitmoot agent review` carries a HeadSHA and no round (which is what
-		// mergeGateReviewFixture.emptyRound documents), so it is never headless. What
-		// does produce this shape is a delegation child whose linkage columns were
-		// never written, and
-		// TestPolicyMergeGateDelegatedReviewEvidenceEnumeration's PARENT_ONLY and
-		// NEITHER_PARENT linkage variants assert - as wantExcluded - that such a row
-		// is UNATTRIBUTABLE and must be ignored rather than allowed to block.
+		// NOT APPLICABLE, THIRD SHAPE - AND ROUNDLESSNESS IS NOT THE TEST. An earlier
+		// version excluded EVERY roundless row, reasoning that no production path
+		// persists a verdict with neither head nor round. THAT WAS FALSE, and a
+		// reviewer proved it by execution rather than by argument: `gitmoot job record
+		// --type review` (internal/cli/job_session.go:214-305) opens an EXTERNALLY
+		// DRIVEN session job through OpenExternalJob, which deliberately persists
+		// neither HeadSHA nor ReviewRound and demotes any supplied head to a display
+		// event (internal/workflow/session_job.go:85-125); CloseExternalJobWithUsage
+		// then stores changes_requested and succeeds the row (session_job.go:170-190).
+		// A roundless headless row can therefore be a REAL blocking objection, and
+		// excluding it left #1933's bypass reachable while the ledger claimed a fix.
 		//
-		// THE RISK, stated for the reviewer to attack: if some production path can
-		// persist a genuine reviewer objection with no head AND no round, this
-		// qualifier would leave #1933's bypass reachable for that shape. I could not
-		// find one, and the two shapes above are the only writers I traced.
-		if strings.TrimSpace(review.payload.ReviewRound) == "" {
+		// What must still be ignored is the UNATTRIBUTABLE DELEGATION REMNANT: a child
+		// whose linkage columns were never written, which
+		// TestPolicyMergeGateDelegatedReviewEvidenceEnumeration's PARENT_ONLY and
+		// NEITHER_PARENT variants assert as wantExcluded. The discriminator is ORIGIN:
+		// db.Job.ExternallyDriven is set only by CreateExternallyDrivenJobWithEvent and
+		// every other insert leaves it at its default 0
+		// (internal/db/store_jobs.go:184), so a session review is positively
+		// identified rather than inferred from what its payload lacks.
+		//
+		// IT FAILS CLOSED BY CONSTRUCTION: a row is excluded only when it is BOTH
+		// engine-inserted AND roundless - provably the remnant shape. Every other
+		// combination, including any shape neither I nor the reviewer has enumerated,
+		// reaches the block below rather than slipping past it.
+		if !review.job.ExternallyDriven && strings.TrimSpace(review.payload.ReviewRound) == "" {
 			continue
 		}
 		// NOT APPLICABLE, and this exclusion is the difference between a gate and a

--- a/internal/workflow/merge_gate.go
+++ b/internal/workflow/merge_gate.go
@@ -2106,12 +2106,24 @@ func reviewRowCanRetireAnObjection(job db.Job, payload JobPayload, headSHA strin
 		!job.ExternallyDriven && strings.TrimSpace(payload.ReviewRound) == "" {
 		return false
 	}
-	// A delegation-child candidate is NOT refused here, and this predicate does not
-	// claim to refuse it: it satisfies every clause above. What actually stops it is
-	// reviewRoundKey, which will not order an explicit round against a roundless
-	// objection - measured, with Evaluate blocking and zero merge calls. Naming the
-	// real mechanism matters because the first version of this comment credited the
-	// refusal to this function, which does not perform it.
+	// LINKAGE, AND THIS IS THE CLAUSE MY OWN ROUND-9 PROBE TALKED ME OUT OF (#1950
+	// F6). A delegation child's verdict is accounted through its PARENT's fan-out
+	// evidence (ensureDelegatedReviewEvidence), never as a standalone verdict about
+	// this head - which is exactly why the objection scan already excludes it. Not
+	// excluding it HERE made the two sides asymmetric: such a row was admitted as a
+	// superseding candidate, retired a live session objection, and was then absent
+	// from the blocking population, so it cleared a block it could never impose and
+	// the PR merged.
+	//
+	// Round 9 probed a delegation-child candidate, measured that it needed no
+	// clause, and reported that. The probe carried an explicit ROUND, so what
+	// refused it was reviewRoundKey declining to order a round against a roundless
+	// objection - not the linkage. A ROUNDLESS externally-driven child is ordered by
+	// timestamp instead and nothing refused it. One shape of a thing is not the
+	// class, and "measured, no clause needed" is only as wide as the shape measured.
+	if isDelegationChild(job) {
+		return false
+	}
 	return true
 }
 

--- a/internal/workflow/merge_gate.go
+++ b/internal/workflow/merge_gate.go
@@ -1102,6 +1102,32 @@ func (g PolicyMergeGate) ensureFinalReviewCaptured(ctx context.Context, request 
 		superseded := false
 		if reviewer != "" {
 			for _, candidate := range taskReviews {
+				// A HEAD-BEARING CANDIDATE MUST MATCH THE EVALUATED HEAD, and omitting
+				// this was a merge-integrity BYPASS in the first version of this arm
+				// (#1950 F5, escalated to P1). The three tests below - identity, a
+				// replacement decision, recency - never asked WHICH HEAD the candidate
+				// described. A production session objection carries neither head nor
+				// round; a later same-reviewer CLI-shaped approval naming a STALE head
+				// is also roundless, so reviewRoundKeyForJob falls back to timestamps,
+				// the stale approval won recency and retired the objection. With an
+				// independent at-head approval present, Evaluate MERGED - measured at
+				// one external merge call in each of three runs.
+				//
+				// EMPTY-OR-EQUAL, DELIBERATELY NOT EMPTY-ONLY. A replacement rendered AT
+				// the evaluated head legitimately answers a headless objection, which is
+				// the ordinary way a reviewer withdraws one; requiring the candidate to
+				// be headless too would deadlock every objection answered by
+				// re-reviewing the current head. The "replaced it at the evaluated head"
+				// arm pins that direction, and the mutant dropping this condition kills
+				// only the stale-head regression.
+				//
+				// A row's authority is the FULL TUPLE - identity, decision class,
+				// recency, and applicable head. Five rounds of this fix each decided it
+				// from a subset: the writer, then the attempt, then the message prefix,
+				// then the identity source, and now the head.
+				if candidateHead := strings.TrimSpace(candidate.payload.HeadSHA); candidateHead != "" && candidateHead != headSHA {
+					continue
+				}
 				if candidate.payload.Result != nil &&
 					effectiveReviewerIdentityName(candidate.job, candidate.payload) == reviewer &&
 					isReviewReplacementDecision(candidate.payload.Result.Decision) &&

--- a/internal/workflow/merge_gate.go
+++ b/internal/workflow/merge_gate.go
@@ -654,7 +654,7 @@ func (g PolicyMergeGate) recordApprovalEvidence(ctx context.Context, job db.Job,
 		JobID: job.ID,
 		Kind:  mergeApprovalEvidenceEvent,
 		Message: fmt.Sprintf("approval by %s at %s: evidence=%s (%s)",
-			strings.TrimSpace(job.Agent), strings.TrimSpace(payload.HeadSHA), evidence, detail),
+			effectiveReviewerIdentityName(job, payload), strings.TrimSpace(payload.HeadSHA), evidence, detail),
 	})
 }
 
@@ -900,13 +900,24 @@ func (g PolicyMergeGate) ensureFinalReviewCaptured(ctx context.Context, request 
 	// in neither direction, so no row is ever hidden by ListJobs' id order.
 	supersededReviewIDs := map[string]struct{}{}
 	for _, review := range reviewsAtHead {
-		reviewer := strings.TrimSpace(review.job.Agent)
+		// THE SIXTH AND LAST INLINE COPY OF THIS RULE (#1950 F4). Every other site
+		// was routed through effectiveReviewerIdentity while THIS one still compared
+		// Agent columns, so an at-head objection authored by an acting ROLE could
+		// never be superseded by that same role's later at-head approval: both Agent
+		// columns are empty, the loop skipped them, and the PR stayed open rendering
+		// "blocking result from " with no author. The helper already resolved both
+		// identities correctly - nothing reached it here.
+		//
+		// Normalization matters on this path specifically: the reviewer's adversary
+		// used " ReVieWer ", and NormalizeActingOrgRole trims and lowercases, so the
+		// objection and its replacement resolve to one identity.
+		reviewer := effectiveReviewerIdentityName(review.job, review.payload)
 		if reviewer == "" {
 			continue
 		}
 		for _, candidate := range reviewsAtHead {
 			if candidate.payload.Result != nil &&
-				strings.TrimSpace(candidate.job.Agent) == reviewer &&
+				effectiveReviewerIdentityName(candidate.job, candidate.payload) == reviewer &&
 				isReviewReplacementDecision(candidate.payload.Result.Decision) &&
 				reviewJobSupersedes(candidate.job, candidate.payload, review.job, review.payload) {
 				supersededReviewIDs[review.job.ID] = struct{}{}
@@ -927,9 +938,9 @@ func (g PolicyMergeGate) ensureFinalReviewCaptured(ctx context.Context, request 
 	for _, review := range activeAtHead {
 		switch JobState(review.job.State) {
 		case JobQueued, JobRunning:
-			return mergePending{reason: fmt.Sprintf("waiting for reviewer %s at evaluated head (job %s is %s)", strings.TrimSpace(review.job.Agent), review.job.ID, review.job.State)}
+			return mergePending{reason: fmt.Sprintf("waiting for reviewer %s at evaluated head (job %s is %s)", effectiveReviewerIdentityName(review.job, review.payload), review.job.ID, review.job.State)}
 		case JobFailed, JobCancelled:
-			return fmt.Errorf("crashed reviewer %s at evaluated head (job %s is %s); retry or settle that same job, or push a new head. Reassigning the review to a different agent cannot clear this reviewer's slot", strings.TrimSpace(review.job.Agent), review.job.ID, review.job.State)
+			return fmt.Errorf("crashed reviewer %s at evaluated head (job %s is %s); retry or settle that same job, or push a new head. Reassigning the review to a different agent cannot clear this reviewer's slot", effectiveReviewerIdentityName(review.job, review.payload), review.job.ID, review.job.State)
 		}
 	}
 	for _, review := range activeAtHead {
@@ -955,7 +966,10 @@ func (g PolicyMergeGate) ensureFinalReviewCaptured(ctx context.Context, request 
 		}
 		switch effectiveReviewDecisionForPayload(review.payload, request.ReviewBlockingSeverity) {
 		case "changes_requested", "blocked", "failed":
-			return mergeBlocked{reason: fmt.Sprintf("review at evaluated head has blocking result from %s", review.job.Agent)}
+			// Named through the resolver: a role-authored objection rendered
+			// "blocking result from " with no author, which is the line an operator
+			// reads while working out why a merge is stuck (#1950 F4).
+			return mergeBlocked{reason: fmt.Sprintf("review at evaluated head has blocking result from %s", effectiveReviewerIdentityName(review.job, review.payload))}
 		}
 	}
 	// #1933. A PERSISTED HEADLESS OBJECTION MUST BLOCK HERE, BEFORE THE EXTERNAL
@@ -1273,7 +1287,7 @@ func (g PolicyMergeGate) ensureFinalReviewCaptured(ctx context.Context, request 
 	for _, review := range eligible {
 		job := review.job
 		payload := review.payload
-		if err := g.ensureReviewMatchesHead(payload, headSHA, job.Agent); err != nil {
+		if err := g.ensureReviewMatchesHead(payload, headSHA, effectiveReviewerIdentityName(job, payload)); err != nil {
 			if reason := reviewAuthorshipFailureReason(selfApprovalReason, unknownImplementerReason, unattributedReviewerReason); reason != "" {
 				return errors.New(reason)
 			}
@@ -1286,7 +1300,7 @@ func (g PolicyMergeGate) ensureFinalReviewCaptured(ctx context.Context, request 
 			children := delegationChildrenByParent[job.ID]
 			if len(children) == 0 {
 				undispatchedFanOuts = append(undispatchedFanOuts, fmt.Sprintf(
-					"%s (job %s, %d declared)", job.Agent, job.ID, len(payload.Result.Delegations)))
+					"%s (job %s, %d declared)", effectiveReviewerIdentityName(job, payload), job.ID, len(payload.Result.Delegations)))
 				continue
 			}
 			// Decided as "approved" by the single evidence call in the arm below.
@@ -1306,7 +1320,7 @@ func (g PolicyMergeGate) ensureFinalReviewCaptured(ctx context.Context, request 
 			// (mergeBlocked), distinct from the transient/process review errors below
 			// (missing approval, not-yet-captured), so the trace-harvester scores only
 			// this one as a negative (#465 INFRA-NOISE-FILTERED).
-			return mergeBlocked{reason: fmt.Sprintf("latest review round has blocking result from %s", job.Agent)}
+			return mergeBlocked{reason: fmt.Sprintf("latest review round has blocking result from %s", effectiveReviewerIdentityName(job, payload))}
 		}
 	}
 	if !approved {

--- a/internal/workflow/merge_gate.go
+++ b/internal/workflow/merge_gate.go
@@ -1960,16 +1960,29 @@ func (g PolicyMergeGate) ensureReviewMatchesHead(payload JobPayload, headSHA str
 // allocated worktree path). The engine clears the inherited HeadSHA for exactly
 // these children so they validate against their isolated worktree HEAD, mirroring
 // isDelegationWorktreeChild in the daemon's checkout validation.
-// effectiveReviewerIdentityName is the effective reviewer identity used by ALL
-// THREE identity sites in this file - headless objection supersession and its
-// diagnostic, implementer attribution, and the at-head reviewer arms: the agent
-// when a row records one, otherwise the normalized
-// ActingOrgRole. OpenExternalJob supports a role IN PLACE OF an agent
-// (mailbox.go:665 persists the normalized role; the job's Agent stays empty), so
-// keying on job.Agent alone made a role's objection unanswerable by that same
-// role - #1950 F2. collectGateImplementerAttribution already resolves identity
-// this way (merge_gate.go, NormalizeActingOrgRole), and sharing the rule is what
-// keeps the two from disagreeing about who a row belongs to.
+// effectiveReviewerIdentityName resolves a review row's author: the agent when
+// the row records one, otherwise the normalized ActingOrgRole. OpenExternalJob
+// supports a role IN PLACE OF an agent (mailbox.go persists the normalized role
+// and leaves the job's Agent empty), so keying on job.Agent alone made a role's
+// objection unanswerable by that same role (#1950 F2) and rendered diagnostics
+// with a blank author.
+//
+// SCOPE OF THIS HELPER, STATED WITHOUT A COUNT ON PURPOSE (#1950 F5). Every
+// reviewer-identity read IN THIS FILE resolves through it - supersession at the
+// evaluated head and for headless rows, the at-head and latest-round approval
+// arms, implementer attribution, and every author-bearing diagnostic and durable
+// approval-evidence event. Earlier versions of this comment claimed "all three
+// sites", then all five; each count was wrong within a round, and quoting one
+// here is the habit those rounds should have ended.
+//
+// IT IS NOT THE WHOLE REPOSITORY, and two consumers outside this file are known
+// NOT to use it, deliberately left for routing rather than silently swept in:
+//   - review_loop.go's FindRepeatedReviewers drops a role-authored verdict,
+//     because db.SucceededReviewVerdict carries only Agent and would need the
+//     role plumbed through awaited_facts.go's query first;
+//   - proof/project.go reports a role-authored review as not comparable, so its
+//     independence attribute stays unknown rather than being computed. That is
+//     conservative - it emits no false independence claim - but incomplete.
 func effectiveReviewerIdentityName(job db.Job, payload JobPayload) string {
 	name, _ := effectiveReviewerIdentity(job, payload)
 	return name

--- a/internal/workflow/merge_gate.go
+++ b/internal/workflow/merge_gate.go
@@ -1072,12 +1072,24 @@ func (g PolicyMergeGate) ensureFinalReviewCaptured(ctx context.Context, request 
 		if effectiveReviewDecisionForPayload(review.payload, request.ReviewBlockingSeverity) != "changes_requested" {
 			continue
 		}
-		reviewer := strings.TrimSpace(review.job.Agent)
+		// IDENTITY IS AGENT-OR-ROLE, NOT AGENT ALONE, and reading it from job.Agent
+		// only was a P1 deadlock of my own making (#1950 F2). OpenExternalJob supports
+		// ActingOrgRole IN PLACE OF an agent and persists Agent="" with
+		// ActingOrgRole=<role> (session_job.go, mailbox.go:665). With an empty agent
+		// the supersession scan below was skipped entirely, so a role's objection
+		// could NEVER be answered by that same role's later approval - a block with no
+		// operator move available - and the refusal text named nobody at all.
+		//
+		// The precedent is already in this file: collectGateImplementerAttribution
+		// resolves the same identity with NormalizeActingOrgRole (merge_gate.go:1564),
+		// so this uses that rather than inventing a second rule. Both SIDES of the
+		// comparison resolve identically, or a role could still never supersede itself.
+		reviewer := headlessReviewerIdentity(review.job, review.payload)
 		superseded := false
 		if reviewer != "" {
 			for _, candidate := range taskReviews {
 				if candidate.payload.Result != nil &&
-					strings.TrimSpace(candidate.job.Agent) == reviewer &&
+					headlessReviewerIdentity(candidate.job, candidate.payload) == reviewer &&
 					isReviewReplacementDecision(candidate.payload.Result.Decision) &&
 					reviewJobSupersedes(candidate.job, candidate.payload, review.job, review.payload) {
 					superseded = true
@@ -1095,9 +1107,16 @@ func (g PolicyMergeGate) ensureFinalReviewCaptured(ctx context.Context, request 
 		}
 	}
 	if headlessObjection != nil {
+		// Name the AGENT-OR-ROLE, never the bare agent: an acting-role session review
+		// has no agent, and the first version of this rendered "objection from  "
+		// with an empty name, which tells an operator nothing about who to go to.
+		author := headlessReviewerIdentity(headlessObjection.job, headlessObjection.payload)
+		if author == "" {
+			author = "an unattributed reviewer"
+		}
 		return mergeBlocked{reason: fmt.Sprintf(
 			"unanswered review objection from %s (job %s) carries no evaluated head; answer or supersede that row, or re-render the verdict against this head",
-			strings.TrimSpace(headlessObjection.job.Agent), headlessObjection.job.ID)}
+			author, headlessObjection.job.ID)}
 	}
 	if len(activeAtHead) > 0 {
 		var selfApprovalReason string
@@ -1918,6 +1937,21 @@ func (g PolicyMergeGate) ensureReviewMatchesHead(payload JobPayload, headSHA str
 // allocated worktree path). The engine clears the inherited HeadSHA for exactly
 // these children so they validate against their isolated worktree HEAD, mirroring
 // isDelegationWorktreeChild in the daemon's checkout validation.
+// headlessReviewerIdentity is the effective reviewer identity for the headless
+// objection scan: the agent when a row records one, otherwise the normalized
+// ActingOrgRole. OpenExternalJob supports a role IN PLACE OF an agent
+// (mailbox.go:665 persists the normalized role; the job's Agent stays empty), so
+// keying on job.Agent alone made a role's objection unanswerable by that same
+// role - #1950 F2. collectGateImplementerAttribution already resolves identity
+// this way (merge_gate.go, NormalizeActingOrgRole), and sharing the rule is what
+// keeps the two from disagreeing about who a row belongs to.
+func headlessReviewerIdentity(job db.Job, payload JobPayload) string {
+	if agent := strings.TrimSpace(job.Agent); agent != "" {
+		return agent
+	}
+	return NormalizeActingOrgRole(payload.ActingOrgRole)
+}
+
 func isIntegrationWorktreeReview(payload JobPayload) bool {
 	return strings.TrimSpace(payload.DelegationID) != "" && strings.TrimSpace(payload.WorktreePath) != ""
 }

--- a/internal/workflow/merge_gate.go
+++ b/internal/workflow/merge_gate.go
@@ -958,6 +958,136 @@ func (g PolicyMergeGate) ensureFinalReviewCaptured(ctx context.Context, request 
 			return mergeBlocked{reason: fmt.Sprintf("review at evaluated head has blocking result from %s", review.job.Agent)}
 		}
 	}
+	// #1933. A PERSISTED HEADLESS OBJECTION MUST BLOCK HERE, BEFORE THE EXTERNAL
+	// MERGE CLAIM. This is an ORDERING fix, and the ordering is the whole fix:
+	// evaluating the objection after ClaimTaskState is what loses the race.
+	//
+	// The interleaving that shipped: reviewsAtHead holds only rows whose
+	// payload.HeadSHA equals the evaluated head, so a headless objection is
+	// invisible to it; the latest-round fallback below never runs because the
+	// strict population is non-empty whenever ANY current-head review exists; the
+	// gate then returns clean, executePullRequestMergeFenced acquires the task
+	// state for the external merge, and the objection's own AdvanceJob transition
+	// fails against that claim with ErrTaskStateClaimed while the merge completes.
+	// The objection was not deferred, it was BYPASSED - which inverts the one
+	// property the gate exists to hold.
+	//
+	// Every qualifier below is load-bearing, and each has a should-SUCCEED arm in
+	// the tests, because a gate that blocks valid merges is its own defect:
+	//   - HEADLESS: a row bound to a head is owned by the strict population above.
+	//     An objection rendered against a DIFFERENT head must still merge.
+	//   - ORDINARY: a fan-out announces a panel and is never a verdict (#1685).
+	//   - SUCCEEDED with a result: a queued, crashed or abstaining row is not an
+	//     objection, and the arms above already speak for rows at this head.
+	//   - UNSUPERSEDED: a strictly later terminal verdict from the SAME reviewer
+	//     is how an objection is answered or withdrawn, so a superseded row must
+	//     not block.
+	//   - APPLICABLE, and it takes FOUR exclusions, because a naive "ordinary
+	//     headless changes_requested" predicate deadlocks legitimate merges in three
+	//     distinct ways. sameCorrelatedTask already filtered by repo/PR/branch. Then:
+	//     a DELEGATION CHILD is headless by engine design and is judged through its
+	//     parent's fan-out evidence; an INTEGRATION-WORKTREE row has its head
+	//     cleared so it can validate an isolated tree; and a row with NEITHER head
+	//     NOR round is an unattributable delegation remnant, not a verdict. All
+	//     three point the OPPOSITE way from everything else here - including any of
+	//     them would block every head forever, which no push could ever clear.
+	//   - LATEST: among survivors the newest row decides, by the same
+	//     reviewRoundKey ordering supersession and round selection use, so no two
+	//     decisions here can disagree about which row is newer.
+	var headlessObjection *taskReview
+	var headlessObjectionKey reviewRoundKey
+	for i := range taskReviews {
+		review := taskReviews[i]
+		if strings.TrimSpace(review.payload.HeadSHA) != "" {
+			continue
+		}
+		if JobState(review.job.State) != JobSucceeded || review.payload.Result == nil {
+			continue
+		}
+		if isRoundHistoryDuplicate(review.job, taskReviewIDs) {
+			continue
+		}
+		// NOT APPLICABLE, FIRST DEADLOCK SHAPE, and it is only visible to the FULL
+		// package: a DELEGATION CHILD is headless because the engine clears a child's
+		// inherited HeadSHA, and its verdict is accounted through its parent's
+		// fan-out evidence (ensureDelegatedReviewEvidence), never as a standalone
+		// verdict about this head. isRoundHistoryDuplicate above is NOT enough - it
+		// only covers a child whose PARENT is itself a task review row, so a child of
+		// any other parent survived it.
+		//
+		// Found by execution rather than reading: a version of this block carrying
+		// only the superseded and integration exclusions passed every scoped headless
+		// test AND both ordering mutants, then failed
+		// TestPolicyMergeGateDelegatedReviewEvidenceEnumeration/H04_CHANGES_REQUESTED
+		// in the full package. A green scoped run is precisely what hides this class.
+		if isDelegationChild(review.job) {
+			continue
+		}
+		// NOT APPLICABLE, THIRD SHAPE, and this one is a JUDGEMENT I am recording
+		// rather than burying. A row that records NEITHER a head NOR a review round
+		// matches no production path that produces a reviewer verdict: an
+		// engine-dispatched review carries a ReviewRound, and a CLI-dispatched
+		// `gitmoot agent review` carries a HeadSHA and no round (which is what
+		// mergeGateReviewFixture.emptyRound documents), so it is never headless. What
+		// does produce this shape is a delegation child whose linkage columns were
+		// never written, and
+		// TestPolicyMergeGateDelegatedReviewEvidenceEnumeration's PARENT_ONLY and
+		// NEITHER_PARENT linkage variants assert - as wantExcluded - that such a row
+		// is UNATTRIBUTABLE and must be ignored rather than allowed to block.
+		//
+		// THE RISK, stated for the reviewer to attack: if some production path can
+		// persist a genuine reviewer objection with no head AND no round, this
+		// qualifier would leave #1933's bypass reachable for that shape. I could not
+		// find one, and the two shapes above are the only writers I traced.
+		if strings.TrimSpace(review.payload.ReviewRound) == "" {
+			continue
+		}
+		// NOT APPLICABLE, and this exclusion is the difference between a gate and a
+		// deadlock (#332 decompose-and-verify, #388). An integration-worktree review
+		// carries no head because the ENGINE CLEARS IT deliberately: the worktree has
+		// no branch and is validated against its own fresh HEAD, so the row's verdict
+		// is about that isolated tree, not about this pull request's head. Treating it
+		// as an objection against the head makes it an objection against EVERY head,
+		// which no push can ever clear -
+		// TestPolicyMergeGateHeadlessIntegrationObjectionDoesNotMatchEveryHead is the
+		// pre-existing test that holds this line, and the first version of this block
+		// failed it by including every headless row indiscriminately.
+		if isIntegrationWorktreeReview(review.payload) {
+			continue
+		}
+		if reviewRowIsFanOut(review.payload.Result) {
+			continue
+		}
+		if effectiveReviewDecisionForPayload(review.payload, request.ReviewBlockingSeverity) != "changes_requested" {
+			continue
+		}
+		reviewer := strings.TrimSpace(review.job.Agent)
+		superseded := false
+		if reviewer != "" {
+			for _, candidate := range taskReviews {
+				if candidate.payload.Result != nil &&
+					strings.TrimSpace(candidate.job.Agent) == reviewer &&
+					isReviewReplacementDecision(candidate.payload.Result.Decision) &&
+					reviewJobSupersedes(candidate.job, candidate.payload, review.job, review.payload) {
+					superseded = true
+					break
+				}
+			}
+		}
+		if superseded {
+			continue
+		}
+		key := reviewRoundKeyForJob(review.job, review.payload)
+		if headlessObjection == nil || reviewRoundKeyAfter(key, headlessObjectionKey) {
+			headlessObjection = &taskReviews[i]
+			headlessObjectionKey = key
+		}
+	}
+	if headlessObjection != nil {
+		return mergeBlocked{reason: fmt.Sprintf(
+			"unanswered review objection from %s (job %s) carries no evaluated head; answer or supersede that row, or re-render the verdict against this head",
+			strings.TrimSpace(headlessObjection.job.Agent), headlessObjection.job.ID)}
+	}
 	if len(activeAtHead) > 0 {
 		var selfApprovalReason string
 		var unknownImplementerReason string

--- a/internal/workflow/merge_gate.go
+++ b/internal/workflow/merge_gate.go
@@ -916,8 +916,23 @@ func (g PolicyMergeGate) ensureFinalReviewCaptured(ctx context.Context, request 
 			continue
 		}
 		for _, candidate := range reviewsAtHead {
-			if candidate.payload.Result != nil &&
-				effectiveReviewerIdentityName(candidate.job, candidate.payload) == reviewer &&
+			// DEFAULT-DENY HERE TOO (#1950 F6, second instance). This loop tested a
+			// bare Result != nil, which ADMITS BY DEFAULT: a succeeded approved
+			// FAN-OUT at the evaluated head - a dispatch announcement, not a verdict
+			// - retired an earlier same-reviewer changes_requested objection, was
+			// then skipped as an announcement by the blocking scan, and the PR
+			// merged on an independent approval.
+			//
+			// The previous round advertised "the same predicate governs both sides,
+			// so they cannot diverge" while shipping the helper at ONE call site.
+			// The invariant was asserted, not censused, and a one-line grep would
+			// have falsified it. Both candidate loops now call this helper, which is
+			// what makes the property true by construction; the count is reported in
+			// the test rather than the property being claimed again.
+			if !reviewRowCanRetireAnObjection(candidate.job, candidate.payload, headSHA) {
+				continue
+			}
+			if effectiveReviewerIdentityName(candidate.job, candidate.payload) == reviewer &&
 				isReviewReplacementDecision(candidate.payload.Result.Decision) &&
 				reviewJobSupersedes(candidate.job, candidate.payload, review.job, review.payload) {
 				supersededReviewIDs[review.job.ID] = struct{}{}
@@ -1017,7 +1032,13 @@ func (g PolicyMergeGate) ensureFinalReviewCaptured(ctx context.Context, request 
 		if strings.TrimSpace(review.payload.HeadSHA) != "" {
 			continue
 		}
-		if JobState(review.job.State) != JobSucceeded || review.payload.Result == nil {
+		// THIRD POPULATION, SHARED CORE (#1950 P1-B). This scan used to hand-compose
+		// succeeded, non-nil, non-fan-out and provenance inline, one clause at a
+		// time, which is how the candidate and objection sides drifted apart in the
+		// first place. Both candidate loops and this objection scan now ask the same
+		// one-row question, and a census test asserts the call-site COUNT so the
+		// property is checkable rather than advertised.
+		if !reviewRowIsVerdictAboutHead(review.job, review.payload, headSHA) {
 			continue
 		}
 		if isRoundHistoryDuplicate(review.job, taskReviewIDs) {
@@ -1064,9 +1085,7 @@ func (g PolicyMergeGate) ensureFinalReviewCaptured(ctx context.Context, request 
 		// engine-inserted AND roundless - provably the remnant shape. Every other
 		// combination, including any shape neither I nor the reviewer has enumerated,
 		// reaches the block below rather than slipping past it.
-		if !review.job.ExternallyDriven && strings.TrimSpace(review.payload.ReviewRound) == "" {
-			continue
-		}
+
 		// NOT APPLICABLE, and this exclusion is the difference between a gate and a
 		// deadlock (#332 decompose-and-verify, #388). An integration-worktree review
 		// carries no head because the ENGINE CLEARS IT deliberately: the worktree has
@@ -1078,9 +1097,6 @@ func (g PolicyMergeGate) ensureFinalReviewCaptured(ctx context.Context, request 
 		// pre-existing test that holds this line, and the first version of this block
 		// failed it by including every headless row indiscriminately.
 		if isIntegrationWorktreeReview(review.payload) {
-			continue
-		}
-		if reviewRowIsFanOut(review.payload.Result) {
 			continue
 		}
 		if effectiveReviewDecisionForPayload(review.payload, request.ReviewBlockingSeverity) != "changes_requested" {
@@ -2041,6 +2057,21 @@ func (g PolicyMergeGate) ensureReviewMatchesHead(payload JobPayload, headSHA str
 //     different code (#1950 F5). Empty is admitted deliberately, because a headless
 //     replacement is the same class as a headless objection and must be able to
 //     answer it.
+//
+// reviewRowIsVerdictAboutHead is the ONE question both sides of supersession
+// share: is this row a verdict about THIS head at all? It is deliberately a
+// one-row test. Identity, decision class and recency are RELATIONAL - properties
+// of a PAIR of rows - so they cannot live here and stay at the callers.
+//
+// Extracted because #1950 P1-B was a claim, not a mechanism: the previous round
+// reported "the same predicate governs the objection side" while the helper had
+// ONE call site and the at-head loop still tested a bare Result != nil. The
+// call-site count is now asserted by a test that reads this file, so the property
+// is checkable by someone who does not trust the comment.
+func reviewRowIsVerdictAboutHead(job db.Job, payload JobPayload, headSHA string) bool {
+	return reviewRowCanRetireAnObjection(job, payload, headSHA)
+}
+
 func reviewRowCanRetireAnObjection(job db.Job, payload JobPayload, headSHA string) bool {
 	if JobState(job.State) != JobSucceeded {
 		return false
@@ -2051,27 +2082,36 @@ func reviewRowCanRetireAnObjection(job db.Job, payload JobPayload, headSHA strin
 	if head := strings.TrimSpace(payload.HeadSHA); head != "" && head != headSHA {
 		return false
 	}
-	// ATTRIBUTABLE PROVENANCE, and this clause is here because a PROBE MERGED, not
-	// because it completed a symmetry argument. An engine-inserted row with neither
-	// head nor round satisfied every clause above - succeeded, non-fan-out, headless
-	// - retired a live session objection, and was then itself excluded from the
-	// blocking population as the unattributable remnant it is, so the merge
-	// completed. Same shape as F6, one row kind further out.
+	// ATTRIBUTABLE PROVENANCE, REQUIRED ONLY OF A HEADLESS ROW (#1950 F5, second
+	// instance). The clause exists because a probe MERGED: an engine-inserted row
+	// with neither head nor round satisfied every clause above, retired a live
+	// session objection, and was then itself excluded from the blocking population
+	// as the unattributable remnant it is.
 	//
-	// ExternallyDriven is set only by CreateExternallyDrivenJobWithEvent and every
-	// other insert leaves it at 0 (internal/db/store_jobs.go:184), so a session
-	// review is positively identified rather than inferred; a round is the other
-	// provenance an engine-dispatched review carries. This mirrors the objection
-	// side exactly, which is the property that keeps the two from diverging.
+	// But requiring it of EVERY row over-blocked the most ordinary supported shape
+	// there is. A CLI review carries a HeadSHA - agent_dispatch resolves it from the
+	// PR and hard-errors without one - and carries NEITHER a round nor
+	// ExternallyDriven, which is set only by CreateExternallyDrivenJobWithEvent
+	// (internal/db/store_jobs.go:184). So the first version of this clause refused a
+	// succeeded CLI approval at the evaluated head, deadlocking a PR that a human
+	// had legitimately re-reviewed. I had measured "CLI review: head always, round
+	// never" earlier in this same campaign and did not apply it here.
 	//
-	// A sibling probe is NOT reflected here on purpose: a delegation-child candidate
-	// also satisfies the floor, yet it already fails to supersede because an
-	// explicit round cannot be ordered against a roundless objection, so the
-	// existing reviewRoundKey machinery refuses it. Adding a clause for it would
-	// have been an unpinned claim, so it is reported and omitted.
-	if !job.ExternallyDriven && strings.TrimSpace(payload.ReviewRound) == "" {
+	// The head clause above forces a non-empty head to EQUAL the evaluated head, so
+	// such a row is attributable BY ITS HEAD: it demonstrably speaks about this
+	// exact commit. Only a HEADLESS row needs a second source of attribution, which
+	// is exactly the remnant the probe found. Guarding the narrow case rather than
+	// the general one is the whole difference between the two.
+	if strings.TrimSpace(payload.HeadSHA) == "" &&
+		!job.ExternallyDriven && strings.TrimSpace(payload.ReviewRound) == "" {
 		return false
 	}
+	// A delegation-child candidate is NOT refused here, and this predicate does not
+	// claim to refuse it: it satisfies every clause above. What actually stops it is
+	// reviewRoundKey, which will not order an explicit round against a roundless
+	// objection - measured, with Evaluate blocking and zero merge calls. Naming the
+	// real mechanism matters because the first version of this comment credited the
+	// refusal to this function, which does not perform it.
 	return true
 }
 

--- a/internal/workflow/merge_gate.go
+++ b/internal/workflow/merge_gate.go
@@ -1084,12 +1084,12 @@ func (g PolicyMergeGate) ensureFinalReviewCaptured(ctx context.Context, request 
 		// resolves the same identity with NormalizeActingOrgRole (merge_gate.go:1564),
 		// so this uses that rather than inventing a second rule. Both SIDES of the
 		// comparison resolve identically, or a role could still never supersede itself.
-		reviewer := headlessReviewerIdentity(review.job, review.payload)
+		reviewer := effectiveReviewerIdentityName(review.job, review.payload)
 		superseded := false
 		if reviewer != "" {
 			for _, candidate := range taskReviews {
 				if candidate.payload.Result != nil &&
-					headlessReviewerIdentity(candidate.job, candidate.payload) == reviewer &&
+					effectiveReviewerIdentityName(candidate.job, candidate.payload) == reviewer &&
 					isReviewReplacementDecision(candidate.payload.Result.Decision) &&
 					reviewJobSupersedes(candidate.job, candidate.payload, review.job, review.payload) {
 					superseded = true
@@ -1110,7 +1110,7 @@ func (g PolicyMergeGate) ensureFinalReviewCaptured(ctx context.Context, request 
 		// Name the AGENT-OR-ROLE, never the bare agent: an acting-role session review
 		// has no agent, and the first version of this rendered "objection from  "
 		// with an empty name, which tells an operator nothing about who to go to.
-		author := headlessReviewerIdentity(headlessObjection.job, headlessObjection.payload)
+		author := effectiveReviewerIdentityName(headlessObjection.job, headlessObjection.payload)
 		if author == "" {
 			author = "an unattributed reviewer"
 		}
@@ -1127,7 +1127,12 @@ func (g PolicyMergeGate) ensureFinalReviewCaptured(ctx context.Context, request 
 		var acceptedJob db.Job
 		var acceptedPayload JobPayload
 		for _, review := range activeAtHead {
-			reviewer := strings.TrimSpace(review.job.Agent)
+			// THE THIRD SITE OF THE SAME IDENTITY RULE (#1950 F4, ruling 126350).
+			// Reading job.Agent alone classified a ROLE-AUTHORED approval as
+			// unattributed and refused it BEFORE the independence check ever ran, so a
+			// role could never approve anything - and the role's own self-approval was
+			// never even tested for. Agent still wins whenever present.
+			reviewer := effectiveReviewerIdentityName(review.job, review.payload)
 			if JobState(review.job.State) != JobSucceeded {
 				return fmt.Errorf("reviewer %s at evaluated head has unusable job state %s (job %s)", reviewer, review.job.State, review.job.ID)
 			}
@@ -1240,7 +1245,9 @@ func (g PolicyMergeGate) ensureFinalReviewCaptured(ctx context.Context, request 
 			continue
 		}
 		if effectiveReviewDecisionForPayload(payload, request.ReviewBlockingSeverity) == "approved" {
-			reviewerAgent := strings.TrimSpace(job.Agent)
+			// Same rule, same helper (#1950 F4): the latest-round arm resolved identity
+			// separately, which is the fourth copy that ruling 126350 removes.
+			reviewerAgent := effectiveReviewerIdentityName(job, payload)
 			switch {
 			case reviewerAgent == "":
 				if unattributedReviewerReason == "" {
@@ -1579,18 +1586,20 @@ func collectImplementerAttributionMatching(jobs []db.Job, current JobPayload,
 		if !matches(current, payload) {
 			continue
 		}
-		agent := strings.TrimSpace(job.Agent)
-		role := NormalizeActingOrgRole(payload.ActingOrgRole)
+		// Identity DERIVATION is shared with the headless scan through
+		// effectiveReviewerIdentity (#1950 F4); the branch semantics below remain
+		// this collector's own.
+		name, fromActingRole := effectiveReviewerIdentity(job, payload)
 		switch {
-		case agent != "":
+		case name != "" && !fromActingRole:
 			// AN AGENT COLUMN ALWAYS WINS OVER A ROLE, and the order is load-bearing
 			// rather than cosmetic. Ordinary dispatched implement jobs carry the
 			// DISPATCHING coordinator's role in this same payload, so reading the role
 			// first would attribute every agent's work to its coordinator, make that
 			// coordinator an implementer of everything, and then disqualify it from
 			// reviewing anything.
-			evidence.agents[agent] = implementerIdentity{Name: agent}
-		case role != "":
+			evidence.agents[name] = implementerIdentity{Name: name}
+		case name != "":
 			// A ROLE NEVER DOWNGRADES AN AGENT ALREADY RECORDED UNDER THE SAME NAME,
 			// AND THAT IS WHY THIS IS A CONDITIONAL WRITE RATHER THAN A PLAIN ONE.
 			// The first version of this switch applied the agent-wins rule WITHIN one
@@ -1600,12 +1609,12 @@ func collectImplementerAttributionMatching(jobs []db.Job, current JobPayload,
 			// could report no dispatchable implementer while the agent row sat right
 			// there - routing decided by job-id order. Found in review, and it is the
 			// same rule I had already written one scope too narrow.
-			if existing, recorded := evidence.agents[role]; recorded && !existing.FromActingRole {
+			if existing, recorded := evidence.agents[name]; recorded && !existing.FromActingRole {
 				continue
 			}
 			// The #1916 shape: implemented in session by an org role, no agent to
 			// name. Attributable, and still subject to the independence check.
-			evidence.agents[role] = implementerIdentity{Name: role, FromActingRole: true}
+			evidence.agents[name] = implementerIdentity{Name: name, FromActingRole: true}
 		default:
 			evidence.sawEmptyAgent = true
 		}
@@ -1937,19 +1946,40 @@ func (g PolicyMergeGate) ensureReviewMatchesHead(payload JobPayload, headSHA str
 // allocated worktree path). The engine clears the inherited HeadSHA for exactly
 // these children so they validate against their isolated worktree HEAD, mirroring
 // isDelegationWorktreeChild in the daemon's checkout validation.
-// headlessReviewerIdentity is the effective reviewer identity for the headless
-// objection scan: the agent when a row records one, otherwise the normalized
+// effectiveReviewerIdentityName is the effective reviewer identity used by ALL
+// THREE identity sites in this file - headless objection supersession and its
+// diagnostic, implementer attribution, and the at-head reviewer arms: the agent
+// when a row records one, otherwise the normalized
 // ActingOrgRole. OpenExternalJob supports a role IN PLACE OF an agent
 // (mailbox.go:665 persists the normalized role; the job's Agent stays empty), so
 // keying on job.Agent alone made a role's objection unanswerable by that same
 // role - #1950 F2. collectGateImplementerAttribution already resolves identity
 // this way (merge_gate.go, NormalizeActingOrgRole), and sharing the rule is what
 // keeps the two from disagreeing about who a row belongs to.
-func headlessReviewerIdentity(job db.Job, payload JobPayload) string {
+func effectiveReviewerIdentityName(job db.Job, payload JobPayload) string {
+	name, _ := effectiveReviewerIdentity(job, payload)
+	return name
+}
+
+// effectiveReviewerIdentity is THE Agent-first/normalized-role rule, in ONE
+// place. It reports the resolved identity and whether it came from the acting
+// role, because the attribution collector needs that distinction while the
+// headless scan does not.
+//
+// It exists because the policy was written TWICE - once here and once inline in
+// collectImplementerAttributionMatching - and #1950 F4 is the observation that
+// two copies of a rule can drift even while they currently agree. The collector
+// keeps its own conditional-write semantics (a role must not downgrade an agent
+// already recorded under the same name); what it no longer keeps is a second copy
+// of how an identity is DERIVED.
+func effectiveReviewerIdentity(job db.Job, payload JobPayload) (string, bool) {
 	if agent := strings.TrimSpace(job.Agent); agent != "" {
-		return agent
+		return agent, false
 	}
-	return NormalizeActingOrgRole(payload.ActingOrgRole)
+	if role := NormalizeActingOrgRole(payload.ActingOrgRole); role != "" {
+		return role, true
+	}
+	return "", false
 }
 
 func isIntegrationWorktreeReview(payload JobPayload) bool {

--- a/internal/workflow/merge_gate.go
+++ b/internal/workflow/merge_gate.go
@@ -1125,11 +1125,18 @@ func (g PolicyMergeGate) ensureFinalReviewCaptured(ctx context.Context, request 
 				// recency, and applicable head. Five rounds of this fix each decided it
 				// from a subset: the writer, then the attempt, then the message prefix,
 				// then the identity source, and now the head.
-				if candidateHead := strings.TrimSpace(candidate.payload.HeadSHA); candidateHead != "" && candidateHead != headSHA {
+				// ADMISSIBILITY IS DEFAULT-DENY (#1950 F6). Three rounds found this loop
+				// admitting rows it should not - an unscoped head, then unusable states,
+				// then an explicit non-verdict - because each round removed one shape and
+				// left the default OPEN. reviewRowCanRetireAnObjection inverts that: a
+				// row must positively qualify, so an unenumerated kind produces a false
+				// BLOCK rather than a false MERGE. A deadlock is visible; a merge is not.
+				if !reviewRowCanRetireAnObjection(candidate.job, candidate.payload, headSHA) {
 					continue
 				}
-				if candidate.payload.Result != nil &&
-					effectiveReviewerIdentityName(candidate.job, candidate.payload) == reviewer &&
+				// The remaining tests are RELATIONAL - they compare two rows rather than
+				// describe one - so they stay out of the predicate.
+				if effectiveReviewerIdentityName(candidate.job, candidate.payload) == reviewer &&
 					isReviewReplacementDecision(candidate.payload.Result.Decision) &&
 					reviewJobSupersedes(candidate.job, candidate.payload, review.job, review.payload) {
 					superseded = true
@@ -2009,6 +2016,65 @@ func (g PolicyMergeGate) ensureReviewMatchesHead(payload JobPayload, headSHA str
 //   - proof/project.go reports a role-authored review as not comparable, so its
 //     independence attribute stays unknown rather than being computed. That is
 //     conservative - it emits no false independence claim - but incomplete.
+//
+// reviewRowCanRetireAnObjection reports whether a row may supersede a live
+// changes_requested objection. It is DEFAULT-DENY by construction: every clause
+// returns false and the final true is reachable only by a row that positively
+// qualifies as an authoritative verdict about the evaluated head.
+//
+// The shape is the point (#1950 F6). Rounds 5, 7 and 8 are one defect class - the
+// candidate set admitting rows it should not - and each round narrowed a denylist
+// that still admitted by default, so the next probe found the next shape: a stale
+// head, then blocked and failed rows, then an approved fan-out announcement. Under
+// default-deny an unenumerated row kind cannot retire an objection at all, so the
+// failure direction is a visible block rather than a silent merge.
+//
+// EVERY CLAUSE HERE IS MEASURED, and the list is deliberately no longer than that.
+// A speculative clause would be a claim rather than a guard, and it is also the
+// direction that starts refusing valid merges:
+//   - SUCCEEDED: a blocked or failed row is not a verdict, and it is itself absent
+//     from the blocking population, so admitting it retires an objection and
+//     leaves nothing behind to block.
+//   - a non-nil, NON-FAN-OUT result: #1685 excludes an announcement as a verdict
+//     for exactly the same reason.
+//   - HEAD APPLICABILITY, empty-or-equal: a row naming a different head describes
+//     different code (#1950 F5). Empty is admitted deliberately, because a headless
+//     replacement is the same class as a headless objection and must be able to
+//     answer it.
+func reviewRowCanRetireAnObjection(job db.Job, payload JobPayload, headSHA string) bool {
+	if JobState(job.State) != JobSucceeded {
+		return false
+	}
+	if payload.Result == nil || reviewRowIsFanOut(payload.Result) {
+		return false
+	}
+	if head := strings.TrimSpace(payload.HeadSHA); head != "" && head != headSHA {
+		return false
+	}
+	// ATTRIBUTABLE PROVENANCE, and this clause is here because a PROBE MERGED, not
+	// because it completed a symmetry argument. An engine-inserted row with neither
+	// head nor round satisfied every clause above - succeeded, non-fan-out, headless
+	// - retired a live session objection, and was then itself excluded from the
+	// blocking population as the unattributable remnant it is, so the merge
+	// completed. Same shape as F6, one row kind further out.
+	//
+	// ExternallyDriven is set only by CreateExternallyDrivenJobWithEvent and every
+	// other insert leaves it at 0 (internal/db/store_jobs.go:184), so a session
+	// review is positively identified rather than inferred; a round is the other
+	// provenance an engine-dispatched review carries. This mirrors the objection
+	// side exactly, which is the property that keeps the two from diverging.
+	//
+	// A sibling probe is NOT reflected here on purpose: a delegation-child candidate
+	// also satisfies the floor, yet it already fails to supersede because an
+	// explicit round cannot be ordered against a roundless objection, so the
+	// existing reviewRoundKey machinery refuses it. Adding a clause for it would
+	// have been an unpinned claim, so it is reported and omitted.
+	if !job.ExternallyDriven && strings.TrimSpace(payload.ReviewRound) == "" {
+		return false
+	}
+	return true
+}
+
 func effectiveReviewerIdentityName(job db.Job, payload JobPayload) string {
 	name, _ := effectiveReviewerIdentity(job, payload)
 	return name

--- a/internal/workflow/merge_gate_test.go
+++ b/internal/workflow/merge_gate_test.go
@@ -5433,3 +5433,384 @@ func insertMergeGatePanelRetry(t *testing.T, store *db.Store, parentID, delegati
 		t.Fatalf("CreateJobWithEvent returned error: %v", err)
 	}
 }
+
+// insertMergeGateHeadlessReview seeds a review row with NO HeadSHA, which
+// insertMergeGateReviewFixture cannot express: it defaults an empty head to
+// "head123". A headless row is what `gitmoot agent review` leaves behind when the
+// head is not recorded, and it is the row issue #1933 turns on.
+func insertMergeGateHeadlessReview(t *testing.T, store *db.Store, id, agent, decision, taskID, round string) {
+	t.Helper()
+	insertCompletedJob(t, store, db.Job{ID: id, Agent: agent, Type: "review"}, JobPayload{
+		Repo:        "gitmoot/gitmoot",
+		PullRequest: 9,
+		HeadSHA:     "",
+		TaskID:      taskID,
+		ReviewRound: round,
+		Result:      &AgentResult{Decision: decision, Summary: "headless verdict"},
+	})
+}
+
+// TestPolicyMergeGateBlocksHeadlessObjectionAheadOfTheExternalMergeClaim is
+// issue #1933, and it enters through Evaluate rather than
+// ensureFinalReviewCaptured because the defect IS the ordering between the
+// review evaluation and the external-merge state claim - a test that called the
+// helper could not observe the claim at all.
+//
+// The interleaving, from the issue: a succeeded current-head APPROVAL and a
+// succeeded ordinary HEADLESS changes_requested row on the same task.
+// reviewsAtHead holds only the approval, because the strict evaluated-head
+// filter drops the headless row; the latest-round fallback never runs because
+// the strict population is non-empty; ClaimTaskState then fences the objection's
+// own transition and the merge completes with the objection unconsumed.
+//
+// Both orderings are asserted because the store returns rows by id and the
+// defect must not be reachable by seeding them the other way round.
+func TestPolicyMergeGateBlocksHeadlessObjectionAheadOfTheExternalMergeClaim(t *testing.T) {
+	for _, tt := range []struct {
+		name           string
+		objectionFirst bool
+	}{
+		{name: "approval recorded before the headless objection", objectionFirst: false},
+		{name: "headless objection recorded before the approval", objectionFirst: true},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			store, gh, gate, request := newMergeGateQuorumScenario(t)
+			if tt.objectionFirst {
+				insertMergeGateHeadlessReview(t, store, "a-review-objection", "gm-review-opus", "changes_requested", "task-9", "review-1")
+				insertMergeGateReviewFixture(t, store, mergeGateReviewFixture{
+					id: "b-review-approval", agent: "audit", decision: "approved", hasResult: true,
+				})
+			} else {
+				insertMergeGateReviewFixture(t, store, mergeGateReviewFixture{
+					id: "a-review-approval", agent: "audit", decision: "approved", hasResult: true,
+				})
+				insertMergeGateHeadlessReview(t, store, "b-review-objection", "gm-review-opus", "changes_requested", "task-9", "review-1")
+			}
+			if err := store.UpsertTask(ctx, db.Task{
+				ID: "task-9", RepoFullName: "gitmoot/gitmoot", Branch: "task-9",
+				State: string(TaskReadyToMerge),
+			}); err != nil {
+				t.Fatal(err)
+			}
+			request.Reviewer = "audit"
+			request.ExpectedTaskState = string(TaskReadyToMerge)
+
+			decision, err := gate.Evaluate(ctx, request)
+
+			if err != nil {
+				t.Fatalf("Evaluate returned error: %v", err)
+			}
+			if decision.Merged || len(gh.merges) != 0 {
+				t.Fatalf("decision=%+v merges=%d, want NO merge: a persisted headless changes_requested objection must block BEFORE the external-merge claim (#1933)",
+					decision, len(gh.merges))
+			}
+			// The claim must never have been taken, or the objection's own advance
+			// would still be fenced even though the merge was refused.
+			task, taskErr := store.GetTask(ctx, "task-9")
+			if taskErr != nil {
+				t.Fatalf("GetTask: %v", taskErr)
+			}
+			if task.State != string(TaskReadyToMerge) {
+				t.Fatalf("task state = %q, want %q: the gate must not claim the task state when a headless objection blocks",
+					task.State, string(TaskReadyToMerge))
+			}
+		})
+	}
+}
+
+// TestPolicyMergeGateStillMergesWhenAHeadlessObjectionDoesNotApply is the
+// should-SUCCEED half of #1933, and it is the half that decides whether the fix
+// is a gate or an outage. Every qualifier in the new block gets an arm here, and
+// each arm must still reach a completed external merge.
+//
+// One honest mapping, because the vocabulary does not contain the words: a
+// review row has no "answered" or "withdrawn" DECISION - isReviewReplacementDecision
+// covers approved/changes_requested/blocked/failed only. At row level both are
+// expressed the same way, by a strictly later terminal verdict from the SAME
+// reviewer superseding the objection, which is what the first two arms drive.
+// The findings ledger's own db.FindingAnswered/db.FindingWithdrawn states are a
+// different surface and are enforced by EnsureLedgerObligationsObserved earlier
+// in this same function, not by this block.
+func TestPolicyMergeGateStillMergesWhenAHeadlessObjectionDoesNotApply(t *testing.T) {
+	for _, tt := range []struct {
+		name string
+		seed func(t *testing.T, store *db.Store)
+		why  string
+		// requestBranch populates MergeRequest.Branch, without which
+		// sameCorrelatedTask's branch comparison is unreachable: an empty side is
+		// treated as no evidence rather than a mismatch.
+		requestBranch string
+		// wantMerge defaults to TRUE - this table is the should-SUCCEED half - and
+		// is set false only by the arms guarding corrections to it.
+		wantMerge *bool
+		// wantReasonContains pins WHICH path refused, not merely that one did: a
+		// block from the headless pre-pass and a block from the parent's delegation
+		// evidence are different guarantees, and shadowing one with the other would
+		// pass a bare "it did not merge" assertion.
+		wantReasonContains string
+	}{
+		{
+			name: "answered: the same reviewer later approved, superseding it",
+			why:  "a strictly later terminal verdict from the same reviewer is how an objection is answered",
+			seed: func(t *testing.T, store *db.Store) {
+				insertMergeGateHeadlessReviewAt(t, store, "objection-early", "gm-review-opus", "changes_requested", "task-9", "review-1", "2026-09-01T10:00:00Z")
+				insertMergeGateHeadlessReviewAt(t, store, "objection-answered", "gm-review-opus", "approved", "task-9", "review-1", "2026-09-01T12:00:00Z")
+			},
+		},
+		{
+			name: "withdrawn: the same reviewer replaced it at the evaluated head",
+			why:  "withdrawal is expressed as a later terminal verdict from the same reviewer, here rendered at the head",
+			seed: func(t *testing.T, store *db.Store) {
+				insertMergeGateHeadlessReviewAt(t, store, "objection-withdrawn", "gm-review-opus", "changes_requested", "task-9", "review-1", "2026-09-01T10:00:00Z")
+				// A strictly LATER ROUND, not an empty one: reviewRoundKey refuses to
+				// order one explicit review-N against an empty round, so an empty-round
+				// replacement supersedes nothing and the objection correctly still
+				// blocks. The first version of this arm made that mistake and failed.
+				insertCompletedJob(t, store, db.Job{ID: "objection-replacement", Agent: "gm-review-opus", Type: "review"}, JobPayload{
+					Repo: "gitmoot/gitmoot", PullRequest: 9, HeadSHA: "head123", TaskID: "task-9",
+					ReviewRound: "review-2",
+					Result:      &AgentResult{Decision: "approved", Summary: "withdrawn and replaced"},
+				})
+			},
+		},
+		{
+			name: "superseded: a later headless verdict from the same reviewer wins",
+			why:  "supersession is same-reviewer and strictly-later, and it must clear the earlier row",
+			seed: func(t *testing.T, store *db.Store) {
+				insertMergeGateHeadlessReviewAt(t, store, "objection-superseded", "gm-review-opus", "changes_requested", "task-9", "review-1", "2026-09-01T09:00:00Z")
+				insertMergeGateHeadlessReviewAt(t, store, "objection-latest", "gm-review-opus", "approved", "task-9", "review-1", "2026-09-01T11:00:00Z")
+			},
+		},
+		{
+			name: "non-applicable: the objection belongs to a different pull request",
+			why:  "sameCorrelatedTask refuses a row from another pull request outright",
+			seed: func(t *testing.T, store *db.Store) {
+				insertCompletedJob(t, store, db.Job{ID: "objection-other-pr", Agent: "gm-review-opus", Type: "review"}, JobPayload{
+					Repo: "gitmoot/gitmoot", PullRequest: 8, HeadSHA: "", TaskID: "task-8",
+					Result: &AgentResult{Decision: "changes_requested", Summary: "another PR's objection"},
+				})
+			},
+		},
+		{
+			name: "non-applicable: the objection's branch disagrees with the request's",
+			why:  "when both sides record a branch and they differ, the row belongs to another lane (#1519)",
+			// A DIFFERENT TASK ID ALONE IS NOT NON-APPLICABLE. sameCorrelatedTask
+			// correlates on repo+PR whenever the branches do not disagree, REGARDLESS
+			// of task id, because review identity migrates between rounds (#1519). An
+			// earlier version of this arm seeded only a divergent task id and expected
+			// a merge; it FAILED, correctly, and weakening the guard to satisfy it
+			// would have reopened the very bypass this block exists to close. The arm
+			// below pins that reading so the mistake cannot be made again silently.
+			requestBranch: "task-9",
+			seed: func(t *testing.T, store *db.Store) {
+				insertCompletedJob(t, store, db.Job{ID: "objection-other-branch", Agent: "gm-review-opus", Type: "review"}, JobPayload{
+					Repo: "gitmoot/gitmoot", PullRequest: 9, Branch: "some-other-branch", HeadSHA: "", TaskID: "review-pr-9-3f3a1026",
+					Result: &AgentResult{Decision: "changes_requested", Summary: "another branch's objection"},
+				})
+			},
+		},
+		{
+			name:      "APPLICABLE despite a migrated task id: this one must BLOCK",
+			why:       "a divergent task id on the same PR still correlates (#1519), so the objection still applies",
+			wantMerge: boolPtr(false),
+			seed: func(t *testing.T, store *db.Store) {
+				insertMergeGateHeadlessReview(t, store, "objection-migrated-id", "gm-review-opus", "changes_requested", "review-pr-9-3f3a1026", "review-1")
+			},
+		},
+		{
+			name: "rendered against another head: not headless at all",
+			why:  "a head-bound objection is owned by the strict evaluated-head population, not by this block",
+			seed: func(t *testing.T, store *db.Store) {
+				insertMergeGateReviewFixture(t, store, mergeGateReviewFixture{
+					id: "objection-other-head", agent: "gm-review-opus", decision: "changes_requested",
+					hasResult: true, headSHA: "someotherhead",
+				})
+			},
+		},
+		{
+			name: "not ordinary: a headless fan-out announcement is not a verdict",
+			why:  "#1685 - a row declaring delegations announces a panel and never answers for the head",
+			seed: func(t *testing.T, store *db.Store) {
+				insertCompletedJob(t, store, db.Job{ID: "objection-fanout", Agent: "gm-review-opus", Type: "review"}, JobPayload{
+					Repo: "gitmoot/gitmoot", PullRequest: 9, HeadSHA: "", TaskID: "task-9",
+					Result: &AgentResult{
+						Decision:    "changes_requested",
+						Summary:     "fan-out announcement",
+						Delegations: []Delegation{{ID: "lens-a", Agent: "lens-a", Action: "review", Prompt: "look at it"}},
+					},
+				})
+			},
+		},
+		{
+			name: "not applicable: an integration-worktree objection records no head by design",
+			why:  "#332/#388 - the engine CLEARS the head for these children, so treating one as an objection against this head makes it an objection against every head, which no push can clear",
+			// The pre-existing TestPolicyMergeGateHeadlessIntegrationObjectionDoesNotMatchEveryHead
+			// already holds this line and I did not touch it. This arm exists so the
+			// exclusion is bound from inside the #1933 suite as well: deleting it must
+			// fail a test written by the change that depends on it, not only an
+			// inherited one.
+			seed: func(t *testing.T, store *db.Store) {
+				insertCompletedJob(t, store, db.Job{ID: "objection-integration", Agent: "objector", Type: "review"}, JobPayload{
+					Repo: "gitmoot/gitmoot", PullRequest: 9, TaskID: "task-9", ReviewRound: "review-1",
+					DelegationID: "verify-old",
+					WorktreePath: "/tmp/gitmoot/integration-verify-old",
+					Result:       &AgentResult{Decision: "changes_requested", Summary: "integration objection"},
+				})
+			},
+		},
+		{
+			name:               "a delegation child blocks through its PARENT'S evidence, not through this block",
+			why:                "the engine clears only the inherited HeadSHA so a real child keeps its round; it must be judged by ensureDelegatedReviewEvidence, and the headless block must not shadow that path with its own reason",
+			wantMerge:          boolPtr(false),
+			wantReasonContains: "blocking delegation evidence",
+			seed: func(t *testing.T, store *db.Store) {
+				encoded, err := marshalPayload(JobPayload{
+					Repo: "gitmoot/gitmoot", PullRequest: 9, TaskID: "task-9", ReviewRound: "review-1",
+					Result: &AgentResult{Decision: "changes_requested", Summary: "delegated child verdict"},
+				})
+				if err != nil {
+					t.Fatalf("marshalPayload: %v", err)
+				}
+				if err := store.CreateJobWithEvent(context.Background(), db.Job{
+					ID: "objection-delegation-child", Agent: "lens-a", Type: "review",
+					State: string(JobSucceeded), Payload: encoded,
+					ParentJobID: "review-approval", DelegationID: "lens-a",
+				}, db.JobEvent{Kind: string(JobSucceeded), Message: "child"}); err != nil {
+					t.Fatalf("CreateJobWithEvent: %v", err)
+				}
+			},
+		},
+		{
+			// PINS THE DELEGATION-CHILD EXCLUSION ITSELF. The arm above it does not:
+			// its parent is a review row, so isRoundHistoryDuplicate already excludes
+			// it and deleting isDelegationChild changed nothing - a surviving mutant
+			// proved that. A child of the IMPLEMENT row is not round history, so this
+			// is the shape where the exclusion is the only thing standing between a
+			// headless child and a permanent block.
+			name: "not applicable: a delegation child whose parent is not a review row",
+			why:  "the engine clears a child's inherited head; a child of the implement row is not round history, so only the delegation-child exclusion keeps it from blocking every head",
+			seed: func(t *testing.T, store *db.Store) {
+				encoded, err := marshalPayload(JobPayload{
+					Repo: "gitmoot/gitmoot", PullRequest: 9, TaskID: "task-9", ReviewRound: "review-1",
+					Result: &AgentResult{Decision: "changes_requested", Summary: "verify child of the implement row"},
+				})
+				if err != nil {
+					t.Fatalf("marshalPayload: %v", err)
+				}
+				if err := store.CreateJobWithEvent(context.Background(), db.Job{
+					ID: "objection-child-of-implement", Agent: "verifier", Type: "review",
+					State: string(JobSucceeded), Payload: encoded,
+					ParentJobID: "implement-job", DelegationID: "verify",
+				}, db.JobEvent{Kind: string(JobSucceeded), Message: "child"}); err != nil {
+					t.Fatalf("CreateJobWithEvent: %v", err)
+				}
+			},
+		},
+		{
+			// PINS "LATEST". With two qualifying objections the reason must name the
+			// NEWER one; reversing the selection was a surviving mutant until this arm
+			// existed, because every other scenario has at most one candidate.
+			name:               "two qualifying objections: the LATEST one is the one reported",
+			why:                "latest is decided by the same reviewRoundKey ordering supersession uses, so the block must name the newer reviewer",
+			wantMerge:          boolPtr(false),
+			wantReasonContains: "later-objector",
+			seed: func(t *testing.T, store *db.Store) {
+				insertMergeGateHeadlessReviewAt(t, store, "objection-older", "earlier-objector", "changes_requested", "task-9", "review-1", "2026-09-01T09:00:00Z")
+				insertMergeGateHeadlessReviewAt(t, store, "objection-newer", "later-objector", "changes_requested", "task-9", "review-2", "2026-09-01T15:00:00Z")
+			},
+		},
+		{
+			name: "not applicable: neither head nor round is an unattributable remnant",
+			why:  "matches no production writer of a reviewer verdict - engine reviews carry a round, CLI reviews carry a head - and TestPolicyMergeGateDelegatedReviewEvidenceEnumeration asserts wantExcluded for exactly this shape",
+			seed: func(t *testing.T, store *db.Store) {
+				insertCompletedJob(t, store, db.Job{ID: "objection-no-round", Agent: "orphan", Type: "review"}, JobPayload{
+					Repo: "gitmoot/gitmoot", PullRequest: 9, TaskID: "task-9",
+					Result: &AgentResult{Decision: "changes_requested", Summary: "unattributable remnant"},
+				})
+			},
+		},
+		{
+			// PINS THE changes_requested NARROWNESS. Widening this block to "anything
+			// not approved" was a surviving mutant until this arm existed, and the
+			// widening is not harmless: an ABSTENTION cannot be answered or superseded
+			// by its author, so blocking on one would deadlock with no operator move.
+			name: "not a changes_requested verdict: a headless abstention must not block",
+			why:  "an abstention is not an objection, and blocking on one would be unanswerable",
+			seed: func(t *testing.T, store *db.Store) {
+				insertMergeGateHeadlessReviewAt(t, store, "objection-abstained", "abstainer", "skipped", "task-9", "review-1", "2026-09-01T10:00:00Z")
+			},
+		},
+		{
+			name: "not succeeded: a queued headless row is not a verdict",
+			why:  "an unfinished row has rendered no objection; rows at the evaluated head are judged above",
+			seed: func(t *testing.T, store *db.Store) {
+				encoded, err := marshalPayload(JobPayload{
+					Repo: "gitmoot/gitmoot", PullRequest: 9, HeadSHA: "", TaskID: "task-9",
+					// A ROUND IS REQUIRED for this arm to reach the succeeded-state
+					// check: without it the round qualifier excludes the row first and
+					// the arm cannot fail, which a surviving mutant proved.
+					ReviewRound: "review-1",
+					Result:      &AgentResult{Decision: "changes_requested", Summary: "still running"},
+				})
+				if err != nil {
+					t.Fatalf("marshalPayload: %v", err)
+				}
+				if err := store.CreateJobWithEvent(context.Background(), db.Job{
+					ID: "objection-queued", Agent: "gm-review-opus", Type: "review",
+					State: string(JobQueued), Payload: encoded,
+				}, db.JobEvent{Kind: string(JobQueued), Message: "queued"}); err != nil {
+					t.Fatalf("CreateJobWithEvent: %v", err)
+				}
+			},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			store, gh, gate, request := newMergeGateQuorumScenario(t)
+			insertMergeGateReviewFixture(t, store, mergeGateReviewFixture{
+				id: "review-approval", agent: "audit", decision: "approved", hasResult: true,
+			})
+			tt.seed(t, store)
+			if err := store.UpsertTask(ctx, db.Task{
+				ID: "task-9", RepoFullName: "gitmoot/gitmoot", Branch: "task-9",
+				State: string(TaskReadyToMerge),
+			}); err != nil {
+				t.Fatal(err)
+			}
+			request.Reviewer = "audit"
+			request.ExpectedTaskState = string(TaskReadyToMerge)
+			request.Branch = tt.requestBranch
+
+			decision, err := gate.Evaluate(ctx, request)
+
+			if err != nil {
+				t.Fatalf("Evaluate returned error: %v (%s)", err, tt.why)
+			}
+			wantMerge := tt.wantMerge == nil || *tt.wantMerge
+			if wantMerge && (!decision.Merged || len(gh.merges) != 1) {
+				t.Fatalf("decision=%+v merges=%d, want ONE completed merge: %s", decision, len(gh.merges), tt.why)
+			}
+			if !wantMerge && (decision.Merged || len(gh.merges) != 0) {
+				t.Fatalf("decision=%+v merges=%d, want NO merge: %s", decision, len(gh.merges), tt.why)
+			}
+			if tt.wantReasonContains != "" && !strings.Contains(decision.Reason.Render(), tt.wantReasonContains) {
+				t.Fatalf("reason = %q, want it to contain %q: %s", decision.Reason.Render(), tt.wantReasonContains, tt.why)
+			}
+		})
+	}
+}
+
+// insertMergeGateHeadlessReviewAt is insertMergeGateHeadlessReview with the
+// recorded timestamps pinned, which is the only way to make supersession
+// decidable between two headless rows: reviewRoundKeyForJob falls back to
+// UpdatedAt then CreatedAt when no round is set, and rows whose order cannot be
+// established supersede in neither direction by design.
+func insertMergeGateHeadlessReviewAt(t *testing.T, store *db.Store, id, agent, decision, taskID, round, recorded string) {
+	t.Helper()
+	insertMergeGateHeadlessReview(t, store, id, agent, decision, taskID, round)
+	setMergeGateJobTimestamps(t, store, id, recorded)
+}
+
+// boolPtr expresses an explicit false in a table whose default is true.
+func boolPtr(v bool) *bool { return &v }

--- a/internal/workflow/merge_gate_test.go
+++ b/internal/workflow/merge_gate_test.go
@@ -6166,3 +6166,77 @@ func TestPolicyMergeGateReachesIndependenceForARoleAuthoredApproval(t *testing.T
 		})
 	}
 }
+
+// TestPolicyMergeGateSupersedesARoleAuthoredAtHeadObjection is #1950 F4's SIXTH
+// identity site, reproduced as the certifying reviewer's adversary did it.
+// Current-head supersession compared Agent columns inline while every other site
+// had been routed through the resolver, so an at-head objection authored by an
+// acting ROLE could never be superseded by that same role's later at-head
+// approval: both Agent columns are empty, the loop skipped them, and the PR
+// stayed open rendering "blocking result from " with no author.
+//
+// The role is deliberately written " ReVieWer " with padding and mixed case,
+// because NormalizeActingOrgRole trims and lowercases and the two rows must
+// resolve to ONE identity. A fix that compared raw role strings would fail here.
+func TestPolicyMergeGateSupersedesARoleAuthoredAtHeadObjection(t *testing.T) {
+	for _, tt := range []struct {
+		name        string
+		addApproval bool
+		wantMerge   bool
+	}{
+		{name: "objection alone blocks and NAMES the role", addApproval: false, wantMerge: false},
+		{name: "a later at-head approval from the same normalized role supersedes it", addApproval: true, wantMerge: true},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			store := openEngineStore(t)
+			insertCompletedJob(t, store, db.Job{ID: "implement-job", Agent: "wave-impl", Type: "implement"}, JobPayload{
+				Repo: "gitmoot/gitmoot", PullRequest: 9, TaskID: "task-9",
+				Result: &AgentResult{Decision: "implemented", Summary: "implemented"},
+			})
+			insertCompletedJob(t, store, db.Job{ID: "a-review-objection", Agent: "", Type: "review"}, JobPayload{
+				Repo: "gitmoot/gitmoot", PullRequest: 9, HeadSHA: "head123", TaskID: "task-9",
+				ReviewRound:   "review-1",
+				ActingOrgRole: " ReVieWer ",
+				Result:        &AgentResult{Decision: "changes_requested", Severity: reviewseverity.P1, Summary: "role objection at head"},
+			})
+			if tt.addApproval {
+				insertCompletedJob(t, store, db.Job{ID: "b-review-approval", Agent: "", Type: "review"}, JobPayload{
+					Repo: "gitmoot/gitmoot", PullRequest: 9, HeadSHA: "head123", TaskID: "task-9",
+					ReviewRound:   "review-2",
+					ActingOrgRole: "reviewer",
+					Result:        &AgentResult{Decision: "approved", Summary: "same role, later round"},
+				})
+			}
+			mergeable := true
+			gh := &fakeMergeGateGitHub{
+				pr: github.PullRequest{
+					Number: 9, State: "open", HeadRef: "task-9", BaseRef: "main",
+					HeadSHA: "head123", Mergeable: &mergeable,
+				},
+				status:      github.CombinedStatus{State: "success", Statuses: []github.CommitStatus{{Context: "ci", State: "success"}}},
+				checks:      []github.PullRequestCheck{{Name: "ci", Bucket: "pass", State: "SUCCESS"}},
+				mergeResult: github.MergeResult{Merged: true, SHA: "merge123"},
+			}
+			gate := PolicyMergeGate{AutoMerge: true, Store: store, GitHub: gh, Git: &fakeMergeGateGit{clean: true}}
+
+			decision, err := gate.Evaluate(ctx, MergeRequest{Repo: "gitmoot/gitmoot", PullRequest: 9, TaskID: "task-9"})
+			if err != nil {
+				t.Fatalf("Evaluate returned error: %v", err)
+			}
+			rendered := decision.Reason.Render()
+			if tt.wantMerge && (!decision.Merged || len(gh.merges) != 1) {
+				t.Fatalf("decision=%+v merges=%d, want ONE merge: the same normalized role's later at-head approval must supersede its objection (#1950 F4 site 6). reason=%q",
+					decision, len(gh.merges), rendered)
+			}
+			if !tt.wantMerge {
+				if decision.Merged || len(gh.merges) != 0 {
+					t.Fatalf("decision=%+v merges=%d, want NO merge: an at-head role objection still blocks", decision, len(gh.merges))
+				}
+				if !strings.Contains(rendered, "reviewer") {
+					t.Fatalf("reason = %q, want the normalized ROLE named; rendering \"blocking result from \" with no author is the defect this pins", rendered)
+				}
+			}
+		})
+	}
+}

--- a/internal/workflow/merge_gate_test.go
+++ b/internal/workflow/merge_gate_test.go
@@ -5948,7 +5948,7 @@ func TestPolicyMergeGateAllowsAnActingRoleSessionObjectionToBeSuperseded(t *test
 			// neither agent nor acting role - can never be superseded by anyone, so it
 			// must still BLOCK rather than be skipped. Under-blocking is how F1
 			// happened; this arm is what stops the identity fix from re-introducing it.
-			name: "no usable identity at all still blocks", noIdentity: true, wantMerge: false,
+			name: "DEFENSIVE INVARIANT (no supported writer produces this): a row with no usable identity still blocks", noIdentity: true, wantMerge: false,
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/workflow/merge_gate_test.go
+++ b/internal/workflow/merge_gate_test.go
@@ -6429,3 +6429,266 @@ func seedHeadlessCandidate(t *testing.T, store *db.Store, id, agent string, stat
 	}
 	setMergeGateJobTimestamps(t, store, id, "2026-09-01T18:00:00Z")
 }
+
+// seedProductionReviewRow drives a review through the PRODUCTION writers -
+// Mailbox.Enqueue then finishWithPayload - rather than assembling a row. That is
+// load-bearing for both arms below: the whole of #1950 F5 is that a CLI review
+// carries a HeadSHA and NEITHER a round nor ExternallyDriven, and a hand-built
+// fixture is free to contradict that. This one cannot.
+func seedProductionReviewRow(t *testing.T, store *db.Store, id, agent, decision, headSHA string, delegations []Delegation) db.Job {
+	t.Helper()
+	ctx := context.Background()
+	mailbox := Mailbox{store: store, resolveDeliveryWorktree: ExcludedDeliveryWorktreeResolver("test_explicit_no_worktree")}
+	if _, err := mailbox.Enqueue(ctx, JobRequest{
+		ID: id, Agent: agent, Action: "review", Repo: "gitmoot/gitmoot", Branch: "task-9",
+		TaskID: "task-9", PullRequest: 9, HeadSHA: headSHA, Instructions: "review",
+		SkipNativeReviewFanout: true,
+	}); err != nil {
+		t.Fatalf("Enqueue(%s) returned error: %v", id, err)
+	}
+	// finishWithPayload only accepts a RUNNING job, exactly as the worker leaves it
+	// after claiming. Skipping this made both arms fail on the FIXTURE rather than
+	// on the behaviour under test, which is how the first run of this test failed -
+	// a green or red arm that never reached the predicate proves nothing.
+	if _, err := store.TransitionJobState(ctx, id, string(JobQueued), string(JobRunning)); err != nil {
+		t.Fatalf("TransitionJobState(%s) queued->running: %v", id, err)
+	}
+	queued, err := store.GetJob(ctx, id)
+	if err != nil {
+		t.Fatalf("GetJob(%s): %v", id, err)
+	}
+	payload, err := unmarshalPayload(queued.Payload)
+	if err != nil {
+		t.Fatalf("unmarshalPayload(%s): %v", id, err)
+	}
+	payload.Result = &AgentResult{Decision: decision, Summary: "production review", Delegations: delegations}
+	if decision == "changes_requested" {
+		payload.Result.Severity = reviewseverity.P1
+	}
+	if err := mailbox.finishWithPayload(ctx, id, JobSucceeded, "job succeeded", payload); err != nil {
+		t.Fatalf("finishWithPayload(%s): %v", id, err)
+	}
+	stored, err := store.GetJob(ctx, id)
+	if err != nil {
+		t.Fatalf("GetJob(%s) after finish: %v", id, err)
+	}
+	return stored
+}
+
+// seedHeadlessRoundCandidate inserts a headless candidate carrying an EXPLICIT
+// review round - the engine-dispatched shape. The distinction from
+// seedHeadlessCandidate is the whole point of the asymmetry probe: roundless
+// against roundless is ordered by TIMESTAMP and legitimately supersedes (that is
+// the session-approval case F1/F2 require), whereas an explicit round against a
+// roundless objection is refused by reviewRoundKey in either direction.
+func seedHeadlessRoundCandidate(t *testing.T, store *db.Store, id, agent, round, decision string) {
+	t.Helper()
+	encoded, err := marshalPayload(JobPayload{
+		Repo: "gitmoot/gitmoot", PullRequest: 9, TaskID: "task-9", ReviewRound: round,
+		Result: &AgentResult{Decision: decision, Summary: "engine-dispatched candidate"},
+	})
+	if err != nil {
+		t.Fatalf("marshalPayload: %v", err)
+	}
+	if err := store.CreateJobWithEvent(context.Background(), db.Job{
+		ID: id, Agent: agent, Type: "review", State: string(JobSucceeded), Payload: encoded,
+	}, db.JobEvent{Kind: string(JobSucceeded), Message: "candidate"}); err != nil {
+		t.Fatalf("CreateJobWithEvent(%s): %v", id, err)
+	}
+	setMergeGateJobTimestamps(t, store, id, "2026-09-01T18:00:00Z")
+}
+
+// TestPolicyMergeGateAdmitsCLIReviewsAndRefusesAtHeadFanOut covers BOTH P1s the
+// exact-head review of b22667017849b0a460026a68f9bf18d9a89ccd26 found, and they
+// point in OPPOSITE directions - which is why they are pinned together and why
+// each has its own mutant:
+//
+//   - F5, OVER-BLOCKING: the provenance clause demanded external origin or a round
+//     of every candidate, and a CLI review has neither, so a legitimate succeeded
+//     approval at the evaluated head could not retire an objection and the PR
+//     deadlocked. Provenance is now asked only of a HEADLESS row.
+//   - F6, UNDER-BLOCKING: default-deny had been added to the headless loop only,
+//     while the at-head loop still tested a bare Result != nil, so an approved
+//     FAN-OUT announcement at the evaluated head retired a real objection and the
+//     PR merged. Both loops now share the predicate - two call sites, asserted
+//     below as a COUNT, because the previous round claimed that property with one.
+func TestPolicyMergeGateAdmitsCLIReviewsAndRefusesAtHeadFanOut(t *testing.T) {
+	t.Run("a CLI approval at the evaluated head RETIRES a session objection (F5: must MERGE)", func(t *testing.T) {
+		ctx := context.Background()
+		store, gh, gate, request := newMergeGateQuorumScenario(t)
+		insertMergeGateReviewFixture(t, store, mergeGateReviewFixture{
+			id: "review-approval", agent: "audit", decision: "approved", hasResult: true,
+		})
+		mailbox := Mailbox{store: store, resolveDeliveryWorktree: ExcludedDeliveryWorktreeResolver("test_explicit_no_worktree")}
+		if _, err := mailbox.OpenExternalJob(ctx, JobRequest{
+			ID: "cli-session-objection", Agent: "returning-reviewer", Action: "review",
+			Repo: "gitmoot/gitmoot", PullRequest: 9, TaskID: "task-9", Sender: "session",
+		}); err != nil {
+			t.Fatalf("OpenExternalJob returned error: %v", err)
+		}
+		if _, err := mailbox.CloseExternalJobWithUsage(ctx, "cli-session-objection", AgentResult{
+			Decision: "changes_requested", Severity: reviewseverity.P1, Summary: "session objection",
+		}, 0, "", "", ExternalJobUsage{}); err != nil {
+			t.Fatalf("CloseExternalJobWithUsage returned error: %v", err)
+		}
+		setMergeGateJobTimestamps(t, store, "cli-session-objection", "2026-09-01T12:00:00Z")
+
+		cli := seedProductionReviewRow(t, store, "cli-review-approval", "returning-reviewer", "approved", "head123", nil)
+		setMergeGateJobTimestamps(t, store, "cli-review-approval", "2026-09-01T18:00:00Z")
+
+		// Assert the shape rather than trust it: if a CLI review ever starts
+		// carrying a round or an external origin, this arm stops reproducing F5 and
+		// must fail loudly instead of passing for the wrong reason.
+		cliPayload, err := unmarshalPayload(cli.Payload)
+		if err != nil {
+			t.Fatalf("unmarshalPayload: %v", err)
+		}
+		if strings.TrimSpace(cliPayload.HeadSHA) != "head123" {
+			t.Fatalf("CLI review head=%q, want head123; fixture no longer reproduces F5", cliPayload.HeadSHA)
+		}
+		if strings.TrimSpace(cliPayload.ReviewRound) != "" || cli.ExternallyDriven {
+			t.Fatalf("CLI review round=%q externally_driven=%v, want empty/false; fixture no longer reproduces F5",
+				cliPayload.ReviewRound, cli.ExternallyDriven)
+		}
+
+		if err := store.UpsertTask(ctx, db.Task{
+			ID: "task-9", RepoFullName: "gitmoot/gitmoot", Branch: "task-9", State: string(TaskReadyToMerge),
+		}); err != nil {
+			t.Fatal(err)
+		}
+		request.Reviewer = "audit"
+		request.ExpectedTaskState = string(TaskReadyToMerge)
+
+		decision, evalErr := gate.Evaluate(ctx, request)
+		if evalErr != nil {
+			t.Fatalf("Evaluate returned error: %v", evalErr)
+		}
+		if !decision.Merged || len(gh.merges) != 1 {
+			t.Fatalf("decision=%+v merges=%d, want ONE merge: a succeeded CLI approval at the evaluated head is a real verdict and must retire that reviewer's own earlier objection (#1950 F5)",
+				decision, len(gh.merges))
+		}
+	})
+
+	t.Run("an at-head approved FAN-OUT does NOT retire an at-head objection (F6: must BLOCK)", func(t *testing.T) {
+		ctx := context.Background()
+		store, gh, gate, request := newMergeGateQuorumScenario(t)
+		insertMergeGateReviewFixture(t, store, mergeGateReviewFixture{
+			id: "review-approval", agent: "audit", decision: "approved", hasResult: true,
+		})
+		seedProductionReviewRow(t, store, "at-head-objection", "fanout-reviewer", "changes_requested", "head123", nil)
+		setMergeGateJobTimestamps(t, store, "at-head-objection", "2026-09-01T12:00:00Z")
+		seedProductionReviewRow(t, store, "at-head-fanout", "fanout-reviewer", "approved", "head123",
+			[]Delegation{{ID: "d1", Agent: "specialist", Action: "review", Prompt: "look again"}})
+		setMergeGateJobTimestamps(t, store, "at-head-fanout", "2026-09-01T18:00:00Z")
+
+		if err := store.UpsertTask(ctx, db.Task{
+			ID: "task-9", RepoFullName: "gitmoot/gitmoot", Branch: "task-9", State: string(TaskReadyToMerge),
+		}); err != nil {
+			t.Fatal(err)
+		}
+		request.Reviewer = "audit"
+		request.ExpectedTaskState = string(TaskReadyToMerge)
+
+		decision, evalErr := gate.Evaluate(ctx, request)
+		if evalErr != nil {
+			t.Fatalf("Evaluate returned error: %v", evalErr)
+		}
+		if decision.Merged || len(gh.merges) != 0 {
+			t.Fatalf("decision=%+v merges=%d, want NO merge: an approved fan-out is a dispatch announcement, not a verdict, so it cannot retire that reviewer's own at-head objection (#1950 F6)",
+				decision, len(gh.merges))
+		}
+		task, taskErr := store.GetTask(ctx, "task-9")
+		if taskErr != nil {
+			t.Fatalf("GetTask: %v", taskErr)
+		}
+		if task.State == string(TaskMerged) {
+			t.Fatalf("task state = %q, want it NOT merged", task.State)
+		}
+	})
+
+	t.Run("all THREE populations share the predicate (static census, not a claim)", func(t *testing.T) {
+		source, err := os.ReadFile("merge_gate.go")
+		if err != nil {
+			t.Fatalf("ReadFile: %v", err)
+		}
+		// THE COUNT IS THE POINT. The previous round advertised "the same predicate
+		// governs the objection side" while the helper had ONE call site, and a
+		// one-line grep would have falsified it. A count fails; a sentence does not.
+		//
+		// Three populations decide whether a row may retire or supersede an
+		// objection: the at-head candidate loop, the headless candidate loop, and
+		// the headless objection scan. Two further objection-side sites MUST differ
+		// and are excluded on stated mechanism, not preference:
+		//
+		//   - the at-head BLOCKING scan is preceded by the crashed-reviewer guard,
+		//     which ERRORS on any non-succeeded row at the evaluated head, so
+		//     routing it would add an unreachable silent skip in place of a loud
+		//     error. Probed: routing it passes the whole control set precisely
+		//     BECAUSE the added check is dead, which is not evidence it belongs.
+		//   - the two slot scans decide whether a reviewer's SLOT is filled - a
+		//     fan-out with dispatched children is judged through the children -
+		//     so routing them would change quorum rather than tighten it.
+		guards := strings.Count(string(source), "!reviewRowIsVerdictAboutHead(") +
+			strings.Count(string(source), "!reviewRowCanRetireAnObjection(")
+		if guards != 3 {
+			t.Fatalf("shared-predicate guard call sites = %d, want 3 (at-head candidate, headless candidate, headless objection): if a fourth population appeared it must either route through the shared core or be excluded here with its mechanism (#1950 P1-B)", guards)
+		}
+	})
+
+	t.Run("ASYMMETRY PROBE, committed so the divergence cannot silently return", func(t *testing.T) {
+		ctx := context.Background()
+		store, gh, gate, request := newMergeGateQuorumScenario(t)
+		insertMergeGateReviewFixture(t, store, mergeGateReviewFixture{
+			id: "review-approval", agent: "audit", decision: "approved", hasResult: true,
+		})
+		mailbox := Mailbox{store: store, resolveDeliveryWorktree: ExcludedDeliveryWorktreeResolver("test_explicit_no_worktree")}
+		if _, err := mailbox.OpenExternalJob(ctx, JobRequest{
+			ID: "asym-objection", Agent: "asym-reviewer", Action: "review",
+			Repo: "gitmoot/gitmoot", PullRequest: 9, TaskID: "task-9", Sender: "session",
+		}); err != nil {
+			t.Fatalf("OpenExternalJob returned error: %v", err)
+		}
+		if _, err := mailbox.CloseExternalJobWithUsage(ctx, "asym-objection", AgentResult{
+			Decision: "changes_requested", Severity: reviewseverity.P1, Summary: "session objection",
+		}, 0, "", "", ExternalJobUsage{}); err != nil {
+			t.Fatalf("CloseExternalJobWithUsage returned error: %v", err)
+		}
+		setMergeGateJobTimestamps(t, store, "asym-objection", "2026-09-01T12:00:00Z")
+
+		// This candidate is ADMITTED by the shared predicate: succeeded,
+		// non-fan-out, headless, and externally driven so provenance is satisfied.
+		// What refuses it is reviewRoundKey, which will not order an explicit round
+		// against a roundless objection. The distinction is recorded because the
+		// previous round's comment credited the REFUSAL to the predicate, which does
+		// not perform it - and naming the wrong mechanism is how the next round
+		// "fixes" the wrong function.
+		seedHeadlessRoundCandidate(t, store, "asym-delegation-child", "asym-reviewer", "review-2", "approved")
+		job, err := store.GetJob(ctx, "asym-delegation-child")
+		if err != nil {
+			t.Fatalf("GetJob: %v", err)
+		}
+		payload, err := unmarshalPayload(job.Payload)
+		if err != nil {
+			t.Fatalf("unmarshalPayload: %v", err)
+		}
+		if !reviewRowIsVerdictAboutHead(job, payload, "head123") {
+			t.Fatalf("shared predicate REFUSED the roundless externally-driven candidate; this probe exists to pin that it ADMITS it and that reviewRoundKey is what refuses it (#1950)")
+		}
+
+		if err := store.UpsertTask(ctx, db.Task{
+			ID: "task-9", RepoFullName: "gitmoot/gitmoot", Branch: "task-9", State: string(TaskReadyToMerge),
+		}); err != nil {
+			t.Fatal(err)
+		}
+		request.Reviewer = "audit"
+		request.ExpectedTaskState = string(TaskReadyToMerge)
+
+		decision, evalErr := gate.Evaluate(ctx, request)
+		if evalErr != nil {
+			t.Fatalf("Evaluate returned error: %v", evalErr)
+		}
+		if decision.Merged || len(gh.merges) != 0 {
+			t.Fatalf("decision=%+v merges=%d, want NO merge: round ordering must refuse this candidate even though the predicate admits it", decision, len(gh.merges))
+		}
+	})
+}

--- a/internal/workflow/merge_gate_test.go
+++ b/internal/workflow/merge_gate_test.go
@@ -6014,8 +6014,153 @@ func TestPolicyMergeGateAllowsAnActingRoleSessionObjectionToBeSuperseded(t *test
 					// out why a merge is stuck.
 					wantAuthor = "an unattributed reviewer"
 				}
-				if rendered := decision.Reason.Render(); !strings.Contains(rendered, wantAuthor) {
+				rendered := decision.Reason.Render()
+				if !strings.Contains(rendered, wantAuthor) {
 					t.Fatalf("reason = %q, want %q named; an empty author leaves an operator with nobody to go to", rendered, wantAuthor)
+				}
+				if !tt.noIdentity && strings.Contains(rendered, "an unattributed reviewer") {
+					t.Fatalf("reason = %q, want the ROLE named and NOT the unattributed fallback; matching %q alone also accepts \"an unattributed reviewer\", which is why a diagnostic-only revert stayed green (#1950 F4)", rendered, wantAuthor)
+				}
+			}
+		})
+	}
+}
+
+// TestPolicyMergeGateAttributesAnImplementRowToItsAgentNotItsDispatchingRole
+// pins the AGENT-FIRST half of effectiveReviewerIdentity, which nothing in the
+// package covered: inverting that order so a role wins passed the entire
+// internal/workflow suite. Extracting the rule into one shared function (#1950
+// F4) concentrates the risk, so the order needs its own guard.
+//
+// The hazard is the one the collector's own comment names. An ordinary dispatched
+// implement row carries the DISPATCHING coordinator's ActingOrgRole in its
+// payload. Read the role first and that coordinator becomes an implementer of
+// everything - and is then disqualified from reviewing anything. This asserts the
+// consequence rather than the mechanism: the coordinator's own approval must
+// still count as independent, so the merge proceeds.
+func TestPolicyMergeGateAttributesAnImplementRowToItsAgentNotItsDispatchingRole(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	insertCompletedJob(t, store, db.Job{ID: "implement-job", Agent: "wave-impl", Type: "implement"}, JobPayload{
+		Repo:          "gitmoot/gitmoot",
+		PullRequest:   9,
+		TaskID:        "task-9",
+		ActingOrgRole: "coordinator", // the DISPATCHER's role, not the implementer
+		Result:        &AgentResult{Decision: "implemented", Summary: "implemented"},
+	})
+	// AGENT-authored, and its name deliberately COLLIDES with the dispatching role
+	// above. That collision is what makes the attribution order observable: with
+	// agent-first the implement row belongs to wave-impl and this reviewer is
+	// independent, while role-first would make "coordinator" the implementer and
+	// turn this into self-approval. An author-LESS approval cannot be used here -
+	// the current-head arm refuses it as "no recorded reviewer author", which is a
+	// different guard and would test the wrong thing.
+	insertCompletedJob(t, store, db.Job{ID: "review-role-approval", Agent: "coordinator", Type: "review"}, JobPayload{
+		Repo:        "gitmoot/gitmoot",
+		PullRequest: 9,
+		HeadSHA:     "head123",
+		TaskID:      "task-9",
+		ReviewRound: "review-1",
+		Result:      &AgentResult{Decision: "approved", Summary: "approved by an agent named for the role"},
+	})
+	mergeable := true
+	gh := &fakeMergeGateGitHub{
+		pr: github.PullRequest{
+			Number: 9, State: "open", HeadRef: "task-9", BaseRef: "main",
+			HeadSHA: "head123", Mergeable: &mergeable,
+		},
+		status:      github.CombinedStatus{State: "success", Statuses: []github.CommitStatus{{Context: "ci", State: "success"}}},
+		checks:      []github.PullRequestCheck{{Name: "ci", Bucket: "pass", State: "SUCCESS"}},
+		mergeResult: github.MergeResult{Merged: true, SHA: "merge123"},
+	}
+	gate := PolicyMergeGate{AutoMerge: true, Store: store, GitHub: gh, Git: &fakeMergeGateGit{clean: true}}
+
+	decision, err := gate.Evaluate(ctx, MergeRequest{Repo: "gitmoot/gitmoot", PullRequest: 9, TaskID: "task-9"})
+	if err != nil {
+		t.Fatalf("Evaluate returned error: %v", err)
+	}
+	if !decision.Merged || len(gh.merges) != 1 {
+		t.Fatalf("decision=%+v merges=%d, want ONE merge: reading the acting role BEFORE the agent makes the dispatching coordinator an implementer of everything and disqualifies it from reviewing (#1950 F4). reason=%q",
+			decision, len(gh.merges), decision.Reason.Render())
+	}
+}
+
+// TestPolicyMergeGateReachesIndependenceForARoleAuthoredApproval covers ruling
+// 126350's third identity site. The at-head reviewer arm read job.Agent alone,
+// so a ROLE-AUTHORED approval was refused as "no recorded reviewer author"
+// BEFORE the independence check ran - which also means the role's own
+// self-approval was never tested for. The arms below drive both directions, so a
+// fix that merely stopped refusing such rows would fail the self-approval arm.
+func TestPolicyMergeGateReachesIndependenceForARoleAuthoredApproval(t *testing.T) {
+	for _, tt := range []struct {
+		name           string
+		implementAgent string
+		implementRole  string
+		approvalRole   string
+		wantMerge      bool
+		wantReason     string
+	}{
+		{
+			name:           "a different role approves an agent's work: independent, so it merges",
+			implementAgent: "wave-impl",
+			approvalRole:   "reviewer",
+			wantMerge:      true,
+		},
+		{
+			name:          "the SAME role that implemented cannot approve its own work",
+			implementRole: "reviewer",
+			approvalRole:  "reviewer",
+			wantMerge:     false,
+			// Self-approval, NOT "no recorded reviewer author": the point of the fix is
+			// that the row reaches the independence check at all.
+			wantReason: "the implementing agent",
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			store := openEngineStore(t)
+			insertCompletedJob(t, store, db.Job{ID: "implement-job", Agent: tt.implementAgent, Type: "implement"}, JobPayload{
+				Repo: "gitmoot/gitmoot", PullRequest: 9, TaskID: "task-9",
+				ActingOrgRole: tt.implementRole,
+				Result:        &AgentResult{Decision: "implemented", Summary: "implemented"},
+			})
+			insertCompletedJob(t, store, db.Job{ID: "review-role-approval", Agent: "", Type: "review"}, JobPayload{
+				Repo: "gitmoot/gitmoot", PullRequest: 9, HeadSHA: "head123", TaskID: "task-9",
+				ReviewRound:   "review-1",
+				ActingOrgRole: tt.approvalRole,
+				Result:        &AgentResult{Decision: "approved", Summary: "approved by a role"},
+			})
+			mergeable := true
+			gh := &fakeMergeGateGitHub{
+				pr: github.PullRequest{
+					Number: 9, State: "open", HeadRef: "task-9", BaseRef: "main",
+					HeadSHA: "head123", Mergeable: &mergeable,
+				},
+				status:      github.CombinedStatus{State: "success", Statuses: []github.CommitStatus{{Context: "ci", State: "success"}}},
+				checks:      []github.PullRequestCheck{{Name: "ci", Bucket: "pass", State: "SUCCESS"}},
+				mergeResult: github.MergeResult{Merged: true, SHA: "merge123"},
+			}
+			gate := PolicyMergeGate{AutoMerge: true, Store: store, GitHub: gh, Git: &fakeMergeGateGit{clean: true}}
+
+			decision, err := gate.Evaluate(ctx, MergeRequest{Repo: "gitmoot/gitmoot", PullRequest: 9, TaskID: "task-9"})
+			if err != nil {
+				t.Fatalf("Evaluate returned error: %v", err)
+			}
+			rendered := decision.Reason.Render()
+			if tt.wantMerge && (!decision.Merged || len(gh.merges) != 1) {
+				t.Fatalf("decision=%+v merges=%d, want ONE merge: a role-authored approval must reach the independence check through its normalized role. reason=%q",
+					decision, len(gh.merges), rendered)
+			}
+			if !tt.wantMerge {
+				if decision.Merged || len(gh.merges) != 0 {
+					t.Fatalf("decision=%+v merges=%d, want NO merge: the same role cannot approve its own implementation", decision, len(gh.merges))
+				}
+				if !strings.Contains(rendered, tt.wantReason) {
+					t.Fatalf("reason = %q, want it to name %q; refusing the row as merely unattributed would pass a bare no-merge assertion while never reaching independence",
+						rendered, tt.wantReason)
+				}
+				if strings.Contains(rendered, "no recorded reviewer author") {
+					t.Fatalf("reason = %q, want the INDEPENDENCE refusal rather than the unattributed fallback (#1950 F4, ruling 126350)", rendered)
 				}
 			}
 		})

--- a/internal/workflow/merge_gate_test.go
+++ b/internal/workflow/merge_gate_test.go
@@ -5958,12 +5958,21 @@ func TestPolicyMergeGateAllowsAnActingRoleSessionObjectionToBeSuperseded(t *test
 				id: "review-approval", agent: "audit", decision: "approved", hasResult: true,
 			})
 			if tt.noIdentity {
-				// NOT through OpenExternalJob: that writer REFUSES a row with neither
-				// agent nor acting role - "job agent or acting org role is required" -
-				// so the no-identity shape is unreachable through the session path and
-				// pretending otherwise would be a fiction. It IS reachable as an
-				// engine-inserted row that records a round and no author, so that is
-				// the shape asserted here.
+				// THIS ARM IS A DEFENSIVE INVARIANT, NOT PRODUCTION-WRITER COVERAGE, and
+				// the previous comment here overclaimed by calling the row "reachable".
+				// #1950 F3 is right: no supported writer can produce Type=review with a
+				// round, an empty Agent AND an empty ActingOrgRole. OpenExternalJob
+				// refuses it outright - pinned by
+				// TestOpenExternalJobRefusesAReviewWithNeitherAgentNorActingRole below -
+				// and every ordinary engine, CLI, daemon, pipeline, delegation and retry
+				// insert goes through Mailbox validation, which requires an agent.
+				//
+				// It is asserted anyway because the gate must FAIL CLOSED on a row it
+				// cannot attribute, whatever produced it: a legacy row from before that
+				// validation, a corrupted payload, or a future writer nobody has
+				// enumerated. insertCompletedJob deliberately bypasses the validators to
+				// construct that state, which is exactly why this is labelled a
+				// corruption/legacy invariant rather than evidence about production.
 				insertCompletedJob(t, store, db.Job{ID: "session-role-objection", Agent: "", Type: "review"}, JobPayload{
 					Repo: "gitmoot/gitmoot", PullRequest: 9, TaskID: "task-9", ReviewRound: "review-1",
 					Result: &AgentResult{Decision: "changes_requested", Severity: reviewseverity.P1, Summary: "authorless objection"},

--- a/internal/workflow/merge_gate_test.go
+++ b/internal/workflow/merge_gate_test.go
@@ -6240,3 +6240,57 @@ func TestPolicyMergeGateSupersedesARoleAuthoredAtHeadObjection(t *testing.T) {
 		})
 	}
 }
+
+// TestPolicyMergeGateRefusesWhenAStaleHeadApprovalWouldRetireASessionObjection
+// is #1950 F5 as the certifier reproduced it, and it is a MERGE-INTEGRITY
+// regression rather than a rendering one: at 5423928d this shape MERGED and
+// called the external merge once in each of three runs.
+//
+// The shape: a production session objection carrying neither head nor round; a
+// later approval from the SAME reviewer that is also roundless but names a STALE
+// head; and an independent approval at the evaluated head so nothing else blocks.
+// Both objection and stale approval being roundless, reviewRoundKeyForJob falls
+// back to timestamps, so the stale approval won recency and retired an objection
+// it never spoke for.
+//
+// It enters through Evaluate and asserts ZERO external merge calls, because a
+// helper-level assertion cannot observe the merge this bug performs.
+func TestPolicyMergeGateRefusesWhenAStaleHeadApprovalWouldRetireASessionObjection(t *testing.T) {
+	ctx := context.Background()
+	store, gh, gate, request := newMergeGateQuorumScenario(t)
+	// Independent approval AT the evaluated head: the gate is otherwise clean.
+	insertMergeGateReviewFixture(t, store, mergeGateReviewFixture{
+		id: "review-approval", agent: "audit", decision: "approved", hasResult: true,
+	})
+	// The objection: production session writers, so neither head nor round.
+	openSessionReviewObjection(t, store, "session-objection", "session-reviewer", "", "changes_requested", reviewseverity.P1)
+	setMergeGateJobTimestamps(t, store, "session-objection", "2026-09-01T10:00:00Z")
+	// The stale-head approval: SAME reviewer, roundless, naming a DIFFERENT head,
+	// recorded LATER so it wins the timestamp fallback.
+	insertCompletedJob(t, store, db.Job{ID: "stale-head-approval", Agent: "session-reviewer", Type: "review"}, JobPayload{
+		Repo: "gitmoot/gitmoot", PullRequest: 9, TaskID: "task-9",
+		HeadSHA: "staleheadsha",
+		Result:  &AgentResult{Decision: "approved", Summary: "approved an older head"},
+	})
+	setMergeGateJobTimestamps(t, store, "stale-head-approval", "2026-09-01T18:00:00Z")
+	if err := store.UpsertTask(ctx, db.Task{
+		ID: "task-9", RepoFullName: "gitmoot/gitmoot", Branch: "task-9",
+		State: string(TaskReadyToMerge),
+	}); err != nil {
+		t.Fatal(err)
+	}
+	request.Reviewer = "audit"
+	request.ExpectedTaskState = string(TaskReadyToMerge)
+
+	decision, err := gate.Evaluate(ctx, request)
+	if err != nil {
+		t.Fatalf("Evaluate returned error: %v", err)
+	}
+	if decision.Merged || len(gh.merges) != 0 {
+		t.Fatalf("decision=%+v merges=%d, want NO merge and ZERO external merge calls: an approval naming %q cannot retire an objection about head %q (#1950 F5)",
+			decision, len(gh.merges), "staleheadsha", "head123")
+	}
+	if task, taskErr := store.GetTask(ctx, "task-9"); taskErr != nil || task.State != string(TaskReadyToMerge) {
+		t.Fatalf("task=%+v err=%v, want the task state unclaimed and unchanged", task, taskErr)
+	}
+}

--- a/internal/workflow/merge_gate_test.go
+++ b/internal/workflow/merge_gate_test.go
@@ -6294,3 +6294,138 @@ func TestPolicyMergeGateRefusesWhenAStaleHeadApprovalWouldRetireASessionObjectio
 		t.Fatalf("task=%+v err=%v, want the task state unclaimed and unchanged", task, taskErr)
 	}
 }
+
+// TestPolicyMergeGateRefusesNonVerdictCandidatesRetiringAnObjection is #1950 F6.
+// The candidate loop checked head, identity, decision spelling and recency but
+// never whether the candidate was a VERDICT AT ALL, so a later blocked review,
+// failed review, or approved fan-out announcement from the same reviewer retired
+// a live changes_requested session objection - and each of those rows is then
+// itself absent from the blocking population, so an independent at-head approval
+// merged.
+//
+// The objection is built through the production session writers, because that is
+// what caught F6; a helper-level assertion cannot observe the merge.
+//
+// The last two arms are PROBES rather than reported findings: a delegation-child
+// candidate and an engine-inserted roundless remnant both satisfy the measured
+// floor (succeeded, non-fan-out, headless), so they are executed here to find out
+// whether the floor is sufficient or whether those kinds need admitting clauses
+// of their own. Whatever they show is reported as measured, not asserted.
+func TestPolicyMergeGateRefusesNonVerdictCandidatesRetiringAnObjection(t *testing.T) {
+	for _, tt := range []struct {
+		name string
+		seed func(t *testing.T, store *db.Store)
+	}{
+		{
+			name: "a later BLOCKED review from the same reviewer is not a verdict",
+			seed: func(t *testing.T, store *db.Store) {
+				seedHeadlessCandidate(t, store, "later-blocked", "session-reviewer", JobBlocked, "approved", nil)
+			},
+		},
+		{
+			name: "a later FAILED review from the same reviewer is not a verdict",
+			seed: func(t *testing.T, store *db.Store) {
+				seedHeadlessCandidate(t, store, "later-failed", "session-reviewer", JobFailed, "approved", nil)
+			},
+		},
+		{
+			name: "a later APPROVED FAN-OUT announcement is a dispatch record, not a verdict",
+			seed: func(t *testing.T, store *db.Store) {
+				seedHeadlessCandidate(t, store, "later-fanout", "session-reviewer", JobSucceeded, "approved",
+					[]Delegation{{ID: "lens-a", Agent: "lens-a", Action: "review", Prompt: "look"}})
+			},
+		},
+		{
+			name: "a delegation-child candidate is already refused by round ordering (probe needed NO clause)",
+			seed: func(t *testing.T, store *db.Store) {
+				encoded, err := marshalPayload(JobPayload{
+					Repo: "gitmoot/gitmoot", PullRequest: 9, TaskID: "task-9", ReviewRound: "review-2",
+					Result: &AgentResult{Decision: "approved", Summary: "child approval"},
+				})
+				if err != nil {
+					t.Fatalf("marshalPayload: %v", err)
+				}
+				if err := store.CreateJobWithEvent(context.Background(), db.Job{
+					ID: "later-child", Agent: "session-reviewer", Type: "review",
+					State: string(JobSucceeded), Payload: encoded,
+					ParentJobID: "implement-job", DelegationID: "verify",
+				}, db.JobEvent{Kind: string(JobSucceeded), Message: "child"}); err != nil {
+					t.Fatalf("CreateJobWithEvent: %v", err)
+				}
+				setMergeGateJobTimestamps(t, store, "later-child", "2026-09-01T18:00:00Z")
+			},
+		},
+		{
+			name: "an engine-inserted roundless remnant is not attributable (probe MERGED before the clause)",
+			seed: func(t *testing.T, store *db.Store) {
+				insertCompletedJob(t, store, db.Job{ID: "later-remnant", Agent: "session-reviewer", Type: "review"}, JobPayload{
+					Repo: "gitmoot/gitmoot", PullRequest: 9, TaskID: "task-9",
+					Result: &AgentResult{Decision: "approved", Summary: "roundless remnant"},
+				})
+				setMergeGateJobTimestamps(t, store, "later-remnant", "2026-09-01T18:00:00Z")
+			},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			store, gh, gate, request := newMergeGateQuorumScenario(t)
+			insertMergeGateReviewFixture(t, store, mergeGateReviewFixture{
+				id: "review-approval", agent: "audit", decision: "approved", hasResult: true,
+			})
+			openSessionReviewObjection(t, store, "session-objection", "session-reviewer", "", "changes_requested", reviewseverity.P1)
+			setMergeGateJobTimestamps(t, store, "session-objection", "2026-09-01T10:00:00Z")
+			tt.seed(t, store)
+			if err := store.UpsertTask(ctx, db.Task{
+				ID: "task-9", RepoFullName: "gitmoot/gitmoot", Branch: "task-9",
+				State: string(TaskReadyToMerge),
+			}); err != nil {
+				t.Fatal(err)
+			}
+			request.Reviewer = "audit"
+			request.ExpectedTaskState = string(TaskReadyToMerge)
+
+			decision, err := gate.Evaluate(ctx, request)
+			if err != nil {
+				t.Fatalf("Evaluate returned error: %v", err)
+			}
+			if decision.Merged || len(gh.merges) != 0 {
+				t.Fatalf("decision=%+v merges=%d, want NO merge and ZERO external merge calls: this candidate is not an authoritative verdict and must not retire a live objection (#1950 F6)",
+					decision, len(gh.merges))
+			}
+			if task, taskErr := store.GetTask(ctx, "task-9"); taskErr != nil || task.State != string(TaskReadyToMerge) {
+				t.Fatalf("task=%+v err=%v, want the task state unclaimed", task, taskErr)
+			}
+		})
+	}
+}
+
+// seedHeadlessCandidate inserts a supersession candidate in the ONLY shape that
+// can actually reach the state and fan-out clauses, which took two wrong fixtures
+// to find and both wrong versions PASSED at the previous head:
+//
+//   - HEADLESS. A candidate carrying the evaluated head enters reviewsAtHead,
+//     where a blocked or failed row is refused as a CRASHED REVIEWER - a different
+//     guard entirely.
+//   - ROUNDLESS. The objection is a session row with no round, and reviewRoundKey
+//     deliberately refuses to order an explicit round against an empty one, so a
+//     candidate carrying a round supersedes NOTHING and the arm proves nothing.
+//   - EXTERNALLY DRIVEN, via CreateExternallyDrivenJobWithEvent, because roundless
+//     alone is refused by the attributable-provenance clause. This is what leaves
+//     recency as the only remaining discriminator, so state and fan-out are the
+//     properties actually under test.
+func seedHeadlessCandidate(t *testing.T, store *db.Store, id, agent string, state JobState, decision string, delegations []Delegation) {
+	t.Helper()
+	encoded, err := marshalPayload(JobPayload{
+		Repo: "gitmoot/gitmoot", PullRequest: 9, TaskID: "task-9",
+		Result: &AgentResult{Decision: decision, Summary: "later candidate", Delegations: delegations},
+	})
+	if err != nil {
+		t.Fatalf("marshalPayload: %v", err)
+	}
+	if err := store.CreateExternallyDrivenJobWithEvent(context.Background(), db.Job{
+		ID: id, Agent: agent, Type: "review", State: string(state), Payload: encoded,
+	}, db.JobEvent{Kind: string(state), Message: "candidate"}); err != nil {
+		t.Fatalf("CreateExternallyDrivenJobWithEvent(%s): %v", id, err)
+	}
+	setMergeGateJobTimestamps(t, store, id, "2026-09-01T18:00:00Z")
+}

--- a/internal/workflow/merge_gate_test.go
+++ b/internal/workflow/merge_gate_test.go
@@ -5814,3 +5814,83 @@ func insertMergeGateHeadlessReviewAt(t *testing.T, store *db.Store, id, agent, d
 
 // boolPtr expresses an explicit false in a table whose default is true.
 func boolPtr(v bool) *bool { return &v }
+
+// TestPolicyMergeGateBlocksASessionReviewObjectionWithNeitherHeadNorRound is
+// #1950's P1 F1, and it is built through the PRODUCTION session writers rather
+// than a hand-assembled row, because the whole point is what those writers
+// actually persist: OpenExternalJob stores neither HeadSHA nor ReviewRound and
+// demotes any supplied head to a display event (session_job.go:85-125), and
+// CloseExternalJobWithUsage then stores the verdict and succeeds the row
+// (session_job.go:170-190). That is `gitmoot job record --type review`
+// (internal/cli/job_session.go:214-305).
+//
+// A predicate that excluded roundless rows dropped this real objection and let
+// the external merge complete. The discriminator is ORIGIN - the row is
+// externally driven - never the absence of a round.
+func TestPolicyMergeGateBlocksASessionReviewObjectionWithNeitherHeadNorRound(t *testing.T) {
+	ctx := context.Background()
+	store, gh, gate, request := newMergeGateQuorumScenario(t)
+	insertMergeGateReviewFixture(t, store, mergeGateReviewFixture{
+		id: "review-approval", agent: "audit", decision: "approved", hasResult: true,
+	})
+
+	mailbox := Mailbox{store: store, resolveDeliveryWorktree: ExcludedDeliveryWorktreeResolver("test_explicit_no_worktree")}
+	if _, err := mailbox.OpenExternalJob(ctx, JobRequest{
+		ID:          "session-review-objection",
+		Agent:       "session-reviewer",
+		Action:      "review",
+		Repo:        "gitmoot/gitmoot",
+		PullRequest: 9,
+		TaskID:      "task-9",
+		HeadSHA:     "head123", // demoted to a display event on purpose
+		Sender:      "session",
+	}); err != nil {
+		t.Fatalf("OpenExternalJob returned error: %v", err)
+	}
+	closed, err := mailbox.CloseExternalJobWithUsage(ctx, "session-review-objection", AgentResult{
+		Decision: "changes_requested", Severity: reviewseverity.P1, Summary: "session objection",
+	}, 0, "", "", ExternalJobUsage{})
+	if err != nil {
+		t.Fatalf("CloseExternalJobWithUsage returned error: %v", err)
+	}
+	// The writers really do leave both fields empty - assert it rather than trust
+	// the comment, since the whole finding turned on this being true.
+	closedPayload, err := unmarshalPayload(closed.Payload)
+	if err != nil {
+		t.Fatalf("unmarshalPayload: %v", err)
+	}
+	if strings.TrimSpace(closedPayload.HeadSHA) != "" || strings.TrimSpace(closedPayload.ReviewRound) != "" {
+		t.Fatalf("session review payload head=%q round=%q, want both empty; the fixture no longer reproduces the finding",
+			closedPayload.HeadSHA, closedPayload.ReviewRound)
+	}
+	if !closed.ExternallyDriven {
+		t.Fatalf("session review job ExternallyDriven=false, want true; the discriminator this fix relies on is absent")
+	}
+
+	if err := store.UpsertTask(ctx, db.Task{
+		ID: "task-9", RepoFullName: "gitmoot/gitmoot", Branch: "task-9",
+		State: string(TaskReadyToMerge),
+	}); err != nil {
+		t.Fatal(err)
+	}
+	request.Reviewer = "audit"
+	request.ExpectedTaskState = string(TaskReadyToMerge)
+
+	decision, evalErr := gate.Evaluate(ctx, request)
+
+	if evalErr != nil {
+		t.Fatalf("Evaluate returned error: %v", evalErr)
+	}
+	if decision.Merged || len(gh.merges) != 0 {
+		t.Fatalf("decision=%+v merges=%d, want NO merge: a session review objection carrying neither head nor round is a real blocking verdict (#1933/#1950 F1)",
+			decision, len(gh.merges))
+	}
+	task, taskErr := store.GetTask(ctx, "task-9")
+	if taskErr != nil {
+		t.Fatalf("GetTask: %v", taskErr)
+	}
+	if task.State != string(TaskReadyToMerge) {
+		t.Fatalf("task state = %q, want %q: the gate must not transition or claim the task state when a session objection blocks",
+			task.State, string(TaskReadyToMerge))
+	}
+}

--- a/internal/workflow/merge_gate_test.go
+++ b/internal/workflow/merge_gate_test.go
@@ -5894,3 +5894,121 @@ func TestPolicyMergeGateBlocksASessionReviewObjectionWithNeitherHeadNorRound(t *
 			task.State, string(TaskReadyToMerge))
 	}
 }
+
+// openSessionReviewObjection records a changes_requested session review through
+// the PRODUCTION writers. agent and actingRole are passed exactly as a caller
+// would: OpenExternalJob supports a role IN PLACE OF an agent, and that shape is
+// what #1950 F2 turned on.
+func openSessionReviewObjection(t *testing.T, store *db.Store, id, agent, actingRole, decision string, severity string) {
+	t.Helper()
+	mailbox := Mailbox{store: store, resolveDeliveryWorktree: ExcludedDeliveryWorktreeResolver("test_explicit_no_worktree")}
+	if _, err := mailbox.OpenExternalJob(context.Background(), JobRequest{
+		ID:            id,
+		Agent:         agent,
+		ActingOrgRole: actingRole,
+		Action:        "review",
+		Repo:          "gitmoot/gitmoot",
+		PullRequest:   9,
+		TaskID:        "task-9",
+		Sender:        "session",
+	}); err != nil {
+		t.Fatalf("OpenExternalJob(%s) returned error: %v", id, err)
+	}
+	result := AgentResult{Decision: decision, Summary: "session verdict"}
+	if severity != "" {
+		result.Severity = severity
+	}
+	if _, err := mailbox.CloseExternalJobWithUsage(context.Background(), id, result, 0, "", "", ExternalJobUsage{}); err != nil {
+		t.Fatalf("CloseExternalJobWithUsage(%s) returned error: %v", id, err)
+	}
+}
+
+// TestPolicyMergeGateAllowsAnActingRoleSessionObjectionToBeSuperseded is #1950
+// F2: OpenExternalJob supports ActingOrgRole in place of Agent, persisting
+// Agent="" with the normalized role. The headless scan derived reviewer identity
+// from job.Agent alone, so with an empty agent supersession was SKIPPED - a
+// role's objection could never be answered by that role's own later approval,
+// which is a block with no operator move available.
+//
+// Both arms run through the production writers. The blocking arm also asserts the
+// refusal NAMES the role: rendering "objection from  " tells an operator nothing.
+func TestPolicyMergeGateAllowsAnActingRoleSessionObjectionToBeSuperseded(t *testing.T) {
+	for _, tt := range []struct {
+		name        string
+		addApproval bool
+		wantMerge   bool
+		// noIdentity drops BOTH the agent and the acting role, which is the shape
+		// that can never be superseded and therefore must never be excluded.
+		noIdentity bool
+	}{
+		{name: "the role's objection alone still blocks, and names the role", addApproval: false, wantMerge: false},
+		{name: "a later approval from the SAME role supersedes it", addApproval: true, wantMerge: true},
+		{
+			// ROUND 1 MUST NOT BE WEAKENED. A row with no usable identity at all -
+			// neither agent nor acting role - can never be superseded by anyone, so it
+			// must still BLOCK rather than be skipped. Under-blocking is how F1
+			// happened; this arm is what stops the identity fix from re-introducing it.
+			name: "no usable identity at all still blocks", noIdentity: true, wantMerge: false,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			store, gh, gate, request := newMergeGateQuorumScenario(t)
+			insertMergeGateReviewFixture(t, store, mergeGateReviewFixture{
+				id: "review-approval", agent: "audit", decision: "approved", hasResult: true,
+			})
+			if tt.noIdentity {
+				// NOT through OpenExternalJob: that writer REFUSES a row with neither
+				// agent nor acting role - "job agent or acting org role is required" -
+				// so the no-identity shape is unreachable through the session path and
+				// pretending otherwise would be a fiction. It IS reachable as an
+				// engine-inserted row that records a round and no author, so that is
+				// the shape asserted here.
+				insertCompletedJob(t, store, db.Job{ID: "session-role-objection", Agent: "", Type: "review"}, JobPayload{
+					Repo: "gitmoot/gitmoot", PullRequest: 9, TaskID: "task-9", ReviewRound: "review-1",
+					Result: &AgentResult{Decision: "changes_requested", Severity: reviewseverity.P1, Summary: "authorless objection"},
+				})
+			} else {
+				openSessionReviewObjection(t, store, "session-role-objection", "", "reviewer", "changes_requested", reviewseverity.P1)
+			}
+			if tt.addApproval {
+				// Same ROLE, no agent, strictly later: this is the only move the
+				// operator has, and before the fix it could not clear the block.
+				setMergeGateJobTimestamps(t, store, "session-role-objection", "2026-09-01T10:00:00Z")
+				openSessionReviewObjection(t, store, "session-role-approval", "", "reviewer", "approved", "")
+				setMergeGateJobTimestamps(t, store, "session-role-approval", "2026-09-01T14:00:00Z")
+			}
+			if err := store.UpsertTask(ctx, db.Task{
+				ID: "task-9", RepoFullName: "gitmoot/gitmoot", Branch: "task-9",
+				State: string(TaskReadyToMerge),
+			}); err != nil {
+				t.Fatal(err)
+			}
+			request.Reviewer = "audit"
+			request.ExpectedTaskState = string(TaskReadyToMerge)
+
+			decision, err := gate.Evaluate(ctx, request)
+			if err != nil {
+				t.Fatalf("Evaluate returned error: %v", err)
+			}
+			if tt.wantMerge && (!decision.Merged || len(gh.merges) != 1) {
+				t.Fatalf("decision=%+v merges=%d, want ONE merge: a later approval from the same acting role must supersede that role's objection (#1950 F2)",
+					decision, len(gh.merges))
+			}
+			if !tt.wantMerge {
+				if decision.Merged || len(gh.merges) != 0 {
+					t.Fatalf("decision=%+v merges=%d, want NO merge: an acting-role session objection is a real blocking verdict", decision, len(gh.merges))
+				}
+				wantAuthor := "reviewer"
+				if tt.noIdentity {
+					// Never an empty name: that is the line a human reads while working
+					// out why a merge is stuck.
+					wantAuthor = "an unattributed reviewer"
+				}
+				if rendered := decision.Reason.Render(); !strings.Contains(rendered, wantAuthor) {
+					t.Fatalf("reason = %q, want %q named; an empty author leaves an operator with nobody to go to", rendered, wantAuthor)
+				}
+			}
+		})
+	}
+}

--- a/internal/workflow/merge_gate_test.go
+++ b/internal/workflow/merge_gate_test.go
@@ -6620,11 +6620,19 @@ func TestPolicyMergeGateAdmitsCLIReviewsAndRefusesAtHeadFanOut(t *testing.T) {
 		// the headless objection scan. Two further objection-side sites MUST differ
 		// and are excluded on stated mechanism, not preference:
 		//
-		//   - the at-head BLOCKING scan is preceded by the crashed-reviewer guard,
-		//     which ERRORS on any non-succeeded row at the evaluated head, so
-		//     routing it would add an unreachable silent skip in place of a loud
-		//     error. Probed: routing it passes the whole control set precisely
-		//     BECAUSE the added check is dead, which is not evidence it belongs.
+		//   - the at-head BLOCKING scan is preceded by TWO guards which between them
+		//     admit nothing non-succeeded, so routing it would add an unreachable
+		//     silent skip in place of a loud message. Probed: routing it passes the
+		//     whole control set precisely BECAUSE the added check is dead, which is
+		//     not evidence it belongs. THEY ARE NOT ONE MECHANISM, and the first
+		//     version of this comment wrongly credited one guard with all of it:
+		//     the crashed-reviewer switch takes queued/running (pending) and
+		//     failed/cancelled (error), while BLOCKED has no case there and is
+		//     taken by the unusable-state guard in the slot scan. Deleting the
+		//     switch makes all five states fall through to that guard and still be
+		//     refused - defence in depth, measured, and now pinned per state with
+		//     its reason by
+		//     TestPolicyMergeGateAtHeadStateGuardAdmitsNothingUnsucceeded.
 		//   - the two slot scans decide whether a reviewer's SLOT is filled - a
 		//     fan-out with dispatched children is judged through the children -
 		//     so routing them would change quorum rather than tighten it.
@@ -6691,4 +6699,188 @@ func TestPolicyMergeGateAdmitsCLIReviewsAndRefusesAtHeadFanOut(t *testing.T) {
 			t.Fatalf("decision=%+v merges=%d, want NO merge: round ordering must refuse this candidate even though the predicate admits it", decision, len(gh.merges))
 		}
 	})
+}
+
+// seedMatrixCandidate inserts a candidate with EXACTLY the head/provenance
+// combination named, so each cell of the four-cell matrix is explicit in the
+// fixture rather than implied by a helper's defaults.
+func seedMatrixCandidate(t *testing.T, store *db.Store, id, agent, headSHA, round string, externallyDriven bool) {
+	t.Helper()
+	encoded, err := marshalPayload(JobPayload{
+		Repo: "gitmoot/gitmoot", PullRequest: 9, TaskID: "task-9",
+		HeadSHA: headSHA, ReviewRound: round,
+		Result: &AgentResult{Decision: "approved", Summary: "matrix candidate"},
+	})
+	if err != nil {
+		t.Fatalf("marshalPayload: %v", err)
+	}
+	job := db.Job{ID: id, Agent: agent, Type: "review", State: string(JobSucceeded), Payload: encoded}
+	event := db.JobEvent{Kind: string(JobSucceeded), Message: "matrix candidate"}
+	if externallyDriven {
+		if err := store.CreateExternallyDrivenJobWithEvent(context.Background(), job, event); err != nil {
+			t.Fatalf("CreateExternallyDrivenJobWithEvent(%s): %v", id, err)
+		}
+	} else if err := store.CreateJobWithEvent(context.Background(), job, event); err != nil {
+		t.Fatalf("CreateJobWithEvent(%s): %v", id, err)
+	}
+	setMergeGateJobTimestamps(t, store, id, "2026-09-01T18:00:00Z")
+}
+
+// TestPolicyMergeGateProvenanceScopeMatrix measures ALL FOUR cells of the
+// head/provenance matrix SIMULTANEOUSLY at one head. F5's fix is a scope
+// NARROWING - provenance applies only to headless rows - and this campaign's
+// signature failure is trading one cell for another: round 7 traded stale-head
+// admission for a bypass, round 9 traded remnant exclusion for the CLI deadlock.
+// Three cells plus an argument is what allowed both. The table is the argument.
+func TestPolicyMergeGateProvenanceScopeMatrix(t *testing.T) {
+	for _, tt := range []struct {
+		name        string
+		headSHA     string
+		round       string
+		extDriven   bool
+		wantRetired bool
+		why         string
+	}{
+		{
+			name: "cell 1: headless WITHOUT provenance must NOT retire", headSHA: "", round: "", extDriven: false, wantRetired: false,
+			why: "the unattributable engine-inserted remnant; admitting it retires a live objection and then vanishes from the blocking population",
+		},
+		{
+			name: "cell 2: headless WITH provenance MUST retire", headSHA: "", round: "", extDriven: true, wantRetired: true,
+			why: "a session-written approval is a real verdict; refusing it would deadlock every session re-review",
+		},
+		{
+			name: "cell 3: head-bearing MATCHING without provenance MUST retire", headSHA: "head123", round: "", extDriven: false, wantRetired: true,
+			why: "the CLI shape - head always, round never, never externally driven. This is the #1950 P1-A deadlock",
+		},
+		{
+			name: "cell 4: head-bearing NON-matching must NOT retire", headSHA: "stale999", round: "", extDriven: false, wantRetired: false,
+			why: "a verdict about a different commit cannot speak for this head",
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			store, gh, gate, request := newMergeGateQuorumScenario(t)
+			insertMergeGateReviewFixture(t, store, mergeGateReviewFixture{
+				id: "review-approval", agent: "audit", decision: "approved", hasResult: true,
+			})
+			mailbox := Mailbox{store: store, resolveDeliveryWorktree: ExcludedDeliveryWorktreeResolver("test_explicit_no_worktree")}
+			if _, err := mailbox.OpenExternalJob(ctx, JobRequest{
+				ID: "matrix-objection", Agent: "matrix-reviewer", Action: "review",
+				Repo: "gitmoot/gitmoot", PullRequest: 9, TaskID: "task-9", Sender: "session",
+			}); err != nil {
+				t.Fatalf("OpenExternalJob returned error: %v", err)
+			}
+			if _, err := mailbox.CloseExternalJobWithUsage(ctx, "matrix-objection", AgentResult{
+				Decision: "changes_requested", Severity: reviewseverity.P1, Summary: "session objection",
+			}, 0, "", "", ExternalJobUsage{}); err != nil {
+				t.Fatalf("CloseExternalJobWithUsage returned error: %v", err)
+			}
+			setMergeGateJobTimestamps(t, store, "matrix-objection", "2026-09-01T12:00:00Z")
+
+			seedMatrixCandidate(t, store, "matrix-candidate", "matrix-reviewer", tt.headSHA, tt.round, tt.extDriven)
+
+			if err := store.UpsertTask(ctx, db.Task{
+				ID: "task-9", RepoFullName: "gitmoot/gitmoot", Branch: "task-9", State: string(TaskReadyToMerge),
+			}); err != nil {
+				t.Fatal(err)
+			}
+			request.Reviewer = "audit"
+			request.ExpectedTaskState = string(TaskReadyToMerge)
+
+			decision, evalErr := gate.Evaluate(ctx, request)
+			if evalErr != nil {
+				t.Fatalf("Evaluate returned error: %v", evalErr)
+			}
+			if tt.wantRetired && (!decision.Merged || len(gh.merges) != 1) {
+				t.Fatalf("decision=%+v merges=%d, want the objection RETIRED (one merge): %s", decision, len(gh.merges), tt.why)
+			}
+			if !tt.wantRetired && (decision.Merged || len(gh.merges) != 0) {
+				t.Fatalf("decision=%+v merges=%d, want the objection to SURVIVE (no merge): %s", decision, len(gh.merges), tt.why)
+			}
+		})
+	}
+}
+
+// TestPolicyMergeGateAtHeadStateGuardAdmitsNothingUnsucceeded drives EVERY
+// non-succeeded job state through Evaluate at the evaluated head and asserts
+// WHICH mechanism refuses it.
+//
+// This is the LOAD-BEARING ASSUMPTION behind not routing the at-head blocking
+// scan through the shared predicate. Asserting only "no merge" does not test
+// it: the FIRST version of this test asserted exactly that, passed on all five
+// states, AND STILL PASSED ON ALL FIVE WITH THE CRASHED-REVIEWER GUARD DELETED.
+// It was measuring a backstop, not the guard. Pinning the reason string is what
+// makes each state's refusal attributable to a named mechanism.
+//
+// TWO guards precede the scan, which is the correction this test encodes:
+//
+//   - the crashed-reviewer switch: queued/running -> PENDING, failed/cancelled
+//     -> a crashed-reviewer error.
+//   - the unusable-state guard in the slot scan (merge_gate.go:1200): BLOCKED.
+//     The switch has no JobBlocked case, so attributing blocked to it - as an
+//     earlier version of the census comment did - is wrong.
+//
+// Measured: with the crashed-reviewer switch deleted, all five fall through to
+// the unusable-state guard and are still refused. Defence in depth, so no
+// bypass - but the two mechanisms are distinct and are named separately.
+func TestPolicyMergeGateAtHeadStateGuardAdmitsNothingUnsucceeded(t *testing.T) {
+	for _, tt := range []struct {
+		state      JobState
+		wantReason string
+		mechanism  string
+	}{
+		{JobQueued, "waiting for reviewer", "crashed-reviewer switch, pending arm"},
+		{JobRunning, "waiting for reviewer", "crashed-reviewer switch, pending arm"},
+		{JobFailed, "crashed reviewer", "crashed-reviewer switch, error arm"},
+		{JobCancelled, "crashed reviewer", "crashed-reviewer switch, error arm"},
+		{JobBlocked, "has unusable job state", "unusable-state guard in the slot scan, NOT the switch"},
+	} {
+		t.Run(string(tt.state), func(t *testing.T) {
+			ctx := context.Background()
+			store, gh, gate, request := newMergeGateQuorumScenario(t)
+			insertMergeGateReviewFixture(t, store, mergeGateReviewFixture{
+				id: "review-approval", agent: "audit", decision: "approved", hasResult: true,
+			})
+			// An APPROVED result in a non-succeeded state is the dangerous
+			// direction: a row that could be mistaken for a verdict satisfying the
+			// gate. It carries the evaluated head so it lands in the at-head
+			// population these guards are responsible for.
+			encoded, err := marshalPayload(JobPayload{
+				Repo: "gitmoot/gitmoot", PullRequest: 9, TaskID: "task-9", HeadSHA: "head123",
+				Result: &AgentResult{Decision: "approved", Summary: "unsucceeded at-head row"},
+			})
+			if err != nil {
+				t.Fatalf("marshalPayload: %v", err)
+			}
+			if err := store.CreateJobWithEvent(ctx, db.Job{
+				ID: "unsucceeded-at-head", Agent: "state-reviewer", Type: "review",
+				State: string(tt.state), Payload: encoded,
+			}, db.JobEvent{Kind: string(tt.state), Message: "at-head row"}); err != nil {
+				t.Fatalf("CreateJobWithEvent: %v", err)
+			}
+			setMergeGateJobTimestamps(t, store, "unsucceeded-at-head", "2026-09-01T18:00:00Z")
+
+			if err := store.UpsertTask(ctx, db.Task{
+				ID: "task-9", RepoFullName: "gitmoot/gitmoot", Branch: "task-9", State: string(TaskReadyToMerge),
+			}); err != nil {
+				t.Fatal(err)
+			}
+			request.Reviewer = "audit"
+			request.ExpectedTaskState = string(TaskReadyToMerge)
+
+			decision, evalErr := gate.Evaluate(ctx, request)
+			if evalErr != nil {
+				t.Fatalf("Evaluate returned error: %v", evalErr)
+			}
+			if decision.Merged || len(gh.merges) != 0 {
+				t.Fatalf("state %s reached a MERGE: decision=%+v merges=%d. The at-head blocking scan is exempt from the shared predicate ONLY because these guards admit nothing non-succeeded; this state slipped past, so that exemption is a live bypass (#1950 arm 2)",
+					tt.state, decision, len(gh.merges))
+			}
+			if rendered := decision.Reason.Render(); !strings.Contains(rendered, tt.wantReason) {
+				t.Fatalf("state %s refused with reason %q, want it to contain %q (%s). A refusal by the WRONG mechanism means the guard this exemption cites is not the one doing the work (#1950 arm 2)",
+					tt.state, rendered, tt.wantReason, tt.mechanism)
+			}
+		})
+	}
 }

--- a/internal/workflow/merge_gate_test.go
+++ b/internal/workflow/merge_gate_test.go
@@ -6475,29 +6475,6 @@ func seedProductionReviewRow(t *testing.T, store *db.Store, id, agent, decision,
 	return stored
 }
 
-// seedHeadlessRoundCandidate inserts a headless candidate carrying an EXPLICIT
-// review round - the engine-dispatched shape. The distinction from
-// seedHeadlessCandidate is the whole point of the asymmetry probe: roundless
-// against roundless is ordered by TIMESTAMP and legitimately supersedes (that is
-// the session-approval case F1/F2 require), whereas an explicit round against a
-// roundless objection is refused by reviewRoundKey in either direction.
-func seedHeadlessRoundCandidate(t *testing.T, store *db.Store, id, agent, round, decision string) {
-	t.Helper()
-	encoded, err := marshalPayload(JobPayload{
-		Repo: "gitmoot/gitmoot", PullRequest: 9, TaskID: "task-9", ReviewRound: round,
-		Result: &AgentResult{Decision: decision, Summary: "engine-dispatched candidate"},
-	})
-	if err != nil {
-		t.Fatalf("marshalPayload: %v", err)
-	}
-	if err := store.CreateJobWithEvent(context.Background(), db.Job{
-		ID: id, Agent: agent, Type: "review", State: string(JobSucceeded), Payload: encoded,
-	}, db.JobEvent{Kind: string(JobSucceeded), Message: "candidate"}); err != nil {
-		t.Fatalf("CreateJobWithEvent(%s): %v", id, err)
-	}
-	setMergeGateJobTimestamps(t, store, id, "2026-09-01T18:00:00Z")
-}
-
 // TestPolicyMergeGateAdmitsCLIReviewsAndRefusesAtHeadFanOut covers BOTH P1s the
 // exact-head review of b22667017849b0a460026a68f9bf18d9a89ccd26 found, and they
 // point in OPPOSITE directions - which is why they are pinned together and why
@@ -6621,11 +6598,13 @@ func TestPolicyMergeGateAdmitsCLIReviewsAndRefusesAtHeadFanOut(t *testing.T) {
 		// and are excluded on stated mechanism, not preference:
 		//
 		//   - the at-head BLOCKING scan is preceded by TWO guards which between them
-		//     admit nothing non-succeeded, so routing it would add an unreachable
-		//     silent skip in place of a loud message. Probed: routing it passes the
-		//     whole control set precisely BECAUSE the added check is dead, which is
-		//     not evidence it belongs. THEY ARE NOT ONE MECHANISM, and the first
-		//     version of this comment wrongly credited one guard with all of it:
+		//     let NOTHING non-succeeded reach a merge - measured per state, not
+		//     argued. An earlier version of this comment also called that routing
+		//     DEAD CODE; the blocked-state control DISPROVES it, because blocked
+		//     does reach that scan (and is refused there). The exemption now rests
+		//     only on the measured outcome, not on reachability. THEY ARE NOT ONE
+		//     MECHANISM, and the first version wrongly credited one guard with all
+		//     of it:
 		//     the crashed-reviewer switch takes queued/running (pending) and
 		//     failed/cancelled (error), while BLOCKED has no case there and is
 		//     taken by the unusable-state guard in the slot scan. Deleting the
@@ -6643,7 +6622,7 @@ func TestPolicyMergeGateAdmitsCLIReviewsAndRefusesAtHeadFanOut(t *testing.T) {
 		}
 	})
 
-	t.Run("ASYMMETRY PROBE, committed so the divergence cannot silently return", func(t *testing.T) {
+	t.Run("ASYMMETRY: an externally-driven ROUNDLESS DELEGATION CHILD must not retire (#1950 F6)", func(t *testing.T) {
 		ctx := context.Background()
 		store, gh, gate, request := newMergeGateQuorumScenario(t)
 		insertMergeGateReviewFixture(t, store, mergeGateReviewFixture{
@@ -6663,14 +6642,31 @@ func TestPolicyMergeGateAdmitsCLIReviewsAndRefusesAtHeadFanOut(t *testing.T) {
 		}
 		setMergeGateJobTimestamps(t, store, "asym-objection", "2026-09-01T12:00:00Z")
 
-		// This candidate is ADMITTED by the shared predicate: succeeded,
-		// non-fan-out, headless, and externally driven so provenance is satisfied.
-		// What refuses it is reviewRoundKey, which will not order an explicit round
-		// against a roundless objection. The distinction is recorded because the
-		// previous round's comment credited the REFUSAL to the predicate, which does
-		// not perform it - and naming the wrong mechanism is how the next round
-		// "fixes" the wrong function.
-		seedHeadlessRoundCandidate(t, store, "asym-delegation-child", "asym-reviewer", "review-2", "approved")
+		// THE SHAPE IS THE WHOLE TEST, and the version this replaces got it wrong.
+		// It was NAMED "asym-delegation-child" while building a row that was
+		// non-external, carried ReviewRound review-2, and set NEITHER linkage field
+		// - so it was refused by round ordering and proved nothing about delegation
+		// children. A misnamed fixture reads as coverage to every future reader.
+		// This one is what the finding describes: externally driven (provenance
+		// passes), ROUNDLESS (timestamps order it, so round ordering cannot save
+		// us), and carrying BOTH ParentJobID and DelegationID (so the objection
+		// scan excludes it at merge_gate.go:1060). Admitted as a candidate and
+		// absent as an objection is how it cleared a block it could never impose.
+		encoded, err := marshalPayload(JobPayload{
+			Repo: "gitmoot/gitmoot", PullRequest: 9, TaskID: "task-9",
+			Result: &AgentResult{Decision: "approved", Summary: "delegation child verdict"},
+		})
+		if err != nil {
+			t.Fatalf("marshalPayload: %v", err)
+		}
+		if err := store.CreateExternallyDrivenJobWithEvent(ctx, db.Job{
+			ID: "asym-delegation-child", Agent: "asym-reviewer", Type: "review",
+			State: string(JobSucceeded), Payload: encoded,
+			ParentJobID: "asym-parent", DelegationID: "asym-delegation",
+		}, db.JobEvent{Kind: string(JobSucceeded), Message: "delegation child"}); err != nil {
+			t.Fatalf("CreateExternallyDrivenJobWithEvent: %v", err)
+		}
+		setMergeGateJobTimestamps(t, store, "asym-delegation-child", "2026-09-01T18:00:00Z")
 		job, err := store.GetJob(ctx, "asym-delegation-child")
 		if err != nil {
 			t.Fatalf("GetJob: %v", err)
@@ -6679,8 +6675,14 @@ func TestPolicyMergeGateAdmitsCLIReviewsAndRefusesAtHeadFanOut(t *testing.T) {
 		if err != nil {
 			t.Fatalf("unmarshalPayload: %v", err)
 		}
-		if !reviewRowIsVerdictAboutHead(job, payload, "head123") {
-			t.Fatalf("shared predicate REFUSED the roundless externally-driven candidate; this probe exists to pin that it ADMITS it and that reviewRoundKey is what refuses it (#1950)")
+		// Assert the fixture really is the finding's shape before asserting
+		// behaviour, so this cannot pass for the wrong reason its predecessor did.
+		if !job.ExternallyDriven || strings.TrimSpace(payload.ReviewRound) != "" || !isDelegationChild(job) {
+			t.Fatalf("fixture is externally_driven=%v round=%q delegation_child=%v; want true/empty/true or it no longer reproduces #1950 F6",
+				job.ExternallyDriven, payload.ReviewRound, isDelegationChild(job))
+		}
+		if reviewRowIsVerdictAboutHead(job, payload, "head123") {
+			t.Fatalf("shared predicate ADMITTED an externally-driven roundless delegation child as a superseding candidate while the objection scan EXCLUDES that same row: it can clear a block it could never impose (#1950 F6)")
 		}
 
 		if err := store.UpsertTask(ctx, db.Task{
@@ -6696,7 +6698,14 @@ func TestPolicyMergeGateAdmitsCLIReviewsAndRefusesAtHeadFanOut(t *testing.T) {
 			t.Fatalf("Evaluate returned error: %v", evalErr)
 		}
 		if decision.Merged || len(gh.merges) != 0 {
-			t.Fatalf("decision=%+v merges=%d, want NO merge: round ordering must refuse this candidate even though the predicate admits it", decision, len(gh.merges))
+			t.Fatalf("decision=%+v merges=%d, want ZERO external merge calls: a delegation child is accounted through its parent's fan-out evidence and must not retire a session objection (#1950 F6)", decision, len(gh.merges))
+		}
+		task, taskErr := store.GetTask(ctx, "task-9")
+		if taskErr != nil {
+			t.Fatalf("GetTask: %v", taskErr)
+		}
+		if task.State != string(TaskReadyToMerge) {
+			t.Fatalf("task state = %q, want it left UNCLAIMED at ready_to_merge (#1950 F6)", task.State)
 		}
 	})
 }
@@ -6883,4 +6892,83 @@ func TestPolicyMergeGateAtHeadStateGuardAdmitsNothingUnsucceeded(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestReviewRowSupersedingImpliesObjectable is the invariant directive 127201
+// names: A ROW THAT SUPERSEDES MUST BE A ROW THAT CAN OBJECT.
+//
+// #1950 F6 was neither predicate being wrong on its own - it was the two
+// disagreeing about the SAME row. An externally driven, roundless delegation
+// child was admitted as a superseding candidate and simultaneously excluded
+// from the objection population, so it cleared a block it could never impose.
+// Fixing that one shape leaves the NEXT disagreement free to appear, which is
+// how rounds 5, 7, 8, 9 and 10 each found a new one.
+//
+// So this enumerates the cross product of every field either side reads and
+// asserts CONTAINMENT: admitted-as-candidate implies not-excluded-as-objection.
+// A future clause added to one side and not the other fails here by
+// construction, without anyone having to think of the shape first.
+func TestReviewRowSupersedingImpliesObjectable(t *testing.T) {
+	const headSHA = "head123"
+	heads := []string{"", headSHA, "stale999"}
+	rounds := []string{"", "review-2"}
+	bools := []bool{false, true}
+	states := []JobState{JobSucceeded, JobBlocked, JobFailed}
+
+	checked, admitted := 0, 0
+	for _, head := range heads {
+		for _, round := range rounds {
+			for _, ext := range bools {
+				for _, child := range bools {
+					for _, fanOut := range bools {
+						for _, state := range states {
+							checked++
+							result := &AgentResult{Decision: "approved", Summary: "enumerated row"}
+							if fanOut {
+								result.Delegations = []Delegation{{ID: "d1", Agent: "specialist", Action: "review", Prompt: "look"}}
+							}
+							payload := JobPayload{
+								Repo: "gitmoot/gitmoot", PullRequest: 9, TaskID: "task-9",
+								HeadSHA: head, ReviewRound: round, Result: result,
+							}
+							job := db.Job{
+								ID: "enumerated", Agent: "reviewer", Type: "review",
+								State: string(state), ExternallyDriven: ext,
+							}
+							if child {
+								job.ParentJobID, job.DelegationID = "parent", "delegation"
+							}
+							if !reviewRowIsVerdictAboutHead(job, payload, headSHA) {
+								continue
+							}
+							admitted++
+							// Every reason the OBJECTION populations drop a row. If an
+							// admitted candidate matches any of them, that row can
+							// supersede an objection while being unable to be one.
+							switch {
+							case JobState(job.State) != JobSucceeded:
+								t.Errorf("admitted candidate is not succeeded (state=%s): the objection scans skip it, so it can retire a block it cannot impose", state)
+							case payload.Result == nil:
+								t.Errorf("admitted candidate has no result: the objection scans skip it")
+							case reviewRowIsFanOut(payload.Result):
+								t.Errorf("admitted candidate is a fan-out announcement: all four objection sites skip it")
+							case isDelegationChild(job):
+								t.Errorf("admitted candidate is a delegation child (head=%q round=%q ext=%v): the objection scan excludes it at merge_gate.go:1060 - this is #1950 F6 exactly", head, round, ext)
+							case isIntegrationWorktreeReview(payload):
+								t.Errorf("admitted candidate is an integration-worktree review: the headless objection scan excludes it")
+							case strings.TrimSpace(head) != "" && strings.TrimSpace(head) != headSHA:
+								t.Errorf("admitted candidate carries a foreign head %q", head)
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+	// Guard against the enumeration silently becoming vacuous: if a future clause
+	// refuses everything, containment holds trivially and proves nothing.
+	if admitted == 0 {
+		t.Fatalf("enumerated %d shapes and NONE were admitted as candidates; containment then holds vacuously and this test proves nothing", checked)
+	}
+	t.Logf("enumerated %d shapes, %d admitted as superseding candidates, all of them objectable", checked, admitted)
 }

--- a/internal/workflow/session_job_test.go
+++ b/internal/workflow/session_job_test.go
@@ -458,3 +458,31 @@ func hasEventKind(events []db.JobEvent, kind string) bool {
 	}
 	return false
 }
+
+// TestOpenExternalJobRefusesAReviewWithNeitherAgentNorActingRole is the
+// committed writer-refusal control #1950 F3 asked for. The merge gate's headless
+// scan carries a fail-closed arm for a review row with no usable identity, and
+// that arm has to be honest about its provenance: no supported writer produces
+// such a row, because this validator refuses it.
+//
+// Pinning the refusal here is what stops the gate's arm from being described as
+// production coverage, and it will fail if the requirement is ever relaxed - at
+// which point that arm stops being merely defensive and needs a real fixture.
+func TestOpenExternalJobRefusesAReviewWithNeitherAgentNorActingRole(t *testing.T) {
+	store := openEngineStore(t)
+	_, err := (Mailbox{store: store, resolveDeliveryWorktree: ExcludedDeliveryWorktreeResolver("test_explicit_no_worktree")}).
+		OpenExternalJob(context.Background(), JobRequest{
+			ID:          "session-no-identity",
+			Action:      "review",
+			Repo:        "gitmoot/gitmoot",
+			PullRequest: 9,
+			TaskID:      "task-9",
+			Sender:      "session",
+		})
+	if err == nil {
+		t.Fatal("OpenExternalJob accepted a review with neither Agent nor ActingOrgRole; the merge gate's no-identity arm is documented as unreachable through production writers and that is no longer true")
+	}
+	if got := err.Error(); !strings.Contains(got, "job agent or acting org role is required") {
+		t.Fatalf("OpenExternalJob error = %q, want the identity requirement; the refusal this control pins has changed shape", got)
+	}
+}

--- a/internal/workflow/session_job_test.go
+++ b/internal/workflow/session_job_test.go
@@ -482,7 +482,8 @@ func TestOpenExternalJobRefusesAReviewWithNeitherAgentNorActingRole(t *testing.T
 	if err == nil {
 		t.Fatal("OpenExternalJob accepted a review with neither Agent nor ActingOrgRole; the merge gate's no-identity arm is documented as unreachable through production writers and that is no longer true")
 	}
-	if got := err.Error(); !strings.Contains(got, "job agent or acting org role is required") {
-		t.Fatalf("OpenExternalJob error = %q, want the identity requirement; the refusal this control pins has changed shape", got)
+	const want = "job agent or acting org role is required"
+	if got := err.Error(); got != want {
+		t.Fatalf("OpenExternalJob error = %q, want exactly %q; strings.Contains here let a PREFIXED message pass, so this control did not pin the string it claims to (#1950 F3)", got, want)
 	}
 }


### PR DESCRIPTION
Fixes the P1 in #1933: `PolicyMergeGate` could complete a merge while a persisted, succeeded `changes_requested` review sat unconsumed.

`reviewsAtHead` admits only rows whose `payload.HeadSHA` equals the evaluated head, so a headless objection is invisible to it, and the latest-round fallback never runs because the strict population is non-empty whenever *any* current-head review exists. The gate returned clean, `executePullRequestMergeFenced` acquired the task state, and the objection's own `AdvanceJob` transition then failed against that claim with `ErrTaskStateClaimed` **while the merge completed**. The objection was not deferred, it was bypassed — the inverse of the one property the gate exists to hold.

Reproduces on clean `main`; not introduced by #1903.

## The fix is the ordering

The latest applicable unsuperseded ordinary headless `changes_requested` review now blocks inside `ensureFinalReviewCaptured`, which runs **before** `ClaimTaskState`, instead of after the gate has already returned clean. `engine_run_budgets.go` is untouched — the transition is not the defect, the ordering is.

## Four qualifiers, and the surface each one protects

A naive "ordinary headless changes_requested" predicate deadlocks legitimate merges in three distinct ways, so every scoping word is load-bearing.

| qualifier | what it protects | what breaks without it |
|---|---|---|
| **unsuperseded** | an answered or withdrawn objection | a withdrawn objection blocks forever |
| not a **delegation child** | delegated review evidence | six pre-existing delegation tests fail; a child is judged by `ensureDelegatedReviewEvidence`, not as a standalone verdict |
| not an **integration-worktree** row | #332 decompose-and-verify | `TestPolicyMergeGateHeadlessIntegrationObjectionDoesNotMatchEveryHead` fails; such a row blocks **every** head, which no push can clear |
| carries a **review round** | unattributable delegation remnants | the enumeration's `PARENT_ONLY_NO_DELEGATION` and `NEITHER_PARENT_NOR_DELEGATION` variants fail — they assert `wantExcluded` |

## The round qualifier could hide the defect rather than fix it, so it was enumerated, not assumed

| production path | HeadSHA set? | ReviewRound set? | file:line |
|---|---|---|---|
| CLI `gitmoot agent review` | **always** — resolved from the PR when omitted, hard error if still empty | never | `internal/cli/agent_dispatch.go:945-959`, `:969-971` |
| CLI `gitmoot agent ask` | n/a | n/a | `internal/workflow/mailbox.go:734` sets `Type` from `Action`, so an ask is type `ask` and never enters the review population; `internal/cli/agent.go:870` forbids `--pr`/`--head-sha` with ask |
| engine PR-lifecycle review dispatch | yes (event head) | **yes** | `internal/workflow/engine_pr_lifecycle.go:280`, `:496` |
| engine run-budget re-dispatch | preserved | preserved | `internal/workflow/engine_run_budgets.go:1160` |
| engine routing/merge re-dispatch | preserved | preserved | `internal/workflow/engine_routing_merge.go:100` |
| daemon re-dispatch | preserved | preserved | `internal/cli/daemon_worker.go:3321` |
| delegation child | **cleared by the engine** | inherited, non-empty | `internal/workflow/merge_gate.go:1851-1858` |
| integration worktree | **cleared by the engine** | inherited | `isIntegrationWorktreeReview`, `internal/workflow/merge_gate.go:1856` |
| read-only worktree seat | cleared **only** when `Action != "review"` | n/a | `internal/cli/agent_dispatch.go:413-417` |

**The round-1 answer that stood here has been DELETED, not struck through, because it was disproven:** it claimed no genuine ordinary `changes_requested` row can carry neither head nor round. `gitmoot job record --type review` persists exactly that. The behaviour actually shipped is in the round-2, round-3 and round-4 sections below; the table above is retained only as the writer census, which was accepted.

## Red before, green after, with counts

`TestPolicyMergeGateBlocksHeadlessObjectionAheadOfTheExternalMergeClaim`, entered through `Evaluate` rather than a helper so the state claim is observable:

- on `origin/main` `3794dee27b370028db8654a4d453ee7c50279e23`, production files unmodified and `go vet` clean: **0 passes / 3 fails**, with `decision={Merged:true …} merges=1`
- at this head: **3 passes / 0 fails**

Both insertion orderings are driven, because the store returns rows by id.

## Nine compiling semantic mutants, all killed

| mutant | killed by |
|---|---|
| ordering reverted (objection evaluated after the clean return) | #1933 regression |
| block gated on an empty strict population | #1933 regression |
| integration-worktree exclusion deleted | pre-existing `…IntegrationObjectionDoesNotMatchEveryHead` + should-succeed arm |
| delegation-child exclusion deleted | should-succeed arm (child of the implement row) |
| **round qualifier deleted** | enumeration + should-succeed arm |
| supersession check deleted | should-succeed arms |
| latest-selection reversed | two-objection arm |
| `changes_requested` filter widened | abstention arm |
| succeeded-state check dropped | queued-row arm |

## Should-succeed arms — 13, all reaching a completed merge unless noted

answered · withdrawn · superseded · another pull request · disagreeing branch · rendered against another head · headless fan-out · integration worktree · delegation child of a review row · **neither head nor round (the round-qualifier arm)** · abstention · queued row — plus three arms that must **block** and assert *which* path refused: a migrated task id still applies, a delegation child blocks through its parent's evidence, and with two objections the **latest** is named.

## Verification

`gofmt` 0 · `go build ./...` · `go generate ./...` with no drift on a clean tree · `go vet ./...` · full `./internal/workflow` **green** (95s) including the six delegation tests and `merge_gate_test.go:4900` · scoped `-race` on `./internal/workflow` green (222s).

`go test ./...`: 39 packages ok, 2 failing — `internal/sandbox` (`TestReadableRootsGrantOnlyRequestedAndFixedSystemRoots`, Landlock) and `internal/cli` (`panic: test timed out after 10m0s`). **Both reproduce identically on unmodified `origin/main`**, and this diff touches neither package.

No pre-existing test was weakened, edited or deleted.

Three of my own new tests were vacuous and the mutants found them, not review: the supersession, queued and first delegation arms all passed an empty round, so the round qualifier excluded them before the guard they claimed to pin ever ran. Two further arms asserted the wrong outcome — a replacement with no round supersedes nothing by design, and a real delegation child must block through its parent's evidence — and both now assert which path refused rather than merely that something did.

Refs #1933

---

## Correction after #1950's exact-head review (P1 F1, `merge_gate.go:1042`)

The fourth qualifier as first shipped excluded **every** roundless review row, and the one-sentence answer above was **wrong**. `gitmoot job record --type review` (`internal/cli/job_session.go:214-305`) opens an **externally driven** session job via `OpenExternalJob`, which deliberately persists neither `HeadSHA` nor `ReviewRound` and demotes any supplied `--head-sha` to a display event (`internal/workflow/session_job.go:85-125`); `CloseExternalJobWithUsage` then stores `changes_requested` and succeeds the row (`session_job.go:170-190`). That is a real blocking objection, so excluding it left the bypass reachable while the ledger claimed a fix. My enumeration missed the writer, and the evidence was already in my own notes — I had measured that `job record --head-sha` is accepted and silently dropped.

**The discriminator is now ORIGIN, not roundlessness.** `db.Job.ExternallyDriven` is set only by `CreateExternallyDrivenJobWithEvent`; every other insert leaves it at its default 0 (`internal/db/store_jobs.go:184`). A row is excluded only when it is **both** engine-inserted **and** roundless — provably the unattributable delegation remnant that the enumeration's `PARENT_ONLY_NO_DELEGATION` and `NEITHER_PARENT_NOR_DELEGATION` variants require be ignored. Every other combination, including shapes nobody has enumerated, now reaches the block: it **fails closed**.

`TestPolicyMergeGateBlocksASessionReviewObjectionWithNeitherHeadNorRound` is built through the production writers, not a hand-assembled row, and asserts the stored payload really carries neither field and the row really is externally driven before evaluating. **RED at `4e52fa9a` (production files unmodified): 0 passes / 3 fails. GREEN here: 3 passes / 0 fails**, `-count=3` on both sides. A tenth mutant deleting the session handling makes it red again.

Controls held at the new head: **24** `TestPolicyMergeGate.*Delegat*` tests, the enumeration's three linkage variants, `TestPolicyMergeGateHeadlessIntegrationObjectionDoesNotMatchEveryHead`, and the should-succeed table's **15** subtests. Full `./internal/workflow` green (81s); scoped `-race` green (230s) — coverage the reviewer's CGO-disabled seat could not provide.

---

## Round 2 correction: `gitmoot/gitmoot#1950-f2` (P1, `merge_gate.go:1075`)

Round 1's fix wedged in the **opposite** direction. `OpenExternalJob` supports `ActingOrgRole` **instead of** `Agent`, persisting `ExternallyDriven=true`, `Agent=""` and the normalized role. The headless scan read identity from `job.Agent` alone and **skipped supersession** when it was empty, so once a role recorded `changes_requested`, a later approval **from that same role** could never clear it — a block with no operator move — and the refusal rendered `"unanswered review objection from  "` with an empty name.

**Same mistake twice, in opposite directions:** round 1 under-blocked by treating a roundless row as illegitimate; round 2 over-blocked by treating an agent-less row as identity-less. Both inferred absence of legitimacy from the absence of *one* field while a supported writer populated a *different* one.

`headlessReviewerIdentity` resolves `Agent` when present, else `NormalizeActingOrgRole(payload.ActingOrgRole)` (trim + lowercase, `mailbox.go:813`). Both sides of the comparison resolve identically, and the diagnostic names the same effective identity. `collectGateImplementerAttribution` already resolved identity this way, so the rule is shared rather than duplicated.

### Identity-bearing fields a supported writer may populate instead of `Agent`

`OpenExternalJob` writes exactly `ActingOrgRole, Agent, Branch, ExternallyDriven, GoalID, ID, Instructions, PullRequest, Repo, Sender, TaskID, TaskTitle, Template*, Type, WorkflowID`, and sets `LeadAgent`, `Reviewers`, `DelegatedBy` **zero** times.

- **Handled:** `Agent`; `ActingOrgRole` (normalized).
- **Deliberately excluded:** `Sender` — it records the *channel* and defaults to `"session"` for every session row, so keying on it would let one role's approval supersede a **different** role's objection; `LeadAgent`/`Reviewers` — the dispatcher and requested panel, not the author; `DelegatedBy`/`DelegationID` — lineage, and delegation children are excluded from this scan entirely; `OperatorOrigin` — a bool.

**Round 1 is not weakened.** A row with no usable identity still **blocks**, named "an unattributed reviewer". That arm does not use `OpenExternalJob`, because that writer *refuses* such a row (`"job agent or acting org role is required"`) — the shape is unreachable on the session path, so the test builds the reachable one: an engine-inserted row with a round and no author.

**RED at `7c726d8814eb5fc1c59ae91b054a0cd4778801a8`** (production files unmodified): 0 passes / 12 fails. **GREEN here:** 12 passes / 0 fails, `-count=3`. Round-1 arms stay green: session 3/0, interleaving 9/0. **Eleventh mutant** — identity reverted to `Agent`-only — kills **only** the acting-role regression; deleting the session handling kills session + acting-role; reverting the ordering kills all three.

Controls: **24** `…Delegat*` tests, the should-succeed table's **15** subtests, the enumeration, the integration test, and `TestPolicyMergeGateMergesPassingPullRequest`. Full `./internal/workflow` green (63.961s); scoped `-race` green (255.766s) — race acceptance is mine, since the reviewer's CGO-disabled seat cannot build race binaries.

---

## Round 3: `gitmoot/gitmoot#1950-f3` (P2, test-only)

F1 and F2 are **answered** at `00af5840`. F3 is a hit on my *test*, and it is correct: the no-identity arm described its row as "an engine-inserted reachable row", which overclaimed. No supported writer can produce `Type=review` with a `ReviewRound`, an empty `Agent` **and** an empty `ActingOrgRole` — `validateExternalJobRequest` (`mailbox.go:1994`) refuses exactly that, and every ordinary engine, CLI, daemon, pipeline, delegation and retry insert goes through `Mailbox` validation requiring an agent. I could not demonstrate a producer and did not invent one.

- The arm is relabelled a **defensive legacy/corruption invariant**, explicitly *not* production-writer coverage. The gate must fail closed on a row it cannot attribute whatever produced it — a row predating that validation, a corrupted payload, or an unenumerated writer — and `insertCompletedJob` bypasses the validators precisely to construct that state, which is why it cannot stand as evidence about production.
- `TestOpenExternalJobRefusesAReviewWithNeitherAgentNorActingRole` is the committed **writer-refusal control**, so the claim lives in an assertion rather than a comment and will fail if the requirement is relaxed — at which point the arm needs a real fixture.

The control is causative: a compiling mutant relaxing the identity requirement in `validateExternalJobRequest` makes it **red**.

**No production behaviour changed in this commit** — the diff is two test files, 0 production files. Controls: **24** `…Delegat*`, **15** should-succeed subtests, the enumeration, the integration test, `…MergesPassingPullRequest`. Full `./internal/workflow` green (91.077s); scoped `-race` green (242.438s), which remains my acceptance rather than the reviewer's.

The framing is carried in the subtest **name** as well, per the correction directive: `DEFENSIVE INVARIANT (no supported writer produces this): a row with no usable identity still blocks`. Stated plainly for a future reader: **no supported writer can currently produce `Type=review` with a non-empty `ReviewRound`, an empty `Agent` and an empty `ActingOrgRole`** — every queued engine, CLI, daemon, pipeline, delegation and retry insert flows through `Mailbox` validation requiring an agent; the only direct production inserts left are `review_coordinator` rows with `Agent=LeadAgent` and non-review produce/implement rows. The fail-closed guard is kept anyway, and remains causative: a compiling mutant that skips a no-identity row instead of blocking makes the arm red.

---

## Round 4: `#1950-f3` closed, `#1950-f4` closed, and the third identity site included (ruling 126350)

Certifying verdict `local-review-g7-review-18d2e63b4c83f698` at old head `706c904c` kept f3 open and raised f4. Both are now closed, and per ruling 126350 the fix covers the **whole class** rather than the two sites the finding named.

**f3.** The refusal control used `strings.Contains`, so a prefixed error string stayed green. It now asserts **equality** against `"job agent or acting org role is required"`, and a compiling mutant that prefixes the production string makes it red. The PR body's disproven round-one claim is **deleted**, and the defensive framing is on all three surfaces — test name, fixture comment, and this body.

**f4.** The acting-role assertion accepted the fallback phrase `"an unattributed reviewer"`, so a diagnostic-only revert stayed green; it now rejects that phrase. And the Agent-first/normalized-role policy existed in **four** places. One resolver, `effectiveReviewerIdentity` (plus the `…Name` wrapper), is now consumed by all of them: headless supersession, the headless diagnostic, implementer attribution, the `activeAtHead` reviewer arm, and the latest-round arm. `Agent` always wins; a role never downgrades an already-recorded agent identity; every fan-out, head, round, severity and replacement-decision gate is untouched.

**The third site mattered on its own.** Reading `job.Agent` alone classified a **role-authored approval** as "no recorded reviewer author" and refused it *before* the independence check — so a role could never approve anything, and the role's own self-approval was never tested for. `TestPolicyMergeGateReachesIndependenceForARoleAuthoredApproval` drives both directions: a different role merges, and the **same** role that implemented is refused as self-approval rather than as unattributed.

Named controls, `-count=3`, pass/fail events: role-approval **9/0** · agent-first attribution **3/0** · acting-role supersession **12/0** · session objection **3/0** · interleaving **9/0** · writer refusal **3/0** · agent-authored unchanged (`…MergesPassingPullRequest`) **3/0**.

Mutants, all compiling and all killed: `activeAtHead` reverted to Agent-only kills **only** the role-approval control while agent-authored behaviour stays green; the diagnostic-only revert kills the acting-role control; inverting the shared rule so a role wins kills the agent-first control — an inversion that previously passed the **entire** package, so that order is now pinned for the first time.

Gate: `gofmt` 0 · `go build ./...` · `go vet ./...` · full `./internal/workflow` **ok 86.286s** · **owned-seat scoped `-race` ok 273.938s** at this head, which is my acceptance and not inferred from the reviewer's CGO-disabled disclaimer or the CI shards.

---

## Round 5: `#1950-f4` — the sixth identity site, and a completed census

The certifying review at `509cf396` found current-head supersession comparing `job.Agent` columns inline while every other site used the resolver. An at-head objection authored by an acting **role** could therefore never be superseded by that same role's later at-head approval — both `Agent` columns are empty, the loop skipped both rows, and the PR stayed open rendering `"blocking result from "` with no author.

**I had already run this census and it missed.** Round 4 claimed the rule was shared "across all three sites"; the reviewer found a fourth, I found a fifth while implementing, and this is the sixth. So this round does not patch the two cited lines — it audits **every** agent-identity read in `merge_gate.go` and routes all of them through `effectiveReviewerIdentity`. The only raw `job.Agent` read left is the resolver's own definition; call sites went **11 → 18**.

Seven were diagnostics and one was a **durable record**, which is why they were not cosmetic: the two `"blocking result from %s"` messages, the pending and crashed reviewer messages, the undispatched fan-out naming, `ensureReviewMatchesHead`'s author argument, and the `mergeApprovalEvidenceEvent` job event — which recorded `"approval by  at <head>"` for a role-authored approval, a permanent row naming nobody.

Normalization is load-bearing here: the adversary used `" ReVieWer "`, and `NormalizeActingOrgRole` trims and lowercases so objection and replacement resolve to one identity. A mutant comparing the raw trimmed role fails the regression.

**RED at `509cf39656d9b3ab23381ced5b3d2ffea796ffb8`** (production files unmodified): 0 passes / 9 fails. **GREEN here:** 9 passes / 0 fails, `-count=3`.

Mutants, compiling: reverting **only** current-head supersession to `Agent`-only kills the new regression; comparing raw trimmed roles kills it as well.

Named controls, `-count=3`, every one `pass=3 fail=0`: at-head role supersession · role-authored approval independence · agent-first attribution · acting-role session supersession · session objection · interleaving · writer refusal · agent-authored unchanged. Plus 24 delegation tests and 15 should-succeed subtests. Full `./internal/workflow` **ok 84.100s**; owned-seat scoped `-race` **ok 254.316s**.

---

## Round 6: `#1950-f5` — the census claim, corrected in both places

F1–F4 are answered. F5 is a **disclosure** finding and it is right on both counts.

**The claim was scoped wrong in code.** The shared helper's comment still read "ALL THREE identity sites" — the exact counting habit the previous round said it was ending, after "three" and then "five" were each wrong within a round. It now states its scope **without a count**: every reviewer-identity read *in `merge_gate.go`* resolves through it — supersession at the evaluated head and for headless rows, the at-head and latest-round approval arms, implementer attribution, and every author-bearing diagnostic plus the durable approval-evidence event.

**And this PR body claimed a completed class census while never naming the two known exceptions.** They were in my plan note and not here, which is the gap F5 measured. Stated now:

### Known gaps outside this diff — not fixed, deliberately left for routing

- **`internal/workflow/review_loop.go:89-91`** — `FindRepeatedReviewers` drops a role-authored exact-head verdict. **I previously framed this as churn-and-spend with no merge impact; the certifier disproved that and I withdraw it.** Its probe drove the whole path: role-only exact-head evidence dropped → `HandlePullRequestOpened` queued a real repeat review → a later same-identity approval **merged**. So it touches the merge path, not just cost. It is not a one-line swap: `db.SucceededReviewVerdict` (`internal/db/awaited_facts.go:242`) projects no `ActingOrgRole`, so the role must be plumbed through that query first — which is also why #1957's `reviewDecisionAgent` approach cannot work as written (recorded by the coordinator on #1957, comment 5565225336). Owned there, deliberately not expanded into this PR.
- **`internal/proof/project.go:260-263`** — a role-authored reviewer leaves `comparable` false, so the proof artifact renders author and independence as `-` and emits a generic `review.approved`. **Conservative** — it never emits a false `independent_approved` — but incomplete.

Both were confirmed by the certifier's own executed probes. Neither is touched here, and neither is filed as an issue without instruction.

**So the accurate claim is narrow:** the merge gate's identity collapse is complete *within `merge_gate.go`*, verified mechanically — the only raw `job.Agent` read left in that file is the resolver's own definition. It is not a repository-wide claim, and this round stops asserting one.

No behaviour changed in round 6: a production comment and this body.

---

## Round 7: `#1950-f5` at P1 — a merge-integrity bypass in my own supersession arm

F1–F4 remain answered. F5 escalated from a documentation finding to **P1** because full-head certification found the arm I added would **merge**.

Headless supersession tested identity, a replacement decision, and recency — and **never asked which head the candidate described**. A production session objection carries neither head nor round; a later same-reviewer CLI-shaped approval naming a **stale** head is also roundless, so `reviewRoundKeyForJob` falls back to timestamps, the stale approval won recency and retired an objection it never spoke for. With an independent at-head approval present, `Evaluate` **merged and called the external merge once in each of three runs**.

A head-bearing candidate must now match the evaluated head — **empty-or-equal, deliberately not empty-only**, because a replacement rendered *at* the evaluated head is the ordinary way a reviewer withdraws an objection, and demanding a headless candidate would deadlock every objection answered by re-reviewing the current head.

**A row's authority is the full tuple — identity, decision class, recency, applicable head.** Five rounds of this fix each decided it from a subset: the writer, then the attempt, then the message prefix, then the identity source, and now the head. That is the defect, stated once rather than re-discovered.

Evidence: the regression enters through `Evaluate` and asserts **zero external merge calls**, since a helper-level assertion cannot observe this merge. **RED at `5423928d707f412eec49c6b644a767407f96602e`** (production files unmodified): 0 passes / 3 fails. **GREEN here:** 3 passes / 0 fails, `-count=3`. A compiling mutant removing the head match kills **only** the new regression while the at-head-replacement arm stays green — that pair proves the asymmetry.

Controls at `-count=3`, all `pass=3 fail=0`: at-head role supersession · acting-role session supersession · exact writer refusal · Agent-first attribution · `TestPolicyMergeGateMergesPassingPullRequest`. The 15-arm table: **45 subtest events, 0 failures, 36 expected merges and 9 expected blocks** — safety was not bought by refusing valid merges. 24 delegation tests pass. Full `./internal/workflow` **ok 64.118s**; owned-seat scoped `-race` **ok 215.097s**. `merge_gate.go` diff: 26 added lines, 23 comment, **3 code**.

---

## Round 8: `#1950-f6` (P1) — supersession is now **default-deny**

Third finding in one candidate loop. It checked head, identity, decision spelling and recency but never whether the candidate was a **verdict at all**, so a later **blocked** review, **failed** review, or **approved fan-out** announcement from the same reviewer retired a live objection — and each of those rows is itself absent from the blocking population, so an independent at-head approval merged.

**The shape is the fix, not a third condition.** Rounds 5, 7 and 8 are one class: the predicate **defaulted to admit**, so each round removed one shape and the next probe found the next. `reviewRowCanRetireAnObjection` inverts that — every clause returns `false`, and the final `true` is reachable only by a row that positively qualifies. An unenumerated row kind now yields a **visible block** rather than a silent merge. ~~The same predicate governs both sides, so they cannot diverge.~~ **[DISPROVEN by review at `b2266701` — see Round 9.** The helper had ONE call site; the at-head loop still tested a bare `Result != nil`. A one-line grep falsifies this sentence, and it was the load-bearing claim of Round 8.]

**Every clause is measured, and the list is deliberately no longer than that.** Succeeded state and non-fan-out are the reviewer's measured floor, reproduced here rather than cited; head applicability carries over from F5.

**I probed the two extra clauses my own plan proposed, and the answer split — only one shipped.** An engine-inserted **roundless remnant merged** under the floor, so attributable provenance (externally driven *or* carrying a round) is demonstrated and is in the predicate. A **delegation-child** candidate needed **no** clause: an explicit round cannot be ordered against a roundless objection, so existing `reviewRoundKey` machinery already refuses it. Adding a clause for it would have been an unpinned claim, so it is reported and omitted.

**Three fixture iterations, and the first two were vacuous** — both passed at the previous head. A candidate carrying the evaluated head enters `reviewsAtHead` and is refused as a *crashed reviewer*, a different guard; a candidate carrying a round supersedes nothing because round ordering refuses it. Only a headless, roundless, externally-driven candidate leaves recency as the sole discriminator, which is what makes state and fan-out the properties actually under test.

Per-arm **RED at `0144d28e309e7c222dbdc1a4a55aa606d3e5b785`** (production files unmodified): blocked, failed, fan-out and remnant all fail on all three repetitions; the delegation-child arm passes there, as measured. **GREEN here:** all five pass ×3. Single-clause mutants each kill **only** their own arms — succeeded → blocked + failed; fan-out → fan-out; provenance → remnant.

Nothing valid refused: the 15-arm table still reads **36 merges / 9 blocks**, and the exclusion-safety set is **699 pass events / 0 failures** at `-count=3`. Seven named controls `pass=3 fail=0`. Full `./internal/workflow` **ok 104.372s**; owned-seat `-race` with `CGO_ENABLED=1` **ok 261.538s**. Base `3794dee2` fails all five arms — the original #1933 bypass, not F6, since base merges with no candidate present at all. `merge_gate.go` diff: **51 comment lines, 17 code**.

---

## Round 9: `#1950-p1a` and `#1950-p1b` — one predicate, three populations, and a retraction

**Round 8's load-bearing sentence was false.** It claimed the same predicate governed both sides while shipping the helper at **one** call site; the at-head loop still tested a bare `Result != nil`. It is struck above rather than deleted. The census is now a **test that reads this file and fails on the guard count**, because a sentence cannot fail.

**P1-A — over-blocking; my default-deny refused valid input.** The provenance clause demanded external origin or a round of *every* candidate. A CLI review carries a `HeadSHA` (`agent_dispatch` resolves it from the PR and hard-errors without one) and carries **neither**, so a succeeded non-fan-out approval at the evaluated head could not retire that reviewer's own objection — the PR deadlocked after a human had legitimately re-reviewed it. Provenance is now asked only of a **headless** row: the clause above forces a non-empty head to *equal* the evaluated head, so such a row is attributable **by its head**. I had measured "CLI review: head always, round never" earlier in this campaign and did not apply it to my own new clause; the reviewer named this deadlock before my diff existed.

**P1-B — under-blocking.** An approved **fan-out** announcement at the evaluated head retired a real objection, was skipped as an announcement by the blocking scan, and the PR merged on an independent approval.

**Three populations now share one one-row question** — *is this row a verdict about this head at all* — as `reviewRowIsVerdictAboutHead`: at-head candidate, headless candidate, and the headless objection scan, which had hand-composed the identical clauses inline. Identity, decision class and recency stay at the callers because they are **relational** — properties of a *pair* of rows.

**Two sites must differ, on mechanism.** The at-head **blocking** scan is preceded by the crashed-reviewer guard, which *errors* on any non-succeeded row at the evaluated head; routing it would replace a loud error with an unreachable silent skip — and probing it **passed the whole control set precisely because the added check is dead**, which is not evidence it belongs. The two **slot** scans decide whether a reviewer's slot is filled, where a fan-out with dispatched children is judged through the children, so routing them would change quorum rather than tighten it. Both reasons are recorded in the census test.

**CI is not evidence here, and that is the point:** 27/27 was green at the parent while both P1s were live. Per-arm **RED at `b22667017849b0a460026a68f9bf18d9a89ccd26`** (production files verified unmodified): CLI arm, at-head fan-out arm and census arm all fail 3/3. **GREEN here:** four arms pass 3/3. Both behavioural arms are built through the production writers — `Mailbox.Enqueue` + `finishWithPayload` — and assert the CLI row's shape so they cannot pass for the wrong reason.

**Four mutants, each killing only its own arm:** revert head-awareness → CLI arm; revert at-head routing → fan-out arm (plus the census arm, the census working as a second detector); delete the provenance clause → roundless-remnant arm; revert the third population → census arm alone, the rest being de-duplication.

The **asymmetry probe** is committed as a regression and passes at the parent too: it pins that the predicate *admits* an externally-driven roundless candidate and that `reviewRoundKey` is what refuses it — a guard against future divergence, not a reproduction of a defect.

Nothing valid refused: **36 merges / 9 blocks**; **714 pass events / 0 failures** across the merge-gate suite at `-count=3`; eight named controls `pass=3 fail=0`. `gofmt` 0, build and vet clean. Full `./internal/workflow` **ok 86.016s**; owned-seat `-race` with `CGO_ENABLED=1` **ok 352.078s**. `merge_gate.go`: **54 comment / 10 code** lines added.

**Two fixture faults were mine** and are recorded in the tests: `finishWithPayload` needs a *running* job, and the asymmetry candidate needs an *explicit* round because roundless-against-roundless is ordered by timestamp and legitimately supersedes. Both first versions failed on the fixture, not the behaviour.

---

## Round 10: the four-cell matrix, and an assumption that was wrong in its attribution

**Tests only.** `merge_gate.go` is byte-unchanged from `10701afa` apart from nothing at all — the one comment corrected in this round lives in the test file, beside the census it describes.

**Arm 1 — all four cells measured simultaneously.** F5's fix is a scope *narrowing*, and this campaign's signature failure is trading one cell for another: round 7 traded stale-head admission for a bypass, round 9 traded remnant exclusion for the CLI deadlock. Three cells plus an argument is what allowed both.

| cell | shape | required | result |
|---|---|---|---|
| 1 | headless **without** provenance | must NOT retire | PASS |
| 2 | headless **with** provenance | MUST retire | PASS |
| 3 | head-bearing **matching**, no provenance | MUST retire | PASS |
| 4 | head-bearing **non-matching** | must NOT retire | PASS |

Cell 3 is the P1-A deadlock, cell 1 is the remnant — the two the last two rounds traded against each other. They now hold together.

**Arm 2 — the stated reason for exempting the at-head blocking scan was incomplete.** It was justified by "the crashed-reviewer guard errors on any non-succeeded row". Driving all five non-succeeded states through `Evaluate` shows that is **false for `blocked`**: the switch has no `JobBlocked` case.

| state | refusing message | mechanism |
|---|---|---|
| queued | `waiting for reviewer` | crashed switch, pending arm |
| running | `waiting for reviewer` | crashed switch, pending arm |
| failed | `crashed reviewer` | crashed switch, error arm |
| cancelled | `crashed reviewer` | crashed switch, error arm |
| blocked | `has unusable job state` | **unusable-state guard, not the switch** |

**No bypass** — nothing reaches a merge in any state, because the two guards are defence in depth: with the crashed switch deleted, all five fall through to the unusable-state guard and are still refused. The exemption stands; its reason is corrected to name both.

**My first version of this test was vacuous and a mutant caught it.** It asserted only "no merge", passed on all five states, and **still passed on all five with the crashed-reviewer guard deleted** — it was measuring a backstop, not the guard. Pinning the reason string per state fixes it: deleting the switch now kills queued, running, failed and cancelled while **`blocked` keeps passing**, which is exactly the attribution the corrected comment claims.

Both new tests pass `-count=3`. 15-arm table still **36 merges / 9 blocks**; **753 pass events / 0 failures** across `TestPolicyMergeGate` + `TestOpenExternalJob` at `-count=3`; guard census still **3**. `gofmt` 0, build and vet clean. Full `./internal/workflow` **ok 84.544s**; owned-seat `-race` **ok 290.131s**.

---

## Round 11: `#1950-f6` — a row that supersedes must be a row that can object

**F6 was live at both previous heads.** An externally driven, **roundless** row carrying `ParentJobID` and `DelegationID` was admitted as a superseding candidate, retired the same-reviewer session objection, and was then **excluded from the objection population** as a delegation child (`merge_gate.go:1060`). One row, two contradictory applicability answers — it cleared a block it could never impose.

Measured, not a pass word — fixture `ext=true round="" child=true`:

| head | MERGE_CALLS | merged | task_state | runs |
|---|---|---|---|---|
| `e4575ed4` | **1** | true | merged | 3/3 |
| `10701afa` | **1** | true | merged | 3/3 |
| this head | **0** | false | `ready_to_merge` | 3/3 |

**Why my round-9 "measurement" let it through.** I probed a delegation-child candidate then, found it needed no clause, and reported that. The probe carried an explicit **round**, so `reviewRoundKey` refused it for declining to order a round against a roundless objection — nothing to do with linkage. A **roundless** externally driven child is ordered by *timestamp*, and nothing refused it. `measured, no clause needed` is only ever as wide as the shape measured.

**And the fixture advertised coverage it did not have.** It was *named* `asym-delegation-child` while building a row that was non-external, carried `ReviewRound review-2`, and set **neither** linkage field. A misnamed fixture is worse than a missing one: it reads as coverage to every future reader, including its author. It is rebuilt to the finding's shape and now asserts that shape before asserting behaviour.

**The fix is the invariant, not the shape.** Excluding one row would leave the *next* disagreement free to appear — which is how rounds 5, 7, 8, 9 and 10 each found a new one. The linkage exclusion joins the shared predicate, symmetric with the objection scan's own reasoning, and `TestReviewRowSupersedingImpliesObjectable` enumerates the cross product of every field either side reads (head × round × externally-driven × delegation-child × fan-out × state = **144 shapes**) asserting **containment**: admitted-as-candidate ⇒ not-excluded-as-objection. **7 admitted, all 7 objectable.** A clause added to one side and not the other fails here by construction. It also fails if *zero* shapes are admitted, so a future over-refusal cannot satisfy containment vacuously.

**A round-10 claim is withdrawn:** I said routing the at-head blocking scan would be *dead code*. The blocked-state control shows `blocked` **reaches** that scan (and is refused there). The exemption now rests only on the measured outcome — two guards, nothing non-succeeded reaches a merge — and the reachability argument is deleted rather than left standing beside a correct conclusion. That is twice this exemption's stated reason has been wrong while its conclusion held.

Mutant **M30** deleting the linkage clause kills exactly two things — the asymmetry arm and the containment invariant, two independent detectors — and touches no other arm, so provenance cell 2 is undisturbed. 39 subtest passes / 0 failures across the matrix, state arms and F6 arms at `-count=3`; 15-arm table still **36 merges / 9 blocks**; **756 pass events / 0 failures**; guard census **3**. `gofmt` 0, build and vet clean. Full `./internal/workflow` **ok 67.717s**; owned-seat `-race` **ok 390.411s**. `merge_gate.go`: **3** code lines added.

CI was 27/27 green at both heads where this P1 reproduced 3/3.
