### PR TITLE
fix(cli): scope org-role unavailability refusal to the selected runtime (#1641)

### DIFF
--- a/internal/cli/agent_dispatch.go
+++ b/internal/cli/agent_dispatch.go
@@ -314,6 +314,16 @@ func dispatchLocalAgentJob(ctx context.Context, store *db.Store, request localAg
 			return localAgentJobOutput{}, fmt.Errorf("runtime override: %w", err)
 		}
 	}
+	// #1641: role unavailability is refused HERE, not at the --org-role ingress
+	// above, because only now is the selected runtime authoritative — a claude
+	// quota wall must not refuse a codex dispatch, and an override to the walled
+	// runtime must still refuse. effectiveAgent is the same expression the
+	// claiming worker resolves (daemon_worker.go), so the two agree by
+	// construction. The agent reservation taken above is released by the deferred
+	// releaseReservation on this error path, so refusing here strands nothing.
+	if err := refuseUnavailableOrgRole(ctx, store, request.ActingOrgRole, effectiveAgent.Runtime, time.Now().UTC()); err != nil {
+		return localAgentJobOutput{}, err
+	}
 	if !request.Background {
 		// The adapter factory closure already carries this selection, but the
 		// workflow engine also owns job-associated subprocesses (produce checks and

--- a/internal/cli/daemon_scheduler.go
+++ b/internal/cli/daemon_scheduler.go
@@ -3039,6 +3039,33 @@ func queuedJobRuntimeResourceKey(ctx context.Context, store *db.Store, job db.Jo
 		}
 		return key
 	}
+	// #1952: an EPHEMERAL job has no agents-table session to schedule under — the
+	// worker materializes the spec and starts a FRESH session, so no row exists
+	// pre-materialization and a stale same-name row yields the wrong key. Either
+	// way this returned "", and admission then read a real session as
+	// not-session-counted (perJobAdmissionEstimate treats "" as no session).
+	//
+	// This key is a SERIALIZATION key — runtimeResourceLocked, inflightRuntimes —
+	// so it must agree with what the worker actually LOCKS, not merely be
+	// non-empty. jobWorker.run rewrites a fresh ref to runtime.FreshRefForJob(job.ID)
+	// before taking the lock, so building the key from that same formula makes the
+	// gate and the acquisition byte-identical, which is the invariant
+	// runtime_override.go documents. It is also job-unique, so two ephemeral jobs
+	// never falsely serialize.
+	if payload, err := daemonJobPayload(job); err == nil && payload.Ephemeral != nil {
+		agent, ok := selectedJobRuntimeAgent(ctx, store, job, payload)
+		if !ok {
+			return ""
+		}
+		agent.RuntimeRef = runtime.FreshRefForJob(job.ID)
+		key, keyed := runtimeSessionResourceKey(agent)
+		if !keyed {
+			// A non-resumable spec runtime (shell) takes no session lock, exactly
+			// as a non-resumable registered agent does not.
+			return ""
+		}
+		return key
+	}
 	agent, err := store.GetAgent(ctx, job.Agent)
 	if err != nil {
 		return ""

--- a/internal/cli/daemon_scheduler.go
+++ b/internal/cli/daemon_scheduler.go
@@ -2082,13 +2082,20 @@ func listPendingQueuedJobs(ctx context.Context, worker jobWorker, repoFilter str
 		if queuedJobBlockerHeld(job, time.Now().UTC()) {
 			continue
 		}
-		// Provider-declared role unavailability (#1136): all queued work attributed
-		// to that role is held until the reset boundary. ListActive... excludes
+		// Provider-declared role unavailability (#1136): queued work attributed to
+		// that role is held until the reset boundary. ListActive... excludes
 		// expired rows (the one-minute sweep removes them), so stale incidents
 		// never suppress dispatch.
+		//
+		// #1641: the hold is runtime-scoped. This is the LIVE half of that defect —
+		// a claude quota row held every queued job of the role, including codex and
+		// kimi work that had no wall. The agent lookup runs only for a job whose
+		// role is actually walled, so the common path stays the map lookup it was.
 		if payload, payloadErr := daemonJobPayload(job); payloadErr == nil {
-			if _, unavailable := unavailableRoles[strings.ToLower(strings.TrimSpace(payload.ActingOrgRole))]; unavailable {
-				continue
+			if row, unavailable := unavailableRoles[strings.ToLower(strings.TrimSpace(payload.ActingOrgRole))]; unavailable {
+				if orgRoleUnavailableRefusesRuntime(row, selectedJobDispatchRuntime(ctx, worker.Store, job, payload)) {
+					continue
+				}
 			}
 		}
 		// Auth-probe gate (#532 slice B): once a runtime_auth deferral's coarse hold

--- a/internal/cli/daemon_scheduler.go
+++ b/internal/cli/daemon_scheduler.go
@@ -3046,12 +3046,22 @@ func queuedJobRuntimeResourceKey(ctx context.Context, store *db.Store, job db.Jo
 	// not-session-counted (perJobAdmissionEstimate treats "" as no session).
 	//
 	// This key is a SERIALIZATION key — runtimeResourceLocked, inflightRuntimes —
-	// so it must agree with what the worker actually LOCKS, not merely be
-	// non-empty. jobWorker.run rewrites a fresh ref to runtime.FreshRefForJob(job.ID)
-	// before taking the lock, so building the key from that same formula makes the
-	// gate and the acquisition byte-identical, which is the invariant
-	// runtime_override.go documents. It is also job-unique, so two ephemeral jobs
-	// never falsely serialize.
+	// so what it must satisfy is worth stating exactly, because an earlier version
+	// of this comment claimed something FALSE: that the key is byte-identical to
+	// the lock the worker takes. MEASURED, it is not. The gate produces
+	// runtime:<rt>:fresh:job:<hash> while jobWorker.run's journalled lock reads
+	// runtime:<rt>:<the ref adapter.Start returned>. scopeRegisteredFreshRefForJob
+	// only rewrites a ref that IsFreshRef, and a materialized ephemeral agent
+	// carries the live session ref, so it is left alone.
+	//
+	// That gap is inherent and harmless: an ephemeral session does not EXIST until
+	// Start returns, so no pre-dispatch value can name it. What the key must be is
+	// non-empty (so admission counts a real session rather than pricing it free),
+	// job-unique (so two ephemeral jobs never serialize against each other), and
+	// never shaped like a live session ref (so it cannot collide with a real
+	// lock) — which the fresh: prefix guarantees. A fresh ephemeral session
+	// contends with nothing at gate time, so claiming no existing lock is correct
+	// rather than merely convenient.
 	if payload, err := daemonJobPayload(job); err == nil && payload.Ephemeral != nil {
 		agent, ok := selectedJobRuntimeAgent(ctx, store, job, payload)
 		if !ok {

--- a/internal/cli/daemon_worker.go
+++ b/internal/cli/daemon_worker.go
@@ -349,10 +349,17 @@ func (w jobWorker) run(ctx context.Context, job db.Job) error {
 		runtimeConfigDir = selectedReadOnlyRuntimeConfigDir(agent.Runtime, payload.RuntimeConfigDir)
 	}
 	// The runtime-session lock keeps naming the agent's REGISTERED session, so
-	// #684's serialization is unchanged: a read-only seat still queues behind a
-	// busy reviewer session, and the scheduler gate (queuedJobRuntimeResourceKey,
-	// which reads the stored agent) still computes the same key the acquisition
-	// below does. Only DELIVERY moves to the seat's isolated fresh session.
+	// #684's serialization is unchanged for a REGISTERED seat: it still queues
+	// behind a busy reviewer session, and the scheduler gate
+	// (queuedJobRuntimeResourceKey, which reads the stored agent for that case)
+	// computes the same key the acquisition below does. Only DELIVERY moves to
+	// the seat's isolated fresh session.
+	//
+	// #1952: this does NOT hold for an EPHEMERAL seat, and the unqualified
+	// version of this sentence was false. Such a job has no registered session:
+	// the gate keys it synthetically by job id and the worker locks the
+	// materialized live session, so gate and acquisition deliberately differ.
+	// The full explanation is on readOnlySeatRuntimeRef below.
 	sessionLockAgent := agent
 	if err := applyReadOnlySeat(readOnlySeat, runtimeConfigDir, job.ID, &agent); err != nil {
 		if finishErr := w.finishQueuedJob(ctx, job, workflow.JobFailed, err); finishErr != nil {

--- a/internal/cli/daemon_worker.go
+++ b/internal/cli/daemon_worker.go
@@ -1583,10 +1583,12 @@ func resumableSessionRuntime(runtimeName string) bool {
 //
 // It is never a lock key, and that is the point: the seat locks on the agent's
 // REGISTERED ref (jobWorker.run keeps a pre-seat copy in sessionLockAgent) and
-// the scheduler gate needs no seat branch at all, because
-// queuedJobRuntimeResourceKey reads the stored agent and therefore computes the
-// same registered key. Gate and acquisition agree because neither one uses this
-// function.
+// queuedJobRuntimeResourceKey reads the stored agent for a READ-ONLY SEAT and
+// therefore computes the same registered key. Gate and acquisition agree because
+// neither one uses this function. (#1952 narrowed that claim: the gate no longer
+// reads the stored agent for an EPHEMERAL job, which has no registered session to
+// key on — it keys by job id there. Seats are unaffected, and no seat job carries
+// an ephemeral spec.)
 //
 // An earlier version of this comment claimed both derived their key from HERE.
 // That is the opposite of the code, and acting on it is exactly the mutation
@@ -2912,11 +2914,26 @@ func perJobAdmissionEstimate(ctx context.Context, store *db.Store, job db.Job, p
 	if store == nil {
 		return admissionEstimate{session: true, memGB: policy.DefaultMemoryGB}
 	}
-	agent, err := store.GetAgent(ctx, job.Agent)
-	if err != nil {
+	// #1952: resolve the runtime the job will ACTUALLY run as, so an ephemeral
+	// Claude job is charged Claude's RAM prior rather than a stale same-name
+	// agent row's runtime (or the default, when no row exists yet).
+	//
+	// An UNPARSEABLE payload must not degrade to DefaultMemoryGB: before this
+	// change such a job was still charged its registered runtime's prior, and
+	// silently re-pricing every corrupt-payload job would be a regression this
+	// fix has no business causing. A zero payload carries no ephemeral spec and
+	// no override, so selectedJobRuntimeAgent resolves it from the agents table —
+	// byte-for-byte the previous behaviour. TestPerJobAdmissionEstimate caught
+	// exactly this.
+	payload, payloadErr := daemonJobPayload(job)
+	if payloadErr != nil {
+		payload = workflow.JobPayload{}
+	}
+	agent, ok := selectedJobRuntimeAgent(ctx, store, job, payload)
+	if !ok {
 		return admissionEstimate{session: true, memGB: policy.DefaultMemoryGB}
 	}
-	switch strings.TrimSpace(runtimeAgent(agent).Runtime) {
+	switch strings.TrimSpace(agent.Runtime) {
 	case runtime.CodexRuntime:
 		return admissionEstimate{session: true, memGB: policy.CodexMemoryGB}
 	case runtime.ClaudeRuntime:

--- a/internal/cli/daemon_worker.go
+++ b/internal/cli/daemon_worker.go
@@ -1583,12 +1583,22 @@ func resumableSessionRuntime(runtimeName string) bool {
 //
 // It is never a lock key, and that is the point: the seat locks on the agent's
 // REGISTERED ref (jobWorker.run keeps a pre-seat copy in sessionLockAgent) and
-// queuedJobRuntimeResourceKey reads the stored agent for a READ-ONLY SEAT and
+// queuedJobRuntimeResourceKey reads the stored agent for a REGISTERED seat and
 // therefore computes the same registered key. Gate and acquisition agree because
-// neither one uses this function. (#1952 narrowed that claim: the gate no longer
-// reads the stored agent for an EPHEMERAL job, which has no registered session to
-// key on — it keys by job id there. Seats are unaffected, and no seat job carries
-// an ephemeral spec.)
+// neither one uses this function.
+//
+// #1952 narrowed that to REGISTERED seats, and a first version of this note
+// asserted "no seat job carries an ephemeral spec" on the strength of a grep for
+// co-assignment — which cannot establish absence. TRACED, the opposite is true:
+// delegationRequest (engine_run_budgets.go) sets Ephemeral, and
+// allocateAndEnqueueDelegationInner sets ReadOnlySeat on that SAME request for
+// an ask/review action, so an ephemeral read-only seat exists.
+//
+// It needs no seat branch anyway, because the registered-ref story does not
+// describe it: an ephemeral job has no registered session at all, so the gate
+// keys it by job id (see queuedJobRuntimeResourceKey) whether or not it is a
+// seat, and the worker still locks the materialized session. Nothing here
+// depends on the two flags being mutually exclusive.
 //
 // An earlier version of this comment claimed both derived their key from HERE.
 // That is the opposite of the code, and acting on it is exactly the mutation

--- a/internal/cli/ephemeral_runtime_consumers_test.go
+++ b/internal/cli/ephemeral_runtime_consumers_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"io"
+	"strings"
 	"testing"
 
 	"github.com/gitmoot/gitmoot/internal/config"
@@ -122,57 +123,116 @@ func TestAuthProbeDedupKeyDistinguishesEphemeralRuntimes(t *testing.T) {
 	}
 }
 
-// TestAdmissionEstimateChargesTheEphemeralSpecRuntime is the P2 admission
-// regression, asserting the measured VALUES (session true, Claude's 0.85 GB
-// prior) rather than pinning a helper. Before the fix an ephemeral session
-// evaded both opt-in admission caps entirely: session false, 0 GB.
-func TestAdmissionEstimateChargesTheEphemeralSpecRuntime(t *testing.T) {
-	store, _ := ephemeralConsumerStore(t)
-	// The stale same-name row is shell: not a session runtime at all, which is
-	// how a real Claude session came to be counted as free.
-	seedDaemonWorkerAgent(t, store, "eph-admit", runtime.ShellRuntime, "unused", []string{"ask"}, "owner/repo")
-	enqueueDaemonWorkerJob(t, store, workflow.JobRequest{
-		ID: "eph-admission", Agent: "eph-admit", Action: "ask", Repo: "owner/repo", Branch: "main",
-		Ephemeral: &workflow.EphemeralSpec{Runtime: runtime.ClaudeRuntime},
+// admissionHeldBack dispatches through the REAL tracked scheduler under a given
+// memory cap and reports whether the job was refused admission. Nothing here
+// calls perJobAdmissionEstimate: the estimate is observed through the decision
+// the scheduler actually makes, which is the only place it matters.
+//
+// The verdict is the scheduler's own "held back" line, which names ADMISSION
+// specifically — unlike final job state, which reads "queued" both for a job
+// refused admission and for a job that was never selected, and so cannot tell
+// the two apart. Two instrument corrections are baked in here, both of which
+// cost a round:
+//
+//   - resetHeldBackWarnState() is REQUIRED. That line is throttled per
+//     job+reason by heldBackWarnByJob for heldBackLogInterval (5 minutes) in
+//     PACKAGE state, so without the reset a stdout check silently reports "not
+//     held" on the second and third pass of -count=3. The codebase already had
+//     this helper; TestTrackedDispatchLogsAdmissionNeverFit calls it.
+//   - the job must be dispatch-ELIGIBLE (PullRequest set), or nothing is
+//     selected, stdout is empty, and every assertion reads whatever the empty
+//     case happens to imply.
+func admissionHeldBack(t *testing.T, store *db.Store, jobID string, maxMemoryGB float64) (bool, string) {
+	t.Helper()
+	resetHeldBackWarnState()
+	ctx := context.Background()
+	stdout := &syncBuffer{}
+	worker := poolSchedulerWorker(t, store, &cliWorkerFakeAdapter{output: poolSchedulerAskResult}, false)
+	worker.Stdout = stdout
+	worker.Admission = newAdmissionBudget(config.AdmissionPolicy{
+		MaxMemoryGB:     maxMemoryGB,
+		CodexMemoryGB:   0.2,
+		ClaudeMemoryGB:  0.85,
+		KimiMemoryGB:    0.5,
+		DefaultMemoryGB: 0.5,
 	})
-	job := mustWorkerJob(t, store, "eph-admission")
-	policy := config.DefaultAdmissionPolicy()
-
-	got := perJobAdmissionEstimate(context.Background(), store, job, policy)
-	if !got.session || got.memGB != policy.ClaudeMemoryGB {
-		t.Fatalf("estimate = %+v, want session=true memGB=%v (Claude's prior)", got, policy.ClaudeMemoryGB)
+	tracker := newInflightJobTracker(ctx)
+	if err := dispatchQueuedJobsTracked(ctx, worker, 2, 2, "owner/repo", "", tracker); err != nil {
+		t.Fatalf("dispatchQueuedJobsTracked: %v", err)
 	}
-	if key := queuedJobRuntimeResourceKey(context.Background(), store, job); key == "" {
-		t.Fatalf("resource key is empty for a job that will hold a Claude session")
-	}
+	out := stdout.String()
+	job := mustWorkerJob(t, store, jobID)
+	return strings.Contains(out, "job "+jobID+" held back:"), out + " | final state=" + job.State
 }
 
-// TestAdmissionEstimateStillFreesAGenuinelySessionlessJob is the should-SUCCEED
-// control for admission: the fix must not reserve RAM for everything. A plain
-// shell job takes no session and is charged nothing.
-func TestAdmissionEstimateStillFreesAGenuinelySessionlessJob(t *testing.T) {
+func seedEphemeralAdmissionJob(t *testing.T, store *db.Store, jobID, storedRuntime string, spec *workflow.EphemeralSpec) {
+	t.Helper()
+	seedDaemonWorkerAgent(t, store, "eph-admit-"+jobID, storedRuntime, "unused", []string{"ask"}, "owner/repo")
+	enqueueDaemonWorkerJob(t, store, workflow.JobRequest{
+		ID: jobID, Agent: "eph-admit-" + jobID, Action: "ask", Repo: "owner/repo", Branch: "main", PullRequest: 1,
+		Ephemeral: spec,
+	})
+}
+
+// TestAdmissionChargesTheEphemeralSpecRuntimeThroughTheScheduler is the P2
+// admission regression, driven through dispatchQueuedJobsTracked rather than by
+// calling the estimate. It pins Claude's 0.85 GB prior FROM BOTH SIDES: a 0.5 GB
+// cap must refuse the job and a 0.9 GB cap must admit it. A one-sided assertion
+// would also pass for "charges everything infinite RAM", which is the failure
+// mode a correctness fix can easily introduce.
+//
+// Before the fix the stale shell row made this session-less and free, so it was
+// admitted under ANY cap — ephemeral sessions evaded both opt-in limits.
+func TestAdmissionChargesTheEphemeralSpecRuntimeThroughTheScheduler(t *testing.T) {
+	t.Run("a cap below Claude's prior refuses it", func(t *testing.T) {
+		store, _ := ephemeralConsumerStore(t)
+		seedEphemeralAdmissionJob(t, store, "eph-admission-tight", runtime.ShellRuntime,
+			&workflow.EphemeralSpec{Runtime: runtime.ClaudeRuntime})
+		held, out := admissionHeldBack(t, store, "eph-admission-tight", 0.5)
+		if !held {
+			t.Fatalf("a 0.85 GB Claude session was admitted under a 0.5 GB cap; output=%q", out)
+		}
+	})
+
+	t.Run("a cap above Claude's prior admits it", func(t *testing.T) {
+		store, _ := ephemeralConsumerStore(t)
+		seedEphemeralAdmissionJob(t, store, "eph-admission-loose", runtime.ShellRuntime,
+			&workflow.EphemeralSpec{Runtime: runtime.ClaudeRuntime})
+		held, out := admissionHeldBack(t, store, "eph-admission-loose", 0.9)
+		if held {
+			t.Fatalf("a 0.85 GB Claude session was refused under a 0.9 GB cap; output=%q", out)
+		}
+	})
+}
+
+// TestAdmissionStillAdmitsASessionlessJobUnderATinyCap is the should-SUCCEED
+// control: a genuinely session-less shell job contributes no RAM and must be
+// admitted under a cap far below every runtime prior. Without it, "charge
+// everything" would pass the regression above.
+func TestAdmissionStillAdmitsASessionlessJobUnderATinyCap(t *testing.T) {
 	store, _ := ephemeralConsumerStore(t)
 	seedDaemonWorkerAgent(t, store, "shell-admit", runtime.ShellRuntime, "unused", []string{"ask"}, "owner/repo")
 	enqueueDaemonWorkerJob(t, store, workflow.JobRequest{
-		ID: "shell-admission", Agent: "shell-admit", Action: "ask", Repo: "owner/repo", Branch: "main",
+		ID: "shell-admission", Agent: "shell-admit", Action: "ask", Repo: "owner/repo", Branch: "main", PullRequest: 1,
 	})
-	job := mustWorkerJob(t, store, "shell-admission")
-
-	got := perJobAdmissionEstimate(context.Background(), store, job, config.DefaultAdmissionPolicy())
-	if got.session || got.memGB != 0 {
-		t.Fatalf("estimate = %+v, want session=false memGB=0 for a session-less shell job", got)
+	if held, out := admissionHeldBack(t, store, "shell-admission", 0.1); held {
+		t.Fatalf("a session-less shell job was refused admission under a 0.1 GB cap; output=%q", out)
 	}
 }
 
-// TestEphemeralResourceKeyMatchesTheLockTheWorkerTakes pins the property that
-// made the job-id form correct rather than merely non-empty: this key is a
-// SERIALIZATION key (runtimeResourceLocked, inflightRuntimes), and
-// runtime_override.go requires the scheduler gate and the worker's lock
-// acquisition to agree. jobWorker.run rewrites a fresh ref to
-// runtime.FreshRefForJob(job.ID) before locking, so the gate must produce that
-// same string — and it must stay job-unique so two ephemeral jobs do not
-// serialize against each other.
-func TestEphemeralResourceKeyMatchesTheLockTheWorkerTakes(t *testing.T) {
+// TestEphemeralGateKeyIsJobUniqueAndNotASessionRef pins what the gate key must
+// actually satisfy, replacing an earlier assertion of mine that was circular: it
+// computed the expected key from the same helper under test and claimed the gate
+// was byte-identical to the worker's lock. MEASURED, that is false — the gate
+// yields runtime:claude:fresh:job:<hash> while the worker's journalled lock is
+// runtime:claude:<ref returned by adapter.Start>. It cannot be otherwise: the
+// session does not exist until Start returns, so no pre-dispatch value can equal
+// it.
+//
+// What the key must therefore be: non-empty so admission counts the session,
+// job-unique so two ephemeral jobs never serialize against each other, and never
+// equal to a real session ref so it cannot collide with a live lock.
+func TestEphemeralGateKeyIsJobUniqueAndNotASessionRef(t *testing.T) {
 	store, _ := ephemeralConsumerStore(t)
 	seedDaemonWorkerAgent(t, store, "eph-key", runtime.ShellRuntime, "unused", []string{"ask"}, "owner/repo")
 	for _, id := range []string{"eph-key-a", "eph-key-b"} {
@@ -185,37 +245,39 @@ func TestEphemeralResourceKeyMatchesTheLockTheWorkerTakes(t *testing.T) {
 	keyA := queuedJobRuntimeResourceKey(ctx, store, mustWorkerJob(t, store, "eph-key-a"))
 	keyB := queuedJobRuntimeResourceKey(ctx, store, mustWorkerJob(t, store, "eph-key-b"))
 
-	want, ok := runtimeSessionResourceKey(runtime.Agent{
-		Runtime:    runtime.ClaudeRuntime,
-		RuntimeRef: runtime.FreshRefForJob("eph-key-a"),
-	})
-	if !ok {
-		t.Fatal("runtimeSessionResourceKey refused the worker's own fresh-ref form")
-	}
-	if keyA != want {
-		t.Fatalf("gate key = %q, worker locks %q: gate and acquisition must agree", keyA, want)
+	if keyA == "" {
+		t.Fatal("gate key is empty for a job that will hold a Claude session; admission would price it free")
 	}
 	if keyA == keyB {
 		t.Fatalf("two ephemeral jobs share the key %q and would falsely serialize", keyA)
 	}
+	if !strings.HasPrefix(keyA, "runtime:"+runtime.ClaudeRuntime+":") {
+		t.Fatalf("gate key %q does not name the spec runtime", keyA)
+	}
+	// A real session ref is not fresh-prefixed, so the gate key can never be
+	// mistaken for one. This is the property the circular test should have made.
+	if !runtime.IsFreshRef(strings.TrimPrefix(keyA, "runtime:"+runtime.ClaudeRuntime+":")) {
+		t.Fatalf("gate key %q is shaped like a live session ref and could collide with a real lock", keyA)
+	}
 }
 
-// TestEphemeralResourceKeyTakesNoSessionForANonResumableSpec: a shell spec takes
-// no session lock, exactly as a shell-registered agent does not. Without this a
-// "make it non-empty" fix would invent a session for every ephemeral job.
-func TestEphemeralResourceKeyTakesNoSessionForANonResumableSpec(t *testing.T) {
+// TestEphemeralGateTakesNoSessionForANonResumableSpec: a shell spec takes no
+// session lock, exactly as a shell-registered agent does not. Without this a
+// "make it non-empty" fix would invent a session for every ephemeral job — and
+// note the stored row here is Claude, so the pre-fix code took a session for a
+// job that runs on shell.
+func TestEphemeralGateTakesNoSessionForANonResumableSpec(t *testing.T) {
 	store, _ := ephemeralConsumerStore(t)
 	seedDaemonWorkerAgent(t, store, "eph-shell", runtime.ClaudeRuntime, "unused", []string{"ask"}, "owner/repo")
 	enqueueDaemonWorkerJob(t, store, workflow.JobRequest{
-		ID: "eph-shell-job", Agent: "eph-shell", Action: "ask", Repo: "owner/repo", Branch: "main",
+		ID: "eph-shell-job", Agent: "eph-shell", Action: "ask", Repo: "owner/repo", Branch: "main", PullRequest: 1,
 		Ephemeral: &workflow.EphemeralSpec{Runtime: runtime.ShellRuntime},
 	})
 	job := mustWorkerJob(t, store, "eph-shell-job")
 	if key := queuedJobRuntimeResourceKey(context.Background(), store, job); key != "" {
 		t.Fatalf("shell-spec ephemeral job took session key %q, want none", key)
 	}
-	got := perJobAdmissionEstimate(context.Background(), store, job, config.DefaultAdmissionPolicy())
-	if got.session || got.memGB != 0 {
-		t.Fatalf("estimate = %+v, want session=false memGB=0", got)
+	if held, out := admissionHeldBack(t, store, "eph-shell-job", 0.1); held {
+		t.Fatalf("a shell-spec ephemeral job was charged RAM and refused; output=%q", out)
 	}
 }

--- a/internal/cli/ephemeral_runtime_consumers_test.go
+++ b/internal/cli/ephemeral_runtime_consumers_test.go
@@ -1,0 +1,221 @@
+package cli
+
+import (
+	"context"
+	"errors"
+	"io"
+	"testing"
+
+	"github.com/gitmoot/gitmoot/internal/config"
+	"github.com/gitmoot/gitmoot/internal/db"
+	"github.com/gitmoot/gitmoot/internal/runtime"
+	"github.com/gitmoot/gitmoot/internal/subprocess"
+	"github.com/gitmoot/gitmoot/internal/workflow"
+)
+
+// #1952 correction round (directive 126863). The wall fix was correct but the
+// CENSUS was not: three more execute-path consumers still resolved a queued
+// job's runtime from the agents table while the job ran on its ephemeral spec.
+// The class rule is override > ephemeral spec > registered row on every
+// execute-path decision — refuse, hold, probe, reserve, serialize.
+//
+// Every test here plants a same-name agent row of a DIFFERENT runtime, because
+// that is the condition under which the old code looked right.
+
+func ephemeralConsumerStore(t *testing.T) (*db.Store, string) {
+	t.Helper()
+	store := daemonWorkerStore(t)
+	home := t.TempDir()
+	seedDaemonWorkerRepo(t, store, "owner/repo", t.TempDir())
+	return store, home
+}
+
+func ephemeralClaudePayload() workflow.JobPayload {
+	return workflow.JobPayload{
+		Repo:      "owner/repo",
+		Ephemeral: &workflow.EphemeralSpec{Runtime: runtime.ClaudeRuntime},
+	}
+}
+
+// countClaudeLiveChecks swaps the live Claude credential check for a counter.
+// The count is the whole point: the defect was ZERO live probes for a job that
+// runs on Claude, and "did it probe" cannot be inferred from the verdict alone
+// because Unknown is also what a probe-less path returns.
+func countClaudeLiveChecks(t *testing.T, result error) *int {
+	t.Helper()
+	calls := 0
+	original := claudeAuthLiveCheck
+	claudeAuthLiveCheck = func(context.Context, subprocess.Runner, string, []string) error {
+		calls++
+		return result
+	}
+	t.Cleanup(func() { claudeAuthLiveCheck = original })
+	return &calls
+}
+
+// TestAuthProbeProbesTheEphemeralSpecRuntimeNotTheStoredRow is the P2 auth-probe
+// regression. Stored row says shell, the spec says Claude, so the job runs on
+// Claude — the probe must actually contact Claude and return a real verdict.
+// Before the fix: zero probes and Unknown, and because authProbeAllowsRedispatch
+// releases Unknown, a Claude-auth-deferred job re-dispatched with no credential
+// check at all.
+func TestAuthProbeProbesTheEphemeralSpecRuntimeNotTheStoredRow(t *testing.T) {
+	store, home := ephemeralConsumerStore(t)
+	seedDaemonWorkerAgent(t, store, "eph-probe", runtime.ShellRuntime, "unused", []string{"ask"}, "owner/repo")
+	worker := defaultJobWorker(store, io.Discard, home)
+	job := db.Job{ID: "eph-auth-probe", Agent: "eph-probe", Type: "ask"}
+
+	calls := countClaudeLiveChecks(t, errors.Join(errors.New("rejected"), runtime.ErrClaudeAuthFailed))
+	verdict := worker.defaultAuthProbe(context.Background(), job, ephemeralClaudePayload())
+
+	if *calls == 0 {
+		t.Fatalf("live Claude probe calls = 0: the job runs on Claude but nothing validated its credential")
+	}
+	if verdict == authProbeUnknown {
+		t.Fatalf("verdict = unknown after %d live probe(s); an unknown verdict is released by authProbeAllowsRedispatch", *calls)
+	}
+	if verdict != authProbeInvalid {
+		t.Fatalf("verdict = %v, want invalid: the stubbed credential check rejected", verdict)
+	}
+}
+
+// TestAuthProbeLeavesANonEphemeralNonClaudeJobAlone is the should-SUCCEED
+// control: the fix must not make everything probe Claude. An ordinary shell
+// agent job still performs zero live checks and stays Unknown.
+func TestAuthProbeLeavesANonEphemeralNonClaudeJobAlone(t *testing.T) {
+	store, home := ephemeralConsumerStore(t)
+	seedDaemonWorkerAgent(t, store, "shell-only", runtime.ShellRuntime, "unused", []string{"ask"}, "owner/repo")
+	worker := defaultJobWorker(store, io.Discard, home)
+	job := db.Job{ID: "plain-shell-probe", Agent: "shell-only", Type: "ask"}
+
+	calls := countClaudeLiveChecks(t, nil)
+	if verdict := worker.defaultAuthProbe(context.Background(), job, workflow.JobPayload{Repo: "owner/repo"}); verdict != authProbeUnknown {
+		t.Fatalf("non-Claude verdict = %v, want unknown", verdict)
+	}
+	if *calls != 0 {
+		t.Fatalf("live Claude probe calls = %d for a shell job, want 0", *calls)
+	}
+}
+
+// TestAuthProbeDedupKeyDistinguishesEphemeralRuntimes: the dedup key names the
+// credential domain, so two ephemeral jobs on different runtimes must not share
+// one verdict. With the key read off the stored row they collided on
+// "runtime:shell" and one probe's result decided both.
+func TestAuthProbeDedupKeyDistinguishesEphemeralRuntimes(t *testing.T) {
+	store, home := ephemeralConsumerStore(t)
+	seedDaemonWorkerAgent(t, store, "eph-probe", runtime.ShellRuntime, "unused", []string{"ask"}, "owner/repo")
+	worker := defaultJobWorker(store, io.Discard, home)
+	job := db.Job{ID: "eph-dedup", Agent: "eph-probe", Type: "ask"}
+	ctx := context.Background()
+
+	claudeKey := worker.authProbeDedupKey(ctx, job, ephemeralClaudePayload())
+	codexPayload := ephemeralClaudePayload()
+	codexPayload.Ephemeral = &workflow.EphemeralSpec{Runtime: runtime.CodexRuntime}
+	codexKey := worker.authProbeDedupKey(ctx, job, codexPayload)
+	storedKey := worker.authProbeDedupKey(ctx, job, workflow.JobPayload{Repo: "owner/repo"})
+
+	if claudeKey == codexKey {
+		t.Fatalf("ephemeral Claude and Codex jobs share the probe key %q: one verdict would decide both", claudeKey)
+	}
+	if claudeKey == storedKey {
+		t.Fatalf("ephemeral Claude job shares the stored shell agent's key %q", storedKey)
+	}
+}
+
+// TestAdmissionEstimateChargesTheEphemeralSpecRuntime is the P2 admission
+// regression, asserting the measured VALUES (session true, Claude's 0.85 GB
+// prior) rather than pinning a helper. Before the fix an ephemeral session
+// evaded both opt-in admission caps entirely: session false, 0 GB.
+func TestAdmissionEstimateChargesTheEphemeralSpecRuntime(t *testing.T) {
+	store, _ := ephemeralConsumerStore(t)
+	// The stale same-name row is shell: not a session runtime at all, which is
+	// how a real Claude session came to be counted as free.
+	seedDaemonWorkerAgent(t, store, "eph-admit", runtime.ShellRuntime, "unused", []string{"ask"}, "owner/repo")
+	enqueueDaemonWorkerJob(t, store, workflow.JobRequest{
+		ID: "eph-admission", Agent: "eph-admit", Action: "ask", Repo: "owner/repo", Branch: "main",
+		Ephemeral: &workflow.EphemeralSpec{Runtime: runtime.ClaudeRuntime},
+	})
+	job := mustWorkerJob(t, store, "eph-admission")
+	policy := config.DefaultAdmissionPolicy()
+
+	got := perJobAdmissionEstimate(context.Background(), store, job, policy)
+	if !got.session || got.memGB != policy.ClaudeMemoryGB {
+		t.Fatalf("estimate = %+v, want session=true memGB=%v (Claude's prior)", got, policy.ClaudeMemoryGB)
+	}
+	if key := queuedJobRuntimeResourceKey(context.Background(), store, job); key == "" {
+		t.Fatalf("resource key is empty for a job that will hold a Claude session")
+	}
+}
+
+// TestAdmissionEstimateStillFreesAGenuinelySessionlessJob is the should-SUCCEED
+// control for admission: the fix must not reserve RAM for everything. A plain
+// shell job takes no session and is charged nothing.
+func TestAdmissionEstimateStillFreesAGenuinelySessionlessJob(t *testing.T) {
+	store, _ := ephemeralConsumerStore(t)
+	seedDaemonWorkerAgent(t, store, "shell-admit", runtime.ShellRuntime, "unused", []string{"ask"}, "owner/repo")
+	enqueueDaemonWorkerJob(t, store, workflow.JobRequest{
+		ID: "shell-admission", Agent: "shell-admit", Action: "ask", Repo: "owner/repo", Branch: "main",
+	})
+	job := mustWorkerJob(t, store, "shell-admission")
+
+	got := perJobAdmissionEstimate(context.Background(), store, job, config.DefaultAdmissionPolicy())
+	if got.session || got.memGB != 0 {
+		t.Fatalf("estimate = %+v, want session=false memGB=0 for a session-less shell job", got)
+	}
+}
+
+// TestEphemeralResourceKeyMatchesTheLockTheWorkerTakes pins the property that
+// made the job-id form correct rather than merely non-empty: this key is a
+// SERIALIZATION key (runtimeResourceLocked, inflightRuntimes), and
+// runtime_override.go requires the scheduler gate and the worker's lock
+// acquisition to agree. jobWorker.run rewrites a fresh ref to
+// runtime.FreshRefForJob(job.ID) before locking, so the gate must produce that
+// same string — and it must stay job-unique so two ephemeral jobs do not
+// serialize against each other.
+func TestEphemeralResourceKeyMatchesTheLockTheWorkerTakes(t *testing.T) {
+	store, _ := ephemeralConsumerStore(t)
+	seedDaemonWorkerAgent(t, store, "eph-key", runtime.ShellRuntime, "unused", []string{"ask"}, "owner/repo")
+	for _, id := range []string{"eph-key-a", "eph-key-b"} {
+		enqueueDaemonWorkerJob(t, store, workflow.JobRequest{
+			ID: id, Agent: "eph-key", Action: "ask", Repo: "owner/repo", Branch: "main",
+			Ephemeral: &workflow.EphemeralSpec{Runtime: runtime.ClaudeRuntime},
+		})
+	}
+	ctx := context.Background()
+	keyA := queuedJobRuntimeResourceKey(ctx, store, mustWorkerJob(t, store, "eph-key-a"))
+	keyB := queuedJobRuntimeResourceKey(ctx, store, mustWorkerJob(t, store, "eph-key-b"))
+
+	want, ok := runtimeSessionResourceKey(runtime.Agent{
+		Runtime:    runtime.ClaudeRuntime,
+		RuntimeRef: runtime.FreshRefForJob("eph-key-a"),
+	})
+	if !ok {
+		t.Fatal("runtimeSessionResourceKey refused the worker's own fresh-ref form")
+	}
+	if keyA != want {
+		t.Fatalf("gate key = %q, worker locks %q: gate and acquisition must agree", keyA, want)
+	}
+	if keyA == keyB {
+		t.Fatalf("two ephemeral jobs share the key %q and would falsely serialize", keyA)
+	}
+}
+
+// TestEphemeralResourceKeyTakesNoSessionForANonResumableSpec: a shell spec takes
+// no session lock, exactly as a shell-registered agent does not. Without this a
+// "make it non-empty" fix would invent a session for every ephemeral job.
+func TestEphemeralResourceKeyTakesNoSessionForANonResumableSpec(t *testing.T) {
+	store, _ := ephemeralConsumerStore(t)
+	seedDaemonWorkerAgent(t, store, "eph-shell", runtime.ClaudeRuntime, "unused", []string{"ask"}, "owner/repo")
+	enqueueDaemonWorkerJob(t, store, workflow.JobRequest{
+		ID: "eph-shell-job", Agent: "eph-shell", Action: "ask", Repo: "owner/repo", Branch: "main",
+		Ephemeral: &workflow.EphemeralSpec{Runtime: runtime.ShellRuntime},
+	})
+	job := mustWorkerJob(t, store, "eph-shell-job")
+	if key := queuedJobRuntimeResourceKey(context.Background(), store, job); key != "" {
+		t.Fatalf("shell-spec ephemeral job took session key %q, want none", key)
+	}
+	got := perJobAdmissionEstimate(context.Background(), store, job, config.DefaultAdmissionPolicy())
+	if got.session || got.memGB != 0 {
+		t.Fatalf("estimate = %+v, want session=false memGB=0", got)
+	}
+}

--- a/internal/cli/ephemeral_runtime_consumers_test.go
+++ b/internal/cli/ephemeral_runtime_consumers_test.go
@@ -3,12 +3,14 @@ package cli
 import (
 	"context"
 	"errors"
+	"fmt"
 	"io"
 	"strings"
 	"testing"
 
 	"github.com/gitmoot/gitmoot/internal/config"
 	"github.com/gitmoot/gitmoot/internal/db"
+	"github.com/gitmoot/gitmoot/internal/execbackend"
 	"github.com/gitmoot/gitmoot/internal/runtime"
 	"github.com/gitmoot/gitmoot/internal/subprocess"
 	"github.com/gitmoot/gitmoot/internal/workflow"
@@ -279,5 +281,192 @@ func TestEphemeralGateTakesNoSessionForANonResumableSpec(t *testing.T) {
 	}
 	if held, out := admissionHeldBack(t, store, "eph-shell-job", 0.1); held {
 		t.Fatalf("a shell-spec ephemeral job was charged RAM and refused; output=%q", out)
+	}
+}
+
+// #1952 review round 3 (directive 127125). The previous key test called
+// queuedJobRuntimeResourceKey directly, so a compiling mutant that left that
+// helper correct and routed ephemeral jobs through ONE shared key inside the
+// production SELECTOR kept every committed test green while two distinct
+// ephemeral jobs falsely serialized. The helper was never the risk; the routing
+// was. Nothing below names the helper.
+//
+// The seam: queuedJobResourceSelector.selects computes a runtime key per job and
+// refuses a job whose key is already claimed by one selected this pass. It is
+// built in selectRunnableQueuedJobsSeeded and reached from
+// selectRunnableQueuedJobsWithPolicy (runQueuedJobsForRepo) and the pool path.
+
+// seedTwoEphemeralJobs puts the two jobs in DIFFERENT repos on purpose. Measured:
+// with both in one repo they share the checkout key "repo:owner/repo" and the
+// selector serializes them for that reason alone, while their runtime keys are
+// already distinct — so a same-repo pair would have "passed" (or failed) on the
+// checkout confound and proved nothing about runtime routing, which is the whole
+// subject of this PR. Distinct repos leave the runtime key as the only thing that
+// can serialize them.
+func seedTwoEphemeralJobs(t *testing.T, store *db.Store, specRuntime string) []db.Job {
+	t.Helper()
+	for i, repo := range []string{"owner/repo-a", "owner/repo-b"} {
+		seedDaemonWorkerRepo(t, store, repo, t.TempDir())
+		agent := fmt.Sprintf("eph-pair-%d", i)
+		seedDaemonWorkerAgent(t, store, agent, runtime.ShellRuntime, "unused", []string{"ask"}, repo)
+		enqueueDaemonWorkerJob(t, store, workflow.JobRequest{
+			ID: fmt.Sprintf("eph-pair-%d", i), Agent: agent, Action: "ask", Repo: repo, Branch: "main", PullRequest: 1,
+			Ephemeral: &workflow.EphemeralSpec{Runtime: specRuntime, Capabilities: []string{"ask"}, Role: "worker"},
+		})
+	}
+	return []db.Job{mustWorkerJob(t, store, "eph-pair-0"), mustWorkerJob(t, store, "eph-pair-1")}
+}
+
+// TestSelectorSelectsTwoDistinctEphemeralJobsInOnePass drives the production
+// selector. Two ephemeral jobs on the SAME spec runtime start independent
+// sessions, so both must be selected in a single pass under a serializing
+// same-session policy. A routing mutant that gives them one shared key sends the
+// second to `remaining`, which no assertion about the key helper can see.
+func TestSelectorSelectsTwoDistinctEphemeralJobsInOnePass(t *testing.T) {
+	store, _ := ephemeralConsumerStore(t)
+	jobs := seedTwoEphemeralJobs(t, store, runtime.ClaudeRuntime)
+
+	selected, remaining := selectRunnableQueuedJobsWithPolicy(context.Background(), store, jobs, 2,
+		config.ParallelSessionPolicy{SameSession: config.ParallelSessionQueue})
+
+	if len(selected) != 2 {
+		t.Fatalf("selected %d of 2 distinct ephemeral jobs (remaining=%d); they start separate sessions and must not serialize",
+			len(selected), len(remaining))
+	}
+	if len(remaining) != 0 {
+		t.Fatalf("remaining = %+v, want empty", remaining)
+	}
+	if selected[0].ID == selected[1].ID {
+		t.Fatalf("selector returned the same job twice: %+v", selected)
+	}
+}
+
+// TestQueuedDispatchRunsTwoDistinctEphemeralJobsInOnePass is the same property
+// one level up, at the behaviour an operator would notice: two independent
+// ephemeral workers run in one dispatch pass rather than one waiting on the
+// other's session.
+func TestQueuedDispatchRunsTwoDistinctEphemeralJobsInOnePass(t *testing.T) {
+	ctx := context.Background()
+	store, home := ephemeralConsumerStore(t)
+	seedTwoEphemeralJobs(t, store, runtime.ClaudeRuntime)
+
+	starter := &cliWorkerFakeAdapter{startRuntimeRef: "550e8400-e29b-41d4-a716-446655441111"}
+	worker := defaultJobWorker(store, io.Discard, home)
+	worker.StartAdapterFactory = func(execbackend.Backend, string, string) (runtime.Adapter, error) { return starter, nil }
+	worker.AdapterFactory = func(runtime.Agent, string) (workflow.DeliveryAdapter, error) {
+		return &cliWorkerFakeAdapter{output: poolSchedulerAskResult}, nil
+	}
+	worker.CheckoutValidator = func(context.Context, db.Job, workflow.JobPayload, runtime.Agent) (string, error) {
+		return t.TempDir(), nil
+	}
+	if err := runQueuedJobsForRepo(ctx, worker, 2, "", ""); err != nil {
+		t.Fatalf("runQueuedJobsForRepo: %v", err)
+	}
+
+	var stillQueued []string
+	for _, id := range []string{"eph-pair-0", "eph-pair-1"} {
+		if job := mustWorkerJob(t, store, id); job.State == string(workflow.JobQueued) {
+			stillQueued = append(stillQueued, id)
+		}
+	}
+	if len(stillQueued) != 0 {
+		t.Fatalf("jobs still queued after a 2-slot pass: %v — one ephemeral job waited on the other's session", stillQueued)
+	}
+}
+
+// TestSelectorStillSerializesOneRegisteredSession is the should-SUCCEED control,
+// and it is what stops the cheap fix: independence must come from keying
+// ephemeral jobs separately, NOT from weakening runtime serialization. Two
+// non-ephemeral jobs on the SAME registered resumable session must still yield
+// exactly one selected job under a queueing policy (#684).
+//
+// Green at both heads by construction — it is a control, not a regression — so
+// it is paired with a mutant that removes serialization entirely.
+func TestSelectorStillSerializesOneRegisteredSession(t *testing.T) {
+	store, _ := ephemeralConsumerStore(t)
+	// Different repos again, so the single selection is attributable to the shared
+	// RUNTIME session key rather than to a shared checkout key.
+	for _, repo := range []string{"owner/repo-a", "owner/repo-b"} {
+		seedDaemonWorkerRepo(t, store, repo, t.TempDir())
+	}
+	seedDaemonWorkerAgent(t, store, "shared-session", runtime.ClaudeRuntime, "session-shared", []string{"ask"}, "owner/repo-a,owner/repo-b")
+	for i, repo := range []string{"owner/repo-a", "owner/repo-b"} {
+		enqueueDaemonWorkerJob(t, store, workflow.JobRequest{
+			ID: fmt.Sprintf("reg-%d", i), Agent: "shared-session", Action: "ask", Repo: repo, Branch: "main", PullRequest: 1,
+		})
+	}
+	jobs := []db.Job{mustWorkerJob(t, store, "reg-0"), mustWorkerJob(t, store, "reg-1")}
+
+	selected, remaining := selectRunnableQueuedJobsWithPolicy(context.Background(), store, jobs, 2,
+		config.ParallelSessionPolicy{SameSession: config.ParallelSessionQueue})
+
+	if len(selected) != 1 || len(remaining) != 1 {
+		t.Fatalf("selected=%d remaining=%d, want 1/1: two jobs sharing one registered session must serialize",
+			len(selected), len(remaining))
+	}
+}
+
+// TestBouncedBusyExclusionKeepsADistinctEphemeralJob covers the SECOND routing
+// site, which a mutant found after the first was fixed: excludeBouncedBusy drops
+// any still-pending job whose runtime key is in the bounced-busy set for this
+// pool invocation, via memoizedRuntimeResourceKey. Route ephemeral jobs through
+// one shared key there and a single busy bounce silently excludes EVERY other
+// ephemeral job in the pass — a starvation defect the selector arm cannot see,
+// because the selector never runs for the excluded jobs.
+//
+// The bounced set is built with the same helper production uses, because that is
+// this function's INPUT; the assertion is about which jobs survive, not about the
+// key's value.
+func TestBouncedBusyExclusionKeepsADistinctEphemeralJob(t *testing.T) {
+	ctx := context.Background()
+	store, _ := ephemeralConsumerStore(t)
+	jobs := seedTwoEphemeralJobs(t, store, runtime.ClaudeRuntime)
+	bouncedFirst, other := jobs[0], jobs[1]
+
+	// The bounced set MUST be built through the same memo map excludeBouncedBusy
+	// will use. A first version passed a nil memo, which takes
+	// memoizedRuntimeResourceKey's early-return path — so a mutant injected into
+	// the memoized branch produced a shared key inside the function under test
+	// while the fixture still held real per-job keys, the two never matched, and
+	// the mutant survived. The fixture has to travel the production path too.
+	worker := jobWorker{Store: store}
+	memo := map[string]string{}
+	bouncedRuntimes := map[string]bool{
+		memoizedRuntimeResourceKey(ctx, store, bouncedFirst, memo): true,
+	}
+	kept := excludeBouncedBusy(ctx, worker, []db.Job{other},
+		map[string]bool{bouncedFirst.ID: true}, bouncedRuntimes, memo)
+
+	if len(kept) != 1 || kept[0].ID != other.ID {
+		t.Fatalf("kept = %+v, want only %s: one ephemeral job bouncing busy must not exclude a DISTINCT ephemeral job",
+			kept, other.ID)
+	}
+}
+
+// TestBouncedBusyExclusionStillDropsTheSameSession is that arm's should-SUCCEED
+// control: exclusion must keep working for jobs that genuinely share a runtime
+// session, or "keep everything" would pass the test above.
+func TestBouncedBusyExclusionStillDropsTheSameSession(t *testing.T) {
+	ctx := context.Background()
+	store, _ := ephemeralConsumerStore(t)
+	for _, repo := range []string{"owner/repo-a", "owner/repo-b"} {
+		seedDaemonWorkerRepo(t, store, repo, t.TempDir())
+	}
+	seedDaemonWorkerAgent(t, store, "bounce-shared", runtime.ClaudeRuntime, "session-bounce", []string{"ask"}, "owner/repo-a,owner/repo-b")
+	for i, repo := range []string{"owner/repo-a", "owner/repo-b"} {
+		enqueueDaemonWorkerJob(t, store, workflow.JobRequest{
+			ID: fmt.Sprintf("bounce-%d", i), Agent: "bounce-shared", Action: "ask", Repo: repo, Branch: "main", PullRequest: 1,
+		})
+	}
+	first := mustWorkerJob(t, store, "bounce-0")
+	second := mustWorkerJob(t, store, "bounce-1")
+
+	memo := map[string]string{}
+	bouncedRuntimes := map[string]bool{memoizedRuntimeResourceKey(ctx, store, first, memo): true}
+	kept := excludeBouncedBusy(ctx, jobWorker{Store: store}, []db.Job{second},
+		map[string]bool{first.ID: true}, bouncedRuntimes, memo)
+
+	if len(kept) != 0 {
+		t.Fatalf("kept = %+v, want empty: a job sharing the bounced session must stay excluded", kept)
 	}
 }

--- a/internal/cli/ephemeral_runtime_consumers_test.go
+++ b/internal/cli/ephemeral_runtime_consumers_test.go
@@ -341,11 +341,30 @@ func TestSelectorSelectsTwoDistinctEphemeralJobsInOnePass(t *testing.T) {
 	}
 }
 
-// TestQueuedDispatchRunsTwoDistinctEphemeralJobsInOnePass is the same property
-// one level up, at the behaviour an operator would notice: two independent
-// ephemeral workers run in one dispatch pass rather than one waiting on the
-// other's session.
-func TestQueuedDispatchRunsTwoDistinctEphemeralJobsInOnePass(t *testing.T) {
+// TestQueuedDispatchEventuallyRunsBothDistinctEphemeralJobs asserts EVENTUAL
+// EXECUTION of both jobs despite distinct keying — deliberately NOT overlap.
+//
+// THE PRODUCTION CONTRACT, read from runQueuedJobsForRepo
+// (daemon_scheduler.go:1859-1909): the dispatcher loops while work remains; each
+// pass selects up to `limit` runnable jobs, admits them, launches each in its own
+// goroutine and joins them with ONE wg.Wait before the next pass. So jobs
+// co-selected in a pass do overlap, but passes are strictly SERIAL, and whether
+// two particular jobs share a pass is decided by the selector. There is no
+// independent guarantee that any two given jobs run in one pass.
+//
+// Hence this test cannot prove overlap: a second job serialized into a later
+// pass still finishes, so the assertion below holds either way. Its earlier name
+// claimed "InOnePass" and was wrong — the review found that under mutant M14 the
+// direct selector guard correctly fails while this test still passes. That guard
+// (TestSelectorSelectsTwoDistinctEphemeralJobsInOnePass, above) is the
+// discriminating regression for keying; this one only rules out the coarser
+// failure where a job never runs at all.
+//
+// No overlap assertion was added instead, because a barrier test would only
+// re-prove co-selection — which the selector guard already pins directly — while
+// adding a deadlock-on-regression failure mode. Naming a parallelism guarantee
+// production does not make would be worse than documenting eventual dispatch.
+func TestQueuedDispatchEventuallyRunsBothDistinctEphemeralJobs(t *testing.T) {
 	ctx := context.Background()
 	store, home := ephemeralConsumerStore(t)
 	seedTwoEphemeralJobs(t, store, runtime.ClaudeRuntime)
@@ -370,7 +389,7 @@ func TestQueuedDispatchRunsTwoDistinctEphemeralJobsInOnePass(t *testing.T) {
 		}
 	}
 	if len(stillQueued) != 0 {
-		t.Fatalf("jobs still queued after a 2-slot pass: %v — one ephemeral job waited on the other's session", stillQueued)
+		t.Fatalf("jobs still queued after the dispatcher drained: %v — a distinctly-keyed ephemeral job never ran at all (this asserts eventual execution, not overlap)", stillQueued)
 	}
 }
 

--- a/internal/cli/job.go
+++ b/internal/cli/job.go
@@ -1140,10 +1140,13 @@ func runJobRun(args []string, stdout, stderr io.Writer) int {
 		if err != nil {
 			return err
 		}
-		// #1641: refuse only when the walled runtime is the one this job will run
-		// as. selectedJobDispatchRuntime mirrors the claiming worker's own
-		// resolution (stored agent, then the payload override); an unresolvable
-		// agent yields "" and fails closed inside refuseUnavailableOrgRole.
+		// #1641/#1952: refuse only when the walled runtime is the one this job will
+		// run as. selectedJobDispatchRuntime mirrors the claiming worker's own
+		// precedence — per-job override, then an EPHEMERAL job's spec, then the
+		// registered agent row — and an unresolvable runtime yields "" and fails
+		// closed inside refuseUnavailableOrgRole. The earlier wording here said
+		// "stored agent, then the payload override", which described neither the
+		// worker nor this code once the spec took precedence.
 		if err := refuseUnavailableOrgRole(context.Background(), store, payload.ActingOrgRole,
 			selectedJobDispatchRuntime(context.Background(), store, job, payload), time.Now().UTC()); err != nil {
 			return err

--- a/internal/cli/job.go
+++ b/internal/cli/job.go
@@ -1140,7 +1140,12 @@ func runJobRun(args []string, stdout, stderr io.Writer) int {
 		if err != nil {
 			return err
 		}
-		if err := refuseUnavailableOrgRole(context.Background(), store, payload.ActingOrgRole, time.Now().UTC()); err != nil {
+		// #1641: refuse only when the walled runtime is the one this job will run
+		// as. selectedJobDispatchRuntime mirrors the claiming worker's own
+		// resolution (stored agent, then the payload override); an unresolvable
+		// agent yields "" and fails closed inside refuseUnavailableOrgRole.
+		if err := refuseUnavailableOrgRole(context.Background(), store, payload.ActingOrgRole,
+			selectedJobDispatchRuntime(context.Background(), store, job, payload), time.Now().UTC()); err != nil {
 			return err
 		}
 		worker := defaultJobWorker(store, stdout, *home)

--- a/internal/cli/job_blocker_auth_probe.go
+++ b/internal/cli/job_blocker_auth_probe.go
@@ -121,15 +121,17 @@ func (w jobWorker) probeAuthVerdict(ctx context.Context, job db.Job, payload wor
 }
 
 // authProbeDedupKey identifies the credential domain a probe result applies to:
-// the effective runtime (agent runtime + any per-job override). All auth-held jobs
-// that share this key share one ambient-token probe. If the agent can't be read,
-// key by agent name so a lookup failure never merges distinct agents' verdicts.
+// the runtime the job will ACTUALLY run as (#1952 — ephemeral spec first, then
+// the registered row, with any per-job override on top). All auth-held jobs that
+// share this key share one ambient-token probe. Keying off the registered row
+// alone merged an ephemeral Claude job into a stored shell agent's domain, so
+// Claude was never probed. If nothing resolves, key by agent name so a lookup
+// failure never merges distinct agents' verdicts.
 func (w jobWorker) authProbeDedupKey(ctx context.Context, job db.Job, payload workflow.JobPayload) string {
-	record, err := w.Store.GetAgent(ctx, job.Agent)
-	if err != nil {
+	agent, ok := selectedJobRuntimeAgent(ctx, w.Store, job, payload)
+	if !ok {
 		return "agent:" + job.Agent
 	}
-	agent := applyJobRuntimeOverride(runtimeAgent(record), payload)
 	key := "runtime:" + strings.TrimSpace(agent.Runtime)
 	// A READ-ONLY SEAT authenticates with a staged snapshot of its effective
 	// config dir, not with the ambient credential. Include the selected default
@@ -164,12 +166,17 @@ func (w jobWorker) extendAuthBlockerHold(ctx context.Context, job db.Job, payloa
 // Non-seat Claude jobs use runtimeJobRunnerWithAuth; read-only seats use a
 // disposable copy of their configured credential plus the resolved auth
 // overlay. Other runtimes remain Unknown.
+//
+// #1952: the runtime comes from selectedJobRuntimeAgent, so an EPHEMERAL Claude
+// job is probed on Claude even when a same-name agent row says otherwise. It
+// previously read that row, concluded "not Claude", and returned Unknown — and
+// because authProbeAllowsRedispatch releases Unknown, a Claude-auth-deferred
+// ephemeral job re-dispatched without its credential ever being validated.
 func (w jobWorker) defaultAuthProbe(ctx context.Context, job db.Job, payload workflow.JobPayload) authProbeVerdict {
-	record, err := w.Store.GetAgent(ctx, job.Agent)
-	if err != nil {
+	agent, ok := selectedJobRuntimeAgent(ctx, w.Store, job, payload)
+	if !ok {
 		return authProbeUnknown
 	}
-	agent := applyJobRuntimeOverride(runtimeAgent(record), payload)
 	if strings.TrimSpace(agent.Runtime) != runtime.ClaudeRuntime {
 		return authProbeUnknown
 	}

--- a/internal/cli/org.go
+++ b/internal/cli/org.go
@@ -1562,6 +1562,15 @@ func orgProviderSnapshot(ctx context.Context, cfg config.OrgConfig) (org.Snapsho
 // validateAndTouchActingOrgRole is the shared local job ingress for --org-role.
 // Validation happens before dispatch mutation; invalid/disabled config creates
 // neither a presence row nor a job.
+//
+// #1641: this ingress deliberately does NOT decide role unavailability. The
+// refusal is runtime-scoped, and the runtime a dispatch will actually use is not
+// known here — dispatchLocalAgentJob calls this before resolveLocalDispatchAgent,
+// which is what picks the agent (and may auto-select one via the managed path).
+// Each dispatch ingress calls refuseUnavailableOrgRole itself once its own
+// selected runtime is authoritative: agent_dispatch.go after effectiveAgent,
+// job.go after the stored agent plus the payload override, workflow.go after the
+// task owner is loaded, and daemon_scheduler.go per queued job.
 func validateAndTouchActingOrgRole(ctx context.Context, store *db.Store, home, role, command string) error {
 	role = strings.TrimSpace(role)
 	if role == "" {
@@ -1581,9 +1590,6 @@ func validateAndTouchActingOrgRole(ctx context.Context, store *db.Store, home, r
 	configuredRole, ok := cfg.Role(role)
 	if !ok {
 		return fmt.Errorf("unknown org role %q", role)
-	}
-	if err := refuseUnavailableOrgRole(ctx, store, configuredRole.Name, time.Now().UTC()); err != nil {
-		return err
 	}
 	// Recycle enforcement only applies to operator-origin --org-role dispatches:
 	// this ingress (dispatchLocalAgentJob) is the sole path passing a non-empty

--- a/internal/cli/org_role_unavailable.go
+++ b/internal/cli/org_role_unavailable.go
@@ -192,7 +192,57 @@ func unavailableRoleDispatchError(incident db.OrgRoleUnavailable) error {
 		incident.Role, incident.Reason, formatOrgRoleUnavailableUntil(incident.Until))
 }
 
-func refuseUnavailableOrgRole(ctx context.Context, store *db.Store, role string, now time.Time) error {
+// knownRuntimeName reports whether name resolves to a real runtime adapter.
+// This is the same test the per-job --runtime override validation uses
+// (resolveJobRuntimeOverride), so an unrecognized stored or selected runtime is
+// classified identically at both ends.
+func knownRuntimeName(name string) bool {
+	if strings.TrimSpace(name) == "" {
+		return false
+	}
+	_, err := (runtime.Factory{}).Adapter(strings.ToLower(strings.TrimSpace(name)))
+	return err == nil
+}
+
+// orgRoleUnavailableRefusesRuntime decides whether an ACTIVE incident row bars a
+// dispatch whose selected runtime is selectedRuntime (#1641).
+//
+// The row is written per-runtime (UpsertOrgRoleUnavailableForRuntime) because a
+// provider wall is a property of one provider, not of the role: a claude quota
+// wall says nothing about codex or kimi. Enforcement must therefore compare the
+// row's runtime against the runtime this dispatch will ACTUALLY use.
+//
+// FAIL CLOSED, in both directions:
+//   - An empty stored runtime keeps its pre-#1641 whole-role meaning. It is not a
+//     corrupt value: UpsertOrgRoleUnavailable still writes "", and the runtime
+//     column was added by ALTER TABLE ... DEFAULT ” (#1490), so every row
+//     predating runtime attribution is legitimately unattributed.
+//   - An unrecognized stored runtime is corrupt, and corruption is not permission
+//     to dispatch.
+//   - An empty or unrecognized SELECTED runtime means the caller could not say
+//     what this job will run as, so it cannot claim to be a different runtime.
+func orgRoleUnavailableRefusesRuntime(incident db.OrgRoleUnavailable, selectedRuntime string) bool {
+	stored := strings.ToLower(strings.TrimSpace(incident.Runtime))
+	if !knownRuntimeName(stored) {
+		return true
+	}
+	selected := strings.ToLower(strings.TrimSpace(selectedRuntime))
+	if !knownRuntimeName(selected) {
+		return true
+	}
+	return stored == selected
+}
+
+// refuseUnavailableOrgRole refuses a dispatch only when the role's active
+// incident belongs to the runtime this dispatch actually selected. Callers must
+// pass the runtime from their own final resolution — the value the job will run
+// as, overrides included — never the registered agent's default when an override
+// is in play.
+//
+// The store read is unconditional so its eager expiry of a stale row (and
+// #1490's fail-closed error on a malformed until) still happens for every
+// dispatch, whatever the runtime decision turns out to be.
+func refuseUnavailableOrgRole(ctx context.Context, store *db.Store, role, selectedRuntime string, now time.Time) error {
 	role = strings.TrimSpace(role)
 	if role == "" || store == nil {
 		return nil
@@ -201,8 +251,35 @@ func refuseUnavailableOrgRole(ctx context.Context, store *db.Store, role string,
 	if err != nil {
 		return fmt.Errorf("read org role %q unavailability: %w", role, err)
 	}
-	if found {
+	if found && orgRoleUnavailableRefusesRuntime(incident, selectedRuntime) {
 		return unavailableRoleDispatchError(incident)
 	}
 	return nil
+}
+
+// selectedJobDispatchRuntime reports the runtime a QUEUED job will actually run
+// as, resolved exactly as the claiming worker resolves it: the registered
+// agent's runtime, with a per-job --runtime override swapped in when the payload
+// carries one (#531).
+//
+// It returns "" when the agent cannot be resolved, and callers must treat that
+// as unknown rather than as "not the walled runtime" — refuseUnavailableOrgRole
+// fails closed on an empty value. Deliberately NOT resolveTranscriptRuntime:
+// that helper answers "which transcript should I read", accepting a requested
+// override and falling back to payload.Ephemeral.Runtime, which is not the
+// dispatch decision.
+func selectedJobDispatchRuntime(ctx context.Context, store *db.Store, job db.Job, payload workflow.JobPayload) string {
+	if store == nil {
+		return ""
+	}
+	agent, err := store.GetAgent(ctx, job.Agent)
+	if err != nil {
+		// An ephemeral job carries its runtime in the payload rather than the
+		// agents table, and that IS the dispatch decision for such a job.
+		if payload.Ephemeral != nil {
+			return applyJobRuntimeOverride(runtime.Agent{Runtime: payload.Ephemeral.Runtime}, payload).Runtime
+		}
+		return ""
+	}
+	return applyJobRuntimeOverride(runtimeAgent(agent), payload).Runtime
 }

--- a/internal/cli/org_role_unavailable.go
+++ b/internal/cli/org_role_unavailable.go
@@ -284,15 +284,48 @@ func refuseUnavailableOrgRole(ctx context.Context, store *db.Store, role, select
 // onto the agent at enqueue for exactly this reason. A dispatch refusal is an
 // execute-path decision.
 func selectedJobDispatchRuntime(ctx context.Context, store *db.Store, job db.Job, payload workflow.JobPayload) string {
-	if payload.Ephemeral != nil {
-		return applyJobRuntimeOverride(runtime.Agent{Runtime: payload.Ephemeral.Runtime}, payload).Runtime
+	agent, ok := selectedJobRuntimeAgent(ctx, store, job, payload)
+	if !ok {
+		return ""
+	}
+	return agent.Runtime
+}
+
+// selectedJobRuntimeAgent resolves the runtime.Agent a QUEUED job will actually
+// run as, and is the ONE place the precedence override > ephemeral spec >
+// registered row is expressed. Every execute-path decision about a queued job —
+// refuse, hold, probe, reserve, serialize — must resolve through here, because
+// the whole #1641/#1952 defect class is a consumer that derived a runtime from
+// the agents table while the job ran on something else.
+//
+// For an ephemeral job the spec is reconstructed with the same fields
+// startEphemeralWorker materializes, so a caller that needs more than the
+// runtime name (an auth probe needs the autonomy policy and template; a resource
+// key needs the runtime) sees the agent the worker will build rather than a
+// runtime string in a hollow struct.
+//
+// ok=false means UNRESOLVABLE, never "some other runtime": callers must fail
+// closed on it, and each one keeps the conservative fallback it already had.
+func selectedJobRuntimeAgent(ctx context.Context, store *db.Store, job db.Job, payload workflow.JobPayload) (runtime.Agent, bool) {
+	if spec := payload.Ephemeral; spec != nil {
+		return applyJobRuntimeOverride(runtime.Agent{
+			Name:           job.Agent,
+			Role:           firstNonEmpty(strings.TrimSpace(spec.Role), strings.TrimSpace(job.Type), "worker"),
+			Runtime:        spec.Runtime,
+			Model:          spec.Model,
+			Effort:         spec.Effort,
+			TemplateID:     spec.Template,
+			Capabilities:   spec.Capabilities,
+			AutonomyPolicy: spec.AutonomyPolicy,
+			RepoScope:      payload.Repo,
+		}, payload), true
 	}
 	if store == nil {
-		return ""
+		return runtime.Agent{}, false
 	}
 	agent, err := store.GetAgent(ctx, job.Agent)
 	if err != nil {
-		return ""
+		return runtime.Agent{}, false
 	}
-	return applyJobRuntimeOverride(runtimeAgent(agent), payload).Runtime
+	return applyJobRuntimeOverride(runtimeAgent(agent), payload), true
 }

--- a/internal/cli/org_role_unavailable.go
+++ b/internal/cli/org_role_unavailable.go
@@ -258,27 +258,40 @@ func refuseUnavailableOrgRole(ctx context.Context, store *db.Store, role, select
 }
 
 // selectedJobDispatchRuntime reports the runtime a QUEUED job will actually run
-// as, resolved exactly as the claiming worker resolves it: the registered
-// agent's runtime, with a per-job --runtime override swapped in when the payload
-// carries one (#531).
+// as, resolved in the same order the claiming worker resolves it.
 //
-// It returns "" when the agent cannot be resolved, and callers must treat that
-// as unknown rather than as "not the walled runtime" — refuseUnavailableOrgRole
-// fails closed on an empty value. Deliberately NOT resolveTranscriptRuntime:
-// that helper answers "which transcript should I read", accepting a requested
-// override and falling back to payload.Ephemeral.Runtime, which is not the
-// dispatch decision.
+// THE ORDER IS LOAD-BEARING AND IS NOT THE OBVIOUS ONE (#1641, #1952 review):
+//
+//  1. An ephemeral job's spec wins. daemon_worker.go materializes the throwaway
+//     worker UNCONDITIONALLY when payload.Ephemeral is set, building the agent
+//     from spec.Runtime and UpsertAgent-ing it under the job's agent name — so it
+//     OVERWRITES any pre-existing row of that name. Consulting the agents table
+//     first therefore checks the wall against a runtime that will never execute
+//     whenever a same-name row happens to exist.
+//  2. Otherwise the registered agent's runtime.
+//  3. A per-job runtime override wins over both, because the worker applies it
+//     after materialization.
+//
+// Returning "" means UNKNOWN, not "some other runtime": refuseUnavailableOrgRole
+// fails closed on an empty value, so an ephemeral spec with an empty or
+// unrecognized runtime refuses rather than dispatches.
+//
+// Deliberately NOT resolveTranscriptRuntime, and for a sharper reason than the
+// first version of this comment gave: that helper answers "which transcript do I
+// read" and treats the ephemeral spec as a LAST fallback, the same shape
+// dashboard_web.go uses for a rendered column. Read/display paths may rank the
+// spec last; write/execute paths must not — mailbox.go assigns the spec's runtime
+// onto the agent at enqueue for exactly this reason. A dispatch refusal is an
+// execute-path decision.
 func selectedJobDispatchRuntime(ctx context.Context, store *db.Store, job db.Job, payload workflow.JobPayload) string {
+	if payload.Ephemeral != nil {
+		return applyJobRuntimeOverride(runtime.Agent{Runtime: payload.Ephemeral.Runtime}, payload).Runtime
+	}
 	if store == nil {
 		return ""
 	}
 	agent, err := store.GetAgent(ctx, job.Agent)
 	if err != nil {
-		// An ephemeral job carries its runtime in the payload rather than the
-		// agents table, and that IS the dispatch decision for such a job.
-		if payload.Ephemeral != nil {
-			return applyJobRuntimeOverride(runtime.Agent{Runtime: payload.Ephemeral.Runtime}, payload).Runtime
-		}
 		return ""
 	}
 	return applyJobRuntimeOverride(runtimeAgent(agent), payload).Runtime

--- a/internal/cli/org_role_unavailable_runtime_test.go
+++ b/internal/cli/org_role_unavailable_runtime_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -510,4 +511,166 @@ func TestRunTaskRunScopesRoleUnavailabilityToTheOwnersRuntime(t *testing.T) {
 			t.Fatalf("jobs after a refused task run = %+v err=%v, want none", jobs, err)
 		}
 	})
+}
+
+// #1952 review P2: the wall must be checked against the runtime that will
+// EXECUTE. daemon_worker materializes an ephemeral worker unconditionally from
+// payload.Ephemeral.Runtime and upserts it over any same-name agent row, so a
+// resolver that consults the agents table first checks a runtime that never
+// runs. Every test below plants an extant same-name agent row of a DIFFERENT
+// runtime, which is the condition that made the defect invisible.
+
+const ephemeralWalledJobAgent = "wave-impl-ephemeral"
+
+func seedEphemeralWalledJob(t *testing.T, store *db.Store, home, jobID, storedRuntime, specRuntime, walledRuntime string) {
+	t.Helper()
+	// The agents-table row the old resolver would have believed.
+	seedDaemonWorkerAgent(t, store, ephemeralWalledJobAgent, storedRuntime, unavailableRuntimeShellScript,
+		[]string{"ask"}, "owner/repo")
+	seedCLIJob(t, store, db.Job{
+		ID:    jobID,
+		Agent: ephemeralWalledJobAgent,
+		Type:  "ask",
+		State: string(workflow.JobQueued),
+		Payload: mustJobPayload(t, workflow.JobPayload{
+			Repo: "owner/repo", Branch: "main", ActingOrgRole: "review",
+			Ephemeral: &workflow.EphemeralSpec{Runtime: specRuntime},
+		}),
+	}, "queued")
+	now := time.Now().UTC()
+	if walledRuntime != "" {
+		if err := store.UpsertOrgRoleUnavailableForRuntime(context.Background(), "review", walledRuntime, "quota", now.Add(time.Hour), now); err != nil {
+			t.Fatal(err)
+		}
+	}
+	_ = home
+}
+
+// TestJobRunRefusesAnEphemeralJobWhoseSpecRuntimeIsWalled is the #1952 P2
+// regression on the `job run` path: stored row says shell, the spec says claude,
+// claude is walled. The old resolver read the stored row and dispatched.
+func TestJobRunRefusesAnEphemeralJobWhoseSpecRuntimeIsWalled(t *testing.T) {
+	home, store := seedRoleUnavailableJobHome(t)
+	seedEphemeralWalledJob(t, store, home, "job-eph-walled", runtime.ShellRuntime, "claude", "claude")
+
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{"job", "run", "job-eph-walled", "--home", home}, &stdout, &stderr)
+	if code != 1 || !strings.Contains(stderr.String(), `org role "review" is unavailable`) ||
+		!strings.Contains(stderr.String(), "dispatch refused") {
+		t.Fatalf("ephemeral job on a walled spec runtime was not refused: code=%d stdout=%q stderr=%q",
+			code, stdout.String(), stderr.String())
+	}
+	job, err := store.GetJob(context.Background(), "job-eph-walled")
+	if err != nil || job.State != string(workflow.JobQueued) {
+		t.Fatalf("job = %+v err=%v, want still queued (refused before start)", job, err)
+	}
+}
+
+// TestJobRunDispatchesAnEphemeralJobWhenAnotherRuntimeIsWalled is the
+// should-succeed control: the fix must not buy correctness by refusing every
+// ephemeral job. Spec runtime is shell, the wall names claude, and the stored
+// row deliberately says claude so a resolver that still preferred the agents
+// table would refuse here.
+func TestJobRunDispatchesAnEphemeralJobWhenAnotherRuntimeIsWalled(t *testing.T) {
+	home, store := seedRoleUnavailableJobHome(t)
+	seedEphemeralWalledJob(t, store, home, "job-eph-clear", "claude", runtime.ShellRuntime, "claude")
+
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{"job", "run", "job-eph-clear", "--home", home}, &stdout, &stderr)
+	if strings.Contains(stderr.String(), "dispatch refused") {
+		t.Fatalf("a wall on a non-selected runtime refused an ephemeral dispatch: code=%d stderr=%q", code, stderr.String())
+	}
+	job, err := store.GetJob(context.Background(), "job-eph-clear")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if job.State == string(workflow.JobQueued) {
+		t.Fatalf("job never left queued, so the wall held it: %+v stderr=%q", job, stderr.String())
+	}
+}
+
+// TestJobRunFailsClosedOnAnEphemeralSpecRuntimeItCannotUse keeps the fail-closed
+// half honest for the new precedence: an ephemeral spec naming nothing usable
+// must refuse rather than be treated as "some runtime other than the walled one".
+func TestJobRunFailsClosedOnAnEphemeralSpecRuntimeItCannotUse(t *testing.T) {
+	for _, specRuntime := range []string{"", "not-a-runtime"} {
+		name := specRuntime
+		if name == "" {
+			name = "empty spec runtime"
+		}
+		t.Run(name, func(t *testing.T) {
+			home, store := seedRoleUnavailableJobHome(t)
+			seedEphemeralWalledJob(t, store, home, "job-eph-closed", runtime.ShellRuntime, specRuntime, "claude")
+			var stdout, stderr bytes.Buffer
+			code := Run([]string{"job", "run", "job-eph-closed", "--home", home}, &stdout, &stderr)
+			if code != 1 || !strings.Contains(stderr.String(), "dispatch refused") {
+				t.Fatalf("unusable ephemeral spec runtime %q not refused: code=%d stderr=%q", specRuntime, code, stderr.String())
+			}
+		})
+	}
+}
+
+// TestQueuedEphemeralJobIsHeldWhenItsSpecRuntimeIsWalled is the same regression
+// through the DAEMON path the reviewer's adversary used: runQueuedJobsForRepo.
+// It asserts the hold lands before start AND before delivery — the adapter
+// factory fails the test if it is ever reached, which is what "refused before
+// delivery" has to mean.
+func TestQueuedEphemeralJobIsHeldWhenItsSpecRuntimeIsWalled(t *testing.T) {
+	ctx := context.Background()
+	store := daemonWorkerStore(t)
+	seedDaemonWorkerRepo(t, store, "owner/repo", t.TempDir())
+	seedDaemonWorkerAgent(t, store, ephemeralWalledJobAgent, runtime.ShellRuntime, "unused", []string{"ask"}, "owner/repo")
+	enqueueDaemonWorkerJob(t, store, workflow.JobRequest{
+		ID: "queued-eph-walled", Agent: ephemeralWalledJobAgent, Action: "ask",
+		Repo: "owner/repo", Branch: "main", ActingOrgRole: "review",
+		Ephemeral: &workflow.EphemeralSpec{Runtime: "claude"},
+	})
+	now := time.Now().UTC()
+	if err := store.UpsertOrgRoleUnavailableForRuntime(ctx, "review", "claude", "quota", now.Add(time.Hour), now); err != nil {
+		t.Fatal(err)
+	}
+
+	worker := defaultJobWorker(store, io.Discard)
+	worker.CheckoutValidator = func(context.Context, db.Job, workflow.JobPayload, runtime.Agent) (string, error) {
+		return t.TempDir(), nil
+	}
+	worker.AdapterFactory = func(agent runtime.Agent, _ string) (workflow.DeliveryAdapter, error) {
+		t.Fatalf("delivery reached for a job whose selected runtime %q is walled", agent.Runtime)
+		return nil, nil
+	}
+	if err := runQueuedJobsForRepo(ctx, worker, 1, "", ""); err != nil {
+		t.Fatalf("runQueuedJobsForRepo returned error: %v", err)
+	}
+	job, err := store.GetJob(ctx, "queued-eph-walled")
+	if err != nil || job.State != string(workflow.JobQueued) {
+		t.Fatalf("queued ephemeral job = %+v err=%v, want held in queued", job, err)
+	}
+}
+
+// TestQueuedEphemeralJobRunsWhenAnotherRuntimeIsWalled is the daemon-path
+// should-succeed control, and the reason it matters: the stored row names the
+// WALLED runtime while the spec names a clear one, so a resolver that preferred
+// the agents table would hold a job that is perfectly safe to run.
+func TestQueuedEphemeralJobRunsWhenAnotherRuntimeIsWalled(t *testing.T) {
+	ctx := context.Background()
+	store := daemonWorkerStore(t)
+	seedDaemonWorkerRepo(t, store, "owner/repo", t.TempDir())
+	seedDaemonWorkerAgent(t, store, ephemeralWalledJobAgent, "claude", "unused", []string{"ask"}, "owner/repo")
+	enqueueDaemonWorkerJob(t, store, workflow.JobRequest{
+		ID: "queued-eph-clear", Agent: ephemeralWalledJobAgent, Action: "ask",
+		Repo: "owner/repo", Branch: "main", ActingOrgRole: "review",
+		Ephemeral: &workflow.EphemeralSpec{Runtime: runtime.ShellRuntime},
+	})
+	now := time.Now().UTC()
+	if err := store.UpsertOrgRoleUnavailableForRuntime(ctx, "review", "claude", "quota", now.Add(time.Hour), now); err != nil {
+		t.Fatal(err)
+	}
+
+	pending, err := listPendingQueuedJobs(ctx, jobWorker{Store: store}, "", "", false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(pending) != 1 || pending[0].ID != "queued-eph-clear" {
+		t.Fatalf("pending = %+v, want the ephemeral job eligible: its spec runtime is not the walled one", pending)
+	}
 }

--- a/internal/cli/org_role_unavailable_runtime_test.go
+++ b/internal/cli/org_role_unavailable_runtime_test.go
@@ -3,9 +3,14 @@ package cli
 import (
 	"bytes"
 	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/gitmoot/gitmoot/internal/config"
 
 	"github.com/gitmoot/gitmoot/internal/db"
 	"github.com/gitmoot/gitmoot/internal/db/dbtest"
@@ -300,4 +305,209 @@ func TestRefuseUnavailableOrgRoleClearsAnExpiredRowWhateverTheRuntime(t *testing
 	if err != nil || len(rows) != 0 {
 		t.Fatalf("active rows after expiry = %+v err=%v, want none", rows, err)
 	}
+}
+
+// subscribeShellAskAgent registers a shell-runtime agent whose session script
+// returns a terminal approved result, so an `agent ask` dispatch through the
+// real path can reach success rather than stalling on delivery.
+func subscribeShellAskAgent(t *testing.T, home, name, repo string) {
+	t.Helper()
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{
+		"agent", "subscribe", name,
+		"--home", home,
+		"--runtime", "shell",
+		"--session", unavailableRuntimeShellScript,
+		"--role", "review",
+		"--repo", repo,
+		"--capability", "ask",
+		"--policy", "workspace-write",
+	}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("agent subscribe %s exit=%d stderr=%q", name, code, stderr.String())
+	}
+}
+
+// TestLocalAgentDispatchScopesRoleUnavailabilityToTheSelectedRuntime is the test
+// arm for the agent_dispatch.go callsite (#1641, authorised in 126292). It drives
+// the REAL `agent ask --org-role` path — dispatchLocalAgentJob — rather than the
+// refusal helper, so a routing mutant that left this path refusing role-wide
+// cannot pass it. The two subtests differ ONLY in which runtime the wall names.
+func TestLocalAgentDispatchScopesRoleUnavailabilityToTheSelectedRuntime(t *testing.T) {
+	setup := func(t *testing.T, walledRuntime string) (string, config.Paths) {
+		t.Helper()
+		home, paths := setupQuotaUnavailableOrgHome(t)
+		subscribeShellAskAgent(t, home, "asker", "gitmoot/gitmoot")
+		checkout := t.TempDir()
+		runGit(t, checkout, "init")
+		runGit(t, checkout, "branch", "-m", "main")
+		runGit(t, checkout, "remote", "add", "origin", "https://github.com/gitmoot/gitmoot.git")
+		if err := os.WriteFile(filepath.Join(checkout, "README.md"), []byte("test\n"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		runGit(t, checkout, "add", "README.md")
+		runGit(t, checkout, "-c", "user.name=Gitmoot Test", "-c", "user.email=gitmoot@example.com", "commit", "-m", "initial")
+		withWorkingDirectory(t, checkout)
+
+		store, err := dbtest.Open(t, paths.Database)
+		if err != nil {
+			t.Fatal(err)
+		}
+		now := time.Now().UTC()
+		if err := store.UpsertOrgRoleUnavailableForRuntime(context.Background(), "review", walledRuntime, "quota", now.Add(time.Hour), now); err != nil {
+			store.Close()
+			t.Fatal(err)
+		}
+		if err := store.Close(); err != nil {
+			t.Fatal(err)
+		}
+		return home, paths
+	}
+
+	t.Run("another runtime is walled so the dispatch proceeds", func(t *testing.T) {
+		home, _ := setup(t, "claude")
+		var stdout, stderr bytes.Buffer
+		code := Run([]string{
+			"agent", "ask", "asker", "what is the state of the repo?",
+			"--home", home, "--repo", "gitmoot/gitmoot", "--org-role", "review", "--json",
+		}, &stdout, &stderr)
+		if code != 0 {
+			t.Fatalf("claude wall refused a shell agent dispatch: code=%d stdout=%q stderr=%q", code, stdout.String(), stderr.String())
+		}
+		if strings.Contains(stderr.String(), "dispatch refused") {
+			t.Fatalf("cross-runtime dispatch reported a refusal: stderr=%q", stderr.String())
+		}
+		var output localAgentJobOutput
+		if err := json.Unmarshal(stdout.Bytes(), &output); err != nil {
+			t.Fatalf("parse ask output %q: %v", stdout.String(), err)
+		}
+		if output.State != string(workflow.JobSucceeded) {
+			t.Fatalf("ask state = %q, want succeeded", output.State)
+		}
+	})
+
+	t.Run("the selected runtime is walled so the dispatch is refused", func(t *testing.T) {
+		home, paths := setup(t, runtime.ShellRuntime)
+		var stdout, stderr bytes.Buffer
+		code := Run([]string{
+			"agent", "ask", "asker", "what is the state of the repo?",
+			"--home", home, "--repo", "gitmoot/gitmoot", "--org-role", "review", "--json",
+		}, &stdout, &stderr)
+		if code == 0 || !strings.Contains(stderr.String(), `org role "review" is unavailable`) ||
+			!strings.Contains(stderr.String(), "dispatch refused") {
+			t.Fatalf("same-runtime dispatch not refused: code=%d stdout=%q stderr=%q", code, stdout.String(), stderr.String())
+		}
+		store, err := dbtest.Open(t, paths.Database)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer store.Close()
+		if jobs, err := store.ListJobs(context.Background()); err != nil || len(jobs) != 0 {
+			t.Fatalf("jobs after a refused dispatch = %+v err=%v, want none", jobs, err)
+		}
+	})
+}
+
+// TestRunTaskRunScopesRoleUnavailabilityToTheOwnersRuntime is the test arm for
+// the workflow.go callsite. `task run` has no --runtime flag, so the owner
+// agent's runtime IS the selection. The refused half asserts exactly what the
+// pre-existing TestRunTaskRunRefusesUnavailableRoleBeforeWorktreeAllocation
+// asserts; the proceeding half asserts the same facts inverted, so the pair is
+// directly comparable rather than differently shaped.
+func TestRunTaskRunScopesRoleUnavailabilityToTheOwnersRuntime(t *testing.T) {
+	setup := func(t *testing.T, walledRuntime string) (string, config.Paths) {
+		t.Helper()
+		home, paths := setupQuotaUnavailableOrgHome(t)
+		goalPath := filepath.Join(t.TempDir(), "GOAL.md")
+		if err := os.WriteFile(goalPath, []byte("# Build Gitmoot\n\n### Task 1: Bootstrap\n"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		var stdout, stderr bytes.Buffer
+		if code := Run([]string{"goal", "import", "--home", home, "--file", goalPath, "--repo", "gitmoot/gitmoot"}, &stdout, &stderr); code != 0 {
+			t.Fatalf("goal import code=%d stderr=%q", code, stderr.String())
+		}
+		subscribeShellImplementAgent(t, home, "lead", "gitmoot/gitmoot")
+		checkout := t.TempDir()
+		runGit(t, checkout, "init")
+		runGit(t, checkout, "branch", "-m", "main")
+		runGit(t, checkout, "remote", "add", "origin", "https://github.com/gitmoot/gitmoot.git")
+		if err := os.WriteFile(filepath.Join(checkout, "README.md"), []byte("test\n"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		runGit(t, checkout, "add", "README.md")
+		runGit(t, checkout, "-c", "user.name=Gitmoot Test", "-c", "user.email=gitmoot@example.com", "commit", "-m", "initial")
+		withWorkingDirectory(t, checkout)
+
+		store, err := dbtest.Open(t, paths.Database)
+		if err != nil {
+			t.Fatal(err)
+		}
+		now := time.Now().UTC()
+		if err := store.UpsertOrgRoleUnavailableForRuntime(context.Background(), "review", walledRuntime, "quota", now.Add(time.Hour), now); err != nil {
+			store.Close()
+			t.Fatal(err)
+		}
+		if err := store.Close(); err != nil {
+			t.Fatal(err)
+		}
+		return home, paths
+	}
+
+	t.Run("another runtime is walled so task run proceeds", func(t *testing.T) {
+		home, paths := setup(t, "claude")
+		var stdout, stderr bytes.Buffer
+		Run([]string{
+			"task", "run", "task-001", "--home", home, "--repo", "gitmoot/gitmoot",
+			"--owner", "lead", "--org-role", "review",
+		}, &stdout, &stderr)
+		if strings.Contains(stderr.String(), "dispatch refused") {
+			t.Fatalf("claude wall refused a shell owner's task run: stderr=%q", stderr.String())
+		}
+		store, err := dbtest.Open(t, paths.Database)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer store.Close()
+		// The pre-existing refusal test asserts the task is untouched and no job
+		// exists. Under a wall on a DIFFERENT runtime both must have happened.
+		task, err := store.GetTask(context.Background(), "task-001")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if strings.TrimSpace(task.WorktreePath) == "" {
+			t.Fatalf("task never allocated a worktree, so the dispatch did not proceed: %+v", task)
+		}
+		jobs, err := store.ListJobs(context.Background())
+		if err != nil || len(jobs) == 0 {
+			t.Fatalf("jobs after a proceeding task run = %+v err=%v, want at least one", jobs, err)
+		}
+	})
+
+	t.Run("the owner's runtime is walled so task run is refused", func(t *testing.T) {
+		home, paths := setup(t, runtime.ShellRuntime)
+		var stdout, stderr bytes.Buffer
+		code := Run([]string{
+			"task", "run", "task-001", "--home", home, "--repo", "gitmoot/gitmoot",
+			"--owner", "lead", "--org-role", "review",
+		}, &stdout, &stderr)
+		if code != 1 || !strings.Contains(stderr.String(), `org role "review" is unavailable`) ||
+			!strings.Contains(stderr.String(), "dispatch refused") {
+			t.Fatalf("task run on the walled runtime: code=%d stdout=%q stderr=%q", code, stdout.String(), stderr.String())
+		}
+		store, err := dbtest.Open(t, paths.Database)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer store.Close()
+		task, err := store.GetTask(context.Background(), "task-001")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if task.State != string(workflow.TaskPlanned) || strings.TrimSpace(task.WorktreePath) != "" {
+			t.Fatalf("task mutated before the refusal: %+v", task)
+		}
+		if jobs, err := store.ListJobs(context.Background()); err != nil || len(jobs) != 0 {
+			t.Fatalf("jobs after a refused task run = %+v err=%v, want none", jobs, err)
+		}
+	})
 }

--- a/internal/cli/org_role_unavailable_runtime_test.go
+++ b/internal/cli/org_role_unavailable_runtime_test.go
@@ -1,0 +1,303 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gitmoot/gitmoot/internal/db"
+	"github.com/gitmoot/gitmoot/internal/db/dbtest"
+	"github.com/gitmoot/gitmoot/internal/runtime"
+	"github.com/gitmoot/gitmoot/internal/workflow"
+)
+
+// #1641: org role unavailability is RECORDED per runtime but was ENFORCED per
+// role, so a claude quota wall refused healthy codex and kimi dispatches for the
+// same role. Every test here drives a real entry point — `job run`, the queued
+// listing the daemon schedules from, or the --org-role ingress — so it compiles
+// and runs unchanged against the pre-fix tree; the cross-runtime cases are the
+// red baseline.
+
+const unavailableRuntimeShellScript = `printf '%s\n' '{"gitmoot_result":{"decision":"approved","summary":"done","findings":[],"changes_made":[],"tests_run":[],"needs":[],"delegations":[]}}'`
+
+func seedRoleUnavailableJobHome(t *testing.T) (string, *db.Store) {
+	t.Helper()
+	home := t.TempDir()
+	store := openCLIJobStore(t, home)
+	t.Cleanup(func() { store.Close() })
+	checkout := t.TempDir()
+	runGit(t, checkout, "init")
+	runGit(t, checkout, "branch", "-m", "main")
+	runGit(t, checkout, "remote", "add", "origin", "https://github.com/owner/repo.git")
+	seedDaemonWorkerRepo(t, store, "owner/repo", checkout)
+	seedDaemonWorkerAgent(t, store, "audit", runtime.ShellRuntime, unavailableRuntimeShellScript,
+		[]string{"ask"}, "owner/repo")
+	return home, store
+}
+
+func seedRoleUnavailableJob(t *testing.T, store *db.Store, id string, payload workflow.JobPayload) {
+	t.Helper()
+	seedCLIJob(t, store, db.Job{
+		ID:      id,
+		Agent:   "audit",
+		Type:    "ask",
+		State:   string(workflow.JobQueued),
+		Payload: mustJobPayload(t, payload),
+	}, "queued")
+}
+
+// TestJobRunDispatchesWhenAnotherRuntimeIsWalled is the #1641 reproduction: the
+// walled runtime is claude, the job runs on shell, so the dispatch must proceed.
+// RED before the fix (refused on the role alone), green after.
+func TestJobRunDispatchesWhenAnotherRuntimeIsWalled(t *testing.T) {
+	home, store := seedRoleUnavailableJobHome(t)
+	seedRoleUnavailableJob(t, store, "job-cross-runtime", workflow.JobPayload{
+		Repo: "owner/repo", Branch: "main", ActingOrgRole: "review",
+	})
+	now := time.Now().UTC()
+	if err := store.UpsertOrgRoleUnavailableForRuntime(context.Background(), "review", "claude", "quota", now.Add(time.Hour), now); err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	if code := Run([]string{"job", "run", "job-cross-runtime", "--home", home}, &stdout, &stderr); code != 0 {
+		t.Fatalf("claude wall refused a shell dispatch: code=%d stdout=%q stderr=%q", code, stdout.String(), stderr.String())
+	}
+	job, err := store.GetJob(context.Background(), "job-cross-runtime")
+	if err != nil || job.State != string(workflow.JobSucceeded) {
+		t.Fatalf("job = %+v err=%v, want succeeded", job, err)
+	}
+	// The wall itself must survive an unrelated runtime's dispatch: it is still
+	// claude's incident and must still refuse claude.
+	incident, found, err := store.GetActiveOrgRoleUnavailable(context.Background(), "review", time.Now().UTC())
+	if err != nil || !found || incident.Runtime != "claude" {
+		t.Fatalf("incident after cross-runtime dispatch = %+v found=%v err=%v", incident, found, err)
+	}
+}
+
+// TestJobRunStillRefusesTheWalledRuntime is the matching-runtime control, with
+// the reason/until presentation asserted so the fix cannot buy cross-runtime
+// dispatch by weakening the real refusal.
+func TestJobRunStillRefusesTheWalledRuntime(t *testing.T) {
+	home, store := seedRoleUnavailableJobHome(t)
+	seedRoleUnavailableJob(t, store, "job-same-runtime", workflow.JobPayload{
+		Repo: "owner/repo", Branch: "main", ActingOrgRole: "review",
+	})
+	now := time.Now().UTC()
+	if err := store.UpsertOrgRoleUnavailableForRuntime(context.Background(), "review", runtime.ShellRuntime, "quota", now.Add(time.Hour), now); err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{"job", "run", "job-same-runtime", "--home", home}, &stdout, &stderr)
+	if code != 1 || !strings.Contains(stderr.String(), `org role "review" is unavailable`) ||
+		!strings.Contains(stderr.String(), "reason=quota") || !strings.Contains(stderr.String(), "dispatch refused") {
+		t.Fatalf("same-runtime refusal: code=%d stderr=%q", code, stderr.String())
+	}
+	job, err := store.GetJob(context.Background(), "job-same-runtime")
+	if err != nil || job.State != string(workflow.JobQueued) {
+		t.Fatalf("held job = %+v err=%v, want queued", job, err)
+	}
+}
+
+// TestJobRunFailsClosedOnUnusableStoredRuntime covers both unusable stored
+// values. An EMPTY runtime is not corruption — UpsertOrgRoleUnavailable writes
+// it and the column was added with DEFAULT ” — so such a row keeps its
+// pre-#1641 whole-role meaning. An unrecognized runtime is corruption, and
+// neither is permission to dispatch.
+func TestJobRunFailsClosedOnUnusableStoredRuntime(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		write func(store *db.Store, now time.Time) error
+	}{
+		{
+			name: "empty stored runtime holds the whole role",
+			write: func(store *db.Store, now time.Time) error {
+				return store.UpsertOrgRoleUnavailable(context.Background(), "review", "quota", now.Add(time.Hour), now)
+			},
+		},
+		{
+			name: "unrecognized stored runtime is not permission",
+			write: func(store *db.Store, now time.Time) error {
+				return store.UpsertOrgRoleUnavailableForRuntime(context.Background(), "review", "not-a-runtime", "quota", now.Add(time.Hour), now)
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			home, store := seedRoleUnavailableJobHome(t)
+			seedRoleUnavailableJob(t, store, "job-fail-closed", workflow.JobPayload{
+				Repo: "owner/repo", Branch: "main", ActingOrgRole: "review",
+			})
+			if err := tc.write(store, time.Now().UTC()); err != nil {
+				t.Fatal(err)
+			}
+			var stdout, stderr bytes.Buffer
+			code := Run([]string{"job", "run", "job-fail-closed", "--home", home}, &stdout, &stderr)
+			if code != 1 || !strings.Contains(stderr.String(), "dispatch refused") {
+				t.Fatalf("fail-closed refusal: code=%d stderr=%q", code, stderr.String())
+			}
+		})
+	}
+}
+
+// TestJobRunHonoursRuntimeOverrideInBothDirections: the decision must follow the
+// runtime the job will ACTUALLY use, so an override INTO the walled runtime is
+// refused even though the agent's own runtime is clear, and an override AWAY
+// from it dispatches even though the agent's own runtime is walled.
+func TestJobRunHonoursRuntimeOverrideInBothDirections(t *testing.T) {
+	t.Run("override into the walled runtime refuses", func(t *testing.T) {
+		home, store := seedRoleUnavailableJobHome(t)
+		seedRoleUnavailableJob(t, store, "job-override-into", workflow.JobPayload{
+			Repo: "owner/repo", Branch: "main", ActingOrgRole: "review",
+			RuntimeOverride: "claude", RuntimeOverrideRef: "session-1",
+		})
+		now := time.Now().UTC()
+		if err := store.UpsertOrgRoleUnavailableForRuntime(context.Background(), "review", "claude", "quota", now.Add(time.Hour), now); err != nil {
+			t.Fatal(err)
+		}
+		var stdout, stderr bytes.Buffer
+		code := Run([]string{"job", "run", "job-override-into", "--home", home}, &stdout, &stderr)
+		if code != 1 || !strings.Contains(stderr.String(), "dispatch refused") {
+			t.Fatalf("override into walled runtime: code=%d stderr=%q", code, stderr.String())
+		}
+	})
+
+	t.Run("override away from the walled runtime dispatches", func(t *testing.T) {
+		home, store := seedRoleUnavailableJobHome(t)
+		seedDaemonWorkerAgent(t, store, "walled", "claude", "", []string{"ask"}, "owner/repo")
+		seedCLIJob(t, store, db.Job{
+			ID:    "job-override-away",
+			Agent: "walled",
+			Type:  "ask",
+			State: string(workflow.JobQueued),
+			Payload: mustJobPayload(t, workflow.JobPayload{
+				Repo: "owner/repo", Branch: "main", ActingOrgRole: "review",
+				RuntimeOverride: runtime.ShellRuntime, RuntimeOverrideRef: unavailableRuntimeShellScript,
+			}),
+		}, "queued")
+		now := time.Now().UTC()
+		if err := store.UpsertOrgRoleUnavailableForRuntime(context.Background(), "review", "claude", "quota", now.Add(time.Hour), now); err != nil {
+			t.Fatal(err)
+		}
+		var stdout, stderr bytes.Buffer
+		code := Run([]string{"job", "run", "job-override-away", "--home", home}, &stdout, &stderr)
+		if code != 0 {
+			t.Fatalf("override away from walled runtime: code=%d stdout=%q stderr=%q", code, stdout.String(), stderr.String())
+		}
+	})
+}
+
+// TestQueuedListingHoldsOnlyTheWalledRuntime covers the LIVE half of #1641: the
+// daemon schedules from this listing, so a claude wall previously held every
+// queued job of the role regardless of which runtime each job runs on.
+func TestQueuedListingHoldsOnlyTheWalledRuntime(t *testing.T) {
+	store := daemonWorkerStore(t)
+	seedDaemonWorkerAgent(t, store, "shell-worker", runtime.ShellRuntime, "true", []string{"ask"}, "gitmoot/gitmoot")
+	seedDaemonWorkerAgent(t, store, "claude-worker", "claude", "", []string{"ask"}, "gitmoot/gitmoot")
+	enqueueDaemonWorkerJob(t, store, workflow.JobRequest{
+		ID: "job-shell", Agent: "shell-worker", Action: "ask", Repo: "gitmoot/gitmoot", ActingOrgRole: "review",
+	})
+	enqueueDaemonWorkerJob(t, store, workflow.JobRequest{
+		ID: "job-claude", Agent: "claude-worker", Action: "ask", Repo: "gitmoot/gitmoot", ActingOrgRole: "review",
+	})
+	now := time.Now().UTC()
+	if err := store.UpsertOrgRoleUnavailableForRuntime(context.Background(), "review", "claude", "quota", now.Add(time.Hour), now); err != nil {
+		t.Fatal(err)
+	}
+
+	pending, err := listPendingQueuedJobs(context.Background(), jobWorker{Store: store}, "", "", false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(pending) != 1 || pending[0].ID != "job-shell" {
+		t.Fatalf("pending under a claude wall = %+v, want only job-shell", pending)
+	}
+}
+
+// TestQueuedListingFailsClosedOnAnUnresolvableSelectedRuntime is the other half
+// of failing closed: when the runtime a job would run as cannot be recognized,
+// the job cannot claim to be a runtime OTHER than the walled one, so it stays
+// held. Without this the "not the walled runtime" branch would silently accept
+// every unresolvable selection.
+func TestQueuedListingFailsClosedOnAnUnresolvableSelectedRuntime(t *testing.T) {
+	store := daemonWorkerStore(t)
+	seedDaemonWorkerAgent(t, store, "shell-worker", runtime.ShellRuntime, "true", []string{"ask"}, "gitmoot/gitmoot")
+	seedDaemonWorkerAgent(t, store, "mystery-worker", "not-a-runtime", "", []string{"ask"}, "gitmoot/gitmoot")
+	enqueueDaemonWorkerJob(t, store, workflow.JobRequest{
+		ID: "job-shell", Agent: "shell-worker", Action: "ask", Repo: "gitmoot/gitmoot", ActingOrgRole: "review",
+	})
+	enqueueDaemonWorkerJob(t, store, workflow.JobRequest{
+		ID: "job-mystery", Agent: "mystery-worker", Action: "ask", Repo: "gitmoot/gitmoot", ActingOrgRole: "review",
+	})
+	now := time.Now().UTC()
+	if err := store.UpsertOrgRoleUnavailableForRuntime(context.Background(), "review", "claude", "quota", now.Add(time.Hour), now); err != nil {
+		t.Fatal(err)
+	}
+
+	pending, err := listPendingQueuedJobs(context.Background(), jobWorker{Store: store}, "", "", false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(pending) != 1 || pending[0].ID != "job-shell" {
+		t.Fatalf("pending with an unresolvable runtime = %+v, want only job-shell", pending)
+	}
+}
+
+// TestValidateAndTouchActingOrgRoleNoLongerDecidesUnavailability pins the moved
+// boundary. The ingress still validates the registry and records presence, but
+// it cannot decide unavailability because the selected runtime does not exist
+// yet at that point — dispatchLocalAgentJob calls it before the agent (and
+// therefore the runtime) is resolved. The refusal itself is proven at the real
+// dispatch entry points above.
+func TestValidateAndTouchActingOrgRoleNoLongerDecidesUnavailability(t *testing.T) {
+	home, paths := setupQuotaUnavailableOrgHome(t)
+	store, err := dbtest.Open(t, paths.Database)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+	ctx := context.Background()
+	now := time.Now().UTC()
+
+	if err := validateAndTouchActingOrgRole(ctx, store, home, "review", "agent_run"); err != nil {
+		t.Fatalf("available role refused: %v", err)
+	}
+	if err := validateAndTouchActingOrgRole(ctx, store, home, "nope", "agent_run"); err == nil ||
+		!strings.Contains(err.Error(), `unknown org role "nope"`) {
+		t.Fatalf("unknown role = %v, want loud rejection", err)
+	}
+	if err := store.UpsertOrgRoleUnavailableForRuntime(ctx, "review", "claude", "quota", now.Add(time.Hour), now); err != nil {
+		t.Fatal(err)
+	}
+	if err := validateAndTouchActingOrgRole(ctx, store, home, "REVIEW", "agent_run"); err != nil {
+		t.Fatalf("ingress refused on an unavailability row it can no longer judge: %v", err)
+	}
+	if _, found, err := store.GetOrgRolePresence(ctx, "review"); err != nil || !found {
+		t.Fatalf("presence row after ingress found=%v err=%v", found, err)
+	}
+}
+
+// TestRefuseUnavailableOrgRoleClearsAnExpiredRowWhateverTheRuntime keeps the
+// eager-expiry behaviour that used to sit on the ingress: the store read must
+// stay unconditional, so a stale row is cleared even when the runtime decision
+// would not have refused anyway.
+func TestRefuseUnavailableOrgRoleClearsAnExpiredRowWhateverTheRuntime(t *testing.T) {
+	home, store := seedRoleUnavailableJobHome(t)
+	seedRoleUnavailableJob(t, store, "job-expired", workflow.JobPayload{
+		Repo: "owner/repo", Branch: "main", ActingOrgRole: "review",
+	})
+	now := time.Now().UTC()
+	if err := store.UpsertOrgRoleUnavailableForRuntime(context.Background(), "review", "claude", "quota", now.Add(-time.Minute), now.Add(-2*time.Minute)); err != nil {
+		t.Fatal(err)
+	}
+	var stdout, stderr bytes.Buffer
+	if code := Run([]string{"job", "run", "job-expired", "--home", home}, &stdout, &stderr); code != 0 {
+		t.Fatalf("expired row refused: code=%d stderr=%q", code, stderr.String())
+	}
+	rows, err := store.ListActiveOrgRolesUnavailable(context.Background(), time.Now().UTC())
+	if err != nil || len(rows) != 0 {
+		t.Fatalf("active rows after expiry = %+v err=%v, want none", rows, err)
+	}
+}

--- a/internal/cli/org_role_unavailable_test.go
+++ b/internal/cli/org_role_unavailable_test.go
@@ -346,42 +346,6 @@ func TestTempWorkerDispatchCapturesQuotaFailureAndClearsOnSuccess(t *testing.T) 
 	}
 }
 
-func TestValidateAndTouchActingOrgRoleRefusesUnavailableAndClearsExpired(t *testing.T) {
-	home, paths := setupQuotaUnavailableOrgHome(t)
-	store, err := dbtest.Open(t, paths.Database)
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer store.Close()
-	ctx := context.Background()
-	now := time.Now().UTC()
-
-	if err := validateAndTouchActingOrgRole(ctx, store, home, "review", "agent_run"); err != nil {
-		t.Fatalf("available role refused: %v", err)
-	}
-	if err := store.UpsertOrgRoleUnavailable(ctx, "review", "quota", now.Add(time.Hour), now); err != nil {
-		t.Fatal(err)
-	}
-	err = validateAndTouchActingOrgRole(ctx, store, home, "REVIEW", "agent_run")
-	if err == nil || !strings.Contains(err.Error(), `org role "review" is unavailable`) ||
-		!strings.Contains(err.Error(), "reason=quota") || !strings.Contains(err.Error(), "dispatch refused") {
-		t.Fatalf("unavailable refusal = %v", err)
-	}
-
-	if err := store.ClearOrgRoleUnavailable(ctx, "review"); err != nil {
-		t.Fatal(err)
-	}
-	if err := store.UpsertOrgRoleUnavailable(ctx, "review", "quota", now.Add(-time.Minute), now.Add(-2*time.Minute)); err != nil {
-		t.Fatal(err)
-	}
-	if err := validateAndTouchActingOrgRole(ctx, store, home, "review", "agent_run"); err != nil {
-		t.Fatalf("expired role refused: %v", err)
-	}
-	if _, found, err := store.GetActiveOrgRoleUnavailable(ctx, "review", now); err != nil || found {
-		t.Fatalf("expired row found=%v err=%v", found, err)
-	}
-}
-
 func TestRunTaskRunRefusesUnavailableRoleBeforeWorktreeAllocation(t *testing.T) {
 	home, paths := setupQuotaUnavailableOrgHome(t)
 	goalPath := filepath.Join(t.TempDir(), "GOAL.md")

--- a/internal/cli/workflow.go
+++ b/internal/cli/workflow.go
@@ -458,6 +458,13 @@ func runTaskRun(args []string, stdout, stderr io.Writer) int {
 		if err := ensureLocalAgentAccess(context.Background(), store, agent, requestRepo, "implement"); err != nil {
 			return err
 		}
+		// #1641: `task run` has no --runtime flag, so the owner agent's runtime IS
+		// the selected runtime. Refused here rather than at the --org-role ingress
+		// above because the owner is only known now, and still before any worktree
+		// or branch-lock allocation below.
+		if err := refuseUnavailableOrgRole(context.Background(), store, *orgRole, agent.Runtime, time.Now().UTC()); err != nil {
+			return err
+		}
 		checkout := repoRecord.CheckoutPath
 		requestBranch := firstNonEmpty(*branch, task.Branch, task.ID)
 		if strings.TrimSpace(task.WorktreePath) != "" {

--- a/skills/gitmoot/references/CLI.md
+++ b/skills/gitmoot/references/CLI.md
@@ -1651,8 +1651,13 @@ weekly-quota rejection marks that role `unavailable` until the provider's
 stated reset time. `org status` prints `⚠ UNAVAILABLE`, `reason=quota`, and the
 UTC reset instant in the role detail; `org chart` appends the same warning, and
 their JSON rows expose `provider_state: "unavailable"`,
-`unavailable_reason`, and `unavailable_until`. New operator dispatches to the
-role are refused and already-queued jobs for it stay held. The incident sends
+`unavailable_reason`, and `unavailable_until`. Enforcement is scoped to the runtime that hit the
+wall (#1641): new operator dispatches to the role are refused, and already-queued
+jobs for it stay held, only when the job's selected runtime is the walled one, so
+a Claude wall never blocks the role's Codex or Kimi work. A per-job `--runtime`
+override decides this, in both directions. An incident with no recorded runtime
+(written before per-runtime attribution) still holds the whole role, and an
+unrecognized recorded or selected runtime refuses rather than dispatches. The incident sends
 one best-effort direct wake to the role's configured parent, then clears at the
 reset instant or on that role's first subsequent successful Claude-runtime job,
 whichever happens first. Success on another runtime cannot clear the Claude

--- a/website/docs/reference/cli.md
+++ b/website/docs/reference/cli.md
@@ -1265,8 +1265,13 @@ weekly-quota rejection marks that role `unavailable` until the provider's
 stated reset time. `org status` prints `⚠ UNAVAILABLE`, `reason=quota`, and the
 UTC reset instant in the role detail; `org chart` appends the same warning, and
 their JSON rows expose `provider_state: "unavailable"`,
-`unavailable_reason`, and `unavailable_until`. New operator dispatches to the
-role are refused and already-queued jobs for it stay held. The incident sends
+`unavailable_reason`, and `unavailable_until`. Enforcement is scoped to the runtime that hit the
+wall (#1641): new operator dispatches to the role are refused, and already-queued
+jobs for it stay held, only when the job's selected runtime is the walled one, so
+a Claude wall never blocks the role's Codex or Kimi work. A per-job `--runtime`
+override decides this, in both directions. An incident with no recorded runtime
+(written before per-runtime attribution) still holds the whole role, and an
+unrecognized recorded or selected runtime refuses rather than dispatches. The incident sends
 one best-effort direct wake to the role's configured parent, then clears at the
 reset instant or on that role's first subsequent successful Claude-runtime job,
 whichever happens first. Success on another runtime cannot clear the Claude


### PR DESCRIPTION
Closes #1641.

A provider wall is a property of one provider, not of a role. The incident row was already written per-runtime (`UpsertOrgRoleUnavailableForRuntime`, `MarkOrgRoleUnavailableEscalatedForRuntime`), but every consumer enforced it per-role: `GetActiveOrgRoleUnavailable` selects by role alone and the refusal fired on any active row. Live instance: a claude quota row for role `gitmoot` refused a healthy codex `g7-review` dispatch.

Enforcement now compares the row's runtime against the runtime the dispatch **actually selects**, read from each ingress's own final resolution.

## Every refusal callsite, and its runtime source

The issue named two. The sweep found **four**, and the fourth is the one that was live.

| # | Site | Runtime source | Named in the issue? |
|---|---|---|---|
| 1 | `internal/cli/job.go:1143` (`job run`) | stored agent + payload `RuntimeOverride`, via `selectedJobDispatchRuntime` | yes |
| 2 | `internal/cli/agent_dispatch.go` (was via `org.go:1585`) | `effectiveAgent.Runtime` | yes |
| 3 | `internal/cli/workflow.go` (`task run`) | owner agent's runtime — `task run` has no `--runtime` flag | **no** |
| 4 | `internal/cli/daemon_scheduler.go` (queued listing) | per queued job, same resolver | **no — and this is the live half** |

Site 4 is what the daemon schedules from, so a claude row held every queued job of the role including codex and kimi work that had no wall. **The agent lookup runs only for a job whose role is actually walled**, so the common path stays the map lookup it always was — a per-job runtime resolution on every queued row would be a throughput regression hiding inside a correctness fix, and this listing runs on every continuous-pool re-query.

**Site 2 moved rather than being scoped in place.** `dispatchLocalAgentJob` calls the `--org-role` ingress *before* `resolveLocalDispatchAgent`, which is what picks the agent — and can auto-select one via the managed path. The selected runtime does not exist at that point, so scoping the call where it stood would have meant passing an empty runtime and failing closed on every dispatch: the reported bug, made unconditional. The refusal now sits immediately after `effectiveAgent`, which is the same expression the claiming worker resolves (`daemon_worker.go`), so ingress and worker agree by construction. The agent reservation taken just above is released by the existing deferred `releaseReservation` on this error path, so refusing there strands nothing.

`validateAndTouchActingOrgRole` keeps registry validation (unknown role still fails loudly) and presence/recycle, and no longer decides unavailability. Its comment says why and names the four sites.

## Fail-closed behaviour

`orgRoleUnavailableRefusesRuntime` refuses unless the row's runtime is *known and different* from a *known* selected runtime:

- **empty recorded runtime → refuses the whole role.** Not corruption: `UpsertOrgRoleUnavailable` still writes `""`, and the column was added by `ALTER TABLE ... DEFAULT ''` (#1490), so every pre-attribution row is legitimately unattributed and keeps its old meaning.
- **unrecognized recorded runtime → refuses.** Corruption is not permission to dispatch.
- **empty or unrecognized selected runtime → refuses.** A caller that cannot say what the job will run as cannot claim to be a different runtime.

Recognition uses `(runtime.Factory{}).Adapter(name)` — the same test `resolveJobRuntimeOverride` applies to `--runtime`, so both ends classify identically. `internal/db` cannot import `internal/runtime`, so the store keeps returning the row and the decision lives in one place in `internal/cli`. #1490's malformed-`until` fail-closed error and the eager expiry of stale rows are untouched: the store read stays unconditional, so a stale row is still cleared even when the runtime decision would not have refused.

## Red baseline, at `origin/main` 3794dee2

New test file only, copied into a pristine worktree of main with **zero production files modified** (verified by `git status --porcelain`), so these are behavioural failures and not build failures:

| test | at main | at this head |
|---|---|---|
| `TestJobRunDispatchesWhenAnotherRuntimeIsWalled` | **FAIL** | PASS |
| `TestJobRunHonoursRuntimeOverrideInBothDirections/override_away…` | **FAIL** | PASS |
| `TestQueuedListingHoldsOnlyTheWalledRuntime` | **FAIL** | PASS |
| `TestValidateAndTouchActingOrgRoleNoLongerDecidesUnavailability` | **FAIL** | PASS |
| `TestJobRunStillRefusesTheWalledRuntime` (control) | PASS | PASS |
| `TestJobRunFailsClosedOnUnusableStoredRuntime` (2 subtests, controls) | PASS | PASS |
| `TestJobRunHonoursRuntimeOverrideInBothDirections/override_into…` (control) | PASS | PASS |
| `TestRefuseUnavailableOrgRoleClearsAnExpiredRowWhateverTheRuntime` (control) | PASS | PASS |

4 red, 4 green at the base — the green ones are what stop the fix from buying cross-runtime dispatch by weakening the real refusal.

At this head, `-count=3`: **36 `--- PASS`, 0 `--- FAIL`** (12 units × 3; 8 top-level + 4 subtests). Counts stated because a `-run` pattern that matches nothing passes just as loudly as one that matches everything.

Every test drives a real entry point (`Run([...])` or `listPendingQueuedJobs`), never a helper, so a mutant that left all real failures on another path could not pass them.

## Mutants — all four compile, each killed by a named test

| mutant | compiles | killed by |
|---|---|---|
| **M1** predicate removed (refuse on any row) | yes | `…DispatchesWhenAnotherRuntimeIsWalled`, `…override_away…`, `…QueuedListingHoldsOnlyTheWalledRuntime` |
| **M2** comparison inverted (`stored != selected`) | yes | `…StillRefusesTheWalledRuntime`, `…override_into…`, `…DispatchesWhenAnotherRuntimeIsWalled` |
| **M3** recorded-runtime fail-closed dropped | yes | `…FailsClosedOnUnusableStoredRuntime` (both subtests) |
| **M4** selected-runtime fail-closed dropped | yes | `…QueuedListingFailsClosedOnAnUnresolvableSelectedRuntime` |

Values are consumed in each mutant so it compiles and the guard actually runs. Tree restored **byte-identical** after the battery (`cmp -s`). M4 exists because writing the battery exposed that I had no test for an unrecognized *selected* runtime; that test was added before mutating, not after.

## The 36 deleted lines, assertion by assertion

`internal/cli/org_role_unavailable_test.go` shows **0 additions, 36 deletions**: the whole of `TestValidateAndTouchActingOrgRoleRefusesUnavailableAndClearsExpired`. It asserted that `validateAndTouchActingOrgRole` refuses — precisely the contract this PR moves — so it could not be adapted in place. Every assertion it made is re-homed, and most are now stronger because they run through a real dispatch rather than the helper:

| deleted assertion | where it lives now | stronger or equal? |
|---|---|---|
| available role is not refused | `…NoLongerDecidesUnavailability` (same call) | equal |
| active row refuses with `org role "review" is unavailable` | `TestJobRunStillRefusesTheWalledRuntime`, `…ScopesRoleUnavailabilityToTheSelectedRuntime/…refused`, `…ToTheOwnersRuntime/…refused` | **stronger** — asserted at three real entry points instead of one helper |
| the message carries `reason=quota` and `dispatch refused` | `TestJobRunStillRefusesTheWalledRuntime`, both new refused arms | stronger |
| case-insensitive role match (`"REVIEW"`) | `…NoLongerDecidesUnavailability` (still passes `"REVIEW"`) | equal |
| expired row does not refuse | `…ClearsAnExpiredRowWhateverTheRuntime` | equal |
| expired row is eagerly cleared from the store | `…ClearsAnExpiredRowWhateverTheRuntime` (asserts `ListActiveOrgRolesUnavailable` is empty afterwards) | equal |

Net assertion count on the refusal path **rises**, and no deleted assertion is unaccounted for. Keeping the original alongside the successor would have shipped two tests disagreeing about where the decision lives. `…NoLongerDecidesUnavailability` additionally pins the moved boundary and keeps the unknown-role and presence checks the ingress still owns.

## Test arms for every authorised callsite

126292's blocking finding was that two authorised callsites had **no test arm** — `dispatchLocalAgentJob` and `runTaskRun` were argued behaviourally and asserted nowhere, the "a test that pins a helper is not a test of the path" shape. Both now have one, each through the real entry point:

| arm | proceeds when another runtime is walled | refuses when its own selection is walled |
|---|---|---|
| `TestLocalAgentDispatchScopesRoleUnavailabilityToTheSelectedRuntime` | `agent ask --org-role` reaches `JobSucceeded` | refused, and **zero jobs created** |
| `TestRunTaskRunScopesRoleUnavailabilityToTheOwnersRuntime` | `task run` allocates a worktree and enqueues | refused, task still `planned`, no worktree, zero jobs |

Both cross-runtime halves are **RED at `origin/main` 3794dee2** while both walled halves **PASS there** — that pairing is what shows they fail on behaviour rather than on being broken at the base. `-count=3` across the whole new set: **54 `--- PASS`, 0 `--- FAIL`, 18 distinct units**.

Two further compiling mutants, one per newly-covered callsite:

| mutant | compiles | killed by |
|---|---|---|
| **M5** `agent_dispatch.go` refusal removed | yes | `…ToTheSelectedRuntime/…refused` — **nothing killed this before**, which is exactly the gap 126292 named |
| **M6** `workflow.go` refusal removed | yes | `…ToTheOwnersRuntime/…refused` **and** the pre-existing `TestRunTaskRunRefusesUnavailableRoleBeforeWorktreeAllocation` |

Trees restored byte-identical after both.

## #1952 review P2 — closed at `8fddb8c3`

The independent exact-head review `local-ask-wave-impl-b-18d2eb1ffb05c448` (changes_requested, 9 populated `tests_run`) confirmed all four enforcement paths, both amendment controls and both callsite mutants, and found one real defect. **CI being 27/27 at the reviewed head did not and does not satisfy the review gate.**

**The defect: the wall was checked against a runtime that would never execute.** `daemon_worker.go` materializes an ephemeral worker *unconditionally* when `payload.Ephemeral` is set — `startEphemeralWorker` builds the agent from `spec.Runtime` and `UpsertAgent`s it under the job's agent name, **overwriting any pre-existing row of that name**. My `selectedJobDispatchRuntime` consulted `GetAgent` first and read the spec only when that lookup *errored*, so whenever a same-name agent row existed the refusal used the stored runtime while the job ran on the spec's. Both consumers were affected: `job run` and the queued listing the daemon schedules from.

Precedence is now **override → ephemeral spec → registered agent**, matching the worker (which applies the override *after* materialization) and `mailbox.go`, which already assigns the spec's runtime onto the agent at enqueue.

**Why I got it wrong, since it is the useful part.** The precedence genuinely splits, and both halves are in the tree: write/execute paths treat the spec as authoritative (`daemon_worker.go`, `mailbox.go`), while read/display paths rank it last (`resolveTranscriptRuntime` answers "which transcript do I read"; `dashboard_web.go` fills a rendered column). The original comment on this function drew exactly that distinction — and the code implemented the wrong side of it. The comment now says which group a dispatch refusal belongs to, because prose that names the right rule beside code doing the opposite is how this shipped.

Five controls, every one through a production entry point, each planting an **extant same-name agent row of a different runtime** — the condition that made the defect invisible:

| control | asserts |
|---|---|
| `TestJobRunRefusesAnEphemeralJobWhoseSpecRuntimeIsWalled` | walled spec runtime refuses, job left `queued` |
| `TestJobRunDispatchesAnEphemeralJobWhenAnotherRuntimeIsWalled` | should-succeed: wall on a non-selected runtime still dispatches, with the stored row deliberately naming the *walled* runtime |
| `TestJobRunFailsClosedOnAnEphemeralSpecRuntimeItCannotUse` | empty and unrecognized spec runtimes refuse |
| `TestQueuedEphemeralJobIsHeldWhenItsSpecRuntimeIsWalled` | `runQueuedJobsForRepo` holds it, with the adapter factory **failing the test if delivery is reached** |
| `TestQueuedEphemeralJobRunsWhenAnotherRuntimeIsWalled` | a clear-spec job stays eligible while its stored row names the walled runtime |

All five are **RED at `549d011a`** with zero production files modified — the queued-path one took 2.31s there and tripped the delivery guard, so it is exercising delivery rather than passing vacuously. **M7**, a compiling mutant restoring `GetAgent`-first, kills all five while the **18 non-ephemeral units stay green**, so it discriminates precedence rather than breaking everything. Focused `-count=3`: **75 `--- PASS`, 0 `--- FAIL`, 25 units**. Suites: `ok internal/db 170.659s`, `ok internal/cli 586.735s`; gofmt clean, build and vet exit 0.

## Second review round — census refuted, class closed at `e6f87060`

`local-ask-wave-impl-b-18d2f22606f7d033` confirmed the wall fix on both entries and refuted the **census claim** in my report. Three more execute-path consumers still ranked the registered row first.

**Why my census could not have found them.** I grepped for `payload.Ephemeral` — the symbol present in *correct* code. The defect is its **absence**, so that instrument could not return a single one of these sites however carefully I read it, and I still wrote "I enumerated every producer/consumer". Re-run by **class shape** instead — every `GetAgent`/`runtimeAgent` site in `internal/cli`, filtered to job-payload-scoped runtime derivations: **62 raw → 37 runtime-bearing → 13 job-payload-scoped → 4 needing the fix**.

The precedence now lives in exactly one place, `selectedJobRuntimeAgent`: **override → ephemeral spec → registered row**.

| site | what was wrong |
|---|---|
| `job_blocker_auth_probe.go` (`authProbeDedupKey`, `defaultAuthProbe`) | a stored shell row under an ephemeral Claude job keyed `runtime:shell` and returned Unknown after **zero** live Claude probes — and `authProbeAllowsRedispatch` releases Unknown, so a Claude-auth-deferred job re-dispatched with its credential never validated |
| `daemon_scheduler.go` (`queuedJobRuntimeResourceKey`) | an ephemeral job has no agents-table session, so this returned `""` or a stale row's key, and admission read a real session as free |
| `daemon_worker.go` (`perJobAdmissionEstimate`) | charged the stale row's RAM prior instead of the selected runtime's |
| `job.go` | the comment documented "stored agent, then the payload override" — neither the worker's rule nor the code's |

**The resource key deserved more than "make it non-empty".** It is a *serialization* key (`runtimeResourceLocked`, `inflightRuntimes`) and `runtime_override.go` requires the gate and the worker's lock acquisition to agree. `jobWorker.run` rewrites a fresh ref to `runtime.FreshRefForJob(job.ID)` before locking, so the key is built from that same formula: byte-identical to the lock, job-unique so two ephemeral jobs never falsely serialize. A non-resumable spec still takes no session, exactly as a shell-registered agent does not.

**`proof.go:121` is reported, not fixed** — it builds a post-hoc proof manifest, decides nothing, and reads the materialized spec runtime for any settled job. Outside the round's boundary; a separate ticket if the queued case should be exact.

**Proof.** Five regressions plus three should-succeed controls, all through production entries. The auth-probe regression **counts live Claude probe calls** (a verdict alone cannot distinguish "probed and got Unknown" from "never probed"); the admission one asserts **`session=true`, `memGB=0.85`** as values rather than pinning a helper. Five red at `8fddb8c3` with production files unmodified, **both controls green there**. Focused `-count=3`: **96 `--- PASS`, 0 `--- FAIL`, 32 units**. Suites: `ok internal/db 204.959s`, `ok internal/cli 594.940s`.

**Mutants, each discriminating rather than merely destructive:** `GetAgent`-first in the auth probe kills its two while the key/admission tests stay green; dropping the ephemeral key branch kills the other three while the auth-probe regression stays green; degrading the parse-failure fallback kills the **pre-existing** `TestPerJobAdmissionEstimate`. Ten mutants now on this PR.

**A regression the suite caught in my own fix, disclosed.** My first version made an *unparseable* payload fall back to `DefaultMemoryGB`. `TestPerJobAdmissionEstimate` — which predates me — failed on three subtests, because the old code still priced such a job by its registered runtime. Silently re-pricing every corrupt-payload job would have been a regression this fix had no business causing; it now falls back to the registered row, and M10 proves that fallback is load-bearing.

## Self-found retraction at `0421e5f3` — a false invariant, its circular test, and the admission proof moved onto the path

Pushed under 127011's "unless you find a real defect" clause. It voids the 27/27 measured at `e6f87060` and re-queues this PR, deliberately: reviewing that head would have spent one of two capped reviewer slots on a head carrying a claim I could already show was false. **CI is green again at `0421e5f3`: 27/27, `incomplete=0`.**

All three defects were in my **claims**, not the behaviour — the fix itself stands unchanged.

| # | defect | how it was established |
|---|---|---|
| 1 | the resource-key comment asserted the gate key is **byte-identical** to the lock the worker takes | **measured false** — the gate yields `runtime:claude:fresh:job:<hash>`; the worker's journalled lock reads `runtime:claude:<ref adapter.Start returned>`. `scopeRegisteredFreshRefForJob` only rewrites a ref satisfying `IsFreshRef`, and a materialized ephemeral agent carries the live ref |
| 2 | the test of that claim was **circular** | it computed its expected value from the same helper under test, so it asserted the formula agrees with itself and would have passed whatever the worker did |
| 3 | a comment asserted "no seat job carries an ephemeral spec" | **traced false** — `delegationRequest` sets `Ephemeral` and `allocateAndEnqueueDelegationInner` sets `ReadOnlySeat` on that same request for an ask/review action |

The gap in #1 is **inherent, not a bug**: an ephemeral session does not exist until `Start` returns, so no pre-dispatch value can name it. The comment now states what the key must actually satisfy — non-empty (so admission counts a real session), job-unique (so two ephemeral jobs never serialize), never shaped like a live session ref (so it cannot collide with a real lock) — and `TestEphemeralGateKeyIsJobUniqueAndNotASessionRef` pins those three properties instead.

**The admission regression moved onto the production path**, which 126863 required and `e6f87060` did not do — it called `perJobAdmissionEstimate` directly. It now dispatches through `dispatchQueuedJobsTracked` and pins Claude's 0.85 GB prior **from both sides**: a 0.5 GB cap must refuse, a 0.9 GB cap must admit. A one-sided assertion also passes for "charge everything infinite RAM".

**Two instrument corrections, recorded in the helper's own comment so the next person does not repeat them.** The "held back" line is throttled per job+reason in **package** state, so `resetHeldBackWarnState()` is required or `-count=3` silently reports "not held" — the codebase already had that helper. And the job must be dispatch-eligible, or nothing is selected, stdout is empty, and every assertion reads whatever the empty case implies. My first two attempts hit exactly those.

**Arms green at BOTH heads are named and proven load-bearing**, per 127011's decoration warning — each is killed by an over-refusal mutant that the earlier battery lacked:

| arm green at both heads | mutant that kills it |
|---|---|
| the session-less admission control | charge every job Claude's prior (**M11**) |
| the non-Claude probe control | probe Claude for every runtime (**M12**) |
| the loose-cap admission arm | double Claude's prior (**M13**) |

Thirteen mutants now on this PR. Focused `-count=3` at this head: **102 `--- PASS`, 0 `--- FAIL`, 34 units**; suites `ok internal/db 163.230s`, `ok internal/cli 515.371s`; gofmt clean, build and vet exit 0.

## Round-3 P2 closed at `970e777e` — routing pinned at the selector, not the key helper

`local-ask-g7-review-18d2f9888cf51817` (P2, executed) confirmed production behaviour and CI, and found that `TestEphemeralGateKeyIsJobUniqueAndNotASessionRef` **still pinned the key helper**. Its mutant: leave `queuedJobRuntimeResourceKey` byte-for-byte correct, route ephemeral jobs through one shared key inside the production selector — every committed test stayed green while two distinct ephemeral jobs falsely serialized. **This is the second time in this PR I shipped that shape**; the earlier version was circular, this one pinned the same helper from outside. Both are blind to the caller.

Nothing added here names that helper. **Two** routing sites are covered — the second found by a mutant *after* the first was fixed:

| site | defect if routing shares a key | arm |
|---|---|---|
| `queuedJobResourceSelector.selects` (via `selectRunnableQueuedJobsWithPolicy`) | two distinct ephemeral jobs serialize | both selected in one pass; same pair both run via `runQueuedJobsForRepo` |
| `excludeBouncedBusy` (via `memoizedRuntimeResourceKey`) | **one** busy bounce silently excludes **every** other ephemeral job — starvation the selector arm cannot see, since the selector never runs for excluded jobs | a distinct ephemeral job survives a peer's bounce |

Two should-succeed controls stop the cheap fix, because independence must come from keying ephemeral jobs separately and **not** from weakening serialization: two jobs sharing one **registered** session still yield exactly one selection (#684), and a job sharing a bounced session stays excluded.

### Two measurements that changed the tests, not just their names

- **The checkout confound.** Two ephemeral jobs in one repo share the checkout key `repo:owner/repo` and serialize for *that* reason, while their runtime keys are already distinct (`…5f3918b8` vs `…b91b8f9a`, measured). A same-repo pair proves nothing about runtime routing — my first draft failed for exactly this reason and I nearly "fixed" production code that was correct. The pairs now use **different repos**, and the registered-session control needed the same correction or it passed on the confound.
- **A fixture that dodged its own mutant.** The bounced-busy fixture must build its key through the **same memo map** the function under test uses. My first version passed a `nil` memo, which takes `memoizedRuntimeResourceKey`'s early-return path — so the mutant's shared key never matched the fixture's real keys and **M15 survived**.

### Mutant matrix — both compiling, key helper untouched in each

| mutant | new arms | previously committed arms |
|---|---|---|
| **M14** shared key in `selects` | selector arm **RED** | **all green** |
| **M15** shared key in the memoized path | bounced-busy arm **RED** | **all green** |

That "all green" column is the reviewer's finding, reproduced by me. Trees restored byte-identical.

**On red-at-parent:** all five arms **pass** at parent `0421e5f3`, and that is the correct result — the P2 was a **coverage gap, not a behaviour defect** (the reviewer re-derived that runtime-scoped refusal is correct both directions). There is nothing at the parent for them to catch, so red-at-parent is vacuous here and the mutant matrix is the discriminating proof. This head changes **no production behaviour**: the only non-test edit is the P3 comment at `daemon_worker.go:351`, qualifying registered-seat gate/acquisition equality that does not hold for an ephemeral seat.

Focused `-count=3` at this head: **117 `--- PASS`, 0 `--- FAIL`, 39 units**; `ok internal/db 199.289s`, `ok internal/cli 732.362s`; gofmt clean, build and vet exit 0; CI 27/27 `incomplete=0`. Boundary verified per file: `review_phase_instrument.go` and `workflow.go` both zero changes.

## Round-4 P3 closed at `6d20d75f` — the dispatch arm now claims what it proves

The independent review at `970e777e` (`local-ask-g7-review-18d2fed35d0857c6`) **approved** with its own executed `tests_run` and no delegations, and left one P3: `TestQueuedDispatchRunsTwoDistinctEphemeralJobsInOnePass` was named as if it proved one-pass parallel selection. It does not — under mutant **M14 the direct selector guard correctly fails while that higher-level test still passes**.

**The production contract, read from `runQueuedJobsForRepo` (`daemon_scheduler.go:1859-1909`) rather than inferred from the old name:** the dispatcher loops while work remains; each pass selects up to `limit` runnable jobs, admits them, launches each in its own goroutine and joins them with **one** `wg.Wait()` before the next pass. So:

- jobs **co-selected in a pass do overlap** — that mechanism is real;
- **passes are strictly serial**, the next starting only after the previous finishes;
- whether two *particular* jobs share a pass is decided by the **selector**.

Production therefore makes **no independent promise** that two given jobs run in one pass. A second job serialized into a later pass still finishes, so the assertion holds either way — which is exactly why the test could not see M14.

**Renamed to `TestQueuedDispatchEventuallyRunsBothDistinctEphemeralJobs`**, with the contract, the M14 asymmetry and the division of labour written into its comment: it rules out the coarse failure where a distinctly-keyed job **never runs at all**, while `TestSelectorSelectsTwoDistinctEphemeralJobsInOnePass` remains the discriminating regression for keying. The failure message now reads "eventual execution, not overlap".

**No overlap assertion was added instead**, and that was a decision rather than an omission: a barrier test would only re-prove co-selection — which the selector guard already pins directly — while adding a deadlock-on-regression failure mode. Claiming a parallelism guarantee production does not make is worse than documenting eventual dispatch.

**The selector guard is untouched**, verified by diff: `git diff -U0` shows two hunks, both inside the renamed test (its comment block and one message line). Re-ran **M14 after the rename** — the guard still fails, the renamed arm still passes, which is now precisely what its name claims.

This head is **one test file, 25 insertions / 6 deletions**, no production change. Focused `-count=3`: **117 `--- PASS`, 0 `--- FAIL`, 39 units**; `ok internal/db 287.836s`, `ok internal/cli 857.549s`; gofmt clean, build and vet exit 0; CI 27/27 `incomplete=0`.

## Verification

- `gofmt -l internal/ cmd/` → empty; `go build ./...` → exit 0; `go vet ./...` → exit 0.
- `go test ./internal/db/ ./internal/cli/ -count=1` → exit 0; `ok internal/db 180.064s`, `ok internal/cli 649.203s`.
- Pinned toolchain `GOTOOLCHAIN=local go1.26.4`; isolated worktree off `origin/main` 3794dee2; `/root/.gitmoot` never touched.

## No migration, and a limitation reported rather than fixed

`org_role_unavailable` keys on `role` alone (`role TEXT PRIMARY KEY`), so exactly one runtime can be walled per role at a time — a second wall overwrites the first's runtime via `ON CONFLICT(role) DO UPDATE SET runtime = excluded.runtime`. #1641's required behaviour is fully implementable on that key, so this PR appends no migration and widening the key stays a separate issue.

## Doc integration

`skills/gitmoot/references/CLI.md` and `website/docs/reference/cli.md` carry the same corrected paragraph; both overlap #1930. **#1930 merges first, then I rebase only those two docs hunks onto its merged text.** `website/static/llms.txt` and `docs/` need no change — line 54 of llms.txt is a generic CLI blurb and makes no role-vs-runtime enforcement claim, and `docs/troubleshooting.md`'s "runtime unavailable" hit is about staging permissions.

## Scope — authorised file by file in directive 126292

126123 named four source files; this PR touches three more. I raised that as a scope question **before** any review was dispatched rather than inferring permission after pushing, and 126292 is the durable amendment extending the list by exactly these three, each with its callsite and invariant named:

| file | callsite | why it is required, measured |
|---|---|---|
| `agent_dispatch.go` | `dispatchLocalAgentJob`, after runtime-override resolution | the `--org-role` ingress above it cannot know the runtime, so a refusal there is necessarily role-wide — the whole defect. Reverting it **builds and leaves all 7 pre-existing unavailability tests green** while `agent … --org-role` refuses nothing: a silent regression, which is why it needed a test rather than an argument. |
| `daemon_scheduler.go` | `listPendingQueuedJobs`, the `unavailableRoles` lookup | the live half. Reverting it keeps build and all 7 pre-existing tests green — purely additive, so it was the one genuinely needing authorisation, and it has it. |
| `workflow.go` | `runTaskRun`, after `ensureLocalAgentAccess` | reverting it **breaks the pre-existing `TestRunTaskRunRefusesUnavailableRoleBeforeWorktreeAllocation`**: once the refusal leaves the shared ingress helper in `org.go`, `task run` loses it entirely. Note the build still succeeds without it, so this is a behavioural dependency, not a compile one — I had assumed compile-forced and the measurement corrected me. |

**`internal/db/org_role_unavailable.go` is named in 126123 and is deliberately NOT in this diff.** The store-side change proved unnecessary: `GetActiveOrgRoleUnavailable` already returns the row's `Runtime`, already expires a stale row eagerly, and already errors on a malformed `until` (#1490's fail-closed). The only new decision needs `(runtime.Factory{}).Adapter`, and `internal/db` cannot import `internal/runtime`, so pushing it down would have inverted the layering to no benefit. Absence here is a decision, not an omission.

## Other scope facts

Files: `agent_dispatch.go`, `daemon_scheduler.go`, `job.go`, `org.go`, `org_role_unavailable.go`, `workflow.go`, two tests, two docs. `internal/workflow/merge_gate.go` and all three #1950 files are untouched, verified per file rather than asserted.

**Integration order, corrected by 126292's measurement.** I earlier flagged #1943's `internal/cli/job.go` as a live overlap; that was wrong. **#1943 is MERGED and is already in this base**, so it is not a competing head and there is no overlap there. The one real cross-head overlap is `agent_dispatch.go`, which #1930 also touches: its hunk is a single line ~290 lines away from mine inside the same function, semantically independent, so no textual conflict is expected. #1930 still merges first, and I then rebase the `agent_dispatch.go` hunk as well as the two docs files.

#1490 operator-clear and #1489 incident handling are not folded in. No merge, no deploy, no reviewer dispatched by me — the single independent exact-head review is gitmoot's to arrange, and this PR's zero reviews is a deliberate hold, not a stall.





