### PR TITLE
fix(workflow): the review-verdict wake announces the reviewer's recorded decision (#1945)

### DIFF
--- a/internal/cli/event_rule_sink_verdict_decision_test.go
+++ b/internal/cli/event_rule_sink_verdict_decision_test.go
@@ -1,0 +1,249 @@
+package cli
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/gitmoot/gitmoot/internal/config"
+	"github.com/gitmoot/gitmoot/internal/events"
+	"github.com/gitmoot/gitmoot/internal/runtime"
+	"github.com/gitmoot/gitmoot/internal/workflow"
+)
+
+// #1945: THE REVIEW-VERDICT WAKE MUST ANNOUNCE THE REVIEWER'S RECORDED DECISION.
+//
+// Measured twice on #1943, hours apart and with distinct reviewer payload
+// shapes: the wake said `approved` while the persisted job row recorded
+// `changes_requested`. The path is exact and short. engine_types.go computes a
+// THRESHOLD-ADJUSTED decision, review_threshold.go:42 folds a
+// changes_requested whose severity does not meet the repository bar into
+// "approved", and event_rule_sink.go renders event.ReviewDecision verbatim into
+// `gitmoot review verdict %s for ...`. A coordinator then acts on the word
+// instead of rereading the row, and `approved` is precisely the word that
+// suppresses that reflex.
+//
+// THIS TEST LIVES AT THE PRODUCTION EVENT-TO-WAKE PATH, not on a helper. It
+// drives the real engine to a review terminal through the real mailbox, takes
+// the event from the injected sink the daemon uses, and renders it with
+// eventRuleWakePrompt, the same function the daemon calls. The blocking bar is
+// installed by applyReviewPolicy from a real config file rather than by setting
+// the field, so the configuration half is production too.
+//
+// It is RED at origin/main, where the prompt reads "approved".
+func TestReviewVerdictWakeAnnouncesRecordedChangesRequested(t *testing.T) {
+	ctx := context.Background()
+	sink, event := runReviewVerdictWakeFixture(t, ctx, reviewVerdictFixture{
+		jobID: "review-1945", pullRequest: 1945, taskID: "task-1945",
+		// P3 is BELOW the configured P1 bar, so the threshold transform folds this
+		// recorded changes_requested to "approved" for the merge gate. The gate is
+		// right to do that; the notification is not.
+		decision: "changes_requested", severity: "P3",
+		blockingSeverity: "P1",
+	})
+
+	if event.Cause != events.EventCauseReviewVerdict {
+		t.Fatalf("event cause = %q, want %q (all=%+v)", event.Cause, events.EventCauseReviewVerdict, sink.events)
+	}
+	if event.ReviewDecision != "changes_requested" {
+		t.Fatalf("event.ReviewDecision = %q, want %q: the wake must carry the RECORDED reviewer decision, not the threshold-adjusted one",
+			event.ReviewDecision, "changes_requested")
+	}
+
+	prompt := eventRuleWakePrompt(eventRuleKindReviewVerdict, event)
+	if !strings.Contains(prompt, "changes_requested") {
+		t.Fatalf("wake prompt does not announce the recorded decision: %q", prompt)
+	}
+	if strings.Contains(prompt, "approved") {
+		t.Fatalf("wake prompt announces approved for a recorded changes_requested review, which is #1945: %q", prompt)
+	}
+}
+
+// SHOULD-SUCCEED CONTROL: a genuinely approved review still announces approved.
+// Without this a mutant that hardcoded "changes_requested" would satisfy the
+// regression above while making every wake wrong in the other direction.
+func TestReviewVerdictWakeStillAnnouncesGenuineApproved(t *testing.T) {
+	ctx := context.Background()
+	_, event := runReviewVerdictWakeFixture(t, ctx, reviewVerdictFixture{
+		jobID: "review-approved", pullRequest: 1946, taskID: "task-1946",
+		decision: "approved", severity: "", blockingSeverity: "P1",
+	})
+
+	if event.ReviewDecision != "approved" {
+		t.Fatalf("event.ReviewDecision = %q, want approved", event.ReviewDecision)
+	}
+	prompt := eventRuleWakePrompt(eventRuleKindReviewVerdict, event)
+	if !strings.Contains(prompt, "approved") || strings.Contains(prompt, "changes_requested") {
+		t.Fatalf("a genuine approval must still announce approved: %q", prompt)
+	}
+}
+
+// SHOULD-SUCCEED CONTROL, and it pins the OTHER defect in this family so my fix
+// cannot re-open it. #1685: a coordinator fan-out is a dispatch record, not an
+// inspection, so it must emit NO review-verdict wake at all. That exclusion is a
+// DIFFERENT mechanism from #1945 - wrong source rather than wrong transform -
+// and it lives on the admission guard, upstream of the value I changed.
+func TestReviewVerdictWakeStaysExcludedForFanOut(t *testing.T) {
+	ctx := context.Background()
+	sink, _ := runReviewVerdictWakeFixtureAllowNoVerdict(t, ctx, reviewVerdictFixture{
+		jobID: "review-fanout", pullRequest: 1947, taskID: "task-1947",
+		decision: "approved", severity: "", blockingSeverity: "P1",
+		delegations: `[{"id":"lens-a","agent":"audit","action":"review","prompt":"look at the diff"}]`,
+	})
+
+	for _, ev := range sink.events {
+		if ev.Cause == events.EventCauseReviewVerdict {
+			t.Fatalf("a fan-out emitted a review-verdict wake, re-opening #1685: %+v", ev)
+		}
+		if strings.TrimSpace(ev.ReviewDecision) != "" {
+			t.Fatalf("a fan-out carried ReviewDecision %q; the delegates' own terminals carry the real verdicts", ev.ReviewDecision)
+		}
+	}
+}
+
+// SHOULD-SUCCEED CONTROL: non-review wake kinds are untouched. The directive
+// prompt is rendered by the same function and must not change shape.
+func TestDirectiveWakePromptUnchangedByVerdictFix(t *testing.T) {
+	event := events.Event{
+		Type:           events.EventJobFinished,
+		Cause:          directiveCompletionOverdueCause,
+		RootID:         "workflow_note:126324",
+		WakeTargetRole: "gm-omp-fanout",
+	}
+	prompt := eventRuleWakePrompt("directive", event)
+	for _, want := range []string{"gitmoot directive 126324", "gm-omp-fanout", "gitmoot org directive done 126324"} {
+		if !strings.Contains(prompt, want) {
+			t.Fatalf("directive wake prompt lost %q: %q", want, prompt)
+		}
+	}
+	if strings.Contains(prompt, "review verdict") {
+		t.Fatalf("directive wake prompt leaked review-verdict text: %q", prompt)
+	}
+}
+
+// THE VOCABULARY INVARIANT the fix relies on instead of a defensive branch.
+//
+// engine_types.go admits a wake only when the THRESHOLD-ADJUSTED decision is
+// approved or changes_requested, then announces the RECORDED one. That is only
+// safe because the transform's single rule maps changes_requested -> approved,
+// so an admitted effective word always implies an admitted recorded word. I did
+// not add an unreachable fallback for a third word - an unfalsifiable guard is
+// worse than none - so this test is what fails if a future transform breaks the
+// implication and widens what a human can be told.
+func TestReviewVerdictWakeVocabularyStaysTwoWords(t *testing.T) {
+	ctx := context.Background()
+	for _, tc := range []struct {
+		name             string
+		decision         string
+		severity         string
+		blockingSeverity string
+		want             string
+	}{
+		{"below bar folds for the gate, recorded word announced", "changes_requested", "P3", "P1", "changes_requested"},
+		{"at bar blocks, recorded word announced", "changes_requested", "P1", "P1", "changes_requested"},
+		{"approved stays approved", "approved", "", "P1", "approved"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			_, event := runReviewVerdictWakeFixture(t, ctx, reviewVerdictFixture{
+				jobID: "review-vocab", pullRequest: 1948, taskID: "task-1948",
+				decision: tc.decision, severity: tc.severity, blockingSeverity: tc.blockingSeverity,
+			})
+			if event.ReviewDecision != tc.want {
+				t.Fatalf("announced %q, want %q", event.ReviewDecision, tc.want)
+			}
+			if event.ReviewDecision != "approved" && event.ReviewDecision != "changes_requested" {
+				t.Fatalf("the wake vocabulary widened to %q; a human can now be told a third word", event.ReviewDecision)
+			}
+		})
+	}
+}
+
+type reviewVerdictFixture struct {
+	jobID            string
+	pullRequest      int
+	taskID           string
+	decision         string
+	severity         string
+	blockingSeverity string
+	delegations      string
+}
+
+func runReviewVerdictWakeFixture(t *testing.T, ctx context.Context, fx reviewVerdictFixture) (*recordingSink, events.Event) {
+	t.Helper()
+	sink, event, ok := reviewVerdictWakeRun(t, ctx, fx)
+	if !ok {
+		t.Fatalf("no review-verdict event was emitted; all=%+v", sink.events)
+	}
+	return sink, event
+}
+
+func runReviewVerdictWakeFixtureAllowNoVerdict(t *testing.T, ctx context.Context, fx reviewVerdictFixture) (*recordingSink, events.Event) {
+	t.Helper()
+	sink, event, _ := reviewVerdictWakeRun(t, ctx, fx)
+	return sink, event
+}
+
+// reviewVerdictWakeRun drives the REAL engine over the REAL mailbox to a review
+// terminal and returns the emitted event. Nothing here stubs the decision path:
+// the blocking bar arrives through applyReviewPolicy reading a config file, and
+// the verdict arrives as adapter output parsed into the job payload.
+func reviewVerdictWakeRun(t *testing.T, ctx context.Context, fx reviewVerdictFixture) (*recordingSink, events.Event, bool) {
+	t.Helper()
+	home := t.TempDir()
+	root := config.PathsForHome(home).Home
+	if err := os.MkdirAll(root, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	body := "[review]\nblocking_severity = \"" + fx.blockingSeverity + "\"\n"
+	if err := os.WriteFile(filepath.Join(root, config.ConfigName), []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	store := daemonWorkerStore(t)
+	checkout := t.TempDir()
+	seedDaemonWorkerRepo(t, store, "owner/repo", checkout)
+	seedDaemonWorkerAgent(t, store, "audit", runtime.ShellRuntime, "printf ok", []string{"review"}, "owner/repo")
+
+	sink := &recordingSink{}
+	engine := workflow.Engine{
+		Store:                   store,
+		ResolveDeliveryWorktree: workflow.UnavailableDeliveryWorktreeResolver("1945 review wake test"),
+		EventSink:               sink,
+	}
+	applyReviewPolicy(&engine, root)
+
+	mailbox := workflow.NewMailbox(store, workflow.UnavailableDeliveryWorktreeResolver("1945 review wake test"))
+	if _, err := mailbox.Enqueue(ctx, workflow.JobRequest{
+		ID: fx.jobID, Agent: "audit", Action: "review", Repo: "owner/repo",
+		Branch: "task-branch", PullRequest: fx.pullRequest, HeadSHA: "head1945",
+		TaskID: fx.taskID, TaskTitle: "Review", LeadAgent: "author",
+		Reviewers: []string{"audit"}, ReviewRound: "review-1",
+		Sender: "local", ActingOrgRole: "requester",
+	}); err != nil {
+		t.Fatalf("Enqueue returned error: %v", err)
+	}
+
+	delegations := "[]"
+	if strings.TrimSpace(fx.delegations) != "" {
+		delegations = fx.delegations
+	}
+	output := `{"gitmoot_result":{"decision":"` + fx.decision + `","severity":"` + fx.severity +
+		`","summary":"verdict summary","findings":[],"changes_made":[],"tests_run":["go test ./... ok"],"needs":[],"delegations":` + delegations + `}}`
+	adapter := &cliWorkerFakeAdapter{output: output}
+
+	if _, err := engine.RunJob(ctx, fx.jobID, runtime.Agent{
+		Name: "audit", Runtime: runtime.ShellRuntime, RuntimeRef: "printf ok",
+		RepoScope: "owner/repo", Role: "reviewer",
+	}, adapter); err != nil {
+		t.Fatalf("RunJob returned error: %v", err)
+	}
+
+	for _, ev := range sink.events {
+		if ev.Cause == events.EventCauseReviewVerdict {
+			return sink, ev, true
+		}
+	}
+	return sink, events.Event{}, false
+}

--- a/internal/workflow/engine_types.go
+++ b/internal/workflow/engine_types.go
@@ -193,7 +193,34 @@ func (e Engine) mailbox() Mailbox {
 					event.Cause = events.EventCauseReviewVerdict
 					wakeTargetRole = owner
 					event.PullRequest = payload.PullRequest
-					event.ReviewDecision = decision
+					// #1945: THE WAKE ANNOUNCES THE REVIEWER'S RECORDED DECISION, NOT
+					// THE GATE'S TRANSFORMED ONE. `decision` above is
+					// threshold-adjusted, and that adjustment is correct for the merge
+					// gate: a changes_requested whose severity is below the repository
+					// bar does not block a merge. It is NOT correct for a human
+					// notification. review_threshold.go:42 folds changes_requested to
+					// "approved" when the severity does not block, so the wake told a
+					// coordinator `approved` for a job row that records
+					// changes_requested. Measured twice on #1943, hours apart, with
+					// distinct reviewer payload shapes. `approved` is precisely the
+					// word that suppresses the reflex to reread the row.
+					//
+					// ONLY THE ANNOUNCED VALUE CHANGES. Admission above and the
+					// changes_requested retargeting below deliberately keep the
+					// threshold-effective decision: which wake fires, and who
+					// receives it, are gate concerns and are not this defect. The
+					// only divergence the transform can produce is
+					// changes_requested -> approved, so whenever admission passes the
+					// recorded word is also one of the two admitted words; there is
+					// no input where this widens the wake vocabulary, and
+					// TestReviewVerdictWakeVocabularyStaysTwoWords pins that rather
+					// than a defensive branch that no mutant could kill.
+					//
+					// #1685's fan-out exclusion is a DIFFERENT mechanism and is
+					// untouched: it suppresses the wake at the guard above because a
+					// coordinator's dispatch record is not an inspection. This line
+					// runs only for payloads that guard already admitted.
+					event.ReviewDecision = strings.TrimSpace(payload.Result.Decision)
 					if decision == "changes_requested" {
 						// Sender is a transport or agent identity, not necessarily a
 						// routable org role. ActingOrgRole is the persisted requester

--- a/internal/workflow/event_sink_test.go
+++ b/internal/workflow/event_sink_test.go
@@ -253,7 +253,25 @@ func TestEngineReturnsChangesRequestedToRequesterWithoutDefaultAutoFix(t *testin
 	}
 }
 
-func TestEngineEmitsSubthresholdReviewVerdictAsApproved(t *testing.T) {
+// #1945 SUPERSEDES THIS TEST'S ORIGINAL EXPECTATION, and it was named
+// TestEngineEmitsSubthresholdReviewVerdictAsApproved when it asserted the
+// opposite. It pinned the emitted wake decision for a recorded
+// changes_requested whose severity is below the repository bar, and it required
+// "approved". That is the defect #1945 records: the wake told a coordinator
+// approved for a job row that says changes_requested, measured twice on #1943.
+//
+// IT NOW ASSERTS BOTH HALVES, which is what the old version could not
+// distinguish and why the defect hid behind it:
+//   - the GATE transform is unchanged. A sub-threshold changes_requested still
+//     resolves to "approved" through effectiveReviewDecisionForPayload, because
+//     a below-bar finding must not block a merge. That is correct and untouched
+//     by #1945; review_threshold.go is not modified.
+//   - the WAKE announces the RECORDED reviewer decision, because a human
+//     notification is not a merge decision.
+//
+// So the sub-threshold behaviour still has a test; only the notification value
+// moved, and this test now fails if either half regresses.
+func TestEngineEmitsSubthresholdReviewVerdictWithRecordedDecision(t *testing.T) {
 	ctx := context.Background()
 	store := openEngineStore(t)
 	if acquired, err := store.AcquireLock(ctx, db.BranchLock{
@@ -274,7 +292,7 @@ func TestEngineEmitsSubthresholdReviewVerdictAsApproved(t *testing.T) {
 	engine.EventSink = sink
 	engine.ReviewBlockingSeverity = func(string) string { return reviewseverity.P1 }
 
-	engine.mailbox().emitTerminal(ctx, "review-45", JobSucceeded, JobPayload{
+	payload := JobPayload{
 		Repo:        "gitmoot/gitmoot",
 		Branch:      "task-45",
 		PullRequest: 45,
@@ -283,14 +301,23 @@ func TestEngineEmitsSubthresholdReviewVerdictAsApproved(t *testing.T) {
 			Severity: reviewseverity.P2,
 			Summary:  "non-blocking polish",
 		},
-	})
+	}
+
+	// HALF ONE, the gate: still folds below the bar. If this ever stops being
+	// "approved" the merge gate's behaviour changed, which is NOT this issue.
+	if got := effectiveReviewDecisionForPayload(payload, reviewseverity.P1); got != "approved" {
+		t.Fatalf("gate decision for a sub-threshold verdict = %q, want approved; review_threshold.go must be unchanged by #1945", got)
+	}
+
+	engine.mailbox().emitTerminal(ctx, "review-45", JobSucceeded, payload)
 
 	finished := sink.byType(events.EventJobFinished)
 	if len(finished) != 1 {
 		t.Fatalf("job.finished emissions = %d, want 1; all=%+v", len(finished), sink.snapshot())
 	}
-	if got := finished[0].ReviewDecision; got != "approved" {
-		t.Fatalf("sub-threshold review decision = %q, want approved", got)
+	// HALF TWO, the wake: announces what the reviewer recorded.
+	if got := finished[0].ReviewDecision; got != "changes_requested" {
+		t.Fatalf("sub-threshold wake decision = %q, want changes_requested: the notification must carry the RECORDED verdict (#1945)", got)
 	}
 }
 


### PR DESCRIPTION
Refs #1945. Plan note **126362** (posted before any code, per directive 126324).

## The defect

A review-verdict wake announced `approved` for a job row recording `changes_requested`. Measured twice on #1943, hours apart, with distinct reviewer payload shapes.

## The value path, traced from source at the merge base

```
payload.Result.Decision                     recorded reviewer word
  -> engine_types.go:178   decision := effectiveReviewDecisionForPayload(payload, bar)
  -> review_threshold.go:42  changes_requested + severity below bar -> "approved"
  -> engine_types.go:179   admits only approved | changes_requested
  -> engine_types.go:196   event.ReviewDecision = decision          <- DEFECT SITE
  -> event_rule_sink.go:558-568  "gitmoot review verdict %s for %s#%d from job %s"
```

The reachable divergence set is a **singleton**: recorded `changes_requested` with severity below the bar. Every other input returns the raw decision unchanged.

## The fix: the announced value only

`event.ReviewDecision` now carries `strings.TrimSpace(payload.Result.Decision)`. **`effectiveReviewDecisionForPayload` and `review_threshold.go` are untouched** - its diff is zero lines. A threshold-adjusted decision is correct for the merge gate, where a below-bar finding must not block a merge.

`decision` feeds three consumers; only one is this defect:

| consumer | site | disposition |
|---|---|---|
| admission - which wake fires | `:179` | unchanged (threshold-effective) |
| **announcement - the word a human is told** | `:196` | **fixed** |
| routing - who receives it | `:197-205` | unchanged (threshold-effective) |

**A question I am raising rather than deciding:** in the divergence case the effective word is `approved`, so routing still wakes the **PR owner**, who now hears the truthful `changes_requested` while the gate still treats the review as approved for merge purposes. Keying routing on the recorded decision would change *who* is woken - a behaviour change beyond notification truthfulness. If you want it, that is a second head, not a silent extra in this one.

**No defensive fallback, deliberately.** The transform's only rule maps `changes_requested -> approved`, so whenever admission passes the recorded word is also admitted. A third-word guard would be unreachable, and an unfalsifiable guard is worse than none - I deleted exactly such a line on #1926 after no mutant could kill it. `TestReviewVerdictWakeVocabularyStaysTwoWords` pins the implication instead.

## #1685: same family, different mechanism, untouched

- **#1685** - wrong **source**: a coordinator fan-out is a dispatch record, not an inspection, so the wake is suppressed entirely at the admission guard (`:177`).
- **#1945** - wrong **transform**: a genuine single-reviewer verdict exists and its announced word is wrong.

My change sits *inside* the block that guard already admits, so a fan-out cannot reach it. `TestReviewVerdictWakeStaysExcludedForFanOut` asserts a fan-out still emits no review-verdict wake, so a future edit weakening `:177` fails a named test.

## Red / green at the production event-to-wake path

`internal/cli/event_rule_sink_verdict_decision_test.go` drives the real engine over the real mailbox to a review terminal, takes the event from the injected sink the daemon uses, and renders it with `eventRuleWakePrompt` - the same function the daemon calls. The blocking bar is installed by `applyReviewPolicy` reading a real config file, not by setting a field.

| arm | `-count=3` result |
|---|---|
| origin/main production file, tests present | **15 PASS / 9 FAIL**, failing `event.ReviewDecision = "approved", want "changes_requested"` |
| this head | **24 PASS / 0 FAIL** |

Controls, all should-succeed: genuine `approved` still announces approved; fan-out emits no verdict wake; directive wake prompt unchanged.

## Mutants

Both compiling semantic substitutions on the production line; sources restored sha256-identical.

| mutation | result |
|---|---|
| restore `event.ReviewDecision = decision` (the exact pre-fix line) | **KILLED** - `TestReviewVerdictWakeAnnouncesRecordedChangesRequested` |
| announce a constant `"changes_requested"` | **KILLED** by the genuine-approved control |

## One superseded test, retargeted rather than deleted

`TestEngineEmitsSubthresholdReviewVerdictAsApproved` asserted the defect. It is renamed to `…WithRecordedDecision` and now asserts **both halves**: the gate still folds a sub-threshold verdict to `approved` through `effectiveReviewDecisionForPayload`, **and** the wake announces the recorded decision. The sub-threshold behaviour therefore keeps a test, and either regression fails it. The old name is retained in a comment so it stays greppable.

## Verification

Pinned `GOTOOLCHAIN=local`, `go1.26.4`: gofmt **0** dirty, `go vet ./...` **rc=0**, `go test ./internal/workflow/ ./internal/cli/ ./internal/events/` all **ok**, `TEST_RC=0`. Isolated worktree off `origin/main`; throwaway `/tmp` HOME for E2E; `/root/.gitmoot` read-only and never written.

## Boundary

Changed: `internal/workflow/engine_types.go`, `internal/workflow/event_sink_test.go`, and the new `internal/cli/event_rule_sink_verdict_decision_test.go`.

**No forbidden file changed** - each checked individually and reported zero: `review_threshold.go`, `merge_gate.go`, `merge_gate_test.go`, `session_job_test.go`, `agent_dispatch.go`, `daemon_worker.go`, `review_phase_*`, `transcript_retention.go`, `internal/db/dashboard_store.go`, `internal/transcript/*`, `skills/gitmoot/references/CLI.md`, `website/docs/reference/cli.md`, `website/static/llms.txt`, `internal/db/org_role_unavailable.go`, `internal/cli/org_role_unavailable.go`, `internal/cli/job.go`, `internal/cli/org.go`.

`internal/cli/event_rule_sink.go` and `internal/events/sink.go` were permitted to me and **needed no production change** - the sink already renders whatever value it is given, which is why the fix belongs upstream of it.

No merge, deploy, or reviewer dispatch from me; 125950 remains deploy authority.

Signed: **GM-OMP-FANOUT**
