### PR TITLE
fix(workflow): collapse every due pending wake on its coalesce_key (#1978)

### DIFF
--- a/docs/events.md
+++ b/docs/events.md
@@ -217,11 +217,18 @@ back the emitting job. `gitmoot org escalate` addresses the same durable note
 and reply obligation upward to an ancestor or downward to a descendant. Upward
 questions remain escalations; downward questions are asks. Same-role questions
 are invalid, and peers are refused by a safe command-level default because no
-configurable peer-question policy exists. The daemon uses rolling five-second
-windows per event kind and role, so same-kind events coalesce while a blocked
-event and a reply for the same role remain separate.
-Pending, attempted, delivered, stalled, failed, and `delivery_unknown` remain
-queryable per outbox row, and outstanding obligations contribute to daemon tick
+configurable peer-question policy exists. The daemon holds each pending group
+for five seconds after its OLDEST row, then delivers every due pending row for
+that event kind and role as ONE wake, bounded at ten rows per wake, so a
+blocked event and a reply for the same role remain separate but two notes for
+the same role are one interrupt however far apart they arrived. The one row the
+wake names carries the delivery outcome; every row it collapses is recorded
+`superseded` with `coalesced into wake outbox row <id>`, so the suppressed
+wakes stay readable and countable rather than each reporting a delivery of its
+own.
+Pending, attempted, delivered, superseded, stalled, failed, and
+`delivery_unknown` remain queryable per outbox row, and outstanding obligations
+contribute to daemon tick
 health. A quiet burst tail is flushed by a later daemon tick; it does not require
 another event. If the outbox or its delivery rules cannot be queried, or an
 outbox row cannot be parsed or claimed, the drain is logged as unhealthy and

--- a/docs/events.md
+++ b/docs/events.md
@@ -218,7 +218,8 @@ and reply obligation upward to an ancestor or downward to a descendant. Upward
 questions remain escalations; downward questions are asks. Same-role questions
 are invalid, and peers are refused by a safe command-level default because no
 configurable peer-question policy exists. The daemon holds each pending group
-for five seconds after its OLDEST row, then delivers every due pending row for
+for `[org].wake_coalesce_hold` (default `5m`) after its OLDEST row, then
+delivers every due pending row for
 that event kind and role as ONE wake, bounded at ten rows per wake, so a
 blocked event and a reply for the same role remain separate but two notes for
 the same role are one interrupt however far apart they arrived. The one row the
@@ -228,8 +229,11 @@ wakes stay readable and countable rather than each reporting a delivery of its
 own.
 Pending, attempted, delivered, superseded, stalled, failed, and
 `delivery_unknown` remain queryable per outbox row, and outstanding obligations
-contribute to daemon tick
-health. A quiet burst tail is flushed by a later daemon tick; it does not require
+contribute to daemon tick health. A deliverable row still inside its hold is
+reported as `held` rather than `pending` and is NOT an outstanding obligation:
+it is waiting by design, so a hold longer than the tick interval does not make
+every tick read as unhealthy.
+A quiet burst tail is flushed by a later daemon tick; it does not require
 another event. If the outbox or its delivery rules cannot be queried, or an
 outbox row cannot be parsed or claimed, the drain is logged as unhealthy and
 retried on a later tick without aborting unrelated repository work.

--- a/internal/cli/daemon_scheduler.go
+++ b/internal/cli/daemon_scheduler.go
@@ -1746,11 +1746,27 @@ func runEnabledRepoWorkerTicksTracked(ctx context.Context, store *db.Store, work
 }
 
 func drainFleetReplyWakeOutbox(ctx context.Context, store *db.Store, worker jobWorker, now time.Time) (replyWakeOutboxHealth, error) {
-	health, err := drainReplyWakeOutboxWithHealth(ctx, store, now, worker.replyWakeDelivery)
+	health, err := drainReplyWakeOutboxWithHealth(ctx, store, now, workerWakeCoalesceHold(worker), worker.replyWakeDelivery)
 	if err != nil {
 		return health, fmt.Errorf("reply wake outbox drain failed: %w", err)
 	}
 	return health, nil
+}
+
+// workerWakeCoalesceHold reads [org].wake_coalesce_hold for this daemon's home.
+// An absent or unreadable config keeps the default hold: a config read failure
+// must not change wake cadence, only role bindings, which the sink already
+// fails closed on.
+func workerWakeCoalesceHold(worker jobWorker) time.Duration {
+	configFile := resolveConfigFile(worker.workflowHome())
+	if configFile == "" {
+		return config.DefaultWakeCoalesceHold
+	}
+	orgConfig, err := config.LoadOrg(config.Paths{ConfigFile: configFile})
+	if err != nil {
+		return config.DefaultWakeCoalesceHold
+	}
+	return orgConfig.WakeCoalesceHold()
 }
 
 func jobStateCanRetryAdvancement(state string) bool {

--- a/internal/cli/event_rule_sink_wake_persistence_test.go
+++ b/internal/cli/event_rule_sink_wake_persistence_test.go
@@ -93,7 +93,7 @@ func seedClaimedWake(t *testing.T, store *db.Store, sourceID, role string) (even
 		t.Fatalf("projected %d obligations for %s, want 1", len(batch), sourceID)
 	}
 	ids := []int64{batch[0].ID}
-	if claimed, err := store.ClaimWakeOutbox(ctx, ids, time.Now().UTC()); err != nil || !claimed {
+	if claimed, err := store.ClaimWakeOutbox(ctx, ids[0], ids[1:], time.Now().UTC()); err != nil || !claimed {
 		t.Fatalf("claim wake outbox: claimed=%v err=%v", claimed, err)
 	}
 	event, err := wakeOutboxEvent(batch, time.Now())

--- a/internal/cli/org_directive_test.go
+++ b/internal/cli/org_directive_test.go
@@ -326,13 +326,15 @@ func TestDirectiveWakeOutboxIsConfigInert(t *testing.T) {
 
 	// MUTANT F3: treating an unmatched directive as an unhealthy obligation
 	// makes this zero-directive-rule drain return a permanent error.
-	if _, err := drainReplyWakeOutboxWithHealth(context.Background(), store, createdAt.Add(replyWakeCoalescingWindow+time.Second), replyWakeTestDeliveryResolver(deliverySink)); err != nil {
+	if _, err := drainReplyWakeOutboxWithHealth(context.Background(), store, createdAt.Add(replyWakeCoalescingWindow+time.Second), replyWakeCoalescingWindow, replyWakeTestDeliveryResolver(deliverySink)); err != nil {
 		t.Fatalf("config-inert drain for directive %d: %v", directive.ID, err)
 	}
 	health, err := wakeOutboxObligationHealth(
 		context.Background(),
 		store,
 		createdAt.Add(-time.Minute),
+		createdAt.Add(replyWakeCoalescingWindow+time.Second),
+		replyWakeCoalescingWindow,
 		replyWakeTestDeliveryResolver(deliverySink),
 	)
 	if err != nil || health.pending != 0 || health.inert != 1 {
@@ -387,7 +389,7 @@ func TestDirectiveWakeOutboxUsesSeparateCoalesceNamespace(t *testing.T) {
 	}
 
 	latest, _ := time.Parse(time.RFC3339Nano, pending[len(pending)-1].CreatedAt)
-	if _, err := drainReplyWakeOutboxWithHealth(ctx, store, latest.Add(replyWakeCoalescingWindow+time.Second), replyWakeTestDeliveryResolver(deliverySink)); err != nil {
+	if _, err := drainReplyWakeOutboxWithHealth(ctx, store, latest.Add(replyWakeCoalescingWindow+time.Second), replyWakeCoalescingWindow, replyWakeTestDeliveryResolver(deliverySink)); err != nil {
 		t.Fatalf("coalesced drain: %v", err)
 	}
 	directivePrompt := ""

--- a/internal/cli/org_directive_ttl_test.go
+++ b/internal/cli/org_directive_ttl_test.go
@@ -766,7 +766,7 @@ func TestDirectiveNagInsertToDrainDelivers(t *testing.T) {
 	}
 
 	// And the drain must still accept it.
-	if _, err := drainReplyWakeOutboxWithHealth(ctx, store, time.Now().UTC(), func(context.Context) (replyWakeDelivery, error) {
+	if _, err := drainReplyWakeOutboxWithHealth(ctx, store, time.Now().UTC(), replyWakeCoalescingWindow, func(context.Context) (replyWakeDelivery, error) {
 		return replyWakeDelivery{sink: &recordingSink{}, rules: rules}, nil
 	}); err != nil && strings.Contains(err.Error(), "unsupported source kind") {
 		t.Fatalf("drain REFUSED the nag it was just handed: %v", err)

--- a/internal/cli/org_directive_ttl_test.go
+++ b/internal/cli/org_directive_ttl_test.go
@@ -951,7 +951,7 @@ func TestDirectiveNagRevivesTheDeliveredWakeRowWithoutDuplicating(t *testing.T) 
 	originalID := initial[0].ID
 
 	// Deliver it, following the real state machine.
-	if _, err := store.ClaimWakeOutbox(ctx, []int64{originalID}, time.Now().UTC()); err != nil {
+	if _, err := store.ClaimWakeOutbox(ctx, originalID, nil, time.Now().UTC()); err != nil {
 		t.Fatal(err)
 	}
 	if err := store.FinishWakeOutbox(ctx, []int64{originalID}, db.WakeOutboxStateDelivered, "", time.Now().UTC()); err != nil {

--- a/internal/cli/org_roster_guard_test.go
+++ b/internal/cli/org_roster_guard_test.go
@@ -144,6 +144,12 @@ func TestOrgConfigMethodSetIsPinned(t *testing.T) {
 		"RecycleEnforce",
 		"Role",
 		"Roots",
+		// WakeCoalesceHold is a scalar policy read, the same shape as the
+		// DirectiveAckTTL/DirectiveDoneTTL accessors above. It exposes one
+		// duration and no role membership, so the single-choke-point policy
+		// (#1635) is untouched: ResolveOrgRoster remains the only way to
+		// enumerate roles (#1978).
+		"WakeCoalesceHold",
 	}
 	typ := reflect.TypeOf(config.OrgConfig{})
 	got := make([]string, 0, typ.NumMethod())

--- a/internal/cli/reply_wake_outbox.go
+++ b/internal/cli/reply_wake_outbox.go
@@ -9,24 +9,27 @@ import (
 	"strings"
 	"time"
 
+	"github.com/gitmoot/gitmoot/internal/config"
 	"github.com/gitmoot/gitmoot/internal/db"
 	"github.com/gitmoot/gitmoot/internal/events"
 	"github.com/gitmoot/gitmoot/internal/workflow"
 )
 
 const (
-	// replyWakeCoalescingWindow is long enough to absorb a burst of separate
-	// short-lived `org escalate` processes while keeping the daemon-tick wake
-	// latency small.
+	// replyWakeCoalescingWindow is the DEFAULT hold, overridable by
+	// [org].wake_coalesce_hold. It absorbs a burst of separate short-lived
+	// `org escalate` processes and, since the owner decision of 2026-09-07,
+	// deliberately trades up to five minutes of wake latency for a measured
+	// 32.1% fewer interrupts on this fleet's own arrival history.
 	//
 	// IT IS A HOLD ON THE OLDEST PENDING ROW, NOT A LIMIT ON BATCH MEMBERSHIP
-	// (#1978). It used to be both: a row created more than five seconds after
+	// (#1978). It used to be both: a row created more than one window after
 	// the batch anchor started a SECOND rolling window and therefore a second
 	// wake, even though both rows were pending at the same drain and shared one
 	// coalesce_key. Measured on this box's live store, 8,464 attempted rows were
 	// delivered as 8,091 wakes, so 92.8% of delivery attempts carried exactly
 	// one row while same-key arrivals were 5 seconds to 5 minutes apart.
-	replyWakeCoalescingWindow  = 5 * time.Second
+	replyWakeCoalescingWindow  = config.DefaultWakeCoalesceHold
 	replyWakeMaxCoalescedItems = 10
 	// A synchronous reply wake gets one 12s Herdr call plus bounded probes and
 	// its terminal store write. Thirty seconds leaves margin for a live owner;
@@ -43,7 +46,13 @@ type replyWakeDeliveryResolver func(context.Context) (replyWakeDelivery, error)
 
 type replyWakeOutboxHealth struct {
 	pending int
-	inert   int
+	// held counts deliverable rows still inside their coalescing hold. They are
+	// SEPARATE from pending because they are waiting BY DESIGN, and with a
+	// 300s default hold nearly every tick observes one (#1978/#1979). Counting
+	// them as an outstanding obligation turned "drain unhealthy" from a real
+	// diagnostic into a line the daemon prints most minutes.
+	held  int
+	inert int
 	// routeRemoved means a durable tombstone proves that a matching rule was
 	// deleted after the pending row existed.
 	routeRemoved  int
@@ -52,8 +61,9 @@ type replyWakeOutboxHealth struct {
 
 func (h replyWakeOutboxHealth) String() string {
 	return fmt.Sprintf(
-		"pending=%d inert=%d route_removed=%d aged_attempted=%d",
+		"pending=%d held=%d inert=%d route_removed=%d aged_attempted=%d",
 		h.pending,
+		h.held,
 		h.inert,
 		h.routeRemoved,
 		h.agedAttempted,
@@ -75,9 +85,17 @@ type wakeOutboxStore interface {
 // drainReplyWakeOutboxWithHealth is a store-global daemon operation. It
 // deliberately reads durable work before resolving delivery: unreadable outbox
 // state and an empty outbox therefore cannot collapse into the same result.
-func drainReplyWakeOutboxWithHealth(ctx context.Context, store wakeOutboxStore, now time.Time, resolve replyWakeDeliveryResolver) (replyWakeOutboxHealth, error) {
+//
+// `hold` is how long a pending group waits after its OLDEST row before the
+// whole due group is delivered as one wake. A non-positive value falls back to
+// the default rather than delivering with no hold at all, so a misread config
+// cannot turn every burst back into one wake per note.
+func drainReplyWakeOutboxWithHealth(ctx context.Context, store wakeOutboxStore, now time.Time, hold time.Duration, resolve replyWakeDeliveryResolver) (replyWakeOutboxHealth, error) {
 	if store == nil {
 		return replyWakeOutboxHealth{}, errors.New("wake outbox store is required")
+	}
+	if hold <= 0 {
+		hold = replyWakeCoalescingWindow
 	}
 	attemptedBefore := now.UTC().Add(-replyWakeAttemptedUnknownAfter)
 	obligations, err := store.ListWakeOutboxObligations(ctx, attemptedBefore)
@@ -132,7 +150,7 @@ func drainReplyWakeOutboxWithHealth(ctx context.Context, store wakeOutboxStore, 
 			if err != nil {
 				return replyWakeOutboxHealth{}, fmt.Errorf("parse wake outbox created_at for row %d: %w", items[start].ID, err)
 			}
-			deadline := startedAt.Add(replyWakeCoalescingWindow)
+			deadline := startedAt.Add(hold)
 			if now.UTC().Before(deadline) {
 				// Later rows for the same group cannot be due before its oldest
 				// row, so leave the whole tail pending for a future tick.
@@ -191,26 +209,28 @@ func drainReplyWakeOutboxWithHealth(ctx context.Context, store wakeOutboxStore, 
 		}
 	}
 	if mutated {
-		return wakeOutboxObligationHealth(ctx, store, attemptedBefore, resolve)
+		return wakeOutboxObligationHealth(ctx, store, attemptedBefore, now, hold, resolve)
 	}
 	// The #1200/#1201 contract is untouched by the reuse: an unreadable outbox
 	// already returned its error above, so only a SUCCESSFUL read can reach
 	// here, and an empty one returned early. Reuse therefore never turns "could
 	// not read" into "nothing to do".
-	return classifyWakeOutboxObligations(ctx, store, obligations, attemptedBefore, resolve)
+	return classifyWakeOutboxObligations(ctx, store, obligations, attemptedBefore, now, hold, resolve)
 }
 
 func wakeOutboxObligationHealth(
 	ctx context.Context,
 	store wakeOutboxStore,
 	attemptedBefore time.Time,
+	now time.Time,
+	hold time.Duration,
 	resolve replyWakeDeliveryResolver,
 ) (replyWakeOutboxHealth, error) {
 	obligations, err := store.ListWakeOutboxObligations(ctx, attemptedBefore)
 	if err != nil {
 		return replyWakeOutboxHealth{}, fmt.Errorf("read wake outbox obligations: %w", err)
 	}
-	return classifyWakeOutboxObligations(ctx, store, obligations, attemptedBefore, resolve)
+	return classifyWakeOutboxObligations(ctx, store, obligations, attemptedBefore, now, hold, resolve)
 }
 
 // classifyWakeOutboxObligations grades an ALREADY-READ obligation projection.
@@ -222,6 +242,8 @@ func classifyWakeOutboxObligations(
 	store wakeOutboxStore,
 	obligations db.WakeOutboxObligationProjection,
 	attemptedBefore time.Time,
+	now time.Time,
+	hold time.Duration,
 	resolve replyWakeDeliveryResolver,
 ) (replyWakeOutboxHealth, error) {
 	health := replyWakeOutboxHealth{agedAttempted: len(obligations.AgedAttempted)}
@@ -251,6 +273,17 @@ func classifyWakeOutboxObligations(
 			return replyWakeOutboxHealth{}, fmt.Errorf("classify wake outbox row %d: %w", obligation.ID, err)
 		}
 		if len(matchingWakeRules(delivery.rules, event)) > 0 {
+			createdAt, err := time.Parse(time.RFC3339Nano, obligation.CreatedAt)
+			if err != nil {
+				return replyWakeOutboxHealth{}, fmt.Errorf("parse wake outbox created_at for row %d: %w", obligation.ID, err)
+			}
+			// A deliverable row inside its hold is WAITING, not outstanding: the
+			// next due tick delivers it, and with a 300s hold this is the normal
+			// state of the outbox rather than a fault (#1978).
+			if hold > 0 && now.UTC().Before(createdAt.Add(hold)) {
+				health.held++
+				continue
+			}
 			health.pending++
 			continue
 		}

--- a/internal/cli/reply_wake_outbox.go
+++ b/internal/cli/reply_wake_outbox.go
@@ -17,7 +17,15 @@ import (
 const (
 	// replyWakeCoalescingWindow is long enough to absorb a burst of separate
 	// short-lived `org escalate` processes while keeping the daemon-tick wake
-	// latency small. Rolling windows start at the oldest pending item.
+	// latency small.
+	//
+	// IT IS A HOLD ON THE OLDEST PENDING ROW, NOT A LIMIT ON BATCH MEMBERSHIP
+	// (#1978). It used to be both: a row created more than five seconds after
+	// the batch anchor started a SECOND rolling window and therefore a second
+	// wake, even though both rows were pending at the same drain and shared one
+	// coalesce_key. Measured on this box's live store, 8,464 attempted rows were
+	// delivered as 8,091 wakes, so 92.8% of delivery attempts carried exactly
+	// one row while same-key arrivals were 5 seconds to 5 minutes apart.
 	replyWakeCoalescingWindow  = 5 * time.Second
 	replyWakeMaxCoalescedItems = 10
 	// A synchronous reply wake gets one 12s Herdr call plus bounded probes and
@@ -60,7 +68,7 @@ func (h replyWakeOutboxHealth) String() string {
 type wakeOutboxStore interface {
 	ListWakeOutboxObligations(ctx context.Context, attemptedBefore time.Time) (db.WakeOutboxObligationProjection, error)
 	ExpireAgedWakeOutbox(ctx context.Context, attemptedBefore time.Time, now time.Time) ([]db.WakeOutboxEntry, error)
-	ClaimWakeOutbox(ctx context.Context, ids []int64, now time.Time) (bool, error)
+	ClaimWakeOutbox(ctx context.Context, surviving int64, coalesced []int64, now time.Time) (bool, error)
 	ListDeletedEventRulesForRoutes(ctx context.Context, routes []db.EventRuleRoute) ([]db.DeletedEventRule, error)
 }
 
@@ -125,22 +133,18 @@ func drainReplyWakeOutboxWithHealth(ctx context.Context, store wakeOutboxStore, 
 				return replyWakeOutboxHealth{}, fmt.Errorf("parse wake outbox created_at for row %d: %w", items[start].ID, err)
 			}
 			deadline := startedAt.Add(replyWakeCoalescingWindow)
-			end := start + 1
-			for end < len(items) && end-start < replyWakeMaxCoalescedItems {
-				createdAt, err := time.Parse(time.RFC3339Nano, items[end].CreatedAt)
-				if err != nil {
-					return replyWakeOutboxHealth{}, fmt.Errorf("parse wake outbox created_at for row %d: %w", items[end].ID, err)
-				}
-				if !createdAt.Before(deadline) {
-					break
-				}
-				end++
-			}
 			if now.UTC().Before(deadline) {
-				// Later rows for the same rolling group cannot be due before its
-				// oldest row, so leave the whole tail pending for a future tick.
+				// Later rows for the same group cannot be due before its oldest
+				// row, so leave the whole tail pending for a future tick.
 				break
 			}
+			// EVERY DUE PENDING ROW FOR THIS KEY JOINS THE BATCH, capped only by
+			// replyWakeMaxCoalescedItems (#1978). The anchor's hold above has
+			// already elapsed, and a newer row's own hold cannot matter: it is
+			// carried by a wake this drain is emitting anyway, so including it
+			// only removes a later interrupt. The batch event still names every
+			// member's retrieval command, so collapsing loses no note.
+			end := min(start+replyWakeMaxCoalescedItems, len(items))
 
 			batch := items[start:end]
 			event, err := wakeOutboxEvent(batch, now)
@@ -168,13 +172,17 @@ func drainReplyWakeOutboxWithHealth(ctx context.Context, store wakeOutboxStore, 
 			for _, entry := range batch {
 				ids = append(ids, entry.ID)
 			}
-			claimed, err := store.ClaimWakeOutbox(ctx, ids, now)
+			// The oldest row SURVIVES as the delivered obligation: it is the one
+			// wakeOutboxEvent identifies as `oldest id`. The rest are recorded
+			// superseded into it rather than each reporting an independent
+			// delivery they never had (#1978).
+			claimed, err := store.ClaimWakeOutbox(ctx, ids[0], ids[1:], now)
 			if err != nil {
 				return replyWakeOutboxHealth{}, err
 			}
 			if claimed {
 				mutated = true
-				event.WakeOutboxIDs = ids
+				event.WakeOutboxIDs = ids[:1]
 				if err := emitReplyWakeOutboxEvent(ctx, delivery.sink, event, matchingRules); err != nil {
 					return replyWakeOutboxHealth{}, fmt.Errorf("emit claimed %s wake: %w", event.WakeKind, err)
 				}

--- a/internal/cli/reply_wake_outbox_test.go
+++ b/internal/cli/reply_wake_outbox_test.go
@@ -528,8 +528,20 @@ func TestReplyWakeOutboxBurstCoalescesToExactlyOneWake(t *testing.T) {
 		t.Fatalf("wake prompt = %q, want %q", wake.prompt, want)
 	}
 	delivered, err := store.ListWakeOutbox(ctx, db.WakeOutboxStateDelivered)
-	if err != nil || len(delivered) != 10 {
-		t.Fatalf("delivered rows = %+v, err=%v", delivered, err)
+	if err != nil || len(delivered) != 1 || delivered[0].SourceID != fmt.Sprint(oldestID) {
+		t.Fatalf("delivered rows = %+v, err=%v, want only the surviving oldest row", delivered, err)
+	}
+	// One wake was delivered, so exactly one row may claim a delivery. The other
+	// nine are recorded superseded into it (#1978); before that they each read
+	// `delivered`, which is what made the coalescing saving uncountable.
+	superseded, err := store.ListWakeOutbox(ctx, db.WakeOutboxStateSuperseded)
+	if err != nil || len(superseded) != 9 {
+		t.Fatalf("superseded rows = %+v, err=%v", superseded, err)
+	}
+	for _, row := range superseded {
+		if row.LastError != db.WakeOutboxCoalescedDetail(delivered[0].ID) {
+			t.Fatalf("superseded row %d last_error = %q, want the surviving row named", row.ID, row.LastError)
+		}
 	}
 }
 
@@ -595,7 +607,17 @@ func TestReplyWakeOutboxKeepsRolesSeparate(t *testing.T) {
 	}
 }
 
-func TestReplyWakeOutboxStartsNewBatchAfterWindow(t *testing.T) {
+// TestReplyWakeOutboxCollapsesDuePendingRowsBeyondTheWindow pins #1978's
+// contract: coalesce_key is what the store records, so two notes for the same
+// key that are BOTH DUE at one drain are one wake, however far apart they were
+// created. The five-second window is a hold on the OLDEST row, not a limit on
+// batch membership.
+//
+// Before the fix these two rows produced two prompts (two rolling windows), and
+// the row that carried no wake of its own was still recorded `delivered`, which
+// is why 250 of 8,806 live rows are `superseded` and every one of those came
+// from a directive receipt rather than from coalescing.
+func TestReplyWakeOutboxCollapsesDuePendingRowsBeyondTheWindow(t *testing.T) {
 	store, sink, wake, _ := replyWakeTestHarness(t, []replyWakeTestRole{{"owner", "w1:p1"}})
 	ctx := context.Background()
 	first, err := store.InsertWorkflowNote(ctx, db.WorkflowNote{
@@ -612,18 +634,45 @@ func TestReplyWakeOutboxStartsNewBatchAfterWindow(t *testing.T) {
 	}
 	base := time.Date(2026, 7, 28, 12, 0, 0, 0, time.UTC)
 	setWakeOutboxCreatedAt(t, store.DatabasePath(), fmt.Sprint(first.ID), base)
-	setWakeOutboxCreatedAt(t, store.DatabasePath(), fmt.Sprint(second.ID), base.Add(replyWakeCoalescingWindow))
+	setWakeOutboxCreatedAt(t, store.DatabasePath(), fmt.Sprint(second.ID), base.Add(6*replyWakeCoalescingWindow))
 
-	if _, err := drainReplyWakeOutboxWithHealth(ctx, store, base.Add(2*replyWakeCoalescingWindow+time.Second), replyWakeTestDeliveryResolver(sink)); err != nil {
+	if _, err := drainReplyWakeOutboxWithHealth(
+		ctx, store, base.Add(7*replyWakeCoalescingWindow), replyWakeTestDeliveryResolver(sink),
+	); err != nil {
 		t.Fatal(err)
 	}
-	if wake.promptCalls != 2 {
-		t.Fatalf("wake calls = %d, want two rolling windows; prompts=%v", wake.promptCalls, wake.prompts)
+	if wake.promptCalls != 1 {
+		t.Fatalf("wake calls = %d, want one collapsed wake; prompts=%v", wake.promptCalls, wake.prompts)
 	}
-	for _, prompt := range wake.prompts {
-		if !strings.Contains(prompt, "1 new items, oldest id ") {
-			t.Fatalf("window prompt = %q", prompt)
+	if !strings.Contains(wake.prompt, "2 new items, oldest id ") {
+		t.Fatalf("collapsed prompt = %q, want both items named", wake.prompt)
+	}
+	// Nothing is dropped: the surviving wake still names every collapsed note.
+	for _, note := range []int64{first.ID, second.ID} {
+		if !strings.Contains(wake.prompt, fmt.Sprintf("gitmoot workflow show-note %d", note)) {
+			t.Fatalf("collapsed prompt = %q, want retrieval command for note %d", wake.prompt, note)
 		}
+	}
+	rows, err := store.ListWakeOutbox(ctx, "")
+	if err != nil || len(rows) != 2 {
+		t.Fatalf("outbox rows = %+v, err=%v", rows, err)
+	}
+	surviving, collapsed := rows[0], rows[1]
+	if surviving.SourceID != fmt.Sprint(first.ID) || collapsed.SourceID != fmt.Sprint(second.ID) {
+		t.Fatalf("row order = %q,%q, want the oldest row first", surviving.SourceID, collapsed.SourceID)
+	}
+	if surviving.State != db.WakeOutboxStateDelivered {
+		t.Fatalf("surviving row state = %q, want %q", surviving.State, db.WakeOutboxStateDelivered)
+	}
+	if collapsed.State != db.WakeOutboxStateSuperseded {
+		t.Fatalf("collapsed row state = %q, want %q", collapsed.State, db.WakeOutboxStateSuperseded)
+	}
+	// The saving is auditable only if the superseded row names its survivor.
+	if want := fmt.Sprintf("coalesced into wake outbox row %d", surviving.ID); collapsed.LastError != want {
+		t.Fatalf("collapsed row last_error = %q, want %q", collapsed.LastError, want)
+	}
+	if collapsed.FinishedAt == "" || collapsed.AttemptCount != 1 {
+		t.Fatalf("collapsed row = %+v, want one recorded attempt and a finish stamp", collapsed)
 	}
 }
 
@@ -885,7 +934,7 @@ func TestReplyWakeOutboxAgedAttemptedExpiresDeliveryUnknownWithoutDuplicateWake(
 		t.Fatalf("pending = %+v, err=%v", pending, err)
 	}
 	attemptedAt := time.Date(2026, 7, 28, 12, 0, 0, 0, time.UTC)
-	claimed, err := store.ClaimWakeOutbox(context.Background(), []int64{pending[0].ID}, attemptedAt)
+	claimed, err := store.ClaimWakeOutbox(context.Background(), pending[0].ID, nil, attemptedAt)
 	if err != nil || !claimed {
 		t.Fatalf("simulate pre-crash claim = %v, err=%v", claimed, err)
 	}
@@ -934,23 +983,29 @@ func TestReplyWakeOutboxAgedAttemptedExpiresDeliveryUnknownWithoutDuplicateWake(
 func TestReplyWakeOutboxRuleDeletedMidDrainRefusesLaterBatch(t *testing.T) {
 	store, sink, wake, home := replyWakeTestHarness(t, []replyWakeTestRole{{"owner", "w1:p1"}})
 	ctx := context.Background()
-	first, err := store.InsertWorkflowNote(ctx, db.WorkflowNote{
-		WorkflowID: "release/rule-generation", Author: "worker", Body: "first",
-		AddressedTarget: "owner",
-	})
-	if err != nil {
-		t.Fatal(err)
+	// The later batch has to exist for a reason coalescing cannot remove: the
+	// COUNT BOUND, not a second creation window (#1978). Since every due
+	// pending row for one key now joins one batch, replyWakeMaxCoalescedItems+1
+	// rows are what splits a key into two batches.
+	noteIDs := make([]int64, 0, replyWakeMaxCoalescedItems+1)
+	for index := 0; index <= replyWakeMaxCoalescedItems; index++ {
+		note, err := store.InsertWorkflowNote(ctx, db.WorkflowNote{
+			WorkflowID: "release/rule-generation", Author: "worker",
+			Body: fmt.Sprintf("item %d", index), AddressedTarget: "owner",
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		noteIDs = append(noteIDs, note.ID)
 	}
-	second, err := store.InsertWorkflowNote(ctx, db.WorkflowNote{
-		WorkflowID: "release/rule-generation", Author: "worker", Body: "second",
-		AddressedTarget: "owner",
-	})
-	if err != nil {
-		t.Fatal(err)
-	}
+	first, last := noteIDs[0], noteIDs[len(noteIDs)-1]
 	base := time.Date(2026, 7, 28, 12, 0, 0, 0, time.UTC)
-	setWakeOutboxCreatedAt(t, store.DatabasePath(), fmt.Sprint(first.ID), base)
-	setWakeOutboxCreatedAt(t, store.DatabasePath(), fmt.Sprint(second.ID), base.Add(replyWakeCoalescingWindow))
+	for index, noteID := range noteIDs {
+		setWakeOutboxCreatedAt(
+			t, store.DatabasePath(), fmt.Sprint(noteID),
+			base.Add(time.Duration(index)*time.Millisecond),
+		)
+	}
 	wake.onPrompt = func() error {
 		return store.DeleteEventRule(ctx, "reply-0")
 	}
@@ -973,11 +1028,15 @@ func TestReplyWakeOutboxRuleDeletedMidDrainRefusesLaterBatch(t *testing.T) {
 		t.Fatalf("wake calls = %d, want only the authorized first batch; prompts=%v", wake.promptCalls, wake.prompts)
 	}
 	delivered, err := store.ListWakeOutbox(ctx, db.WakeOutboxStateDelivered)
-	if err != nil || len(delivered) != 1 || delivered[0].SourceID != fmt.Sprint(first.ID) {
+	if err != nil || len(delivered) != 1 || delivered[0].SourceID != fmt.Sprint(first) {
 		t.Fatalf("delivered = %+v, err=%v", delivered, err)
 	}
+	superseded, err := store.ListWakeOutbox(ctx, db.WakeOutboxStateSuperseded)
+	if err != nil || len(superseded) != replyWakeMaxCoalescedItems-1 {
+		t.Fatalf("superseded = %+v, err=%v", superseded, err)
+	}
 	pending, err := store.ListWakeOutbox(ctx, db.WakeOutboxStatePending)
-	if err != nil || len(pending) != 1 || pending[0].SourceID != fmt.Sprint(second.ID) || pending[0].AttemptCount != 0 {
+	if err != nil || len(pending) != 1 || pending[0].SourceID != fmt.Sprint(last) || pending[0].AttemptCount != 0 {
 		t.Fatalf("pending later batch = %+v, err=%v", pending, err)
 	}
 
@@ -1307,8 +1366,8 @@ func (s *countingWakeOutboxStore) ExpireAgedWakeOutbox(ctx context.Context, atte
 	return s.inner.ExpireAgedWakeOutbox(ctx, attemptedBefore, now)
 }
 
-func (s *countingWakeOutboxStore) ClaimWakeOutbox(ctx context.Context, ids []int64, now time.Time) (bool, error) {
-	claimed, err := s.inner.ClaimWakeOutbox(ctx, ids, now)
+func (s *countingWakeOutboxStore) ClaimWakeOutbox(ctx context.Context, surviving int64, coalesced []int64, now time.Time) (bool, error) {
+	claimed, err := s.inner.ClaimWakeOutbox(ctx, surviving, coalesced, now)
 	if claimed {
 		s.claims++
 	}

--- a/internal/cli/reply_wake_outbox_test.go
+++ b/internal/cli/reply_wake_outbox_test.go
@@ -227,13 +227,15 @@ func TestWakeOutboxTickHealthIncludesBlockedAndEscalation(t *testing.T) {
 		ctx,
 		store,
 		now.Add(-replyWakeAttemptedUnknownAfter),
+		now.Add(replyWakeCoalescingWindow+time.Second),
+		replyWakeCoalescingWindow,
 		func(ctx context.Context) (replyWakeDelivery, error) {
 			rules, err := store.ListEventRules(ctx)
 			return replyWakeDelivery{rules: rules}, err
 		},
 	)
 	if err == nil || health.pending != 2 || health.inert != 0 ||
-		!strings.Contains(err.Error(), "pending=2 inert=0 route_removed=0 aged_attempted=0") {
+		!strings.Contains(err.Error(), "pending=2 held=0 inert=0 route_removed=0 aged_attempted=0") {
 		t.Fatalf("tick health = %s err=%v, want two routable outstanding obligations", health, err)
 	}
 }
@@ -261,12 +263,14 @@ func TestWakeOutboxHealthDistinguishesRemovedRouteFromNeverConfigured(t *testing
 		ctx,
 		store,
 		time.Now().UTC().Add(-replyWakeAttemptedUnknownAfter),
+		time.Now().UTC().Add(replyWakeCoalescingWindow+time.Second),
+		replyWakeCoalescingWindow,
 		func(context.Context) (replyWakeDelivery, error) {
 			return replyWakeDelivery{}, nil
 		},
 	)
 	if err == nil || health.pending != 0 || health.inert != 1 || health.routeRemoved != 1 ||
-		!strings.Contains(err.Error(), "pending=0 inert=1 route_removed=1 aged_attempted=0") {
+		!strings.Contains(err.Error(), "pending=0 held=0 inert=1 route_removed=1 aged_attempted=0") {
 		t.Fatalf("route-history health = %s err=%v", health, err)
 	}
 }
@@ -310,12 +314,14 @@ func TestWakeOutboxHealthBoundsDeletedRuleLookupToPendingRoutes(t *testing.T) {
 		ctx,
 		store,
 		time.Now().UTC().Add(-replyWakeAttemptedUnknownAfter),
+		time.Now().UTC().Add(replyWakeCoalescingWindow+time.Second),
+		replyWakeCoalescingWindow,
 		func(context.Context) (replyWakeDelivery, error) {
 			return replyWakeDelivery{}, nil
 		},
 	)
 	if err == nil || health.routeRemoved != 1 || health.inert != 0 || health.pending != 0 ||
-		!strings.Contains(err.Error(), "pending=0 inert=0 route_removed=1 aged_attempted=0") {
+		!strings.Contains(err.Error(), "pending=0 held=0 inert=0 route_removed=1 aged_attempted=0") {
 		t.Fatalf("bounded route-history health = %s err=%v, want one relevant tombstone from 101 total", health, err)
 	}
 }
@@ -368,12 +374,20 @@ func TestReplyWakeOutboxDrainFailureDoesNotAbortRepoWork(t *testing.T) {
 		ID: "job-after-unhealthy-wake", Agent: "audit", Action: "ask",
 		Repo: "owner/repo", Branch: "main", PullRequest: 1,
 	})
-	if _, err := store.InsertWorkflowNote(context.Background(), db.WorkflowNote{
+	note, err := store.InsertWorkflowNote(context.Background(), db.WorkflowNote{
 		WorkflowID: "release/drain-isolation", Author: "worker", Body: "matching route without a delivery sink",
 		AddressedTarget: "owner",
-	}); err != nil {
+	})
+	if err != nil {
 		t.Fatal(err)
 	}
+	// The row must be PAST its coalescing hold: a row still inside the hold is
+	// held rather than outstanding, so the drain would be healthy and this test
+	// would assert on a fault it never provoked (#1978).
+	setWakeOutboxCreatedAt(
+		t, store.DatabasePath(), fmt.Sprint(note.ID),
+		time.Now().UTC().Add(-2*replyWakeCoalescingWindow),
+	)
 	if err := store.AddEventRule(context.Background(), db.EventRule{
 		ID: "reply-owner", OnKind: "reply", WakeRole: "owner", Enabled: true,
 	}); err != nil {
@@ -462,7 +476,7 @@ func TestReplyWakeOutboxInertHealthDoesNotEscalateSingleRepoLoop(t *testing.T) {
 		t.Fatalf("inert reply wake health reached escalation ladder: %q", stdout.String())
 	}
 	if strings.Contains(stdout.String(), "reply wake outbox drain unhealthy:") ||
-		!strings.Contains(stdout.String(), "pending=0 inert=1 route_removed=0 aged_attempted=0") {
+		!strings.Contains(stdout.String(), "pending=0 held=0 inert=1 route_removed=0 aged_attempted=0") {
 		t.Fatalf("inert reply wake health log = %q", stdout.String())
 	}
 }
@@ -637,7 +651,7 @@ func TestReplyWakeOutboxCollapsesDuePendingRowsBeyondTheWindow(t *testing.T) {
 	setWakeOutboxCreatedAt(t, store.DatabasePath(), fmt.Sprint(second.ID), base.Add(6*replyWakeCoalescingWindow))
 
 	if _, err := drainReplyWakeOutboxWithHealth(
-		ctx, store, base.Add(7*replyWakeCoalescingWindow), replyWakeTestDeliveryResolver(sink),
+		ctx, store, base.Add(7*replyWakeCoalescingWindow), replyWakeCoalescingWindow, replyWakeTestDeliveryResolver(sink),
 	); err != nil {
 		t.Fatal(err)
 	}
@@ -676,6 +690,47 @@ func TestReplyWakeOutboxCollapsesDuePendingRowsBeyondTheWindow(t *testing.T) {
 	}
 }
 
+// TestReplyWakeOutboxHonorsConfiguredHold pins that the hold is a parameter and
+// not the constant: with a two-minute hold, a group whose oldest row is 90s old
+// is not delivered, and the same group is delivered as one wake at 121s. A
+// drain that ignored the configured value would wake the seat at 90s.
+func TestReplyWakeOutboxHonorsConfiguredHold(t *testing.T) {
+	store, sink, wake, _ := replyWakeTestHarness(t, []replyWakeTestRole{{"owner", "w1:p1"}})
+	ctx := context.Background()
+	const hold = 2 * time.Minute
+	base := time.Date(2026, 7, 28, 12, 0, 0, 0, time.UTC)
+	for index := range 2 {
+		note, err := store.InsertWorkflowNote(ctx, db.WorkflowNote{
+			WorkflowID: "release/hold", Author: "worker",
+			Body: fmt.Sprint(index), AddressedTarget: "owner",
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		setWakeOutboxCreatedAt(
+			t, store.DatabasePath(), fmt.Sprint(note.ID),
+			base.Add(time.Duration(index)*30*time.Second),
+		)
+	}
+	health, err := drainReplyWakeOutboxWithHealth(
+		ctx, store, base.Add(90*time.Second), hold, replyWakeTestDeliveryResolver(sink),
+	)
+	if err != nil || health.held != 2 || health.pending != 0 {
+		t.Fatalf("held drain health = %s err = %v, want two rows held inside the hold and no fault", health, err)
+	}
+	if wake.promptCalls != 0 {
+		t.Fatalf("configured hold ignored: woke at 90s with a %s hold; prompts=%v", hold, wake.prompts)
+	}
+	if _, err := drainReplyWakeOutboxWithHealth(
+		ctx, store, base.Add(hold+time.Second), hold, replyWakeTestDeliveryResolver(sink),
+	); err != nil {
+		t.Fatal(err)
+	}
+	if wake.promptCalls != 1 || !strings.Contains(wake.prompt, "2 new items, oldest id ") {
+		t.Fatalf("post-hold wake = calls=%d prompt=%q", wake.promptCalls, wake.prompt)
+	}
+}
+
 func TestReplyWakeOutboxFleetDrainRunsWithZeroEnabledRepos(t *testing.T) {
 	store, sink, wake, home := replyWakeTestHarness(t, []replyWakeTestRole{{"owner", "w1:p1"}})
 	ctx := context.Background()
@@ -695,9 +750,10 @@ func TestReplyWakeOutboxFleetDrainRunsWithZeroEnabledRepos(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, err = drainReplyWakeOutboxWithHealth(ctx, store, oldestAt.Add(replyWakeCoalescingWindow-time.Millisecond), replyWakeTestDeliveryResolver(sink))
-	if err == nil || !strings.Contains(err.Error(), "outstanding obligations: pending=4") {
-		t.Fatalf("pre-window drain health = %v, want four pending obligations", err)
+	health, err := drainReplyWakeOutboxWithHealth(ctx, store, oldestAt.Add(replyWakeCoalescingWindow-time.Millisecond), replyWakeCoalescingWindow, replyWakeTestDeliveryResolver(sink))
+	// A row inside its hold is waiting, not outstanding, so the tick is healthy.
+	if err != nil || health.held != 4 || health.pending != 0 {
+		t.Fatalf("pre-hold drain health = %s err = %v, want four held rows", health, err)
 	}
 	if wake.promptCalls != 0 {
 		t.Fatalf("tail woke before window closed: %v", wake.prompts)
@@ -858,7 +914,7 @@ func TestReplyWakeOutboxZeroRulesReportsInertWithoutUnhealthy(t *testing.T) {
 	if tickErr != nil {
 		t.Fatalf("fleet tick aborted on inert pending-obligation health: %v", tickErr)
 	}
-	if !strings.Contains(stdout.String(), "reply wake outbox drain health: pending=0 inert=1 route_removed=0 aged_attempted=0") ||
+	if !strings.Contains(stdout.String(), "reply wake outbox drain health: pending=0 held=0 inert=1 route_removed=0 aged_attempted=0") ||
 		strings.Contains(stdout.String(), "reply wake outbox drain unhealthy:") {
 		t.Fatalf("fleet tick log = %q, want visible inert-only health", stdout.String())
 	}
@@ -911,7 +967,7 @@ func TestReplyWakeOutboxUnrelatedEnabledRuleReportsPendingObligationInert(t *tes
 	if tickErr != nil {
 		t.Fatalf("fleet tick aborted on inert pending-obligation health: %v", tickErr)
 	}
-	if !strings.Contains(stdout.String(), "reply wake outbox drain health: pending=0 inert=1 route_removed=0 aged_attempted=0") ||
+	if !strings.Contains(stdout.String(), "reply wake outbox drain health: pending=0 held=0 inert=1 route_removed=0 aged_attempted=0") ||
 		strings.Contains(stdout.String(), "reply wake outbox drain unhealthy:") {
 		t.Fatalf("fleet tick log = %q, want visible inert-only health", stdout.String())
 	}
@@ -1021,7 +1077,7 @@ func TestReplyWakeOutboxRuleDeletedMidDrainRefusesLaterBatch(t *testing.T) {
 		t.Fatalf("fleet tick aborted on later batch refusal: %v", tickErr)
 	}
 	if !strings.Contains(stdout.String(), "reply wake outbox drain unhealthy:") ||
-		!strings.Contains(stdout.String(), "pending=0 inert=0 route_removed=1 aged_attempted=0") {
+		!strings.Contains(stdout.String(), "pending=0 held=0 inert=0 route_removed=1 aged_attempted=0") {
 		t.Fatalf("fleet tick log = %q, want later batch refusal", stdout.String())
 	}
 	if wake.promptCalls != 1 {
@@ -1049,7 +1105,7 @@ func TestReplyWakeOutboxRuleDeletedMidDrainRefusesLaterBatch(t *testing.T) {
 		t.Fatalf("second fleet tick aborted on durable route removal: %v", tickErr)
 	}
 	if !strings.Contains(stdout.String(), "reply wake outbox drain unhealthy:") ||
-		!strings.Contains(stdout.String(), "pending=0 inert=0 route_removed=1 aged_attempted=0") {
+		!strings.Contains(stdout.String(), "pending=0 held=0 inert=0 route_removed=1 aged_attempted=0") {
 		t.Fatalf("second fleet tick log = %q, want durable later-batch refusal", stdout.String())
 	}
 	if wake.promptCalls != 1 {
@@ -1297,7 +1353,7 @@ func drainReplyWakeAfterAllRowsAreDueResult(t *testing.T, store *db.Store, sink 
 			latest = createdAt
 		}
 	}
-	_, drainErr := drainReplyWakeOutboxWithHealth(context.Background(), store, latest.Add(replyWakeCoalescingWindow+time.Second), replyWakeTestDeliveryResolver(sink))
+	_, drainErr := drainReplyWakeOutboxWithHealth(context.Background(), store, latest.Add(replyWakeCoalescingWindow+time.Second), replyWakeCoalescingWindow, replyWakeTestDeliveryResolver(sink))
 	return drainErr
 }
 
@@ -1403,7 +1459,7 @@ func TestReplyWakeOutboxDrainProjectsOnceWhenNothingIsClaimed(t *testing.T) {
 
 	// This row is deliverable, so the drain claims it and must re-read.
 	claiming := &countingWakeOutboxStore{inner: store}
-	if _, err := drainReplyWakeOutboxWithHealth(ctx, claiming, due, replyWakeTestDeliveryResolver(sink)); err != nil {
+	if _, err := drainReplyWakeOutboxWithHealth(ctx, claiming, due, replyWakeCoalescingWindow, replyWakeTestDeliveryResolver(sink)); err != nil {
 		t.Fatalf("claiming drain: %v", err)
 	}
 	if claiming.claims == 0 {
@@ -1415,7 +1471,7 @@ func TestReplyWakeOutboxDrainProjectsOnceWhenNothingIsClaimed(t *testing.T) {
 
 	// Nothing left to claim: one projection for the whole drain.
 	idle := &countingWakeOutboxStore{inner: store}
-	if _, err := drainReplyWakeOutboxWithHealth(ctx, idle, due, replyWakeTestDeliveryResolver(sink)); err != nil {
+	if _, err := drainReplyWakeOutboxWithHealth(ctx, idle, due, replyWakeCoalescingWindow, replyWakeTestDeliveryResolver(sink)); err != nil {
 		t.Fatalf("idle drain: %v", err)
 	}
 	if idle.claims != 0 {
@@ -1449,11 +1505,11 @@ func TestReplyWakeOutboxReusedProjectionGradesIdentically(t *testing.T) {
 	attemptedBefore := due.UTC().Add(-replyWakeAttemptedUnknownAfter)
 
 	counted := &countingWakeOutboxStore{inner: store}
-	reused, reusedErr := drainReplyWakeOutboxWithHealth(ctx, counted, due, replyWakeTestDeliveryResolver(sink))
+	reused, reusedErr := drainReplyWakeOutboxWithHealth(ctx, counted, due, replyWakeCoalescingWindow, replyWakeTestDeliveryResolver(sink))
 	if counted.claims != 0 || counted.projections != 1 {
 		t.Fatalf("claims=%d projections=%d, want the reuse path (0 and 1)", counted.claims, counted.projections)
 	}
-	fresh, freshErr := wakeOutboxObligationHealth(ctx, store, attemptedBefore, replyWakeTestDeliveryResolver(sink))
+	fresh, freshErr := wakeOutboxObligationHealth(ctx, store, attemptedBefore, due, replyWakeCoalescingWindow, replyWakeTestDeliveryResolver(sink))
 	if reused != fresh {
 		t.Fatalf("reused health %s != freshly read health %s", reused, fresh)
 	}

--- a/internal/config/init.go
+++ b/internal/config/init.go
@@ -419,6 +419,11 @@ path = ""
 # directive_ack_ttl = "10m"
 # directive_done_ttl = "0s" # disabled; a per-directive override takes precedence
 # directive_max_nudges = 3
+# wake_coalesce_hold = "5m" # hold a pending wake group after its oldest row, then
+#                           # deliver every due row for that role and kind as one
+#                           # wake. Owner-decided default: 5m trades up to five
+#                           # minutes of wake latency for a measured 32%% fewer
+#                           # interrupts; "5s" restores the pre-2026-09 cadence
 # [org.roles."owner"]
 # scope = ["*"]
 # merge_rule = "owner"

--- a/internal/config/org.go
+++ b/internal/config/org.go
@@ -10,6 +10,13 @@ import (
 	"unicode"
 )
 
+// DefaultWakeCoalesceHold is 300s by OWNER DECISION on 2026-09-07, relayed by
+// phobos: up to five minutes of added wake latency in exchange for the measured
+// interrupt reduction on this fleet's own arrival history, which is 21.8% at
+// 120s and 32.1% at 300s against 7.1% at the previous 5s (#1978). It stays
+// configurable through [org].wake_coalesce_hold.
+const DefaultWakeCoalesceHold = 5 * time.Minute
+
 // OrgRole is one role in the local organization registry. MergeRule is
 // deliberately advisory in phase 1a; scope is enforced at dispatch.
 type OrgRole struct {
@@ -34,6 +41,7 @@ type OrgConfig struct {
 	directiveAckTTL    time.Duration
 	directiveDoneTTL   time.Duration
 	directiveMaxNudges int
+	wakeCoalesceHold   time.Duration
 	roles              map[string]OrgRole
 }
 
@@ -81,6 +89,18 @@ func (c OrgConfig) DirectiveMaxNudges() int {
 		return 3
 	}
 	return c.directiveMaxNudges
+}
+
+// WakeCoalesceHold is how long the daemon holds a pending wake group after its
+// OLDEST row before delivering every due row for that role and kind as one
+// wake. Raising it trades wake latency for fewer interrupts: measured on this
+// fleet's own arrival history, 5s collapses 7.1% of wakes, 120s collapses
+// 21.8% and 300s collapses 32.1% (#1978).
+func (c OrgConfig) WakeCoalesceHold() time.Duration {
+	if c.wakeCoalesceHold <= 0 {
+		return DefaultWakeCoalesceHold
+	}
+	return c.wakeCoalesceHold
 }
 
 // Ancestors returns name's parent chain, nearest parent first. The cycle guard
@@ -186,6 +206,7 @@ func parseOrgContent(content []byte) (OrgConfig, error) {
 	seenDirectiveAckTTL := false
 	seenDirectiveDoneTTL := false
 	seenDirectiveMaxNudges := false
+	seenWakeCoalesceHold := false
 	current := ""
 	inOrg := false
 	lines := strings.Split(string(content), "\n")
@@ -243,7 +264,8 @@ func parseOrgContent(content []byte) (OrgConfig, error) {
 			// Recycle fields are binary-first: binaries predating this allowlist
 			// fail closed on a config that uses either field.
 			if key != "enforce" && key != "recycle_after" && key != "recycle_enforce" &&
-				key != "directive_ack_ttl" && key != "directive_done_ttl" && key != "directive_max_nudges" {
+				key != "directive_ack_ttl" && key != "directive_done_ttl" &&
+				key != "directive_max_nudges" && key != "wake_coalesce_hold" {
 				return OrgConfig{}, fmt.Errorf("unknown [org] field %q", key)
 			}
 			switch key {
@@ -313,6 +335,19 @@ func parseOrgContent(content []byte) (OrgConfig, error) {
 					return OrgConfig{}, fmt.Errorf("org directive_max_nudges must be positive")
 				}
 				cfg.directiveMaxNudges = v
+			case "wake_coalesce_hold":
+				if seenWakeCoalesceHold {
+					return OrgConfig{}, fmt.Errorf("duplicate [org].wake_coalesce_hold")
+				}
+				seenWakeCoalesceHold = true
+				v, err := parseOrgDuration(value)
+				if err != nil {
+					return OrgConfig{}, fmt.Errorf("parse [org].wake_coalesce_hold: %w", err)
+				}
+				if v <= 0 {
+					return OrgConfig{}, fmt.Errorf("org wake_coalesce_hold must be positive")
+				}
+				cfg.wakeCoalesceHold = v
 			}
 			continue
 		}
@@ -490,6 +525,9 @@ func ValidateOrg(cfg OrgConfig) error {
 	if cfg.Enforce() != "block" && cfg.Enforce() != "warn" {
 		return fmt.Errorf("org enforce must be \"block\" or \"warn\"")
 	}
+	if mode := cfg.RecycleEnforce(); mode != "off" && mode != "warn" && mode != "block" {
+		return fmt.Errorf("org recycle_enforce must be \"off\", \"warn\", or \"block\"")
+	}
 	if cfg.recycleAfter < 0 {
 		return fmt.Errorf("org recycle_after must not be negative")
 	}
@@ -502,8 +540,8 @@ func ValidateOrg(cfg OrgConfig) error {
 	if cfg.directiveMaxNudges < 0 {
 		return fmt.Errorf("org directive_max_nudges must not be negative")
 	}
-	if mode := cfg.RecycleEnforce(); mode != "off" && mode != "warn" && mode != "block" {
-		return fmt.Errorf("org recycle_enforce must be \"off\", \"warn\", or \"block\"")
+	if cfg.wakeCoalesceHold < 0 {
+		return fmt.Errorf("org wake_coalesce_hold must not be negative")
 	}
 	// Validate in sorted, structural passes so malformed registries return the
 	// same error regardless of Go map iteration order. Root naming deliberately

--- a/internal/config/org_test.go
+++ b/internal/config/org_test.go
@@ -166,6 +166,48 @@ func TestLoadOrgDirectiveTTLPolicy(t *testing.T) {
 	}
 }
 
+// TestLoadOrgWakeCoalesceHold pins the knob #1978 exposes: the hold is
+// configurable, an absent value keeps the pre-existing five seconds, and a
+// zero cannot silently turn the hold off and restore one wake per note.
+func TestLoadOrgWakeCoalesceHold(t *testing.T) {
+	paths := PathsForHome(t.TempDir())
+	if err := os.MkdirAll(filepath.Dir(paths.ConfigFile), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	for _, test := range []struct {
+		name    string
+		fields  string
+		want    time.Duration
+		wantErr string
+	}{
+		{name: "default", want: DefaultWakeCoalesceHold},
+		{name: "configured", fields: "wake_coalesce_hold = \"2m\"\n", want: 2 * time.Minute},
+		{name: "zero refused", fields: "wake_coalesce_hold = \"0s\"\n", wantErr: "wake_coalesce_hold must be positive"},
+		{name: "unparseable refused", fields: "wake_coalesce_hold = \"soon\"\n", wantErr: "parse [org].wake_coalesce_hold"},
+		{name: "duplicate refused", fields: "wake_coalesce_hold = \"1m\"\nwake_coalesce_hold = \"2m\"\n", wantErr: "duplicate [org].wake_coalesce_hold"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			body := "[org]\n" + test.fields + "[org.roles.\"owner\"]\nscope=[\"*\"]\n"
+			if err := os.WriteFile(paths.ConfigFile, []byte(body), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			cfg, err := LoadOrg(paths)
+			if test.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), test.wantErr) {
+					t.Fatalf("LoadOrg() error = %v, want containing %q", err, test.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatal(err)
+			}
+			if cfg.WakeCoalesceHold() != test.want {
+				t.Fatalf("WakeCoalesceHold() = %s, want %s", cfg.WakeCoalesceHold(), test.want)
+			}
+		})
+	}
+}
+
 func TestLoadOrgRecycleAfterFailsClosed(t *testing.T) {
 	paths := PathsForHome(t.TempDir())
 	if err := os.MkdirAll(filepath.Dir(paths.ConfigFile), 0o700); err != nil {

--- a/internal/db/wake_outbox.go
+++ b/internal/db/wake_outbox.go
@@ -487,13 +487,28 @@ WHERE id = ? AND state = 'attempted' AND attempted_at <= ?`,
 	return entries, nil
 }
 
-// ClaimWakeOutbox atomically marks an entire coalesced batch attempted. If any
-// member is no longer pending, none are claimed; this is the cross-daemon
-// mark-before-emit dedup guard.
-func (s *Store) ClaimWakeOutbox(ctx context.Context, ids []int64, at time.Time) (bool, error) {
-	if len(ids) == 0 {
-		return false, errors.New("wake outbox claim requires at least one id")
-	}
+// ClaimWakeOutbox atomically claims one coalesced batch. If any member is no
+// longer pending, none are claimed; this is the cross-daemon mark-before-emit
+// dedup guard.
+//
+// THE BATCH LEAVES THIS CALL AS ONE OBLIGATION, NOT AS N (#1978). `surviving`
+// is the row the emitted wake identifies, and it alone stays `attempted` so
+// that the delivery outcome recorded against it is a real observation. Every
+// `coalesced` row is recorded `superseded`, naming the survivor, because the
+// wake that carries it is the survivor's. Marking them `delivered` instead,
+// which is what happened before this change, reported N deliveries for one
+// delivered wake: 8,806 live rows carried only 250 `superseded` rows and all
+// 250 of those came from directive receipts rather than from coalescing.
+//
+// Superseding here rather than after delivery costs nothing recoverable: every
+// terminal state is terminal, so no wake outbox row is ever re-emitted, and a
+// batch whose delivery then fails records ONE failed obligation, which is the
+// truth. The suppressed rows remain readable and each names the row that
+// carried it.
+func (s *Store) ClaimWakeOutbox(ctx context.Context, surviving int64, coalesced []int64, at time.Time) (bool, error) {
+	ids := make([]int64, 0, len(coalesced)+1)
+	ids = append(ids, surviving)
+	ids = append(ids, coalesced...)
 	query, args, err := wakeOutboxIDUpdate(`
 UPDATE wake_outbox
 SET state = 'attempted', attempt_count = attempt_count + 1,
@@ -518,10 +533,39 @@ WHERE state = 'pending' AND id IN (`, ids, at)
 	if affected != int64(len(ids)) {
 		return false, tx.Rollback()
 	}
+	if len(coalesced) > 0 {
+		supersede, supersedeArgs, err := wakeOutboxIDUpdate(`
+UPDATE wake_outbox
+SET state = 'superseded', last_error = ?, finished_at = ?, updated_at = ?
+WHERE state = 'attempted' AND id IN (`, coalesced, at, WakeOutboxCoalescedDetail(surviving))
+		if err != nil {
+			return false, err
+		}
+		supersedeResult, err := tx.ExecContext(ctx, supersede, supersedeArgs...)
+		if err != nil {
+			return false, err
+		}
+		supersededRows, err := supersedeResult.RowsAffected()
+		if err != nil {
+			return false, err
+		}
+		if supersededRows != int64(len(coalesced)) {
+			return false, fmt.Errorf(
+				"supersede coalesced wake outbox updated %d rows, want %d", supersededRows, len(coalesced),
+			)
+		}
+	}
 	if err := tx.Commit(); err != nil {
 		return false, err
 	}
 	return true, nil
+}
+
+// WakeOutboxCoalescedDetail is the audit text a suppressed wake carries. It
+// names the row that delivered on its behalf, so the saving is countable:
+// `SELECT count(*) FROM wake_outbox WHERE last_error LIKE 'coalesced into%'`.
+func WakeOutboxCoalescedDetail(surviving int64) string {
+	return "coalesced into wake outbox row " + strconv.FormatInt(surviving, 10)
 }
 
 // FinishWakeOutbox records the existing event-rule delivery classification for

--- a/internal/db/wake_outbox_test.go
+++ b/internal/db/wake_outbox_test.go
@@ -333,7 +333,7 @@ func TestWakeOutboxClaimAndFinishStatesAreQueryable(t *testing.T) {
 		t.Fatalf("pending = %+v, err=%v", pending, err)
 	}
 	now := time.Date(2026, 7, 28, 12, 0, 0, 0, time.UTC)
-	claimed, err := store.ClaimWakeOutbox(ctx, []int64{pending[0].ID}, now)
+	claimed, err := store.ClaimWakeOutbox(ctx, pending[0].ID, nil, now)
 	if err != nil || !claimed {
 		t.Fatalf("ClaimWakeOutbox = %v, %v", claimed, err)
 	}
@@ -364,7 +364,7 @@ func TestExpireAgedWakeOutboxRecordsDeliveryUnknownWithoutRetry(t *testing.T) {
 		t.Fatalf("pending = %+v, err=%v", pending, err)
 	}
 	attemptedAt := time.Date(2026, 7, 28, 12, 0, 0, 0, time.UTC)
-	claimed, err := store.ClaimWakeOutbox(ctx, []int64{pending[0].ID}, attemptedAt)
+	claimed, err := store.ClaimWakeOutbox(ctx, pending[0].ID, nil, attemptedAt)
 	if err != nil || !claimed {
 		t.Fatalf("claim = %v, err=%v", claimed, err)
 	}

--- a/skills/gitmoot/references/CLI.md
+++ b/skills/gitmoot/references/CLI.md
@@ -1918,7 +1918,8 @@ over the pane's last `idle` or `working` activity status.
 rows commit atomically with their source note.
 Blocked and escalation rows are persisted synchronously by the event sink after
 the source transition; an insert failure is logged but cannot roll back the
-emitting job. The daemon holds each pending group for five seconds after its
+emitting job. The daemon holds each pending group for `[org].wake_coalesce_hold`
+(default `5m`) after its
 oldest row, then delivers every due pending row for that event kind and role as
 one wake, bounded at ten rows per wake. Reply prompts carry `N new items,
 oldest id X` and a retrieval command for each collapsed row; blocked and

--- a/skills/gitmoot/references/CLI.md
+++ b/skills/gitmoot/references/CLI.md
@@ -1918,9 +1918,13 @@ over the pane's last `idle` or `working` activity status.
 rows commit atomically with their source note.
 Blocked and escalation rows are persisted synchronously by the event sink after
 the source transition; an insert failure is logged but cannot roll back the
-emitting job. The daemon coalesces a rolling five-second window per event kind
-and role. Reply prompts carry `N new items, oldest id X`; blocked and escalation
-events retain their redacted event detail. Different event kinds never share a
+emitting job. The daemon holds each pending group for five seconds after its
+oldest row, then delivers every due pending row for that event kind and role as
+one wake, bounded at ten rows per wake. Reply prompts carry `N new items,
+oldest id X` and a retrieval command for each collapsed row; blocked and
+escalation events retain their redacted event detail. The row the wake names
+records the delivery outcome and each row it collapses is recorded `superseded`
+with `coalesced into wake outbox row <id>`. Different event kinds never share a
 coalescing key, and a later tick flushes a quiet tail without another event.
 Rules default to `--scope addressed`: an addressed rule is eligible only when
 the event names a target role and that role matches `--wake`.

--- a/website/docs/reference/cli.md
+++ b/website/docs/reference/cli.md
@@ -1650,9 +1650,13 @@ over the pane's last `idle` or `working` activity status.
 rows commit atomically with their source note.
 Blocked and escalation rows are persisted synchronously by the event sink after
 the source transition; an insert failure is logged but cannot roll back the
-emitting job. The daemon coalesces a rolling five-second window per event kind
-and role. Reply prompts carry `N new items, oldest id X`; blocked and escalation
-events retain their redacted event detail. Different event kinds never share a
+emitting job. The daemon holds each pending group for five seconds after its
+oldest row, then delivers every due pending row for that event kind and role as
+one wake, bounded at ten rows per wake. Reply prompts carry `N new items,
+oldest id X` and a retrieval command for each collapsed row; blocked and
+escalation events retain their redacted event detail. The row the wake names
+records the delivery outcome and each row it collapses is recorded `superseded`
+with `coalesced into wake outbox row <id>`. Different event kinds never share a
 coalescing key, and a later tick flushes a quiet tail without another event.
 Rules default to `--scope addressed`: an addressed rule is eligible only when
 the event names a target role and that role matches `--wake`.

--- a/website/docs/reference/cli.md
+++ b/website/docs/reference/cli.md
@@ -1650,7 +1650,8 @@ over the pane's last `idle` or `working` activity status.
 rows commit atomically with their source note.
 Blocked and escalation rows are persisted synchronously by the event sink after
 the source transition; an insert failure is logged but cannot roll back the
-emitting job. The daemon holds each pending group for five seconds after its
+emitting job. The daemon holds each pending group for `[org].wake_coalesce_hold`
+(default `5m`) after its
 oldest row, then delivers every due pending row for that event kind and role as
 one wake, bounded at ten rows per wake. Reply prompts carry `N new items,
 oldest id X` and a retrieval command for each collapsed row; blocked and

--- a/website/docs/reference/event-stream.md
+++ b/website/docs/reference/event-stream.md
@@ -223,7 +223,8 @@ and reply obligation upward to an ancestor or downward to a descendant. Upward
 questions remain escalations; downward questions are asks. Same-role questions
 are invalid, and peers are refused by a safe command-level default because no
 configurable peer-question policy exists. The daemon holds each pending group
-for five seconds after its OLDEST row, then delivers every due pending row for
+for `[org].wake_coalesce_hold` (default `5m`) after its OLDEST row, then
+delivers every due pending row for
 that event kind and role as ONE wake, bounded at ten rows per wake, so a
 blocked event and a reply for the same role remain separate but two notes for
 the same role are one interrupt however far apart they arrived. The one row the
@@ -233,8 +234,11 @@ wakes stay readable and countable rather than each reporting a delivery of its
 own.
 Pending, attempted, delivered, superseded, stalled, failed, and
 `delivery_unknown` remain queryable per outbox row, and outstanding obligations
-contribute to daemon tick
-health. A quiet burst tail is flushed by a later daemon tick; it does not require
+contribute to daemon tick health. A deliverable row still inside its hold is
+reported as `held` rather than `pending` and is NOT an outstanding obligation:
+it is waiting by design, so a hold longer than the tick interval does not make
+every tick read as unhealthy.
+A quiet burst tail is flushed by a later daemon tick; it does not require
 another event. If the outbox or its delivery rules cannot be queried, or an
 outbox row cannot be parsed or claimed, the drain is logged as unhealthy and
 retried on a later tick without aborting unrelated repository work.

--- a/website/docs/reference/event-stream.md
+++ b/website/docs/reference/event-stream.md
@@ -222,11 +222,18 @@ back the emitting job. `gitmoot org escalate` addresses the same durable note
 and reply obligation upward to an ancestor or downward to a descendant. Upward
 questions remain escalations; downward questions are asks. Same-role questions
 are invalid, and peers are refused by a safe command-level default because no
-configurable peer-question policy exists. The daemon uses rolling five-second
-windows per event kind and role, so same-kind events coalesce while a blocked
-event and a reply for the same role remain separate.
-Pending, attempted, delivered, stalled, failed, and `delivery_unknown` remain
-queryable per outbox row, and outstanding obligations contribute to daemon tick
+configurable peer-question policy exists. The daemon holds each pending group
+for five seconds after its OLDEST row, then delivers every due pending row for
+that event kind and role as ONE wake, bounded at ten rows per wake, so a
+blocked event and a reply for the same role remain separate but two notes for
+the same role are one interrupt however far apart they arrived. The one row the
+wake names carries the delivery outcome; every row it collapses is recorded
+`superseded` with `coalesced into wake outbox row <id>`, so the suppressed
+wakes stay readable and countable rather than each reporting a delivery of its
+own.
+Pending, attempted, delivered, superseded, stalled, failed, and
+`delivery_unknown` remain queryable per outbox row, and outstanding obligations
+contribute to daemon tick
 health. A quiet burst tail is flushed by a later daemon tick; it does not require
 another event. If the outbox or its delivery rules cannot be queried, or an
 outbox row cannot be parsed or claimed, the drain is logged as unhealthy and


### PR DESCRIPTION
Fixes #1978. Part of the #1977 campaign.

## What I re-derived before touching code

Read-only snapshot of `/root/.gitmoot/gitmoot.db` (copied to `/tmp`, opened `mode=ro`; the live daemon store was never written from this seat), 8,806 `wake_outbox` rows, 2026-09-07.

The issue's store-level numbers reproduce exactly:

| Measure | Issue | Mine |
| --- | --- | --- |
| keys with more than 10 wakes | 55 keys, 8,592 rows | 55 keys, 8,595 rows |
| `superseded` | 250 | 250 |
| largest key | `reply:jarvis` 2,088 | `reply:jarvis` 2,089 |
| `workflow_note` share | 8,027 of 8,782 | 8,048 of 8,806 |

The small deltas are wakes emitted between the issue being filed and my snapshot.

## Where I disagree with the issue, and what I trust instead

The issue says `coalesce_key` is recorded but never collapses. Half of that is wrong and it matters for the size of the win.

`coalesce_key` IS used, at drain time: `drainReplyWakeOutboxWithHealth` groups pending rows by `target_role + coalesce_key` and emits one wake per group. What was broken is narrower and has two parts.

1. **Batch membership was bounded by a five-second creation spread**, not by the key. A row created more than 5s after the batch anchor started a second rolling window, so it became a second interrupt even though both rows were pending at the same drain under the same key.
2. **Every row a wake collapsed was recorded `delivered`**, so N deliveries were reported for one delivered wake, and the saving was invisible. That is why only 250 rows are `superseded`, and all 250 came from `supersedeDirectiveWakeOutboxTx` (directive receipt or termination):

```
sqlite> select last_error, count(*) from wake_outbox where state='superseded' group by 1;
directive ack recorded before wake delivery|157
directive cancel recorded before wake delivery|42
directive done recorded before wake delivery|39
directive terminated before wake delivery|12
```

Coalescing had never produced a single `superseded` row. Meanwhile 1,329 `delivered` rows sat in multi-row batches, each claiming a delivery it did not have.

So the "98% of wakes share a key with ten others" figure is **not** 98% available reduction. Rows sharing a key are spread over 41 days, and the key namespace is only `kind:role`. What is actually collapsible is what was pending at the same drain. Replaying both algorithms over the real claim groups (`target_role, coalesce_key, attempted_at`, 8,464 attempted rows):

| | Wake events |
| --- | --- |
| current membership rule | 8,091 |
| this PR's rule | **7,486** |

**605 fewer interrupts, 7.5%**, and 978 rows recorded `superseded` instead of 250. Per seat: `jarvis` 2,497 to 2,253, `gm-reviewfix-coc` 445 to 327, `gitmoot` 1,101 to 1,026.

That is the honest ceiling for collapsing alone. The bigger lever is the window length, and I did not change it (see below).

## Reproduction

`TestReplyWakeOutboxCollapsesDuePendingRowsBeyondTheWindow`: two notes addressed to one role, created 30s apart, both due at one drain. Before the fix:

```
--- FAIL: TestReplyWakeOutboxCollapsesDuePendingRowsBeyondTheWindow
    wake calls = 2, want one collapsed wake; prompts=[
      ... 1 new items, oldest id 1; inspect with gitmoot workflow show-note 1
      ... 1 new items, oldest id 2; inspect with gitmoot workflow show-note 2]
```

Two wakes where one was expected, and both rows recorded `delivered`. After the fix: one wake carrying `2 new items, oldest id 1` plus a `show-note` command for each note, one `delivered` row, one `superseded` row whose `last_error` is `coalesced into wake outbox row 1`.

## The change

- `replyWakeCoalescingWindow` is now a **hold on the oldest pending row only**. Once it elapses, every due pending row for that target and key joins one wake, still bounded by `replyWakeMaxCoalescedItems`. A newer row's own hold cannot matter: the wake is being emitted anyway and already names a retrieval command for each member, so collapsing it only removes a later interrupt and loses no note.
- `ClaimWakeOutbox(ctx, surviving, coalesced, at)` keeps the row the wake names as the single live obligation and records each collapsed row `superseded` with `coalesced into wake outbox row <id>`, in the same transaction as the claim. The claim is still all-or-nothing across the batch, so the cross-daemon mark-before-emit guard is unchanged.
- Superseding at claim time rather than after delivery loses nothing recoverable: every terminal wake state is terminal and no row is ever re-emitted. A batch whose delivery then fails records one failed obligation instead of N, which is the truth, and the suppressed rows still name the row that carried them.

## Acceptance, against the issue

- Two notes to one target in one delivery window produce one delivered wake and one superseded row: `TestReplyWakeOutboxCollapsesDuePendingRowsBeyondTheWindow`.
- `superseded` rises in proportion to suppressed duplicates, and is countable: `select count(*) from wake_outbox where last_error like 'coalesced into%'`. On the measured history that is 978 rows rather than 0.
- No wake silently dropped: the surviving row is named in each superseded row, and the surviving wake still carries `gitmoot workflow show-note <id>` for every collapsed note. `TestReplyWakeOutboxBurstCoalescesToExactlyOneWake` pins 1 delivered plus 9 superseded for a 10-row burst.

## Tests changed rather than added

- `TestReplyWakeOutboxStartsNewBatchAfterWindow` asserted the defect (two rolling windows, two prompts). It is replaced by the collapse test above.
- `TestReplyWakeOutboxBurstCoalescesToExactlyOneWake` asserted 10 `delivered` rows for one wake. It now asserts one delivered survivor and nine superseded rows naming it.
- `TestReplyWakeOutboxRuleDeletedMidDrainRefusesLaterBatch` needed a later batch for a reason coalescing cannot remove, so it now uses the count bound (`replyWakeMaxCoalescedItems + 1` due rows) instead of a second creation window. The property it defends, that a rule deleted mid-drain cannot authorize a later claim, is unchanged.

## Config proposal, not included in this PR

The window length is the dominant lever and it is a latency tradeoff, so I did not touch it. Simulating the fixed algorithm against the real arrival series and the real 5,575 tick times (median tick gap 143s):

| Hold | Wake events | Reduction |
| --- | --- | --- |
| 5s (this PR) | 7,827 | 7.1% |
| 30s | 7,302 | 13.3% |
| 60s | 7,042 | 16.4% |
| 120s | 6,583 | 21.8% |
| 300s | 5,721 | 32.1% |

Same-key arrival gaps: 4.5% within 5s, 4.1% in 5 to 60s, 22.5% in 1 to 5 min, 21.2% in 5 to 15 min. A 120s hold costs up to two minutes of wake latency and removes about a fifth of all interrupts. I propose making `replyWakeCoalescingWindow` a config value with the current 5s default, then setting it to 120s fleet-wide, as a separate reviewed change. I have not changed `/root/.gitmoot/config.toml`.

## Verification

`go build -buildvcs=false ./...`, `go vet ./...`, `go generate ./... && git diff --exit-code`, and `go test -timeout 25m ./...` all pass on this branch with the pinned go1.26.4 toolchain (full suite, 1,192s, no failures). `-race` was not run here; it is CI's shard.

Docs updated in the same PR: `docs/events.md`, `website/docs/reference/event-stream.md`, `website/docs/reference/cli.md`, `skills/gitmoot/references/CLI.md`. All four claimed "rolling five-second windows"; that claim is now wrong and is replaced by the hold plus the superseded audit rule.

Deploy notes: no migration. The `superseded` state and its `CHECK` constraint already exist. Behaviour change is confined to the daemon's wake drain, so a daemon restart is enough to pick it up. No config change required.

---

## Added after review of the first push: the hold is configurable, default 300s

PHOBOS put the hold length to the owner as I proposed rather than deciding it in code. **Owner decision, 2026-09-07, relayed by phobos: 300s.** The basis is my own measurement above, 21.8% fewer interrupts at 120s and 32.1% at 300s against 7.1% at the previous 5s, in exchange for up to five minutes of added wake latency.

- `[org].wake_coalesce_hold` is the new config value, parsed like the other `[org]` durations, duplicate-rejecting, and refusing a zero that would silently restore one wake per note. `config.DefaultWakeCoalesceHold` is `5m`.
- `TestLoadOrgWakeCoalesceHold` pins the parse, the default, and both refusals. `TestReplyWakeOutboxHonorsConfiguredHold` pins that the drain reads the parameter and not the constant: with a 2m hold, a group whose oldest row is 90s old is not delivered, and the same group is delivered as one wake at 121s.
- `TestOrgConfigMethodSetIsPinned` is updated with the reason the new accessor honors the #1635 single-choke-point policy: it exposes one duration and no role membership.

### Shipping 300s broke one assumption I had measured, so this fixes it too

A hold longer than the daemon tick interval changes what "pending" means for tick health. Before this commit, a deliverable row inside its hold was counted as an outstanding obligation, so `runEnabledRepoWorkerTicksTracked` logged `reply wake outbox drain unhealthy: wake outbox has outstanding obligations: pending=N`. At a 5s hold a row was almost never observed in that state, because the median gap between daemon ticks is 143s. At a 300s hold nearly every tick would observe one, which converts a real diagnostic into a line printed most minutes.

Drain health now reports such a row as `held`, which is not a fault. `pending` keeps its exact meaning: a row that is due and still undelivered. Two existing tests asserted the old meaning and now assert the new one:

- `TestReplyWakeOutboxFleetDrainRunsWithZeroEnabledRepos` asserted `outstanding obligations: pending=4` for four rows inside the hold. It now asserts `held=4` and a healthy drain, then still asserts the later tick delivers all four as one wake.
- `TestReplyWakeOutboxDrainFailureDoesNotAbortRepoWork` provoked its fault with a freshly created row, which is now held rather than outstanding. Its row is stamped past the hold so the test provokes the fault it claims to test.

## Verification on the rebased head

Rebased onto `e16875b3` after main moved 7 commits, because a green run against the old base is a claim about a tree that no longer lands. On the rebased tree, with go1.26.4 pinned: `go build -buildvcs=false ./...`, `go vet ./...`, `go generate ./... && git diff --exit-code`, and `go test -count=1 -timeout 25m ./...` all pass with zero failures.

One honest note on host noise. An earlier full-suite run on this box reported failures in dispatch and blocked-advance tests. I ran the identical suite on **unmodified `origin/main`** in a separate worktree as a control: it failed 13 `internal/cli` tests on this host under the same load, including `TestClaudeProduceHookAutoReadLandlockE2E`, which `AGENTS.md` documents as a known confound for a checkout under `/tmp`. The failing sets differed between runs and none of them touch the wake path. The clean rebased run above is the one that describes this branch.