### PR TITLE
fix(toolchain): a published binary runtime must survive its own revalidation (#1974)

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -842,6 +842,19 @@ kernel never resolves the entrypoint's original shebang, which would reach the
 operator's copy. A binary runtime gets a relative symlink instead, needing no
 shell.
 
+THE ENGINE'S OWN LAUNCHER DIRECTORY IS EXCLUDED FROM REVALIDATION, and the
+exclusion is a traversal rule rather than a filter applied afterwards (#1974).
+A published tree is re-proved on every reuse by recomputing the digest of its
+members with the same symlink-refusing traversal, and `.bin/` never contributed
+to that digest - the recorded value is the digest of the SOURCE members, which
+cannot contain a launcher the publish created after reading them. Collecting it
+and dropping it afterwards still had to OPEN it, so a binary runtime's symlink
+launcher failed the reuse with `too many levels of symbolic links` and the
+runtime was republished as the exit-126 shim on every subsequent staging. Only
+the TOP-LEVEL `.bin` is excluded; a `.bin` directory that came from a source
+package, which is the ordinary shape of a node-packaged runtime, is payload and
+is still hashed.
+
 Every runtime class the engine can dispatch is staged, not only the seat's own.
 An absent runtime, an unresolvable interpreter, an ambiguous tree, or a kernel
 without `openat2` all resolve to engine-owned commands that print

--- a/internal/toolchain/runtime_publish.go
+++ b/internal/toolchain/runtime_publish.go
@@ -230,12 +230,21 @@ func validatePublished(publishedPath string, runtimeName string, entrypoint stri
 }
 
 // publishedMembersDigest hashes a published tree excluding engine metadata.
+//
+// The launcher directory is excluded BEFORE it is opened (#1974): it is engine
+// metadata that never contributed to the digest, and a binary runtime's launcher
+// is a symlink that openat2's RESOLVE_NO_SYMLINKS refuses, so collecting it and
+// dropping it afterwards turned every reuse of such a root into ELOOP. The
+// recorded digest is unchanged either way - it is the digest of the source
+// members, which cannot contain a launcher the publish created after reading
+// them.
 func publishedMembersDigest(publishedPath string, entrypoint string) (string, error) {
 	tree, err := openSourceTree(publishedPath)
 	if err != nil {
 		return "", err
 	}
 	tree.engineOwned = true
+	tree.excludeRoot = launcherDirName
 	defer tree.close()
 	members, err := tree.collectMembers(entrypoint)
 	if err != nil {
@@ -244,7 +253,7 @@ func publishedMembersDigest(publishedPath string, entrypoint string) (string, er
 	defer closeMembers(members)
 	kept := members[:0]
 	for _, member := range members {
-		if member.relative == entrypointDigestName || strings.HasPrefix(member.relative, launcherDirName+string(filepath.Separator)) {
+		if member.relative == entrypointDigestName {
 			_ = member.file.Close()
 			continue
 		}

--- a/internal/toolchain/runtime_stage_test.go
+++ b/internal/toolchain/runtime_stage_test.go
@@ -262,6 +262,107 @@ func TestStageRuntimeRefusesCorruptedPublishedCopy(t *testing.T) {
 	}
 }
 
+// TestStageRuntimeReusesAPublishedBinaryRuntime is #1974, and the shape is the
+// whole defect: writeLauncher publishes a BINARY runtime's launcher as a
+// relative symlink and a SCRIPT runtime's as a generated file, and only the
+// second shape was ever revalidated.
+//
+// The first staging publishes without validating, so it passed. Every REUSE ran
+// publishedMembersDigest over the published tree, whose traversal refuses a
+// symlink at any component, so it returned ELOOP and stageSeatRuntimes
+// published the runtime as the exit-126 unavailable shim - permanently, because
+// the published name is fingerprint-derived and the same root is chosen every
+// time. Measured on this host as claude and kimi unusable for every read-only
+// seat while codex, a node script, kept working.
+//
+// Every other reuse test in this file uses a "#!/bin/sh" source, which is why
+// the reuse path was covered only for the launcher shape that happens to work.
+func TestStageRuntimeReusesAPublishedBinaryRuntime(t *testing.T) {
+	home := t.TempDir()
+	source := filepath.Join(t.TempDir(), "claude")
+	// No shebang: RuntimeInterpreter reports ok=false, so the runtime stages as
+	// a binary and its launcher is a symlink rather than an exec script.
+	if err := os.WriteFile(source, []byte("\x7fELF\x02\x01\x01 not a script\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	first, err := StageRuntime(home, "claude", source)
+	if err != nil {
+		t.Fatalf("first StageRuntime: %v", err)
+	}
+	// PIN THE MECHANISM. If the launcher ever stops being a symlink this test
+	// still passes while covering nothing, so it must say so out loud.
+	info, err := os.Lstat(first)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Mode()&os.ModeSymlink == 0 {
+		t.Fatalf("launcher %q has mode %s, want a symlink: this regression covers the symlink-launcher reuse path and a regular launcher no longer exercises it", first, info.Mode())
+	}
+	second, err := StageRuntime(home, "claude", source)
+	if err != nil {
+		t.Fatalf("reusing the published binary runtime: %v", err)
+	}
+	if second != first {
+		t.Fatalf("reuse published a different launcher %q, want the existing %q", second, first)
+	}
+}
+
+// TestStageRuntimeDigestCoversANestedLauncherDirectory bounds the exclusion the
+// fix above introduces. Only the TOP-LEVEL launcher directory is engine
+// metadata; a ".bin" directory that came from the source package is payload and
+// must still be hashed, or a member could be swapped without changing the
+// digest. A nested node_modules/.bin is the ordinary shape of the packaged
+// runtime this engine stages, so the widened exclusion is a live hazard rather
+// than a hypothetical one.
+func TestStageRuntimeDigestCoversANestedLauncherDirectory(t *testing.T) {
+	home := t.TempDir()
+	base := t.TempDir()
+	pkg := filepath.Join(base, "lib", "node_modules", "@openai", "codex")
+	nested := filepath.Join(pkg, "node_modules", launcherDirName)
+	if err := os.MkdirAll(filepath.Join(pkg, "bin"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(nested, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(pkg, "package.json"), []byte(`{"name":"@openai/codex"}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(nested, "helper"), []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	source := filepath.Join(pkg, "bin", "codex.js")
+	if err := os.WriteFile(source, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	staged, err := StageRuntime(home, "codex", source)
+	if err != nil {
+		t.Fatalf("StageRuntime: %v", err)
+	}
+	published, err := StagedRuntimeRoot(home, staged)
+	if err != nil {
+		t.Fatal(err)
+	}
+	publishedHelper := filepath.Join(published, "node_modules", launcherDirName, "helper")
+	if _, err := os.Stat(publishedHelper); err != nil {
+		t.Fatalf("a nested %s member was not staged, so the packaged runtime is incomplete: %v", launcherDirName, err)
+	}
+	if _, err := StageRuntime(home, "codex", source); err != nil {
+		t.Fatalf("reusing a package that contains a nested %s directory: %v", launcherDirName, err)
+	}
+	// The engine tree is published read-only, so the tamper needs the directory
+	// writable first. This is the operator-corruption case, not a seat one.
+	if err := os.Chmod(filepath.Dir(publishedHelper), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Remove(publishedHelper); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := StageRuntime(home, "codex", source); !errors.Is(err, ErrRuntimeNotStageable) {
+		t.Fatalf("removing a nested %s member left the published digest valid (err = %v); the launcher exclusion must apply to the top level only", launcherDirName, err)
+	}
+}
+
 func TestStagedRuntimeRootRefusesAnotherHome(t *testing.T) {
 	firstHome := t.TempDir()
 	command, err := StageUnavailableRuntime(firstHome, "codex")

--- a/internal/toolchain/source_tree.go
+++ b/internal/toolchain/source_tree.go
@@ -40,6 +40,24 @@ type sourceTree struct {
 	// 0700 and whose files are 0400/0500 so no seat can rewrite them. Symlink
 	// refusal still applies - that is openat2's job and it is unconditional.
 	engineOwned bool
+	// excludeRoot names ONE top-level entry the traversal must neither open nor
+	// descend into. It is empty for every operator boundary and is set only by
+	// publishedMembersDigest, for the engine's own launcher directory.
+	//
+	// IT IS A TRAVERSAL RULE BECAUSE THE DIGEST RULE WAS TOO LATE (#1974).
+	// publishedMembersDigest already dropped .bin members AFTER collection, so
+	// the launcher never contributed to the digest - but collection had to OPEN
+	// it first, and writeLauncher publishes a binary runtime's launcher as a
+	// relative SYMLINK, which openat2's RESOLVE_NO_SYMLINKS refuses at any
+	// component. Every reuse of such a root therefore failed with ELOOP and the
+	// caller published the runtime as an exit-126 shim: measured on this host as
+	// claude and kimi permanently unavailable while codex, whose launcher is a
+	// generated script rather than a symlink, kept working.
+	//
+	// Excluding it here is digest-invariant by construction: the value the
+	// publish recorded is the digest of the SOURCE members, a set that cannot
+	// contain a launcher the publish itself created afterwards.
+	excludeRoot string
 }
 
 // resolveFlags apply to every component of every path opened through here.
@@ -149,6 +167,11 @@ func (s *sourceTree) collectMembers(entrypoint string) ([]stagedMember, error) {
 			child := name
 			if relative != "." {
 				child = filepath.Join(relative, name)
+			}
+			// Excluded at the TOP LEVEL ONLY, so a nested directory of the same
+			// name inside an operator boundary is still collected and judged.
+			if relative == "." && s.excludeRoot != "" && name == s.excludeRoot {
+				continue
 			}
 			// THE SUBSTITUTION WINDOW IS HERE: the name has been enumerated and
 			// is about to be opened. In production the barrier is nil; in the

--- a/website/docs/operations/troubleshooting.md
+++ b/website/docs/operations/troubleshooting.md
@@ -753,6 +753,19 @@ kernel never resolves the entrypoint's original shebang, which would reach the
 operator's copy. A binary runtime gets a relative symlink instead, needing no
 shell.
 
+THE ENGINE'S OWN LAUNCHER DIRECTORY IS EXCLUDED FROM REVALIDATION, and the
+exclusion is a traversal rule rather than a filter applied afterwards (#1974).
+A published tree is re-proved on every reuse by recomputing the digest of its
+members with the same symlink-refusing traversal, and `.bin/` never contributed
+to that digest - the recorded value is the digest of the SOURCE members, which
+cannot contain a launcher the publish created after reading them. Collecting it
+and dropping it afterwards still had to OPEN it, so a binary runtime's symlink
+launcher failed the reuse with `too many levels of symbolic links` and the
+runtime was republished as the exit-126 shim on every subsequent staging. Only
+the TOP-LEVEL `.bin` is excluded; a `.bin` directory that came from a source
+package, which is the ordinary shape of a node-packaged runtime, is payload and
+is still hashed.
+
 Every runtime class the engine can dispatch is staged, not only the seat's own.
 An absent runtime, an unresolvable interpreter, an ambiguous tree, or a kernel
 without `openat2` all resolve to engine-owned commands that print


### PR DESCRIPTION
Fixes #1974.

## The mechanism is not a legacy layout, it is the current publish path

The issue reads a published root created under "an older symlink layout" as an upgrade-migration case. Re-measured, that framing is wrong and the defect is larger than described: `writeLauncher` (`internal/toolchain/runtime_launcher.go:189-205`) publishes a BINARY runtime's launcher as a relative symlink on the current code, today, for every binary runtime. Nothing legacy is required.

- First staging PUBLISHES and never validates (`runtime_stage.go:126-129`), so it succeeds.
- Every REUSE calls `validatePublished` -> `publishedMembersDigest` -> `openSourceTree` + `collectMembers` (`runtime_publish.go:233-254`), whose traversal opens with `openat2` under `RESOLVE_NO_SYMLINKS` (`source_tree.go:46`) and therefore refuses the launcher symlink with ELOOP.
- `stageSeatRuntimes` maps any `StageRuntime` error to `StageUnavailableRuntime`, the exit-126 shim.
- The published name is fingerprint-derived, so the same unusable root is selected on every subsequent staging. Permanent, not transient.

`.bin/` never contributed to the digest: the recorded value is the digest of the SOURCE members, a set that cannot contain a launcher the publish created after reading them. The exclusion existed, it was just applied AFTER collection, so the traversal still had to open the symlink.

codex was unaffected because its resolved entrypoint is `codex.js` with a shebang, so `interpreter != ""` and its launcher is a generated script, a regular file. That is the entire difference between the runtime that worked and the two that did not.

## Re-derived measurement

Repro against the REAL on-host artifacts, in isolated `/tmp` homes, at the daemon's own published fingerprints:

```
base dee61c25 (origin/main)
  claude: first stage ok, launcher mode=Lrwxrwxrwx
          REUSE FAILED: runtime cannot be staged: resolve ".bin/claude" under
          "<home>/runtimes/claude-ba7128fd22b1bc20": too many levels of symbolic links
  kimi:   REUSE FAILED: ... resolve ".bin/kimi" under
          "<home>/runtimes/kimi-64cd3ee7e0bc9897": too many levels of symbolic links

this branch
  claude: reuse ok  <home>/runtimes/claude-ba7128fd22b1bc20/.bin/claude
  kimi:   reuse ok  <home>/runtimes/kimi-64cd3ee7e0bc9897/.bin/kimi
```

The fingerprints `claude-ba7128fd22b1bc20` and `kimi-64cd3ee7e0bc9897` are byte-identical to the roots in `/root/.gitmoot/runtimes/`, so this is the same artifact identity the daemon computes, and the error string is the one in the daemon journal quoted in the issue. Nothing under `/root/.gitmoot` was read, written or staged by the probe; the probe itself was throwaway and is not in this branch.

## Why the operational repair is not the fix

The hardlink repair applied at 15:48Z works because it makes the launcher a regular file. It survives exactly until the next claude or kimi version change: a new version means a new content fingerprint, a new published root, and `writeLauncher` creates a symlink launcher again. The repair is therefore one runtime upgrade from re-breaking, and it is invisible when it does, because the failure is a shim that reports `runtime unavailable`.

## Why not re-stage on a failed revalidation

The issue's suggested remedy is to re-stage rather than publish unavailability. Not done here, deliberately: with this defect present, "re-stage on invalid" would have re-copied 214 MB (claude) and 183 MB (kimi) on EVERY seat staging instead of failing, turning a visible outage into a silent disk and latency cost, and it would delete a published root that live seats hold Landlock grants over. The correct behaviour for a root the current resolver cannot use remains an open design question; this PR removes the reason it could not use one.

## Change

- `sourceTree.excludeRoot`: one top-level entry the traversal neither opens nor descends into. Empty for every operator boundary.
- `publishedMembersDigest` sets it to `.bin` and no longer needs its post-collection prefix filter, which is now unreachable.
- Scoped to the top level, so a `.bin` that came from a source package (the ordinary shape of a node-packaged runtime) is still collected and hashed.

Digest-invariant by construction: no member that was previously hashed stops being hashed.

## Test, failing before and passing after

`TestStageRuntimeReusesAPublishedBinaryRuntime` stages a non-shebang source twice.

```
base dee61c25: FAIL  reusing the published binary runtime: ... too many levels of symbolic links
this branch:   PASS
```

It asserts the launcher IS a symlink and fails loudly if that ever stops being true, because the regression would otherwise keep passing while covering nothing.

Every pre-existing reuse test in that file (`TestStageRuntimeRepublishesWhenTheSourceChanges`, `TestStageRuntimeRefusesCorruptedPublishedCopy`) uses a `#!/bin/sh` source, so the revalidation path was covered only for the launcher shape that happens to work. That is why this shipped.

`TestStageRuntimeDigestCoversANestedLauncherDirectory` bounds the exclusion. Mutant control: dropping the `relative == "."` guard so the exclusion applies at any depth makes it fail with `hashes to "2ab482090b3350cb" but records "40d3fbce55779727"`.

## Verification

```
go build ./...                                          ok
go vet ./internal/toolchain/ ./internal/cli/            ok
go test -count=1 ./internal/toolchain/                  ok  18.0s
go test -count=1 -run 'Toolchain|Seat|Runtime|Stage' ./internal/cli/   ok  377.6s
```

Not verified: that a dispatched read-only review now stages and runs on claude or kimi end to end. That needs a deploy, which is barred by standing hold 125950, and a review dispatch. The staging step this PR fixes is proven against the real artifacts above.

## Effect on the campaign

This is the first link of the #1520 chain (#1974, #1965, #1963, #1950) because it is the only one that changes whether a reviewer can run at all. It does not restore codex, which is separately quota-exhausted, and it widens nobody's permissions: claude and kimi were already the configured review runtimes for `gm-review-opus` and `gm-review-kimi`.

Deploy notes: no config change, no migration, no restart requirement beyond the ordinary binary swap. Existing published roots keep their names and validate unchanged.
