### PR TITLE
fix(workflow): record the dispatcher on every job Gitmoot creates (#1967)

### DIFF
--- a/internal/cli/daemon_supervision.go
+++ b/internal/cli/daemon_supervision.go
@@ -610,16 +610,21 @@ func runOneHeartbeat(ctx context.Context, store *db.Store, enqueue heartbeatEnqu
 		}
 	}
 	job, enqueueErr := enqueue(ctx, workflow.JobRequest{
-		ID:                 heartbeatJobID(heartbeat.Agent, heartbeat.Name, now),
-		Agent:              heartbeat.Agent,
-		Action:             heartbeat.Action,
-		Repo:               heartbeat.Repo,
-		Branch:             implementFields.Branch,
-		TaskID:             implementFields.TaskID,
-		TaskTitle:          implementFields.TaskTitle,
-		GoalID:             implementFields.GoalID,
-		HeadSHA:            implementFields.HeadSHA,
-		Sender:             "heartbeat",
+		ID:        heartbeatJobID(heartbeat.Agent, heartbeat.Name, now),
+		Agent:     heartbeat.Agent,
+		Action:    heartbeat.Action,
+		Repo:      heartbeat.Repo,
+		Branch:    implementFields.Branch,
+		TaskID:    implementFields.TaskID,
+		TaskTitle: implementFields.TaskTitle,
+		GoalID:    implementFields.GoalID,
+		HeadSHA:   implementFields.HeadSHA,
+		Sender:    "heartbeat",
+		// #1967: a heartbeat has no seat behind it, so the honest dispatcher is the
+		// schedule that fired. Naming the schedule (not just "heartbeat") is what
+		// lets a finding be traced back to the configuration entry that ordered
+		// the review rather than to the reviewer that wrote it.
+		DispatchedBy:       "heartbeat:" + heartbeat.Name,
 		Instructions:       heartbeat.Prompt,
 		Fingerprint:        fingerprint,
 		RuntimeOverride:    overrideRuntime,

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -1543,6 +1543,12 @@ func (d Daemon) handlePullRequestWorkflowChange(ctx context.Context, pull github
 		// fanout children identically with zero extra queries. Empty is the legacy
 		// and undirected value; the fanout then behaves exactly as it does today.
 		ActingOrgRole: lock.ActingOrgRole,
+		// #1967: the branch lock owner is the seat whose work caused this review to
+		// be asked for. It is read from the SAME lock row as ActingOrgRole above,
+		// so this costs no extra query, and it is recorded separately from
+		// LeadAgent because LeadAgent means "the reviewer's lead" on other
+		// dispatch paths. An empty owner degrades to Sender ("github").
+		DispatchedBy: lock.Owner,
 	})
 	return mergeReadinessHandled, err
 }

--- a/internal/daemon/dispatcher_attribution_1967_test.go
+++ b/internal/daemon/dispatcher_attribution_1967_test.go
@@ -1,0 +1,91 @@
+package daemon
+
+import (
+	"context"
+	"testing"
+
+	"github.com/gitmoot/gitmoot/internal/db"
+	"github.com/gitmoot/gitmoot/internal/github"
+	"github.com/gitmoot/gitmoot/internal/workflow"
+)
+
+// #1967 READER 2 of 2 - the daemon PR-watcher fan-out.
+//
+// This is the path where the gap was total: the fan-out review's only recorded
+// identity was Sender: "github", a channel, so a finding it produced could not
+// be resolved to any seat at all. The dispatcher is the branch lock owner, read
+// from the SAME lock row the watcher already fetches for ActingOrgRole, so the
+// two readers cannot drift.
+//
+// The assertion deliberately rejects three specific wrong answers rather than
+// only checking non-emptiness: "github" (the channel, which was the pre-fix
+// value), and the reviewer agent name (the identity #1890 misroutes on).
+func TestDaemonPRWatcherFanoutRecordsTheBranchLockOwnerAsDispatcher(t *testing.T) {
+	ctx := context.Background()
+	store := testStore(t)
+	repo := github.Repository{Owner: "gitmoot", Name: "gitmoot"}
+	if err := store.UpsertTask(ctx, db.Task{
+		ID:           "task-1967",
+		RepoFullName: repo.FullName(),
+		GoalID:       "goal-1967",
+		Title:        "Attribute the dispatcher",
+		State:        string(workflow.TaskPullRequestOpen),
+		Branch:       "task-1967",
+	}); err != nil {
+		t.Fatalf("UpsertTask returned error: %v", err)
+	}
+	for _, agent := range []db.Agent{
+		{Name: "builder", Role: "builder", Capabilities: []string{"implement"}},
+		{Name: "reviewer", Role: "reviewer", Capabilities: []string{"review"}},
+	} {
+		agent.Runtime = "codex"
+		agent.RuntimeRef = "last"
+		agent.RepoScope = repo.FullName()
+		agent.AutonomyPolicy = "workspace-write"
+		agent.HealthStatus = "ok"
+		if err := store.UpsertAgent(ctx, agent); err != nil {
+			t.Fatalf("UpsertAgent(%s) returned error: %v", agent.Name, err)
+		}
+	}
+	if acquired, err := store.AcquireLock(ctx, db.BranchLock{
+		RepoFullName: repo.FullName(),
+		Branch:       "task-1967",
+		Owner:        "builder",
+	}); err != nil || !acquired {
+		t.Fatalf("AcquireLock returned acquired=%v err=%v", acquired, err)
+	}
+
+	engine := workflow.Engine{Store: store, RequiredReviewers: []string{"reviewer"}}
+	daemon := Daemon{Repo: repo, Store: store, Workflow: &engine}
+	pull := github.PullRequest{
+		Number:  1967,
+		Title:   "Attribute the dispatcher",
+		State:   "open",
+		HeadRef: "task-1967",
+		BaseRef: "main",
+		HeadSHA: "head1967",
+	}
+
+	if _, err := daemon.handlePullRequestWorkflowChange(ctx, pull, newReviewJobsMemo(store)); err != nil {
+		t.Fatalf("handlePullRequestWorkflowChange returned error: %v", err)
+	}
+
+	jobs, err := store.ListJobsByType(ctx, "review")
+	if err != nil {
+		t.Fatalf("ListJobsByType returned error: %v", err)
+	}
+	if len(jobs) != 1 {
+		t.Fatalf("daemon fanout enqueued %d review jobs, want 1; cannot assert attribution", len(jobs))
+	}
+	switch jobs[0].DispatchedBy {
+	case "builder":
+	case "":
+		t.Fatal("daemon fanout review has no dispatcher; a finding it records can only be routed by the reviewer's own name (#1890)")
+	case "github":
+		t.Fatal(`daemon fanout review dispatched_by = "github": that is the dispatch channel, not the seat whose work caused the review`)
+	case "reviewer":
+		t.Fatal(`daemon fanout review dispatched_by = "reviewer": attributing a finding to its own author is the defect #1967 exists to fix`)
+	default:
+		t.Fatalf("daemon fanout review dispatched_by = %q, want %q", jobs[0].DispatchedBy, "builder")
+	}
+}

--- a/internal/db/cleanup_obligations_test.go
+++ b/internal/db/cleanup_obligations_test.go
@@ -135,22 +135,22 @@ func TestCleanupObligationsRebuildPreservesLegacyRows(t *testing.T) {
 // test would pass on precisely the mutant it exists to kill.
 func TestMigrationsUpgradeFromPreviousReleasedVersion(t *testing.T) {
 	ctx := context.Background()
-	// The marker names THIS BRANCH's migration, and it has moved six times as main
-	// advanced: the cleanup_obligations rebuild, #1766's SkillOpt/evals teardown,
-	// #1770's Activepieces trigger removal, #1731's escalation_rounds table,
-	// #1754's chat/moot teardown, #1756's preset-delivery removal and #1753's
-	// cockpit/interactive table drop each joined the released prefix, leaving
-	// #1822's findings ledger appended last. Two branches cannot both be "last",
-	// and the ordering that matters is the one a deployed database sees, which is
-	// why this marker MUST be repointed on every branch that appends a migration,
-	// and why the failure reads as "not appended last" rather than as a merge
-	// conflict.
+	// The marker names THIS BRANCH's migration, and it has moved seven times as
+	// main advanced: the cleanup_obligations rebuild, #1766's SkillOpt/evals
+	// teardown, #1770's Activepieces trigger removal, #1731's escalation_rounds
+	// table, #1754's chat/moot teardown, #1756's preset-delivery removal,
+	// #1753's cockpit/interactive table drop and #1822's findings ledger (plus
+	// its #1850 rebuild) each joined the released prefix, leaving #1967's
+	// jobs.dispatched_by column appended last. Two branches cannot both be
+	// "last", and the ordering that matters is the one a deployed database sees,
+	// which is why this marker MUST be repointed on every branch that appends a
+	// migration, and why the failure reads as "not appended last" rather than as
+	// a merge conflict.
+	//
 	// The marker must name THIS BRANCH'S LAST migration and must be UNIQUE. The
-	// #1850 round 2 F3 fix appends a rebuild of review_finding_observations, so
-	// the bare CREATE string now matches TWO migrations (the original additive one
-	// and the rebuild) and this test correctly refused it as ambiguous. The
-	// rebuild's own table name is unique to it.
-	const branchMigrationMarker = "review_finding_observations_1850 RENAME TO"
+	// index name is unique to #1967's migration; the bare ALTER would not be,
+	// because the column name also appears in that migration's own prose.
+	const branchMigrationMarker = "idx_jobs_dispatched_by"
 	branchIndex := -1
 	for index, migration := range migrations {
 		if strings.Contains(migration, branchMigrationMarker) {

--- a/internal/db/review_findings_schema_test.go
+++ b/internal/db/review_findings_schema_test.go
@@ -133,12 +133,33 @@ func TestReviewFindingRebuildUpgradesAPreFixDatabase(t *testing.T) {
 			t.Fatalf("recreate pre-fix table: %v", err)
 		}
 	}
-	// A DAEMON ON THE PRIOR HEAD HAS APPLIED EVERY VERSION EXCEPT THE NEWEST, so
+	// A DAEMON ON THE PRIOR HEAD HAS APPLIED EVERY VERSION EXCEPT THE REBUILD, so
 	// the fixture must remove the rebuild's bookkeeping row. Without this the
 	// cached template has ALL versions recorded, Migrate finds nothing to do, and
 	// the test fails for a fixture reason rather than a code one - which is
 	// exactly how it failed on its first run, and why the premise assertions
 	// above matter more than the verdict below.
+	//
+	// THE REBUILD IS FOUND BY ITS MARKER, NOT BY BEING NEWEST. The first version
+	// deleted `version = len(migrations)`, which encoded "the rebuild is the last
+	// migration" - true when it was written and false the moment any branch
+	// appended one (#1967 did, and this test then un-applied THAT migration and
+	// re-ran it, failing with `duplicate column name`). applyMigration checks
+	// each version's own bookkeeping row, so deleting exactly one middle row
+	// re-runs exactly that migration.
+	const rebuildMarker = "review_finding_observations_1850 RENAME TO"
+	rebuildVersion := 0
+	for index, migration := range migrations {
+		if strings.Contains(migration, rebuildMarker) {
+			if rebuildVersion != 0 {
+				t.Fatalf("marker %q matches versions %d and %d", rebuildMarker, rebuildVersion, index+1)
+			}
+			rebuildVersion = index + 1
+		}
+	}
+	if rebuildVersion == 0 {
+		t.Fatalf("marker %q matches no migration", rebuildMarker)
+	}
 	var applied int
 	if err := store.db.QueryRowContext(ctx, `SELECT COUNT(*) FROM schema_migrations`).Scan(&applied); err != nil {
 		t.Fatalf("count applied migrations: %v", err)
@@ -146,8 +167,8 @@ func TestReviewFindingRebuildUpgradesAPreFixDatabase(t *testing.T) {
 	if applied != len(migrations) {
 		t.Fatalf("fixture holds %d applied migrations for %d defined; the template is not fully migrated", applied, len(migrations))
 	}
-	if _, err := store.db.ExecContext(ctx, `DELETE FROM schema_migrations WHERE version = ?`, len(migrations)); err != nil {
-		t.Fatalf("un-apply the newest migration: %v", err)
+	if _, err := store.db.ExecContext(ctx, `DELETE FROM schema_migrations WHERE version = ?`, rebuildVersion); err != nil {
+		t.Fatalf("un-apply the rebuild migration: %v", err)
 	}
 	insert := `INSERT INTO review_finding_observations(
 		finding_uid, repo, pull_request, head_sha, observer_job, state, evidence_kind)

--- a/internal/db/store_jobs.go
+++ b/internal/db/store_jobs.go
@@ -28,8 +28,15 @@ func rootIDFromPayload(payload string) string {
 }
 
 type jobPayloadProjection struct {
-	WorkflowID             string          `json:"workflow_id"`
-	Repo                   string          `json:"repo"`
+	WorkflowID string `json:"workflow_id"`
+	Repo       string `json:"repo"`
+	// DispatchedBy denormalizes payload.dispatched_by onto the indexed
+	// jobs.dispatched_by column (#1967). Projecting it here rather than reading
+	// job.DispatchedBy is what makes attribution unforgettable: all four INSERT
+	// paths already derive their denormalized columns from the payload, so a
+	// caller that hand-builds a db.Job (the high-risk review coordinator does)
+	// cannot land an attributed payload behind an unattributed row.
+	DispatchedBy           string          `json:"dispatched_by"`
 	PullRequest            int             `json:"pull_request"`
 	BlockerRetryAt         string          `json:"blocker_retry_at"`
 	BlockerSuggestedAction string          `json:"blocker_suggested_action"`
@@ -64,11 +71,11 @@ func (s *Store) CreateJob(ctx context.Context, job Job) error {
 	// the invariant — payload root when set, else self-root — holds regardless of
 	// caller. payload.RootJobID stays the value source of truth.
 	projection := jobProjectionFromPayload(job.Payload)
-	_, err := s.db.ExecContext(ctx, `INSERT INTO jobs(id, agent, type, state, payload, model, result_hash, parent_job_id, delegation_id, delegation_depth, delegated_by, root_id, workflow_id, repo, pull_request, blocker_retry_at, blocker_suggested_action, updated_at)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, COALESCE(NULLIF(?,''), ?), ?, ?, ?, ?, ?, CURRENT_TIMESTAMP)`,
+	_, err := s.db.ExecContext(ctx, `INSERT INTO jobs(id, agent, type, state, payload, model, result_hash, parent_job_id, delegation_id, delegation_depth, delegated_by, dispatched_by, root_id, workflow_id, repo, pull_request, blocker_retry_at, blocker_suggested_action, updated_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, COALESCE(NULLIF(?,''), ?), ?, ?, ?, ?, ?, CURRENT_TIMESTAMP)`,
 		job.ID, job.Agent, job.Type, job.State, job.Payload, job.Model,
 		jobResultHashFromPayload(job.Payload),
-		job.ParentJobID, job.DelegationID, job.DelegationDepth, job.DelegatedBy,
+		job.ParentJobID, job.DelegationID, job.DelegationDepth, job.DelegatedBy, projection.DispatchedBy,
 		rootIDFromPayload(job.Payload), job.ID, projection.WorkflowID, projection.Repo, projection.PullRequest,
 		projection.BlockerRetryAt, projection.BlockerSuggestedAction)
 	return err
@@ -94,11 +101,11 @@ func (s *Store) CreateJobWithEvent(ctx context.Context, job Job, event JobEvent,
 // job.ID) denormalizes the rootJobID() rule onto the indexed root_id column.
 func createJobWithEventTx(ctx context.Context, tx *sql.Tx, s *Store, job Job, event JobEvent, additionalEvents ...JobEvent) error {
 	projection := jobProjectionFromPayload(job.Payload)
-	if _, err := tx.ExecContext(ctx, `INSERT INTO jobs(id, agent, type, state, payload, model, result_hash, parent_job_id, delegation_id, delegation_depth, delegated_by, root_id, workflow_id, repo, pull_request, blocker_retry_at, blocker_suggested_action, updated_at)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, COALESCE(NULLIF(?,''), ?), ?, ?, ?, ?, ?, CURRENT_TIMESTAMP)`,
+	if _, err := tx.ExecContext(ctx, `INSERT INTO jobs(id, agent, type, state, payload, model, result_hash, parent_job_id, delegation_id, delegation_depth, delegated_by, dispatched_by, root_id, workflow_id, repo, pull_request, blocker_retry_at, blocker_suggested_action, updated_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, COALESCE(NULLIF(?,''), ?), ?, ?, ?, ?, ?, CURRENT_TIMESTAMP)`,
 		job.ID, job.Agent, job.Type, job.State, job.Payload, job.Model,
 		jobResultHashFromPayload(job.Payload),
-		job.ParentJobID, job.DelegationID, job.DelegationDepth, job.DelegatedBy,
+		job.ParentJobID, job.DelegationID, job.DelegationDepth, job.DelegatedBy, projection.DispatchedBy,
 		rootIDFromPayload(job.Payload), job.ID, projection.WorkflowID, projection.Repo, projection.PullRequest,
 		projection.BlockerRetryAt, projection.BlockerSuggestedAction); err != nil {
 		return err
@@ -191,11 +198,11 @@ func (s *Store) CreateExternallyDrivenJobWithEvent(ctx context.Context, job Job,
 	defer tx.Rollback()
 
 	projection := jobProjectionFromPayload(job.Payload)
-	if _, err := tx.ExecContext(ctx, `INSERT INTO jobs(id, agent, type, state, payload, model, result_hash, parent_job_id, delegation_id, delegation_depth, delegated_by, root_id, workflow_id, repo, pull_request, blocker_retry_at, blocker_suggested_action, externally_driven, updated_at)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, COALESCE(NULLIF(?,''), ?), ?, ?, ?, ?, ?, 1, CURRENT_TIMESTAMP)`,
+	if _, err := tx.ExecContext(ctx, `INSERT INTO jobs(id, agent, type, state, payload, model, result_hash, parent_job_id, delegation_id, delegation_depth, delegated_by, dispatched_by, root_id, workflow_id, repo, pull_request, blocker_retry_at, blocker_suggested_action, externally_driven, updated_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, COALESCE(NULLIF(?,''), ?), ?, ?, ?, ?, ?, 1, CURRENT_TIMESTAMP)`,
 		job.ID, job.Agent, job.Type, job.State, job.Payload, job.Model,
 		jobResultHashFromPayload(job.Payload),
-		job.ParentJobID, job.DelegationID, job.DelegationDepth, job.DelegatedBy,
+		job.ParentJobID, job.DelegationID, job.DelegationDepth, job.DelegatedBy, projection.DispatchedBy,
 		rootIDFromPayload(job.Payload), job.ID, projection.WorkflowID, projection.Repo, projection.PullRequest,
 		projection.BlockerRetryAt, projection.BlockerSuggestedAction); err != nil {
 		return err
@@ -255,9 +262,9 @@ func (s *Store) IsRootJobKilled(ctx context.Context, rootID string) (bool, error
 }
 
 func (s *Store) GetJob(ctx context.Context, id string) (Job, error) {
-	row := s.db.QueryRowContext(ctx, `SELECT id, agent, type, state, payload, model, parent_job_id, delegation_id, delegation_depth, delegated_by, workflow_id, root_killed, input_tokens, output_tokens, updated_at, created_at, externally_driven, lifecycle_generation FROM jobs WHERE id = ?`, id)
+	row := s.db.QueryRowContext(ctx, `SELECT id, agent, type, state, payload, model, parent_job_id, delegation_id, delegation_depth, delegated_by, dispatched_by, workflow_id, root_killed, input_tokens, output_tokens, updated_at, created_at, externally_driven, lifecycle_generation FROM jobs WHERE id = ?`, id)
 	var job Job
-	if err := row.Scan(&job.ID, &job.Agent, &job.Type, &job.State, &job.Payload, &job.Model, &job.ParentJobID, &job.DelegationID, &job.DelegationDepth, &job.DelegatedBy, &job.WorkflowID, &job.RootKilled, &job.InputTokens, &job.OutputTokens, &job.UpdatedAt, &job.CreatedAt, &job.ExternallyDriven, &job.LifecycleGeneration); err != nil {
+	if err := row.Scan(&job.ID, &job.Agent, &job.Type, &job.State, &job.Payload, &job.Model, &job.ParentJobID, &job.DelegationID, &job.DelegationDepth, &job.DelegatedBy, &job.DispatchedBy, &job.WorkflowID, &job.RootKilled, &job.InputTokens, &job.OutputTokens, &job.UpdatedAt, &job.CreatedAt, &job.ExternallyDriven, &job.LifecycleGeneration); err != nil {
 		return Job{}, err
 	}
 	return job, nil
@@ -356,7 +363,7 @@ func (s *Store) LatestDelegationWorktreeCleanupOutcome(ctx context.Context, jobI
 // jobColumns is the shared core projection ListJobs and ListJobsByType both
 // read, kept as one const so their SELECT lists and scanJobs order cannot drift.
 // Workflow-only scalar projections are selected by ListJobsByWorkflow.
-const jobColumns = `id, agent, type, state, payload, model, parent_job_id, delegation_id, delegation_depth, delegated_by, workflow_id, root_killed, input_tokens, output_tokens, updated_at, created_at, externally_driven, lifecycle_generation`
+const jobColumns = `id, agent, type, state, payload, model, parent_job_id, delegation_id, delegation_depth, delegated_by, dispatched_by, workflow_id, root_killed, input_tokens, output_tokens, updated_at, created_at, externally_driven, lifecycle_generation`
 
 const listJobsByStateSQL = `SELECT ` + jobColumns + ` FROM jobs WHERE state = ? ORDER BY updated_at, id`
 
@@ -368,7 +375,7 @@ func scanJobs(rows *sql.Rows) ([]Job, error) {
 	var jobs []Job
 	for rows.Next() {
 		var job Job
-		if err := rows.Scan(&job.ID, &job.Agent, &job.Type, &job.State, &job.Payload, &job.Model, &job.ParentJobID, &job.DelegationID, &job.DelegationDepth, &job.DelegatedBy, &job.WorkflowID, &job.RootKilled, &job.InputTokens, &job.OutputTokens, &job.UpdatedAt, &job.CreatedAt, &job.ExternallyDriven, &job.LifecycleGeneration); err != nil {
+		if err := rows.Scan(&job.ID, &job.Agent, &job.Type, &job.State, &job.Payload, &job.Model, &job.ParentJobID, &job.DelegationID, &job.DelegationDepth, &job.DelegatedBy, &job.DispatchedBy, &job.WorkflowID, &job.RootKilled, &job.InputTokens, &job.OutputTokens, &job.UpdatedAt, &job.CreatedAt, &job.ExternallyDriven, &job.LifecycleGeneration); err != nil {
 			return nil, err
 		}
 		jobs = append(jobs, job)
@@ -487,7 +494,7 @@ func (s *Store) ListJobsByParent(ctx context.Context, parentJobID string) ([]Job
 // idx_jobs_root_id for an indexed lookup instead of a full-table scan that
 // unmarshals every payload. ORDER BY id is deterministic.
 func (s *Store) ListJobsByRoot(ctx context.Context, rootID string) ([]Job, error) {
-	rows, err := s.db.QueryContext(ctx, `SELECT id, agent, type, state, payload, model, parent_job_id, delegation_id, delegation_depth, delegated_by, root_id, workflow_id, repo, pull_request, root_killed, input_tokens, output_tokens, updated_at, created_at, result_hash
+	rows, err := s.db.QueryContext(ctx, `SELECT id, agent, type, state, payload, model, parent_job_id, delegation_id, delegation_depth, delegated_by, dispatched_by, root_id, workflow_id, repo, pull_request, root_killed, input_tokens, output_tokens, updated_at, created_at, result_hash
 		FROM jobs WHERE root_id = ? ORDER BY id`, rootID)
 	if err != nil {
 		return nil, err
@@ -497,7 +504,7 @@ func (s *Store) ListJobsByRoot(ctx context.Context, rootID string) ([]Job, error
 	var jobs []Job
 	for rows.Next() {
 		var job Job
-		if err := rows.Scan(&job.ID, &job.Agent, &job.Type, &job.State, &job.Payload, &job.Model, &job.ParentJobID, &job.DelegationID, &job.DelegationDepth, &job.DelegatedBy, &job.RootID, &job.WorkflowID, &job.Repo, &job.PullRequest, &job.RootKilled, &job.InputTokens, &job.OutputTokens, &job.UpdatedAt, &job.CreatedAt, &job.ResultHash); err != nil {
+		if err := rows.Scan(&job.ID, &job.Agent, &job.Type, &job.State, &job.Payload, &job.Model, &job.ParentJobID, &job.DelegationID, &job.DelegationDepth, &job.DelegatedBy, &job.DispatchedBy, &job.RootID, &job.WorkflowID, &job.Repo, &job.PullRequest, &job.RootKilled, &job.InputTokens, &job.OutputTokens, &job.UpdatedAt, &job.CreatedAt, &job.ResultHash); err != nil {
 			return nil, err
 		}
 		jobs = append(jobs, job)

--- a/internal/db/store_migrations.go
+++ b/internal/db/store_migrations.go
@@ -2707,4 +2707,27 @@ DROP TABLE review_finding_observations;
 ALTER TABLE review_finding_observations_1850 RENAME TO review_finding_observations;
 CREATE INDEX IF NOT EXISTS idx_review_findings_pr ON review_finding_observations(repo, pull_request, observed_at);
 `,
+	// #1967 dispatcher attribution. review_finding_observations records
+	// observer_job (who FOUND it) and source_job (whose claim it repeats), and
+	// nothing recorded who ASKED for the review. Measured on this box's store on
+	// 2026-09-07: 268 of 271 open findings resolved to a job whose sender was the
+	// literal "local", 3 of 271 had any dispatcher field set at all, so the only
+	// identity available downstream was the reviewer agent name - which is
+	// exactly the misrouting mechanism recorded on #1890.
+	//
+	// A separate column rather than reusing parent_job_id: parent_job_id carries
+	// DAG semantics (delegation depth, per-root job budget, loop detection,
+	// root-kill propagation, and the #1277 skip-fanout inheritance that is gated
+	// on it). Back-filling it to make attribution work would silently rewire
+	// termination bounds for every fan-out review. dispatched_by is attribution
+	// only and no scheduler reads it.
+	//
+	// DEFAULT '' preserves every pre-migration row: the 426 findings measured on
+	// #1967 stay unattributable, which the issue states as intended. The partial
+	// index skips them, so it indexes only rows that can answer the question.
+	// Append-only tail; migrations are positional.
+	`
+ALTER TABLE jobs ADD COLUMN dispatched_by TEXT NOT NULL DEFAULT '';
+CREATE INDEX IF NOT EXISTS idx_jobs_dispatched_by ON jobs(dispatched_by) WHERE dispatched_by != '';
+	`,
 }

--- a/internal/db/store_types.go
+++ b/internal/db/store_types.go
@@ -177,6 +177,14 @@ type Job struct {
 	DelegationID    string
 	DelegationDepth int
 	DelegatedBy     string
+	// DispatchedBy is the identity that CAUSED this job to exist: the delegating
+	// coordinator, the acting org role of the dispatching seat, or, failing both,
+	// the dispatch channel (#1967). It is a denormalized index of
+	// payload.dispatched_by, written by the same projection that denormalizes
+	// workflow_id/repo/pull_request, so every INSERT path carries it without its
+	// caller naming a column. It is deliberately NOT parent_job_id: attribution
+	// must not rewire delegation depth, budget or root-kill semantics.
+	DispatchedBy string
 	// RootID is the id of the coordination tree's originating coordinator,
 	// denormalized onto the row as an indexed column (idx_jobs_root_id, #420) so
 	// root-scoped helpers can answer "which jobs belong to this run?" with one

--- a/internal/pipeline/run.go
+++ b/internal/pipeline/run.go
@@ -264,14 +264,19 @@ func PipelineStageJobRequest(rec db.Pipeline, stage Stage, run db.PipelineRun, a
 	}
 	if stage.Agent != "" {
 		request := workflow.JobRequest{
-			ID:               pipelineStageJobID(run.ID, stage.ID, attempt),
-			Agent:            stage.Agent,
-			Action:           stage.Action,
-			Repo:             rec.Repo,
-			Sender:           workflow.PipelineJobSender,
-			Instructions:     instructions,
-			Fingerprint:      pipelineStageFingerprint(rec.Name, run.ID, stage.ID, attempt),
-			RootJobID:        run.ID,
+			ID:           pipelineStageJobID(run.ID, stage.ID, attempt),
+			Agent:        stage.Agent,
+			Action:       stage.Action,
+			Repo:         rec.Repo,
+			Sender:       workflow.PipelineJobSender,
+			Instructions: instructions,
+			Fingerprint:  pipelineStageFingerprint(rec.Name, run.ID, stage.ID, attempt),
+			RootJobID:    run.ID,
+			// #1967: RootJobID already ties the job to its run, but root_id is not
+			// dispatcher identity - a run self-roots when no root is passed, so an
+			// empty-rooted job and a genuinely root-dispatched one are
+			// indistinguishable. Name the pipeline that ordered the stage.
+			DispatchedBy:     "pipeline:" + rec.Name,
 			JobTimeout:       stage.Timeout,
 			PipelineInputEnv: append([]string(nil), pipelineInputEnv...),
 		}

--- a/internal/workflow/dispatcher_attribution_1967_test.go
+++ b/internal/workflow/dispatcher_attribution_1967_test.go
@@ -1,0 +1,232 @@
+package workflow
+
+import (
+	"context"
+	"testing"
+
+	"github.com/gitmoot/gitmoot/internal/db"
+)
+
+// #1967. review_finding_observations records observer_job (the reviewer that
+// FOUND a finding) and source_job (the job whose claim it repeats). Nothing
+// recorded who ASKED for the review, so the only identity a finding could be
+// routed by was the reviewer agent name - the misrouting mechanism on #1890.
+//
+// Measured on this box's live store on 2026-09-07, joining every open finding
+// to its observing job: 271 open findings, 271 matched a jobs row, 3 had any
+// dispatcher field set, and 268 resolved to a job whose entire recorded
+// identity was Sender: "local".
+//
+// READER 1 of 2 - the in-process PR-open trigger. The implement job that just
+// opened the PR is the dispatcher, and it is the ADVANCING job's agent, not the
+// reviewer that will answer.
+func TestInProcessPROpenRecordsTheDispatchingSeatOnFanoutChildren(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	seedAgent(t, store, "lead", []string{"implement"}, "gitmoot/gitmoot")
+	seedAgent(t, store, "reviewer", []string{"review"}, "gitmoot/gitmoot")
+	engine := testEngine(store)
+	engine.RequiredReviewers = []string{"reviewer"}
+
+	if acquired, err := store.AcquireLock(ctx, db.BranchLock{
+		RepoFullName: "gitmoot/gitmoot",
+		Branch:       "task-1967",
+		Owner:        "lead",
+	}); err != nil || !acquired {
+		t.Fatalf("AcquireLock returned acquired=%v err=%v", acquired, err)
+	}
+	insertCompletedJob(t, store, db.Job{
+		ID:    "dispatching-implement",
+		Agent: "lead",
+		Type:  "implement",
+	}, JobPayload{
+		Repo:        "gitmoot/gitmoot",
+		Branch:      "task-1967",
+		PullRequest: 1967,
+		HeadSHA:     "head1967",
+		TaskID:      "task-1967",
+		LeadAgent:   "lead",
+		Result:      &AgentResult{Decision: "implemented", Summary: "opened PR"},
+	})
+
+	if err := engine.AdvanceJob(ctx, "dispatching-implement"); err != nil {
+		t.Fatalf("AdvanceJob returned error: %v", err)
+	}
+
+	review := onlyReviewJob(t, ctx, store)
+	if review.DispatchedBy != "lead" {
+		t.Fatalf("fanout child dispatched_by = %q, want %q; an unattributed review finding can only be routed by the reviewer's own name (#1890)", review.DispatchedBy, "lead")
+	}
+	if review.DispatchedBy == review.Agent {
+		t.Fatalf("fanout child dispatched_by = %q equals the reviewer agent; that is the attribution #1967 exists to replace", review.DispatchedBy)
+	}
+}
+
+// The read-back half. #1250 finding 3 established the failure mode this guards:
+// a column written but omitted from the SELECT projection returns a
+// structurally valid but FALSELY BLANK field, which reads as "nobody dispatched
+// this" rather than "not loaded". jobs.root_id already has exactly that defect
+// (GetJob and jobColumns omit it), so a new attribution column that only the
+// writer knows about would be worth nothing to the query in #1967's acceptance.
+func TestDispatcherSurvivesEveryJobReadBack(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	seedAgent(t, store, "reviewer", []string{"review"}, "gitmoot/gitmoot")
+	mailbox := NewMailbox(store, UnavailableDeliveryWorktreeResolver("test"))
+
+	if _, err := mailbox.Enqueue(ctx, JobRequest{
+		ID:           "readback-review",
+		Agent:        "reviewer",
+		Action:       "review",
+		Repo:         "gitmoot/gitmoot",
+		PullRequest:  7,
+		Sender:       "github",
+		DispatchedBy: "impl-seat",
+		Instructions: "review it",
+	}); err != nil {
+		t.Fatalf("Enqueue returned error: %v", err)
+	}
+
+	got, err := store.GetJob(ctx, "readback-review")
+	if err != nil {
+		t.Fatalf("GetJob returned error: %v", err)
+	}
+	if got.DispatchedBy != "impl-seat" {
+		t.Fatalf("GetJob dispatched_by = %q, want %q", got.DispatchedBy, "impl-seat")
+	}
+
+	jobs, err := store.ListJobs(ctx)
+	if err != nil {
+		t.Fatalf("ListJobs returned error: %v", err)
+	}
+	if len(jobs) != 1 {
+		t.Fatalf("ListJobs returned %d jobs, want 1", len(jobs))
+	}
+	if jobs[0].DispatchedBy != "impl-seat" {
+		t.Fatalf("ListJobs dispatched_by = %q, want %q", jobs[0].DispatchedBy, "impl-seat")
+	}
+}
+
+// The chokepoint resolution. Six independent JobRequest literals create review
+// jobs and none named a dispatcher field; fixing the six leaves the seventh
+// unattributed, so the resolution lives at Enqueue - the same argument #1277
+// made for inheriting the skip-fanout intent there.
+//
+// The two "never" rows are the point of the test, not padding: on a CLI review
+// dispatch LeadAgent defaults to the reviewer agent itself
+// (agent_dispatch.go: firstNonEmpty(request.LeadAgent, agent.Name)), so a
+// fallback to either Agent or LeadAgent would make the column look answered
+// while carrying exactly the identity #1890 misroutes on.
+func TestEnqueueResolvesTheDispatcherFromTheMostSpecificSourceAvailable(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	seedAgent(t, store, "reviewer", []string{"review"}, "gitmoot/gitmoot")
+	mailbox := NewMailbox(store, UnavailableDeliveryWorktreeResolver("test"))
+
+	for _, tc := range []struct {
+		name    string
+		request JobRequest
+		want    string
+	}{
+		{
+			name:    "explicit dispatcher wins",
+			request: JobRequest{DispatchedBy: "impl-seat", DelegatedBy: "coordinator", ActingOrgRole: "role", Sender: "github"},
+			want:    "impl-seat",
+		},
+		{
+			name:    "delegation child is attributed to its delegating coordinator",
+			request: JobRequest{DelegatedBy: "coordinator", ActingOrgRole: "role", Sender: "coordinator-agent"},
+			want:    "coordinator",
+		},
+		{
+			name:    "a CLI dispatch is attributed to its acting org role",
+			request: JobRequest{ActingOrgRole: "gm-findings", Sender: "local"},
+			want:    "gm-findings",
+		},
+		{
+			name:    "with no identity at all the channel is recorded, never nothing",
+			request: JobRequest{Sender: "local"},
+			want:    "local",
+		},
+		{
+			name:    "never the reviewer agent",
+			request: JobRequest{Agent: "reviewer"},
+			want:    "",
+		},
+		{
+			name:    "never the lead agent, which is the reviewer on a CLI dispatch",
+			request: JobRequest{Agent: "reviewer", LeadAgent: "reviewer"},
+			want:    "",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			request := tc.request
+			request.ID = "dispatch-" + t.Name()
+			request.Agent = "reviewer"
+			request.Action = "review"
+			request.Repo = "gitmoot/gitmoot"
+			request.PullRequest = 7
+			request.Instructions = "review it"
+			if _, err := mailbox.Enqueue(ctx, request); err != nil {
+				t.Fatalf("Enqueue returned error: %v", err)
+			}
+			got, err := store.GetJob(ctx, request.ID)
+			if err != nil {
+				t.Fatalf("GetJob returned error: %v", err)
+			}
+			if got.DispatchedBy != tc.want {
+				t.Fatalf("dispatched_by = %q, want %q", got.DispatchedBy, tc.want)
+			}
+		})
+	}
+}
+
+// Attribution must not rewire scheduling. parent_job_id carries delegation
+// depth, the per-root job budget, loop detection, root-kill propagation and the
+// #1277 skip-fanout inheritance; #1967's proposed change ("populate dispatcher
+// identity") would have been satisfiable by back-filling it, and that would
+// silently give every fan-out review a delegation parent it never had.
+func TestRecordingTheDispatcherDoesNotSynthesizeADelegationParent(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	seedAgent(t, store, "reviewer", []string{"review"}, "gitmoot/gitmoot")
+	mailbox := NewMailbox(store, UnavailableDeliveryWorktreeResolver("test"))
+
+	if _, err := mailbox.Enqueue(ctx, JobRequest{
+		ID:           "attribution-only",
+		Agent:        "reviewer",
+		Action:       "review",
+		Repo:         "gitmoot/gitmoot",
+		PullRequest:  7,
+		Sender:       "github",
+		DispatchedBy: "impl-seat",
+		Instructions: "review it",
+	}); err != nil {
+		t.Fatalf("Enqueue returned error: %v", err)
+	}
+	got, err := store.GetJob(ctx, "attribution-only")
+	if err != nil {
+		t.Fatalf("GetJob returned error: %v", err)
+	}
+	if got.ParentJobID != "" || got.DelegationID != "" || got.DelegationDepth != 0 || got.DelegatedBy != "" {
+		t.Fatalf("attribution leaked into the delegation DAG: parent=%q delegation=%q depth=%d delegated_by=%q", got.ParentJobID, got.DelegationID, got.DelegationDepth, got.DelegatedBy)
+	}
+}
+
+func onlyReviewJob(t *testing.T, ctx context.Context, store *db.Store) db.Job {
+	t.Helper()
+	jobs, err := store.ListJobs(ctx)
+	if err != nil {
+		t.Fatalf("ListJobs returned error: %v", err)
+	}
+	var reviews []db.Job
+	for _, job := range jobs {
+		if job.Type == "review" {
+			reviews = append(reviews, job)
+		}
+	}
+	if len(reviews) != 1 {
+		t.Fatalf("found %d review jobs, want exactly 1; cannot assert attribution", len(reviews))
+	}
+	return reviews[0]
+}

--- a/internal/workflow/dispatcher_attribution_1967_test.go
+++ b/internal/workflow/dispatcher_attribution_1967_test.go
@@ -17,9 +17,17 @@ import (
 // dispatcher field set, and 268 resolved to a job whose entire recorded
 // identity was Sender: "local".
 //
-// READER 1 of 2 - the in-process PR-open trigger. The implement job that just
-// opened the PR is the dispatcher, and it is the ADVANCING job's agent, not the
-// reviewer that will answer.
+// READER 1 of 2 - the in-process PR-open trigger, end to end through AdvanceJob.
+//
+// NOTE ON WHAT THIS DOES AND DOES NOT DISCRIMINATE. On this trigger production
+// sets Sender to the advancing job's agent as well, so the resolution would
+// reach the same value through the Sender fallback: removing the explicit
+// DispatchedBy from the trigger leaves this test green (verified by mutation).
+// It pins the end-to-end outcome, not that one line. The line is kept because
+// Sender means the CHANNEL on every other dispatch path ("github", "local",
+// "heartbeat"), so attribution that reads it is correct only by coincidence -
+// and TestPROpenFanoutPrefersTheDispatcherOverTheSenderChannel below is the
+// test that separates the two.
 func TestInProcessPROpenRecordsTheDispatchingSeatOnFanoutChildren(t *testing.T) {
 	ctx := context.Background()
 	store := openEngineStore(t)
@@ -59,6 +67,40 @@ func TestInProcessPROpenRecordsTheDispatchingSeatOnFanoutChildren(t *testing.T) 
 	}
 	if review.DispatchedBy == review.Agent {
 		t.Fatalf("fanout child dispatched_by = %q equals the reviewer agent; that is the attribution #1967 exists to replace", review.DispatchedBy)
+	}
+}
+
+// The fan-out literal itself, at the seam where the two candidate values
+// DIFFER. This is the shape the daemon PR-watcher produces: Sender is the forge
+// channel "github", and the only seat identity on the event is the dispatcher.
+// Before #1967 the fan-out child's whole recorded identity was that channel, so
+// 0 of its findings could name a seat.
+func TestPROpenFanoutPrefersTheDispatcherOverTheSenderChannel(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	seedAgent(t, store, "lead", []string{"implement"}, "gitmoot/gitmoot")
+	seedAgent(t, store, "reviewer", []string{"review"}, "gitmoot/gitmoot")
+	engine := testEngine(store)
+	engine.RequiredReviewers = []string{"reviewer"}
+
+	if err := engine.HandlePullRequestOpened(ctx, PullRequestEvent{
+		Repo:              "gitmoot/gitmoot",
+		Branch:            "task-1967-forge",
+		PullRequest:       1968,
+		HeadSHA:           "head1968",
+		TaskID:            "task-1967-forge",
+		TaskTitle:         "Forge-observed PR",
+		LeadAgent:         "lead",
+		Sender:            "github",
+		DispatchedBy:      "impl-seat",
+		RequiredReviewers: []string{"reviewer"},
+	}); err != nil {
+		t.Fatalf("HandlePullRequestOpened returned error: %v", err)
+	}
+
+	review := onlyReviewJob(t, ctx, store)
+	if review.DispatchedBy != "impl-seat" {
+		t.Fatalf("fanout child dispatched_by = %q, want %q; %q is the forge channel and %q is the reviewer, neither of which can own an obligation (#1890)", review.DispatchedBy, "impl-seat", "github", "reviewer")
 	}
 }
 

--- a/internal/workflow/engine_pr_lifecycle.go
+++ b/internal/workflow/engine_pr_lifecycle.go
@@ -266,21 +266,26 @@ func (e Engine) HandlePullRequestOpened(ctx context.Context, event PullRequestEv
 			// The role rides the event from the branch lock, one source for both
 			// triggers.
 			ActingOrgRole: event.ActingOrgRole,
-			Agent:         reviewer,
-			Action:        "review",
-			Repo:          event.Repo,
-			Branch:        event.Branch,
-			PullRequest:   event.PullRequest,
-			HeadSHA:       event.HeadSHA,
-			GoalID:        event.GoalID,
-			TaskID:        event.TaskID,
-			TaskTitle:     event.TaskTitle,
-			LeadAgent:     event.LeadAgent,
-			Reviewers:     reviewers,
-			ReviewRound:   reviewRound,
-			ReviewScope:   scope,
-			Sender:        event.Sender,
-			Instructions:  instructions,
+			// #1967: the review is dispatched on behalf of the seat that opened the
+			// PR, not by the reviewer that will answer it. Without this the fan-out
+			// child's only identity was Sender ("github" from the daemon), so a
+			// finding it recorded could not be routed back to an owning lane.
+			DispatchedBy: event.DispatchedBy,
+			Agent:        reviewer,
+			Action:       "review",
+			Repo:         event.Repo,
+			Branch:       event.Branch,
+			PullRequest:  event.PullRequest,
+			HeadSHA:      event.HeadSHA,
+			GoalID:       event.GoalID,
+			TaskID:       event.TaskID,
+			TaskTitle:    event.TaskTitle,
+			LeadAgent:    event.LeadAgent,
+			Reviewers:    reviewers,
+			ReviewRound:  reviewRound,
+			ReviewScope:  scope,
+			Sender:       event.Sender,
+			Instructions: instructions,
 		}
 		requests = append(requests, request)
 	}
@@ -495,6 +500,7 @@ func (e Engine) dispatchHighRiskReview(ctx context.Context, event PullRequestEve
 		Reviewers:     reviewers,
 		ReviewRound:   round,
 		Sender:        event.Sender,
+		DispatchedBy:  event.DispatchedBy,
 		Instructions: fmt.Sprintf(
 			"Synthesize the high-risk adversarial review of pull request #%d for task %s from the lens findings below.",
 			event.PullRequest, taskLabel(event.TaskID, event.TaskTitle),

--- a/internal/workflow/engine_run_budgets.go
+++ b/internal/workflow/engine_run_budgets.go
@@ -793,6 +793,12 @@ func (e Engine) AdvanceJob(ctx context.Context, jobID string) (retErr error) {
 			RequiredReviewers:       e.requiredReviewers(payload),
 			SkipReviewFanout:        skipFanout,
 			ActingOrgRole:           actingOrgRole,
+			// #1967: the implement job that just opened the PR is the dispatcher.
+			// job.Agent is already used as Sender here, but Sender is a channel on
+			// every other path ("github", "local", "heartbeat"), so attribution
+			// cannot be read off it - it needs its own field to mean the same thing
+			// everywhere.
+			DispatchedBy: job.Agent,
 		}
 		// The branch-lock persist for the daemon's PR-watcher path (trigger 2) now
 		// happens above, before the no-PR early return, so it covers the PR arm and

--- a/internal/workflow/engine_types.go
+++ b/internal/workflow/engine_types.go
@@ -260,6 +260,14 @@ type PullRequestEvent struct {
 	// (#1347). Empty means unattributed, which is also the legacy value for locks
 	// predating the migration: the fanout then behaves exactly as it does today.
 	ActingOrgRole string
+	// DispatchedBy is the identity that caused this fan-out to be asked for
+	// (#1967). Both PR-open triggers carry the implementing seat: the daemon
+	// PR-watcher reads the branch lock owner, the in-process trigger uses the
+	// advancing implement job's agent. It is NOT the reviewer and NOT LeadAgent
+	// by coincidence - LeadAgent happens to be the lock owner here, but on a CLI
+	// dispatch it is the reviewer itself, so the two must not be conflated.
+	// Empty degrades to Sender at the enqueue chokepoint.
+	DispatchedBy string
 	// HumanMergeRequested records an explicit authorized @gitmoot merge command.
 	// It permits the native policy gate to merge even when automatic merging is
 	// disabled for the repository; ordinary daemon advancement leaves this false.

--- a/internal/workflow/mailbox.go
+++ b/internal/workflow/mailbox.go
@@ -220,12 +220,17 @@ type JobRequest struct {
 	// for this job only (the agent's identity is unchanged). Used by the
 	// orchestrate/run --recipe flag to route a coordinator to a built-in recipe
 	// template's prompt without rebinding the agent.
-	TemplateOverride      *db.AgentTemplate
-	ParentJobID           string
-	DelegationID          string
-	DelegationDepth       int
-	DelegatedBy           string
-	RootJobID             string
+	TemplateOverride *db.AgentTemplate
+	ParentJobID      string
+	DelegationID     string
+	DelegationDepth  int
+	DelegatedBy      string
+	RootJobID        string
+	// DispatchedBy names the identity that asked for this job, when the dispatch
+	// site knows something more specific than DelegatedBy/ActingOrgRole/Sender
+	// can express (#1967). It is optional: dispatcherIdentity resolves a value
+	// for every request, so a dispatch site that omits it is still attributed.
+	DispatchedBy          string
 	Deps                  []string
 	JobTimeout            string
 	RetryCount            int
@@ -375,14 +380,18 @@ type JobPayload struct {
 	DelegationDepth         int          `json:"delegation_depth,omitempty"`
 	DelegatedBy             string       `json:"delegated_by,omitempty"`
 	RootJobID               string       `json:"root_job_id,omitempty"`
-	Deps                    []string     `json:"deps,omitempty"`
-	JobTimeout              string       `json:"job_timeout,omitempty"`
-	RetryCount              int          `json:"retry_count,omitempty"`
-	Fingerprint             string       `json:"fingerprint,omitempty"`
-	FailurePolicy           string       `json:"failure_policy,omitempty"`
-	SynthesisRule           string       `json:"synthesis_rule,omitempty"`
-	DelegationArtifactDir   string       `json:"delegation_artifact_dir,omitempty"`
-	WorktreePath            string       `json:"worktree_path,omitempty"`
+	// DispatchedBy is the resolved dispatcher identity (#1967), the value source
+	// of truth for the denormalized jobs.dispatched_by column. omitempty keeps
+	// pre-#1967 payloads byte-identical.
+	DispatchedBy          string   `json:"dispatched_by,omitempty"`
+	Deps                  []string `json:"deps,omitempty"`
+	JobTimeout            string   `json:"job_timeout,omitempty"`
+	RetryCount            int      `json:"retry_count,omitempty"`
+	Fingerprint           string   `json:"fingerprint,omitempty"`
+	FailurePolicy         string   `json:"failure_policy,omitempty"`
+	SynthesisRule         string   `json:"synthesis_rule,omitempty"`
+	DelegationArtifactDir string   `json:"delegation_artifact_dir,omitempty"`
+	WorktreePath          string   `json:"worktree_path,omitempty"`
 	// RuntimePID is the exact subprocess started by the runtime runner for the
 	// current delivery. RuntimePIDStartTime is Linux /proc starttime field 22,
 	// captured at the same moment so liveness checks cannot mistake a recycled
@@ -577,6 +586,45 @@ type PreparedEnqueue struct {
 	Events []db.JobEvent
 }
 
+// dispatcherIdentity resolves who asked for a job to exist, most specific first.
+//
+// #1967. review_finding_observations records observer_job (the reviewer that
+// found it) and source_job (the job whose claim it repeats). Nothing recorded
+// the DISPATCHER, so no rule of the form "the obligation belongs to the seat
+// that asked for the review" was implementable, and recipient selection fell
+// back to the reviewer agent name - the misrouting mechanism on #1890, where 16
+// escalations authored by one reviewer went to a seat with authority over none
+// of them.
+//
+// The order is deliberate, and the omissions more so:
+//
+//   - DelegatedBy before ActingOrgRole: a delegation child's direct dispatcher
+//     is the coordinator that delegated it, which is narrower than the org role
+//     that whole tree inherits.
+//   - Sender last and never dropped, so the column is non-empty for every
+//     dispatch path. It degrades to a CHANNEL ("local", "github", "heartbeat",
+//     the pipeline sender) rather than a seat, which is honest: a CLI dispatch
+//     with no --org-role and no GITMOOT_ORG_ROLE genuinely carries no seat
+//     identity, and recording the channel says so without inventing one.
+//   - request.Agent and request.LeadAgent are NEVER consulted. On a CLI review
+//     dispatch LeadAgent defaults to the reviewer agent itself
+//     (agent_dispatch.go: firstNonEmpty(request.LeadAgent, agent.Name)), so
+//     either would reintroduce reviewer-name attribution as a fallback and make
+//     the column read as an answer while carrying the same wrong identity.
+func dispatcherIdentity(request JobRequest) string {
+	for _, candidate := range []string{
+		request.DispatchedBy,
+		request.DelegatedBy,
+		request.ActingOrgRole,
+		request.Sender,
+	} {
+		if trimmed := strings.TrimSpace(candidate); trimmed != "" {
+			return trimmed
+		}
+	}
+	return ""
+}
+
 // PrepareEnqueue runs Enqueue's read-and-compute half and returns the row to insert.
 // It writes NOTHING durable: that is the whole point, and it is what lets a resolution
 // commit its job insert in the same transaction as its task write and its receipt.
@@ -646,6 +694,14 @@ func (m Mailbox) prepareEnqueue(ctx context.Context, request JobRequest) (db.Job
 		}
 	}
 
+	// #1967: resolve the dispatcher HERE, for the same reason the skip-fanout
+	// intent above is inherited here. Every review-creating request in the tree
+	// is a flat keyed struct literal, and six of them never named a dispatcher
+	// field, so on this box's store 268 of 271 open review findings resolved to
+	// a job whose only identity was Sender: "local" and the reviewer agent's own
+	// name. Fixing the six literals leaves the seventh unattributed; fixing the
+	// chokepoint attributes it for free.
+
 	// Cleanup selectors compare WorktreePath textually with the allocator-derived
 	// obligation path, so managed allocators must preserve their canonical path.
 	payload, err := marshalPayload(JobPayload{
@@ -670,6 +726,7 @@ func (m Mailbox) prepareEnqueue(ctx context.Context, request JobRequest) (db.Job
 		DelegationDepth:        request.DelegationDepth,
 		DelegatedBy:            request.DelegatedBy,
 		RootJobID:              request.RootJobID,
+		DispatchedBy:           dispatcherIdentity(request),
 		Deps:                   compactStrings(request.Deps),
 		JobTimeout:             strings.TrimSpace(request.JobTimeout),
 		RetryCount:             request.RetryCount,

--- a/skills/gitmoot/references/RESULT_CONTRACT.md
+++ b/skills/gitmoot/references/RESULT_CONTRACT.md
@@ -465,6 +465,32 @@ Each child job carries `parent_job_id`, `delegation_id`, `root_job_id`,
 `delegation_depth`, and `task_id`, so a child can be traced to its parent, its
 originating delegation, and the root of the job tree.
 
+Separately from that tree linkage, **every** job Gitmoot creates carries
+`dispatched_by`: the identity that asked for the job to exist. It is resolved at
+the single enqueue chokepoint from the most specific source available, in order:
+an explicit dispatcher supplied by the dispatch site, then `delegated_by`, then
+the acting org role, then the dispatch channel (`local`, `github`, `heartbeat`,
+the pipeline sender). It never falls back to the job's own agent or to
+`lead_agent`, because on a CLI review dispatch `lead_agent` defaults to the
+reviewer itself.
+
+`dispatched_by` is attribution only, deliberately not `parent_job_id`: nothing
+in the scheduler reads it, so recording it cannot change delegation depth, the
+per-root job budget, loop detection or root-kill propagation. Its purpose is
+that a review finding can be resolved to the seat that ORDERED the review
+rather than only to the reviewer that wrote it:
+
+```sql
+SELECT f.finding_uid, f.severity, f.state, j.dispatched_by
+FROM review_finding_observations f
+JOIN jobs j ON j.id = f.observer_job
+WHERE f.state = 'open';
+```
+
+Jobs created before the column existed carry an empty `dispatched_by`. There is
+no backfill: the dispatcher of a past review was never recorded anywhere, and
+inventing one would be worse than an honest blank.
+
 ### Termination bounds
 
 Delegation trees are bounded so they cannot run forever:

--- a/website/docs/reference/result-contract.md
+++ b/website/docs/reference/result-contract.md
@@ -543,6 +543,32 @@ These fields let Gitmoot connect a child back to its parent, to the specific
 delegation that spawned it, and to the root of the job tree, and they are what
 the termination bounds below are measured against.
 
+Separately from that tree linkage, **every** job Gitmoot creates carries
+`dispatched_by`: the identity that asked for the job to exist. It is resolved at
+the single enqueue chokepoint from the most specific source available, in this
+order: an explicit dispatcher supplied by the dispatch site, then
+`delegated_by`, then the acting org role, then the dispatch channel
+(`local`, `github`, `heartbeat`, the pipeline sender). It never falls back to
+the job's own agent or to `lead_agent`, because on a CLI review dispatch
+`lead_agent` defaults to the reviewer itself.
+
+`dispatched_by` is attribution only. It is deliberately not `parent_job_id`:
+nothing in the scheduler reads it, so recording it cannot change delegation
+depth, the per-root job budget, loop detection or root-kill propagation. Its
+purpose is that a review finding can be resolved to the seat that ordered the
+review, rather than only to the reviewer that wrote it:
+
+```sql
+SELECT f.finding_uid, f.severity, f.state, j.dispatched_by
+FROM review_finding_observations f
+JOIN jobs j ON j.id = f.observer_job
+WHERE f.state = 'open';
+```
+
+Jobs created before this column existed carry an empty `dispatched_by`; there is
+no backfill, because the dispatcher of a past review was never recorded anywhere
+and inventing one would be worse than an honest blank.
+
 ## Top-level fields
 
 - `artifact_body` (optional): the artifact payload made available to delegated


### PR DESCRIPTION
Fixes #1967. Part of campaign #1966.

## The defect, named at the line

`review_finding_observations` records `observer_job` (the reviewer that FOUND a
finding) and `source_job` (the job whose claim it repeats). Nothing recorded who
ASKED for the review, so no ownership rule of the form "the obligation belongs
to the seat that dispatched the review" was implementable, and recipient
selection fell back to the reviewer agent name. That is the mechanism visible on
#1890.

The issue did not name the component. It is not one component: `Mailbox.Enqueue`
(`internal/workflow/mailbox.go`) already copies `ParentJobID`, `DelegationID`,
`DelegationDepth` and `DelegatedBy` faithfully onto both the row and the payload,
and `internal/db/store_jobs.go` writes all four. The fields are empty because
every review-creating request is a flat keyed struct literal that never names
them. Six of them:

| Path | Site | Identity it recorded before this PR |
| --- | --- | --- |
| daemon PR-watcher fan-out | `internal/workflow/engine_pr_lifecycle.go:261` | `Sender: "github"` only |
| in-process implement to PR trigger | `internal/workflow/engine_run_budgets.go:781` | `Sender: job.Agent` |
| high-risk lens coordinator | `internal/workflow/engine_pr_lifecycle.go:512` | `Sender` only |
| PR and issue comment triggers | `internal/daemon/daemon.go:2726`, `:2877` | `Sender: comment.Author` |
| every CLI verb (`agent review`, `run`, `ask`, `implement`, `orchestrate`) | `internal/cli/agent_dispatch.go:441`, `:823` | `Sender: "local"` |
| heartbeat `action = review` | `internal/cli/daemon_supervision.go:612` | `Sender: "heartbeat"` |
| pipeline review stage | `internal/pipeline/run.go:266` | `Sender`, plus `RootJobID` |

Only `delegationRequest` (`engine_run_budgets.go:1146`) and the three
continuation constructors stamp the DAG fields, which is why exactly the
delegation children were attributable.

One correction to the issue's record-level reading: `jobs.root_id` is **not**
empty on disk. The INSERT self-roots via `COALESCE(NULLIF(?,''), job.ID)`, so a
fan-out review becomes its own tree root. What is empty is `payload.root_job_id`
and `db.Job.RootID` as read back, because `GetJob` and `jobColumns` do not
`SELECT root_id`.

## Re-measured before writing code

Read-only against `/root/.gitmoot/gitmoot.db` on 2026-09-07, after PHOBOS's
approved cleanup, so the denominator is 271 rather than the issue's 426:

| | open findings | matched a `jobs` row | dispatcher recorded |
| --- | --- | --- | --- |
| issue #1967, pre-cleanup | 426 | 426 | 6 |
| this seat, post-cleanup | 271 | 271 | 3 |

Same ratio, so the measurement stands. Two things the issue did not measure,
which changed where the fix had to go:

- **268 of the 271 open findings came from one path.** Grouping open findings by
  their observing job's `payload.sender`: 268 `local` (the CLI dispatch), 3
  `g6-review-sol` (a delegation child). Zero from the daemon `github` fan-out,
  zero from heartbeat, zero from pipeline in the window. The fan-out is where the
  gap is total, but the CLI is where the volume is.
- **The identity was usually present and simply not recorded as a dispatcher.**
  454 of 573 `local` review jobs already carried `payload.acting_org_role`.

## The change

One new attribution dimension, resolved at the one chokepoint every request
passes through, plus an explicit value at the sites that know something more
specific than the chokepoint can infer.

`dispatcherIdentity` (`internal/workflow/mailbox.go`) resolves, most specific
first: an explicit `DispatchedBy` from the dispatch site, then `DelegatedBy`,
then `ActingOrgRole`, then `Sender`. It never consults `request.Agent` or
`request.LeadAgent`, because on a CLI review dispatch `LeadAgent` defaults to
the reviewer itself (`firstNonEmpty(request.LeadAgent, agent.Name)`), so either
would reintroduce reviewer-name attribution as a fallback and make the column
read as an answer while carrying the identity #1890 misroutes on.

Resolving here rather than at the seven literals is the #1277 argument applied
again: fixing the literals leaves the eighth one unattributed.

`Sender` last and never dropped means the column is non-empty for every dispatch
path, degrading to a CHANNEL (`local`, `github`, `heartbeat`, the pipeline
sender) rather than a seat. That is deliberate and honest: a CLI dispatch with
no `--org-role` and no `GITMOOT_ORG_ROLE` genuinely carries no seat identity,
and recording the channel says so without inventing one.

Explicit dispatchers where a better value exists:

- daemon PR-watcher: `lock.Owner`, read from the same branch-lock row the
  watcher already fetches for `ActingOrgRole`, so the two readers cannot drift
  and it costs no extra query.
- in-process PR-open trigger: the advancing implement job's agent.
- heartbeat: `"heartbeat:" + heartbeat.Name`, so a finding traces to the
  configuration entry that ordered the review.
- pipeline stage: `"pipeline:" + rec.Name`.

### Why not `parent_job_id`

The issue's proposed change ("at minimum `delegated_by` or an explicit
`dispatched_by`") is satisfiable by back-filling `parent_job_id`, and that would
be a scheduling change disguised as an attribution change. `parent_job_id`
carries delegation depth, the per-root job budget, loop detection, root-kill
propagation, and the #1277 skip-fanout inheritance which is gated on it being
non-empty. Giving every fan-out review a synthetic delegation parent would
silently rewire termination bounds. `dispatched_by` is read by nothing in the
scheduler. `TestRecordingTheDispatcherDoesNotSynthesizeADelegationParent` pins
that separation.

### Storage

`dispatched_by` is denormalized from `payload.dispatched_by` by the same
`jobPayloadProjection` that already denormalizes `workflow_id`, `repo` and
`pull_request`, so all four INSERT paths carry it without their callers naming a
column. This matters for the high-risk lens coordinator, which hand-builds a
`db.Job`: it cannot land an attributed payload behind an unattributed row.

Read back by `GetJob`, `jobColumns` (so `ListJobs`/`ListJobsByType`/
`ListActiveJobs`) and `ListJobsByRoot`. `jobs.root_id` is the cautionary case:
written since #420 and omitted from those projections, so it reads back falsely
blank. A column only the writer knows about is worth nothing to the query in
#1967's acceptance.

`gitmoot job show --json` exposes it with no CLI change, because `jobShowOutput`
embeds `db.Job` and `workflow.JobPayload`.

Migration appends `jobs.dispatched_by TEXT NOT NULL DEFAULT ''` plus a partial
index over non-empty values. **No backfill**, as the issue requires: the 271
existing rows stay unattributable.

## Verification

### Live probe, no LLM, isolated `/tmp` home

Built from this branch, `gitmoot init` on a throwaway home, real
`gitmoot agent run --action review` dispatches through the production CLI path,
`shell` runtime override so no model is involved.

```
id                                            type    dispatched_by  sender  agent
--------------------------------------------  ------  -------------  ------  --------------
local-review-probe-reviewer-18d30f402c956715  review  gm-findings    local   probe-reviewer
```

`parent_job_id` and `delegated_by` stayed empty on all probe rows: attribution
did not touch the DAG.

Then the acceptance query itself, on a real ledger row written by a real review
job through `RecordReviewFindingsToLedger`:

```
$ sqlite3 "$H/.gitmoot/gitmoot.db" "
  select f.finding_uid, f.severity, f.state, j.dispatched_by as dispatching_seat, j.agent as reviewer
  from review_finding_observations f join jobs j on j.id = f.observer_job;"

finding_uid             severity  state  dispatching_seat  reviewer
----------------------  --------  -----  ----------------  --------------
gitmoot/probe1967#3-f1  P2        open   gm-findings       probe-reviewer
```

A finding resolved to its dispatching seat, distinct from the reviewer that
wrote it, with no reliance on the reviewer agent name. That is acceptance
criterion 2.

Three CLI arms, all real dispatches:

| dispatch | `dispatched_by` |
| --- | --- |
| `--org-role gm-findings` | `gm-findings` |
| `GITMOOT_ORG_ROLE=gm-findings`, no flag | `gm-findings` |
| no role at all | `local` (channel, never blank) |

### Upgrade from a pre-fix database

A copy of the live store (14,285 job rows, pre-fix schema, `dispatched_by`
absent) opened with the new binary: column added, all 14,285 rows preserved,
all blank, and the 271 open findings still unattributable. No wedge.

### Re-measured projection

Applying the new resolution rule to the identity already present in existing
payloads:

| | today | would name a seat | would be non-empty |
| --- | --- | --- | --- |
| open findings (271) | 3 | 230 | 271 |
| review jobs since 2026-09-01 (632) | 18 | 473 | 632 |

This is a projection over past payloads, not a post-fix measurement of past
rows: there is no backfill, so those rows keep an empty `dispatched_by`. It is
the rate to expect on new dispatches, and the remaining gap is dispatches that
pass no org role, which is a fleet-configuration matter and not this PR's.

### Mutation proof

Baseline green first, then one production line removed at a time. Each mutant
compiles and changes production behaviour.

| Mutant | Result |
| --- | --- |
| chokepoint resolution removed | all 5 workflow tests FAIL, daemon test FAILS |
| INSERT stops binding the column | all 5 FAIL |
| column written but dropped from `GetJob`/`jobColumns` | all 5 FAIL |
| daemon stops carrying `lock.Owner` | daemon test FAILS: `dispatched_by = "github"` |
| fan-out literal stops carrying `event.DispatchedBy` | `TestPROpenFanoutPrefersTheDispatcherOverTheSenderChannel` FAILS, daemon test FAILS |
| resolution falls back to `LeadAgent` | the `never the lead agent` row FAILS |

One mutant did NOT fail, and the test comment says so rather than claiming
coverage it does not have: removing `DispatchedBy: job.Agent` from the
in-process PR-open trigger leaves `TestInProcessPROpenRecordsTheDispatchingSeatOnFanoutChildren`
green, because production sets `Sender` to the same value on that trigger, so
the `Sender` fallback reaches the same answer. The explicit line is kept because
`Sender` means the channel on every other path, so attribution that reads it is
correct only by coincidence. `TestPROpenFanoutPrefersTheDispatcherOverTheSenderChannel`
is the test that separates the two, at the seam where the values differ.

### Two existing guards fired, and both were right

`go test ./...` on the first pass failed in `internal/db`:

1. `TestMigrationsUpgradeFromPreviousReleasedVersion`: `branchMigrationMarker`
   must name THIS branch's last migration. Repointed to `idx_jobs_dispatched_by`.
2. `TestReviewFindingRebuildUpgradesAPreFixDatabase`: the fixture un-applied
   `version = len(migrations)`, encoding "the #1850 rebuild is the last
   migration". True when written, false as soon as any branch appends one. It
   therefore un-applied MY migration and re-ran it, failing with
   `duplicate column name: dispatched_by`. Fixed by locating the rebuild through
   its own unique marker rather than by position, which is correct for every
   future appended migration too. Positive control: with the un-apply disabled
   the test still fails on the rebuild never running, so the repair did not
   neuter it.

### Gate

`go build -buildvcs=false ./...`, `go generate ./... && git diff --exit-code`,
`go vet ./...`, `go test -timeout 25m ./...` all pass.

`-race` was not run: it requires cgo, which is unavailable here, and it is
covered by CI's race shards.

## Not claimed

- No backfill. Every pre-existing row keeps an empty `dispatched_by`.
- The remaining unattributed CLI dispatches carry a channel, not a seat. Closing
  that means seats passing `--org-role` or `GITMOOT_ORG_ROLE`, which is fleet
  configuration and is not changed here.
- #1890's routing side is untouched. This PR makes the identity queryable; it
  does not change any recipient selection.
- No changes to `/root/.gitmoot/config.toml` or any fleet-wide configuration.

## Deploy notes

Schema migration, so the daemon applies it on next open. No config change. Both
binaries need replacing per the two-services rule if deployed:
`/root/.local/bin/gitmoot` and `/root/.local/bin/gitmoot-dashboard-web`.

## Adoption check on the retired seats' PRs

Per PHOBOS: #1942 (`fix/1938-job-record-rules-lifecycle`) is the event-sink
goroutine lifecycle around `CloseExternalJobWithUsage`. It has no scope overlap
with dispatcher attribution and no file overlap with this PR
(`internal/cli/event_rule_sink.go`, `event_sink.go`, `job_session.go` against
this PR's set), so it is not adopted here. #1941 is `findings_ledger_writer.go`
territory and belongs to #1968/#1970; it will be adopted there, not in this PR.
