### PR TITLE
fix(workflow): a fan-out announcement must not be published as a verdict (#1963)

### DIFF
--- a/internal/cli/daemon_scheduler_test.go
+++ b/internal/cli/daemon_scheduler_test.go
@@ -541,7 +541,12 @@ func TestRunQueuedJobsPostsAttributedResultComment(t *testing.T) {
 		"> Agent: `audit`",
 		"> Runtime: `shell`",
 		"> Job: `job-comment`",
-		"**Decision:** `approved`",
+		// The fixture declares a delegation alongside a terminal verdict, which
+		// makes it a coordinator ANNOUNCEMENT by workflow.ResultIsFanOut, so the
+		// headline scalar names the dispatch instead of asserting a verdict
+		// (#1963). The announced value stays in the record.
+		"**Decision:** `fan-out`",
+		"announced `approved`",
 		"**Summary:** done with token=[REDACTED]",
 		"**Findings**",
 		"**Changes Made**",

--- a/internal/workflow/job_comment.go
+++ b/internal/workflow/job_comment.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"regexp"
 	"sort"
+	"strconv"
 	"strings"
 )
 
@@ -62,7 +63,38 @@ func RenderJobResultComment(comment JobResultComment) string {
 	if summary == "" {
 		summary = "No summary provided."
 	}
-	writeScalar(&builder, "Decision", "`"+markdownInline(decision)+"`")
+	// A FAN-OUT ANNOUNCEMENT IS NOT A VERDICT, AND THE PUBLISHED RECORD MUST SAY
+	// SO (#1963). Every surface that ACTS on a decision already discounts this
+	// row through the one shared rule - the merge gate's candidate and objection
+	// scans, the pipeline auto-merge gate, the proof projector, and
+	// db.SucceededReviewVerdicts, which mirrors it because workflow cannot be
+	// imported there. This renderer did not, so the one surface a human reads
+	// asserted the opposite of what the engine believed: measured on 70
+	// PR-attached rows across 27 pull requests, 62 of them with an empty
+	// tests_run, and every single one of them rendered "approved" because a
+	// fan-out that carries a terminal verdict has never once carried
+	// "changes_requested".
+	//
+	// The announced value stays visible rather than being suppressed: the record
+	// has to remain auditable, and what was wrong was the field ASSERTING a
+	// verdict, not the value being disclosed.
+	if ResultIsFanOut(comment.Result) {
+		note := "`fan-out` (coordinator announcement, not a verdict: announced `" +
+			markdownInline(decision) + "`"
+		// COUNT THE DECLARED DELEGATIONS, not the agent names: a delegation may
+		// name a role rather than an agent, and the pipeline mailbox seam strips
+		// delegations[] entirely and records FanOut instead, so a name-derived
+		// count reads zero for rows that fanned out to three children. My first
+		// version used delegationAgentNames and the regression above caught it.
+		if declared := len(comment.Result.Delegations); declared > 0 {
+			note += ", evidence comes from the " + strconv.Itoa(declared) + " delegated child job(s) below"
+		} else {
+			note += ", evidence comes from its delegated child jobs"
+		}
+		writeScalar(&builder, "Decision", note+")")
+	} else {
+		writeScalar(&builder, "Decision", "`"+markdownInline(decision)+"`")
+	}
 	writeScalar(&builder, "Summary", limitCommentText(summary))
 	if comment.Result != nil && strings.TrimSpace(comment.Result.Severity) != "" {
 		writeScalar(&builder, "Severity", "`"+markdownInline(comment.Result.Severity)+"`")

--- a/internal/workflow/job_comment_fanout_test.go
+++ b/internal/workflow/job_comment_fanout_test.go
@@ -48,6 +48,84 @@ func TestRenderJobResultCommentNeverFoldsAFanOutDispatchRecord(t *testing.T) {
 	}
 }
 
+// TestRenderJobResultCommentHeadlineDecisionIsNotAVerdictForAFanOut is #1963,
+// and the fixture is a VERBATIM reproduction of a comment this renderer already
+// published: gitmoot/gitmoot#1731 issuecomment-5481374373, from job
+// local-review-g6-review-sol-18d0f0b0b9134f90, which reads
+//
+//	**Decision:** `approved`
+//	**Summary:** Convening three report-only reviewers against exact head ...
+//
+// The summary says it is CONVENING reviewers. The headline said it approved.
+//
+// The exclusion above only kept a fan-out out of the approved-with-notes FOLD;
+// the headline scalar still asserted the verdict, which is the field a human
+// reads first and the only one a skimmer reads at all. Measured across the live
+// store: 70 PR-attached rows on 27 pull requests, 62 with an empty tests_run,
+// and every one of them rendered "approved", because a fan-out carrying a
+// terminal verdict has never once carried changes_requested.
+func TestRenderJobResultCommentHeadlineDecisionIsNotAVerdictForAFanOut(t *testing.T) {
+	comment := JobResultComment{
+		AgentName: "g6-review-sol",
+		Runtime:   "codex",
+		JobID:     "local-review-g6-review-sol-18d0f0b0b9134f90",
+		JobType:   "review",
+		JobState:  string(JobSucceeded),
+		Payload:   JobPayload{TemplateID: "review-panel"},
+		Result: &AgentResult{
+			Decision: "approved",
+			Summary:  "Convening three report-only reviewers against exact head 2322fc865580de5d078676fe861219ded5db9352.",
+			Delegations: []Delegation{
+				{ID: "lens-correctness"}, {ID: "lens-security"}, {ID: "lens-regression"},
+			},
+		},
+	}
+	if !ResultIsFanOut(comment.Result) {
+		t.Fatal("fixture is not a fan-out result, so it cannot exercise the announcement path")
+	}
+
+	body := RenderJobResultComment(comment)
+
+	if strings.Contains(body, "**Decision:** `approved`") {
+		t.Fatalf("the published record still asserts a verdict for a coordinator announcement:\n%s", body)
+	}
+	if !strings.Contains(body, "**Decision:** `fan-out`") {
+		t.Fatalf("the headline scalar does not name the row as a dispatch:\n%s", body)
+	}
+	// The announced value must remain auditable. Suppressing it would trade one
+	// dishonest record for an incomplete one.
+	if !strings.Contains(body, "announced `approved`") {
+		t.Fatalf("the announced decision was dropped instead of being labelled:\n%s", body)
+	}
+	if !strings.Contains(body, "3 delegated child job(s)") {
+		t.Fatalf("the record does not say where the evidence actually is:\n%s", body)
+	}
+}
+
+// The negative control, on the exact shape that must NOT change: an ordinary
+// review verdict with no delegations keeps its headline decision. Without this,
+// relabelling every decision would satisfy the case above.
+func TestRenderJobResultCommentKeepsTheHeadlineDecisionForARealVerdict(t *testing.T) {
+	body := RenderJobResultComment(JobResultComment{
+		AgentName: "g7-review",
+		Runtime:   "codex",
+		JobID:     "local-review-g7-review-real",
+		JobType:   "review",
+		JobState:  string(JobSucceeded),
+		Result: &AgentResult{
+			Decision: "approved",
+			Summary:  "Exact-head review of the diff; every check executed.",
+			TestsRun: []string{"go test ./internal/workflow/"},
+		},
+	})
+	if !strings.Contains(body, "**Decision:** `approved`") {
+		t.Fatalf("a real verdict lost its headline decision:\n%s", body)
+	}
+	if strings.Contains(body, "fan-out") {
+		t.Fatalf("a real verdict was labelled a dispatch:\n%s", body)
+	}
+}
+
 // The other half, and the one a one-sided guard would break: an ORDINARY
 // below-bar review must still fold. TestRenderJobResultCommentExplainsApprovedWithNotes
 // already pins the positive case; this restates it beside the exclusion so the

--- a/internal/workflow/job_comment_test.go
+++ b/internal/workflow/job_comment_test.go
@@ -31,7 +31,13 @@ func TestRenderJobResultCommentIncludesAttributionAndResult(t *testing.T) {
 		"> Runtime: `codex`",
 		"> Template: `thermo-nuclear-code-quality-review`",
 		"> Job: `job-123`",
-		"**Decision:** `changes_requested`",
+		// This kitchen-sink fixture declares delegations alongside a terminal
+		// verdict, which is a coordinator ANNOUNCEMENT by the engine's shared rule
+		// (ResultIsFanOut), so the headline scalar names the dispatch rather than
+		// asserting a verdict (#1963). Only the stable prefix is pinned here; the
+		// announced value and the wording are pinned by the dedicated fan-out test.
+		"**Decision:** `fan-out`",
+		"announced `changes_requested`",
 		"**Summary:** fix the edge case",
 		"**Findings**",
 		"- **bad branch** (high)",


### PR DESCRIPTION
Addresses the reportable half of #1963.

## What I could reproduce, and what I could not

The issue asks for three things: fail the parent when no child produced a result, settle it blocked with the refusal propagated, and never settle it while a child is still running. Re-measuring the mechanism first, all three are the wrong shape for this engine, and one of them would break the delegation design:

A coordinator settles its own result the moment it delivers it. Its children have only just been ENQUEUED at that point, so at the parent's settle boundary there is no child evidence to consult, by construction, and the final answer is meant to come from the continuation job that runs after the children finish (`maybeEnqueueContinuation`). "Never settle the parent while a child is still running" is therefore not a bug fix, it is the removal of the continuation pattern.

The measured job is also not a merge-gate exposure. `local-ask-g6-review-sol-18d2fe1276dfc862` has type=ask, pull_request=0, 3 delegations, tests_run=0, findings=0, decision=approved. Every surface that ACTS on a decision already discounts exactly this row through one shared rule:

- `merge_gate.go:953,978,1116` via `reviewRowIsFanOut` / `ResultIsFanOut`
- `ensureDelegatedReviewEvidence`, which decides a fan-out on its children and returns `mergePending` while any child is queued or running
- `db.SucceededReviewVerdicts` (`internal/db/awaited_facts.go:230-293`), which duplicates the rule because `workflow` depends on `db` and never the reverse
- the pipeline auto-merge gate and the proof projector, per the `ResultIsFanOut` doc comment

So `approved` from a fan-out cannot satisfy a merge gate, cannot enter same-head verdict history, and cannot suppress a retry.

## What IS broken, measured and published

`RenderJobResultComment` never learned the rule, so the one surface a human reads asserts the opposite of what the engine believes. This is not a hypothetical: it has already been published.

[gitmoot/gitmoot#1731 issuecomment-5481374373](https://github.com/gitmoot/gitmoot/pull/1731#issuecomment-5481374373), from job `local-review-g6-review-sol-18d0f0b0b9134f90`:

```
> Agent: `g6-review-sol`
> Runtime: `codex`
> Template: `review-panel`
> Job: `local-review-g6-review-sol-18d0f0b0b9134f90`

**Decision:** `approved`
**Summary:** Convening three report-only reviewers against exact head 2322fc86...
```

The summary says it is CONVENING reviewers. The headline says it approved. That comment sits on the PR that `AGENTS.md` records as having merged on an armed engine merge gate.

Population, queried against the live store:

```sql
select type, count(*) n,
 sum(case when coalesce(json_array_length(json_extract(payload,'$.result.tests_run')),0)=0 then 1 else 0 end) empty_tests,
 count(distinct repo||'#'||pull_request) prs
from jobs
where pull_request>0
  and json_extract(payload,'$.result.decision') in ('approved','changes_requested')
  and (coalesce(json_array_length(json_extract(payload,'$.result.delegations')),0)>0
       or json_extract(payload,'$.result.fan_out')=1)
group by 1;
-- review | 70 | 62 | 27
```

**70 PR-attached announcements across 27 pull requests, 62 with an empty tests_run.** Widening to rows with no PR: 111 `ask` + 72 `review` = 183, of which 165 have an empty tests_run.

The asymmetry is the part that matters: across the whole fan-out population, `changes_requested` appears **zero** times. Every fan-out that carries a terminal verdict carries `approved`, so the misreading is always in the merge-permitting direction. That is not a coincidence of sampling, it is what an announcement means: a coordinator that successfully dispatched a panel reports success.

## Change

`RenderJobResultComment` routes the headline scalar through `ResultIsFanOut`, the same predicate every acting surface uses:

```
**Decision:** `fan-out` (coordinator announcement, not a verdict: announced `approved`, evidence comes from the 3 delegated child job(s) below)
```

The announced value stays in the record. Suppressing it would trade a dishonest record for an incomplete one, and the row has to remain auditable.

The prior #1557 guard on this file covered only the `approved-with-notes` FOLD (`job_comment_fanout_test.go`), not the headline scalar, which is the field a human reads first and the only one a skimmer reads at all.

## Test, failing before and passing after

`TestRenderJobResultCommentHeadlineDecisionIsNotAVerdictForAFanOut` reproduces issuecomment-5481374373 verbatim as its fixture.

```
base dee61c25: FAIL  the published record still asserts a verdict for a coordinator announcement
this branch:   PASS
```

`TestRenderJobResultCommentKeepsTheHeadlineDecisionForARealVerdict` is the negative control: an ordinary review with no delegations keeps `**Decision:** `approved``, so relabelling every decision cannot satisfy the case above.

The new test caught a defect in my own first version: I counted `delegationAgentNames` rather than declared delegations, which reads zero for a delegation that names a role instead of an agent and for the pipeline mailbox seam, where `delegations[]` is stripped and `FanOut` is recorded instead. That is in the code comment so the next reader does not repeat it.

Two pre-existing tests pinned `**Decision:** `approved` / `changes_requested`` on fixtures that happen to declare delegations (`TestRenderJobResultCommentIncludesAttributionAndResult`, `TestRunQueuedJobsPostsAttributedResultComment`). Both are field-rendering tests whose fan-out-ness was incidental; their expectations are updated to the announcement form with the reason stated inline, rather than the contract being bent back to keep them green.

## Deliberately not changed

Three other places read a decision for DISPLAY and are not touched, because they are local diagnostics rather than a published record, and because widening this slice would make it unreviewable:

- `internal/cli/job.go` `gitmoot job show` and the transcript export metadata
- `internal/report/report.go` bug-report body, plus its fingerprint, which must stay raw or historical fingerprints change

If the owner wants one rule on every display surface too, that is a separate slice and I will take it. Naming them here so the omission is a decision rather than an oversight.

## Verification

```
go build ./...                                              ok
go vet ./internal/workflow/ ./internal/cli/                 ok
go test -count=1 ./internal/workflow/                       ok  99.8s
go test -count=1 -run 'RunQueuedJobs|DaemonAdvanceBlocked|Comment' ./internal/cli/   ok  34.5s
```

Deploy notes: rendering-only, no config, no migration, no stored value changes. Existing published comments are unaffected; new ones become honest.
