### PR TITLE
fix(db): a repo-unqualified continues_uid is a spelling, not a refusal (#1965)

### DIFF
--- a/internal/cli/daemon_scheduler_test.go
+++ b/internal/cli/daemon_scheduler_test.go
@@ -541,7 +541,12 @@ func TestRunQueuedJobsPostsAttributedResultComment(t *testing.T) {
 		"> Agent: `audit`",
 		"> Runtime: `shell`",
 		"> Job: `job-comment`",
-		"**Decision:** `approved`",
+		// The fixture declares a delegation alongside a terminal verdict, which
+		// makes it a coordinator ANNOUNCEMENT by workflow.ResultIsFanOut, so the
+		// headline scalar names the dispatch instead of asserting a verdict
+		// (#1963). The announced value stays in the record.
+		"**Decision:** `fan-out`",
+		"announced `approved`",
 		"**Summary:** done with token=[REDACTED]",
 		"**Findings**",
 		"**Changes Made**",

--- a/internal/db/review_findings.go
+++ b/internal/db/review_findings.go
@@ -184,6 +184,17 @@ func pathLikeRelevanceKey(key string) bool {
 	return !strings.Contains(first, ".")
 }
 
+// quoteAll renders candidate uids for a refusal message so the caller can read
+// the exact spelling the store looked for, including the qualified form it
+// derived (#1965).
+func quoteAll(values []string) []string {
+	out := make([]string, 0, len(values))
+	for _, value := range values {
+		out = append(out, fmt.Sprintf("%q", value))
+	}
+	return out
+}
+
 // RecordReviewFindingObservation validates at the STORE BOUNDARY and inserts.
 // Every rejection here is a refusal, never a warning: a warning on a write path
 // is indistinguishable from success to the caller that ignores it.
@@ -307,14 +318,43 @@ func (s *Store) RecordReviewFindingObservation(ctx context.Context, obs ReviewFi
 
 	uid := strings.TrimSpace(obs.ContinuesUID)
 	if uid != "" {
-		var exists int
-		if err := tx.QueryRowContext(ctx,
-			`SELECT COUNT(*) FROM review_finding_observations WHERE finding_uid = ?`, uid).Scan(&exists); err != nil {
-			return "", err
+		// A REPO-UNQUALIFIED CITATION IS A SPELLING, NOT A DIFFERENT PERMISSION
+		// (#1965). A minted uid is "<repo>#<pr>-f<n>", and a brief that cited
+		// "#1950-f1" instead of "gitmoot/gitmoot#1950-f1" cost a 47m50s exact-head
+		// verdict its entire ledger effect: the store refused all six observations
+		// and the engine recorded "0 of 6" AFTER the reviewer had finished, so the
+		// only signal was six findings_ledger_skipped job events.
+		//
+		// Qualifying against THIS observation's own repo grants nothing new: the
+		// fully qualified form is already accepted from any observation, since the
+		// existence check is not scoped to repo or pull request. Requiring the
+		// short form's pull request to match would make the abbreviation STRICTER
+		// than the spelling it abbreviates, which is a different rule, not this fix.
+		//
+		// THE REFUSAL ITSELF IS UNCHANGED, deliberately. A uid naming nothing is
+		// still refused - a store that invented a uid would be worse than this bug
+		// - and the refusal now names every form it looked for, so the corrective
+		// spelling is in the error text instead of in someone's memory.
+		candidates := []string{uid}
+		if strings.HasPrefix(uid, "#") {
+			candidates = append(candidates, repo+uid)
 		}
-		if exists == 0 {
-			return "", fmt.Errorf("%w: %q", ErrFindingUnknownContinues, uid)
+		resolved := ""
+		for _, candidate := range candidates {
+			var exists int
+			if err := tx.QueryRowContext(ctx,
+				`SELECT COUNT(*) FROM review_finding_observations WHERE finding_uid = ?`, candidate).Scan(&exists); err != nil {
+				return "", err
+			}
+			if exists > 0 {
+				resolved = candidate
+				break
+			}
 		}
+		if resolved == "" {
+			return "", fmt.Errorf("%w: %q (looked for %s)", ErrFindingUnknownContinues, uid, strings.Join(quoteAll(candidates), ", "))
+		}
+		uid = resolved
 	} else {
 		// MINT. Never derived from the reviewer's label, so a renumbered F-1
 		// cannot collide with a prior finding. The candidate is then CHECKED for

--- a/internal/db/review_findings.go
+++ b/internal/db/review_findings.go
@@ -184,17 +184,6 @@ func pathLikeRelevanceKey(key string) bool {
 	return !strings.Contains(first, ".")
 }
 
-// quoteAll renders candidate uids for a refusal message so the caller can read
-// the exact spelling the store looked for, including the qualified form it
-// derived (#1965).
-func quoteAll(values []string) []string {
-	out := make([]string, 0, len(values))
-	for _, value := range values {
-		out = append(out, fmt.Sprintf("%q", value))
-	}
-	return out
-}
-
 // RecordReviewFindingObservation validates at the STORE BOUNDARY and inserts.
 // Every rejection here is a refusal, never a warning: a warning on a write path
 // is indistinguishable from success to the caller that ignores it.
@@ -413,6 +402,17 @@ VALUES (?, ?, ?, ?, COALESCE(NULLIF(?, ''), strftime('%Y-%m-%dT%H:%M:%fZ','now')
 		return "", err
 	}
 	return uid, nil
+}
+
+// quoteAll renders candidate uids for a refusal message so the caller can read
+// the exact spelling the store looked for, including the qualified form it
+// derived (#1965).
+func quoteAll(values []string) []string {
+	out := make([]string, 0, len(values))
+	for _, value := range values {
+		out = append(out, fmt.Sprintf("%q", value))
+	}
+	return out
 }
 
 // normaliseKeys seeds relevance from the finding's own file so the set is never

--- a/internal/db/review_findings_continues_test.go
+++ b/internal/db/review_findings_continues_test.go
@@ -1,0 +1,92 @@
+package db
+
+import (
+	"context"
+	"errors"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestRecordReviewFindingObservationResolvesARepoUnqualifiedContinuesUID is
+// #1965, reproduced through the production write path.
+//
+// MEASURED DEFECT: job local-review-g7-review-18d2fbd1b3e82f2c reviewed
+// gitmoot/gitmoot#1950 at head 10701afae36347c3126c3a9b29048332cb267054 for
+// 47m50s, returned changes_requested with 6 findings and 13 tests_run, and
+// contributed NOTHING to the ledger. Its brief spelled the citations "#1950-f1"
+// rather than "gitmoot/gitmoot#1950-f1", so the store refused all six and the
+// engine recorded "recorded 0 of 6 ... (6 skipped)". The adjacent round, whose
+// brief used the qualified form, recorded 6 of 6. Same reviewer, same agent,
+// same repo, adjacent heads: the only variable was the spelling.
+//
+// The failure is also discovered AFTER the reviewer finishes, and the only
+// signal is six findings_ledger_skipped job events, so a coordinator reading the
+// verdict publishes an inherited-observation count against an empty record.
+func TestRecordReviewFindingObservationResolvesARepoUnqualifiedContinuesUID(t *testing.T) {
+	ctx := context.Background()
+	store, err := openCachedTestStore(t, filepath.Join(t.TempDir(), "gitmoot.db"))
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	head := strings.Repeat("a", 40)
+	observation := func(repo string, pr int64, observer string, continues string) ReviewFindingObservation {
+		return ReviewFindingObservation{
+			Repo: repo, PullRequest: pr, HeadSHA: head, ObserverJob: observer,
+			State: FindingOpen, Severity: "P1", Title: "t", Detail: "d",
+			File: "internal/workflow/merge_gate.go", EvidenceKind: EvidenceExecuted,
+			ExecutedCommands: []string{"go test ./internal/workflow/"}, ExecutedCount: 1,
+			ContinuesUID: continues,
+		}
+	}
+
+	minted, err := store.RecordReviewFindingObservation(ctx, observation("gitmoot/gitmoot", 1950, "round-9", ""))
+	if err != nil {
+		t.Fatalf("mint: %v", err)
+	}
+	if minted != "gitmoot/gitmoot#1950-f1" {
+		t.Fatalf("minted uid = %q; the abbreviation this test is about is defined relative to that shape", minted)
+	}
+
+	// THE REGRESSION: the round-10 spelling.
+	got, err := store.RecordReviewFindingObservation(ctx, observation("gitmoot/gitmoot", 1950, "round-10", "#1950-f1"))
+	if err != nil {
+		t.Fatalf("continuing %q: %v", "#1950-f1", err)
+	}
+	if got != minted {
+		t.Fatalf("short form resolved to %q, want the canonical %q; a continuation that mints a second uid leaves the first permanently unobserved", got, minted)
+	}
+
+	// The fully qualified form is unchanged.
+	qualified, err := store.RecordReviewFindingObservation(ctx, observation("gitmoot/gitmoot", 1950, "round-11", minted))
+	if err != nil {
+		t.Fatalf("continuing the qualified uid: %v", err)
+	}
+	if qualified != minted {
+		t.Fatalf("qualified continuation resolved to %q, want %q", qualified, minted)
+	}
+
+	// THE REFUSAL IS UNCHANGED, which is the property the issue explicitly asks
+	// not to weaken: an abbreviation naming nothing is still refused, and the
+	// message now names every spelling the store looked for so the corrective
+	// form is in the error rather than in someone's memory.
+	unknown, err := store.RecordReviewFindingObservation(ctx, observation("gitmoot/gitmoot", 1950, "round-12", "#1950-f9"))
+	if !errors.Is(err, ErrFindingUnknownContinues) {
+		t.Fatalf("an abbreviation naming nothing was accepted: uid=%q err=%v", unknown, err)
+	}
+	if !strings.Contains(err.Error(), `"gitmoot/gitmoot#1950-f9"`) {
+		t.Fatalf("refusal does not name the qualified form it derived, so the caller cannot correct it: %v", err)
+	}
+
+	// THE SCOPE CONTROL, and the one a careless normalisation breaks: the
+	// abbreviation is qualified against THIS observation's own repo, never
+	// searched across repos. A row in another repo citing "#1950-f1" must not
+	// silently continue gitmoot/gitmoot's finding.
+	crossRepo, err := store.RecordReviewFindingObservation(ctx, observation("other/repo", 1950, "round-13", "#1950-f1"))
+	if !errors.Is(err, ErrFindingUnknownContinues) {
+		t.Fatalf("an abbreviation resolved across repositories: uid=%q err=%v", crossRepo, err)
+	}
+	if !strings.Contains(err.Error(), `"other/repo#1950-f1"`) {
+		t.Fatalf("cross-repo refusal does not show which repo it qualified against: %v", err)
+	}
+}

--- a/internal/workflow/job_comment.go
+++ b/internal/workflow/job_comment.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"regexp"
 	"sort"
+	"strconv"
 	"strings"
 )
 
@@ -62,7 +63,38 @@ func RenderJobResultComment(comment JobResultComment) string {
 	if summary == "" {
 		summary = "No summary provided."
 	}
-	writeScalar(&builder, "Decision", "`"+markdownInline(decision)+"`")
+	// A FAN-OUT ANNOUNCEMENT IS NOT A VERDICT, AND THE PUBLISHED RECORD MUST SAY
+	// SO (#1963). Every surface that ACTS on a decision already discounts this
+	// row through the one shared rule - the merge gate's candidate and objection
+	// scans, the pipeline auto-merge gate, the proof projector, and
+	// db.SucceededReviewVerdicts, which mirrors it because workflow cannot be
+	// imported there. This renderer did not, so the one surface a human reads
+	// asserted the opposite of what the engine believed: measured on 70
+	// PR-attached rows across 27 pull requests, 62 of them with an empty
+	// tests_run, and every single one of them rendered "approved" because a
+	// fan-out that carries a terminal verdict has never once carried
+	// "changes_requested".
+	//
+	// The announced value stays visible rather than being suppressed: the record
+	// has to remain auditable, and what was wrong was the field ASSERTING a
+	// verdict, not the value being disclosed.
+	if ResultIsFanOut(comment.Result) {
+		note := "`fan-out` (coordinator announcement, not a verdict: announced `" +
+			markdownInline(decision) + "`"
+		// COUNT THE DECLARED DELEGATIONS, not the agent names: a delegation may
+		// name a role rather than an agent, and the pipeline mailbox seam strips
+		// delegations[] entirely and records FanOut instead, so a name-derived
+		// count reads zero for rows that fanned out to three children. My first
+		// version used delegationAgentNames and the regression above caught it.
+		if declared := len(comment.Result.Delegations); declared > 0 {
+			note += ", evidence comes from the " + strconv.Itoa(declared) + " delegated child job(s) below"
+		} else {
+			note += ", evidence comes from its delegated child jobs"
+		}
+		writeScalar(&builder, "Decision", note+")")
+	} else {
+		writeScalar(&builder, "Decision", "`"+markdownInline(decision)+"`")
+	}
 	writeScalar(&builder, "Summary", limitCommentText(summary))
 	if comment.Result != nil && strings.TrimSpace(comment.Result.Severity) != "" {
 		writeScalar(&builder, "Severity", "`"+markdownInline(comment.Result.Severity)+"`")

--- a/internal/workflow/job_comment_fanout_test.go
+++ b/internal/workflow/job_comment_fanout_test.go
@@ -48,6 +48,84 @@ func TestRenderJobResultCommentNeverFoldsAFanOutDispatchRecord(t *testing.T) {
 	}
 }
 
+// TestRenderJobResultCommentHeadlineDecisionIsNotAVerdictForAFanOut is #1963,
+// and the fixture is a VERBATIM reproduction of a comment this renderer already
+// published: gitmoot/gitmoot#1731 issuecomment-5481374373, from job
+// local-review-g6-review-sol-18d0f0b0b9134f90, which reads
+//
+//	**Decision:** `approved`
+//	**Summary:** Convening three report-only reviewers against exact head ...
+//
+// The summary says it is CONVENING reviewers. The headline said it approved.
+//
+// The exclusion above only kept a fan-out out of the approved-with-notes FOLD;
+// the headline scalar still asserted the verdict, which is the field a human
+// reads first and the only one a skimmer reads at all. Measured across the live
+// store: 70 PR-attached rows on 27 pull requests, 62 with an empty tests_run,
+// and every one of them rendered "approved", because a fan-out carrying a
+// terminal verdict has never once carried changes_requested.
+func TestRenderJobResultCommentHeadlineDecisionIsNotAVerdictForAFanOut(t *testing.T) {
+	comment := JobResultComment{
+		AgentName: "g6-review-sol",
+		Runtime:   "codex",
+		JobID:     "local-review-g6-review-sol-18d0f0b0b9134f90",
+		JobType:   "review",
+		JobState:  string(JobSucceeded),
+		Payload:   JobPayload{TemplateID: "review-panel"},
+		Result: &AgentResult{
+			Decision: "approved",
+			Summary:  "Convening three report-only reviewers against exact head 2322fc865580de5d078676fe861219ded5db9352.",
+			Delegations: []Delegation{
+				{ID: "lens-correctness"}, {ID: "lens-security"}, {ID: "lens-regression"},
+			},
+		},
+	}
+	if !ResultIsFanOut(comment.Result) {
+		t.Fatal("fixture is not a fan-out result, so it cannot exercise the announcement path")
+	}
+
+	body := RenderJobResultComment(comment)
+
+	if strings.Contains(body, "**Decision:** `approved`") {
+		t.Fatalf("the published record still asserts a verdict for a coordinator announcement:\n%s", body)
+	}
+	if !strings.Contains(body, "**Decision:** `fan-out`") {
+		t.Fatalf("the headline scalar does not name the row as a dispatch:\n%s", body)
+	}
+	// The announced value must remain auditable. Suppressing it would trade one
+	// dishonest record for an incomplete one.
+	if !strings.Contains(body, "announced `approved`") {
+		t.Fatalf("the announced decision was dropped instead of being labelled:\n%s", body)
+	}
+	if !strings.Contains(body, "3 delegated child job(s)") {
+		t.Fatalf("the record does not say where the evidence actually is:\n%s", body)
+	}
+}
+
+// The negative control, on the exact shape that must NOT change: an ordinary
+// review verdict with no delegations keeps its headline decision. Without this,
+// relabelling every decision would satisfy the case above.
+func TestRenderJobResultCommentKeepsTheHeadlineDecisionForARealVerdict(t *testing.T) {
+	body := RenderJobResultComment(JobResultComment{
+		AgentName: "g7-review",
+		Runtime:   "codex",
+		JobID:     "local-review-g7-review-real",
+		JobType:   "review",
+		JobState:  string(JobSucceeded),
+		Result: &AgentResult{
+			Decision: "approved",
+			Summary:  "Exact-head review of the diff; every check executed.",
+			TestsRun: []string{"go test ./internal/workflow/"},
+		},
+	})
+	if !strings.Contains(body, "**Decision:** `approved`") {
+		t.Fatalf("a real verdict lost its headline decision:\n%s", body)
+	}
+	if strings.Contains(body, "fan-out") {
+		t.Fatalf("a real verdict was labelled a dispatch:\n%s", body)
+	}
+}
+
 // The other half, and the one a one-sided guard would break: an ORDINARY
 // below-bar review must still fold. TestRenderJobResultCommentExplainsApprovedWithNotes
 // already pins the positive case; this restates it beside the exclusion so the

--- a/internal/workflow/job_comment_test.go
+++ b/internal/workflow/job_comment_test.go
@@ -31,7 +31,13 @@ func TestRenderJobResultCommentIncludesAttributionAndResult(t *testing.T) {
 		"> Runtime: `codex`",
 		"> Template: `thermo-nuclear-code-quality-review`",
 		"> Job: `job-123`",
-		"**Decision:** `changes_requested`",
+		// This kitchen-sink fixture declares delegations alongside a terminal
+		// verdict, which is a coordinator ANNOUNCEMENT by the engine's shared rule
+		// (ResultIsFanOut), so the headline scalar names the dispatch rather than
+		// asserting a verdict (#1963). Only the stable prefix is pinned here; the
+		// announced value and the wording are pinned by the dedicated fan-out test.
+		"**Decision:** `fan-out`",
+		"announced `changes_requested`",
 		"**Summary:** fix the edge case",
 		"**Findings**",
 		"- **bad branch** (high)",


### PR DESCRIPTION
Fixes #1965 with the issue's option 2, at the store boundary.

## Re-derived measurement

Reproduced through the production write path, in a temp store, before touching anything:

```
minted uid = "gitmoot/gitmoot#1950-f1"
continuing "#1950-f1": continues_uid does not name an existing finding: "#1950-f1"
```

That is the same refusal string as the six `findings_ledger_skipped` job events on job `local-review-g7-review-18d2fbd1b3e82f2c`, which ran 47m50s on #1950 at head `10701afae36347c3126c3a9b29048332cb267054`, returned `changes_requested` with 6 findings and 13 tests_run, and left `review_finding_observations` with **zero rows at that head**.

Confirmed independently against the live store, which is why the ledger's last word on #1950 is three heads old:

```sql
select substr(head_sha,1,8), count(*) from review_finding_observations
where repo='gitmoot/gitmoot' and pull_request=1950 group by 1;
-- newest observation of all six uids sits at b2266701; heads 10701afa,
-- e4575ed4 and c1ca9824 carry none
```

## Why the store and not the dispatch

The issue offers either or both remedies. Option 1, validating at dispatch, is not available here, and the reason is measurable rather than aesthetic: the ENGINE's own brief is already correct. `ledgerObligationBrief` prints `uid=%s` from `obligation.FindingUID`, the canonical minted value (`internal/workflow/findings_ledger_writer.go:337-339`). The abbreviation came from a hand-written coordinator brief in `payload.instructions`, which is prose. A dispatch-time validator would have to scan prose for uid-shaped substrings and could not tell an intended continuation from a mention of a withdrawn finding, so it would either refuse legitimate briefs or miss the case it exists for.

Option 2 alone would have recorded all six observations here, exactly as the issue states.

## Change

`RecordReviewFindingObservation` resolves a `continues_uid` that begins with `#` against the observation's own repo before refusing.

This grants nothing new. The fully qualified form is already accepted from any observation, because the existence check is scoped to neither repo nor pull request. Requiring the abbreviation's pull request to match `obs.PullRequest` would make the abbreviation **stricter** than the spelling it abbreviates, which is a different rule and not this fix.

The refusal itself is untouched, which the issue explicitly asks for: a uid naming nothing is still refused, since a store that invented a uid would be worse than the bug. What changes is that the message now names every spelling the store looked for, so the corrective form is in the error text instead of in someone's memory:

```
continues_uid does not name an existing finding: "#1950-f9" (looked for "#1950-f9", "gitmoot/gitmoot#1950-f9")
```

## Test, failing before and passing after

`TestRecordReviewFindingObservationResolvesARepoUnqualifiedContinuesUID`:

```
base dee61c25: FAIL  continuing "#1950-f1": continues_uid does not name an existing finding: "#1950-f1"
this branch:   PASS
```

Four controls in the same test, each defending a distinct property:

1. the minted shape is asserted, so the abbreviation this test is about stays defined relative to it;
2. the fully qualified form still resolves, so the unchanged path is pinned;
3. an abbreviation naming nothing is still refused with `ErrFindingUnknownContinues`, and the message must contain the derived qualified form;
4. **the scope control**: an observation in `other/repo` citing `#1950-f1` must NOT continue `gitmoot/gitmoot#1950-f1`. It qualifies against its own repo, fails, and the refusal shows which repo it qualified against. A normalisation that searched across repos would pass 1 through 3 and fail this one.

## Verification

```
go build ./...                              ok
go vet ./internal/db/                       ok
go test -count=1 ./internal/db/             ok  254.7s
go test -count=1 ./internal/workflow/       ok  126.8s
```

## Effect on the campaign

This is what makes #1950's ledger able to record a verdict again, so it is a prerequisite for certifying that PR rather than a cosmetic fix. It does not retroactively record the six lost observations, and it must not: inventing historical observations at a head no reviewer observed would be the same class of defect this campaign exists to remove. Per jarvis note 127205, F1 through F5 on #1950 must not be published as ledger-answered at `10701afa`.

Deploy notes: no config, no migration, no stored value changes. Existing rows are untouched.
