### PR TITLE
fix(workflow): one fix leg per branch at a time (#1533)

### DIFF
--- a/internal/workflow/engine_fix_leg_exclusion_1533_test.go
+++ b/internal/workflow/engine_fix_leg_exclusion_1533_test.go
@@ -1,0 +1,162 @@
+package workflow
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/gitmoot/gitmoot/internal/db"
+)
+
+// #1533: concurrent fix legs race on git push and the loser's completed work is
+// destroyed.
+//
+// MECHANISM, all three parts measured rather than argued:
+//
+//  1. a blocking verdict dispatches a fix leg REGARDLESS of whether a leg is
+//     already in flight on that branch, so a two-family panel that both object
+//     produces two legs seconds apart;
+//  2. the branch lock cannot stop it, because Store.AcquireLock returns true
+//     when the existing owner equals the requester, so one lock admits N
+//     concurrent same-owner legs. Every leg in the measured races ran under the
+//     same lock;
+//  3. the loser's push rejection is TERMINAL: a push failure maps to
+//     blockedResultDelivery with no rebase, no retry and no salvage.
+//
+// LIVE POPULATION, re-derived from the job store: 34 implement jobs carry
+// "failed to push some refs", from 2026-08-27 to 2026-09-07. Of the 20 whose own
+// window is under 6h, 14 overlapped another short-window implement leg on the
+// SAME branch. The 14 long-window rows are left unattributed on purpose, since a
+// 226h window makes an overlap test meaningless.
+//
+// The refusal that would have stopped this already existed, but only on the
+// OPERATOR path: findActiveImplementJobForTask in internal/cli, reached from
+// agent_dispatch. The engine's automatic fix-leg path consulted nothing.
+func TestChangesRequestedDoesNotDispatchASecondFixLegOnABranchAlreadyBeingWritten(t *testing.T) {
+	ctx := context.Background()
+	store, engine := reviewRefanoutFixture(t)
+	enableAutoFix(t, store, 1678)
+
+	// The first family's leg, already working. This is the shape the race needs:
+	// dispatched against the head the reviewers saw, minutes from its push.
+	insertActiveJob(t, store, db.Job{ID: "fix-leg-family-a", Agent: "lead", Type: "implement"}, JobPayload{
+		Repo:        "gitmoot/gitmoot",
+		Branch:      "task-1678",
+		PullRequest: 1678,
+		TaskID:      "task-1678",
+		LeadAgent:   "lead",
+	}, JobRunning)
+
+	// The second family's verdict arrives while that leg is still running.
+	insertPriorReviewResult(t, store, "sibling-review", "head-one", AgentResult{
+		Decision: "changes_requested",
+		Summary:  "The same property from a different angle.",
+		Findings: []json.RawMessage{
+			json.RawMessage(`{"id":"F-1","file":"internal/boundary.go","summary":"Also unguarded on the failure path."}`),
+		},
+	})
+	if err := engine.AdvanceJob(ctx, "sibling-review"); err != nil {
+		t.Fatalf("AdvanceJob sibling review: %v", err)
+	}
+
+	if _, err := store.GetJob(ctx, "implement-lead-task-1678-review-1"); err == nil {
+		t.Fatal("a second fix leg was dispatched onto a branch already being written; whichever leg finishes second loses the push and its completed work is discarded")
+	}
+
+	// THE SKIP MUST BE ON THE RECORD. A silent skip is the same defect class this
+	// campaign exists to remove: the reason a leg was not dispatched has to be
+	// findable, or an operator reads "no fix leg" as "nothing to fix".
+	events, err := store.ListJobEvents(ctx, "sibling-review")
+	if err != nil {
+		t.Fatalf("ListJobEvents: %v", err)
+	}
+	var skip db.JobEvent
+	for _, event := range events {
+		if event.Kind == "auto_fix_skipped_active_leg" {
+			skip = event
+		}
+	}
+	if skip.Kind == "" {
+		t.Fatalf("no auto_fix_skipped_active_leg event recorded; the skip is invisible. events = %+v", events)
+	}
+	if !strings.Contains(skip.Message, "fix-leg-family-a") {
+		t.Fatalf("the skip record does not name the leg that owns the branch: %q", skip.Message)
+	}
+
+	// The objection still transitioned the task, so the PR is not left looking
+	// approved. Only the duplicate WRITER is refused.
+	assertTaskState(t, store, "task-1678", TaskChangesRequested)
+}
+
+// The control, and the one a blunt guard breaks: with no leg in flight, the
+// verdict must still dispatch its fix. A guard that simply stopped dispatching
+// would pass the case above and silently disable auto-fix.
+func TestChangesRequestedStillDispatchesAFixLegWhenTheBranchIsIdle(t *testing.T) {
+	ctx := context.Background()
+	store, engine := reviewRefanoutFixture(t)
+	enableAutoFix(t, store, 1678)
+
+	// A SETTLED leg on the same branch must not be mistaken for a live writer:
+	// every fix round after the first has one of these behind it, so counting it
+	// would refuse every round but the first.
+	insertCompletedJob(t, store, db.Job{ID: "earlier-leg", Agent: "lead", Type: "implement"}, JobPayload{
+		Repo:        "gitmoot/gitmoot",
+		Branch:      "task-1678",
+		PullRequest: 1678,
+		TaskID:      "task-1678",
+		LeadAgent:   "lead",
+	})
+	// An ACTIVE job on a DIFFERENT branch is not a writer of this one.
+	insertActiveJob(t, store, db.Job{ID: "other-branch-leg", Agent: "lead", Type: "implement"}, JobPayload{
+		Repo:        "gitmoot/gitmoot",
+		Branch:      "some-other-branch",
+		PullRequest: 1679,
+		TaskID:      "task-1679",
+		LeadAgent:   "lead",
+	}, JobRunning)
+	// An ACTIVE REVIEW job on this branch is not a writer either: it pushes
+	// nothing, and holding the fix for it would stall every round.
+	insertActiveJob(t, store, db.Job{ID: "reviewer-in-flight", Agent: "audit", Type: "review"}, JobPayload{
+		Repo:        "gitmoot/gitmoot",
+		Branch:      "task-1678",
+		PullRequest: 1678,
+		TaskID:      "task-1678",
+		LeadAgent:   "lead",
+	}, JobRunning)
+
+	insertPriorReviewResult(t, store, "lone-review", "head-one", AgentResult{
+		Decision: "changes_requested",
+		Summary:  "Fix the boundary check.",
+		Findings: []json.RawMessage{
+			json.RawMessage(`{"id":"F-1","file":"internal/boundary.go","summary":"Fix the boundary check."}`),
+		},
+	})
+	if err := engine.AdvanceJob(ctx, "lone-review"); err != nil {
+		t.Fatalf("AdvanceJob lone review: %v", err)
+	}
+	fix, err := store.GetJob(ctx, "implement-lead-task-1678-review-1")
+	if err != nil {
+		t.Fatalf("an idle branch did not receive its fix leg, so the guard disabled auto-fix instead of bounding it: %v", err)
+	}
+	payload, err := unmarshalPayload(fix.Payload)
+	if err != nil {
+		t.Fatalf("unmarshal fix payload: %v", err)
+	}
+	if !strings.Contains(payload.Instructions, `"id":"F-1"`) {
+		t.Fatalf("the dispatched fix lost the finding it exists for: %q", payload.Instructions)
+	}
+}
+
+func insertActiveJob(t *testing.T, store *db.Store, job db.Job, payload JobPayload, state JobState) {
+	t.Helper()
+	encoded, err := marshalPayload(payload)
+	if err != nil {
+		t.Fatalf("marshalPayload: %v", err)
+	}
+	job.State = string(state)
+	job.Payload = encoded
+	if err := store.CreateJobWithEvent(context.Background(), job, db.JobEvent{Kind: string(state), Message: "in flight"}); err != nil {
+		t.Fatalf("CreateJobWithEvent: %v", err)
+	}
+}

--- a/internal/workflow/engine_routing_merge.go
+++ b/internal/workflow/engine_routing_merge.go
@@ -62,7 +62,44 @@ func validatePullRequestEvent(event PullRequestEvent) error {
 	return nil
 }
 
-func (e Engine) dispatchFix(ctx context.Context, reviewer string, payload JobPayload, result AgentResult, ref taskRef) error {
+func (e Engine) dispatchFix(ctx context.Context, verdictJob db.Job, reviewer string, payload JobPayload, result AgentResult, ref taskRef) error {
+	// ONE FIX LEG PER BRANCH AT A TIME (#1533). A two-family panel that both
+	// object dispatches one leg PER VERDICT with no mutual exclusion. Each leg
+	// starts from the head it was dispatched against, works for minutes, and
+	// pushes; whichever finishes second is GUARANTEED a non-fast-forward
+	// rejection, and that rejection is terminal - daemon_workflow.go maps a push
+	// failure to blockedResultDelivery with no rebase, no retry and no salvage,
+	// so a completed leg's work is discarded.
+	//
+	// Measured on the live store: 34 implement jobs carry "failed to push some
+	// refs", 2026-08-27 through 2026-09-07. Of the 20 whose own window is under
+	// 6h, 14 overlapped another short-window implement leg on the SAME branch.
+	//
+	// THE BRANCH LOCK CANNOT SERVE THIS PURPOSE and it is worth saying why, since
+	// the obvious question is why a lock is not enough: Store.AcquireLock returns
+	// true when the existing owner EQUALS the requester, so one lock admits N
+	// concurrent same-owner legs by design. Every leg in the measured races ran
+	// under the same lock.
+	//
+	// SKIP, NOT BLOCK, and not a queue. Blocking the task would need an operator
+	// resume-work for a condition that resolves itself in minutes. Skipping is
+	// safe because the sibling verdict's substance does not live in this dispatch:
+	// its findings are in the #1822 ledger, still open, and the merge gate refuses
+	// a verdict at a head that has not observed them, so the next round re-raises
+	// them against the head the in-flight leg is about to push. A dropped dispatch
+	// costs one round; a lost race costs a completed leg's work and leaves the
+	// finding open anyway.
+	if active, found, err := e.activeImplementLegOnBranch(ctx, payload); err != nil {
+		return err
+	} else if found {
+		return e.Store.AddJobEvent(ctx, db.JobEvent{
+			JobID: verdictJob.ID,
+			Kind:  "auto_fix_skipped_active_leg",
+			Message: fmt.Sprintf(
+				"auto-fix leg not dispatched for %s pull request #%d: implement job %s is already %s on branch %q; a second writer would lose the push race and its work would be discarded. The findings stay open in the ledger and are re-raised against the head that leg pushes",
+				payload.Repo, payload.PullRequest, active.ID, active.State, strings.TrimSpace(payload.Branch)),
+		})
+	}
 	policy, configured, err := e.Store.PullRequestAutoFixPolicyFor(ctx, payload.Repo, payload.PullRequest)
 	if err != nil {
 		return err
@@ -135,6 +172,61 @@ func (e Engine) dispatchFix(ctx context.Context, reviewer string, payload JobPay
 		return err
 	}
 	return nil
+}
+
+// activeImplementLegOnBranch reports a queued or running implement job that
+// already owns this fix leg's write target.
+//
+// THE KEY IS THE BRANCH, because the branch is the resource the legs collide on:
+// they race on `git push`, not on the task row. When the payload carries no
+// branch there is nothing to push to and no branch to key on, so it falls back
+// to the task, which is the same pairing the operator-side refusal uses
+// (findActiveImplementJobForTask takes both).
+//
+// The engine could not simply call that refusal: it lives in internal/cli, and
+// workflow must never import cli. The query is duplicated rather than the
+// dependency inverted, for the same reason db.SucceededReviewVerdicts duplicates
+// ResultIsFanOut, and it is a narrower query than the CLI's - implement jobs
+// only, since a review or ask job on the branch does not push a fix leg's work.
+func (e Engine) activeImplementLegOnBranch(ctx context.Context, payload JobPayload) (db.Job, bool, error) {
+	if e.Store == nil {
+		return db.Job{}, false, nil
+	}
+	repo := strings.TrimSpace(payload.Repo)
+	branch := strings.TrimSpace(payload.Branch)
+	taskID := strings.TrimSpace(payload.TaskID)
+	if repo == "" || (branch == "" && taskID == "") {
+		return db.Job{}, false, nil
+	}
+	active, err := e.Store.ListActiveJobs(ctx)
+	if err != nil {
+		return db.Job{}, false, fmt.Errorf("inspect active implement legs on %s branch %q: %w", repo, branch, err)
+	}
+	for _, job := range active {
+		if job.Type != "implement" {
+			continue
+		}
+		candidate, err := unmarshalPayload(job.Payload)
+		if err != nil {
+			// A payload this engine cannot read cannot be proven to target another
+			// branch, and admitting an unreadable row is how a second writer gets
+			// in. Treat it as an owner of the branch it claims to be on.
+			return job, true, nil
+		}
+		if !strings.EqualFold(strings.TrimSpace(candidate.Repo), repo) {
+			continue
+		}
+		if branch != "" {
+			if strings.TrimSpace(candidate.Branch) == branch {
+				return job, true, nil
+			}
+			continue
+		}
+		if strings.TrimSpace(candidate.TaskID) == taskID {
+			return job, true, nil
+		}
+	}
+	return db.Job{}, false, nil
 }
 
 // autoFixOwner names the agent that will RUN the auto-fix, so it must return

--- a/internal/workflow/engine_run_budgets.go
+++ b/internal/workflow/engine_run_budgets.go
@@ -854,7 +854,7 @@ func (e Engine) AdvanceJob(ctx context.Context, jobID string) (retErr error) {
 			// context and worktree. A durable per-PR enable is the explicit
 			// unattended-chain opt-in for dispatching a fresh implement job (#1712).
 			if configured && !policy.Disabled {
-				if err := e.dispatchFix(ctx, reviewer, payload, *payload.Result, ref); err != nil {
+				if err := e.dispatchFix(ctx, job, reviewer, payload, *payload.Result, ref); err != nil {
 					return err
 				}
 			}


### PR DESCRIPTION
Bounds #1533. Implements suggestion 1 from its 2026-08-18 comment: per-branch mutual exclusion on the engine's automatic fix-leg dispatch.

## Mechanism, confirmed at `a5903154`

The 2026-09-03 read-only verdict on the issue is correct on all three parts:

1. **Nothing bounded how many legs may run on one branch.** `Store.AcquireLock` returns `true` when the existing lock owner equals the requester, so one branch lock admits N concurrent same-owner legs by design. Every leg in the measured races ran under the same lock.
2. **The refusal existed only on the operator path.** `findActiveImplementJobForTask` (`internal/cli/workflow.go:1196`) is called from exactly one place, `internal/cli/agent_dispatch.go:1134`, the operator CLI dispatch. `findActiveJobForBranch` is called from exactly one place, `internal/cli/daemon_workflow.go:724`, the merge-gate hold. The engine's `dispatchFix` consulted neither.
3. **A rejected push is terminal**: it maps to `blockedResultDelivery` with no rebase, no retry and no salvage, which is why the symptom is "destroy completed work" rather than "one leg waits".

## Re-measured population, larger and more current than the issue records

The issue records "measured twice", and a later comment three instances. Live job store, today:

```sql
select state, type, count(*) n, min(updated_at) first, max(updated_at) last
from jobs where payload like '%failed to push some refs%' group by 1,2;
-- cancelled | implement | 34 | 2026-08-27 20:56:10 | 2026-09-07 07:22:55
-- succeeded | review    |  2 | 2026-08-17 00:39:54 | 2026-08-17 00:49:12
```

**34 implement legs carrying a push rejection, most recent today at 07:22:55Z.** Live, not historical.

Attributing them to the race rather than to the operator-push cause the issue also documents. For each rejected leg I counted other implement legs on the same branch whose window overlaps it. 14 of the 34 have windows from 8.67h to 225.98h, where an overlap test is meaningless, so they are excluded rather than counted in my favour. Of the 20 with a window under 6h (0.25h to 5.02h):

```
short-window legs          20
with a concurrent sibling  14
without                     6
```

**14 of 20 are engine-on-engine on the same branch.** The 6 without a sibling are consistent with an operator push. The 14 long-window rows are unattributable from this data and I do not claim them.

Rejected legs by branch: `feat/review-blocking-severity` 8, `docs/773-test-account-policy` 5 (joltra), `pipelines-own-checkout` 3 (keephair), `fix/1528-review-loop-family-count` 2 (this issue's original instance 1), then eight branches with one each across three repositories.

## Change

`dispatchFix` now refuses to become a second writer: before resolving policy, owner, lock or worktree, it checks for a queued or running **implement** job already targeting this `(repo, branch)`.

- **Keyed on the branch**, because the branch is what the legs collide on. They race on `git push`, not on the task row. When the payload carries no branch there is nothing to push to, so it falls back to the task, which is the same pairing the operator refusal uses.
- **Duplicated, not inverted.** `workflow` must never import `cli`, so the query lives in `workflow`, exactly as `db.SucceededReviewVerdicts` duplicates `ResultIsFanOut` for the same reason. It is narrower than the CLI's: implement jobs only, since a review or ask job on the branch does not push a fix leg's work.
- **An unreadable payload counts as an owner.** A payload the engine cannot parse cannot be proven to target another branch, and admitting an unreadable row is how a second writer gets in.
- **The guard is inside `dispatchFix`, not at its call site**, so a future second caller cannot miss it. That is the failure mode this campaign keeps finding: a rule applied at one of N surfaces.

## Skip, not block, and not a queue

Blocking the task would need an operator `resume-work` for a condition that clears in minutes.

Skipping is safe because the sibling verdict's substance does not live in this dispatch. Its findings are in the #1822 ledger, still open, and the merge gate refuses a verdict at a head that has not observed them, so the next round re-raises them against the head the in-flight leg is about to push. A dropped dispatch costs one round. A lost race costs a completed leg's work AND leaves the finding open anyway, which is what makes the current behaviour strictly worse than the skip.

The skip is recorded as `auto_fix_skipped_active_leg`, naming the leg that owns the branch and why the dispatch was withheld. A silent skip reads as "nothing to fix", which is the defect class this campaign exists to remove, so the test asserts the event exists and names the owner.

## Tests, failing before and passing after

`TestChangesRequestedDoesNotDispatchASecondFixLegOnABranchAlreadyBeingWritten` drives the real dispatch chain (`PullRequestAutoFixPolicyFor` to `dispatchFix` to `autoFixOwner` to `fixBranchLockOwner` to `FixWorktreeAllocator` to `enqueue`) with a running leg already on the branch:

```
base a5903154: FAIL  a second fix leg was dispatched onto a branch already being written;
                     whichever leg finishes second loses the push and its completed work is discarded
this branch:   PASS
```

It also asserts the objection still transitions the task to `changes_requested`, so only the duplicate WRITER is refused and the PR is not left looking approved.

`TestChangesRequestedStillDispatchesAFixLegWhenTheBranchIsIdle` is the control a blunt guard fails, and it carries three near-miss rows that would each break a real workflow if counted as a writer:

- a **settled** implement leg on the same branch: every fix round after the first has one behind it, so counting it would refuse every round but the first;
- an **active** implement leg on a **different** branch;
- an **active review** job on this branch: it pushes nothing, and holding the fix for it would stall every round.

It then asserts the dispatched fix still carries the finding it exists for, so the guard cannot pass by disabling auto-fix.

## Scope, stated so the omission is a decision

Suggestions 2 and 3 from the issue are NOT in this slice. Suggestion 2, rebase-or-supersede instead of a hard fail, is the right long-term answer for a leg that loses anyway (two writers can still arrive from outside this path: an operator push, or a leg dispatched before this guard existed). Suggestion 3, coalescing two blocking verdicts into one leg, belongs with #1522, which owns the panel-timing trigger. Neither is needed to stop the destruction, and I would rather land the bound than bundle it. This PR does not close #1533's rebase-or-salvage half and I say so on the issue.

## Verification

```
go build ./...                                   ok
go vet ./...                                     ok
go test -count=1 ./internal/workflow/            (see the pre-merge comment)
go test -count=1 ./internal/cli/                 (see the pre-merge comment)
```

Ran on a frozen detached worktree at the exact commit, because an earlier run of mine was invalidated by my own checkout in the same clone while a test that reads source from disk was still running. That is recorded rather than hidden.

Deploy notes: no config, no migration, no schema change. The only behaviour change is that a blocking verdict arriving while an implement leg is already in flight on the branch records an event instead of dispatching a second leg.
