### PR TITLE
fix(cli): bind a review prompt's target to the dispatch head (#1819)

### DIFF
--- a/internal/cli/agent.go
+++ b/internal/cli/agent.go
@@ -92,7 +92,7 @@ func printAgentUsage(w io.Writer) {
 	fmt.Fprintln(w, "  gitmoot agent start <name> --runtime codex|claude|kimi|omp --repo owner/repo [--path .] [--template <template-id>] [--model model] [--effort effort] [--start-daemon]")
 	fmt.Fprintln(w, "  gitmoot agent ask <name> \"message\" [--repo owner/repo] [--background] [--model model] [--effort effort] [--workflow id] [--runtime rt] [--session ref] [--home path] [--json]")
 	fmt.Fprintln(w, "  gitmoot agent run <name> \"message\" [--repo owner/repo] [--task task-id] [--pr number] [--lead implementer] [--head-sha sha] [--base ref] [--branch branch] [--background] [--type type] [--action ask|review|implement] [--model model] [--effort effort] [--workflow id] [--runtime rt] [--session ref] [--home path] [--json]")
-	fmt.Fprintln(w, "  gitmoot agent review <name> \"message\" --repo owner/repo --pr number [--lead implementer] [--head-sha sha] [--branch branch] [--background] [--type type] [--action review] [--model model] [--effort effort] [--workflow id] [--runtime rt] [--session ref] [--home path] [--json]")
+	fmt.Fprintln(w, "  gitmoot agent review <name> \"message\" --repo owner/repo --pr number [--lead implementer] [--head-sha sha] [--branch branch] [--background] [--type type] [--action review] [--model model] [--effort effort] [--workflow id] [--runtime rt] [--session ref] [--allow-prompt-head-mismatch] [--home path] [--json]")
 	fmt.Fprintln(w, "  gitmoot agent implement <name> \"message\" [--repo owner/repo] [--task task-id] [--pr number] [--base ref] [--head-sha sha] [--branch branch] [--background] [--type type] [--action implement] [--model model] [--effort effort] [--workflow id] [--runtime rt] [--session ref] [--home path] [--json]")
 	printAgentRuntimeOverrideHelp(w)
 	fmt.Fprintln(w, "  gitmoot agent type list|show|set ...")
@@ -368,31 +368,32 @@ func printAgentRuntimeOverrideHelp(w io.Writer) {
 }
 
 type agentRunOptions struct {
-	home                   string
-	repo                   string
-	jsonOutput             bool
-	background             bool
-	typeName               string
-	action                 string
-	model                  string
-	effort                 string
-	workflowID             string
-	workflowSet            bool
-	orgRole                string
-	runtime                string
-	session                string
-	taskID                 string
-	prNumber               int
-	pullRequestReady       bool
-	pullRequestMode        string
-	headSHA                string
-	base                   string
-	branch                 string
-	lead                   string
-	agent                  string
-	message                string
-	skipNativeReviewFanout bool
-	recipe                 string
+	home                    string
+	repo                    string
+	jsonOutput              bool
+	background              bool
+	typeName                string
+	action                  string
+	model                   string
+	effort                  string
+	workflowID              string
+	workflowSet             bool
+	orgRole                 string
+	runtime                 string
+	session                 string
+	taskID                  string
+	prNumber                int
+	pullRequestReady        bool
+	pullRequestMode         string
+	headSHA                 string
+	base                    string
+	branch                  string
+	lead                    string
+	agent                   string
+	message                 string
+	skipNativeReviewFanout  bool
+	allowPromptHeadMismatch bool
+	recipe                  string
 }
 
 func runAgentRun(args []string, stdout, stderr io.Writer) int {
@@ -601,32 +602,33 @@ func dispatchAgentCommand(options agentRunOptions, action string, reason string,
 
 func localAgentDispatchRequestFromOptions(options agentRunOptions, action, reason, executionPath string) localAgentDispatchRequest {
 	return localAgentDispatchRequest{
-		RepoFlag:               options.repo,
-		Agent:                  options.agent,
-		Action:                 action,
-		Instructions:           options.message,
-		Background:             options.background,
-		Type:                   options.typeName,
-		Model:                  options.model,
-		Effort:                 options.effort,
-		WorkflowID:             options.workflowID,
-		ActingOrgRole:          options.orgRole,
-		OperatorOrigin:         true,
-		Runtime:                options.runtime,
-		RuntimeSession:         options.session,
-		Home:                   options.home,
-		TaskID:                 options.taskID,
-		PullRequest:            options.prNumber,
-		PullRequestReady:       options.pullRequestReady,
-		HeadSHA:                options.headSHA,
-		ImplementBase:          options.base,
-		Branch:                 options.branch,
-		LeadAgent:              options.lead,
-		SkipNativeReviewFanout: options.skipNativeReviewFanout,
-		Recipe:                 options.recipe,
-		SelectedAction:         action,
-		SelectedActionReason:   reason,
-		ExecutionPath:          executionPath,
+		RepoFlag:                options.repo,
+		Agent:                   options.agent,
+		Action:                  action,
+		Instructions:            options.message,
+		Background:              options.background,
+		Type:                    options.typeName,
+		Model:                   options.model,
+		Effort:                  options.effort,
+		WorkflowID:              options.workflowID,
+		ActingOrgRole:           options.orgRole,
+		OperatorOrigin:          true,
+		Runtime:                 options.runtime,
+		RuntimeSession:          options.session,
+		Home:                    options.home,
+		TaskID:                  options.taskID,
+		PullRequest:             options.prNumber,
+		PullRequestReady:        options.pullRequestReady,
+		HeadSHA:                 options.headSHA,
+		ImplementBase:           options.base,
+		Branch:                  options.branch,
+		LeadAgent:               options.lead,
+		SkipNativeReviewFanout:  options.skipNativeReviewFanout,
+		AllowPromptHeadMismatch: options.allowPromptHeadMismatch,
+		Recipe:                  options.recipe,
+		SelectedAction:          action,
+		SelectedActionReason:    reason,
+		ExecutionPath:           executionPath,
 	}
 }
 
@@ -670,6 +672,8 @@ func parseAgentRunOptions(command string, args []string, stderr io.Writer) (agen
 			options.jsonOutput = true
 		case arg == "--skip-native-review-fanout":
 			options.skipNativeReviewFanout = true
+		case arg == "--allow-prompt-head-mismatch":
+			options.allowPromptHeadMismatch = true
 		case arg == "--draft" || arg == "--ready":
 			mode := strings.TrimPrefix(arg, "--")
 			if options.pullRequestMode != "" && options.pullRequestMode != mode {

--- a/internal/cli/agent_dispatch.go
+++ b/internal/cli/agent_dispatch.go
@@ -102,6 +102,16 @@ type localAgentDispatchRequest struct {
 	// production path that forgets it degrades to the pre-#1817 late failure,
 	// which is the safe way to be wrong.
 	ExecsDeclaredBinary bool
+	// AllowPromptHeadMismatch is #1819's explicit escape. A review dispatch whose
+	// prompt cites a commit outside this pull request's history is refused before
+	// any job row exists; this flag dispatches it deliberately.
+	//
+	// The escape has to exist, and naming it in the refusal is part of the fix.
+	// The alternative move available to a blocked operator is to stop passing
+	// --head-sha, which removes exactly the binding this guard protects. A
+	// deliberate override is a recorded decision; an unpinned dispatch is a
+	// silent one.
+	AllowPromptHeadMismatch bool
 	// Runtime, when non-empty, is the per-job runtime override (#531): this one
 	// job runs through the named runtime while the agent's registered default
 	// runtime (and its session) stays untouched. RuntimeSession optionally names
@@ -404,6 +414,22 @@ func dispatchLocalAgentJob(ctx context.Context, store *db.Store, request localAg
 		// committed-tip worktree clears that head. Only review scans its newly
 		// allocated exact-head checkout below.
 		promptHeadWarnings = dispatchPromptHeadContradictionWarnings(ctx, jobGitClient(checkoutPath, localDispatchJobRunner(request)), request.Instructions, request.HeadSHA)
+	}
+	// #1819: REFUSE A REVIEW WHOSE PROMPT NAMES A DIFFERENT REVIEW TARGET, and
+	// refuse it HERE - before the read-only worktree is allocated and before the
+	// job row exists, which is what the issue's acceptance requires.
+	//
+	// It runs on the CANONICAL checkout rather than the exact-head worktree
+	// allocated below. That checkout can resolve the head by construction (the
+	// worktree is created at that commit from it), and scanning before allocation
+	// is what keeps the refusal from having to unwind a worktree it created. The
+	// warning scan below is left exactly as it was, on the allocated worktree.
+	if request.Action == "review" && !request.AllowPromptHeadMismatch {
+		citations := classifyPromptCommitCitations(ctx, jobGitClient(record.CheckoutPath, localDispatchJobRunner(request)),
+			store, request.Instructions, request.HeadSHA, repo.FullName(), request.PullRequest)
+		if err := reviewPromptTargetMismatchError(citations, request.HeadSHA); err != nil {
+			return localAgentJobOutput{}, err
+		}
 	}
 	// A --recipe routes this coordinator to a named built-in recipe template's
 	// prompt (resolved from the installed-template store) without rebinding the

--- a/internal/cli/prompt_head_binding.go
+++ b/internal/cli/prompt_head_binding.go
@@ -1,0 +1,248 @@
+package cli
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+
+	gitutil "github.com/gitmoot/gitmoot/internal/git"
+)
+
+// #1819. A review dispatch whose PROMPT names a commit other than --head-sha
+// used to record a prompt_head_warning and run anyway, against the dispatch head
+// with the wrong instructions. For a review that is the one job type where the
+// instructions ARE the specification: a review that reads PR #1810's diff
+// against PR #1783's brief produces a confident, wrong, gate-eligible verdict.
+//
+// THE GUARD IS NOT "REFUSE IF ANY OTHER SHA APPEARS", and the issue thread has
+// six measured dispatches proving why. Naming another commit is how a prompt
+// states provenance: the previous round's head, the branch base, a retracted
+// head cited under a do-not-trust heading. One of those was nearly destroyed on
+// the strength of the warnings alone. The rule below binds the prompt's review
+// TARGET to the dispatch head instead.
+//
+// RE-DERIVED ON REAL DATA before implementing, over every prompt_head_warning
+// this store holds for a gitmoot/gitmoot review job: 911 events, 644 distinct
+// (cited, head, pull request) citations. 282 are ancestors of the dispatch head,
+// 246 are recorded heads of the same pull request but NOT ancestors, 18 are
+// neither with both objects present, and 98 cannot be classified because an
+// object is absent from the dispatching clone. So:
+//
+//   - REFUSING ON ANY NON-EQUAL TOKEN would refuse 644 of 644.
+//   - The recorded-head arm is NOT the residual force-push corner the issue
+//     describes. It is 38% of all citations, and dropping it refuses 362.
+//   - UNDETERMINABLE NEEDS ITS OWN ARM, which the issue's four-arm ordering does
+//     not have. Folding it into refuse turns 18 refusals into 116, and 72 of
+//     those 98 are undeterminable because the DISPATCH HEAD is missing from the
+//     clone rather than the cited sha - a fact about clone freshness, not about
+//     the citation. That is the same "wrong side of the boundary" error #1817
+//     was about, so it fails OPEN.
+type promptCommitRelation string
+
+const (
+	// promptCommitIsHead is the dispatch head itself. Silent, as today.
+	promptCommitIsHead promptCommitRelation = "the dispatch head"
+	// promptCommitIsAncestor covers prior heads on this branch AND the branch
+	// base. The base is its own category: it was never a head of the pull
+	// request, so a recorded-head check alone misses it.
+	promptCommitIsAncestor promptCommitRelation = "an ancestor of the dispatch head"
+	// promptCommitIsPriorHead is a head this pull request recorded at some
+	// dispatch. Append-only, so it survives a force push that leaves the commit
+	// unreachable.
+	promptCommitIsPriorHead promptCommitRelation = "a recorded head of this pull request"
+	// promptCommitIsForeign is the defect: not the head, not reachable from it,
+	// never a head of this pull request, and both objects resolve so the answer
+	// is real rather than absent.
+	promptCommitIsForeign promptCommitRelation = "not the dispatch head, not an ancestor of it, and never a recorded head of this pull request"
+	// promptCommitUnresolved means the dispatching checkout could not resolve one
+	// of the two commits, so no relationship could be established. Never refuses.
+	promptCommitUnresolved promptCommitRelation = "unresolvable in the dispatching checkout, so its relationship to the head could not be established"
+)
+
+// recordedPullRequestHeadSource is the store surface this guard needs. It is an
+// interface so the classifier can be driven without a database, and so the
+// prompt-scoped nature of the query is visible at the seam.
+type recordedPullRequestHeadSource interface {
+	RecordedPullRequestHeads(ctx context.Context, repo string, pullRequest int) ([]string, error)
+	PullRequestsForRecordedHead(ctx context.Context, repo string, prefix string) ([]int, error)
+}
+
+type promptCommitCitation struct {
+	// token is the text as the prompt wrote it, which is what an operator will
+	// search for when they go and read their own prompt.
+	token    string
+	resolved string
+	relation promptCommitRelation
+	// ownedBy names the pull requests that recorded this sha as a head, so a
+	// refusal can say "that is #1810's head" instead of "unknown commit".
+	ownedBy []int
+}
+
+// classifyPromptCommitCitations resolves every commit-shaped token in a prompt
+// against the dispatch head and the store's recorded heads.
+//
+// It returns nothing when the dispatch head cannot be resolved: with no head
+// there is no relationship to establish, and this is the existing
+// promptHeadContradictionWarnings behaviour rather than a new fail-open.
+func classifyPromptCommitCitations(ctx context.Context, git gitutil.Client, heads recordedPullRequestHeadSource, prompt string, dispatchHead string, repo string, pullRequest int) []promptCommitCitation {
+	if strings.TrimSpace(prompt) == "" {
+		return nil
+	}
+	headRef := strings.TrimSpace(dispatchHead)
+	if headRef == "" {
+		headRef = "HEAD"
+	}
+	resolvedHead, headErr := git.RevParse(ctx, headRef+"^{commit}")
+	resolvedHead = strings.ToLower(strings.TrimSpace(resolvedHead))
+	if headErr != nil || resolvedHead == "" {
+		return nil
+	}
+
+	var recorded []string
+	if heads != nil {
+		if stored, err := heads.RecordedPullRequestHeads(ctx, repo, pullRequest); err == nil {
+			recorded = stored
+		}
+	}
+
+	citations := make([]promptCommitCitation, 0)
+	seen := make(map[string]struct{})
+	for _, token := range promptCommitTokenRE.FindAllString(prompt, -1) {
+		lowered := strings.ToLower(strings.TrimSpace(token))
+		if lowered == "" {
+			continue
+		}
+		// The DEDUP KEY IS THE TOKEN, not the resolved commit, because an
+		// unresolvable token has nothing to resolve to and every one of them
+		// would otherwise collapse into a single entry.
+		if _, duplicate := seen[lowered]; duplicate {
+			continue
+		}
+		seen[lowered] = struct{}{}
+
+		citation := promptCommitCitation{token: token}
+		resolvedToken, tokenErr := git.RevParse(ctx, token+"^{commit}")
+		citation.resolved = strings.ToLower(strings.TrimSpace(resolvedToken))
+		// ANCESTRY IS ANSWERED BEFORE THE SWITCH so an INSTRUMENT FAILURE cannot
+		// fall through to the foreign arm. IsAncestor already reads git's exit 1 as
+		// the ordinary false, so a non-nil error is a broken repository, an invalid
+		// ref or a cancelled context. Refusing a dispatch because the instrument
+		// failed is the one direction this guard must never take, so an
+		// undeterminable answer ends at promptCommitUnresolved, which allows.
+		ancestor, ancestryKnown := false, false
+		if tokenErr == nil && citation.resolved != "" {
+			ancestor, ancestryKnown = promptCitationAncestry(ctx, git, citation.resolved, resolvedHead)
+		}
+		switch {
+		case tokenErr != nil || citation.resolved == "":
+			// A recorded head still identifies the citation even when git cannot
+			// resolve it, which is the whole point of the append-only arm: after a
+			// force push the object may be gone while the store still knows it.
+			if matchesRecordedHead(lowered, recorded) {
+				citation.relation = promptCommitIsPriorHead
+			} else {
+				citation.relation = promptCommitUnresolved
+			}
+		case citation.resolved == resolvedHead:
+			citation.relation = promptCommitIsHead
+		case ancestor:
+			citation.relation = promptCommitIsAncestor
+		case matchesRecordedHead(citation.resolved, recorded) || matchesRecordedHead(lowered, recorded):
+			citation.relation = promptCommitIsPriorHead
+		case !ancestryKnown:
+			citation.relation = promptCommitUnresolved
+		default:
+			citation.relation = promptCommitIsForeign
+		}
+		if citation.relation == promptCommitIsForeign && heads != nil {
+			prefix := citation.resolved
+			if prefix == "" {
+				prefix = lowered
+			}
+			if owners, err := heads.PullRequestsForRecordedHead(ctx, repo, prefix); err == nil {
+				for _, owner := range owners {
+					if owner != pullRequest {
+						citation.ownedBy = append(citation.ownedBy, owner)
+					}
+				}
+				sort.Ints(citation.ownedBy)
+			}
+		}
+		citations = append(citations, citation)
+	}
+	return citations
+}
+
+// promptCitationAncestry answers reachability AND whether the answer was
+// established at all.
+//
+// IsAncestor already reads git's exit 1 as the ordinary "not an ancestor", so a
+// non-nil error is a broken repository, an invalid ref or a cancelled context.
+// The second return exists so the caller can distinguish that from a real false:
+// collapsing them lets an instrument failure refuse a dispatch, which is the one
+// direction this guard must never take.
+func promptCitationAncestry(ctx context.Context, git gitutil.Client, ancestor string, descendant string) (reachable bool, known bool) {
+	reachable, err := git.IsAncestor(ctx, ancestor, descendant)
+	if err != nil {
+		return false, false
+	}
+	return reachable, true
+}
+
+// matchesRecordedHead compares by PREFIX in both directions, because a prompt
+// cites abbreviated SHAs while the store records full ones.
+func matchesRecordedHead(candidate string, recorded []string) bool {
+	candidate = strings.ToLower(strings.TrimSpace(candidate))
+	if candidate == "" {
+		return false
+	}
+	for _, head := range recorded {
+		head = strings.ToLower(strings.TrimSpace(head))
+		if head == "" {
+			continue
+		}
+		if strings.HasPrefix(head, candidate) || strings.HasPrefix(candidate, head) {
+			return true
+		}
+	}
+	return false
+}
+
+// reviewPromptTargetMismatchError refuses a review dispatch whose prompt cites a
+// commit that is not this pull request's history at all. Only
+// promptCommitIsForeign refuses; every other relation, including unresolvable,
+// returns nil.
+//
+// The message names BOTH SHAs because the operator has to find the citation in
+// their own prompt, and it names the owning pull request when the store knows
+// it: "that sha is #1810's head" is a diagnosis, "unknown commit referenced" is
+// a shrug. It also names the escape, because a refusal an operator cannot get
+// past is answered by dropping --head-sha, which removes the binding this guard
+// exists to protect.
+func reviewPromptTargetMismatchError(citations []promptCommitCitation, dispatchHead string) error {
+	var foreign []promptCommitCitation
+	for _, citation := range citations {
+		if citation.relation == promptCommitIsForeign {
+			foreign = append(foreign, citation)
+		}
+	}
+	if len(foreign) == 0 {
+		return nil
+	}
+	described := make([]string, 0, len(foreign))
+	for _, citation := range foreign {
+		detail := fmt.Sprintf("%s is %s", citation.token, citation.relation)
+		if len(citation.ownedBy) > 0 {
+			owners := make([]string, 0, len(citation.ownedBy))
+			for _, owner := range citation.ownedBy {
+				owners = append(owners, fmt.Sprintf("#%d", owner))
+			}
+			detail = fmt.Sprintf("%s is a recorded head of %s, not of this pull request", citation.token, strings.Join(owners, ", "))
+		}
+		described = append(described, detail)
+	}
+	return fmt.Errorf(
+		"review prompt names a commit outside this pull request's history, so the instructions and the dispatch head describe different changes: %s; the dispatch head is %s. A review's instructions are its specification, so this is refused before any job row exists. Cite a prior head of this pull request, its base, or the head itself; or pass --allow-prompt-head-mismatch to dispatch it deliberately",
+		strings.Join(described, "; "), strings.TrimSpace(dispatchHead))
+}

--- a/internal/cli/prompt_head_binding_test.go
+++ b/internal/cli/prompt_head_binding_test.go
@@ -1,0 +1,253 @@
+package cli
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/gitmoot/gitmoot/internal/db"
+	"github.com/gitmoot/gitmoot/internal/runtime"
+	"github.com/gitmoot/gitmoot/internal/workflow"
+)
+
+// promptHeadBindingCheckout builds the one repository shape all the arms need:
+// a base commit on main, two commits on the reviewed branch, and a commit on a
+// SECOND branch that is reachable from neither.
+//
+// The last one is the whole point. `readonlyReviewWorktreeGitCheckout` gives two
+// heads on one branch, and a prior head on the reviewed branch is an ANCESTOR of
+// the later one - so it can only exercise the arm that allows. Reproducing the
+// defect needs a commit on another branch, which is what a different pull
+// request's head actually is.
+func promptHeadBindingCheckout(t *testing.T) (checkout string, base string, firstHead string, head string, foreign string) {
+	t.Helper()
+	checkout = readonlyWorktreeGitCheckout(t, "owner/repo")
+	base = readonlyWorktreeHead(t, checkout)
+
+	runGit(t, checkout, "switch", "-c", "feature/review")
+	writeFile(t, filepath.Join(checkout, "review.txt"), "round one\n")
+	runGit(t, checkout, "add", "review.txt")
+	runGit(t, checkout, "commit", "-m", "review round one")
+	firstHead = readonlyWorktreeHead(t, checkout)
+	writeFile(t, filepath.Join(checkout, "review.txt"), "round two\n")
+	runGit(t, checkout, "add", "review.txt")
+	runGit(t, checkout, "commit", "-m", "review round two")
+	head = readonlyWorktreeHead(t, checkout)
+
+	// A different pull request's branch, cut from the same base so it is a
+	// sibling rather than a descendant.
+	runGit(t, checkout, "switch", "-c", "feature/other", base)
+	writeFile(t, filepath.Join(checkout, "other.txt"), "other pull request\n")
+	runGit(t, checkout, "add", "other.txt")
+	runGit(t, checkout, "commit", "-m", "other pull request")
+	foreign = readonlyWorktreeHead(t, checkout)
+
+	runGit(t, checkout, "switch", "main")
+	return checkout, base, firstHead, head, foreign
+}
+
+// seedRecordedReviewHead writes a review job row that RECORDED a head for a pull
+// request, which is what the append-only arm reads. It is a real job row rather
+// than a hand-built fact because the query reads payload JSON.
+func seedRecordedReviewHead(t *testing.T, store *db.Store, id string, pullRequest int, head string) {
+	t.Helper()
+	insertCLIJobWithPayload(t, store, id, pullRequest, head)
+}
+
+func insertCLIJobWithPayload(t *testing.T, store *db.Store, id string, pullRequest int, head string) {
+	t.Helper()
+	payload := mustJobPayload(t, workflow.JobPayload{
+		Repo: "owner/repo", PullRequest: pullRequest, HeadSHA: head, Branch: "feature/review",
+	})
+	if err := store.CreateJobWithEvent(context.Background(), db.Job{
+		ID: id, Agent: "reviewer", Type: "review", State: string(workflow.JobSucceeded),
+		Repo: "owner/repo", PullRequest: pullRequest, Payload: payload,
+	}, db.JobEvent{Kind: "succeeded", Message: "recorded head fixture"}); err != nil {
+		t.Fatalf("CreateJobWithEvent(%s): %v", id, err)
+	}
+}
+
+// TestReviewDispatchBindsThePromptsTargetToTheDispatchHead drives the REAL
+// dispatch entry, `dispatchLocalAgentJob`, once per relation.
+//
+// Before the fix every arm dispatched: Gitmoot recorded a `prompt_head_warning`,
+// printed it, and ran the job against the dispatch head with the wrong
+// instructions. Measured on this store, 911 such warnings on gitmoot/gitmoot
+// review jobs alone and not one refusal.
+//
+// The ALLOW arms are not padding, they are the reason this guard is shaped the
+// way it is. Re-derived over 644 distinct citations from real dispatches: 282
+// are ancestors, 246 are recorded heads of the same pull request that are NOT
+// ancestors, 98 cannot be classified at all, and only 18 are the defect. A guard
+// that refuses on any non-head token refuses all 644; one without the
+// recorded-head arm refuses 362; one that folds "cannot tell" into refuse
+// refuses 116 instead of 18.
+func TestReviewDispatchBindsThePromptsTargetToTheDispatchHead(t *testing.T) {
+	checkout, base, firstHead, head, foreign := promptHeadBindingCheckout(t)
+	// Syntactically valid, in no object database, so neither ancestry nor
+	// identity can be established for it.
+	const unresolvable = "0123456789abcdef0123456789abcdef01234567"
+
+	for _, tt := range []struct {
+		name string
+		// cited is appended to the prompt as the prompt would write it.
+		cited string
+		// recordAs, when non-zero, seeds a prior job that recorded cited as a
+		// head of that pull request.
+		recordAs   int
+		allow      bool
+		wantRefuse bool
+		// wantNamed are substrings the refusal must carry.
+		wantNamed []string
+	}{
+		{
+			name:  "the dispatch head itself dispatches",
+			cited: head,
+		},
+		{
+			name: "an ANCESTOR dispatches: this is the branch base, which every prompt that says what the branch sits on names",
+			// The base was never a head of this pull request, so the
+			// recorded-head arm alone would miss it. It needs the ancestry arm.
+			cited: base,
+		},
+		{
+			name:  "a prior head on the reviewed branch dispatches",
+			cited: firstHead,
+		},
+		{
+			name: "a RECORDED head of this pull request dispatches even though it is not an ancestor",
+			// This is the force-push shape: a legitimate prior head that a
+			// rewrite left unreachable from the current one. Ancestry says no;
+			// the append-only store says yes.
+			cited:    foreign,
+			recordAs: 12,
+		},
+		{
+			name: "an UNRESOLVABLE sha dispatches, because that is a fact about the checkout and not about the citation",
+			// 72 of the 98 unclassifiable citations measured on this store were
+			// unclassifiable because the DISPATCH HEAD was missing from the
+			// clone, not the cited sha. Refusing on it would make dispatch
+			// depend on clone freshness.
+			cited: unresolvable,
+		},
+		{
+			name:       "a commit outside this pull request's history is REFUSED",
+			cited:      foreign,
+			wantRefuse: true,
+			wantNamed:  []string{foreign, head, "--allow-prompt-head-mismatch"},
+		},
+		{
+			name:       "the refusal NAMES the pull request the sha belongs to when the store knows",
+			cited:      foreign,
+			recordAs:   99,
+			wantRefuse: true,
+			wantNamed:  []string{foreign, "#99", "not of this pull request"},
+		},
+		{
+			name:  "the escape hatch dispatches a deliberate mismatch",
+			cited: foreign,
+			allow: true,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			store, home := blockerE2EHome(t)
+			seedReviewDispatchFixture(t, store, checkout)
+			if tt.recordAs != 0 {
+				seedRecordedReviewHead(t, store, "recorded-head-fixture", tt.recordAs, tt.cited)
+			}
+			before, err := store.ListJobs(ctx)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			request := reviewDispatchRequest(home, head)
+			request.Instructions = "Review this exact head. Round history: commit " + tt.cited + " for context."
+			request.AllowPromptHeadMismatch = tt.allow
+
+			out, dispatchErr := dispatchLocalAgentJob(ctx, store, request)
+
+			after, listErr := store.ListJobs(ctx)
+			if listErr != nil {
+				t.Fatal(listErr)
+			}
+			if !tt.wantRefuse {
+				if dispatchErr != nil {
+					t.Fatalf("dispatch was refused: %v\nA legitimate provenance citation must still dispatch; refusing it is how operators learn to stop pinning --head-sha.", dispatchErr)
+				}
+				if strings.TrimSpace(out.JobID) == "" {
+					t.Fatalf("dispatch returned no job id: %+v", out)
+				}
+				return
+			}
+			if dispatchErr == nil {
+				t.Fatalf("dispatch succeeded (job %s); a review whose prompt names a different review target must be refused", out.JobID)
+			}
+			// No job row: the refusal has to land before the row exists, which is
+			// what makes it cost zero model tokens.
+			if len(after) != len(before) {
+				t.Errorf("job rows went from %d to %d; the refusal created a row", len(before), len(after))
+			}
+			for _, want := range tt.wantNamed {
+				if !strings.Contains(dispatchErr.Error(), want) {
+					t.Errorf("refusal %q does not name %q", dispatchErr.Error(), want)
+				}
+			}
+		})
+	}
+}
+
+// TestReviewDispatchRefusalLeavesNoWorktreeBehind pins the ORDERING, separately
+// from the refusal itself.
+//
+// The refusal has to precede the read-only worktree allocation, not merely the
+// job row. A refusal placed after allocation would have to unwind a worktree it
+// created, and #1817 measured what happens when nothing unwinds one: 29
+// throwaway worktrees across 32 dead dispatches.
+func TestReviewDispatchRefusalLeavesNoWorktreeBehind(t *testing.T) {
+	ctx := context.Background()
+	checkout, _, _, head, foreign := promptHeadBindingCheckout(t)
+	store, home := blockerE2EHome(t)
+	seedReviewDispatchFixture(t, store, checkout)
+
+	worktreeRoot := filepath.Join(home, ".gitmoot", "worktrees")
+	request := reviewDispatchRequest(home, head)
+	request.Instructions = "Review commit " + foreign + " please."
+
+	if _, err := dispatchLocalAgentJob(ctx, store, request); err == nil {
+		t.Fatal("dispatch succeeded; expected a prompt-target refusal")
+	}
+	entries, err := os.ReadDir(worktreeRoot)
+	if err != nil && !os.IsNotExist(err) {
+		t.Fatal(err)
+	}
+	if len(entries) != 0 {
+		t.Fatalf("refused dispatch left %d entries under %s; the refusal must precede allocation", len(entries), worktreeRoot)
+	}
+}
+
+// TestAskAndImplementDispatchAreUnaffectedByThePromptTargetGuard is the scope
+// control. The guard is review-only on purpose: a review's instructions ARE its
+// specification, while an ask legitimately discusses any commit in the
+// repository and an implement is bound by its own stricter checkout-head proof.
+func TestAskAndImplementDispatchAreUnaffectedByThePromptTargetGuard(t *testing.T) {
+	ctx := context.Background()
+	checkout, _, _, head, foreign := promptHeadBindingCheckout(t)
+	store, home := blockerE2EHome(t)
+	seedDaemonWorkerRepo(t, store, "owner/repo", checkout)
+	seedDaemonWorkerAgent(t, store, "responder", runtime.ShellRuntime, "true", []string{"ask"}, "owner/repo")
+
+	out, err := dispatchLocalAgentJob(ctx, store, localAgentDispatchRequest{
+		RepoFlag: "owner/repo", Agent: "responder", Action: "ask", Background: true,
+		Instructions: "What changed in commit " + foreign + " compared with " + head + "?",
+		PullRequest:  12, HeadSHA: head, Home: home,
+	})
+	if err != nil {
+		t.Fatalf("an ask naming another branch's commit was refused: %v", err)
+	}
+	if strings.TrimSpace(out.JobID) == "" {
+		t.Fatalf("ask dispatch returned no job id: %+v", out)
+	}
+}

--- a/internal/db/store_prompt_heads.go
+++ b/internal/db/store_prompt_heads.go
@@ -1,0 +1,93 @@
+package db
+
+import (
+	"context"
+	"strings"
+)
+
+// The head a job was dispatched against lives in the payload JSON, not in a
+// column: `jobs` has `repo` and `pull_request` but no `head_sha`. Both queries
+// below therefore read `$.head_sha` through the guarded form this package
+// already uses everywhere else - json_valid plus a json_type check - because
+// modernc SQLite REJECTS malformed JSON where the legacy Go parser tolerated it
+// by returning an empty payload (see ListDashboardJobSummaries).
+//
+// They exist for #1819's prompt-head guard, which has to answer "was this sha
+// ever a recorded head of this pull request" for a sha that git may no longer be
+// able to reach. A recorded head is an APPEND-ONLY fact that survives a force
+// push, which is exactly the case ancestry cannot answer.
+//
+// SCOPE WARNING, because the natural instinct is to share this with the #1561
+// re-sync gate and that would be a defect. This answers a question about
+// HISTORY - may a prompt cite this sha - and the re-sync gate answers a question
+// about WHAT GETS REVIEWED, where accepting a non-descendant target is the
+// failure mode. The same force push makes the correct answers opposite. Keep
+// this prompt-scoped.
+//
+// A recorded head is also what was stored AT DISPATCH, and resync can rewrite
+// payload.head_sha in place, so this reads a set of historical values rather
+// than a claim about what any reviewer actually read.
+
+const recordedPullRequestHeadsSQL = `SELECT DISTINCT lower(trim(json_extract(payload, '$.head_sha')))
+	FROM jobs
+	WHERE repo = ? AND pull_request = ?
+	  AND json_valid(payload) AND json_type(payload, '$.head_sha') = 'text'
+	  AND trim(json_extract(payload, '$.head_sha')) <> ''`
+
+// RecordedPullRequestHeads returns every distinct head SHA any job has recorded
+// for one pull request, lowercased.
+func (s *Store) RecordedPullRequestHeads(ctx context.Context, repo string, pullRequest int) ([]string, error) {
+	repo = strings.TrimSpace(repo)
+	if repo == "" || pullRequest <= 0 {
+		return nil, nil
+	}
+	rows, err := s.db.QueryContext(ctx, recordedPullRequestHeadsSQL, repo, pullRequest)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var heads []string
+	for rows.Next() {
+		var head string
+		if err := rows.Scan(&head); err != nil {
+			return nil, err
+		}
+		if head != "" {
+			heads = append(heads, head)
+		}
+	}
+	return heads, rows.Err()
+}
+
+const pullRequestsForRecordedHeadSQL = `SELECT DISTINCT pull_request
+	FROM jobs
+	WHERE repo = ? AND pull_request > 0
+	  AND json_valid(payload) AND json_type(payload, '$.head_sha') = 'text'
+	  AND lower(trim(json_extract(payload, '$.head_sha'))) LIKE ? || '%'
+	ORDER BY pull_request`
+
+// PullRequestsForRecordedHead returns the pull requests that have recorded a
+// head starting with prefix. It takes a PREFIX because prompts cite abbreviated
+// SHAs, and it is used only to turn a refusal into a diagnosis: "that sha is
+// #1810's head" is actionable where "unknown commit referenced" is a shrug.
+func (s *Store) PullRequestsForRecordedHead(ctx context.Context, repo string, prefix string) ([]int, error) {
+	repo = strings.TrimSpace(repo)
+	prefix = strings.ToLower(strings.TrimSpace(prefix))
+	if repo == "" || prefix == "" {
+		return nil, nil
+	}
+	rows, err := s.db.QueryContext(ctx, pullRequestsForRecordedHeadSQL, repo, prefix)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var pullRequests []int
+	for rows.Next() {
+		var pullRequest int
+		if err := rows.Scan(&pullRequest); err != nil {
+			return nil, err
+		}
+		pullRequests = append(pullRequests, pullRequest)
+	}
+	return pullRequests, rows.Err()
+}

--- a/skills/gitmoot/references/CLI.md
+++ b/skills/gitmoot/references/CLI.md
@@ -1109,6 +1109,25 @@ and dispatch refuses before Task mutation when the Gitmoot filesystem has less
 than 5 GiB free or free-space measurement is unavailable. The prior verdict is
 escalation evidence only and is never served as the new result.
 
+A review dispatch is also bound to its own head by its PROMPT. Before the
+read-only worktree is allocated and before any job row exists, Gitmoot resolves
+every commit-shaped token in a review's instructions and classifies it against
+the dispatch head: the head itself, an ancestor of it (which covers prior heads
+on the branch and the branch base), a head this pull request recorded at some
+earlier dispatch, or none of those. Only the last refuses, with a non-zero exit
+naming both SHAs and, when the store knows it, the pull request whose head the
+cited commit actually is. `--allow-prompt-head-mismatch` dispatches such a
+request deliberately.
+
+Three arms allow on purpose, because a prompt naming another commit is usually
+how it states provenance. The recorded-head arm reads an append-only store fact
+rather than git, so a legitimate prior head still passes after a force push has
+left it unreachable. A citation whose relationship cannot be established at all,
+because the dispatching checkout resolves neither commit, also dispatches: that
+is a fact about the checkout rather than about the citation. The pre-existing
+`prompt_head_warning` job event is unchanged and still records every non-head
+citation, including the ones that are allowed.
+
 This exact `(repo, PR, head_sha, decision)` evidence key is intentional: the
 #1419 review panel rejected round counters and other instruments, so this guard
 does not infer a loop from a numeric threshold. Direct PR-comment review ingress

--- a/website/docs/reference/cli.md
+++ b/website/docs/reference/cli.md
@@ -828,6 +828,25 @@ and dispatch refuses before Task mutation when the Gitmoot filesystem has less
 than 5 GiB free or free-space measurement is unavailable. The prior verdict is
 escalation evidence only and is never served as the new result.
 
+A review dispatch is also bound to its own head by its PROMPT. Before the
+read-only worktree is allocated and before any job row exists, Gitmoot resolves
+every commit-shaped token in a review's instructions and classifies it against
+the dispatch head: the head itself, an ancestor of it (which covers prior heads
+on the branch and the branch base), a head this pull request recorded at some
+earlier dispatch, or none of those. Only the last refuses, with a non-zero exit
+naming both SHAs and, when the store knows it, the pull request whose head the
+cited commit actually is. `--allow-prompt-head-mismatch` dispatches such a
+request deliberately.
+
+Three arms allow on purpose, because a prompt naming another commit is usually
+how it states provenance. The recorded-head arm reads an append-only store fact
+rather than git, so a legitimate prior head still passes after a force push has
+left it unreachable. A citation whose relationship cannot be established at all,
+because the dispatching checkout resolves neither commit, also dispatches: that
+is a fact about the checkout rather than about the citation. The pre-existing
+`prompt_head_warning` job event is unchanged and still records every non-head
+citation, including the ones that are allowed.
+
 This exact `(repo, PR, head_sha, decision)` evidence key is intentional: the
 #1419 review panel rejected round counters and other instruments, so this guard
 does not infer a loop from a numeric threshold. Direct PR-comment review ingress


### PR DESCRIPTION
Closes #1819. Second slice of campaign #1818, after #1817 (PR #1926, merged `e16875b3`).

## The defect

A review dispatch whose **prompt text names a different commit than `--head-sha`** was accepted. Gitmoot recorded a `prompt_head_warning`, printed it, and ran the job against the dispatch head with the wrong instructions. The warning's own message asserts the unsafe resolution: "Gitmoot will use dispatch head X".

For a review that is the one job type where the instructions **are** the specification. A review that reads PR #1810's diff against PR #1783's brief produces a confident, wrong, gate-eligible verdict, and refusing costs zero model tokens.

## Re-measured, and it corrects the issue in three places

I re-derived the discriminator from `/root/.gitmoot/gitmoot.db` before implementing anything, over **every** `prompt_head_warning` this store holds for a `gitmoot/gitmoot` review job: **911 events, 644 distinct (cited commit, dispatch head, pull request) citations, and not one refusal.** The issue's own evidence is a hand-count of 7.

Classified with the issue's ordered rule:

| relation to the dispatch head | citations | share | correct action |
|---|---|---|---|
| ancestor of the dispatch head | 282 | 43.8% | allow |
| recorded head of the **same** pull request, not an ancestor | 246 | 38.2% | allow |
| relationship **undeterminable** in this clone | 98 | 15.2% | allow |
| none of those, both commits resolve | **18** | 2.8% | **refuse** |

16 of the 18 refusals name another pull request's recorded head, which is exactly the shape the issue was filed on. `0bfb614f`, the issue's canonical example, is one of them: a recorded head of #1783 cited on a #1810 dispatch.

Three corrections follow:

1. **Refusing on any non-head token refuses 644 of 644.** The issue already argues this; the number puts it beyond debate.
2. **The recorded-head arm is not a residual corner.** The issue introduces it as the case "ancestry cannot" answer after a force push. On real data it is **38% of all citations**, more than a third. Shipping only the identity and ancestry arms refuses 362 of 644.
3. **The issue's four-arm ordering has no arm for "cannot tell", and it needs one.** Folding undeterminable into refuse turns 18 refusals into 116, a **6.4x** over-refusal. And the reason matters: **72 of those 98 are undeterminable because the DISPATCH HEAD is missing from the clone, not the cited sha.** That is a fact about clone freshness, not about the citation, so it fails open. It is #1817's lesson restated: a check must not answer about the wrong side of the boundary.

### An instrument error of my own, corrected

My first pass used `git cat-file -e <sha>^{commit}` and reported 89 objects absent. `git rev-parse --verify --quiet <sha>^{commit}` resolves every one of them. I found it because the refuse count looked implausibly high and I added a positive control (a known-good ref, a known-bad ref, and a known abbreviation). **The corrected refuse count is 18, not 116.** Reporting it because the wrong number would have justified a much blunter guard.

## What this does

For `action=review` only, before the read-only worktree is allocated and before any job row exists, every commit-shaped token in the instructions is classified against the dispatch head:

| relation | outcome |
|---|---|
| the dispatch head | allow, silently, exactly as today |
| an ancestor of it | allow (covers prior heads on the branch **and** the branch base) |
| a recorded head of this pull request | allow, from an append-only store fact, so it survives a force push |
| unresolvable / ancestry undeterminable | allow |
| none of the above | **refuse**, non-zero, no job row |

The refusal names both SHAs, the owning pull request when the store knows it ("`658a6062` is a recorded head of #1810, not of this pull request"), and the escape. `--allow-prompt-head-mismatch` dispatches a deliberate mismatch.

Two design points worth stating:

- **The escape hatch is not a convenience.** The move available to a blocked operator otherwise is to stop passing `--head-sha`, which removes precisely the binding this guard protects. A deliberate override is a recorded decision; an unpinned dispatch is a silent one.
- **The recorded-head query is prompt-scoped, and the code says so.** The natural instinct is to share it with the #1561 re-sync gate. That would be a defect: the same force push makes the correct answers opposite, because this asks a question about *history* and the re-sync gate asks *what gets reviewed*, where accepting a non-descendant target is the failure mode.

Scope: `ask` and `implement` are untouched, and the existing `prompt_head_warning` event and its message are byte-identical. An ask legitimately discusses any commit; `implement` has the stricter form already (`daemon_workflow.go` proves the checkout is at the dispatch head).

## Tests

`internal/cli/prompt_head_binding_test.go`, three functions, all entering through the real dispatch entry `dispatchLocalAgentJob` rather than the classifier.

`TestReviewDispatchBindsThePromptsTargetToTheDispatchHead` has eight arms, five of which must **allow**: the head itself, the branch base, a prior head on the branch, a recorded-but-unreachable head, and an unresolvable sha. The allow arms are the point of the shape, not padding.

The fixture needed a commit on a **second branch**, because two heads on one branch are always in an ancestor relation and can only exercise the arms that allow. A sibling commit off the same base is what another pull request's head actually is.

`TestReviewDispatchRefusalLeavesNoWorktreeBehind` pins the ordering separately: the refusal must precede allocation, not merely the job row.

### Fails before, passes after

Refusal disabled in `agent_dispatch.go`, tests unchanged: both refuse arms and the ordering test fail. Restored: all pass.

### Mutants, each killed by the test that owns it

| mutant | killed by |
|---|---|
| remove the refusal | the two refuse arms + the ordering test |
| drop the **ancestor** arm | the branch-base and prior-head allow arms |
| drop the **recorded-head** arm | the recorded-but-unreachable allow arm |
| fold **undeterminable** into refuse | the unresolvable allow arm |
| refuse **after** worktree allocation | only `...LeavesNoWorktreeBehind`, which is what it is for |

Every mutant compiled; both mutated files verified sha256-identical after restore.

## Gate

```
go1.26.4 linux/amd64   GOTOOLCHAIN=local   CGO_ENABLED=0
go build -buildvcs=false ./...   PASS
go vet ./...                     PASS
go generate ./... && git status  clean
gofmt -l internal/               empty
```

Full-suite results are posted as a comment once both halves finish; `internal/cli` needs more than the repo recipe's 25m on this box when run beside the rest of `./...`.

Not run and not claimed: `-race` locally (requires cgo, unavailable here); covered by CI's race shards.

## Deliberately not in this PR

The issue's thread asks for one more thing: a warning that names the **relationship** (`base`, `prior head of this pull request`, `unknown, belongs to #1810`) rather than the bare "prompt references commit X". Its argument is strong: a coordinator read two bare warnings, ordered a correct dispatch cancelled, and retracted only after opening the stored prompt.

It is not here because it changes a message three job types share and re-pins `TestDispatchReviewAllocatesDistinctExactHeadWorktrees`, a deliberate existing test about **which checkout** review scans. That is a separate change with its own blast radius, and none of this issue's four acceptance criteria depend on it. Filing it as a follow-up rather than smuggling it in.
