### PR TITLE
fix(cli): disclose ledger obligations on the review path that actually records findings (#1969)

### DIFF
--- a/internal/cli/agent_dispatch.go
+++ b/internal/cli/agent_dispatch.go
@@ -430,6 +430,42 @@ func dispatchLocalAgentJob(ctx context.Context, store *db.Store, request localAg
 			}
 		}
 	}
+	// #1969: DISCLOSE THE LEDGER OBLIGATIONS ON THIS PATH TOO.
+	//
+	// The findings ledger has a write half and a read half, and the file header
+	// of findings_ledger_writer.go states why one without the other is worse
+	// than neither: obligations accumulate that no reviewer was ever told about,
+	// and the gate then refuses heads whose reviewer could not have discharged
+	// anything, because a uid is obtainable ONLY by being told it.
+	//
+	// The read half was wired to HandlePullRequestOpened's fan-out only. Measured
+	// on this box: all 571 recorded findings came from CLI-dispatched review jobs
+	// and ZERO from the fan-out, so the read half had never run. The separation
+	// across eight repositories is total - every repository that ever answered a
+	// finding had review prompts that mentioned continues_uid because a SEAT had
+	// hand-written the obligations in (gitmoot 32 prompts / 100 answered,
+	// keephair 2 / 11, coordinator-checkin 1 / 17), and every repository whose
+	// prompts never mentioned it answered nothing (joltra 0 / 0 despite 49
+	// implement jobs, plus vetrina, numbra, among-friends, omp-role-router).
+	// Consumption was manual, and where nobody did it by hand 211 findings were
+	// recorded and none was ever answered.
+	//
+	// The resolvers come from daemonLedgerResolvers, the SAME single constructor
+	// the merge gate is built with, so the brief cannot disclose one set of
+	// obligations while the gate demands another (#1850 R3-F1). The brief text
+	// itself is rendered by the engine, never re-implemented here.
+	//
+	// It is additive and fails open: a review with no PR, no head, or no prior
+	// obligations at that head gets a byte-identical prompt.
+	if request.Action == "review" && request.PullRequest > 0 && strings.TrimSpace(request.HeadSHA) != "" {
+		briefEngine := workflow.Engine{
+			Store:           store,
+			LedgerResolvers: daemonLedgerResolvers(nil, record.CheckoutPath, localDispatchJobRunner(request)),
+		}
+		if brief := briefEngine.ReviewObligationBrief(ctx, repo.FullName(), request.PullRequest, request.HeadSHA, request.TaskID); brief != "" {
+			request.Instructions += brief
+		}
+	}
 	// A foreground dispatch already knows the runtime it will execute. Persist it
 	// in the initial job insert so recording cannot fail separately and leave a
 	// daemon-claimable queued row. Background jobs deliberately omit it here: the

--- a/internal/cli/review_obligation_disclosure_1969_test.go
+++ b/internal/cli/review_obligation_disclosure_1969_test.go
@@ -1,0 +1,130 @@
+package cli
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/gitmoot/gitmoot/internal/db"
+)
+
+// #1969. The findings ledger has a write half and a read half. The read half -
+// disclosing each prior obligation's uid in the review brief - was reachable
+// from HandlePullRequestOpened's fan-out ONLY, and the fan-out has never
+// recorded a finding on this fleet.
+//
+// Measured on this box's ledger, 2026-09-05 to 2026-09-07: all 571 recorded
+// findings were written by CLI-dispatched review jobs (observer_job LIKE
+// 'local-%'), ZERO by the fan-out, and not one of their prompts contains a
+// rendered 'uid=' line. So no reviewer has ever been handed a uid by the
+// engine, and a uid is obtainable ONLY by being told it.
+//
+// The consequence, and the separation is total across eight repositories: every
+// repository that ever answered a finding had review prompts mentioning
+// continues_uid, because a SEAT hand-wrote the obligations in - gitmoot 32
+// prompts and 100 answered, keephair 2 and 11, coordinator-checkin 1 and 17.
+// Every repository whose prompts never mentioned it answered nothing: joltra
+// 0 and 0 despite 49 implement jobs, plus vetrina, numbra, among-friends and
+// omp-role-router. 211 findings recorded in those five, none ever answered.
+//
+// This test drives the REAL dispatch path, which is the whole point: a test
+// against HandlePullRequestOpened would have passed throughout the defect.
+func TestCLIReviewDispatchDisclosesPriorLedgerObligations(t *testing.T) {
+	ctx := context.Background()
+	store, home := blockerE2EHome(t)
+	checkout, firstHead, secondHead := readonlyReviewWorktreeGitCheckout(t)
+	seedReviewDispatchFixture(t, store, checkout)
+	replaceDiskGuardMeasurement(t, func(string) (diskFilesystemUsage, error) {
+		return diskFilesystemUsage{TotalBytes: 20 << 30, FreeBytes: 10 << 30}, nil
+	})
+
+	// A prior round recorded an open obligation at the FIRST head. The second
+	// round is dispatched at the second head and must be told its uid.
+	uid, err := store.RecordReviewFindingObservation(ctx, db.ReviewFindingObservation{
+		Repo:             "owner/repo",
+		PullRequest:      12,
+		HeadSHA:          firstHead,
+		ObserverJob:      "local-review-prior-round",
+		State:            db.FindingOpen,
+		Severity:         "P1",
+		RoundLabel:       "F1",
+		Title:            "the fix leg pushes before it validates the branch",
+		Detail:           "asset files are written before branch validation and neither is rolled back",
+		File:             "internal/cli/agent_dispatch.go",
+		Line:             411,
+		EvidenceKind:     db.EvidenceExecuted,
+		ExecutedCommands: []string{"go test ./internal/cli"},
+		ExecutedCount:    1,
+	})
+	if err != nil {
+		t.Fatalf("RecordReviewFindingObservation: %v", err)
+	}
+	if strings.TrimSpace(uid) == "" {
+		t.Fatal("fixture recorded no uid")
+	}
+
+	out, err := dispatchLocalAgentJob(ctx, store, reviewDispatchRequest(home, secondHead))
+	if err != nil {
+		t.Fatalf("dispatchLocalAgentJob: %v", err)
+	}
+	job, err := store.GetJob(ctx, out.JobID)
+	if err != nil {
+		t.Fatalf("GetJob: %v", err)
+	}
+	payload, err := daemonJobPayload(job)
+	if err != nil {
+		t.Fatalf("daemonJobPayload: %v", err)
+	}
+
+	// THE UID IS THE ASSERTION, not the surrounding prose. A brief that explains
+	// the rules without naming the obligation leaves it exactly as undischargeable
+	// as no brief at all, which is the state this test was written against.
+	if !strings.Contains(payload.Instructions, uid) {
+		t.Fatalf("review prompt does not name the prior obligation %q, so the reviewer cannot cite it as continues_uid and the finding can never be answered; prompt tail: %q",
+			uid, tailOf(payload.Instructions, 600))
+	}
+	if !strings.Contains(payload.Instructions, "continues_uid") {
+		t.Fatalf("review prompt names the uid but never says how to cite it; prompt tail: %q", tailOf(payload.Instructions, 600))
+	}
+	// The operator's own instructions must survive: the brief is additive.
+	if !strings.Contains(payload.Instructions, "Review this exact head.") {
+		t.Fatalf("the brief replaced the operator's instructions instead of appending to them: %q", payload.Instructions)
+	}
+}
+
+// The control. A review dispatch with no prior obligations at its head must get
+// a byte-identical prompt, or this change becomes prompt noise on every review
+// in the fleet, most of which have no ledger history.
+func TestCLIReviewDispatchLeavesThePromptUntouchedWithNoObligations(t *testing.T) {
+	ctx := context.Background()
+	store, home := blockerE2EHome(t)
+	checkout, _, secondHead := readonlyReviewWorktreeGitCheckout(t)
+	seedReviewDispatchFixture(t, store, checkout)
+	replaceDiskGuardMeasurement(t, func(string) (diskFilesystemUsage, error) {
+		return diskFilesystemUsage{TotalBytes: 20 << 30, FreeBytes: 10 << 30}, nil
+	})
+
+	request := reviewDispatchRequest(home, secondHead)
+	out, err := dispatchLocalAgentJob(ctx, store, request)
+	if err != nil {
+		t.Fatalf("dispatchLocalAgentJob: %v", err)
+	}
+	job, err := store.GetJob(ctx, out.JobID)
+	if err != nil {
+		t.Fatalf("GetJob: %v", err)
+	}
+	payload, err := daemonJobPayload(job)
+	if err != nil {
+		t.Fatalf("daemonJobPayload: %v", err)
+	}
+	if payload.Instructions != request.Instructions {
+		t.Fatalf("prompt changed with an empty ledger:\n got %q\nwant %q", payload.Instructions, request.Instructions)
+	}
+}
+
+func tailOf(value string, n int) string {
+	if len(value) <= n {
+		return value
+	}
+	return "..." + value[len(value)-n:]
+}

--- a/internal/workflow/findings_ledger_writer.go
+++ b/internal/workflow/findings_ledger_writer.go
@@ -285,6 +285,27 @@ func (e Engine) recordLedgerSkip(ctx context.Context, jobID string, index int, r
 	})
 }
 
+// ReviewObligationBrief exposes the obligation brief to a dispatcher outside
+// this package. It exists because the brief was reachable from ONE dispatch
+// path and that path records nothing (#1969).
+//
+// Measured on this box's ledger, 2026-09-05 to 2026-09-07: all 571 recorded
+// findings were written by CLI-dispatched review jobs (observer_job LIKE
+// 'local-%') and ZERO by the daemon fan-out, while ledgerObligationBrief was
+// called only from HandlePullRequestOpened's fan-out loop and the high-risk
+// lens. So the read half of the loop this file's header describes has never
+// fired in production: no reviewer has ever been handed a uid by the engine,
+// and not one of the 571 findings' prompts contains a rendered 'uid=' line.
+//
+// It is a thin accessor ON PURPOSE. The brief's TEXT must have exactly one
+// author, and the scope it is computed with must be the gate's own, or the
+// brief discloses one set of obligations while the gate demands another - the
+// #1850 R3-F1 wedge. Callers supply the same LedgerResolvers value the gate
+// holds; they do not get to render their own version.
+func (e Engine) ReviewObligationBrief(ctx context.Context, repo string, pullRequest int, head string, taskID string) string {
+	return e.ledgerObligationBrief(ctx, repo, pullRequest, head, taskID)
+}
+
 // ledgerObligationBrief renders the prior findings a round at this head must
 // observe, for inclusion in the review brief. THIS IS THE HALF THAT KEEPS THE
 // GATE FROM REJECTING VALID INPUT: an obligation can only be discharged by


### PR DESCRIPTION
Fixes #1969. Part of campaign #1966.

## The issue's cause is not the cause

#1969 says 241 findings across five application repositories were never answered because "nobody is on the other end". Measured, that is not what happened.

**joltra has 49 implement jobs and 51 review jobs since the ledger began, and answered 0 of 57 findings.** There is somebody on the other end; they are implementing constantly. So the thesis that predicts joltra's zero is wrong.

## What is actually broken

The findings ledger has a write half and a read half. `findings_ledger_writer.go`'s own file header states why one without the other is worse than neither:

> If only the write half existed, prior findings would accumulate as open obligations that no reviewer was ever told about, and the gate would block legitimate merges forever ... So `ledgerObligationBrief` discloses the obligations IN THE REVIEW BRIEF, naming each uid, which is the only way a reviewer can cite one.

`ledgerObligationBrief` had exactly two callers, both in `engine_pr_lifecycle.go`: the fan-out loop at `:260` and the high-risk lens at `:479`.

**The fan-out has never recorded a finding on this fleet.** All 571 recorded findings have an `observer_job` matching `local-%`, i.e. CLI dispatch. Zero match `workflow-%`.

| repo | findings | CLI-dispatched | fan-out |
| --- | --- | --- | --- |
| gitmoot/gitmoot | 282 | 282 | 0 |
| themartianapp/among-friends | 59 | 59 | 0 |
| jerryfane/vetrina | 58 | 58 | 0 |
| jerryfane/joltra | 57 | 57 | 0 |
| themartianapp/keephair | 44 | 44 | 0 |
| jerryfane/numbra | 36 | 36 | 0 |
| gitmoot/coordinator-checkin | 34 | 34 | 0 |
| jerryfane/omp-role-router | 1 | 1 | 0 |

So the read half of the loop has never fired in production. Corroborating instrument: not one of the 571 findings' review prompts contains a rendered `uid=` line, which is the brief's own output format.

## The discriminator, and it separates all eight repositories perfectly

A discharge requires citing a uid, and a uid is obtainable only by being told it. So: which repositories' review prompts ever mentioned `continues_uid` at all?

| repo | review jobs | prompts mentioning `continues_uid` | findings answered |
| --- | --- | --- | --- |
| gitmoot/gitmoot | 161 | **32** | **100** |
| themartianapp/keephair | 29 | **2** | **11** |
| gitmoot/coordinator-checkin | 19 | **1** | **17** |
| jerryfane/joltra | 51 | 0 | **0** |
| jerryfane/vetrina | 18 | 0 | **0** |
| jerryfane/numbra | 17 | 0 | **0** |
| themartianapp/among-friends | 16 | 0 | **0** |
| jerryfane/omp-role-router | 2 | 0 | **0** |

Every repository that ever answered a finding had prompts that mentioned it. Every repository that answered zero had none. No exceptions in either direction.

Since the engine never produced those prompts, a **seat hand-wrote them**. Consumption in this fleet has been entirely manual, and the five repositories with zero are the five where no human happened to do it.

## Corrections to the issue's numbers

- **`keephair` does not belong in the five.** It has 44 findings and **11 answered**. The issue split keephair across two observing agents and counted only the zero-answer one. Corrected set: `among-friends`, `vetrina`, `joltra`, `numbra`, `omp-role-router`, totalling **211** findings, not 241.
- **"0 consumed" understates it.** 72 findings in those repositories reached `withdrawn`, which looks like consumption. Every one of the 72 is PHOBOS's owner-approved operator cleanup of 2026-09-07: the `withdraw_reason` says so verbatim on all 72. **Zero reviewer-authored dispositions of any kind** have ever occurred in those repositories.
- The issue's per-agent framing hid the repo picture. Grouped by repo, `gitmoot/coordinator-checkin` (17 answered) also appears as a consumer the issue does not mention.

## Hypotheses I tested and rejected

- **No consumer.** Rejected: joltra has 49 implement jobs.
- **Second rounds never run**, so there is never an opportunity to discharge. Rejected: heads-per-PR is 15 for vetrina, 12 for among-friends and 6 for numbra, against 4.24 for gitmoot, which answers 100. Rounds re-run more in the failing repositories, not less.
- **No local checkout, so the ledger scope resolver is unavailable.** Rejected: `gitmoot repo list` shows a registered checkout for every one of them.

## The change

Attach the brief on the dispatch path that actually records findings.

- `Engine.ReviewObligationBrief` is a thin exported accessor for `ledgerObligationBrief`. Thin on purpose: the brief's text must have exactly one author, and a CLI-side re-implementation is how the brief and the gate come to disagree.
- `dispatchLocalAgentJob` appends it for a review dispatch with a PR and a head, using `daemonLedgerResolvers`, the **same single constructor** the merge gate is built with. That constructor exists because #1850 R3-F1 had two call sites and only one was wired, so the gate demanded obligations the brief could not disclose and the merge wedged permanently.
- Additive and fails open: no PR, no head, or no pending obligations at that head leaves the prompt byte-identical.

## Verification

`TestCLIReviewDispatchDisclosesPriorLedgerObligations` drives the real `dispatchLocalAgentJob`, records a prior open obligation at an earlier head, dispatches the next round at a later head, and asserts the stored payload names the uid. That it goes through the real dispatch path is the point: a test against `HandlePullRequestOpened` would have passed throughout the entire defect.

`TestCLIReviewDispatchLeavesThePromptUntouchedWithNoObligations` is the control, so this cannot become prompt noise on every review in the fleet.

### Mutation proof

| Mutant | Result |
| --- | --- |
| CLI stops attaching the brief (the shipped defect) | FAILS: `review prompt does not name the prior obligation "owner/repo#12-f1"` |
| the attach condition is disabled, i.e. regression to fan-out-only | FAILS, same assertion |
| the brief renders its rules but stops naming the uid | FAILS, prompt tail shows the rules present and `was=F1 severity=P1` with no uid |

**One mutant survives and it is reported, not hidden:** removing `LedgerResolvers` from the CLI-side engine leaves both tests green. With an empty scope the obligation is still pending, fail-closed, so the resolver wiring is correctness-relevant for brief/gate agreement but is not observable in these tests. I did not manufacture a test to cover it.

**An instrument failure I caught in myself:** my first run of the third mutant reported SURVIVED. It had not survived; the patch script silently matched nothing, so I ran unmutated code and read the pass as a result. Re-run with an assertion on the match count, it kills the test. A mutation result without proof the edit landed is worth nothing.

### Gate

`gofmt` clean, `go build -buildvcs=false ./...`, `go vet ./...` pass. Full `go test ./internal/cli/` on this branch: **ok, 756s**.

`go test ./...` on this branch reported failures in seven `internal/cli` dispatch and credential tests, and **I do not believe they are this change's** on the following evidence rather than on assumption:

1. Those exact tests pass on `main` in isolation: `ok 60.9s`.
2. They pass on **this branch** in isolation: `ok 45.9s`.
3. The whole `internal/cli` package passes on this branch: `ok 756s`.
4. Load average was **14.73 / 18.14 / 16.85 on 12 cores** during the failing run, and every failure is a delivery-timing assertion (`never started delivering`, `posted comments = []`, a 32s timeout).

The change is also inert for those tests by construction: it is gated on `Action == "review" && PullRequest > 0 && HeadSHA != ""`, and the failing tests dispatch `ask`/`implement` with `pull_request: 0`.

CI on an unloaded runner is the authoritative arbiter and I am deferring to it rather than asserting a green I did not observe. `-race` not run locally: it requires cgo, which this seat does not have.

## Not claimed

- **I have not shown that disclosure causes discharge.** This removes the precondition that made discharge impossible; whether reviewers in those five repositories then answer findings is measurable only after it ships. That is the honest boundary of this PR.
- #1969's acceptance also asks for a per-repository consuming-versus-advisory declaration and a report showing answered-versus-open. Not in this PR. Declaring a repository advisory while the reviewer is never told the uids would have declared a policy for a mechanism that does not work yet. Worth doing next, on top of this.
- The 211-findings backlog is untouched. No backfill, no bulk withdrawal.
- No config change, no migration.

## Deploy notes

No migration. Prompt-assembly change on the CLI review dispatch path, so it takes effect on the next dispatched review after the binary is replaced. Both binaries per the two-services rule.
