### PR TITLE
fix(workflow): dispatch the fix leg on the last review to settle at a head (#1522)

### DIFF
--- a/internal/workflow/engine_routing_merge.go
+++ b/internal/workflow/engine_routing_merge.go
@@ -535,6 +535,134 @@ func (e Engine) approvalSupersedesChangesRequested(ctx context.Context, payload 
 	return true, "", false, nil
 }
 
+// dispatchFixWhenHeadHasSettled dispatches AT MOST ONE fix leg per head, and
+// only once every review dispatched at that head has settled (#1522).
+//
+// THE OLD RULE WAS "THE FIRST BLOCKING VERDICT DISPATCHES", which makes a
+// cross-family pair unsatisfiable in one round whenever it splits: the first
+// objection's leg pushes a new head while the sibling is still reading the old
+// one, so the sibling's verdict is stale the moment it lands. Measured over the
+// live job store: 37 of 334 dispatched fix legs (11.1%) were created while at
+// least one sibling review at the SAME head was still running, and those
+// siblings then landed 51 verdicts against a head that no longer existed - 29
+// approvals, average 12.0 minutes late, worst 58 minutes, and 22 further
+// objections at 9.2 minutes late.
+//
+// The 29 stale APPROVALS are the merge-integrity half: an "approved" recorded
+// for a commit the fix leg superseded minutes later is a record asserting
+// something it cannot support, which is the whole subject of #1520.
+//
+// THE LAST REVIEW TO SETTLE IS THE ONE THAT DISPATCHES, which is why this is
+// reachable from the approving arm too. If only the objecting arm called it, a
+// pair that splits objection-then-approval would defer the leg and then never
+// dispatch it: the approval does not fix anything, and the objection's arm has
+// already returned. That is a deadlock, not a delay, and it is the shape #1524
+// was opened for.
+//
+// ONE LEG PER HEAD is also what makes the concurrency this cannot see impossible
+// in the panel case: two blocking verdicts at one head now produce one leg
+// rather than two racing writers (#1533). It does not replace #1533's guard,
+// which still bounds legs arriving from separate rounds and other routes.
+func (e Engine) dispatchFixWhenHeadHasSettled(ctx context.Context, job db.Job, payload JobPayload, ref taskRef) error {
+	head := strings.TrimSpace(payload.HeadSHA)
+	if head == "" {
+		// No evaluated head means no head to reason about, so behave exactly as
+		// before rather than inventing a reason never to dispatch. Withholding a
+		// fix is a liveness cost and it must never be the accidental default.
+		if payload.Result == nil {
+			return nil
+		}
+		return e.dispatchFix(ctx, job, reviewDecisionAgent(job, payload), payload, *payload.Result, ref)
+	}
+	jobs, err := e.Store.ListJobs(ctx)
+	if err != nil {
+		return err
+	}
+	blockingSeverity := e.reviewBlockingSeverity(payload.Repo)
+	var pending []string
+	var existingLeg string
+	var verdictJob db.Job
+	var verdictPayload JobPayload
+	// The current job is included in the scan on equal terms with its siblings:
+	// the objecting arm arrives here carrying its own blocking result, and the
+	// approving arm arrives carrying none, so a single rule covers both.
+	candidates := append([]db.Job{job}, jobs...)
+	seen := map[string]struct{}{}
+	for _, candidate := range candidates {
+		if _, dup := seen[candidate.ID]; dup {
+			continue
+		}
+		seen[candidate.ID] = struct{}{}
+		candidatePayload, err := unmarshalPayload(candidate.Payload)
+		if err != nil {
+			return err
+		}
+		if !sameTask(payload, candidatePayload) {
+			continue
+		}
+		if strings.TrimSpace(candidatePayload.HeadSHA) != head {
+			continue
+		}
+		switch candidate.Type {
+		case "review":
+			if candidate.ID != job.ID &&
+				(JobState(candidate.State) == JobQueued || JobState(candidate.State) == JobRunning) {
+				pending = append(pending, candidate.ID+" ("+candidate.State+")")
+				continue
+			}
+			if candidatePayload.Result == nil || ResultIsFanOut(candidatePayload.Result) {
+				continue
+			}
+			if effectiveReviewDecisionForPayload(candidatePayload, blockingSeverity) != "changes_requested" {
+				continue
+			}
+			// NEWEST OBJECTION WINS, ordered by the row's own updated_at with the id
+			// as a deterministic tie-break. NOT by ListJobs order: engine job ids are
+			// deterministic strings like "review-audit-task-9-review-2", so id order
+			// is lexical and not chronological. I wrote that claim first and it was
+			// wrong; the leg must carry the most recent statement of the objection at
+			// this head, and two rows in the same second must still pick the same one
+			// on every replay.
+			if verdictPayload.Result != nil {
+				if candidate.UpdatedAt < verdictJob.UpdatedAt {
+					continue
+				}
+				if candidate.UpdatedAt == verdictJob.UpdatedAt && candidate.ID <= verdictJob.ID {
+					continue
+				}
+			}
+			verdictJob, verdictPayload = candidate, candidatePayload
+		case "implement":
+			if candidatePayload.FixWorktree {
+				existingLeg = candidate.ID
+			}
+		}
+	}
+	if len(pending) > 0 {
+		sort.Strings(pending)
+		return e.Store.AddJobEvent(ctx, db.JobEvent{
+			JobID: job.ID,
+			Kind:  "auto_fix_deferred_live_sibling",
+			Message: fmt.Sprintf(
+				"auto-fix leg deferred at head %s: sibling review(s) %s have not settled. Dispatching now would push a new head while they are still reading this one, so their verdicts would be stale on arrival; the last review to settle at this head dispatches instead",
+				head, strings.Join(pending, ", ")),
+		})
+	}
+	if existingLeg != "" {
+		return e.Store.AddJobEvent(ctx, db.JobEvent{
+			JobID: job.ID,
+			Kind:  "auto_fix_skipped_head_already_dispatched",
+			Message: fmt.Sprintf(
+				"auto-fix leg not dispatched at head %s: implement job %s already carries this head's fix pass",
+				head, existingLeg),
+		})
+	}
+	if verdictPayload.Result == nil {
+		return nil
+	}
+	return e.dispatchFix(ctx, verdictJob, reviewDecisionAgent(verdictJob, verdictPayload), verdictPayload, *verdictPayload.Result, ref)
+}
+
 func (e Engine) latestReviewRound(ctx context.Context, current JobPayload) (string, error) {
 	jobs, err := e.Store.ListJobs(ctx)
 	if err != nil {

--- a/internal/workflow/engine_run_budgets.go
+++ b/internal/workflow/engine_run_budgets.go
@@ -854,12 +854,32 @@ func (e Engine) AdvanceJob(ctx context.Context, jobID string) (retErr error) {
 			// context and worktree. A durable per-PR enable is the explicit
 			// unattended-chain opt-in for dispatching a fresh implement job (#1712).
 			if configured && !policy.Disabled {
-				if err := e.dispatchFix(ctx, job, reviewer, payload, *payload.Result, ref); err != nil {
+				// #1522: dispatch on the LAST review to settle at this head, not the
+				// first blocking verdict to arrive.
+				if err := e.dispatchFixWhenHeadHasSettled(ctx, job, payload, ref); err != nil {
 					return err
 				}
 			}
 			return nil
 		case "approved":
+			// #1522: AN APPROVAL CAN BE THE LAST REVIEW TO SETTLE AT THIS HEAD, and
+			// when it is, it owes the head's deferred fix leg. Without this the pair
+			// objection-then-approval defers the leg on the objection's arm and then
+			// nobody dispatches it: the approval fixes nothing and the objection's
+			// arm has already returned. That is a deadlock rather than a delay.
+			//
+			// It runs BEFORE the approval's own logic so the ordering is the honest
+			// one: the objection at this head still stands, and the arm below is
+			// already built to hold rather than merge in that case
+			// (approvalSupersedesChangesRequested). Dispatching here therefore
+			// cannot advance a refuted change toward merge.
+			if autoFixPolicy, autoFixConfigured, err := e.Store.PullRequestAutoFixPolicyFor(ctx, payload.Repo, payload.PullRequest); err != nil {
+				return err
+			} else if autoFixConfigured && !autoFixPolicy.Disabled {
+				if err := e.dispatchFixWhenHeadHasSettled(ctx, job, payload, ref); err != nil {
+					return err
+				}
+			}
 			// High-risk review (#650): the native required-reviewer gate approves a PR
 			// as soon as every required reviewer has ONE approving review in the round.
 			// With the lens fan-out that is too weak — a single approving lens (or one

--- a/internal/workflow/engine_split_pair_1522_test.go
+++ b/internal/workflow/engine_split_pair_1522_test.go
@@ -1,0 +1,284 @@
+package workflow
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/gitmoot/gitmoot/internal/db"
+)
+
+// #1522: the fix leg was dispatched on the FIRST blocking verdict at a head, so
+// a cross-family pair that splits is unsatisfiable in one round. The first
+// objection's leg pushes a new head while the sibling is still reading the old
+// one, and the sibling's verdict is stale the moment it lands.
+//
+// MEASURED over the live job store, and larger than the 8 occurrences the issue
+// records: 37 of 334 dispatched fix legs (11.1%) were created while at least one
+// sibling review AT THE SAME HEAD was still running. Those siblings then landed
+// 51 verdicts against a head that no longer existed: 29 approvals at an average
+// of 12.0 minutes late (worst 58 minutes) and 22 further objections at 9.2
+// minutes late.
+//
+// The 29 stale approvals are the merge-integrity half. An "approved" recorded
+// for a commit the fix leg superseded minutes later is a record asserting
+// something it cannot support.
+//
+// NOT REPRODUCED, and reported on the issue rather than fixed: defect (A), "the
+// leg predates the record that authorises it", measured there as -1s in 5 of 5.
+// It does not survive re-derivation against the full store. 325 of 330 matched
+// legs have BOTH the verdict's `succeeded` and its `advance_started` job events
+// stamped before the leg's created_at, so causality is reconstructible from the
+// ordered event log. The -1s is an artifact of comparing against jobs.updated_at,
+// which is the last write to the row and not the verdict time.
+func TestSplitPairDefersTheFixLegUntilTheSiblingReviewSettles(t *testing.T) {
+	ctx := context.Background()
+	store, engine := reviewRefanoutFixture(t)
+	enableAutoFix(t, store, 1678)
+	// The durable implementer attribution row autoFixOwner requires, exactly as
+	// TestFollowUpReviewScopesFindingsAndFilesFromReviewerHead seeds it. Present
+	// here so a run against the pre-fix engine fails on the ORDERING assertion
+	// below rather than on an attribution gap it would hit first.
+	insertCompletedJob(t, store, db.Job{ID: "initial-implement", Agent: "lead", Type: "implement"}, JobPayload{
+		Repo:        "gitmoot/gitmoot",
+		Branch:      "task-1678",
+		PullRequest: 1678,
+		TaskID:      "task-1678",
+		LeadAgent:   "lead",
+	})
+
+	// The sibling family, dispatched at the same head and still running.
+	insertActiveJob(t, store, db.Job{ID: "sibling-claude", Agent: "audit", Type: "review"}, JobPayload{
+		Repo:        "gitmoot/gitmoot",
+		Branch:      "task-1678",
+		PullRequest: 1678,
+		TaskID:      "task-1678",
+		HeadSHA:     "head-one",
+		LeadAgent:   "lead",
+	}, JobRunning)
+
+	insertPriorReviewResult(t, store, "codex-objection", "head-one", AgentResult{
+		Decision: "changes_requested",
+		Summary:  "Three MAJORs on the boundary path.",
+		Findings: []json.RawMessage{
+			json.RawMessage(`{"id":"F-1","file":"internal/boundary.go","summary":"unguarded failure path"}`),
+		},
+	})
+	if err := engine.AdvanceJob(ctx, "codex-objection"); err != nil {
+		t.Fatalf("AdvanceJob objection: %v", err)
+	}
+
+	if _, err := store.GetJob(ctx, "implement-lead-task-1678-review-1"); err == nil {
+		t.Fatal("the fix leg was dispatched while a sibling review at the same head was still running; its verdict is stale on arrival and its round is wasted")
+	}
+	assertJobEvent(t, store, "codex-objection", "auto_fix_deferred_live_sibling", "sibling-claude")
+
+	// The objection must still transition the task. Deferring the WRITER must not
+	// make the PR read as unobjected.
+	assertTaskState(t, store, "task-1678", TaskChangesRequested)
+}
+
+// The deadlock control, and the reason the approving arm is wired to the same
+// helper: a pair that splits objection-then-APPROVAL must still get its fix leg.
+// The approval fixes nothing and the objection's arm has already returned, so
+// without this the leg is deferred and never dispatched.
+func TestSplitPairApprovalIsTheLastSettlerAndOwesTheFixLeg(t *testing.T) {
+	ctx := context.Background()
+	store, engine := reviewRefanoutFixture(t)
+	enableAutoFix(t, store, 1678)
+	// The durable implementer attribution row autoFixOwner requires, exactly as
+	// TestFollowUpReviewScopesFindingsAndFilesFromReviewerHead seeds it. Without
+	// it the dispatch blocks on an attribution gap before it can reach the
+	// ordering this test is about.
+	insertCompletedJob(t, store, db.Job{ID: "initial-implement", Agent: "lead", Type: "implement"}, JobPayload{
+		Repo:        "gitmoot/gitmoot",
+		Branch:      "task-1678",
+		PullRequest: 1678,
+		TaskID:      "task-1678",
+		LeadAgent:   "lead",
+	})
+
+	// The objection already settled at this head, with its leg deferred.
+	insertPriorReviewResult(t, store, "codex-objection", "head-one", AgentResult{
+		Decision: "changes_requested",
+		Summary:  "Three MAJORs on the boundary path.",
+		Findings: []json.RawMessage{
+			json.RawMessage(`{"id":"F-1","file":"internal/boundary.go","summary":"unguarded failure path"}`),
+		},
+	})
+	// The sibling approves the SAME head, and is the last review to settle.
+	insertPriorReviewResult(t, store, "claude-approval", "head-one", AgentResult{
+		Decision: "approved",
+		Summary:  "No blocking findings from this lens.",
+	})
+	if err := engine.AdvanceJob(ctx, "claude-approval"); err != nil {
+		t.Fatalf("AdvanceJob approval: %v", err)
+	}
+
+	fix, err := store.GetJob(ctx, "implement-lead-task-1678-review-1")
+	if err != nil {
+		t.Fatalf("the approving sibling settled last and no fix leg was dispatched, so the objection is stranded: %v", err)
+	}
+	fixPayload, err := unmarshalPayload(fix.Payload)
+	if err != nil {
+		t.Fatalf("unmarshal fix payload: %v", err)
+	}
+	// The leg must carry the OBJECTION's findings, not the approval's silence.
+	if !strings.Contains(fixPayload.Instructions, `"id":"F-1"`) {
+		t.Fatalf("the fix leg dispatched by the approving arm does not carry the objection it exists for: %q", fixPayload.Instructions)
+	}
+}
+
+// One leg per head, built so that #1533's guard CANNOT be what satisfies it:
+// that guard refuses a second writer only while the first is queued or running,
+// so the first leg is SETTLED here before the second objection advances.
+//
+// WHAT THE PRE-FIX ENGINE ACTUALLY DOES, measured rather than assumed, because
+// my first version of this comment guessed wrong. It does not produce two legs
+// in this shape. It fails the second review's advance outright:
+//
+//	AdvanceJob second objection: constraint failed: UNIQUE constraint failed: jobs.id (1555)
+//
+// The fix-leg id is deterministic from task and review round, so two objections
+// in one round derive the SAME id and the second insert collides. The advance
+// therefore never reconciles and the daemon re-drives it on every tick, while
+// the collision is the only thing standing between this PR and a duplicate
+// writer. That is protection by accident: change the id derivation, or let the
+// two objections fall in different rounds, and the duplicate leg is back.
+//
+// After the fix the second objection reaches a DECISION instead of a constraint
+// error: the head already carries a fix pass, so it records that and settles.
+// The distinction phobos asked to keep visible is exactly this: #1533 changed
+// the symptom of a split pair, and only the head rule changes the outcome.
+func TestASecondObjectionAtAnAlreadyDispatchedHeadDoesNotDispatchAgain(t *testing.T) {
+	ctx := context.Background()
+	store, engine := reviewRefanoutFixture(t)
+	enableAutoFix(t, store, 1678)
+	insertCompletedJob(t, store, db.Job{ID: "initial-implement", Agent: "lead", Type: "implement"}, JobPayload{
+		Repo:        "gitmoot/gitmoot",
+		Branch:      "task-1678",
+		PullRequest: 1678,
+		TaskID:      "task-1678",
+		LeadAgent:   "lead",
+	})
+
+	insertPriorReviewResult(t, store, "codex-objection", "head-one", AgentResult{
+		Decision: "changes_requested",
+		Summary:  "First family objection.",
+		Findings: []json.RawMessage{json.RawMessage(`{"id":"F-1","file":"internal/a.go","summary":"first"}`)},
+	})
+	if err := engine.AdvanceJob(ctx, "codex-objection"); err != nil {
+		t.Fatalf("AdvanceJob first objection: %v", err)
+	}
+	first := fixLegIDs(t, store)
+	if len(first) != 1 {
+		t.Fatalf("first objection produced fix legs %v, want exactly 1", first)
+	}
+	// Settle it, so the branch is idle and the concurrency bound cannot be what
+	// refuses the second dispatch.
+	leg, err := store.GetJob(ctx, first[0])
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := store.UpdateJobState(ctx, leg.ID, string(JobSucceeded)); err != nil {
+		t.Fatalf("settle the first leg: %v", err)
+	}
+
+	insertPriorReviewResult(t, store, "claude-objection", "head-one", AgentResult{
+		Decision: "changes_requested",
+		Summary:  "Second family objection at the same head.",
+		Findings: []json.RawMessage{json.RawMessage(`{"id":"F-2","file":"internal/b.go","summary":"second"}`)},
+	})
+	if err := engine.AdvanceJob(ctx, "claude-objection"); err != nil {
+		t.Fatalf("AdvanceJob second objection: %v", err)
+	}
+
+	after := fixLegIDs(t, store)
+	if len(after) != 1 {
+		t.Fatalf("fix legs at one head = %v, want exactly 1; a second leg for a head whose fix pass already landed re-does or conflicts with work that exists", after)
+	}
+}
+
+func fixLegIDs(t *testing.T, store *db.Store) []string {
+	t.Helper()
+	jobs, err := store.ListJobs(context.Background())
+	if err != nil {
+		t.Fatalf("ListJobs: %v", err)
+	}
+	var legs []string
+	for _, candidate := range jobs {
+		if candidate.Type != "implement" {
+			continue
+		}
+		candidatePayload, err := unmarshalPayload(candidate.Payload)
+		if err != nil {
+			t.Fatalf("unmarshal %s: %v", candidate.ID, err)
+		}
+		if candidatePayload.FixWorktree {
+			legs = append(legs, candidate.ID)
+		}
+	}
+	return legs
+}
+
+// The liveness control a deferral guard breaks if it is written carelessly: a
+// SOLE review at a head, with no sibling ever dispatched, must dispatch
+// immediately. Withholding a fix must never become the accidental default.
+func TestSoleObjectionAtAHeadStillDispatchesImmediately(t *testing.T) {
+	ctx := context.Background()
+	store, engine := reviewRefanoutFixture(t)
+	enableAutoFix(t, store, 1678)
+	// The durable implementer attribution row autoFixOwner requires, exactly as
+	// TestFollowUpReviewScopesFindingsAndFilesFromReviewerHead seeds it. Without
+	// it the dispatch blocks on an attribution gap before it can reach the
+	// ordering this test is about.
+	insertCompletedJob(t, store, db.Job{ID: "initial-implement", Agent: "lead", Type: "implement"}, JobPayload{
+		Repo:        "gitmoot/gitmoot",
+		Branch:      "task-1678",
+		PullRequest: 1678,
+		TaskID:      "task-1678",
+		LeadAgent:   "lead",
+	})
+
+	// A settled review at a DIFFERENT head, and an active review on a different
+	// head, neither of which may defer this one.
+	insertPriorReviewResult(t, store, "older-round", "head-zero", AgentResult{
+		Decision: "changes_requested",
+		Summary:  "an objection about a superseded head",
+	})
+	insertActiveJob(t, store, db.Job{ID: "reviewer-on-next-head", Agent: "audit", Type: "review"}, JobPayload{
+		Repo:        "gitmoot/gitmoot",
+		Branch:      "task-1678",
+		PullRequest: 1678,
+		TaskID:      "task-1678",
+		HeadSHA:     "head-two",
+		LeadAgent:   "lead",
+	}, JobRunning)
+
+	insertPriorReviewResult(t, store, "lone-objection", "head-one", AgentResult{
+		Decision: "changes_requested",
+		Summary:  "Fix the boundary check.",
+		Findings: []json.RawMessage{json.RawMessage(`{"id":"F-1","file":"internal/boundary.go","summary":"boundary"}`)},
+	})
+	if err := engine.AdvanceJob(ctx, "lone-objection"); err != nil {
+		t.Fatalf("AdvanceJob lone objection: %v", err)
+	}
+	if _, err := store.GetJob(ctx, "implement-lead-task-1678-review-1"); err != nil {
+		t.Fatalf("a sole objection at its head did not dispatch, so the guard withholds fixes instead of ordering them: %v", err)
+	}
+}
+
+func assertJobEvent(t *testing.T, store *db.Store, jobID string, kind string, mustContain string) {
+	t.Helper()
+	events, err := store.ListJobEvents(context.Background(), jobID)
+	if err != nil {
+		t.Fatalf("ListJobEvents(%s): %v", jobID, err)
+	}
+	for _, event := range events {
+		if event.Kind == kind && strings.Contains(event.Message, mustContain) {
+			return
+		}
+	}
+	t.Fatalf("job %s has no %q event naming %q; the decision is invisible to anyone reading the record. events = %+v", jobID, kind, mustContain, events)
+}


### PR DESCRIPTION
Fixes defect (B) of #1522. Refutes defect (A) with a measurement rather than implementing it.

## Re-derived: (B) is real and larger than recorded

The issue reports 8 occurrences; the campaign parent repeats that number. Over the whole live job store:

```
fix legs with an evaluated head                                334
dispatched while a SIBLING review at the SAME head was running  37   (11.1%)
```

Live siblings per leg: 297 had none, 29 had one, 3 had two, 4 had three, 1 had four.

**The wasted work, which is the cost the issue is really about:**

| sibling verdict | count | avg minutes late |
|---|---|---|
| `approved` | 29 | 12.0 |
| `changes_requested` | 22 | 9.2 |

Worst case 58 minutes: `gitmoot/gitmoot#1556` at head `444618c1`, where `gm-review-kimi` approved a head the fix leg had already superseded. PR #1556 supplies six of the worst ten.

**The 29 stale approvals are why this sits in #1520.** An `approved` recorded for a commit the fix leg superseded minutes later is a record asserting something it cannot support. It is the same disease as the rest of the campaign, arriving through dispatch ordering rather than through a gate.

## Re-derived: (A) does not survive, and I did not implement it

The issue reports Δ = −1s in 5 of 5 between a leg's `created_at` and its triggering verdict's `updated_at`, and concludes that "anyone reconstructing causality from the durable rows sees the effect precede the cause". I cannot support that conclusion. Over all 330 legs I could pair to a triggering verdict (matched on repo, PR, reviewer agent and review round, nearest verdict per leg):

```
verdict `succeeded` event stamped BEFORE the leg's created_at        325
verdict `advance_started` event stamped BEFORE the leg's created_at  325
no settle event at all                                                 0
settle event after the leg                                             5
```

Causality is reconstructible from the durable record via `job_events`, which is the ordered log and carries an `AUTOINCREMENT` id, so even same-second rows have a total order. The issue measured `jobs.updated_at`, which is the last write to the row rather than the verdict time: the advance keeps writing to the review row after dispatching.

The `updated_at` distribution really is what the issue saw (177 of 330 negative, 147 positive, 6 same-second, negatives dominated by −1s and −2s). That is stamping order in one column with different semantics.

So there is no reordering in this PR, and I would argue against one: it would be a change made to satisfy a reading of the wrong column. Reported on the issue so the claim is corrected rather than silently dropped.

## Change

`dispatchFixWhenHeadHasSettled` replaces the direct `dispatchFix` call in the objecting arm, and is also called from the approving arm. It dispatches at most one leg per head, and only once every review at that head has settled.

**Why the approving arm is wired to it, and this is load-bearing rather than tidy.** Without it, an objection-then-approval pair defers the leg on the objection's arm and then nobody dispatches: the approval fixes nothing and the objection's arm has already returned. That is a deadlock, not a delay, and it is the shape #1524 exists for. It runs before the approval's own logic, and that arm already holds rather than merges while an objection stands at the head (`approvalSupersedesChangesRequested`), so dispatching there cannot advance a refuted change toward merge.

**Selection is by `updated_at` with the id as tie-break, not by scan order.** My first version claimed "ListJobs is id-ordered and ids are monotonic per creation". That is false: engine job ids are deterministic strings like `review-audit-task-9-review-2`, so id order is lexical. The comment in the code records that I got it wrong, because the next reader will be tempted by the same shortcut.

**An empty evaluated head falls through to the previous behaviour** rather than deferring. Withholding a fix is a liveness cost and must never be the accidental default.

## What #1533 already covers, and what it does not

#1533's per-branch guard (`76d2ba2f`) refuses a second writer only while the first is queued or running. It changes the **symptom** of a split pair without touching the cause. Measured on base with the first leg SETTLED, so the branch is idle and the concurrency bound cannot apply:

```
AdvanceJob second objection: constraint failed: UNIQUE constraint failed: jobs.id (1555)
```

The fix-leg id is deterministic from task and review round, so two objections in one round derive the same id and the second insert collides. The second review's advance never reconciles and the daemon re-drives it every tick, and that collision is the only thing between this PR and a duplicate writer. Change the id derivation, or let the two objections fall in different rounds, and the duplicate returns. After this change the second objection reaches a recorded decision instead of a constraint error.

This PR also delivers the issue's suggestion 3 in effect: two blocking verdicts at one head produce one leg.

## Tests, and what each one would catch

All four run against base `76d2ba2f`:

1. `TestSplitPairDefersTheFixLegUntilTheSiblingReviewSettles` — base FAILS: `the fix leg was dispatched while a sibling review at the same head was still running`. Also asserts the deferral is RECORDED naming the sibling, and that the objection still transitions the task, so deferring the writer cannot make the PR read as unobjected.
2. `TestSplitPairApprovalIsTheLastSettlerAndOwesTheFixLeg` — base FAILS: `the approving sibling settled last and no fix leg was dispatched, so the objection is stranded: sql: no rows in result set`. Asserts the leg carries the OBJECTION's findings, not the approval's silence.
3. `TestASecondObjectionAtAnAlreadyDispatchedHeadDoesNotDispatchAgain` — base FAILS with the `UNIQUE constraint` error above. The first leg is settled first specifically so #1533's guard cannot be what satisfies it.
4. `TestSoleObjectionAtAHeadStillDispatchesImmediately` — the liveness control, with an unrelated settled review at an OLDER head and an active review at a NEWER head, neither of which may defer this one. Passes on base too, by design: it is a bound on my change, not a reproduction.

I also had to correct my own documented reason for test 3 after measuring it: I had written that base produces two legs, and it does not in that shape. The code comment now states what actually happens.

## Verification

```
go build ./...                             ok
go vet ./...                               ok
go test -count=1 ./internal/workflow/      ok  69.9s
go test -count=1 ./internal/cli/           see the pre-merge comment
```

Run on a frozen detached worktree at the exact commit, one suite at a time. Note for anyone re-verifying locally: `./internal/cli/` fails around 19 tests on any tree when this host is below `DefaultDiskGuardMinFreePercent = 5.0`, because job dispatch is refused; check free space before reading those as a regression.

Deploy notes: no config, no migration, no schema change. Behaviour change: a blocking verdict at a head with an unsettled sibling review records a deferral instead of dispatching, and the last review to settle at that head dispatches instead.
