### PR TITLE
fix(cli): never nag a working seat to finish its deliverable (#1979)

### DIFF
--- a/internal/cli/blocked_since.go
+++ b/internal/cli/blocked_since.go
@@ -76,6 +76,18 @@ type directiveTTLDependencies struct {
 	markDone  func(context.Context, *db.Store, int64, int, string, time.Time) (int, bool, error)
 	exhaust   func(context.Context, *db.Store, int64, time.Time) (bool, error)
 	countOpen func(context.Context, *db.Store) (int, error)
+	// presence overrides the persisted live-pane read that decides whether a
+	// seat is mid-turn (#1979). The sweep deliberately reads the PERSISTED
+	// observation rather than probing Herdr: it runs before this lane takes its
+	// snapshot, and a nag is not worth a subprocess.
+	presence func(context.Context, *db.Store) ([]db.RoleLivePresence, error)
+}
+
+func (d directiveTTLDependencies) livePresence(ctx context.Context, store *db.Store) ([]db.RoleLivePresence, error) {
+	if d.presence != nil {
+		return d.presence(ctx, store)
+	}
+	return store.ListRoleLivePresence(ctx)
 }
 
 func defaultBlockedRoleWakeDependencies() blockedRoleWakeDependencies {
@@ -471,6 +483,7 @@ func evaluateOrgDirectiveTTLs(ctx context.Context, store *db.Store, sink events.
 	if err != nil {
 		return err
 	}
+	workingSeats := directiveWorkingSeats(ctx, store, deps, stdout, now)
 	for _, item := range items {
 		from, to, _, _, ok := workflow.ParseOrgDirectiveNote(item.Body)
 		if !ok {
@@ -485,6 +498,43 @@ func evaluateOrgDirectiveTTLs(ctx context.Context, store *db.Store, sink events.
 		anchor, ttl, phase, unacked, due := directiveTTLDue(item, orgConfig, now)
 		if !due {
 			continue
+		}
+		// #1979: NEVER NAG A SEAT THAT IS WORKING. The completion nag's own text
+		// is "acknowledged but incomplete; finish the assigned deliverable", and
+		// every inbound pane message ends the turn in flight, so delivering it
+		// to a working seat TERMINATES the attempt to finish. Measured across
+		// the fleet's transcripts: 675 such prompts delivered, 1,524 completion
+		// ladder firings recorded, and the directive-driven panes ran a 0.9 to
+		// 4.5 minute median turn against 76 to 345 minute turns in the same
+		// panes when the prompt carried a deliverable instead of a reminder.
+		//
+		// Scoped to the COMPLETION phase on purpose: the acknowledgment request
+		// asks for a receipt the seat has not yet given, so it is not a nag
+		// about unfinished work, and routing receipts off the pane entirely is
+		// its own slice (#1980).
+		if !unacked {
+			switch directiveCompletionNagDecision(workingSeats, to, anchor, ttl, orgConfig.DirectiveMaxNudges(), now) {
+			case directiveNagDefer:
+				writeLine(stdout,
+					"org directive %d completion nudge deferred: %s is working (obligation open %s)",
+					item.ID, to, now.Sub(anchor).Round(time.Second))
+				continue
+			case directiveNagEscalate:
+				// The deferral is BOUNDED. A seat that reports working forever
+				// would otherwise hold an unmet obligation with nothing ever
+				// escalating, which trades one defect for a worse one. Stamp
+				// first so the escalation is at-most-once even if this tick
+				// repeats.
+				if terminated := terminateDirectiveCompletionLadder(ctx, store, deps, item, to, stdout, now); !terminated {
+					continue
+				}
+				events.EmitEvent(ctx, sink,
+					buildDirectiveWorkingEscalationEvent(item, orgConfig, from, to, anchor, now))
+				writeLine(stdout,
+					"org directive %d completion nudge escalated instead of interrupting %s, working past its nudge budget",
+					item.ID, to)
+				continue
+			}
 		}
 		// #1352: each phase advances its OWN counter, so each caps independently.
 		var newCount int
@@ -514,27 +564,133 @@ func evaluateOrgDirectiveTTLs(ctx context.Context, store *db.Store, sink events.
 			// is its own counter at the cap — pre-existing, queryable, and it does
 			// not block the phase that follows it.
 			if !unacked {
-				if stamped, err := deps.markExhausted(ctx, store, item, now); err != nil {
-					writeLine(stdout, "org directive %d exhausted mark failed: %v", item.ID, err)
-				} else if stamped {
-					// #1352 B1: the COLUMN alone was invisible to operators — Comms
-					// builds threads from NOTES, so a column-only terminal state showed
-					// no thread at all. The marker is what makes exhaustion discoverable;
-					// the column stays for the evaluator's own reads.
-					if _, err := store.InsertWorkflowNote(ctx, db.WorkflowNote{
-						WorkflowID: item.WorkflowID,
-						Author:     to,
-						Body:       workflow.FormatOrgDirectiveExhaustedNote(item.ID, to),
-						Repo:       item.Repo,
-					}); err != nil {
-						writeLine(stdout, "org directive %d exhausted marker note failed: %v", item.ID, err)
-					}
+				if terminateDirectiveCompletionLadder(ctx, store, deps, item, to, stdout, now) {
 					writeLine(stdout, "org directive %d %s ladder exhausted after %d nudges; obligation remains open and queryable", item.ID, phase, newCount)
 				}
 			}
 		}
 	}
 	return nil
+}
+
+// directiveWorkingPresenceFreshness bounds how old a `working` observation may
+// be and still suppress a nag. The lane that persists live presence runs every
+// blockedRoleWakeInterval, so five intervals tolerate missed ticks while
+// refusing to trust an observation from a pane that has since gone away.
+const directiveWorkingPresenceFreshness = 5 * blockedRoleWakeInterval
+
+type directiveNagDecision uint8
+
+const (
+	directiveNagDeliver directiveNagDecision = iota
+	directiveNagDefer
+	directiveNagEscalate
+)
+
+// directiveWorkingSeats returns the roles whose persisted pane observation is a
+// FRESH `working`. An unreadable presence store yields an empty set, so the
+// ladder behaves exactly as it did before #1979: failing toward delivering the
+// nag is the conservative direction, because a missed nag is a missed
+// obligation while a spurious one is only an interrupt.
+func directiveWorkingSeats(ctx context.Context, store *db.Store, deps directiveTTLDependencies, stdout io.Writer, now time.Time) map[string]struct{} {
+	working := map[string]struct{}{}
+	rows, err := deps.livePresence(ctx, store)
+	if err != nil {
+		writeLine(stdout, "org directive nudge presence read failed, nudging as if idle: %v", err)
+		return working
+	}
+	for _, row := range rows {
+		if !strings.EqualFold(strings.TrimSpace(row.State), string(org.StateWorking)) {
+			continue
+		}
+		observedAt := parseTranscriptStoreTime(row.ObservedAt)
+		if observedAt.IsZero() || now.Sub(observedAt) > directiveWorkingPresenceFreshness {
+			continue
+		}
+		working[strings.ToLower(strings.TrimSpace(row.Role))] = struct{}{}
+	}
+	return working
+}
+
+// directiveCompletionNagDecision decides between the seat and its supervisor.
+// A working seat is not interrupted, but the deferral is bounded by the ladder
+// the nag would otherwise have run: past anchor + ttl*(max_nudges+1) the whole
+// ladder could have fired, so the obligation escalates instead of waiting on a
+// turn that may never end.
+func directiveCompletionNagDecision(
+	working map[string]struct{},
+	target string,
+	anchor time.Time,
+	ttl time.Duration,
+	maxNudges int,
+	now time.Time,
+) directiveNagDecision {
+	if _, ok := working[strings.ToLower(strings.TrimSpace(target))]; !ok {
+		return directiveNagDeliver
+	}
+	if anchor.IsZero() || ttl <= 0 || maxNudges <= 0 {
+		return directiveNagDeliver
+	}
+	if now.After(anchor.Add(ttl * time.Duration(maxNudges+1))) {
+		return directiveNagEscalate
+	}
+	return directiveNagDefer
+}
+
+// terminateDirectiveCompletionLadder stamps the completion phase terminal and
+// records the operator-visible marker note (#1352 B1). It reports whether THIS
+// call performed the stamp, so a caller can emit exactly one escalation even if
+// its tick repeats.
+func terminateDirectiveCompletionLadder(
+	ctx context.Context,
+	store *db.Store,
+	deps directiveTTLDependencies,
+	item db.OrgDirectiveObligation,
+	target string,
+	stdout io.Writer,
+	now time.Time,
+) bool {
+	stamped, err := deps.markExhausted(ctx, store, item, now)
+	if err != nil {
+		writeLine(stdout, "org directive %d exhausted mark failed: %v", item.ID, err)
+		return false
+	}
+	if !stamped {
+		return false
+	}
+	if _, err := store.InsertWorkflowNote(ctx, db.WorkflowNote{
+		WorkflowID: item.WorkflowID,
+		Author:     target,
+		Body:       workflow.FormatOrgDirectiveExhaustedNote(item.ID, target),
+		Repo:       item.Repo,
+	}); err != nil {
+		writeLine(stdout, "org directive %d exhausted marker note failed: %v", item.ID, err)
+	}
+	return true
+}
+
+// buildDirectiveWorkingEscalationEvent tells the SENDER'S PARENT that an
+// obligation is unmet while its seat is working, rather than interrupting the
+// seat with the same information (#1979). It keeps the shape of the ordinary
+// ladder escalation so routing and delivery are unchanged.
+func buildDirectiveWorkingEscalationEvent(
+	item db.OrgDirectiveObligation,
+	orgConfig config.OrgConfig,
+	sender, target string,
+	anchor time.Time,
+	now time.Time,
+) events.Event {
+	id := fmt.Sprint(item.ID)
+	detail := fmt.Sprintf(
+		"directive %s to %s remains incomplete after %s while %s is working; escalated instead of interrupting the seat",
+		id, target, now.Sub(anchor).Round(time.Second), target,
+	)
+	ev := events.NewEvent(events.EventJobNeedsAttention, "org-directive:"+id, db.WakeOutboxSourceWorkflowNote+":"+id, item.Repo, "overdue", detail, now, workflow.RedactCommentText)
+	ev.Cause = "escalation"
+	if role, ok := orgConfig.Role(sender); ok {
+		ev.WakeTargetRole = role.Parent
+	}
+	return ev
 }
 
 func directiveTTLDue(item db.OrgDirectiveObligation, orgConfig config.OrgConfig, now time.Time) (anchor time.Time, ttl time.Duration, phase string, unacked, due bool) {

--- a/internal/cli/doctor_event_observers.go
+++ b/internal/cli/doctor_event_observers.go
@@ -33,6 +33,13 @@ var wakeTargetRoleProducers = []wakeTargetRoleProducer{
 		Kinds:    directiveEscalationDirectedKinds,
 	},
 	{
+		// #1979: the same escalation route as the ladder's terminal escalation,
+		// taken when a completion nag would otherwise interrupt a working seat.
+		File:     "internal/cli/blocked_since.go",
+		Function: "buildDirectiveWorkingEscalationEvent",
+		Kinds:    directiveEscalationDirectedKinds,
+	},
+	{
 		File:     "internal/cli/event_rule_sink.go",
 		Function: "addressBlockedEvent",
 		Kinds:    blockedWakeDirectedKinds,

--- a/internal/cli/event_rule_sink_test.go
+++ b/internal/cli/event_rule_sink_test.go
@@ -176,7 +176,7 @@ func TestClassifyEventRuleKinds(t *testing.T) {
 
 func TestWakeTargetRoleProductionWritesMatchObserverRegistry(t *testing.T) {
 	writes := productionWakeTargetRoleWrites(t)
-	if got, want := fmt.Sprint(writes), "[internal/cli/blocked_since.go:buildDirectiveEscalationEvent internal/cli/blocked_since.go:buildDirectiveNudgeEvent internal/cli/blocked_since.go:emitInputPendingEpisode internal/cli/event_rule_sink.go:addressBlockedEvent internal/cli/event_sink.go:emitDaemonTerminalEvent internal/cli/reply_wake_outbox.go:wakeOutboxEvent internal/daemon/task_disposal.go:strandTask internal/workflow/engine_types.go:mailbox]"; got != want {
+	if got, want := fmt.Sprint(writes), "[internal/cli/blocked_since.go:buildDirectiveEscalationEvent internal/cli/blocked_since.go:buildDirectiveNudgeEvent internal/cli/blocked_since.go:buildDirectiveWorkingEscalationEvent internal/cli/blocked_since.go:emitInputPendingEpisode internal/cli/event_rule_sink.go:addressBlockedEvent internal/cli/event_sink.go:emitDaemonTerminalEvent internal/cli/reply_wake_outbox.go:wakeOutboxEvent internal/daemon/task_disposal.go:strandTask internal/workflow/engine_types.go:mailbox]"; got != want {
 		t.Fatalf("production WakeTargetRole writes = %s, want %s", got, want)
 	}
 	registryWrites := make([]wakeTargetRoleWrite, 0, len(wakeTargetRoleProducers))

--- a/internal/cli/org_directive_ttl_test.go
+++ b/internal/cli/org_directive_ttl_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/gitmoot/gitmoot/internal/db"
 	"github.com/gitmoot/gitmoot/internal/db/dbtest"
 	"github.com/gitmoot/gitmoot/internal/events"
+	"github.com/gitmoot/gitmoot/internal/org"
 	"github.com/gitmoot/gitmoot/internal/workflow"
 )
 
@@ -276,6 +277,140 @@ func TestDirectiveTTLAckSkipsAckNudgesAndDoneOverrideWins(t *testing.T) {
 	}
 	if got := readDirectiveTTLObligation(t, store, ackOnly.ID).NudgeCount; got != 0 {
 		t.Fatalf("acked directive got %d ack nudges, want 0", got)
+	}
+}
+
+// TestDirectiveCompletionNagDefersWhileSeatIsWorking is #1979's reproduction.
+// The completion nag reads "acknowledged but incomplete; finish the assigned
+// deliverable", and every inbound pane message ends the turn in flight, so
+// delivering it to a seat that IS working terminates the attempt to finish.
+// Measured across the fleet's own transcripts: 675 such prompts, and 1,524
+// completion-ladder firings recorded in the store.
+func TestDirectiveCompletionNagDefersWhileSeatIsWorking(t *testing.T) {
+	home := t.TempDir()
+	cfg := writeDirectiveTTLConfig(t, home, "supervisor", 10*time.Minute, time.Hour, 3)
+	store := openDirectiveTTLStore(t, home)
+	defer store.Close()
+	ctx := context.Background()
+	directive := seedDirectiveTTLNote(t, store, "carry this to completion", 0, false)
+	acknowledgeDirectiveTTLNote(t, store, directive)
+	now := time.Now().UTC().Add(2 * time.Hour)
+	// The seat is mid-turn at the moment the nag comes due.
+	if err := store.UpsertRoleLivePresence(ctx, "worker", string(org.StateWorking), now.Add(-30*time.Second)); err != nil {
+		t.Fatal(err)
+	}
+	sink := &recordingSink{}
+	if err := evaluateOrgDirectiveTTLs(ctx, store, sink, cfg, io.Discard, now, directiveTTLDependencies{}); err != nil {
+		t.Fatal(err)
+	}
+	if wakes := sink.byType(events.EventOrgDirective); len(wakes) != 0 {
+		t.Fatalf("nagged a working seat: %+v", wakes)
+	}
+	// The ladder must not spend a nudge on an undelivered nag either, or the
+	// seat loses its escalation budget while it is working.
+	if got := readDirectiveTTLObligation(t, store, directive.ID).DoneNudgeCount; got != 0 {
+		t.Fatalf("done nudge count while working = %d, want 0", got)
+	}
+
+	// Once the seat stops, the deferred nag fires: deferral is not suppression.
+	if err := store.UpsertRoleLivePresence(ctx, "worker", string(org.StateIdle), now.Add(time.Minute)); err != nil {
+		t.Fatal(err)
+	}
+	if err := evaluateOrgDirectiveTTLs(ctx, store, sink, cfg, io.Discard, now.Add(2*time.Minute), directiveTTLDependencies{}); err != nil {
+		t.Fatal(err)
+	}
+	wakes := sink.byType(events.EventOrgDirective)
+	if len(wakes) != 1 || wakes[0].WakeTargetRole != "worker" || wakes[0].Cause != directiveCompletionOverdueCause {
+		t.Fatalf("post-idle completion wake = %+v, want one completion nag to worker", wakes)
+	}
+	if got := readDirectiveTTLObligation(t, store, directive.ID).DoneNudgeCount; got != 1 {
+		t.Fatalf("done nudge count after idle = %d, want 1", got)
+	}
+}
+
+// TestDirectiveCompletionNagIgnoresUnusableWorkingSignal keeps the deferral
+// narrow. A pane whose observation is stale, or whose state is anything other
+// than `working` (a closed pane reports `unknown`), must not silence the
+// ladder: an obligation to a seat nobody is running has to escalate.
+func TestDirectiveCompletionNagIgnoresUnusableWorkingSignal(t *testing.T) {
+	for _, test := range []struct {
+		name       string
+		state      string
+		observedAt func(time.Time) time.Time
+	}{
+		{name: "stale working observation", state: string(org.StateWorking), observedAt: func(now time.Time) time.Time {
+			return now.Add(-directiveWorkingPresenceFreshness - time.Minute)
+		}},
+		{name: "closed pane reports unknown", state: string(org.StateUnknown), observedAt: func(now time.Time) time.Time {
+			return now.Add(-time.Second)
+		}},
+		{name: "seat is done", state: string(org.StateDone), observedAt: func(now time.Time) time.Time {
+			return now.Add(-time.Second)
+		}},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			home := t.TempDir()
+			cfg := writeDirectiveTTLConfig(t, home, "supervisor", 10*time.Minute, time.Hour, 3)
+			store := openDirectiveTTLStore(t, home)
+			defer store.Close()
+			ctx := context.Background()
+			directive := seedDirectiveTTLNote(t, store, "unusable signal", 0, false)
+			acknowledgeDirectiveTTLNote(t, store, directive)
+			now := time.Now().UTC().Add(2 * time.Hour)
+			if err := store.UpsertRoleLivePresence(ctx, "worker", test.state, test.observedAt(now)); err != nil {
+				t.Fatal(err)
+			}
+			sink := &recordingSink{}
+			if err := evaluateOrgDirectiveTTLs(ctx, store, sink, cfg, io.Discard, now, directiveTTLDependencies{}); err != nil {
+				t.Fatal(err)
+			}
+			if wakes := sink.byType(events.EventOrgDirective); len(wakes) != 1 {
+				t.Fatalf("completion wakes = %+v, want one; an unusable working signal must not defer", wakes)
+			}
+		})
+	}
+}
+
+// TestDirectiveCompletionNagEscalatesInsteadOfNaggingAnEndlessTurn bounds the
+// deferral. A seat that reports `working` forever would otherwise hold an
+// unmet obligation with nothing ever escalating, which trades one defect for
+// a worse one. Past the ladder's own budget the supervisor is told instead of
+// the worker being interrupted.
+func TestDirectiveCompletionNagEscalatesInsteadOfNaggingAnEndlessTurn(t *testing.T) {
+	home := t.TempDir()
+	cfg := writeDirectiveTTLConfig(t, home, "supervisor", 10*time.Minute, time.Hour, 3)
+	store := openDirectiveTTLStore(t, home)
+	defer store.Close()
+	ctx := context.Background()
+	directive := seedDirectiveTTLNote(t, store, "endless turn", 0, false)
+	acknowledgeDirectiveTTLNote(t, store, directive)
+	// Past ack + done_ttl * (max_nudges + 1): the whole ladder could have run.
+	now := time.Now().UTC().Add(5 * time.Hour)
+	if err := store.UpsertRoleLivePresence(ctx, "worker", string(org.StateWorking), now.Add(-time.Second)); err != nil {
+		t.Fatal(err)
+	}
+	sink := &recordingSink{}
+	for range 2 {
+		if err := evaluateOrgDirectiveTTLs(ctx, store, sink, cfg, io.Discard, now, directiveTTLDependencies{}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if wakes := sink.byType(events.EventOrgDirective); len(wakes) != 0 {
+		t.Fatalf("nagged the working seat instead of escalating: %+v", wakes)
+	}
+	escalations := sink.byType(events.EventJobNeedsAttention)
+	if len(escalations) != 1 {
+		t.Fatalf("escalations = %+v, want exactly one past the deferral budget", escalations)
+	}
+	event := escalations[0]
+	if event.WakeTargetRole != "supervisor" || event.Cause != "escalation" {
+		t.Fatalf("escalation routing = %+v, want the sender's parent", event)
+	}
+	if !strings.Contains(event.Detail, "working") || !strings.Contains(event.Detail, "incomplete") {
+		t.Fatalf("escalation detail = %q, want it to name the working seat and the unmet obligation", event.Detail)
+	}
+	if item := readDirectiveTTLObligation(t, store, directive.ID); item.ExhaustedAt == "" {
+		t.Fatalf("obligation = %+v, want the completion ladder stamped terminal once escalated", item)
 	}
 }
 

--- a/skills/gitmoot/references/CLI.md
+++ b/skills/gitmoot/references/CLI.md
@@ -1849,6 +1849,24 @@ newer ones out of the window. TTL nags are delivered through the durable wake
 outbox with coalescing, like blocked and escalation wakes, rather than one live
 prompt per due directive per sweep.
 
+A completion nudge is **not delivered to a seat that is working**. The nudge
+says "acknowledged but incomplete; finish the assigned deliverable", and an
+inbound pane message ends the turn in flight, so nagging a working seat
+terminates the attempt to finish. The sweep reads the persisted live-pane
+observation: a `working` state observed within the last five minutes defers the
+nudge without spending a ladder step, and the nudge fires on the first sweep
+after the seat stops or is superseded by the completion receipt arriving. Any
+other state, including the `unknown` a closed pane reports, and any staler
+observation, deliver the nudge exactly as before.
+
+The deferral is bounded. Past `anchor + directive_done_ttl * (directive_max_nudges + 1)`,
+the point at which the whole ladder could have run, Gitmoot escalates to the
+sender's current parent instead of interrupting the seat, stamps
+`directive_exhausted_at` and records the marker note. A seat that reports
+`working` forever therefore cannot hold an unmet obligation in silence, and it
+is still never interrupted. The acknowledgment phase is unaffected: a receipt
+request is not a nag about unfinished work.
+
 The daemon evaluates directive TTLs on the existing one-minute org supervision
 lane. `[org].directive_ack_ttl` defaults to `10m`,
 `[org].directive_done_ttl` defaults to `0s` (completion nudges off), and

--- a/website/docs/reference/cli.md
+++ b/website/docs/reference/cli.md
@@ -1581,6 +1581,24 @@ newer ones out of the window. TTL nags are delivered through the durable wake
 outbox with coalescing, like blocked and escalation wakes, rather than one live
 prompt per due directive per sweep.
 
+A completion nudge is **not delivered to a seat that is working**. The nudge
+says "acknowledged but incomplete; finish the assigned deliverable", and an
+inbound pane message ends the turn in flight, so nagging a working seat
+terminates the attempt to finish. The sweep reads the persisted live-pane
+observation: a `working` state observed within the last five minutes defers the
+nudge without spending a ladder step, and the nudge fires on the first sweep
+after the seat stops or is superseded by the completion receipt arriving. Any
+other state, including the `unknown` a closed pane reports, and any staler
+observation, deliver the nudge exactly as before.
+
+The deferral is bounded. Past `anchor + directive_done_ttl * (directive_max_nudges + 1)`,
+the point at which the whole ladder could have run, Gitmoot escalates to the
+sender's current parent instead of interrupting the seat, stamps
+`directive_exhausted_at` and records the marker note. A seat that reports
+`working` forever therefore cannot hold an unmet obligation in silence, and it
+is still never interrupted. The acknowledgment phase is unaffected: a receipt
+request is not a nag about unfinished work.
+
 The daemon evaluates directive TTLs on the existing one-minute org supervision
 lane. `[org].directive_ack_ttl` defaults to `10m`,
 `[org].directive_done_ttl` defaults to `0s` (completion nudges off), and


### PR DESCRIPTION
Fixes #1979. Part of the #1977 campaign.

## The headline

**424 of 675 completion nags, 62.9%, arrived within TEN SECONDS of the seat's own last output. Median gap: 0.1 seconds.**

That is not a coordinator checking on an idle seat. It is a prompt reading "acknowledged but incomplete; finish the assigned deliverable" landing on a seat mid-sentence, and every inbound pane message ends the turn in flight. The nag was terminating the attempt to finish.

## How that number was derived

Source: the seats' own omp session transcripts under `/root/.omp/agent/sessions/`, read-only. I counted only JSONL entries with `message.role == "user"` whose body contains the nag string, which excludes the tool results a naive grep picks up when a seat greps its own source. `__advisor.handoff.jsonl` is excluded because it duplicates its pane's session. For each such prompt I measured the gap back to that session's own most recent non-user message, which is the seat producing output.

The window is **everything before 2026-09-07T14:40Z**, deliberately. PHOBOS retired the coordinator layer and removed four wake routes this afternoon, and both suppress nag traffic independently of this fix; measuring across that boundary would credit my code with an org change.

| Gap between the seat's last output and the nag arriving | Nags | Share |
| --- | --- | --- |
| within 10s | **424** | **62.9%** |
| within 30s | 432 | 64.1% |
| within 60s | 436 | 64.7% |
| within 300s | 514 | 76.3% |

675 nag prompts in the window, 674 with a measurable preceding gap. The store-side count is larger and independent of pane lifetime: `directive_done_nudge_count` summed over 2,899 directives is **1,524 completion-ladder firings**, against 390 acknowledgment-phase nudges. Top target roles: `gitmoot` 252, `numbra` 148, `joltra` 138, `apps-coc` 136, `herdr-app` 129, `gm-omp-impl` 93. The affected set is wider than the gm-* seats named in the issue.

Frozen pre-change baseline for a later before/after: `/tmp/gmt-measure/baseline-1979.json` on this host, and https://github.com/gitmoot/gitmoot/issues/1979#issuecomment-5572006139.

## The change

`evaluateOrgDirectiveTTLs` reads the persisted live-pane observation once per sweep, before it claims a ladder step.

- **Deferral.** A completion nudge whose target is `working`, observed within `directiveWorkingPresenceFreshness` (5 lane intervals, 5 minutes), is not emitted and does not spend a nudge. Not spending the nudge matters: a seat must not lose its escalation budget to nags nobody delivered.
- **Release.** The nudge fires on the first sweep after the seat leaves `working`, or is superseded by the completion receipt arriving. Deferral, not suppression.
- **Bound.** Past `anchor + done_ttl * (max_nudges + 1)`, the point at which the whole ladder could have run, the obligation escalates to the sender's current parent, stamps `directive_exhausted_at` and records the `[org:directive-exhausted ]` marker note. A seat that reports `working` forever therefore cannot hold an unmet obligation in silence, and it is still never interrupted. The stamp happens before the emit, so the escalation is at-most-once even if a tick repeats.
- **Narrow on purpose.** Any other state, including the `unknown` a closed pane reports, and any staler observation, deliver the nudge exactly as before. An unreadable presence store nudges as if idle: failing toward delivering is the conservative direction, because a missed nag is a missed obligation while a spurious one is only an interrupt.
- **Acknowledgment phase untouched.** A receipt request is not a nag about unfinished work, and routing receipts off the pane is #1980.

Why persisted presence and not a Herdr probe: `evaluateOrgDirectiveTTLs` deliberately runs before this lane takes its snapshot and is documented as not depending on one. `org_role_live_presence` is written every tick the lane reaches Herdr, so the observation is at most one minute old, and the freshness bound refuses it once it is not.

## Tests that fail before and pass after

Three tests in `internal/cli/org_directive_ttl_test.go`:

1. `TestDirectiveCompletionNagDefersWhileSeatIsWorking` (positive): a due completion nag with the seat `working` emits nothing and leaves `directive_done_nudge_count` at 0; once presence flips to `idle` the same obligation emits exactly one completion nag and the counter reaches 1.
2. `TestDirectiveCompletionNagIgnoresUnusableWorkingSignal` (negative control): a stale `working` observation, a `unknown` closed pane, and a `done` seat each still get their nag.
3. `TestDirectiveCompletionNagEscalatesInsteadOfNaggingAnEndlessTurn` (bound): past the budget, two sweeps produce zero seat nags and exactly one escalation to `supervisor`, whose detail names both `working` and `incomplete`, with the obligation stamped terminal.

Discrimination was checked with a mutant rather than by asserting they pass. Forcing `directiveCompletionNagDecision` to always deliver, which is the pre-fix behaviour, and re-running:

```
--- FAIL: TestDirectiveCompletionNagDefersWhileSeatIsWorking
    nagged a working seat: [... Detail:directive 1 to worker awaits completion after 2h0m1s; nudge 1
                                Cause:directive_completion_overdue WakeTargetRole:worker]
--- FAIL: TestDirectiveCompletionNagEscalatesInsteadOfNaggingAnEndlessTurn
    nagged the working seat instead of escalating: [... Cause:directive_completion_overdue
                                WakeTargetRole:worker]
```

Both positive tests die on the mutant; the negative control passes on both versions, which is what makes it a control rather than a duplicate.

## Config

None changed. `directive_done_ttl = "1h"` stays exactly as the owner set it, which is what makes completion nags active fleet-wide; this PR changes when one may be delivered, not whether the obligation exists. No new config value was needed, since the freshness bound derives from the existing lane interval.

## Verification

Branched from `dd8b433f`'s tree (`main` at merge time). With go1.26.4 pinned: `go build -buildvcs=false ./...`, `go vet ./...`, and `go test -count=1 -timeout 25m ./...` all pass with zero failures. `-race` is CI's shards, since race requires cgo, which this repo's gate documents as unavailable locally.

`TestWakeTargetRoleProductionWritesMatchObserverRegistry` forced a deliberate registration: the new escalation builder is added to `wakeTargetRoleProducers` with the same directed kind as the ladder's existing escalation, so `gitmoot doctor`'s wake-coverage warnings keep seeing every production `WakeTargetRole` write.

## Not verified

- No live probe. This is daemon sweep behaviour and deploys are owner-gated. The right production evidence is a `completion nudge deferred` line in the daemon log for a seat that is working, and the absence of a nag prompt in that seat's transcript for the same minute. I will run it after a deploy if asked.
- The before/after transcript count cannot be closed by me today: the coordinator retirement removes nag traffic on its own, so the after-number will be dominated by the org change. The frozen baseline plus the mid-output share above is what a later comparison should be scored against, per-directive rather than fleet-total.

Deploy notes: no migration, no config change. Behaviour is confined to the one-minute org supervision lane, so a daemon restart picks it up.
