### PR TITLE
fix(workflow): a task under repair is not mergeable, and the transition is recorded (#1555)

### DIFF
--- a/internal/cli/daemon_workflow.go
+++ b/internal/cli/daemon_workflow.go
@@ -732,6 +732,9 @@ func (g daemonMergeGate) Evaluate(ctx context.Context, request workflow.MergeReq
 			Deferred:   true,
 			Reason:     workflow.PlainReason(fmt.Sprintf("active %s job %s in flight on branch %s; holding merge until it settles", active.Type, active.ID, request.Branch)),
 			BlockClass: workflow.MergeBlockTransient,
+			// #1555: name the writer so the engine can refuse to call the task
+			// mergeable while it holds the branch, without matching this sentence.
+			HeldByJob: active.ID,
 		}, nil
 	}
 	// Resolve the policy before looking up a checkout.

--- a/internal/workflow/engine_ready_to_merge_audit_1555_test.go
+++ b/internal/workflow/engine_ready_to_merge_audit_1555_test.go
@@ -1,0 +1,169 @@
+package workflow
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/gitmoot/gitmoot/internal/db"
+)
+
+// #1555, as re-scoped by its own 2026-09-03 verification: (a) a Deferred merge
+// decision must not become ready_to_merge while a fix leg holds the branch, and
+// (b) the ready_to_merge transition must emit a task_event.
+//
+// MEASURED ON PR #1546. A reviewer reproduced a host escape with a compiled
+// probe ("a temporary implemented second backend executed locally and finished
+// succeeded"), the engine dispatched the fix leg for it at 20:18:04, the verdict
+// landed at 20:18:06, and at 20:21:12 two later approvals drove the task to
+// ready_to_merge WHILE that leg was still running. `task_events` held ZERO rows
+// for the transition. The only operation the engine would then accept was the
+// merge, so a coordinator reading `gitmoot task list` plus an approval count
+// would have shipped the escape.
+//
+// Two of the issue's four original asks were WITHDRAWN by its author after
+// checking: the fix-pass refusal was correct and protective, and the escape
+// hatch (`task dismiss`/`recover`/`resume-work`/`events`) exists. Neither is
+// touched here.
+func TestDeferredMergeDoesNotCallATaskMergeableWhileAWriterHoldsTheBranch(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	engine := testEngine(store)
+	ref := seedReadyToMergeTask(t, store, TaskChangesRequested)
+
+	engine.MergeGate = stubMergeGate{decision: MergeDecision{
+		Deferred:   true,
+		BlockClass: MergeBlockTransient,
+		Reason:     PlainReason("active implement job fix-leg-1 in flight on branch task-1546; holding merge until it settles"),
+		HeldByJob:  "fix-leg-1",
+	}}
+
+	if _, err := engine.runMergeGate(ctx, "reviewer", readyToMergePayload(), ref, TaskChangesRequested); err != nil {
+		t.Fatalf("runMergeGate: %v", err)
+	}
+
+	task, err := store.GetTask(ctx, ref.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if task.State == string(TaskReadyToMerge) {
+		t.Fatal("the task was called ready_to_merge while a writer still owned the branch and an objection stood at this head; a task cannot be mergeable and under repair at once")
+	}
+	if task.State != string(TaskChangesRequested) {
+		t.Fatalf("task state = %q, want the arriving %q preserved", task.State, TaskChangesRequested)
+	}
+	assertTaskEvent(t, store, ref.ID, "merge_deferred_branch_held", "fix-leg-1")
+}
+
+// (b), and the half that is pure addition: the transition that DOES happen must
+// be auditable. Without this an operator sees the strongest merge signal the
+// engine produces and can never learn what produced it.
+func TestReadyToMergeTransitionsAreRecordedInTaskEvents(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("ready", func(t *testing.T) {
+		store := openEngineStore(t)
+		engine := testEngine(store)
+		ref := seedReadyToMergeTask(t, store, TaskReviewing)
+		engine.MergeGate = stubMergeGate{decision: MergeDecision{
+			Ready:  true,
+			Reason: PlainReason("every required reviewer approved at the evaluated head"),
+		}}
+		if _, err := engine.runMergeGate(ctx, "reviewer", readyToMergePayload(), ref, TaskReviewing); err != nil {
+			t.Fatalf("runMergeGate: %v", err)
+		}
+		assertTaskState(t, store, ref.ID, TaskReadyToMerge)
+		assertTaskEvent(t, store, ref.ID, "task_ready_to_merge", "every required reviewer approved")
+	})
+
+	// A deferral that is NOT a branch hold still parks in ready_to_merge, because
+	// that is what the merge poll re-drives. It must say so rather than looking
+	// like a clean approval: same state, different recorded reason.
+	t.Run("deferred_without_a_branch_hold", func(t *testing.T) {
+		store := openEngineStore(t)
+		engine := testEngine(store)
+		ref := seedReadyToMergeTask(t, store, TaskReviewing)
+		engine.MergeGate = stubMergeGate{decision: MergeDecision{
+			Deferred:   true,
+			BlockClass: MergeBlockTransient,
+			Reason:     PlainReason("pull request head is not observable yet"),
+		}}
+		if _, err := engine.runMergeGate(ctx, "reviewer", readyToMergePayload(), ref, TaskReviewing); err != nil {
+			t.Fatalf("runMergeGate: %v", err)
+		}
+		assertTaskState(t, store, ref.ID, TaskReadyToMerge)
+		assertTaskEvent(t, store, ref.ID, "task_ready_to_merge_deferred", "not observable yet")
+	})
+}
+
+// The bound on (a), and the case that decides whether this is a scoped refusal
+// or a liveness regression: a branch hold on a task that is NOT carrying an
+// objection must still park in ready_to_merge, or a transient hold on an
+// ordinary reviewing task would stop being re-driven by the merge poll.
+func TestBranchHeldDeferralStillParksATaskThatCarriesNoObjection(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	engine := testEngine(store)
+	ref := seedReadyToMergeTask(t, store, TaskReviewing)
+	engine.MergeGate = stubMergeGate{decision: MergeDecision{
+		Deferred:   true,
+		BlockClass: MergeBlockTransient,
+		Reason:     PlainReason("active ask job helper-1 in flight on branch task-1546; holding merge until it settles"),
+		HeldByJob:  "helper-1",
+	}}
+	if _, err := engine.runMergeGate(ctx, "reviewer", readyToMergePayload(), ref, TaskReviewing); err != nil {
+		t.Fatalf("runMergeGate: %v", err)
+	}
+	assertTaskState(t, store, ref.ID, TaskReadyToMerge)
+	assertTaskEvent(t, store, ref.ID, "task_ready_to_merge_deferred", "helper-1")
+}
+
+type stubMergeGate struct {
+	decision MergeDecision
+}
+
+func (s stubMergeGate) Evaluate(context.Context, MergeRequest) (MergeDecision, error) {
+	return s.decision, nil
+}
+
+func seedReadyToMergeTask(t *testing.T, store *db.Store, state TaskState) taskRef {
+	t.Helper()
+	task := db.Task{
+		ID:           "task-1546",
+		RepoFullName: "gitmoot/gitmoot",
+		GoalID:       "goal-1546",
+		Title:        "E2B execution backend",
+		Branch:       "task-1546",
+		State:        string(state),
+	}
+	if err := store.UpsertTask(context.Background(), task); err != nil {
+		t.Fatalf("UpsertTask: %v", err)
+	}
+	return taskRef{ID: task.ID, Repo: task.RepoFullName, GoalID: task.GoalID, Title: task.Title, Branch: task.Branch}
+}
+
+func readyToMergePayload() JobPayload {
+	return JobPayload{
+		Repo:        "gitmoot/gitmoot",
+		Branch:      "task-1546",
+		PullRequest: 1546,
+		HeadSHA:     "36f7c70122b3",
+		TaskID:      "task-1546",
+		GoalID:      "goal-1546",
+		LeadAgent:   "wave-impl",
+	}
+}
+
+func assertTaskEvent(t *testing.T, store *db.Store, taskID string, kind string, mustContain string) {
+	t.Helper()
+	events, err := store.ListTaskEvents(context.Background(), taskID)
+	if err != nil {
+		t.Fatalf("ListTaskEvents(%s): %v", taskID, err)
+	}
+	for _, event := range events {
+		if event.Kind == kind && strings.Contains(event.Reason, mustContain) {
+			return
+		}
+	}
+	t.Fatalf("task %s has no %q event whose reason contains %q; the transition is unauditable. events = %+v", taskID, kind, mustContain, events)
+}

--- a/internal/workflow/engine_routing_merge.go
+++ b/internal/workflow/engine_routing_merge.go
@@ -1042,6 +1042,37 @@ func (e Engine) runMergeGateWithHumanMerge(ctx context.Context, reviewer string,
 	}
 	if !decision.Ready {
 		if decision.Deferred {
+			// A TASK CANNOT BE MERGEABLE AND UNDER REPAIR AT THE SAME TIME (#1555).
+			//
+			// Measured on PR #1546: a reviewer reproduced a host escape with a
+			// compiled probe at 20:18:06, the engine had already dispatched the fix
+			// leg for it at 20:18:04, and at 20:21:12 two later approvals drove the
+			// task to ready_to_merge WHILE that leg was still running. task_events
+			// held zero rows for the transition, so the only remaining permitted
+			// operation was the merge, and a coordinator reading `gitmoot task list`
+			// plus an approval count would have shipped the escape.
+			//
+			// The parking below is not wrong in general: ready_to_merge is what
+			// lookupReadyPullRequestTask polls, so it is how a transient hold gets
+			// re-driven. It is wrong for exactly one deferral, the one where a live
+			// job owns the branch AND the task arrived carrying an objection. There
+			// the state would assert mergeability over an unanswered blocking verdict
+			// AND over the repair addressing it.
+			//
+			// Liveness is preserved without the poll in that case: the holding leg's
+			// own completion advances the task, which is how every fix round already
+			// reaches its next review. Nothing else re-drives from changes_requested,
+			// and nothing needs to.
+			if decision.HeldByJob != "" && expectedTaskState == string(TaskChangesRequested) {
+				return decision, e.recordTaskEventBestEffort(ctx, ref, db.TaskEvent{
+					Kind:      "merge_deferred_branch_held",
+					FromState: expectedTaskState,
+					ToState:   expectedTaskState,
+					Reason: fmt.Sprintf(
+						"not transitioned to ready_to_merge: job %s still owns branch %s while an objection stands at this head; a task cannot be mergeable and under repair at once. %s",
+						decision.HeldByJob, strings.TrimSpace(payload.Branch), decision.Reason.Render()),
+				})
+			}
 			// Park the task in ready_to_merge (NOT whatever state it arrived in) so
 			// the daemon's lookupReadyPullRequestTask poll re-drives it every tick until
 			// the hold settles. A task-owned retry already expected in ready_to_merge
@@ -1049,7 +1080,22 @@ func (e Engine) runMergeGateWithHumanMerge(ctx context.Context, reviewer string,
 			if expectedTaskState == string(TaskReadyToMerge) {
 				return decision, nil
 			}
-			return decision, e.setTaskState(ctx, ref, TaskReadyToMerge)
+			// AUDITED, because it was not (#1555 ask 2). ready_to_merge is the
+			// strongest merge signal the engine produces and it was written through a
+			// plain upsert with no task_events row, so an operator could see the state
+			// and never learn why. The write itself is unchanged; only the record is
+			// added, and it names the deferral that caused it rather than implying a
+			// clean approval.
+			if err := e.setTaskState(ctx, ref, TaskReadyToMerge); err != nil {
+				return decision, err
+			}
+			return decision, e.recordTaskEventBestEffort(ctx, ref, db.TaskEvent{
+				Kind:      "task_ready_to_merge_deferred",
+				FromState: expectedTaskState,
+				ToState:   string(TaskReadyToMerge),
+				Reason: fmt.Sprintf("parked in ready_to_merge to be re-driven by the merge poll: %s",
+					decision.Reason.Render()),
+			})
 		}
 		reason := decision.Reason.Render()
 		if reason == "" {
@@ -1105,7 +1151,41 @@ func (e Engine) runMergeGateWithHumanMerge(ctx context.Context, reviewer string,
 		}
 		return decision, nil
 	}
-	return decision, e.setTaskState(ctx, ref, TaskReadyToMerge)
+	// The READY arm, audited for the same reason as the deferred one (#1555 ask 2).
+	// This is the transition that means "this really is mergeable", so it is the one
+	// an operator most needs to be able to audit after the fact.
+	if err := e.setTaskState(ctx, ref, TaskReadyToMerge); err != nil {
+		return decision, err
+	}
+	reason := decision.Reason.Render()
+	if reason == "" {
+		reason = "merge gate reported ready"
+	}
+	return decision, e.recordTaskEventBestEffort(ctx, ref, db.TaskEvent{
+		Kind:      "task_ready_to_merge",
+		FromState: expectedTaskState,
+		ToState:   string(TaskReadyToMerge),
+		Reason:    reason,
+	})
+}
+
+// recordTaskEventBestEffort records a task_events row for a transition the
+// engine has already committed.
+//
+// BEST EFFORT IS DELIBERATE AND IT IS NOT LAXITY. The state write has already
+// landed by the time this is called, so returning an error here would report a
+// failure for an effect that succeeded, and a caller retrying on it would
+// re-drive a transition that does not need re-driving. An audit row that fails
+// to insert must not invalidate the thing it describes. A refused write is
+// visible as a missing row, which is the same signal the absence of these rows
+// was in the first place.
+func (e Engine) recordTaskEventBestEffort(ctx context.Context, ref taskRef, event db.TaskEvent) error {
+	if e.Store == nil || strings.TrimSpace(ref.ID) == "" {
+		return nil
+	}
+	event.TaskID = ref.ID
+	_ = e.Store.AddTaskEvent(ctx, event)
+	return nil
 }
 
 func (e Engine) parkTaskAwaitingHumanMerge(ctx context.Context, ref taskRef, reason string) error {

--- a/internal/workflow/engine_types.go
+++ b/internal/workflow/engine_types.go
@@ -375,6 +375,20 @@ type MergeDecision struct {
 	// changes the transition itself (Deferred controls retry-later semantics), so
 	// behavior is byte-identical when the harvester is off.
 	BlockClass MergeBlockClass
+	// HeldByJob names the live job that owns the pull-request branch when THAT is
+	// why the decision deferred. It is a JOB ID rather than a flag so the record
+	// can say which writer the merge is waiting on.
+	//
+	// IT IS TYPED BECAUSE THE ALTERNATIVE WAS MATCHING THE REASON PROSE (#1555).
+	// The deferral reason already reads "active <type> job <id> in flight on
+	// branch <name>", and a consumer deciding a task's state by substring-matching
+	// that sentence is precisely the proxy-instead-of-property defect this
+	// campaign exists to remove.
+	//
+	// Only the branch-ownership deferral sets it. Every other transient hold
+	// (head not yet observable, freshness unknown) leaves it empty and keeps the
+	// pre-existing parking behaviour.
+	HeldByJob string
 }
 
 // MergeBlockClass classifies a merge-gate block (#465 INFRA-NOISE-FILTERED).


### PR DESCRIPTION
Implements both asks of #1555 as re-scoped by its own 2026-09-03 verification: (a) a Deferred merge decision must not become `ready_to_merge` while a fix leg holds the branch, and (b) the `ready_to_merge` transition must emit a `task_event`.

Full evidence, including the base measurements, is on the issue at issuecomment-5573679821. Summary:

## (a) measured on base

With a stub gate returning a branch-held deferral and the task arriving in `changes_requested`:

```
BASE BEHAVIOUR: task state after a branch-held deferral from changes_requested = "ready_to_merge"
```

On PR #1546 that produced a task reading `ready_to_merge` at 20:21:12 while the fix leg for a reproduced host escape had been running since 20:18:04, and the only operation the engine would then accept was the merge.

**The parking is not removed.** `lookupReadyPullRequestTask` admits only `ready_to_merge` on the branch path, so parking is how every transient hold gets re-driven. The refusal is scoped to one case: a live job owns the branch AND the task arrived carrying an objection. Liveness there does not depend on the poll, because the holding leg's own completion advances the task, which is how every fix round already reaches its next review.

The hold is identified by a new typed `MergeDecision.HeldByJob`, not by matching the deferral's reason prose. Deciding a task's state by substring-matching a sentence is the proxy-instead-of-property defect this campaign exists to remove.

## (b) broader than the issue narrowed it to

The issue's third comment narrowed this to the approval-driven transition. Measured, **every** `ready_to_merge` transition in this function leaves the table empty: all four cases report `events = []` on base. Three now record a row with the deciding reason: `task_ready_to_merge`, `task_ready_to_merge_deferred` (so a parked transition cannot be misread as a clean approval), and `merge_deferred_branch_held`.

The event write is best-effort by design: the state write has already committed, so failing the call would report a failure for an effect that succeeded and a retry would re-drive a transition that does not need it.

## Tests

Three, all failing on base `dd8b433f` except the bound:

1. `TestDeferredMergeDoesNotCallATaskMergeableWhileAWriterHoldsTheBranch`
2. `TestReadyToMergeTransitionsAreRecordedInTaskEvents` (two arms, both `events = []` on base)
3. `TestBranchHeldDeferralStillParksATaskThatCarriesNoObjection` — the bound that decides whether this is a scoped refusal or a liveness regression. It passes on base too, by design.

The base control for (a) required a variant with the new field removed, because the field does not exist there; that is stated rather than presented as a clean before/after.

## Not implemented

Asks 3 and 4 were withdrawn by the author after checking and I agree with both: the fix-pass refusal was correct and protective, and `task dismiss` / `recover` / `resume-work` / `events` all exist. Ask 1's general "sticky `changes_requested`" belongs to #1524 and #1950; #1950 landed today as `d7d894ea`.

## Verification

```
go build ./...                          ok
go vet ./...                            ok
go test -count=1 ./internal/workflow/   ok  106.6s
go test -count=1 ./internal/cli/        ok  662.5s
```

Frozen detached worktree at `41e172d8`, one suite at a time.

Deploy notes: no config, no migration, no schema change. New `task_events` rows appear for `ready_to_merge` transitions; one deferral case now preserves `changes_requested` instead of overwriting it.