### PR TITLE
fix(github): a primary rate-limit refusal names its reset (#1994)

### DIFF
--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -1710,7 +1710,24 @@ func (c *GhClient) runRequest(ctx context.Context, mutate bool, conditional bool
 		// failure can be classified as network_outage and short-backoff deferred.
 		// Non-outage failures (and every failure's exact text) are untouched, and
 		// best-effort callers that swallow the error are byte-identical.
-		return result, classifyTransientError(result, commandError(result, err))
+		failure := classifyTransientError(result, commandError(result, err))
+		// #1994: A PRIMARY rate limit reaches the operator with its RESET, because
+		// the reset decides whether waiting or re-dispatching is correct and the
+		// bare message decides nothing. Scoped to the primary class deliberately:
+		// a SECONDARY limit already engages the process-wide backoff above and
+		// answers to Retry-After rather than to a window reset, so probing it
+		// would add a request to an abuse window this code is trying to leave
+		// alone.
+		//
+		// It WRAPS, so the original text and the TransientError marker both
+		// survive, and it is best effort: a probe that cannot answer leaves the
+		// failure exactly as it was.
+		if isRateLimit(result) && !sawSecondary {
+			if window, ok := c.rateLimitWindowForRequest(ctx, runner, args); ok {
+				return result, &RateLimitError{Window: window, Err: failure}
+			}
+		}
+		return result, failure
 	}
 	return result, nil
 }

--- a/internal/github/ratelimit_reset.go
+++ b/internal/github/ratelimit_reset.go
@@ -1,0 +1,129 @@
+package github
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/gitmoot/gitmoot/internal/subprocess"
+)
+
+// #1994. A PRIMARY rate-limit refusal used to reach the operator as bare
+// `gh: API rate limit exceeded`, dropping the one fact that decides what to do
+// next: when the bucket refills. Two agents on this host then burned four
+// dispatch attempts against the same exhausted bucket before anyone read the
+// response headers, where the reset had been the whole time.
+//
+// THE RESET IS ONLY AVAILABLE FROM A REAL REQUEST'S HEADERS, and that is
+// measured rather than assumed. `GET /rate_limit` is not a usable instrument:
+// on one credential, one host, seconds apart, it reported core 4999/5000
+// used=1 while a real core request returned 403 with remaining=0 used=5000,
+// and their resets were thirteen minutes apart. Five minutes later it reported
+// a completely FRESH window, 5000/5000 used=0, while real calls were still
+// refused; the 403 header's own reset was accurate throughout. So this probes
+// the SAME request that failed, whose 403 carries authoritative headers,
+// instead of asking a different endpoint about a bucket it does not own.
+var (
+	rateLimitResetPattern     = regexp.MustCompile(`(?i)x-ratelimit-reset:\s*(\d+)`)
+	rateLimitRemainingPattern = regexp.MustCompile(`(?i)x-ratelimit-remaining:\s*(\d+)`)
+	rateLimitLimitPattern     = regexp.MustCompile(`(?i)x-ratelimit-limit:\s*(\d+)`)
+	rateLimitResourcePattern  = regexp.MustCompile(`(?i)x-ratelimit-resource:\s*(\S+)`)
+)
+
+// RateLimitWindow is what a refused request's own headers say about the bucket
+// it was charged against.
+type RateLimitWindow struct {
+	Resource  string
+	Limit     int
+	Remaining int
+	Reset     time.Time
+}
+
+// parseRateLimitWindow reads the headers of a `gh api -i` response. It requires
+// a RESET, because a window with no reset cannot answer the only question this
+// exists for; every other field is decoration on the message.
+func parseRateLimitWindow(result subprocess.Result) (RateLimitWindow, bool) {
+	text := result.Stdout + "\n" + result.Stderr
+	match := rateLimitResetPattern.FindStringSubmatch(text)
+	if len(match) < 2 {
+		return RateLimitWindow{}, false
+	}
+	seconds, err := strconv.ParseInt(match[1], 10, 64)
+	if err != nil || seconds <= 0 {
+		return RateLimitWindow{}, false
+	}
+	window := RateLimitWindow{Reset: time.Unix(seconds, 0).UTC()}
+	if m := rateLimitResourcePattern.FindStringSubmatch(text); len(m) >= 2 {
+		window.Resource = strings.TrimSpace(m[1])
+	}
+	if m := rateLimitLimitPattern.FindStringSubmatch(text); len(m) >= 2 {
+		if value, convErr := strconv.Atoi(m[1]); convErr == nil {
+			window.Limit = value
+		}
+	}
+	if m := rateLimitRemainingPattern.FindStringSubmatch(text); len(m) >= 2 {
+		if value, convErr := strconv.Atoi(m[1]); convErr == nil {
+			window.Remaining = value
+		}
+	}
+	return window, true
+}
+
+// RateLimitError carries a primary rate-limit refusal together with the window
+// its own response reported, so every caller's message names the reset without
+// each one having to parse headers.
+//
+// It wraps rather than replaces: the original error text is preserved verbatim,
+// because callers and existing tests key on it and because the operator should
+// still see exactly what gh said.
+type RateLimitError struct {
+	Window RateLimitWindow
+	Err    error
+}
+
+func (e *RateLimitError) Error() string {
+	resource := strings.TrimSpace(e.Window.Resource)
+	if resource == "" {
+		resource = "GitHub API"
+	}
+	// The WAIT is rendered as well as the timestamp. An absolute reset alone
+	// still leaves an operator computing a subtraction under time pressure, and
+	// that subtraction is exactly what nobody did today.
+	wait := time.Until(e.Window.Reset).Round(time.Second)
+	if wait < 0 {
+		wait = 0
+	}
+	return fmt.Sprintf("%v; %s rate limit exhausted (%d/%d remaining), resets at %s (in %s) - waiting is the only remedy, retrying before then cannot succeed",
+		e.Err, resource, e.Window.Remaining, e.Window.Limit,
+		e.Window.Reset.Format(time.RFC3339), wait)
+}
+
+func (e *RateLimitError) Unwrap() error { return e.Err }
+
+// rateLimitWindowForRequest re-issues the SAME request with `-i` and reads the
+// rate-limit headers off its response.
+//
+// It runs only on a request that has already failed with a primary rate limit,
+// and it costs one refused request. A refused request consumes no further
+// quota - there is none left to consume - and a 403 carries the same
+// `X-Ratelimit-*` headers as a 200, which is what makes this work.
+//
+// It is BEST EFFORT and silent on failure. If the probe cannot run, or answers
+// without a reset, the caller keeps the original unwrapped error. A diagnostic
+// improvement must never be able to change whether a call failed.
+func (c *GhClient) rateLimitWindowForRequest(ctx context.Context, runner subprocess.Runner, args []string) (RateLimitWindow, bool) {
+	if len(args) == 0 || args[0] != "api" {
+		return RateLimitWindow{}, false
+	}
+	probe := make([]string, 0, len(args)+1)
+	probe = append(probe, "api", "-i")
+	probe = append(probe, args[1:]...)
+	result, err := runner.Run(ctx, c.Dir, "gh", probe...)
+	if err != nil && strings.TrimSpace(result.Stdout+result.Stderr) == "" {
+		return RateLimitWindow{}, false
+	}
+	return parseRateLimitWindow(result)
+}

--- a/internal/github/ratelimit_reset_test.go
+++ b/internal/github/ratelimit_reset_test.go
@@ -1,0 +1,223 @@
+package github
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gitmoot/gitmoot/internal/subprocess"
+)
+
+// The 403 gh actually returns when the core bucket is exhausted, captured on
+// this host at 2026-09-07T16:12Z with `gh api -i repos/gitmoot/gitmoot`. Reset
+// 1788799425 is 2026-09-07T16:43:45Z, and the real call did succeed after it.
+//
+// NOTE WHAT IS ABSENT: no Retry-After. That is what distinguishes the primary
+// class from the secondary/abuse one, and it is why waiting for the reset is
+// the only remedy.
+const measuredRateLimit403 = `HTTP/2.0 403 Forbidden
+X-Github-Request-Id: A4C8:48A5A:12D10FD4:1234D4F7:6A9EE252
+X-Ratelimit-Limit: 5000
+X-Ratelimit-Remaining: 0
+X-Ratelimit-Reset: 1788799425
+X-Ratelimit-Resource: core
+X-Ratelimit-Used: 5000
+
+{"message":"API rate limit exceeded for user ID 38183696."}
+`
+
+// The body-only failure the FAILING call itself produces. `gh api` without -i
+// prints no headers, which is the whole reason the reset has to be probed for
+// rather than read off the original result.
+const measuredRateLimitStderr = `gh: API rate limit exceeded for user ID 38183696.`
+
+func rateLimitTestClient(runner subprocess.Runner) *GhClient {
+	return &GhClient{
+		Runner:     runner,
+		Dir:        ".",
+		MaxRetries: 2,
+		Limiter:    NewRateLimiter(RateLimiterConfig{}),
+		Sleep:      func(context.Context, time.Duration) error { return nil },
+	}
+}
+
+// TestPrimaryRateLimitRefusalNamesItsReset is #1994's whole point.
+//
+// Before this, `resolve pull request #N` reached the operator as bare
+// `gh: API rate limit exceeded`, and the observed consequence was four dispatch
+// attempts against one exhausted bucket by two agents. The reset was in the
+// response headers the entire time.
+func TestPrimaryRateLimitRefusalNamesItsReset(t *testing.T) {
+	runner := &fakeRunner{}
+	// Three attempts at the real call (MaxRetries 2), then one -i probe.
+	for range 3 {
+		runner.results = append(runner.results, subprocess.Result{Stderr: measuredRateLimitStderr})
+		runner.errs = append(runner.errs, errors.New("exit status 1"))
+	}
+	runner.results = append(runner.results, subprocess.Result{Stdout: measuredRateLimit403})
+	runner.errs = append(runner.errs, errors.New("exit status 1"))
+
+	client := rateLimitTestClient(runner)
+	_, err := client.GetPullRequest(context.Background(), Repository{Owner: "gitmoot", Name: "gitmoot"}, 1941)
+	if err == nil {
+		t.Fatal("GetPullRequest succeeded against an exhausted bucket")
+	}
+
+	var rateLimit *RateLimitError
+	if !errors.As(err, &rateLimit) {
+		t.Fatalf("error is %v (%T), want a *RateLimitError carrying the window", err, err)
+	}
+	message := err.Error()
+	// Each of these is a separate decision the operator has to make, and the
+	// bare message supported none of them: WHICH bucket, HOW empty, and WHEN it
+	// refills. The wait is asserted as a rendered field rather than a value,
+	// because it is relative to now.
+	for _, want := range []string{
+		"core",                 // the resource, so a graphql or search limit is not misread as core
+		"2026-09-07T16:43:45Z", // the reset, from the header rather than from /rate_limit
+		"0/5000",               // how empty
+		"retrying before then cannot succeed",
+	} {
+		if !strings.Contains(message, want) {
+			t.Errorf("refusal %q does not name %q", message, want)
+		}
+	}
+	// The original text survives, because callers and existing tests key on it
+	// and the operator should still see what gh said.
+	if !strings.Contains(message, "API rate limit exceeded") {
+		t.Errorf("refusal %q dropped the original gh error text", message)
+	}
+
+	// ONE probe, not one per attempt. Probing inside the retry loop would triple
+	// the requests fired at an already-refusing endpoint, which is the behaviour
+	// this issue exists to stop rather than to add.
+	probes := 0
+	for _, call := range runner.calls {
+		for _, arg := range call {
+			if arg == "-i" {
+				probes++
+				break
+			}
+		}
+	}
+	if probes != 1 {
+		t.Fatalf("issued %d header probes, want exactly 1; calls=%v", probes, runner.calls)
+	}
+	// And the probe asked about the SAME request. Asking a different endpoint is
+	// how /rate_limit gets the answer wrong.
+	runner.wantArgs(t, 3, "api", "-i", "repos/gitmoot/gitmoot/pulls/1941")
+}
+
+// TestNonRateLimitFailureIsUnchanged is the control that matters most: a
+// diagnostic improvement must not alter any other failure, and must not fire a
+// probe at an endpoint that was never rate limited.
+func TestNonRateLimitFailureIsUnchanged(t *testing.T) {
+	runner := &fakeRunner{
+		results: []subprocess.Result{{Stderr: "gh: Not Found (HTTP 404)"}},
+		errs:    []error{errors.New("exit status 1")},
+	}
+	client := rateLimitTestClient(runner)
+	_, err := client.GetPullRequest(context.Background(), Repository{Owner: "gitmoot", Name: "gitmoot"}, 1941)
+	if err == nil {
+		t.Fatal("GetPullRequest succeeded on a 404")
+	}
+	var rateLimit *RateLimitError
+	if errors.As(err, &rateLimit) {
+		t.Fatalf("a 404 was wrapped as a rate limit: %v", err)
+	}
+	if !strings.Contains(err.Error(), "Not Found") {
+		t.Errorf("error %q lost the original text", err)
+	}
+	if len(runner.calls) != 1 {
+		t.Fatalf("a 404 issued %d calls, want 1 (no header probe); calls=%v", len(runner.calls), runner.calls)
+	}
+}
+
+// TestSecondaryRateLimitIsNotProbed keeps the two classes apart. A secondary
+// limit already engages the process-wide backoff and answers to Retry-After;
+// adding a request to an abuse window is the opposite of what that path wants.
+func TestSecondaryRateLimitIsNotProbed(t *testing.T) {
+	const secondary = "gh: You have exceeded a secondary rate limit. Retry-After: 60"
+	runner := &fakeRunner{}
+	for range 3 {
+		runner.results = append(runner.results, subprocess.Result{Stderr: secondary})
+		runner.errs = append(runner.errs, errors.New("exit status 1"))
+	}
+	client := rateLimitTestClient(runner)
+	_, err := client.GetPullRequest(context.Background(), Repository{Owner: "gitmoot", Name: "gitmoot"}, 1941)
+	if err == nil {
+		t.Fatal("GetPullRequest succeeded against a secondary limit")
+	}
+	var rateLimit *RateLimitError
+	if errors.As(err, &rateLimit) {
+		t.Fatalf("a secondary limit was wrapped with a window: %v", err)
+	}
+	for _, call := range runner.calls {
+		for _, arg := range call {
+			if arg == "-i" {
+				t.Fatalf("a secondary limit was probed for headers; calls=%v", runner.calls)
+			}
+		}
+	}
+}
+
+// TestRateLimitProbeWithoutAResetLeavesTheFailureAlone is the fail-open arm. A
+// probe that answers without a reset cannot improve the message, and must not
+// be able to change whether or how the call failed.
+func TestRateLimitProbeWithoutAResetLeavesTheFailureAlone(t *testing.T) {
+	runner := &fakeRunner{}
+	for range 3 {
+		runner.results = append(runner.results, subprocess.Result{Stderr: measuredRateLimitStderr})
+		runner.errs = append(runner.errs, errors.New("exit status 1"))
+	}
+	// Headers present, reset absent: the one field the window requires.
+	runner.results = append(runner.results, subprocess.Result{Stdout: "HTTP/2.0 403 Forbidden\nX-Ratelimit-Remaining: 0\n"})
+	runner.errs = append(runner.errs, errors.New("exit status 1"))
+
+	client := rateLimitTestClient(runner)
+	_, err := client.GetPullRequest(context.Background(), Repository{Owner: "gitmoot", Name: "gitmoot"}, 1941)
+	if err == nil {
+		t.Fatal("GetPullRequest succeeded against an exhausted bucket")
+	}
+	var rateLimit *RateLimitError
+	if errors.As(err, &rateLimit) {
+		t.Fatalf("a reset-less probe still produced a window: %v", err)
+	}
+	if !strings.Contains(err.Error(), "API rate limit exceeded") {
+		t.Errorf("error %q lost the original text", err)
+	}
+}
+
+// TestParseRateLimitWindowRequiresAReset pins the parser's own contract,
+// because "a window with no reset" is the shape that would render
+// "resets at 1970-01-01" and send an operator to the wrong conclusion with
+// full confidence.
+func TestParseRateLimitWindowRequiresAReset(t *testing.T) {
+	if window, ok := parseRateLimitWindow(subprocess.Result{Stdout: measuredRateLimit403}); !ok {
+		t.Fatal("the measured 403 did not parse")
+	} else {
+		if window.Resource != "core" || window.Limit != 5000 || window.Remaining != 0 {
+			t.Errorf("window = %+v, want core 0/5000", window)
+		}
+		if got := window.Reset.UTC().Format(time.RFC3339); got != "2026-09-07T16:43:45Z" {
+			t.Errorf("reset = %s, want 2026-09-07T16:43:45Z", got)
+		}
+	}
+	for _, tt := range []struct {
+		name string
+		body string
+	}{
+		{name: "no headers at all", body: measuredRateLimitStderr},
+		{name: "reset absent", body: "X-Ratelimit-Remaining: 0\nX-Ratelimit-Resource: core\n"},
+		{name: "reset unparseable", body: "X-Ratelimit-Reset: not-a-number\n"},
+		{name: "reset zero", body: "X-Ratelimit-Reset: 0\n"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			if _, ok := parseRateLimitWindow(subprocess.Result{Stdout: tt.body}); ok {
+				t.Fatalf("%q parsed as a usable window", tt.body)
+			}
+		})
+	}
+}

--- a/skills/gitmoot/references/CLI.md
+++ b/skills/gitmoot/references/CLI.md
@@ -657,6 +657,23 @@ backoff is on. Set `max_concurrent` (e.g. `6`) and/or a small `min_interval`
 dropped — they queue/delay. `gitmoot daemon status` shows the configured budget
 (`github limiter: max_concurrent=… min_interval=… secondary_backoff=… conditional_requests=… calls_per_hour_warn=…`).
 
+The **primary** limit is a different failure and now reports itself as one. When
+a call fails on primary exhaustion, Gitmoot re-issues that same request once with
+headers and reports the window its own response named: the resource, how empty it
+is, the reset timestamp and the remaining wait, wrapped around the original `gh`
+text. Waiting is the only remedy, because a primary window carries no
+`Retry-After` and cannot be shortened.
+
+It probes the **failed request**, never `GET /rate_limit`, and that is measured
+rather than stylistic. On one credential and one host, seconds apart,
+`/rate_limit` reported core `4999/5000 used=1` while a real core request returned
+403 with `remaining=0 used=5000`, and their resets were thirteen minutes apart;
+minutes later it reported a completely fresh `5000/5000 used=0` while real calls
+were still refused, and the 403 header's reset was accurate throughout. **Do not
+use `/rate_limit` as a precondition**: it reads full while every real call fails.
+A secondary hit is deliberately not probed, since it answers to `Retry-After` and
+already pauses process-wide.
+
 After `idle_grace_ticks` consecutive successful polls in which every conditional
 read is a 304, a repo's GitHub poll cadence decays to 2x and then up to
 `idle_max_multiplier` (default `4`; `1` disables decay). Any response-body miss,

--- a/website/docs/workflows/parallel-jobs-workflow.md
+++ b/website/docs/workflows/parallel-jobs-workflow.md
@@ -172,6 +172,20 @@ concurrency**, not total volume, so concurrent bursts can trip it (HTTP 403
 fine — the only manual workaround being to stop the daemon and wait out the
 cooldown (#683).
 
+The **primary** limit is a separate failure with a separate remedy. When a call
+fails on primary exhaustion, Gitmoot re-issues that same request once with
+headers and reports the window its own response named: the resource, how empty
+it is, the reset timestamp and the remaining wait. A primary window carries no
+`Retry-After` and cannot be shortened, so waiting is the only remedy and a
+retry before the reset cannot succeed.
+
+It reads the **failed request's** headers, never `GET /rate_limit`. That endpoint
+is not a usable precondition: measured on one credential and one host seconds
+apart, it reported core `4999/5000 used=1` while a real core request returned 403
+with `remaining=0 used=5000`, their resets thirteen minutes apart, and minutes
+later it reported a fresh `5000/5000 used=0` while real calls were still refused.
+The 403 header's reset was accurate throughout.
+
 The opt-in `[github]` section installs a **GitHub call budget + adaptive backoff**
 that is **in-process to the daemon** — it covers the `gh`/API calls gitmoot itself
 issues from the daemon process (polling, comments, merges, status). It is enforced


### PR DESCRIPTION
Closes #1994. Third slice of campaign #1818, after #1817 (`e16875b3`) and #1819 (`62f65b5c`).

## The defect

A call refused for **primary** rate-limit exhaustion reached the operator as bare `gh: API rate limit exceeded`. On a review dispatch that is:

```
resolve pull request #1941: gh: API rate limit exceeded
```

Nothing in that message distinguishes "wait 32 minutes" from "retry now", and the observed behaviour is that people retry. The reset was in the 403's own headers the entire time.

**Measured cost, today, on this host:** two agents burned **four** dispatch attempts against one exhausted bucket before anyone read the headers. Zero model tokens, because every attempt died before creating a job, but four wasted round trips and a live probe held up for half an hour.

## The measurement that shapes the fix: `/rate_limit` is not a usable instrument

The obvious implementation is to ask `GET /rate_limit` before dispatching. That is wrong, and it is wrong in a way that reads as healthy. Measured on one credential, one host, seconds apart, and independently reproduced from two panes:

```
$ gh api -i rate_limit                       $ gh api -i repos/gitmoot/gitmoot
HTTP/2.0 200 OK                              HTTP/2.0 403 Forbidden
X-Ratelimit-Resource: core                   X-Ratelimit-Resource: core
X-Ratelimit-Remaining: 4999                  X-Ratelimit-Remaining: 0
X-Ratelimit-Used: 1                          X-Ratelimit-Used: 5000
X-Ratelimit-Reset: 1788798653                X-Ratelimit-Reset: 1788799425
```

Both name `core`. The resets are **thirteen minutes apart**. Ruled out by measurement, not argument: not two identities (`gh auth status` shows one active account and the 403 body names that same user ID), not a stale body (`/rate_limit`'s own headers agree with its body), not the secondary class (`remaining=0`, `used=5000`, **no** `Retry-After`), and not another bucket (`graphql` 5000/5000, `search` 30/30 at the same moment).

Sharper still, at 16:38:28Z while the bucket was still closed, `/rate_limit` had rolled to a **completely fresh** window, `5000/5000 used=0`, while real calls were unchanged. At 16:44:21Z, past the 403 header's reset, the same real call returned `200` with `remaining=4993`.

**So `/rate_limit` was wrong in both directions across one window while the 403 header was right throughout.** The only trustworthy source is a real request's response.

## What this does

On a failure that `isRateLimit` classifies and that is **not** secondary, the client re-issues **that same request** once with `-i` and reads `X-Ratelimit-Resource`, `-Limit`, `-Remaining` and `-Reset` off the response. The error is then wrapped:

```
resolve pull request #1941: gh: API rate limit exceeded for user ID 38183696.;
core rate limit exhausted (0/5000 remaining), resets at 2026-09-07T16:43:45Z
(in 31m18s) - waiting is the only remedy, retrying before then cannot succeed
```

Four properties, each with a reason:

- **It probes the same request**, so the resource matches by construction. A 403 carries the same `X-Ratelimit-*` headers as a 200, and a refused request consumes no further quota because there is none left.
- **It wraps rather than replaces.** The original `gh` text and the `TransientError` marker both survive, so callers and existing tests that key on the text are unaffected.
- **Primary only.** A secondary limit already engages the process-wide backoff and answers to `Retry-After`; probing it would add a request to an abuse window this code is trying to leave alone.
- **Best effort, fail open.** A probe that cannot run, or answers without a reset, leaves the failure exactly as it was. A diagnostic improvement must never change whether a call failed.

### Deliberately out of scope, as the issue and my brief both require

- **The retry policy is unchanged.** `isRateLimit` still drives up to `MaxRetries` retries, so a primary exhaustion is still retried three times with 1s+2s backoff into a bucket that may not refill for an hour. That is arguably wasteful, but it is a behaviour change with its own blast radius. I measured it and left it; if it should change, it needs its own issue and its own evidence.
- No rate-limit budget manager, no request accounting, no pre-emptive throttling.

## Tests

`internal/github/ratelimit_reset_test.go`, five functions. The fixture is the **verbatim 403** captured on this host, including the absence of `Retry-After`, which is what distinguishes the two classes.

| test | what it holds |
|---|---|
| `...NamesItsReset` | resource, `0/5000`, the exact reset, the "cannot succeed" line, and that the original text survives; also that **exactly one** probe is issued despite three attempts, and that it names the same endpoint |
| `...NonRateLimitFailureIsUnchanged` | a 404 is not wrapped and fires **no** probe |
| `...SecondaryRateLimitIsNotProbed` | the class split |
| `...ProbeWithoutAResetLeavesTheFailureAlone` | fail-open |
| `...ParseRateLimitWindowRequiresAReset` | the measured 403 parses to `core 0/5000` at the right instant; missing, unparseable and zero resets all refuse |

### Fails before, passes after

Wrapping disabled, tests unchanged: `...NamesItsReset` fails. Restored: all pass, and the pre-existing limiter suite stays green.

### Mutants, each killed by the test that owns it

| mutant | killed by |
|---|---|
| attach no window at all | `...NamesItsReset` |
| drop the `!sawSecondary` exclusion | `...SecondaryRateLimitIsNotProbed` |
| probe `/rate_limit` instead of the failed request | `...NamesItsReset` (same-endpoint assertion) |
| let the parser accept a missing reset | `...ProbeWithoutAResetLeavesTheFailureAlone` + 3 parser arms |

Both mutated files verified sha256-identical after restore.

## Gate

```
go1.26.4 linux/amd64   GOTOOLCHAIN=local   CGO_ENABLED=0
go build -buildvcs=false ./...   PASS
go vet ./...                     PASS
go generate ./... && git status  clean
gofmt -l internal/               empty
```

Full-suite halves posted as a comment when they finish. Not run and not claimed: `-race` locally (cgo unavailable); covered by CI's race shards.

## What I could not verify

**I could not re-observe the live 403 on demand**, because the bucket refilled at 16:43:45Z and I am not going to exhaust it to make a test convenient. The fixture is the captured response rather than a live one, and the end-to-end path from `agent review` through to the improved message is therefore **not** exercised against a real exhausted GitHub. The unit path is, at the seam that builds the message.
