### PR TITLE
fix(workflow): a delegated review inherits its head from the stored pull request (#1557)

### DIFF
--- a/internal/workflow/engine_delegation.go
+++ b/internal/workflow/engine_delegation.go
@@ -175,7 +175,7 @@ func (e Engine) dispatchDelegations(ctx context.Context, job db.Job, payload Job
 	// immediately rather than only when its deps clear. Use a lightweight check
 	// that does not acquire branch locks or other execution side effects.
 	for _, d := range delegations {
-		request := e.delegationRequest(job, payload, d)
+		request := e.delegationRequest(ctx, job, payload, d)
 		if err := e.preflightDelegation(ctx, request); err != nil {
 			// An unroutable delegation set (an unknown / not-allowed / uncapable
 			// agent — usually a runtime name where an agent NAME was required) is no
@@ -507,7 +507,7 @@ func (e Engine) enqueueFinalizeContinuation(ctx context.Context, job db.Job, pay
 // matches the request, so it is safe to call from both dispatchDelegations and
 // advanceDelegations.
 func (e Engine) enqueueDelegation(ctx context.Context, job db.Job, payload JobPayload, d Delegation, artifactDir string, upstreamContext string, ref taskRef) error {
-	request := e.delegationRequest(job, payload, d)
+	request := e.delegationRequest(ctx, job, payload, d)
 	request.DelegationArtifactDir = artifactDir
 	// Append the #419 "Upstream dependency results" block (built by the caller
 	// from this dependent's succeeded direct deps) to the child's instructions.
@@ -958,7 +958,7 @@ func (e Engine) requeueDelegation(ctx context.Context, parentJob db.Job, parentP
 	}
 	next := attempt + 1
 
-	request := e.delegationRequest(parentJob, parentPayload, d)
+	request := e.delegationRequest(ctx, parentJob, parentPayload, d)
 	request.ID = parentJob.ID + "/delegation/" + d.ID + "/retry/" + strconv.Itoa(next)
 	request.RetryCount = next
 	request.DelegationArtifactDir = artifactDir

--- a/internal/workflow/engine_escalation_resume.go
+++ b/internal/workflow/engine_escalation_resume.go
@@ -1388,7 +1388,7 @@ func (e Engine) resumeRetryLeg(ctx context.Context, parentJob db.Job, parentPayl
 	if err != nil {
 		return err
 	}
-	request := e.delegationRequest(parentJob, parentPayload, d)
+	request := e.delegationRequest(ctx, parentJob, parentPayload, d)
 	request.ID = parentJob.ID + "/delegation/" + d.ID + "/resume"
 	request.Instructions = strings.TrimSpace(d.Prompt)
 	request.DelegationArtifactDir = artifactDir

--- a/internal/workflow/engine_fanout_intent_1277_test.go
+++ b/internal/workflow/engine_fanout_intent_1277_test.go
@@ -26,7 +26,7 @@ func TestDelegationChildInheritsSkipNativeReviewFanout(t *testing.T) {
 		SkipNativeReviewFanout: true,
 	}
 
-	child := engine.delegationRequest(parent, payload, Delegation{
+	child := engine.delegationRequest(context.Background(), parent, payload, Delegation{
 		ID:     "leg-1",
 		Agent:  "impl",
 		Action: "implement",

--- a/internal/workflow/engine_lens_head_1557_test.go
+++ b/internal/workflow/engine_lens_head_1557_test.go
@@ -1,0 +1,114 @@
+package workflow
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/gitmoot/gitmoot/internal/db"
+)
+
+// #1557: review fanout lens legs fail silently. The dominant cause, measured
+// rather than inferred, is that a delegated REVIEW child is created with no head
+// SHA and is then correctly refused by the worker with "review job for PR #N has
+// no head SHA" (internal/cli/daemon_checkout.go:469). A review that cannot name
+// the commit it read is not a review, so the refusal is right and the defect is
+// upstream, in creating the child at all.
+//
+// LIVE STORE, 2026-07-28 to 2026-09-07: 156 failed `lens-*` delegation legs, 145
+// with no head, and the recorded failure reason on 135 of them is literally that
+// sentence. Of the 145, 141 carry a PR number, and for ALL 141 the
+// `pull_requests` mirror already held a head SHA. The head was in the store the
+// whole time.
+//
+// The issue also reports these legs as carrying "no recorded reason at all".
+// That is true of `payload.error` and `payload.failure_diagnostics`, and false of
+// the record: every one of the 156 has a `failed` job event carrying its reason.
+// Corrected on the issue rather than fixed here.
+func TestReviewDelegationChildInheritsTheHeadFromTheStoredPullRequest(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	engine := testEngine(store)
+	const head = "203263dccd20fa155a88dcd973ede08de3c2fe3d"
+	if err := store.UpsertPullRequest(ctx, db.PullRequest{
+		RepoFullName: "gitmoot/gitmoot",
+		Number:       1903,
+		HeadBranch:   "feat/lens",
+		BaseBranch:   "main",
+		State:        "open",
+		HeadSHA:      head,
+	}); err != nil {
+		t.Fatalf("UpsertPullRequest: %v", err)
+	}
+
+	// The coordinator as observed: it knows its PR but its payload carries no
+	// head, which is exactly the shape that produced the silent legs.
+	parent := db.Job{ID: "local-review-g6-review-sol-18d283b232f739f7", Agent: "g6-review-sol", Type: "review"}
+	payload := JobPayload{
+		Repo:        "gitmoot/gitmoot",
+		PullRequest: 1903,
+		TaskID:      "review-pr-1903",
+		LeadAgent:   "lead",
+	}
+
+	child := engine.delegationRequest(ctx, parent, payload, Delegation{
+		ID:     "lens-citations-durability",
+		Action: "review",
+		Agent:  "auditor",
+		Prompt: "one lens",
+	})
+	if child.HeadSHA != head {
+		t.Fatalf("review delegation child head = %q, want the stored pull-request head %q; without it the worker refuses the leg with \"review job for PR #%d has no head SHA\" and the lens never runs", child.HeadSHA, head, payload.PullRequest)
+	}
+	if !strings.HasSuffix(child.ID, "/delegation/lens-citations-durability") {
+		t.Fatalf("child id = %q, want the delegation suffix preserved", child.ID)
+	}
+}
+
+// Three bounds, because a head is not free to invent.
+func TestDelegationHeadResolutionIsBounded(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	engine := testEngine(store)
+	const mirrorHead = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	if err := store.UpsertPullRequest(ctx, db.PullRequest{
+		RepoFullName: "gitmoot/gitmoot", Number: 7, HeadBranch: "b", BaseBranch: "main",
+		State: "open", HeadSHA: mirrorHead,
+	}); err != nil {
+		t.Fatalf("UpsertPullRequest: %v", err)
+	}
+	parent := db.Job{ID: "parent", Agent: "coordinator", Type: "review"}
+
+	// 1. THE PARENT'S OWN HEAD WINS. The mirror is a fallback, never an override:
+	//    a coordinator pinned to an exact head must not have its children
+	//    silently re-targeted at a newer one, which would be the #1522 staleness
+	//    defect arriving from the other direction.
+	const pinned = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+	pinnedChild := engine.delegationRequest(ctx, parent, JobPayload{
+		Repo: "gitmoot/gitmoot", PullRequest: 7, HeadSHA: pinned,
+	}, Delegation{ID: "lens", Action: "review", Agent: "auditor"})
+	if pinnedChild.HeadSHA != pinned {
+		t.Fatalf("child head = %q, want the parent's pinned %q; the mirror must not override an exact head", pinnedChild.HeadSHA, pinned)
+	}
+
+	// 2. REVIEW ONLY. An implement or ask child legitimately runs without a
+	//    pinned head, and pinning one changes where it works.
+	for _, action := range []string{"implement", "ask", "produce"} {
+		child := engine.delegationRequest(ctx, parent, JobPayload{
+			Repo: "gitmoot/gitmoot", PullRequest: 7,
+		}, Delegation{ID: "leg", Action: action, Agent: "worker"})
+		if child.HeadSHA != "" {
+			t.Fatalf("%s delegation child head = %q, want empty; only a review child is pinned", action, child.HeadSHA)
+		}
+	}
+
+	// 3. NO PR, NO HEAD. A PR-less review delegation has nothing to resolve
+	//    against and must stay exactly as it was rather than borrowing a head
+	//    from somewhere else.
+	prLess := engine.delegationRequest(ctx, parent, JobPayload{
+		Repo: "gitmoot/gitmoot",
+	}, Delegation{ID: "lens", Action: "review", Agent: "auditor"})
+	if prLess.HeadSHA != "" {
+		t.Fatalf("PR-less review delegation child head = %q, want empty", prLess.HeadSHA)
+	}
+}

--- a/internal/workflow/engine_run_budgets.go
+++ b/internal/workflow/engine_run_budgets.go
@@ -1156,7 +1156,7 @@ func effectiveDelegationTimeout(d Delegation, defaults DelegationTimeoutDefaults
 // shared by dispatchDelegations (initial enqueue of ready delegations) and
 // advanceDelegations (deferred enqueue once deps clear) so both paths produce
 // identical, idempotent requests for the same delegation ID.
-func (e Engine) delegationRequest(job db.Job, payload JobPayload, d Delegation) JobRequest {
+func (e Engine) delegationRequest(ctx context.Context, job db.Job, payload JobPayload, d Delegation) JobRequest {
 	// An ephemeral delegation has no pre-registered agent: synthesize a stable
 	// agent name carrying the "-ephemeral-" infix used to exclude transient
 	// workers from registry listings, and thread the worker spec through so the
@@ -1177,7 +1177,7 @@ func (e Engine) delegationRequest(job db.Job, payload JobPayload, d Delegation) 
 		Repo:            payload.Repo,
 		Branch:          payload.Branch,
 		PullRequest:     payload.PullRequest,
-		HeadSHA:         payload.HeadSHA,
+		HeadSHA:         e.delegationHeadSHA(ctx, payload, d),
 		GoalID:          payload.GoalID,
 		TaskID:          payload.TaskID,
 		TaskTitle:       payload.TaskTitle,
@@ -1217,6 +1217,48 @@ func (e Engine) delegationRequest(job db.Job, payload JobPayload, d Delegation) 
 		// job that happened to receive the flag.
 		SkipNativeReviewFanout: payload.SkipNativeReviewFanout,
 	}
+}
+
+// delegationHeadSHA resolves the head a delegated REVIEW child will be pinned
+// to, falling back to the stored pull-request mirror when the parent's payload
+// carries none.
+//
+// WHY THIS EXISTS (#1557). A review child with no head cannot run at all:
+// validateReviewCheckoutForRunner refuses it with "review job for PR #N has no
+// head SHA", and that refusal is correct, because a review that cannot name the
+// commit it read is not a review. The defect is upstream, in creating the child
+// at all.
+//
+// MEASURED on the live job store: 156 failed `lens-*` delegation legs between
+// 2026-07-28 and 2026-09-07, of which 145 carry no head, and 135 of the recorded
+// failure reasons are literally "review job for PR #N has no head SHA". Of the
+// 145, 141 carry a PR number, and for ALL 141 the `pull_requests` mirror already
+// held a head SHA at that moment. The head was in the store the whole time; the
+// child simply never asked for it.
+//
+// The issue reports these legs as having "no recorded reason at all - error
+// empty, signal absent, phase absent". That is true of the PAYLOAD and false of
+// the record: all 156 have a `failed` job event carrying the reason. Reported on
+// the issue rather than treated as a second defect.
+//
+// Best-effort and fail-soft: an unresolvable head leaves the request exactly as
+// it was, so nothing that dispatches today stops dispatching. It narrows a
+// silent-failure population; it does not add a new refusal.
+func (e Engine) delegationHeadSHA(ctx context.Context, payload JobPayload, d Delegation) string {
+	head := strings.TrimSpace(payload.HeadSHA)
+	if head != "" || e.Store == nil {
+		return payload.HeadSHA
+	}
+	// REVIEW ONLY. An implement or ask child legitimately runs without a pinned
+	// head, and pinning one would change where it works.
+	if !strings.EqualFold(strings.TrimSpace(d.Action), "review") || payload.PullRequest <= 0 {
+		return payload.HeadSHA
+	}
+	pr, err := e.Store.GetPullRequest(ctx, payload.Repo, int64(payload.PullRequest))
+	if err != nil {
+		return payload.HeadSHA
+	}
+	return strings.TrimSpace(pr.HeadSHA)
 }
 
 // MaxDelegationDepth bounds how deep delegation nesting and coordinator

--- a/internal/workflow/engine_test.go
+++ b/internal/workflow/engine_test.go
@@ -4326,7 +4326,7 @@ func TestEngineDelegationModelAndEffortPlumbedToChildPayload(t *testing.T) {
 func TestEngineDelegationRequestCopiesModelAndEffort(t *testing.T) {
 	engine := Engine{}
 	request := engine.delegationRequest(
-		db.Job{ID: "parent-job", Agent: "audit"},
+		context.Background(), db.Job{ID: "parent-job", Agent: "audit"},
 		JobPayload{Repo: "gitmoot/gitmoot", Effort: "low"},
 		Delegation{ID: "del-1", Agent: "helper", Action: "review", Prompt: "go", Model: "opus", Effort: "high"},
 	)
@@ -4377,7 +4377,7 @@ func TestEngineDelegationPhasePlumbedToChildPayload(t *testing.T) {
 func TestEngineDelegationRequestCopiesPhase(t *testing.T) {
 	engine := Engine{}
 	request := engine.delegationRequest(
-		db.Job{ID: "parent-job", Agent: "audit"},
+		context.Background(), db.Job{ID: "parent-job", Agent: "audit"},
 		JobPayload{Repo: "gitmoot/gitmoot"},
 		Delegation{ID: "del-1", Agent: "helper", Action: "review", Prompt: "go", Phase: "  design  "},
 	)
@@ -4390,7 +4390,7 @@ func TestEngineDelegationRequestThreadsEphemeralSpec(t *testing.T) {
 	engine := Engine{}
 	spec := &EphemeralSpec{Runtime: runtime.CodexRuntime, Model: "gpt-5.4", Effort: "high"}
 	request := engine.delegationRequest(
-		db.Job{ID: "parent-job", Agent: "audit"},
+		context.Background(), db.Job{ID: "parent-job", Agent: "audit"},
 		JobPayload{Repo: "gitmoot/gitmoot"},
 		Delegation{ID: "worker", Ephemeral: spec, Action: "implement", Prompt: "hi"},
 	)
@@ -4408,7 +4408,7 @@ func TestEngineDelegationRequestThreadsEphemeralSpec(t *testing.T) {
 
 	// A non-ephemeral delegation keeps routing to its named agent unchanged.
 	plain := engine.delegationRequest(
-		db.Job{ID: "parent-job", Agent: "audit"},
+		context.Background(), db.Job{ID: "parent-job", Agent: "audit"},
 		JobPayload{Repo: "gitmoot/gitmoot"},
 		Delegation{ID: "del-1", Agent: "helper", Action: "review", Prompt: "go"},
 	)

--- a/internal/workflow/integration_worktree_test.go
+++ b/internal/workflow/integration_worktree_test.go
@@ -144,7 +144,7 @@ func TestAllocateAndEnqueueDelegationRoutesVerifyToIntegrationWorktree(t *testin
 		}},
 	}
 	verify := Delegation{ID: "verify", Agent: "checker", Action: "review", Prompt: "verify the combined work", Deps: []string{"legA", "legB"}}
-	request := engine.delegationRequest(parentJob, parentPayload, verify)
+	request := engine.delegationRequest(context.Background(), parentJob, parentPayload, verify)
 
 	if err := engine.allocateAndEnqueueDelegation(ctx, parentJob, parentPayload, verify, request, taskRefFromPayload(parentPayload)); err != nil {
 		t.Fatalf("allocateAndEnqueueDelegation returned error: %v", err)
@@ -189,7 +189,7 @@ func TestAllocateAndEnqueueDelegationAllowsImplementDepAlreadyOnBase(t *testing.
 		}},
 	}
 	verify := Delegation{ID: "verify", Agent: "checker", Action: "review", Prompt: "verify the base work", Deps: []string{"legA"}}
-	request := engine.delegationRequest(parentJob, parentPayload, verify)
+	request := engine.delegationRequest(context.Background(), parentJob, parentPayload, verify)
 
 	if err := engine.allocateAndEnqueueDelegation(ctx, parentJob, parentPayload, verify, request, taskRefFromPayload(parentPayload)); err != nil {
 		t.Fatalf("allocateAndEnqueueDelegation returned error: %v", err)
@@ -240,7 +240,7 @@ func TestAllocateAndEnqueueDelegationBlocksWhenImplementLegUnresolved(t *testing
 		}},
 	}
 	verify := Delegation{ID: "verify", Agent: "checker", Action: "review", Prompt: "verify", Deps: []string{"legA"}}
-	request := engine.delegationRequest(parentJob, parentPayload, verify)
+	request := engine.delegationRequest(context.Background(), parentJob, parentPayload, verify)
 
 	err := engine.allocateAndEnqueueDelegation(ctx, parentJob, parentPayload, verify, request, taskRefFromPayload(parentPayload))
 	var blocked BlockedError
@@ -279,7 +279,7 @@ func TestAllocateAndEnqueueDelegationBlocksWhenAnyImplementLegUnresolved(t *test
 		}},
 	}
 	verify := Delegation{ID: "verify", Agent: "checker", Action: "review", Prompt: "verify the combined work", Deps: []string{"legA", "legB"}}
-	request := engine.delegationRequest(parentJob, parentPayload, verify)
+	request := engine.delegationRequest(context.Background(), parentJob, parentPayload, verify)
 
 	err := engine.allocateAndEnqueueDelegation(ctx, parentJob, parentPayload, verify, request, taskRefFromPayload(parentPayload))
 	var blocked BlockedError

--- a/internal/workflow/org_role_test.go
+++ b/internal/workflow/org_role_test.go
@@ -1,6 +1,7 @@
 package workflow
 
 import (
+	"context"
 	"testing"
 
 	"github.com/gitmoot/gitmoot/internal/db"
@@ -8,7 +9,7 @@ import (
 
 func TestDelegationRequestInheritsActingOrgRole(t *testing.T) {
 	request := (Engine{}).delegationRequest(
-		db.Job{ID: "root", Agent: "coordinator"},
+		context.Background(), db.Job{ID: "root", Agent: "coordinator"},
 		JobPayload{Repo: "owner/repo", ActingOrgRole: "owner"},
 		Delegation{ID: "review", Agent: "reviewer", Action: "review", Prompt: "review it"},
 	)

--- a/internal/workflow/workflow_id_test.go
+++ b/internal/workflow/workflow_id_test.go
@@ -57,7 +57,7 @@ func TestValidateWorkflowID(t *testing.T) {
 
 func TestWorkflowIDInheritedByDelegationAndComparedForIdempotency(t *testing.T) {
 	request := (Engine{}).delegationRequest(
-		db.Job{ID: "parent", Agent: "coord"},
+		context.Background(), db.Job{ID: "parent", Agent: "coord"},
 		JobPayload{Repo: "acme/widget", WorkflowID: "release-42"},
 		Delegation{ID: "child", Agent: "worker", Action: "ask", Prompt: "check"},
 	)


### PR DESCRIPTION
Fixes the dominant cause of #1557's silently failing review fanout legs. Full evidence on the issue at issuecomment-5574026084.

## Re-derived: 156 legs, one dominant reason, and the reason was never missing

```sql
select count(*) from jobs where id like '%lens-%' and state='failed';
-- 156, from 2026-07-28 to 2026-09-07
```

The issue reports 28 legs with "no recorded reason at all". Both halves needed correcting. It is 156, and **all 156 carry a `failed` job event with a reason**. What is empty is `payload.error` and `payload.failure_diagnostics`, which is where the issue looked.

Grouped, **135 of the 156 are one sentence**: `review job for PR #N has no head SHA`.

## Cause, with the answer already in the store

`validateReviewCheckoutForRunner` (`internal/cli/daemon_checkout.go:469`) refuses a review job with no `payload.HeadSHA`. **That refusal is correct and is untouched here**: a review that cannot name the commit it read is not a review. The defect is that the child was created at all.

```
failed lens legs                                    156
child carries no head_sha                           145
of those, carrying a PR number                      141
of those, pull_requests mirror ALREADY had a head   141   <- all of them
```

`delegationRequest` propagated `HeadSHA: payload.HeadSHA` faithfully; the coordinator's payload had none and nothing fell back to the mirror. I ruled out the obvious alternative: of the 141, 90 parents have a `review_head_resynced` event but **zero** were resynced after the child was created, so a late resync is not what emptied the child.

## Change and its bounds

A delegated **review** child resolves its head from the stored pull request when the parent's payload carries none. Three bounds, each tested, because a head is not free to invent:

1. **The parent's own head always wins** — the mirror is a fallback, never an override. Re-targeting an exact-head coordinator's children at a newer commit would be #1522's staleness defect arriving from the other direction.
2. **Review only** — an implement or ask child legitimately runs without a pinned head.
3. **No PR, no resolution.**

Fail-soft: an unresolvable head leaves the request unchanged, so nothing that dispatches today stops dispatching.

## What I did not implement

**Ask 1** is already satisfied on both surfaces, and the issue's own final comment says so for the first: `reviewRowIsFanOut` plus `ensureDelegatedReviewEvidence` mean the gate never honours a fan-out parent's `approved`, and #1963 (`81c98384`, merged today) makes the published PR comment say `fan-out` instead of `approved`. Per phobos: if the remedy here started looking like #1963's, that would mean fixing the same thing twice rather than the second thing once. This PR fixes the thing neither covers, which is why the legs failed at all.

**Ask 2** needs no change; the reason is already durable. **Ask 3** is deliberately deferred and should be re-specified against post-fix behaviour, since with this change the legs run and with #1963 the parent row no longer reads as a verdict.

## Test

```
TestReviewDelegationChildInheritsTheHeadFromTheStoredPullRequest
  base c931c20f: FAIL  review delegation child head = "", want the stored pull-request head
                       "203263dccd20fa155a88dcd973ede08de3c2fe3d"
  this branch:   PASS

TestDelegationHeadResolutionIsBounded   pins the three bounds; passes on base by design
```

The signature change to `delegationRequest` (adding `ctx`) touched four production callers and six test files. No behaviour change in those callers.

## Verification

```
go build ./...                          ok
go vet ./...                            ok
go test -count=1 ./internal/workflow/   ok   97.6s
go test -count=1 ./internal/cli/        ok  636.1s
```

**One run of `./internal/cli/` was contaminated and is reported rather than hidden.** It failed 106 tests, all dispatch or blocked-advance shapes, because this host fell below the disk guard mid-run:

```
DISK GUARD REFUSED JOB DISPATCH: free_percent=4.68 min_free_percent=5.00   (7 occurrences)
```

Re-run on the same commit at 6.21% free: **0 failures, 0 guard refusals**. That is the second independent causal demonstration today, and gm-transport reached it separately on another branch. If you see that failure shape locally, check free space before reading it as a regression.

Deploy notes: no config, no migration, no schema change.