### PR TITLE
fix(cli): report the stored session row, not the flags, and carry the dispatcher (#1990)

### DIFF
--- a/internal/cli/job_record_head_plane_1990_test.go
+++ b/internal/cli/job_record_head_plane_1990_test.go
@@ -1,0 +1,168 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/gitmoot/gitmoot/internal/workflow"
+)
+
+// #1990, found by gm-staged on their own verdict row.
+//
+// `gitmoot job record --type review --head-sha <H>` accepted the head, echoed it
+// back in its own --json, and stored it nowhere in the payload, so the operator
+// read their own input back as confirmation. That is why it survived: the CLI
+// reported what it was GIVEN, not what it STORED.
+//
+// Measured on this host: externally-driven review jobs 41, payload head_sha set
+// on 0, pull_request set on 41. Engine-dispatched succeeded reviews 3391, head
+// set on 3387.
+//
+// THE ASSERTION IS THE ONE GM-STAGED SPECIFIED, and the distinction is the whole
+// test: it compares the JSON against the row RE-READ FROM THE STORE. A test that
+// asserted "head_sha is non-null" passes with the echo fully intact.
+//
+// The quarantine itself is NOT the defect and this test does not ask for it to
+// be lifted. A supplied head is caller-asserted, and the codebase types that:
+// evidence.SessionReviewGrade is GradeReported, stamped onto every session
+// review payload at close time, because "session review inputs are
+// caller-supplied, so this can never be stronger than reported". Persisting it
+// into the payload would put reported-grade data in the field the merge gate
+// reads as system-observed, and an operator could then claim an approval at any
+// head. What this pins is that the CLI tells the truth about which plane the
+// value landed on.
+func TestJobRecordReportsTheStoredRowRatherThanItsOwnFlags(t *testing.T) {
+	home := t.TempDir()
+	store := openCLIJobStore(t, home)
+	seedSessionAgentRepo(t, store)
+	store.Close()
+	seedConfiguredRole(t, home, "gm-staged")
+
+	const claimedHead = "c1ca9824cf3ab0be2eb1a4d0a6e6cb2a5b40e0f1"
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{
+		"job", "record", "--home", home,
+		"--acting-role", "gm-staged",
+		"--repo", "owner/repo",
+		"--type", "review",
+		"--decision", "approved",
+		"--summary", "exact-head review of the reviewed head",
+		"--pr", "1950",
+		"--head-sha", claimedHead,
+		"--json",
+	}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("job record exit = %d, stderr=%s", code, stderr.String())
+	}
+	var out jobSessionOutput
+	if err := json.Unmarshal(stdout.Bytes(), &out); err != nil {
+		t.Fatalf("decode session output: %v (stdout=%s)", err, stdout.String())
+	}
+
+	verify := openCLIJobStore(t, home)
+	defer verify.Close()
+	job, err := verify.GetJob(context.Background(), out.JobID)
+	if err != nil {
+		t.Fatalf("GetJob(%q): %v", out.JobID, err)
+	}
+	payload, err := workflow.ParseJobPayload(job.Payload)
+	if err != nil {
+		t.Fatalf("ParseJobPayload: %v", err)
+	}
+
+	// THE PREMISE, asserted rather than assumed: the payload really does carry no
+	// head. If this ever starts failing, the quarantine moved and the rest of this
+	// test is reasoning about a world that no longer exists.
+	if strings.TrimSpace(payload.HeadSHA) != "" {
+		t.Fatalf("payload head_sha = %q, want empty: the quarantine this test is written around has moved", payload.HeadSHA)
+	}
+
+	// The reported head must not be presentable as merge evidence: it is reported
+	// alongside the plane it actually lives on.
+	if out.HeadSHA != claimedHead {
+		t.Fatalf("reported head_sha = %q, want the caller's asserted head %q on the display plane", out.HeadSHA, claimedHead)
+	}
+	if out.HeadSHAPlane != "display" {
+		t.Fatalf("reported head_sha_plane = %q, want %q; printing a head with no plane is what let an operator read a display value as a stored one",
+			out.HeadSHAPlane, "display")
+	}
+
+	// EVERY OTHER FIELD MUST MATCH THE STORED ROW. The echo was wider than the
+	// head: decision, severity and summary were all printed from the flags, so any
+	// normalisation or refusal between the CLI and the store was invisible in
+	// exactly the same way.
+	//
+	// WHAT THIS LOOP DOES NOT DO, MEASURED RATHER THAN ASSUMED. It is currently
+	// NON-DISCRIMINATING: I mutated the production code to feed these three
+	// fields from the flags again and the test still passed. Nothing between the
+	// CLI and the store transforms them - validateSessionSeverity validates
+	// without normalising, and the summary is trimmed before it is stored - so
+	// flag-echo and store-read produce byte-identical strings today. It is kept
+	// because it costs nothing and it fails the moment any normalisation,
+	// defaulting or refusal is introduced, which is precisely when an echo would
+	// start lying again. The assertions that DO kill mutants are the head plane
+	// and the dispatcher below.
+	if payload.Result == nil {
+		t.Fatal("stored payload carries no result")
+	}
+	for _, field := range []struct {
+		name     string
+		reported string
+		stored   string
+	}{
+		{"decision", out.Decision, payload.Result.Decision},
+		{"severity", out.Severity, payload.Result.Severity},
+		{"summary", out.Summary, payload.Result.Summary},
+		{"state", out.State, job.State},
+		{"type", out.Type, job.Type},
+	} {
+		if field.reported != field.stored {
+			t.Errorf("--json %s = %q but the store holds %q; the CLI must report what it stored", field.name, field.reported, field.stored)
+		}
+	}
+	if out.PullRequest != payload.PullRequest {
+		t.Errorf("--json pull_request = %d but the store holds %d", out.PullRequest, payload.PullRequest)
+	}
+
+	// #1990's second half, and my own overclaim on #1967: OpenExternalJob is a
+	// FOURTH insert path around prepareEnqueue, so the dispatcher resolution I
+	// merged at the Enqueue chokepoint never reached a session row. Same payload
+	// construction, same structural reason, two fields.
+	if strings.TrimSpace(job.DispatchedBy) != "gm-staged" {
+		t.Errorf("session row dispatched_by = %q, want %q: a session job bypasses the Enqueue chokepoint, so it needs the dispatcher resolved here too",
+			job.DispatchedBy, "gm-staged")
+	}
+}
+
+// A record with no --head-sha must not claim a plane for a value it does not
+// have, or the field becomes noise on every session row in the fleet.
+func TestJobRecordOmitsTheHeadPlaneWhenNoHeadWasSupplied(t *testing.T) {
+	home := t.TempDir()
+	store := openCLIJobStore(t, home)
+	seedSessionAgentRepo(t, store)
+	store.Close()
+	seedConfiguredRole(t, home, "gm-staged")
+
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{
+		"job", "record", "--home", home,
+		"--acting-role", "gm-staged",
+		"--repo", "owner/repo",
+		"--type", "review",
+		"--decision", "approved",
+		"--json",
+	}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("job record exit = %d, stderr=%s", code, stderr.String())
+	}
+	var out jobSessionOutput
+	if err := json.Unmarshal(stdout.Bytes(), &out); err != nil {
+		t.Fatalf("decode session output: %v (stdout=%s)", err, stdout.String())
+	}
+	if out.HeadSHA != "" || out.HeadSHAPlane != "" {
+		t.Fatalf("head_sha=%q plane=%q, want both empty when no head was supplied", out.HeadSHA, out.HeadSHAPlane)
+	}
+}

--- a/internal/cli/job_session.go
+++ b/internal/cli/job_session.go
@@ -35,6 +35,13 @@ type jobSessionOutput struct {
 	Summary          string `json:"summary,omitempty"`
 	PullRequest      int    `json:"pull_request,omitempty"`
 	HeadSHA          string `json:"head_sha,omitempty"`
+	// HeadSHAPlane names which plane HeadSHA above came from, because the two are
+	// not interchangeable and printing the value alone is what made #1990
+	// invisible for three days. "display" means the value lives in a
+	// session_job_display event and NOT in the job payload: no merge policy reads
+	// it, and it cannot satisfy an exact-head review requirement. It is emitted
+	// only when a head was supplied, so a record without one is unchanged.
+	HeadSHAPlane string `json:"head_sha_plane,omitempty"`
 }
 
 func runJobOpen(args []string, stdout, stderr io.Writer) int {
@@ -48,7 +55,7 @@ func runJobOpen(args []string, stdout, stderr io.Writer) int {
 	task := fs.String("task", "", "optional task id to associate")
 	parentJobID := fs.String("parent-job-id", "", "optional existing parent job id")
 	pr := fs.Int("pr", 0, "optional pull request number")
-	headSHA := fs.String("head-sha", "", "optional pull request head SHA")
+	headSHA := fs.String("head-sha", "", "optional caller-asserted head SHA, recorded as display metadata only: it is NOT stored in the job payload and no merge policy reads it (#1990)")
 	workflowID := fs.String("workflow", "", "external-coordinator workflow label")
 	jsonOutput := fs.Bool("json", false, "print the created job as JSON")
 	if err := fs.Parse(args); err != nil {
@@ -131,7 +138,7 @@ func runJobClose(args []string, stdout, stderr io.Writer) int {
 	severity := fs.String("severity", "", "review severity: "+strings.Join(workflow.ReviewSeverities, "|"))
 	summary := fs.String("summary", "", "optional result summary")
 	pr := fs.Int("pr", 0, "optional pull request number to record")
-	headSHA := fs.String("head-sha", "", "optional pull request head SHA to record")
+	headSHA := fs.String("head-sha", "", "optional caller-asserted head SHA, recorded as display metadata only: it is NOT stored in the job payload and no merge policy reads it (#1990)")
 	branch := fs.String("branch", "", "optional branch to record")
 	model := fs.String("model", "", "optional model used for the session work")
 	inputTokens := fs.Int("input-tokens", 0, "input tokens used by the session work")
@@ -188,6 +195,9 @@ func runJobClose(args []string, stdout, stderr io.Writer) int {
 		if err != nil {
 			return err
 		}
+		// #1990: same rule as `job record` above - report the STORED row, never
+		// the flags. `job close` had the identical echo, and leaving one verb
+		// honest and its sibling lying is how the defect comes back.
 		payload, _ := workflow.ParseJobPayload(job.Payload)
 		out = jobSessionOutput{
 			JobID:            job.ID,
@@ -196,11 +206,16 @@ func runJobClose(args []string, stdout, stderr io.Writer) int {
 			Type:             job.Type,
 			Repo:             payload.Repo,
 			ExternallyDriven: job.ExternallyDriven,
-			Decision:         *decision,
-			Severity:         strings.TrimSpace(*severity),
-			Summary:          strings.TrimSpace(*summary),
 			PullRequest:      payload.PullRequest,
-			HeadSHA:          loadSessionJobDisplayHeadSHA(context.Background(), store, job.ID),
+		}
+		if payload.Result != nil {
+			out.Decision = payload.Result.Decision
+			out.Severity = payload.Result.Severity
+			out.Summary = payload.Result.Summary
+		}
+		if head := loadSessionJobDisplayHeadSHA(context.Background(), store, job.ID); strings.TrimSpace(head) != "" {
+			out.HeadSHA = head
+			out.HeadSHAPlane = "display"
 		}
 		return nil
 	}); err != nil {
@@ -226,7 +241,7 @@ func runJobRecord(args []string, stdout, stderr io.Writer) int {
 	task := fs.String("task", "", "optional task id to associate")
 	parentJobID := fs.String("parent-job-id", "", "optional existing parent job id")
 	pr := fs.Int("pr", 0, "optional pull request number")
-	headSHA := fs.String("head-sha", "", "optional pull request head SHA")
+	headSHA := fs.String("head-sha", "", "optional caller-asserted head SHA, recorded as display metadata only: it is NOT stored in the job payload and no merge policy reads it (#1990)")
 	branch := fs.String("branch", "", "optional branch to record")
 	model := fs.String("model", "", "optional model used for the session work")
 	inputTokens := fs.Int("input-tokens", 0, "input tokens used by the session work")
@@ -310,7 +325,31 @@ func runJobRecord(args []string, stdout, stderr io.Writer) int {
 		if err != nil {
 			return err
 		}
+		// #1990: REPORT WHAT WAS STORED, NEVER WHAT WAS GIVEN.
+		//
+		// This is the reason the defect survived: --head-sha was accepted, echoed
+		// here, and stored nowhere in the payload, so the operator read their own
+		// input back as confirmation. gm-staged found it on their own verdict row
+		// and named the right test for it - assert the output equals the stored
+		// record, not that a field is non-empty, because the second passes with
+		// the echo still in place.
+		//
+		// The echo was wider than the head. Decision, Severity and Summary were
+		// all printed from the FLAG values too, so any normalisation or refusal
+		// applied between here and the store would have been invisible in exactly
+		// the same way. Every field below now comes from the stored row.
 		payload, _ := workflow.ParseJobPayload(job.Payload)
+		storedDecision, storedSeverity, storedSummary := "", "", ""
+		if payload.Result != nil {
+			storedDecision = payload.Result.Decision
+			storedSeverity = payload.Result.Severity
+			storedSummary = payload.Result.Summary
+		}
+		displayHead := loadSessionJobDisplayHeadSHA(context.Background(), store, job.ID)
+		headPlane := ""
+		if strings.TrimSpace(displayHead) != "" {
+			headPlane = "display"
+		}
 		out = jobSessionOutput{
 			JobID:            job.ID,
 			State:            job.State,
@@ -318,11 +357,12 @@ func runJobRecord(args []string, stdout, stderr io.Writer) int {
 			Type:             job.Type,
 			Repo:             fullName,
 			ExternallyDriven: job.ExternallyDriven,
-			Decision:         *decision,
-			Severity:         strings.TrimSpace(*severity),
-			Summary:          strings.TrimSpace(*summary),
+			Decision:         storedDecision,
+			Severity:         storedSeverity,
+			Summary:          storedSummary,
 			PullRequest:      payload.PullRequest,
-			HeadSHA:          loadSessionJobDisplayHeadSHA(context.Background(), store, job.ID),
+			HeadSHA:          displayHead,
+			HeadSHAPlane:     headPlane,
 		}
 		return nil
 	}); err != nil {

--- a/internal/pipeline/pipeline_dispatcher_1990_test.go
+++ b/internal/pipeline/pipeline_dispatcher_1990_test.go
@@ -1,0 +1,49 @@
+package pipeline
+
+import (
+	"testing"
+
+	"github.com/gitmoot/gitmoot/internal/db"
+)
+
+// #1990. #1967 resolved the dispatcher at the enqueue chokepoint and then also
+// set an explicit, more specific value at each construction site that knew one.
+// I got the pipeline site WRONG: PipelineStageJobRequest has five per-kind
+// JobRequest literals and I set DispatchedBy in one of them, the read-only agent
+// branch.
+//
+// FOUND IN PRODUCTION, not by reading. After the deploy, five real prun-* stage
+// jobs recorded dispatched_by "pipeline" - the Sender channel - instead of the
+// pipeline that ordered them. The chokepoint did its job: the column was
+// non-empty, which is what #1967 was for. But four stage kinds out of five never
+// got the specific value, and nothing would have told me.
+//
+// So this asserts EVERY stage kind, and the fix stamps the value at the
+// function's single exit rather than in its branches, so a sixth kind inherits
+// it without its author knowing the rule exists. A per-branch test would pass on
+// a per-branch fix and then rot the moment a kind is added; this table is the
+// shape that cannot.
+func TestEveryPipelineStageKindNamesTheDispatchingPipeline(t *testing.T) {
+	rec := db.Pipeline{Name: "nightly-audit", Repo: "owner/repo"}
+	run := db.PipelineRun{ID: "prun-nightly-audit-abc", Pipeline: "nightly-audit"}
+	const want = "pipeline:nightly-audit"
+
+	for _, tc := range []struct {
+		kind  string
+		stage Stage
+	}{
+		{"orchestrate", Stage{ID: "decompose", Agent: "coordinator", Prompt: "Fan out.", Action: "ask", Orchestrate: true}},
+		{"agent produce", Stage{ID: "collect", Agent: "producer", Prompt: "Produce.", Action: "produce", Writes: []string{"out.json"}}},
+		{"agent implement", Stage{ID: "fix", Agent: "implementer", Prompt: "Fix.", Action: "implement"}},
+		{"agent read-only", Stage{ID: "review", Agent: "reviewer", Prompt: "Review.", Action: "review"}},
+		{"shell", Stage{ID: "deliver", Cmd: "echo delivered"}},
+	} {
+		t.Run(tc.kind, func(t *testing.T) {
+			request := PipelineStageJobRequest(rec, tc.stage, run, 0, "", PipelineStagePRBinding{}, false)
+			if request.DispatchedBy != want {
+				t.Fatalf("%s stage dispatched_by = %q, want %q; without it the row falls back to the %q channel and a finding cannot be traced to the pipeline that ordered the review",
+					tc.kind, request.DispatchedBy, want, "pipeline")
+			}
+		})
+	}
+}

--- a/internal/pipeline/run.go
+++ b/internal/pipeline/run.go
@@ -137,7 +137,29 @@ type PipelineStagePRBinding struct {
 	LeadAgent   string
 }
 
+// PipelineStageJobRequest stamps the dispatcher on every stage request, then
+// delegates the per-kind construction below.
+//
+// #1990: THIS IS THE #1967 ARGUMENT ONE LEVEL DOWN, and I needed it because I
+// got the shallow version wrong first. #1967 set DispatchedBy in ONE of the five
+// JobRequest literals in pipelineStageJobRequest - the read-only agent branch -
+// and left orchestrate, produce, implement and shell alone. Measured in
+// production after the deploy: five real prun-* stage jobs recorded
+// dispatched_by "pipeline", the Sender channel, rather than the pipeline that
+// ordered them. The enqueue chokepoint saved them from being EMPTY, which is
+// what #1967 was for, but the more specific value was missing from four stage
+// kinds out of five.
+//
+// So it is stamped at this function's single exit instead of in its branches. A
+// sixth stage kind inherits it without its author knowing this rule exists,
+// which is the only version of this that stays true.
 func PipelineStageJobRequest(rec db.Pipeline, stage Stage, run db.PipelineRun, attempt int, upstreamContext string, binding PipelineStagePRBinding, skipNativeReviewFanout bool) workflow.JobRequest {
+	request := pipelineStageJobRequest(rec, stage, run, attempt, upstreamContext, binding, skipNativeReviewFanout)
+	request.DispatchedBy = "pipeline:" + rec.Name
+	return request
+}
+
+func pipelineStageJobRequest(rec db.Pipeline, stage Stage, run db.PipelineRun, attempt int, upstreamContext string, binding PipelineStagePRBinding, skipNativeReviewFanout bool) workflow.JobRequest {
 	// Service input is schema-validated and delivered exclusively through the
 	// dedicated PipelineInputEnv field. Never project a service run's payload into
 	// an agent prompt; Pass 2 will attach the typed env after loading its service

--- a/internal/workflow/routing_telemetry.go
+++ b/internal/workflow/routing_telemetry.go
@@ -23,6 +23,19 @@ const maxRouterContextRows = 9
 // effective values the delivery used (a #531 per-job runtime override has already
 // been applied to agent.Runtime by the caller); tokens are re-read from the job
 // row where the delivery persisted them (0 for a runtime that reports none).
+// A SESSION JOB HAS NO ROW HERE, AND THAT IS CORRECT (#1990). Measured on the
+// live store: 0 of 41 externally-driven review jobs have a routing_telemetry
+// row. This function is called only from the mailbox DELIVERY path, and a
+// session job has no engine delivery - the session did the work itself. Every
+// column below describes that delivery: Runtime and Model are the values the
+// delivery resolved, TemplateID/TemplateCommit the snapshot it ran, DurationMS
+// the time it took, and the tokens are re-read from what the delivery
+// persisted. None of those facts exists for a session row.
+//
+// Synthesising one would not be neutral. buildRouterContextBlock feeds this
+// table into coordinator prompts as OBSERVED PERFORMANCE, so rows with an empty
+// runtime, an empty model and a zero duration would degrade routing advice with
+// measurements nobody made. Absent is right; undocumented was not.
 func (m Mailbox) recordRoutingTelemetry(ctx context.Context, job db.Job, agent runtime.Agent, payload JobPayload, result AgentResult, state JobState, duration time.Duration) {
 	if m.store == nil {
 		return

--- a/internal/workflow/session_job.go
+++ b/internal/workflow/session_job.go
@@ -100,6 +100,20 @@ func (m Mailbox) OpenExternalJob(ctx context.Context, request JobRequest) (db.Jo
 		// was previously dropped here, which is why a recorded session job could
 		// only ever be attributed to an agent.
 		ActingOrgRole: NormalizeActingOrgRole(request.ActingOrgRole),
+		// #1990: THIS IS A FOURTH INSERT PATH AROUND prepareEnqueue, and that is
+		// why two unrelated-looking fields were both missing from it.
+		//
+		// #1967 resolved the dispatcher at Mailbox.Enqueue and argued that a
+		// chokepoint fixes the whole class. A session job never reaches that
+		// chokepoint: OpenExternalJob builds its own payload and inserts through
+		// CreateExternallyDrivenJobWithEvent. So every session row carried an
+		// empty dispatched_by, and #1967's PR body overclaimed. Measured on the
+		// live store: session-review-gm-staged-18d31434c33800ec has
+		// acting_org_role=gm-staged, head_sha NULL and dispatched_by empty, all
+		// on one row.
+		//
+		// Resolved with the SAME function the chokepoint uses, not a second rule.
+		DispatchedBy: dispatcherIdentity(request),
 	})
 	if err != nil {
 		return db.Job{}, err
@@ -119,6 +133,27 @@ func (m Mailbox) OpenExternalJob(ctx context.Context, request JobRequest) (db.Jo
 		Kind:    string(JobRunning),
 		Message: "job started (externally driven session)",
 	}}
+	// THE HEAD IS DELIBERATELY NOT PAYLOAD, and #1990 is what happens when that
+	// is true in the code and invisible at the CLI.
+	//
+	// A supplied head comes from the caller, not from anything the engine
+	// observed, so persisting it would make a CLI assertion into merge evidence:
+	// an operator could claim an approval at any head and the exact-head gate
+	// would count it. This repo already quarantines caller-asserted authority
+	// for the same reason - review_findings.go refuses a caller-supplied
+	// observed_at as an ordering authority. See SessionJobDisplayEventKind.
+	//
+	// THE ASYMMETRY IS REAL AND WORTH KNOWING BEFORE YOU CHANGE THIS.
+	// CloseExternalJobWithUsage takes prOverride, headSHAOverride and
+	// branchOverride from the same caller in the same call, and it PERSISTS the
+	// first and third to the payload while quarantining only the second. That is
+	// defensible - a claimed pull request or branch does not let anybody satisfy
+	// an exact-head review requirement, and a claimed head does - but it was
+	// undocumented, so the three arguments looked alike and were not.
+	//
+	// What #1990 fixed is not the quarantine. It is that `job record` accepted
+	// --head-sha, echoed it back in its own --json, and stored nothing, so the
+	// operator saw their own input reflected and read it as recorded.
 	if displayEvent, ok := sessionJobDisplayEvent(job.ID, request.HeadSHA); ok {
 		events = append(events, displayEvent)
 	}


### PR DESCRIPTION
Fixes #1990. Part of campaign #1966. Handed to me by `gm-staged`, who found it on their own verdict row.

## The reported defect is real. Its proposed fix is not the one to make.

`gitmoot job record --type review --head-sha <H>` accepts the head, echoes it back in its own `--json`, and stores nothing in the payload. Verified at the line: `OpenExternalJob` (`session_job.go:72`) builds its payload with no `HeadSHA` field and touches `request.HeadSHA` exactly once, at `:122`, only to build `sessionJobDisplayEvent`.

Verified population, independently re-derived: externally-driven review jobs **41**, payload `head_sha` set on **0**, `pull_request` set on **41**. Engine-dispatched succeeded reviews **3391**, head set on **3387**.

`gm-staged` also flagged that their origin discriminator was unverified. **Discharged:** `externally_driven` is set at exactly one INSERT site (`store_jobs.go:201`) and no `UPDATE` anywhere sets it, so 41 is exact rather than an over-count.

**But the quarantine is deliberate and typed, not an oversight.** `session_job.go:15-17`: "Merge policy must not read it: its head SHA comes from the CLI caller, not system-observed evidence." And it is a typed evidence grade, not a convention: `evidence.SessionReviewGrade` is `GradeReported`, stamped onto every session review payload at close, because "session review inputs are caller-supplied, so this can never be stronger than reported."

Persisting `--head-sha` into the payload would put reported-grade data into the field the merge gate reads as system-observed, so any operator could claim an approval at an arbitrary head. That is the hole #1950 exists to close.

So the issue's headline, "nineteen approvals no exact-head gate can count", is the wrong way round: under the boundary those approvals **should not** count. The defect is that the CLI made an operator believe a head was recorded. `gm-staged` conceded this and corrected the issue themselves; the exchange is on #1990.

## The sharper finding, which is what to read first

`CloseExternalJobWithUsage` receives `prOverride`, `headSHAOverride` and `branchOverride` from the same caller in the same call. It **persists** `prOverride` to `payload.PullRequest` (`:179-181`), **persists** `branchOverride` to `payload.Branch` (`:182-184`), and for the head emits **another display event** (`:192`).

Three caller assertions, two trusted into the payload, one quarantined, and no comment in that function on why. The asymmetry is defensible - a claimed PR or branch does not let anyone satisfy an exact-head review requirement, and a claimed head does - but it was undocumented, so the three arguments looked alike and were not.

## The echo was wider than the head

`decision`, `severity` and `summary` were **also** printed from the flag values rather than the stored result, in both `job record` and `job close`. Any normalisation, defaulting or refusal between the CLI and the store would have been invisible in exactly the same way.

## The change

1. **Report the stored row, never the flags,** in both `job record` and `job close`. Leaving one verb honest and its sibling lying is how this comes back.
2. **Name the plane.** A new `head_sha_plane` field reports `display` when a head was supplied, so the value can no longer be mistaken for a stored, gate-readable head. Additive and omitted when no head was given.
3. **Keep the flag and the display event.** `gm-staged` and I both initially preferred refusing the flag; their own constraint overrides that preference and they were right: the display event is the only durable record of which commit a session reviewer says they read, and refusing the flag would delete it. The flag's help text now states that it is caller-asserted, is not stored in the payload, and no merge policy reads it.
4. **Document the quarantine at the point of use**, including the PR/branch asymmetry, so the next reader does not have to rediscover that the three arguments are not treated alike.
5. **Answer the telemetry question with field-level evidence** rather than a shrug. `recordRoutingTelemetry` is called only from the mailbox delivery path, and every column describes that delivery: `Runtime`, `Model`, `TemplateID`, `TemplateCommit`, `DurationMS`, and tokens re-read from what the delivery persisted. A session job has no engine delivery, so none of those facts exists. Synthesising a row would not be neutral: `buildRouterContextBlock` feeds this table into coordinator prompts as **observed performance**, so empty runtimes and zero durations would degrade routing advice. Absent is correct; undocumented was the defect. Recorded in the source.

## And two corrections to my own merged work

**`OpenExternalJob` is a fourth insert path around `prepareEnqueue`.** #1967 resolved the dispatcher at the `Mailbox.Enqueue` chokepoint and its PR body claimed that covers every dispatch path. A session job never reaches that chokepoint, so every session row carried an empty `dispatched_by`. Live evidence, one row, both defects at once: `session-review-gm-staged-18d31434c33800ec` has `acting_org_role=gm-staged`, `head_sha` NULL and `dispatched_by` empty. Resolved here with the same `dispatcherIdentity` function, not a second rule.

**#1967's pipeline enrichment covered one stage kind out of five, and production found it, not I.** `PipelineStageJobRequest` has five per-kind `JobRequest` literals; #1967 set `DispatchedBy` only in the read-only agent branch. After the deploy, five real `prun-*` stage jobs recorded `dispatched_by = "pipeline"`, the Sender channel, rather than the pipeline that ordered them. The chokepoint kept the column non-empty, which is what #1967 was for, but four kinds never got the specific value. Now stamped at the function's single exit, so a sixth stage kind inherits it without its author knowing the rule exists.

## Verification

`TestJobRecordReportsTheStoredRowRatherThanItsOwnFlags` uses the assertion `gm-staged` specified: compare the `--json` output against the row **re-read from the store**. A test asserting `head_sha` is non-null passes with the echo fully intact, which is how this survived three days. It also asserts the premise (the payload really carries no head), so if the quarantine ever moves the test says so instead of silently reasoning about a world that no longer exists.

`TestEveryPipelineStageKindNamesTheDispatchingPipeline` asserts **every** stage kind rather than the one that was broken.

### Mutation proof

| Mutant | Result |
| --- | --- |
| the head is printed with no plane | FAILS: `reported head_sha_plane = "", want "display"` |
| `OpenExternalJob` stops carrying the dispatcher | FAILS: `session row dispatched_by = "", want "gm-staged"` |
| the per-branch pipeline fix I shipped in #1967 is restored | FAILS **4 of 5** subtests, leaving the read-only agent kind green: the shipped defect exactly |

**One mutant survives, and the test says so in the source rather than implying coverage:** feeding `decision`, `severity` and `summary` from the flags again leaves the test green. Nothing between the CLI and the store transforms them - `validateSessionSeverity` validates without normalising, and the summary is trimmed before storage - so flag-echo and store-read are byte-identical today. That comparison is kept because it costs nothing and fails the moment any normalisation is introduced, which is exactly when an echo would start lying again. The assertions that kill mutants are the plane and the dispatcher.

### Gate, and an honest account of a contaminated one

`gofmt` clean, `go build -buildvcs=false ./...`, `go vet ./...` pass. All new tests pass on the current head.

`go test ./internal/cli/` fails ~20 dispatch and blocked-advance tests on this host, and **it is the disk guard, not this change.** `checkDiskGuard` measures the real filesystem and refuses dispatch below `min_free_percent=5.00`, printing `DISK GUARD REFUSED JOB DISPATCH: free_percent=... min_free_percent=5.00`; every dispatch test then fails in ~0.04s. `gm-transport` and `gm-integrity` diagnosed the identical shape independently today, and the host has crossed that floor twice in three hours, both times inside a full-suite run - the suite's own temp homes and worktrees consume the margin. Every one of these tests passes in isolation at 28 GiB free, including on this branch.

**I got the mechanism wrong first and am correcting it rather than leaving it:** on PR #1992 I attributed the same failure shape to CPU load average. That was wrong. I had measured free space *after* the run rather than during it, which is the wrong moment to sample a resource the run itself consumes. The conclusion (not my change) was right; the stated cause was not, and I have corrected #1992.

One further void: a deploy build briefly checked this clone out to `origin/main` while a package run was reading source from disk. `phobos` reported it immediately; I verified branch, both commits, clean tree and the reflog round trip, and discarded that run's result rather than interpreting it.

CI on an unloaded runner with disk headroom is the authoritative arbiter here. `-race` not run: requires cgo, unavailable in this seat.

## Not claimed

- **Session verdicts remain headless, deliberately.** A session `changes_requested` still blocks every head, which is what #1950 wants. `gm-staged` confirmed from the line that giving these rows a head would move them into the strict `reviewsAtHead` population, where a push would leave the objection behind and clear the block. I am not doing that.
- No migration, no config change, no backfill. The 41 existing rows keep their empty payload head.
- I did not enumerate every consumer that drops session rows. `gm-staged`'s lead - `review_loop.go` `FindRepeatedReviewers` and `proof/project.go`, both named in #1950's own helper comment as not using the shared identity resolver - is unmeasured by me and stays open.

## Deploy notes

No migration. CLI output and payload-construction changes, effective on the next `job record` / `job close` and the next pipeline stage dispatch. Both binaries per the two-services rule.
