### PR TITLE
fix(workflow): record whether a reviewer declared its evidence mode (#1817)

### DIFF
--- a/internal/prompts/contract_drift_test.go
+++ b/internal/prompts/contract_drift_test.go
@@ -68,6 +68,12 @@ var normalizationOwnedResultFields = map[string]string{
 	// lives in the result so RetryJob clears it along with the result. An agent
 	// claiming it would be asserting a lifecycle fact the product owns.
 	"superseded_pull_request_closed": "set by the closed-pull-request sweep, never requested from an agent",
+	// Assigned by normalizeAgentResult from whether the producer sent `evidence`
+	// at all, so an honest static_only stays distinguishable from a producer that
+	// never emitted the field (#1817). Naming it in the prompt would invite an
+	// agent to assert its own provenance, which is the one thing it must not do:
+	// normalization overwrites any supplied value for exactly that reason.
+	"evidence_declared": "assigned by result normalization from the producer's own silence, never requested from an agent",
 }
 
 func contractFieldNames() []string {

--- a/internal/prompts/contractgen/main.go
+++ b/internal/prompts/contractgen/main.go
@@ -81,6 +81,18 @@ var resultFieldAnnotations = map[string]fieldAnnotation{
 	// fact the product owns. The empty entry still satisfies the every-field-accounted
 	// -for check, so a future rename cannot silently drop it.
 	"superseded_pull_request_closed": {},
+	// evidence_declared is ENGINE-OWNED for the same reason, so it carries neither
+	// an example nor help. normalizeAgentResult assigns it from whether the
+	// producer sent `evidence` at all, BEFORE the safe default overwrites the
+	// value, so an honest static_only stays distinguishable from a producer that
+	// never emitted the field (#1817 - measured at 93% of succeeded reviews
+	// omitting it, which is why a policy refusing static_only today would refuse
+	// almost every review). Advertising it would invite an agent to assert its own
+	// provenance, and provenance about a value must not come from that value's
+	// author; normalization overwrites any supplied value for exactly that reason.
+	// The empty entry still satisfies the every-field-accounted-for check, so a
+	// future rename cannot silently drop it.
+	"evidence_declared": {},
 }
 
 // delegationFieldAnnotations covers every JSON field of workflow.Delegation.

--- a/internal/workflow/evidence_declared_test.go
+++ b/internal/workflow/evidence_declared_test.go
@@ -1,0 +1,122 @@
+package workflow
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// #1817's acceptance criterion 2 asked for a first-class field distinguishing a
+// reviewer that could not execute from one that ran the suite. That field
+// already existed as `evidence`, and it already normalises an omission to
+// `static_only` so silence can never read as an execution claim.
+//
+// What it could not do was distinguish the two REASONS a stored result says
+// `static_only`. Measured over 3,431 succeeded review jobs on this host: 3,192
+// (93%, 14.328 G tokens) omit the field entirely, 198 declare `executed`, 41
+// declare `static_only`. So an honest "I could run nothing" and "I have never
+// heard of this field" stored the same value, which is what makes any policy
+// built on the field unsafe: refusing `static_only` today would refuse 93% of
+// all reviews, almost none of which made the claim.
+func TestEvidenceDeclaredSeparatesAnHonestStaticOnlyFromSilence(t *testing.T) {
+	for _, tt := range []struct {
+		name         string
+		raw          string
+		wantEvidence string
+		wantDeclared bool
+	}{
+		{
+			name:         "an omitted field still defaults to static_only, and is marked undeclared",
+			raw:          `{"decision":"approved","summary":"looks fine"}`,
+			wantEvidence: EvidenceStaticOnly,
+			wantDeclared: false,
+		},
+		{
+			name:         "an explicit static_only is the same value and IS declared",
+			raw:          `{"decision":"approved","summary":"read only","evidence":"static_only"}`,
+			wantEvidence: EvidenceStaticOnly,
+			wantDeclared: true,
+		},
+		{
+			name:         "executed is declared",
+			raw:          `{"decision":"approved","summary":"ran it","evidence":"executed"}`,
+			wantEvidence: EvidenceExecuted,
+			wantDeclared: true,
+		},
+		{
+			name:         "an empty string is silence, not a declaration",
+			raw:          `{"decision":"approved","summary":"blank","evidence":""}`,
+			wantEvidence: EvidenceStaticOnly,
+			wantDeclared: false,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			var result AgentResult
+			if err := json.Unmarshal([]byte(tt.raw), &result); err != nil {
+				t.Fatal(err)
+			}
+			normalizeAgentResult(&result)
+			if result.Evidence != tt.wantEvidence {
+				t.Errorf("evidence = %q, want %q; the safe default must not change", result.Evidence, tt.wantEvidence)
+			}
+			if got := EvidenceWasDeclared(result); got != tt.wantDeclared {
+				t.Errorf("declared = %v, want %v", got, tt.wantDeclared)
+			}
+		})
+	}
+}
+
+// TestEvidenceDeclaredCannotBeAssertedByTheProducer is the spoof arm, and it is
+// the reason the flag is engine-owned rather than a plain input field.
+//
+// Provenance about a value must not come from that value's author. The same
+// idiom is already used for ReviewStatusGrade, and for #1926's real-adapter
+// declaration, which binds a claim to the thing it was made about rather than
+// storing a bare boolean a fixture can overwrite.
+func TestEvidenceDeclaredCannotBeAssertedByTheProducer(t *testing.T) {
+	// A producer claiming it declared, while declaring nothing.
+	var forged AgentResult
+	if err := json.Unmarshal([]byte(`{"decision":"approved","summary":"trust me","evidence_declared":true}`), &forged); err != nil {
+		t.Fatal(err)
+	}
+	normalizeAgentResult(&forged)
+	if EvidenceWasDeclared(forged) {
+		t.Fatalf("a producer asserted evidence_declared with no evidence and it survived normalization")
+	}
+	if forged.Evidence != EvidenceStaticOnly {
+		t.Errorf("evidence = %q, want %q", forged.Evidence, EvidenceStaticOnly)
+	}
+
+	// And the inverse: a producer that declares executed but sends
+	// evidence_declared:false does not get to hide that it made the claim.
+	var denied AgentResult
+	if err := json.Unmarshal([]byte(`{"decision":"approved","summary":"ran it","evidence":"executed","evidence_declared":false}`), &denied); err != nil {
+		t.Fatal(err)
+	}
+	normalizeAgentResult(&denied)
+	if !EvidenceWasDeclared(denied) {
+		t.Fatalf("a producer suppressed evidence_declared while declaring executed")
+	}
+}
+
+// TestEvidenceDeclaredDoesNotChangeExecutionSemantics pins the boundary this
+// change deliberately does not cross. `EvidenceWasExecuted` is what every
+// existing consumer asks, and a merge policy that refused static_only would
+// refuse 93% of reviews on this store, so nothing here may alter that answer.
+func TestEvidenceDeclaredDoesNotChangeExecutionSemantics(t *testing.T) {
+	for _, raw := range []string{
+		`{"decision":"approved","summary":"s"}`,
+		`{"decision":"approved","summary":"s","evidence":"static_only"}`,
+		`{"decision":"approved","summary":"s","evidence":"executed"}`,
+	} {
+		var result AgentResult
+		if err := json.Unmarshal([]byte(raw), &result); err != nil {
+			t.Fatal(err)
+		}
+		normalizeAgentResult(&result)
+		want := strings.Contains(raw, `"evidence":"executed"`)
+		if got := EvidenceWasExecuted(result); got != want {
+			t.Errorf("EvidenceWasExecuted(%s) = %v, want %v", raw, got, want)
+		}
+	}
+}

--- a/internal/workflow/merge_gate.go
+++ b/internal/workflow/merge_gate.go
@@ -644,6 +644,17 @@ func (g PolicyMergeGate) recordApprovalEvidence(ctx context.Context, job db.Job,
 	detail := "executed"
 	if !EvidenceWasExecuted(*payload.Result) {
 		detail = "NOT executed - this approval's claims were not produced by running anything"
+		// #1817: SAY WHETHER THE REVIEWER ACTUALLY CLAIMED THIS. An omitted
+		// evidence field normalises to static_only, so without this the record
+		// reads identically for a reviewer that honestly reported running nothing
+		// and one that has never emitted the field - and the second group is 93%
+		// of succeeded reviews on this store. Anyone reading these rows to decide
+		// whether a static-only refusal is safe needs the two separated.
+		if EvidenceWasDeclared(*payload.Result) {
+			detail += "; the reviewer declared this"
+		} else {
+			detail += "; the reviewer declared NO evidence mode, so this is the safe default rather than a claim"
+		}
 	}
 	// IF ABSENT, because ensureFinalReviewCaptured runs on EVERY merge-gate
 	// pass: a PR pending on CI is re-evaluated on every poll, so AddJobEvent

--- a/internal/workflow/result.go
+++ b/internal/workflow/result.go
@@ -390,6 +390,25 @@ type AgentResult struct {
 	// A static-only verdict is LEGITIMATE and no check fails it. What fails is
 	// claiming execution while naming nothing that was run.
 	Evidence string `json:"evidence,omitempty"`
+	// EvidenceDeclared records whether the PRODUCER sent an evidence value, as
+	// distinct from the engine defaulting one. It is ENGINE-OWNED: normalizeAgentResult
+	// assigns it unconditionally, so a producer that sends it is overwritten and
+	// cannot assert its own provenance. Same idiom as ReviewStatusGrade - a fact
+	// about where a value came from does not come from the value's author.
+	//
+	// It exists because the default above is safe but LOSSY, and the loss is
+	// large: measured over 3,431 succeeded review jobs, 3,192 of them (93%,
+	// 14.328 G tokens) omit evidence entirely, 198 declare executed and 41
+	// declare static_only. So "I could not execute anything" and "I have never
+	// heard of this field" stored the same value, which makes the field
+	// uninformative in aggregate and makes any policy built on it unsafe: a
+	// refusal on static_only today would refuse 93% of all reviews, the
+	// overwhelming majority of which never made the claim at all.
+	//
+	// It changes no policy. Evidence still normalises to static_only, and
+	// EvidenceWasExecuted still answers the same question. This only makes the
+	// silence countable, which is the prerequisite for anyone acting on it.
+	EvidenceDeclared bool `json:"evidence_declared,omitempty"`
 }
 
 // The two values Evidence accepts. A closed pair of strings rather than a
@@ -416,6 +435,17 @@ func ValidEvidence(value string) bool {
 // TestsRun describing what it could NOT run.
 func EvidenceWasExecuted(r AgentResult) bool {
 	return strings.TrimSpace(r.Evidence) == EvidenceExecuted
+}
+
+// EvidenceWasDeclared reports whether the producer actually stated its evidence
+// mode, rather than the engine defaulting it to static_only.
+//
+// A consumer that wants to ACT on static_only - refuse it, escalate it, count
+// it - must ask this too. Without it, an honest reviewer reporting that it could
+// run nothing is indistinguishable from a producer that has never emitted the
+// field, and on this store the second group is 93% of succeeded reviews.
+func EvidenceWasDeclared(r AgentResult) bool {
+	return r.EvidenceDeclared
 }
 
 // authorityGrantingResultFields are AgentResult fields an agent may NEVER supply,
@@ -991,7 +1021,15 @@ func normalizeAgentResult(result *AgentResult) {
 	// passed". A reviewer that DID execute says so; silence is treated as the
 	// weaker claim, because the alternative is inferring an execution that may
 	// never have happened.
-	if !ValidEvidence(result.Evidence) {
+	//
+	// #1817's adoption measurement showed the default is also LOSSY: 3,192 of
+	// 3,431 succeeded reviews omit the field, so an honest static_only and a
+	// producer that never emitted one stored the same value. Capture DECLARED
+	// before the default overwrites it. Assigned unconditionally, so a producer
+	// that supplies evidence_declared itself is overwritten and cannot assert
+	// its own provenance.
+	result.EvidenceDeclared = ValidEvidence(result.Evidence)
+	if !result.EvidenceDeclared {
 		result.Evidence = EvidenceStaticOnly
 	}
 	if result.Needs == nil {

--- a/skills/gitmoot/references/RESULT_CONTRACT.md
+++ b/skills/gitmoot/references/RESULT_CONTRACT.md
@@ -39,6 +39,20 @@ Omitting the field records `static_only`. Silence never becomes an execution
 claim, so a producer that does not know about this field cannot be read as
 having run anything. An unrecognised value is rejected outright.
 
+**The engine now records WHETHER YOU DECLARED IT**, alongside the value, in an
+engine-owned `evidence_declared` flag. Do not send that flag: it is assigned
+during normalization and a supplied value is overwritten, because provenance
+about a value must not come from the value's author.
+
+It exists because the safe default is lossy. Measured over 3,431 succeeded
+review jobs on one host, 3,192 of them (93%, 14.3 G tokens) omitted `evidence`
+entirely, 198 declared `executed` and 41 declared `static_only`. So an honest
+"I could run nothing" and "I have never heard of this field" stored the same
+value. **The practical consequence for anyone reading these rows: a policy that
+refused `static_only` would today refuse 93% of all reviews**, almost none of
+which made the claim. Declaring the field is what makes your verdict
+distinguishable from silence, so declare it.
+
 **No check fails a static-only review.** The distinction a merge decision needs
 is carried by the stored field, not by refusing the verdict. An earlier version
 of this feature failed every static-only review, which under


### PR DESCRIPTION
Refs #1817, acceptance criterion 2. Campaign #1818, after #1817 (`e16875b3`), #1819 (`62f65b5c`) and #1994 (`e8b48f54`).

## First, a correction, because it decides what this PR is

I claimed on #1817 that "there is still no first-class `could_not_execute` field in the verdict envelope." **That was false and I withdrew it** ([comment 5574267939](https://github.com/gitmoot/gitmoot/issues/1817#issuecomment-5574267939)). The field exists and has for some time:

- `evidence`, values `executed` / `static_only` (`result.go:399-400`), with one `EvidenceKinds` list so "the prompt, the validator and the gate cannot disagree".
- Validated (`:546`); an **omitted** field normalises to `static_only` (`:1031`) so silence can never be read as an execution claim.
- Documented in `RESULT_CONTRACT.md`.
- **Consumed** by the merge gate: `recordApprovalEvidence` (`merge_gate.go:636`) records it against every approval, deliberately recording rather than refusing because refusal "belongs to whoever owns merge policy".

So criterion 2 was substantially built. This PR closes the one part that was not.

## The headline number, which is the most consequential thing I measured today

Succeeded review jobs, 3,431 of them, by declared evidence:

| `evidence` | jobs | tokens | mean |
|---|---|---|---|
| **absent** (defaults to `static_only`) | **3,192** (93%) | 14.328 G | 4.49 M |
| `executed` | 198 | 0.733 G | 3.70 M |
| `static_only` | 41 | 0.050 G | 1.21 M |

Producer adoption is **6%**. Among the static-only-or-absent population there are **1,090 approvals**, of which only **17** are explicitly declared.

**A merge policy that refused `static_only` today would refuse 93% of all reviews**, because absence defaults to it and almost none of those reviews made the claim. Anyone who reads #1817's criterion 2 and reaches for a refusal needs to hit that sentence before writing any code. #1817's own thread warned that a static-only refusal would block every merge while reviewers could not execute; the warning now holds for a completely different reason.

## What this does

`normalizeAgentResult` captures whether the producer sent a valid `evidence` value **before** the default overwrites it, into an engine-owned `evidence_declared` flag, plus an `EvidenceWasDeclared` accessor. The merge gate's approval record now distinguishes `the reviewer declared this` from `the reviewer declared NO evidence mode, so this is the safe default rather than a claim`.

Three properties, each deliberate:

- **Engine-owned and spoof-proof.** The flag is assigned unconditionally, so a producer supplying `evidence_declared: true` with no `evidence` is overwritten, and one supplying `false` beside `executed` cannot hide that it made the claim. Provenance about a value must not come from that value's author, which is the same rule `ReviewStatusGrade` follows.
- **Registered in the prompt drift guard.** `evidence_declared` goes into `normalizationOwnedResultFields`, whose paired test asserts such fields must **not** appear in the prompt. Naming it would invite agents to assert their own provenance. Without this registration the contract drift guard fails, which is how I found the right home for it rather than inventing one.
- **No policy change whatsoever.** `Evidence` still normalises to `static_only`; `EvidenceWasExecuted` answers exactly as before; the gate still records rather than refuses. This only makes the silence countable.

## Tests

`internal/workflow/evidence_declared_test.go`, three functions.

- `...SeparatesAnHonestStaticOnlyFromSilence` — four arms: omitted, explicit `static_only`, `executed`, and empty-string. The value must not change in any of them; only the flag does.
- `...CannotBeAssertedByTheProducer` — the spoof arm, both directions: a forged `true` with no evidence is destroyed, and a suppressed `false` beside `executed` cannot hide the claim.
- `...DoesNotChangeExecutionSemantics` — pins the boundary this must not cross.

### Fails before, passes after

The before-arm is the **natural mistake** rather than a straw man: compute `declared` *after* the default instead of before. Everything then looks declared, and three arms catch it.

| mutant | killed by |
|---|---|
| compute `declared` after the default (wrong order) | 3 arms across 2 functions |
| trust the producer's flag (`x = x \|\| valid`) | `...CannotBeAssertedByTheProducer` |

`result.go` verified sha256-identical after restore.

## Gate

```
go1.26.4 linux/amd64   GOTOOLCHAIN=local   CGO_ENABLED=0
gofmt -l internal/                empty
go build -buildvcs=false ./...    PASS
go vet ./...                      PASS
go generate ./... && git status   clean
go test ./internal/workflow/      ok  102.915s
go test ./internal/prompts/...    ok
go test ./skills/                 ok
```

Not run and not claimed: `-race` locally (cgo unavailable), covered by CI's race shards. Remaining packages posted as a comment when they finish.

## What this does not do, named so nobody assumes it

- **It does not refuse anything.** On these numbers a refusal is unsafe regardless of who authorises it, and that decision is reserved in the code to merge-policy ownership.
- **It does not raise adoption.** Making silence countable is not the same as making producers speak. The 6% is now measurable rather than fixed, and the contract doc now tells producers why declaring matters, but the number will not move until emitters change.
- **It measures nothing retroactively.** Rows already stored keep an absent flag, so the 93% is a statement about history read from the raw payloads, not something this field can recover.
