### PR TITLE
fix(cli): let the transport record a directive receipt, not the seat (#1980)

### DIFF
--- a/internal/cli/event_rule_sink.go
+++ b/internal/cli/event_rule_sink.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"strconv"
 	"strings"
 	"time"
 	"unicode/utf8"
@@ -271,6 +272,7 @@ func (s *eventRuleSink) evaluateRules(ctx context.Context, event events.Event, r
 			}
 			ccancel()
 			slog.Info("org event wake delivered", "rule_id", rule.ID, "role", rule.WakeRole, "job_id", event.JobID, "delivered", true)
+			s.recordDirectiveDeliveryReceipt(ctx, event)
 			if err := s.finishWakeOutbox(ctx, event, db.WakeOutboxStateDelivered, ""); err != nil {
 				return err
 			}
@@ -451,6 +453,58 @@ func (s *eventRuleSink) finishWakeOutbox(ctx context.Context, event events.Event
 	return nil
 }
 
+// recordDirectiveDeliveryReceipt writes the transport's own receipt for a
+// directive whose prompt Herdr has just confirmed landed (#1980).
+//
+// WHY THE TRANSPORT AND NOT THE SEAT: an acknowledgment answers "did this
+// reach you", which the delivery confirmation already answers. Routing that
+// question through a model turn spent the turn boundary, and the turn boundary
+// is the scarce resource. Measured on this fleet: 3,306 ack markers, 124 of
+// the last 125 written by the addressed seat itself, median 96s after the
+// directive.
+//
+// IT IS BEST-EFFORT ON PURPOSE. A failed receipt write must not turn a
+// DELIVERED wake into a failure: the wake did land. The cost of losing it is
+// one extra acknowledgment-phase nudge, which is the pre-#1980 behaviour, so
+// the failure direction is the old behaviour rather than a new one.
+func (s *eventRuleSink) recordDirectiveDeliveryReceipt(ctx context.Context, event events.Event) {
+	if s == nil || s.store == nil {
+		return
+	}
+	if !strings.EqualFold(strings.TrimSpace(event.WakeKind), db.WakeOutboxKindDirective) {
+		return
+	}
+	role := strings.ToLower(strings.TrimSpace(event.WakeTargetRole))
+	if role == "" {
+		return
+	}
+	directiveID, err := strconv.ParseInt(
+		strings.TrimPrefix(event.RootID, db.WakeOutboxSourceWorkflowNote+":"), 10, 64)
+	if err != nil || directiveID <= 0 {
+		return
+	}
+	writeCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), db.DurableWriteBudget)
+	defer cancel()
+	directive, err := s.store.GetWorkflowNote(writeCtx, directiveID)
+	if err != nil {
+		slog.Warn("directive delivery receipt skipped", "directive", directiveID, "error", err)
+		return
+	}
+	inserted, err := s.store.InsertOrgDirectiveReceipt(writeCtx, db.WorkflowNote{
+		WorkflowID: directive.WorkflowID,
+		Author:     role,
+		Body:       workflow.FormatOrgDirectiveDeliveredNote(directiveID, role),
+		Repo:       directive.Repo,
+	}, directiveID, "delivered")
+	if err != nil {
+		slog.Warn("directive delivery receipt failed", "directive", directiveID, "role", role, "error", err)
+		return
+	}
+	if inserted {
+		slog.Info("directive delivery receipt recorded", "directive", directiveID, "role", role)
+	}
+}
+
 // loadOrgConfig reads the org registry once per event. Best-effort: a missing or
 // unreadable config disables all wakes for this event (no role bindings resolve).
 func (s *eventRuleSink) loadOrgConfig() (config.OrgConfig, bool) {
@@ -578,9 +632,13 @@ func eventRuleWakePrompt(kind string, event events.Event) string {
 		case directiveTerminalCause:
 			return fmt.Sprintf("gitmoot directive %s for %s is already terminal; no receipt or completion action is required", directiveID, event.WakeTargetRole)
 		default:
+			// #1980: the transport records the receipt itself the moment this
+			// prompt lands, so the seat is told what it OWES, not asked to
+			// confirm what delivery already proved. The only remaining receipt
+			// a seat can add information to is completion.
 			return fmt.Sprintf(
-				"gitmoot directive %s for %s; acknowledge receipt with: gitmoot org directive ack %s --by %s",
-				directiveID, event.WakeTargetRole, directiveID, event.WakeTargetRole,
+				"gitmoot directive %s for %s; read it with: gitmoot workflow show-note %s, then record completion with: gitmoot org directive done %s --by %s",
+				directiveID, event.WakeTargetRole, directiveID, directiveID, event.WakeTargetRole,
 			)
 		}
 	}

--- a/internal/cli/event_rule_sink_test.go
+++ b/internal/cli/event_rule_sink_test.go
@@ -85,10 +85,14 @@ func TestEventRuleDirectiveWakePromptMatchesCurrentPhase(t *testing.T) {
 		forbidden []string
 	}{
 		{
+			// #1980: the first-delivery prompt carries the OBLIGATION, not a
+			// receipt chore. The transport records receipt itself when this very
+			// prompt lands, so asking the seat for an ack spent a turn boundary
+			// to learn what delivery already proved.
 			name:      "receipt",
 			cause:     "addressed_directive",
-			want:      []string{"acknowledge receipt", "gitmoot org directive ack 42 --by worker"},
-			forbidden: []string{"gitmoot org directive done"},
+			want:      []string{"gitmoot workflow show-note 42", "gitmoot org directive done 42 --by worker"},
+			forbidden: []string{"acknowledge receipt", "gitmoot org directive ack"},
 		},
 		{
 			// MUTANT: reverting to the fixed receipt prompt would tell an already

--- a/internal/cli/org_directive_test.go
+++ b/internal/cli/org_directive_test.go
@@ -394,12 +394,117 @@ func TestDirectiveWakeOutboxUsesSeparateCoalesceNamespace(t *testing.T) {
 	}
 	directivePrompt := ""
 	for _, prompt := range wake.prompts {
-		if strings.Contains(prompt, "gitmoot org directive ack") {
+		if strings.Contains(prompt, "gitmoot org directive") {
 			directivePrompt = prompt
 		}
 	}
-	if wake.promptCalls != 2 || !strings.Contains(directivePrompt, fmt.Sprintf("directive %d", directive.ID)) || !strings.Contains(directivePrompt, fmt.Sprintf("gitmoot org directive ack %d --by owner", directive.ID)) {
+	if wake.promptCalls != 2 || !strings.Contains(directivePrompt, fmt.Sprintf("directive %d", directive.ID)) {
 		t.Fatalf("directive wake calls=%d prompts=%q", wake.promptCalls, wake.prompts)
+	}
+}
+
+// TestDeliveredDirectiveRecordsReceiptWithoutASeatTurn is #1980's
+// reproduction. An acknowledgement is a state transition the transport can
+// observe: it is the pane accepting the prompt. Asking the seat to run
+// `gitmoot org directive ack` spent a whole turn boundary on bookkeeping, and
+// the turn boundary is the scarce resource. Measured on this fleet: 3,306 ack
+// markers all-time, 125 in one day, and 124 of those 125 were recorded by the
+// addressed seat itself with a median 96 seconds from directive to receipt.
+func TestDeliveredDirectiveRecordsReceiptWithoutASeatTurn(t *testing.T) {
+	store, deliverySink, wake, _ := replyWakeTestHarness(t, []replyWakeTestRole{
+		{name: "owner", pane: "w1:p1"},
+		{name: "worker", pane: "w1:p2"},
+	})
+	ctx := context.Background()
+	if err := store.AddEventRule(ctx, db.EventRule{
+		ID: "directive-worker", OnKind: db.WakeOutboxKindDirective, WakeRole: "worker", Enabled: true,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	directive, err := store.InsertWorkflowNote(ctx, db.WorkflowNote{
+		WorkflowID: "release/receipt", Author: "owner",
+		Body:              workflow.FormatOrgDirectiveNote("owner", "worker", "release/receipt", "carry this"),
+		AddressedTarget:   "worker",
+		AddressedWakeKind: db.WakeOutboxKindDirective,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	drainReplyWakeAfterAllRowsAreDue(t, store, deliverySink)
+
+	if wake.promptCalls != 1 {
+		t.Fatalf("directive wake calls = %d, want one; prompts=%q", wake.promptCalls, wake.prompts)
+	}
+	// The seat is no longer told to run a receipt command it cannot add
+	// information to.
+	if strings.Contains(wake.prompt, "directive ack") {
+		t.Fatalf("prompt still routes the receipt through the pane: %q", wake.prompt)
+	}
+	receipts, err := store.ListWorkflowNotes(ctx, "release/receipt", 100)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := workflow.FormatOrgDirectiveDeliveredNote(directive.ID, "worker")
+	found := 0
+	for _, note := range receipts {
+		if note.Body == want {
+			found++
+		}
+	}
+	if found != 1 {
+		t.Fatalf("delivered receipt notes = %d, want exactly one %q in %+v", found, want, receipts)
+	}
+	// The obligation that remains is COMPLETION, so the receipt question must be
+	// closed for every reader that asks it.
+	outstanding, err := store.ListUnacknowledgedOrgDirectives(ctx, "worker")
+	if err != nil || len(outstanding) != 0 {
+		t.Fatalf("unacknowledged directives = %+v, err=%v, want none after proven delivery", outstanding, err)
+	}
+	open, err := store.ListOpenOrgDirectiveObligations(ctx, 50)
+	if err != nil || len(open) != 1 || open[0].AckedAt == "" {
+		t.Fatalf("open obligations = %+v, err=%v, want directive %d with a receipt time", open, err, directive.ID)
+	}
+}
+
+// TestUndeliveredDirectiveRecordsNoReceipt is the control that keeps the
+// receipt honest: the marker means the TRANSPORT observed the pane accept the
+// prompt. A stalled wake proves nothing, so the acknowledgment ladder keeps
+// running and now means exactly "delivery is not proven".
+func TestUndeliveredDirectiveRecordsNoReceipt(t *testing.T) {
+	store, deliverySink, wake, _ := replyWakeTestHarness(t, []replyWakeTestRole{
+		{name: "owner", pane: "w1:p1"},
+		{name: "worker", pane: "w1:p2"},
+	})
+	wake.stalled = true
+	ctx := context.Background()
+	if err := store.AddEventRule(ctx, db.EventRule{
+		ID: "directive-worker", OnKind: db.WakeOutboxKindDirective, WakeRole: "worker", Enabled: true,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	directive, err := store.InsertWorkflowNote(ctx, db.WorkflowNote{
+		WorkflowID: "release/unproven", Author: "owner",
+		Body:              workflow.FormatOrgDirectiveNote("owner", "worker", "release/unproven", "carry this"),
+		AddressedTarget:   "worker",
+		AddressedWakeKind: db.WakeOutboxKindDirective,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	drainReplyWakeAfterAllRowsAreDue(t, store, deliverySink)
+
+	notes, err := store.ListWorkflowNotes(ctx, "release/unproven", 100)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, note := range notes {
+		if strings.HasPrefix(note.Body, workflow.OrgDirectiveDeliveredPrefix) {
+			t.Fatalf("stalled wake recorded a delivery receipt: %q", note.Body)
+		}
+	}
+	outstanding, err := store.ListUnacknowledgedOrgDirectives(ctx, "worker")
+	if err != nil || len(outstanding) != 1 || outstanding[0].ID != directive.ID {
+		t.Fatalf("unacknowledged directives = %+v, err=%v, want directive %d still outstanding", outstanding, err, directive.ID)
 	}
 }
 
@@ -464,9 +569,12 @@ func TestDirectiveWakeDrainDoesNotCoalesceDifferentObligations(t *testing.T) {
 	var completionPrompt, acknowledgmentPrompt string
 	for _, prompt := range wake.prompts {
 		switch {
-		case strings.Contains(prompt, fmt.Sprintf("gitmoot org directive done %d --by worker", completion.ID)):
+		case strings.Contains(prompt, fmt.Sprintf("directive %d for worker is acknowledged but incomplete", completion.ID)):
 			completionPrompt = prompt
-		case strings.Contains(prompt, fmt.Sprintf("gitmoot org directive ack %d --by worker", unread.ID)):
+		// #1980: the first-delivery prompt no longer asks for a receipt, so the
+		// two phases are told apart by their own wording rather than by which
+		// receipt command they carry.
+		case strings.Contains(prompt, fmt.Sprintf("gitmoot workflow show-note %d", unread.ID)):
 			acknowledgmentPrompt = prompt
 		}
 	}

--- a/internal/db/org_directive_park.go
+++ b/internal/db/org_directive_park.go
@@ -187,7 +187,10 @@ SELECT d.id, d.workflow_id, d.author, d.body, d.repo, d.memory_observation_id, d
 	COALESCE((
 		SELECT MIN(a.created_at) FROM workflow_notes a
 		WHERE a.workflow_id = d.workflow_id
-			AND substr(a.body, 1, length('[org:directive-ack id=' || d.id || ' ')) = '[org:directive-ack id=' || d.id || ' '
+			AND (
+				substr(a.body, 1, length('[org:directive-ack id=' || d.id || ' ')) = '[org:directive-ack id=' || d.id || ' '
+				OR substr(a.body, 1, length('[org:directive-delivered id=' || d.id || ' ')) = '[org:directive-delivered id=' || d.id || ' '
+			)
 	), '')
 FROM workflow_notes d
 WHERE substr(d.body, 1, length('[org:directive ')) = '[org:directive '

--- a/internal/db/wake_outbox.go
+++ b/internal/db/wake_outbox.go
@@ -398,7 +398,10 @@ SELECT id, source_kind, source_id, target_role, coalesce_key, state,
 				FROM workflow_notes d
 				JOIN workflow_notes r ON r.workflow_id = d.workflow_id
 				WHERE d.id = CAST(wake_outbox.source_id AS INTEGER)
-					AND substr(r.body, 1, length('[org:directive-ack id=' || wake_outbox.source_id || ' ')) = '[org:directive-ack id=' || wake_outbox.source_id || ' '
+					AND (
+						substr(r.body, 1, length('[org:directive-ack id=' || wake_outbox.source_id || ' ')) = '[org:directive-ack id=' || wake_outbox.source_id || ' '
+						OR substr(r.body, 1, length('[org:directive-delivered id=' || wake_outbox.source_id || ' ')) = '[org:directive-delivered id=' || wake_outbox.source_id || ' '
+					)
 			) THEN 'completion'
 			ELSE 'acknowledgment'
 		END

--- a/internal/db/wake_outbox_test.go
+++ b/internal/db/wake_outbox_test.go
@@ -77,7 +77,10 @@ SELECT id, source_kind, source_id, target_role, coalesce_key, state,
 				FROM workflow_notes d
 				JOIN workflow_notes r ON r.workflow_id = d.workflow_id
 				WHERE d.id = CAST(wake_outbox.source_id AS INTEGER)
-					AND substr(r.body, 1, length('[org:directive-ack id=' || wake_outbox.source_id || ' ')) = '[org:directive-ack id=' || wake_outbox.source_id || ' '
+					AND (
+						substr(r.body, 1, length('[org:directive-ack id=' || wake_outbox.source_id || ' ')) = '[org:directive-ack id=' || wake_outbox.source_id || ' '
+						OR substr(r.body, 1, length('[org:directive-delivered id=' || wake_outbox.source_id || ' ')) = '[org:directive-delivered id=' || wake_outbox.source_id || ' '
+					)
 			) THEN 'completion'
 			ELSE 'acknowledgment'
 		END

--- a/internal/db/workflow_store.go
+++ b/internal/db/workflow_store.go
@@ -308,7 +308,7 @@ func (s *Store) InsertOrgDirectiveReceipt(
 		return false, errors.New("directive receipt requires a positive directive id")
 	}
 	switch kind {
-	case "ack", "done", "cancel":
+	case "ack", "done", "cancel", "delivered":
 	default:
 		return false, fmt.Errorf("unsupported directive receipt kind %q", kind)
 	}
@@ -408,9 +408,15 @@ UPDATE workflow_notes SET workflow_id = workflow_id WHERE id = ?`, directiveID)
 	}
 
 	recordedKinds := []string{kind}
-	if kind == "ack" {
+	switch kind {
+	case "ack":
 		recordedKinds = []string{"ack", "done", "cancel"}
-	} else {
+	case "delivered":
+		// A delivered marker adds nothing once ANY receipt exists, and it must
+		// be at-most-once per directive because a nag revives the same stable
+		// wake row and would otherwise append one marker per delivery (#1980).
+		recordedKinds = []string{"delivered", "ack", "done", "cancel"}
+	default:
 		// Completion and cancellation are both terminal. The first terminal
 		// marker wins; a delayed prompt cannot append the opposite marker.
 		recordedKinds = []string{"done", "cancel"}
@@ -428,8 +434,13 @@ UPDATE workflow_notes SET workflow_id = workflow_id WHERE id = ?`, directiveID)
 	if _, err := insertWorkflowNoteTx(ctx, tx, note); err != nil {
 		return false, err
 	}
-	if err := supersedeDirectiveWakeOutboxTx(ctx, tx, directiveID, kind); err != nil {
-		return false, err
+	// A delivered marker is written WHILE its own wake is being delivered, so
+	// there is no pending row to retire and the supersede reason would be a
+	// falsehood ("recorded before wake delivery").
+	if kind != "delivered" {
+		if err := supersedeDirectiveWakeOutboxTx(ctx, tx, directiveID, kind); err != nil {
+			return false, err
+		}
 	}
 	if err := tx.Commit(); err != nil {
 		return false, err
@@ -1079,6 +1090,7 @@ WHERE substr(d.body, 1, length('[org:directive ')) = '[org:directive '
 		SELECT 1 FROM workflow_notes r
 		WHERE r.workflow_id = d.workflow_id AND (
 			substr(r.body, 1, length('[org:directive-ack id=' || d.id || ' ')) = '[org:directive-ack id=' || d.id || ' '
+			OR substr(r.body, 1, length('[org:directive-delivered id=' || d.id || ' ')) = '[org:directive-delivered id=' || d.id || ' '
 			OR substr(r.body, 1, length('[org:directive-cancel id=' || d.id || ' ')) = '[org:directive-cancel id=' || d.id || ' '
 			OR substr(r.body, 1, length('[org:directive-done id=' || d.id || ' ')) = '[org:directive-done id=' || d.id || ' '
 		)
@@ -1146,7 +1158,10 @@ SELECT d.id, d.workflow_id, d.author, d.body, d.repo, d.memory_observation_id, d
 	COALESCE((
 		SELECT MIN(a.created_at) FROM workflow_notes a
 		WHERE a.workflow_id = d.workflow_id
-			AND substr(a.body, 1, length('[org:directive-ack id=' || d.id || ' ')) = '[org:directive-ack id=' || d.id || ' '
+			AND (
+				substr(a.body, 1, length('[org:directive-ack id=' || d.id || ' ')) = '[org:directive-ack id=' || d.id || ' '
+				OR substr(a.body, 1, length('[org:directive-delivered id=' || d.id || ' ')) = '[org:directive-delivered id=' || d.id || ' '
+			)
 	), '')
 FROM workflow_notes d INDEXED BY idx_workflow_notes_directive_oldest
 WHERE substr(d.body, 1, length('[org:directive ')) = '[org:directive '

--- a/internal/workflow/org_directive.go
+++ b/internal/workflow/org_directive.go
@@ -8,6 +8,13 @@ const (
 	OrgDirectiveCancelPrefix    = "[org:directive-cancel "
 	OrgDirectiveDonePrefix      = "[org:directive-done "
 	OrgDirectiveExhaustedPrefix = "[org:directive-exhausted "
+	// OrgDirectiveDeliveredPrefix marks a receipt the TRANSPORT observed: the
+	// pane accepted the directive prompt (#1980). It is deliberately a separate
+	// verb from `ack`, and carries `to=` rather than `by=`, because a seat's
+	// acknowledgment is the seat's own assertion and a machine must not write
+	// one on its behalf. Both satisfy the receipt obligation; only one claims
+	// the seat said anything.
+	OrgDirectiveDeliveredPrefix = "[org:directive-delivered "
 )
 
 func FormatOrgDirectiveNote(from, to, wf, directive string) string {
@@ -68,6 +75,30 @@ func formatOrgDirectiveReceipt(kind string, directiveID int64, by string) string
 	return formatAddressedOrgNote(kind, []addressedOrgNoteField{
 		{key: "id", value: strconv.FormatInt(directiveID, 10)}, {key: "by", value: by},
 	}, "")
+}
+
+// FormatOrgDirectiveDeliveredNote records transport-observed delivery to the
+// addressed role. `to` is the addressee, not an actor: nothing in this note
+// asserts that the seat read or accepted the directive.
+func FormatOrgDirectiveDeliveredNote(directiveID int64, to string) string {
+	if directiveID <= 0 {
+		return ""
+	}
+	return formatAddressedOrgNote("directive-delivered", []addressedOrgNoteField{
+		{key: "id", value: strconv.FormatInt(directiveID, 10)}, {key: "to", value: to},
+	}, "")
+}
+
+func ParseOrgDirectiveDeliveredNote(body string) (directiveID int64, to string, ok bool) {
+	values, content, ok := parseAddressedOrgNote("directive-delivered", body)
+	if !ok || content != "" || len(values) != 2 || values["to"] == "" {
+		return 0, "", false
+	}
+	id, err := strconv.ParseInt(values["id"], 10, 64)
+	if err != nil || id <= 0 {
+		return 0, "", false
+	}
+	return id, values["to"], true
 }
 
 func parseOrgDirectiveReceipt(kind, body string) (directiveID int64, by string, ok bool) {

--- a/skills/gitmoot/SKILL.md
+++ b/skills/gitmoot/SKILL.md
@@ -255,8 +255,10 @@ In org mode, `gitmoot org message send --to <role> --workflow <label>
 heads-up. It creates no acknowledgment, completion, TTL, or nag obligation.
 In org mode, obligations and questions have a full lifecycle and closing it is
 part of the work: `gitmoot org directive send --to <role> --workflow <label>`
-mints a tracked, TTL-nudged obligation; `org directive ack <id>` records
-RECEIPT only; `org directive done <id>` records COMPLETION and ends the
+mints a tracked, TTL-nudged obligation; RECEIPT is recorded by the transport
+when the prompt lands in your pane, so you do not owe an `ack` (`org directive
+ack <id>` still exists for the rare case where a receipt must be asserted by
+hand); `org directive done <id>` records COMPLETION and ends the
 obligation with its nudges (target subtree only — the sender cancels with
 `org directive cancel` instead). Finished work left un-`done` stays an outstanding
 obligation on every owed-work surface (and, where completion TTLs are

--- a/skills/gitmoot/references/CLI.md
+++ b/skills/gitmoot/references/CLI.md
@@ -1824,6 +1824,26 @@ not completion. `gitmoot org directive cancel <id> [--by <role>] [--home
 from `--by` or `GITMOOT_ORG_ROLE`; missing identity fails closed. They append
 typed markers to the directive's workflow journal.
 
+Receipt is normally recorded by the **transport**, not by the seat. When Herdr
+confirms that a directive prompt landed in the addressed role's pane, Gitmoot
+appends an `[org:directive-delivered id=<id> to=<role>]` marker itself, and
+that marker satisfies the receipt obligation everywhere an `[org:directive-ack ]`
+marker does: the acknowledgment ladder stops and the completion phase starts
+from the delivery time. The delivered marker is a separate verb from `ack` and
+carries `to=` rather than `by=`, because an acknowledgment is the seat's own
+assertion and a machine must not write one on its behalf. Nothing in the
+delivered marker claims the seat read the directive.
+
+`gitmoot org directive ack` therefore remains available but is no longer part
+of the delivery path, and the first-delivery prompt no longer asks for it. The
+receipt write is best-effort: if it fails, the wake still counts as delivered
+and the directive simply takes another acknowledgment-phase nudge, which is the
+behaviour that predates this change.
+
+**A remaining acknowledgment-phase nudge now means "delivery is not proven".**
+A stalled, failed or `delivery_unknown` wake records no receipt, so the ladder
+keeps running for exactly the directives whose arrival nobody can demonstrate.
+
 `gitmoot org directive done <id> [--by <role>] [--home <dir>]` records
 COMPLETION and ends the obligation, including its TTL nudges. **Completion
 authority is the target subtree**: the addressed role, or a role below it in the

--- a/website/docs/reference/cli.md
+++ b/website/docs/reference/cli.md
@@ -1556,6 +1556,28 @@ not completion. `gitmoot org directive cancel <id> [--by <role>] [--home
 from `--by` or `GITMOOT_ORG_ROLE`; missing identity fails closed. They append
 typed markers to the directive's workflow journal.
 
+Receipt is normally recorded by the **transport**, not by the seat. When Herdr
+confirms that a directive prompt landed in the addressed role's pane, Gitmoot
+appends an `[org:directive-delivered id=<id> to=<role>]` marker itself, and
+that marker satisfies the receipt obligation everywhere an `[org:directive-ack ]`
+marker does: the acknowledgment ladder stops and the completion phase starts
+from the delivery time. The delivered marker is a separate verb from `ack` and
+carries `to=` rather than `by=`, because an acknowledgment is the seat's own
+assertion and a machine must not write one on its behalf. Nothing in the
+delivered marker claims the seat read the directive.
+
+`gitmoot org directive ack` therefore remains available but is no longer part
+of the delivery path, and the first-delivery prompt no longer asks for it. An
+acknowledgment answers "did this reach you", which the delivery confirmation
+already answers, and routing that question through a model turn spent the turn
+boundary. The receipt write is best-effort: if it fails, the wake still counts
+as delivered and the directive simply takes another acknowledgment-phase nudge,
+which is the behaviour that predates this change.
+
+**A remaining acknowledgment-phase nudge now means "delivery is not proven".**
+A stalled, failed or `delivery_unknown` wake records no receipt, so the ladder
+keeps running for exactly the directives whose arrival nobody can demonstrate.
+
 `gitmoot org directive done <id> [--by <role>] [--home <dir>]` records
 COMPLETION and ends the obligation, including its TTL nudges. **Completion
 authority is the target subtree**: the addressed role, or a role below it in the


### PR DESCRIPTION
Fixes #1980. Part of the #1977 campaign.

## What the traffic actually is, both numbers, as PHOBOS asked

He warned that the population this slice acts on may have vanished with the coordinator retirement, and that I should state the current rate rather than manufacture a before/after. Both numbers, read-only from `/root/.gitmoot/gitmoot.db`:

| Measure | Value |
| --- | --- |
| ack marker notes, all time | **3,306** |
| ack markers in the last full day | **125** |
| of those, recorded by the addressed seat itself | **124 of 125** |
| median seconds from directive to its ack | **96** (p90 801, max 12,473) |
| ack markers since 2026-09-07T14:40Z, the org change | **1** |
| directives in the last day | 128, of which **74 were addressed to now-retired roles** |
| directives since 14:40Z | 1 |

So both are true and neither on its own is honest. **The historical volume was real** and self-inflicted: 124 of the last 125 receipts were a seat spending a turn to tell the store something the transport had already observed. **The current rate has collapsed**, because 58% of the last day's directives were addressed to seats that no longer exist. But the path is not dead: the surviving `apps-coc` subtree accounted for 50 of the last 125 receipts (`vetrina` 20, `keephair` 12, `numbra` 11, `apps-coc` 4, `joltra` 2, `among-friends-omp` 1), so this traffic resumes whenever those seats are active.

I am therefore **not** claiming a measured interrupt reduction from this PR. The claim is narrower and checkable: a receipt no longer requires a model turn, and the 3,306-marker path that produced it is gone.

## The change

On confirmed delivery, the sink appends the transport's own receipt:

```
[org:directive-delivered id=<id> to=<role>]
```

and that marker satisfies the receipt obligation everywhere an `[org:directive-ack ]` marker does:

- `ListUnacknowledgedOrgDirectives` no longer reports it,
- `ListOpenOrgDirectiveObligations`'s receipt anchor (`AckedAt`) uses whichever receipt came first, so the completion phase starts from the delivery time,
- the parked-directive view uses the same anchor,
- the wake outbox's directive-phase projection classifies the next wake as `completion` rather than `acknowledgment`.

**It is a separate verb from `ack`, and carries `to=` rather than `by=`.** An acknowledgment is the seat's own assertion; a machine must not write one on the seat's behalf. Nothing in the delivered marker claims the seat read the directive, only that the pane accepted the prompt. `gitmoot org directive ack` still exists and is unchanged for the case where a receipt must be asserted by hand.

The first-delivery prompt drops the receipt request. Before:

```
gitmoot directive 126161 for gm-omp-seat; acknowledge receipt with: gitmoot org directive ack 126161 --by gm-omp-seat
```

After:

```
gitmoot directive 126161 for gm-omp-seat; read it with: gitmoot workflow show-note 126161, then record completion with: gitmoot org directive done 126161 --by gm-omp-seat
```

One command instead of two, and the remaining one is a state transition only the seat can make.

### Failure directions are the old behaviour, not a new one

- The receipt write is **best-effort**: a failed write leaves a delivered wake delivered and costs one extra acknowledgment-phase nudge, which is exactly the pre-#1980 behaviour.
- A **stalled, failed or `delivery_unknown`** wake records nothing. That sharpens the acknowledgment ladder rather than removing it: it now runs for exactly the directives whose arrival nobody can demonstrate, which is the population #1982 is about.
- The delivered marker is **at-most-once per directive** and yields to any existing receipt, so a nag reviving the same stable wake row cannot append a second marker.

## Tests that fail before and pass after

- `TestDeliveredDirectiveRecordsReceiptWithoutASeatTurn`: a delivered directive wake produces exactly one `[org:directive-delivered ]` note, closes `ListUnacknowledgedOrgDirectives`, gives the open obligation a receipt time, and the prompt contains no `directive ack`. On the pre-fix code this fails on the first assertion, since `FormatOrgDirectiveDeliveredNote` did not exist and no receipt was written.
- `TestUndeliveredDirectiveRecordsNoReceipt` is the control that keeps the receipt honest: with the transport reporting `stalled`, no receipt is written and the directive stays outstanding. This is what stops the change from degrading into "mark everything acknowledged".

Two existing tests pinned the old wording and were re-pointed rather than deleted, because their real properties survive:

- `TestEventRuleDirectiveWakePromptMatchesCurrentPhase` still discriminates all three phases; the receipt phase now requires `show-note` plus the completion command and **forbids** `acknowledge receipt` and `directive ack`.
- `TestDirectiveWakeDrainDoesNotCoalesceDifferentObligations` still proves two distinct obligations do not coalesce; it tells the phases apart by their wording now that only one carries a receipt command.
- `TestListWakeOutboxObligationsExecutesGeneratedQuery`, the independently handwritten copy of the obligation query, was updated in lockstep with the phase projection. That guard did its job: it failed the moment the two drifted.

## Verification

Full local gate on this head with go1.26.4 pinned: `go build -buildvcs=false ./...`, `go vet ./...`, `go test -count=1 -timeout 25m ./...`, **zero failures**, disk at 5.49% free throughout.

Worth recording because it will happen to someone else: an earlier run of this same gate reported **20 failures**, all dispatch or blocked-advance tests, and every one was the daemon disk guard rather than this change. The cause is printed verbatim in the test log: `DISK GUARD REFUSED JOB DISPATCH: free_percent=4.70 min_free_percent=5.00`. If you see that shape, check `df` before reading the diff.

`-race` is CI's shards; race requires cgo, which this repo's gate documents as unavailable locally.

## Not verified

- **No live probe.** This is daemon delivery behaviour and deploys are owner-gated. After a deploy the production evidence is a `[org:directive-delivered id=... to=...]` note appearing in a directive's workflow journal with no `[org:directive-ack ]` note and no seat turn between them.
- **The share-of-pane-input acceptance criterion cannot be closed by me.** The seats whose transcripts produced the 675 ack requests are retired, so the after-number would be dominated by that org change. The correct later check is per-directive, not fleet-total: for a directive delivered after this ships, the journal should carry a delivered marker and no seat-authored ack.
- **`TRANSPORT ONLY` relays are not in this diff and cannot be.** I grepped the whole repository: the string appears nowhere in Gitmoot's code. Those 24 prompts were written by coordinators calling `herdr agent prompt` directly, so they are a practice rather than a code path, and no change here can remove them. That half of the issue's acceptance needs an instruction to coordinators, not a patch.

Deploy notes: no migration. Existing directives are unaffected, since an already-recorded `ack` still satisfies every reader. Behaviour is confined to the daemon's wake delivery path plus four store queries, so a daemon restart picks it up.
