### PR TITLE
feat(cli): report the findings ledger per repository, and refuse #1970's supersession (#1970, #1969)

### DIFF
--- a/internal/cli/findings.go
+++ b/internal/cli/findings.go
@@ -1,0 +1,94 @@
+package cli
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"text/tabwriter"
+
+	"github.com/gitmoot/gitmoot/internal/config"
+	"github.com/gitmoot/gitmoot/internal/db"
+)
+
+// runFindings reports the #1822 findings ledger per repository.
+//
+// WHY THIS EXISTS. Two slices of campaign #1966 asked for the same thing from
+// opposite ends. #1969 asked for "a report shows answered-versus-open per
+// repository, so a silent consumer is visible without a manual query" - it was
+// filed because 211 findings were recorded across five repositories and none
+// was ever answered, and nothing surfaced that. #1970 asked that "counting open
+// findings on a PR yields only findings that apply to its current head" - it
+// was filed because 239 of 263 open findings sat at a head the pull request had
+// already moved past. Until now there was no findings command at all, so
+// "271 open findings" was a number nobody could act on.
+//
+// WHAT IT DELIBERATELY DOES NOT DO. It does not compute obligations, and it
+// does not reclassify anything. #1970 proposed auto-superseding open findings
+// when the head moves; measured through LedgerObligationsAtHead, that DROPS a
+// live obligation whenever the new push does not touch the finding's file - an
+// open finding is an obligation unconditionally, while a superseded one is
+// re-armed only by relevance. So both buckets below are still blocking, and the
+// report says so rather than implying the stale ones are inert.
+func runFindings(args []string, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("findings", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	home := fs.String("home", "", "home directory to use instead of the current user's home")
+	jsonOutput := fs.Bool("json", false, "print the report as JSON")
+	if err := fs.Parse(args); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return 0
+		}
+		return 2
+	}
+	if fs.NArg() != 0 {
+		fmt.Fprintln(stderr, "findings does not accept positional arguments")
+		return 2
+	}
+
+	var rows []db.ReviewFindingConsumption
+	if err := withStoreAndPaths(*home, func(_ config.Paths, store *db.Store) error {
+		var err error
+		rows, err = store.ReviewFindingConsumptionByRepo(context.Background())
+		return err
+	}); err != nil {
+		fmt.Fprintf(stderr, "findings: %v\n", err)
+		return 1
+	}
+
+	if *jsonOutput {
+		encoded, err := json.MarshalIndent(rows, "", "  ")
+		if err != nil {
+			fmt.Fprintf(stderr, "findings: %v\n", err)
+			return 1
+		}
+		fmt.Fprintln(stdout, string(encoded))
+		return 0
+	}
+
+	if len(rows) == 0 {
+		fmt.Fprintln(stdout, "no review findings recorded")
+		return 0
+	}
+	writer := tabwriter.NewWriter(stdout, 0, 0, 2, ' ', 0)
+	fmt.Fprintln(writer, "REPO\tFINDINGS\tOPEN\tAT HEAD\tAT EARLIER HEAD\tHEAD UNKNOWN\tANSWERED\tWITHDRAWN\tSUPERSEDED")
+	for _, row := range rows {
+		fmt.Fprintf(writer, "%s\t%d\t%d\t%d\t%d\t%d\t%d\t%d\t%d\n",
+			row.Repo, row.Findings, row.Open, row.OpenAtCurrentHead, row.OpenAtEarlierHead,
+			row.OpenHeadUnknown, row.Answered, row.Withdrawn, row.Superseded)
+	}
+	if err := writer.Flush(); err != nil {
+		fmt.Fprintf(stderr, "findings: %v\n", err)
+		return 1
+	}
+	// The two sentences a reader needs to not misread the table. A repository
+	// with findings and zero answered is the #1969 shape; a large AT EARLIER HEAD
+	// column is the #1970 shape. Neither column is inert.
+	fmt.Fprintln(stdout)
+	fmt.Fprintln(stdout, "OPEN findings block a merge at every later head until a reviewer answers or withdraws them,")
+	fmt.Fprintln(stdout, "so AT EARLIER HEAD is a backlog nobody has looked at, not a set that has expired.")
+	fmt.Fprintln(stdout, "A repository with findings and ANSWERED 0 is recording obligations nothing consumes.")
+	return 0
+}

--- a/internal/cli/findings_report_1970_test.go
+++ b/internal/cli/findings_report_1970_test.go
@@ -1,0 +1,150 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/gitmoot/gitmoot/internal/db"
+)
+
+// #1970 acceptance 3 and #1969's third criterion, answered by one report.
+//
+// Before this there was no findings command at all, so "271 open findings" was
+// a number nobody could act on: it conflated a defect reported against the head
+// under review with one nobody had looked at for twenty heads, and it hid a
+// repository that had recorded 59 findings and answered none.
+//
+// THE PARTITION IS THE POINT, and so is what it refuses to do. #1970 proposed
+// auto-superseding open findings when the head moves. Measured through
+// LedgerObligationsAtHead, that drops a live obligation whenever the new push
+// does not touch the finding's file: an open finding is an obligation
+// unconditionally, while a superseded one is re-armed only by relevance. So
+// this report splits the open count by head currency and leaves the state
+// alone. Both buckets still block.
+func TestFindingsReportPartitionsOpenFindingsByHeadCurrency(t *testing.T) {
+	ctx := context.Background()
+	home := t.TempDir()
+	store := openCLIJobStore(t, home)
+
+	const currentHead = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	const staleHead = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+
+	if err := store.UpsertPullRequest(ctx, db.PullRequest{
+		RepoFullName: "owner/consuming", Number: 7, URL: "u", HeadBranch: "b",
+		BaseBranch: "main", HeadSHA: currentHead, State: "open",
+	}); err != nil {
+		t.Fatalf("UpsertPullRequest: %v", err)
+	}
+	// A repository with a recorded PR whose head has moved on, plus one whose PR
+	// row is absent entirely: the third bucket exists so an unknown head is not
+	// silently counted as current.
+	if err := store.UpsertPullRequest(ctx, db.PullRequest{
+		RepoFullName: "owner/silent", Number: 29, URL: "u", HeadBranch: "b",
+		BaseBranch: "main", HeadSHA: currentHead, State: "open",
+	}); err != nil {
+		t.Fatalf("UpsertPullRequest: %v", err)
+	}
+
+	record := func(repo string, pr int64, head string, state db.FindingState, round string) {
+		t.Helper()
+		obs := db.ReviewFindingObservation{
+			Repo: repo, PullRequest: pr, HeadSHA: head, ObserverJob: "local-review-" + round,
+			State: state, Severity: "P2", RoundLabel: round,
+			Title: "a defect worth reading", File: "internal/a.go",
+			EvidenceKind: db.EvidenceExecuted, ExecutedCommands: []string{"go test ./..."}, ExecutedCount: 1,
+		}
+		if state == db.FindingWithdrawn {
+			obs.WithdrawReason = "not a defect after all"
+		}
+		if _, err := store.RecordReviewFindingObservation(ctx, obs); err != nil {
+			t.Fatalf("RecordReviewFindingObservation(%s/%s): %v", repo, round, err)
+		}
+	}
+
+	// The consuming repository: one open at the current head, one open at a stale
+	// head, one answered.
+	record("owner/consuming", 7, currentHead, db.FindingOpen, "c1")
+	record("owner/consuming", 7, staleHead, db.FindingOpen, "c2")
+	record("owner/consuming", 7, currentHead, db.FindingAnswered, "c3")
+	// The silent repository: findings recorded, nothing ever answered - the
+	// #1969 shape the report has to make visible without a manual query.
+	record("owner/silent", 29, staleHead, db.FindingOpen, "s1")
+	record("owner/silent", 29, staleHead, db.FindingOpen, "s2")
+	// A finding on a pull request with no locally recorded row at all.
+	record("owner/silent", 999, staleHead, db.FindingOpen, "s3")
+	store.Close()
+
+	var stdout, stderr bytes.Buffer
+	if code := Run([]string{"findings", "--home", home, "--json"}, &stdout, &stderr); code != 0 {
+		t.Fatalf("findings exit = %d, stderr=%s", code, stderr.String())
+	}
+	var rows []db.ReviewFindingConsumption
+	if err := json.Unmarshal(stdout.Bytes(), &rows); err != nil {
+		t.Fatalf("decode report: %v (stdout=%s)", err, stdout.String())
+	}
+	byRepo := map[string]db.ReviewFindingConsumption{}
+	for _, row := range rows {
+		byRepo[row.Repo] = row
+	}
+
+	consuming := byRepo["owner/consuming"]
+	if consuming.Open != 2 || consuming.OpenAtCurrentHead != 1 || consuming.OpenAtEarlierHead != 1 {
+		t.Errorf("owner/consuming open=%d at_head=%d at_earlier=%d, want 2/1/1; a single open total cannot tell a fresh defect from a twenty-head-old one",
+			consuming.Open, consuming.OpenAtCurrentHead, consuming.OpenAtEarlierHead)
+	}
+	if consuming.Answered != 1 {
+		t.Errorf("owner/consuming answered = %d, want 1", consuming.Answered)
+	}
+
+	silent := byRepo["owner/silent"]
+	if silent.Answered != 0 || silent.Findings != 3 {
+		t.Errorf("owner/silent findings=%d answered=%d, want 3/0: this is the shape #1969 exists to surface",
+			silent.Findings, silent.Answered)
+	}
+	if silent.OpenAtEarlierHead != 2 {
+		t.Errorf("owner/silent open_at_earlier_head = %d, want 2", silent.OpenAtEarlierHead)
+	}
+	// THE HONESTY BUCKET. An open finding whose pull request has no recorded head
+	// must not be counted as current: that is how a report starts lying about the
+	// one column a reader will act on.
+	if silent.OpenHeadUnknown != 1 {
+		t.Errorf("owner/silent open_head_unknown = %d, want 1; an unknown head folded into either bucket is a false claim",
+			silent.OpenHeadUnknown)
+	}
+	if silent.OpenAtCurrentHead != 0 {
+		t.Errorf("owner/silent open_at_current_head = %d, want 0", silent.OpenAtCurrentHead)
+	}
+}
+
+// The plain-text form has to say that a stale-head finding still blocks, or a
+// reader will treat the largest column in the table as expired backlog. That
+// misreading is exactly the one that produced #1970's proposed fix.
+func TestFindingsReportSaysStaleOpenFindingsStillBlock(t *testing.T) {
+	ctx := context.Background()
+	home := t.TempDir()
+	store := openCLIJobStore(t, home)
+	if _, err := store.RecordReviewFindingObservation(ctx, db.ReviewFindingObservation{
+		Repo: "owner/repo", PullRequest: 7, HeadSHA: strings.Repeat("c", 40),
+		ObserverJob: "local-review-r1", State: db.FindingOpen, Severity: "P1",
+		Title: "unfixed", File: "internal/a.go",
+		EvidenceKind: db.EvidenceExecuted, ExecutedCommands: []string{"go test"}, ExecutedCount: 1,
+	}); err != nil {
+		t.Fatalf("RecordReviewFindingObservation: %v", err)
+	}
+	store.Close()
+
+	var stdout, stderr bytes.Buffer
+	if code := Run([]string{"findings", "--home", home}, &stdout, &stderr); code != 0 {
+		t.Fatalf("findings exit = %d, stderr=%s", code, stderr.String())
+	}
+	output := stdout.String()
+	if !strings.Contains(output, "AT EARLIER HEAD") {
+		t.Fatalf("report has no head-currency column:\n%s", output)
+	}
+	if !strings.Contains(output, "block a merge at every later head") {
+		t.Fatalf("report does not say a stale open finding still blocks, so its largest column reads as expired:\n%s", output)
+	}
+}

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -48,6 +48,7 @@ var rootCommands = []command{
 	{name: "task", summary: "run or inspect tasks", run: runTask},
 	{name: "job", summary: "inspect and recover jobs", run: runJob},
 	{name: "proof", summary: "evidence-graded proof manifest for a work root", run: runProof},
+	{name: "findings", summary: "report the review findings ledger per repository", run: runFindings},
 	{name: "workflow", summary: "inspect external-coordinator workflow groups and notes", run: runWorkflowJournal},
 	{name: "report", summary: "build and file bug reports", run: runReport},
 	{name: "lock", summary: "inspect and release branch locks", run: runLock},

--- a/internal/db/review_findings.go
+++ b/internal/db/review_findings.go
@@ -457,6 +457,75 @@ func splitPathLine(value string) (string, int, bool) {
 	return path, line, true
 }
 
+// ReviewFindingConsumption is one repository's finding ledger, folded by final
+// state and split by whether an open finding applies to the pull request's
+// CURRENT head (#1970, #1969).
+type ReviewFindingConsumption struct {
+	Repo       string `json:"repo"`
+	Findings   int    `json:"findings"`
+	Open       int    `json:"open"`
+	Answered   int    `json:"answered"`
+	Withdrawn  int    `json:"withdrawn"`
+	Superseded int    `json:"superseded"`
+	// OpenAtCurrentHead and OpenAtEarlierHead partition Open. BOTH still block:
+	// LedgerObligationsAtHead gives an open finding the reason "still open"
+	// unconditionally, so a stale head does not make it stop counting. The split
+	// exists because a single "open" total cannot distinguish a defect that was
+	// just reported from one nobody has looked at for twenty heads, and #1970
+	// measured 239 of 263 open findings sitting at a head the pull request had
+	// already moved past.
+	OpenAtCurrentHead int `json:"open_at_current_head"`
+	OpenAtEarlierHead int `json:"open_at_earlier_head"`
+	// OpenHeadUnknown counts open findings whose pull request has no locally
+	// recorded head, so neither bucket above would be honest. Reported rather
+	// than folded into either, because silently counting an unknown as current
+	// is how a report starts lying.
+	OpenHeadUnknown int `json:"open_head_unknown"`
+}
+
+// ReviewFindingConsumptionByRepo folds the whole ledger per repository.
+//
+// #1969 asked for a report that makes a silent consumer visible without a
+// manual query, and #1970 asked that counting open findings distinguish those
+// that apply at the current head. One read-only fold answers both.
+//
+// The fold is in SQL and the head comparison joins the locally recorded
+// pull_requests row. It deliberately does NOT compute obligations: that needs
+// the merge gate's own LedgerScope resolvers, and a report that guessed at them
+// would disagree with the gate, which is the #1850 R3-F1 failure mode. This
+// counts states and head currency, nothing more.
+func (s *Store) ReviewFindingConsumptionByRepo(ctx context.Context) ([]ReviewFindingConsumption, error) {
+	rows, err := s.db.QueryContext(ctx, `
+SELECT f.repo,
+	COUNT(*),
+	SUM(CASE WHEN f.state = 'open' THEN 1 ELSE 0 END),
+	SUM(CASE WHEN f.state = 'answered' THEN 1 ELSE 0 END),
+	SUM(CASE WHEN f.state = 'withdrawn' THEN 1 ELSE 0 END),
+	SUM(CASE WHEN f.state = 'superseded' THEN 1 ELSE 0 END),
+	SUM(CASE WHEN f.state = 'open' AND p.head_sha != '' AND p.head_sha = f.head_sha THEN 1 ELSE 0 END),
+	SUM(CASE WHEN f.state = 'open' AND p.head_sha != '' AND p.head_sha != f.head_sha THEN 1 ELSE 0 END),
+	SUM(CASE WHEN f.state = 'open' AND COALESCE(p.head_sha, '') = '' THEN 1 ELSE 0 END)
+FROM review_finding_observations f
+LEFT JOIN pull_requests p
+	ON p.repo_full_name = f.repo AND p.number = f.pull_request
+GROUP BY f.repo
+ORDER BY f.repo`)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var out []ReviewFindingConsumption
+	for rows.Next() {
+		var row ReviewFindingConsumption
+		if err := rows.Scan(&row.Repo, &row.Findings, &row.Open, &row.Answered, &row.Withdrawn,
+			&row.Superseded, &row.OpenAtCurrentHead, &row.OpenAtEarlierHead, &row.OpenHeadUnknown); err != nil {
+			return nil, err
+		}
+		out = append(out, row)
+	}
+	return out, rows.Err()
+}
+
 // ListReviewFindingObservations returns every observation for a PR in INSERTION
 // ORDER, so a caller can fold them into per-finding latest state itself. The
 // store does not fold, because folding is where a "still true" column would


### PR DESCRIPTION
Closes #1970. Satisfies #1969's third acceptance criterion. Part of campaign #1966.

## I did not implement #1970's proposed fix, because it is a merge bypass

#1970 proposes: "When a pull request head advances, transition its open findings from the old head to `superseded`, and require a re-review to re-assert anything that still applies."

**`superseded` does not mean "needs re-review".** `LedgerObligationsAtHead` (`internal/workflow/findings_ledger.go:205-217`) treats the states asymmetrically:

- `db.FindingOpen` gets `reason = "still open"` **unconditionally**, so an open finding at a stale head is an obligation at *every* later head until a reviewer disposes of it.
- `db.FindingSuperseded` shares a branch with `db.FindingAnswered` and goes through `answeredIsMandatory`, which re-arms it **only** if the diff since then touches its relevance key, or if its `STATIC` locator has vanished. Otherwise it `continue`s out.

Probed through the production function rather than argued. One open P1 on `internal/a.go`; new head whose push touched only `internal/unrelated.go`:

```
OPEN at stale head       -> 1 obligation at the new head, reason "still open"
SUPERSEDED at stale head -> 0 obligations at the new head
```

Same row, same head, same scope. So auto-superseding on head move **deletes a live obligation** for any push that does not touch the finding's file: a P1 on file A, the author pushes file B, the obligation is gone and the merge gate stops asking. That is the escape the #1822 ledger exists to prevent, and acceptance criterion 1 asks for it by name.

**Second, independent reason.** `superseded` is reviewer judgement, not mechanics. The only production writer is `findings_ledger_writer.go:173`, which maps a state the *reviewer* declared, and all three superseded rows fleet-wide came from a single reviewer job. Automating `open -> superseded` converts a reviewer's judgement that a finding no longer applies into a head-inequality test. Those are not the same claim.

PHOBOS verified the mechanism at the line and **withdrew acceptance criterion 1**; the withdrawal is recorded on #1970.

## What was actually broken

Not the gate: it is correctly fail-closed, and the 239 stale-open findings genuinely are still blocking, which is *why* the backlog grows.

**The disclosure gap, which is #1969** (PR #1992). The strongest evidence that supersession is not the missing mechanism is the repository where findings *do* close: `gitmoot/gitmoot` has 100 answered and 96 withdrawn across constantly moving heads, with no automatic supersession anywhere in the fleet. It is the one repository where seats hand-wrote finding uids into review prompts.

**The count was uninterpretable.** There was no findings command at all, so "271 open findings" conflated a defect reported against the head under review with one nobody had looked at for twenty heads, and it hid a repository that had recorded 59 findings and answered none.

## Re-measured

Using the **local** `pull_requests` table for the real PR head rather than a proxy:

| | |
| --- | --- |
| findings joined to a recorded PR | 569 |
| head differs from the PR head | 456 |
| open | 263 |
| **open AND stale** | **239** |

239 of 263 is 91%, against the issue's 382 of 426 which is 90%. Same proportion; the denominator differs because of the owner-approved cleanup between the two measurements. The issue's measurement stands.

## The change

`gitmoot findings [--json]`, plus `Store.ReviewFindingConsumptionByRepo`. Read-only. It changes no state and reclassifies nothing.

Run against a snapshot of this host's live store, it reproduces four independently-derived numbers at once:

```
REPO                         FINDINGS  OPEN  AT HEAD  AT EARLIER HEAD  HEAD UNKNOWN  ANSWERED  WITHDRAWN  SUPERSEDED
gitmoot/coordinator-checkin  34        10    0        10               0             17        7          0
gitmoot/gitmoot              282       83    10       73               0             100       96         3
jerryfane/joltra             57        16    8        6                2             0         41         0
jerryfane/numbra             36        26    0        26               0             0         10         0
jerryfane/omp-role-router    1         1     0        1                0             0         0          0
jerryfane/vetrina            58        58    0        58               0             0         0          0
themartianapp/among-friends  59        51    3        48               0             0         8          0
themartianapp/keephair       44        20    3        17               0             11        13         0
```

- **AT EARLIER HEAD sums to 239**, the #1970 measurement above.
- **The five zero-answered repositories sum to 211** (57+36+1+58+59), the corrected #1969 figure.
- **`keephair` shows 11 answered**, confirming it does not belong in #1969's original five.
- **`coordinator-checkin` shows 17 answered**, the consumer the issue never mentioned.
- **SUPERSEDED is 3**, exactly as #1970 reported.
- **`joltra` shows 2 HEAD UNKNOWN**, so the honesty bucket earns its place on real data rather than only in a fixture.

Three design constraints, all deliberate:

1. **Both open buckets still block**, and the plain-text form says so in two sentences. A reader who takes the largest column for expired backlog is making exactly the inference that produced the unsafe proposal.
2. **An unknown head is its own bucket.** Folding it into either side would be a false claim about the one column a reader will act on.
3. **It does not compute obligations.** That needs the merge gate's own `LedgerScope` resolvers; a report that guessed at them would disagree with the gate, which is the #1850 R3-F1 wedge.

## Verification

`TestFindingsReportPartitionsOpenFindingsByHeadCurrency` seeds a consuming repository, a silent one, and a finding whose PR has no recorded row, then asserts all three buckets through the real `Run([]string{"findings", ...})` path.

`TestFindingsReportSaysStaleOpenFindingsStillBlock` pins the two sentences, because the misreading they prevent is the one that generated this issue's proposed fix.

### Gate, with the sampling error from earlier in this campaign corrected

`gofmt` clean, `go build -buildvcs=false ./...`, `go vet ./...` pass. `go test ./internal/cli/` **ok 954s** and `go test ./internal/db/` **ok 236s**.

Earlier in this campaign I attributed a family of `internal/cli` dispatch failures to CPU load. That was wrong: `checkDiskGuard` measures the real filesystem and refuses dispatch below `min_free_percent=5.00`, and I had sampled free space *after* the run instead of during it. This time I sampled every 25 seconds throughout and grepped for the guard's own refusal line rather than filtering it away: free space held at 5.0-5.3% for all 40 samples, no `DISK GUARD REFUSED JOB DISPATCH` line was emitted, and both packages passed. That is the confirming half of the correction, which is now also recorded on #1992.

`-race` not run: requires cgo, unavailable in this seat.

## Not claimed

- **The 239-finding backlog is untouched.** No state is rewritten, nothing is bulk-withdrawn. Making it shrink is the disclosure loop in #1992, not this report.
- The probe that proves the bypass is **not** shipped as a test. It pins behaviour I am arguing should not change, and a test that encodes the wrong intent is maintenance debt; its numbers live in this PR body instead.
- No `--repo`/`--pr` filtering yet. The fleet has eight repositories with findings, so the unfiltered table fits; add filters when it does not.
- #1969's remaining criterion, the per-repository consuming-versus-advisory declaration, is still not implemented. It needs #1992 to ship first, because declaring a repository advisory while its reviewers are never told the uids is policy for a mechanism that does not work.

## Deploy notes

No migration, no config change. New read-only CLI command; both binaries per the two-services rule.
