### PR TITLE
fix(workflow): the merge gate's independence check compares runtime families (#1531)

### DIFF
--- a/internal/workflow/merge_gate.go
+++ b/internal/workflow/merge_gate.go
@@ -1241,6 +1241,15 @@ func (g PolicyMergeGate) ensureFinalReviewCaptured(ctx context.Context, request 
 					if _, selfApproved := implementingAgents[reviewer]; selfApproved && selfApprovalReason == "" {
 						selfApprovalReason = fmt.Sprintf("latest review round's approval was authored by %s, the implementing agent; an independent reviewer is required", reviewer)
 					}
+					if selfApprovalReason == "" {
+						sameFamily, familyReason, err := g.sameRuntimeFamilyAsImplementer(ctx, review.job.ID, reviewer, review.payload.EffectiveRuntime, implementingAgents)
+						if err != nil {
+							return err
+						}
+						if sameFamily {
+							selfApprovalReason = familyReason
+						}
+					}
 				}
 			case "changes_requested", "blocked", "failed":
 				return mergeBlocked{reason: fmt.Sprintf("review at evaluated head has blocking result from %s", reviewer)}
@@ -1326,6 +1335,16 @@ func (g PolicyMergeGate) ensureFinalReviewCaptured(ctx context.Context, request 
 				if _, selfApproved := implementingAgents[reviewerAgent]; selfApproved {
 					if selfApprovalReason == "" {
 						selfApprovalReason = fmt.Sprintf("latest review round's approval was authored by %s, the implementing agent; an independent reviewer is required", reviewerAgent)
+					}
+					continue
+				}
+				sameFamily, familyReason, err := g.sameRuntimeFamilyAsImplementer(ctx, job.ID, reviewerAgent, payload.EffectiveRuntime, implementingAgents)
+				if err != nil {
+					return err
+				}
+				if sameFamily {
+					if selfApprovalReason == "" {
+						selfApprovalReason = familyReason
 					}
 					continue
 				}
@@ -1595,6 +1614,11 @@ type implementerIdentity struct {
 	// FromActingRole records that this attribution came from the payload's acting
 	// org role rather than the job's agent column. A role cannot be enqueued.
 	FromActingRole bool
+	// RecordedRuntime is the implement job's own payload effective_runtime, kept
+	// so the gate can resolve a runtime FAMILY without re-reading the job (#1531).
+	// Empty for a job that predates #1528's recording; ResolveRuntimeFamily then
+	// falls back to the agent registry default.
+	RecordedRuntime string
 }
 
 type implementerAttributionEvidence struct {
@@ -1661,7 +1685,7 @@ func collectImplementerAttributionMatching(jobs []db.Job, current JobPayload,
 			// first would attribute every agent's work to its coordinator, make that
 			// coordinator an implementer of everything, and then disqualify it from
 			// reviewing anything.
-			evidence.agents[name] = implementerIdentity{Name: name}
+			evidence.agents[name] = implementerIdentity{Name: name, RecordedRuntime: payload.EffectiveRuntime}
 		case name != "":
 			// A ROLE NEVER DOWNGRADES AN AGENT ALREADY RECORDED UNDER THE SAME NAME,
 			// AND THAT IS WHY THIS IS A CONDITIONAL WRITE RATHER THAN A PLAIN ONE.
@@ -1677,7 +1701,7 @@ func collectImplementerAttributionMatching(jobs []db.Job, current JobPayload,
 			}
 			// The #1916 shape: implemented in session by an org role, no agent to
 			// name. Attributable, and still subject to the independence check.
-			evidence.agents[name] = implementerIdentity{Name: name, FromActingRole: true}
+			evidence.agents[name] = implementerIdentity{Name: name, FromActingRole: true, RecordedRuntime: payload.EffectiveRuntime}
 		default:
 			evidence.sawEmptyAgent = true
 		}
@@ -2536,4 +2560,90 @@ func parseRepoFullName(value string) (github.Repository, error) {
 		return github.Repository{}, fmt.Errorf("invalid repo %q", value)
 	}
 	return github.Repository{Owner: owner, Name: name}, nil
+}
+
+// sameRuntimeFamilyAsImplementer reports whether an approving reviewer shares a
+// RUNTIME FAMILY with any recorded implementer of this pull request (#1531).
+//
+// THE NAME CHECK ABOVE CANNOT ENFORCE THE PROPERTY THE GATE EXISTS FOR. The bar
+// is cross-family review; the comparison was `reviewer != implementer` as
+// strings. Measured on PR #1527 at head 2e0dd2ee: implementer `wave-impl` and
+// reviewer `g7-review` are both codex/gpt-5.6-sol, and `g7-review != wave-impl`,
+// so the self-approval check passed on a same-family, same-model approval. That
+// panel was caught only because the gate failed closed for an unrelated
+// bookkeeping reason and never reached this test.
+//
+// IT USES THE ONE SHARED RESOLVER, whose own doc names this as its second
+// consumer: `ResolveRuntimeFamily` prefers the runtime recorded on the job and
+// falls back to the agent registry default, so an override-run job attributes
+// correctly even after its agent's default later changes.
+//
+// UNRESOLVABLE IS NOT SILENTLY CLEAN, AND IT IS ALSO NOT A BLOCK. This is the
+// tension #1531's own comment warns about: "doing (2) without (1) produces a
+// gate that silently passes whenever the field is absent". Re-measured on jobs
+// since 2026-08-25, resolution now covers 1335 of 1432 reviews and 427 of 449
+// implement jobs once the registry fallback is counted - 93 to 95 percent, up
+// from the 11 percent that made the issue defer this. The residue is dominated
+// by EPHEMERAL and TEMP agents, which are deliberately absent from the registry,
+// plus rows with an empty agent column.
+//
+// Refusing on that residue would block the native review fanout, whose lens legs
+// are ephemeral by construction, so an unresolved family falls through to the
+// name check exactly as before AND records why it could not be compared. That
+// keeps the gate's behaviour unchanged where it cannot see, while never claiming
+// a check it did not perform. Making the residue resolvable - temp agent names
+// embed their parent - is the follow-up that would let this fail closed.
+func (g PolicyMergeGate) sameRuntimeFamilyAsImplementer(ctx context.Context, reviewJobID string, reviewer string,
+	reviewerRuntime string, implementers map[string]implementerIdentity) (bool, string, error) {
+	if g.Store == nil || strings.TrimSpace(reviewer) == "" || len(implementers) == 0 {
+		return false, "", nil
+	}
+	reviewerFamily, ok, err := ResolveRuntimeFamily(ctx, g.Store, reviewer, reviewerRuntime)
+	if err != nil {
+		return false, "", err
+	}
+	if !ok {
+		g.recordFamilyUnresolved(ctx, reviewJobID, fmt.Sprintf(
+			"runtime family unresolved for reviewer %q; independence was decided on agent name alone", reviewer))
+		return false, "", nil
+	}
+	names := make([]string, 0, len(implementers))
+	for name := range implementers {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	for _, name := range names {
+		identity := implementers[name]
+		family, ok, err := ResolveRuntimeFamily(ctx, g.Store, name, identity.RecordedRuntime)
+		if err != nil {
+			return false, "", err
+		}
+		if !ok {
+			g.recordFamilyUnresolved(ctx, reviewJobID, fmt.Sprintf(
+				"runtime family unresolved for implementer %q; independence was decided on agent name alone", name))
+			continue
+		}
+		if family == reviewerFamily {
+			return true, fmt.Sprintf(
+				"latest review round's approval was authored by %s on runtime family %q, the same family as implementer %s; the bar is cross-family review, and distinct agent names are not evidence of independence",
+				reviewer, reviewerFamily, name), nil
+		}
+	}
+	return false, "", nil
+}
+
+// recordFamilyUnresolved makes an uncomparable family visible instead of letting
+// the gate report a check it did not perform. Best effort: the observation must
+// never change the merge decision it describes.
+func (g PolicyMergeGate) recordFamilyUnresolved(ctx context.Context, jobID string, message string) {
+	if g.Store == nil || strings.TrimSpace(jobID) == "" {
+		return
+	}
+	// IfAbsent, for the reason the CI observation beside it gives: a pending PR is
+	// re-evaluated on every poll, so a plain append would grow one row per tick.
+	_ = g.Store.AddJobEventIfAbsent(ctx, db.JobEvent{
+		JobID:   jobID,
+		Kind:    "merge_gate_family_unresolved",
+		Message: message,
+	})
 }

--- a/internal/workflow/merge_gate_family_1531_test.go
+++ b/internal/workflow/merge_gate_family_1531_test.go
@@ -1,0 +1,142 @@
+package workflow
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/gitmoot/gitmoot/internal/db"
+)
+
+// #1531: the merge gate's independence check compared reviewer and implementer
+// AGENT NAMES, never runtime or model, so two agents with different names and
+// the same family satisfied a gate whose entire purpose is cross-family review.
+//
+// MEASURED INSTANCE, PR #1527 at head 2e0dd2ee: implementer `wave-impl` and
+// reviewer `g7-review` are both codex/gpt-5.6-sol. `g7-review != wave-impl` as
+// strings, so the self-approval check passed. That panel was caught only because
+// the gate failed closed for an unrelated bookkeeping reason and never reached
+// this test, which is the worse shape: a noisy failure mode masking a silent one.
+//
+// WHY THIS IS IMPLEMENTABLE NOW AND WAS NOT WHEN THE ISSUE WAS FILED. Its own
+// comment defers the fix because `effective_runtime` was recorded on 11% of
+// review jobs, and "doing (2) without (1) produces a gate that silently passes
+// whenever the field is absent". Re-measured on jobs since 2026-08-25, with the
+// agent-registry fallback counted: reviews 1335 of 1432 resolvable, implement
+// jobs 427 of 449. The prerequisite landed as #1528, and `ResolveRuntimeFamily`
+// already names this gate as its second consumer.
+func TestMergeGateRefusesASameFamilyApprovalWithADifferentAgentName(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	seedFamilyAgent(t, store, "wave-impl", "codex")
+	seedFamilyAgent(t, store, "g7-review", "codex")
+	gate := PolicyMergeGate{Store: store}
+
+	implementers := map[string]implementerIdentity{
+		"wave-impl": {Name: "wave-impl", RecordedRuntime: "codex"},
+	}
+	same, reason, err := gate.sameRuntimeFamilyAsImplementer(ctx, "review-job", "g7-review", "codex", implementers)
+	if err != nil {
+		t.Fatalf("sameRuntimeFamilyAsImplementer: %v", err)
+	}
+	if !same {
+		t.Fatal("a reviewer on the implementer's own runtime family was accepted as independent; the gate's bar is cross-family review and distinct agent names are not evidence of independence")
+	}
+	for _, want := range []string{"g7-review", "codex", "wave-impl", "cross-family"} {
+		if !strings.Contains(reason, want) {
+			t.Fatalf("refusal reason %q does not name %q, so an operator cannot act on it", reason, want)
+		}
+	}
+}
+
+// The control that decides whether this is an independence check or a blanket
+// refusal: a genuinely different family must still pass.
+func TestMergeGateAcceptsACrossFamilyApproval(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	seedFamilyAgent(t, store, "wave-impl", "codex")
+	seedFamilyAgent(t, store, "gm-review-opus", "claude")
+	gate := PolicyMergeGate{Store: store}
+
+	same, reason, err := gate.sameRuntimeFamilyAsImplementer(ctx, "review-job", "gm-review-opus", "claude",
+		map[string]implementerIdentity{"wave-impl": {Name: "wave-impl", RecordedRuntime: "codex"}})
+	if err != nil {
+		t.Fatalf("sameRuntimeFamilyAsImplementer: %v", err)
+	}
+	if same {
+		t.Fatalf("a cross-family approval was refused as same-family: %q", reason)
+	}
+}
+
+// THE RECORDED RUNTIME WINS OVER THE REGISTRY DEFAULT, which is what makes an
+// override-run job attribute correctly. Both agents are registered as codex, but
+// the reviewer actually RAN on kimi, so it is independent despite the registry.
+// Without this precedence the gate would refuse a legitimate override.
+func TestMergeGateUsesTheRuntimeAJobActuallyRanOn(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	seedFamilyAgent(t, store, "wave-impl", "codex")
+	seedFamilyAgent(t, store, "g7-review", "codex")
+	gate := PolicyMergeGate{Store: store}
+
+	same, _, err := gate.sameRuntimeFamilyAsImplementer(ctx, "review-job", "g7-review", "kimi",
+		map[string]implementerIdentity{"wave-impl": {Name: "wave-impl", RecordedRuntime: "codex"}})
+	if err != nil {
+		t.Fatalf("sameRuntimeFamilyAsImplementer: %v", err)
+	}
+	if same {
+		t.Fatal("a reviewer that RAN on kimi was refused because its registry default is codex; the runtime recorded on the job must win")
+	}
+}
+
+// AN UNRESOLVABLE FAMILY MUST NOT READ AS CLEAN. It falls through to the name
+// check, exactly as before, and records why it could not be compared. The issue
+// warns about precisely the opposite outcome: "a gate that silently passes
+// whenever the field is absent", which looks installed and is not.
+//
+// Refusing on the residue is not an option today: it is dominated by EPHEMERAL
+// and TEMP agents, which are deliberately absent from the registry, and the
+// native review fanout dispatches its lens legs as ephemeral by construction.
+func TestMergeGateRecordsAnUnresolvableFamilyRatherThanClaimingAClean(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	seedFamilyAgent(t, store, "wave-impl", "codex")
+	insertCompletedJob(t, store, db.Job{ID: "review-job", Agent: "lens-ephemeral-abc", Type: "review"}, JobPayload{
+		Repo: "gitmoot/gitmoot", PullRequest: 1527,
+	})
+	gate := PolicyMergeGate{Store: store}
+
+	// The reviewer is an ephemeral agent: not in the registry, no recorded runtime.
+	same, _, err := gate.sameRuntimeFamilyAsImplementer(ctx, "review-job", "lens-ephemeral-abc", "",
+		map[string]implementerIdentity{"wave-impl": {Name: "wave-impl", RecordedRuntime: "codex"}})
+	if err != nil {
+		t.Fatalf("sameRuntimeFamilyAsImplementer: %v", err)
+	}
+	if same {
+		t.Fatal("an unresolvable family was reported as a same-family match; absence is not evidence")
+	}
+	events, err := store.ListJobEvents(ctx, "review-job")
+	if err != nil {
+		t.Fatal(err)
+	}
+	found := false
+	for _, event := range events {
+		if event.Kind == "merge_gate_family_unresolved" && strings.Contains(event.Message, "lens-ephemeral-abc") {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("no merge_gate_family_unresolved event naming the reviewer; the gate would report a check it never performed. events = %+v", events)
+	}
+}
+
+func seedFamilyAgent(t *testing.T, store *db.Store, name string, runtime string) {
+	t.Helper()
+	if err := store.UpsertAgent(context.Background(), db.Agent{
+		Name:         name,
+		Runtime:      runtime,
+		Capabilities: []string{"review", "implement"},
+	}); err != nil {
+		t.Fatalf("UpsertAgent(%s): %v", name, err)
+	}
+}

--- a/internal/workflow/merge_gate_family_1531_test.go
+++ b/internal/workflow/merge_gate_family_1531_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/gitmoot/gitmoot/internal/db"
+	"github.com/gitmoot/gitmoot/internal/github"
 )
 
 // #1531: the merge gate's independence check compared reviewer and implementer
@@ -138,5 +139,59 @@ func seedFamilyAgent(t *testing.T, store *db.Store, name string, runtime string)
 		Capabilities: []string{"review", "implement"},
 	}); err != nil {
 		t.Fatalf("UpsertAgent(%s): %v", name, err)
+	}
+}
+
+// THE GATE-LEVEL DISCRIMINATOR, and the test the issue actually asked for: "a
+// firing test where reviewer and implementer have DIFFERENT NAMES and the SAME
+// family, asserting the gate REFUSES".
+//
+// It is the PR #1527 shape end to end through Evaluate, with a real merge client
+// that would perform the merge if the gate let it. The unit tests above cannot
+// serve as a before/after because the helper they call does not exist on base;
+// this one does, so it measures behaviour rather than compilation.
+func TestPolicyMergeGateRefusesSameFamilyApprovalEndToEnd(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	// Same family, different names: the exact PR #1527 pairing.
+	seedFamilyAgent(t, store, "wave-impl", "codex")
+	seedFamilyAgent(t, store, "g7-review", "codex")
+
+	payload := JobPayload{
+		Repo: "gitmoot/gitmoot", Branch: "task-9", PullRequest: 9,
+		HeadSHA: "head123", TaskID: "task-9", ReviewRound: "review-1",
+	}
+	implementPayload := payload
+	implementPayload.ReviewRound = ""
+	implementPayload.EffectiveRuntime = "codex"
+	implementPayload.Result = &AgentResult{Decision: "implemented", Summary: "implemented"}
+	insertCompletedJob(t, store, db.Job{ID: "implement-job", Agent: "wave-impl", Type: "implement"}, implementPayload)
+
+	reviewPayload := payload
+	reviewPayload.EffectiveRuntime = "codex"
+	reviewPayload.Result = &AgentResult{Decision: "approved", Summary: "approved"}
+	insertCompletedJob(t, store, db.Job{ID: "review-job", Agent: "g7-review", Type: "review"}, reviewPayload)
+
+	mergeable := true
+	gh := &fakeMergeGateGitHub{
+		pr: github.PullRequest{
+			Number: 9, State: "open", HeadRef: "task-9", BaseRef: "main",
+			HeadSHA: "head123", Mergeable: &mergeable,
+		},
+		status:      github.CombinedStatus{State: "success", Statuses: []github.CommitStatus{{Context: "ci", State: "success"}}},
+		checks:      []github.PullRequestCheck{{Name: "ci", Bucket: "pass", State: "SUCCESS"}},
+		mergeResult: github.MergeResult{Merged: true, SHA: "merge123"},
+	}
+	gate := PolicyMergeGate{AutoMerge: true, Store: store, GitHub: gh, Git: &fakeMergeGateGit{clean: true}}
+
+	decision, err := gate.Evaluate(ctx, MergeRequest{Repo: "gitmoot/gitmoot", PullRequest: 9, TaskID: "task-9"})
+	if err != nil {
+		t.Fatalf("Evaluate returned error: %v", err)
+	}
+	if decision.Merged || len(gh.merges) != 0 {
+		t.Fatalf("the gate MERGED a head whose only approval came from the implementer's own runtime family: decision=%+v merges=%+v", decision, gh.merges)
+	}
+	if !strings.Contains(decision.Reason.Render(), "same family as implementer") {
+		t.Fatalf("decision reason = %q, want it to name the family collision", decision.Reason.Render())
 	}
 }


### PR DESCRIPTION
Fixes #1531. The gate compared reviewer and implementer **agent names** and never runtime or model, so two agents with different names and the same family satisfied a gate whose entire purpose is cross-family review.

## The measurement that matters: on base, the gate MERGES

This is not inferred from reading the comparison. `TestPolicyMergeGateRefusesSameFamilyApprovalEndToEnd` drives `PolicyMergeGate.Evaluate` end to end with the PR #1527 pairing (`wave-impl` and `g7-review`, different names, both codex) and a merge client that will perform the merge if the gate allows it. On base `3f2c3cb3`:

```
the gate MERGED a head whose only approval came from the implementer's own runtime family:
decision={Ready:true Merged:true MergeCommitSHA:merge123 ...}
merges=[{Repo:{gitmoot gitmoot} Number:9 Method:squash MatchHeadCommit:head123}]
```

An actual merge call. On this branch it refuses, naming the family collision.

The original instance was caught only because the gate failed closed for an unrelated bookkeeping reason and never reached this test, which is the worse shape: a noisy failure mode masking a silent one.

## Why this is implementable now and was not when the issue was filed

#1531 deliberately deferred it: `effective_runtime` was recorded on **11%** of review jobs, and "doing (2) without (1) produces a gate that silently passes whenever the field is absent - which today is 89% of the time, i.e. a guard that looks installed and is not."

Re-measured on jobs since 2026-08-25, counting the agent-registry fallback:

```
                  jobs  recorded  registry fallback  unresolvable
review            1432      1114                221            97   (93.2% resolvable)
implement          449       251                176            22   (95.1% resolvable)
```

The prerequisite landed as #1528, and `ResolveRuntimeFamily`'s own doc comment already names this gate as its second consumer: "the ONE resolver shared by the review-loop guard (#1528) and, in a later round, the merge gate's independence check (#1531); do not grow a second copy." I did not grow a second copy.

## The unresolvable residue: neither clean nor blocked

This is the tension the issue warns about, and it needed a decision rather than a default.

An unresolved family falls through to the name check **exactly as before**, and records `merge_gate_family_unresolved` naming the side it could not resolve. So the gate never reports a check it did not perform, which is the failure the issue names, and it never silently starts refusing work it used to allow.

**Why not fail closed**, which the resolver's own doc recommends for safety-critical callers: the residue is dominated by EPHEMERAL and TEMP agents, deliberately absent from the registry, plus rows with an empty agent column. The native review fanout dispatches its lens legs as ephemeral by construction, so refusing on unresolvable would block the panel path. Measured residue by agent: empty-agent rows (11), `gm-omp-nag` (4), and the rest `*-temp-*` / `*-ephemeral-*`.

Temp agent names embed their parent (`g7-review-temp-local-review-g7-review-18d0a957...`), so making them resolvable is the follow-up that would let this fail closed. I did not do it here because it belongs in the shared resolver and would change the review-loop guard's behaviour too.

## Precedence

The runtime **recorded on the job** wins over the registry default, so an override-run reviewer attributes to the family it actually ran on. `TestMergeGateUsesTheRuntimeAJobActuallyRanOn` pins it: both agents are registered codex, the reviewer ran on kimi, and it is accepted as independent. Without that precedence the gate would refuse a legitimate override.

## Tests

```
TestPolicyMergeGateRefusesSameFamilyApprovalEndToEnd   base: MERGES; branch: refuses   <- the discriminator
TestMergeGateRefusesASameFamilyApprovalWithADifferentAgentName   unit; asserts the reason names both agents and the family
TestMergeGateAcceptsACrossFamilyApproval               the control: codex implementer, claude reviewer, still passes
TestMergeGateUsesTheRuntimeAJobActuallyRanOn           recorded runtime beats registry default
TestMergeGateRecordsAnUnresolvableFamilyRatherThanClaimingAClean   ephemeral reviewer: no match claimed, event recorded
```

The four unit tests cannot give a base before/after because the helper they call does not exist on base; a base run is a build failure. That is stated rather than presented as a red-then-green, which is why the end-to-end test exists.

## Scope: this is #1531 only, not #1534

#1531 is family-blindness; #1534 is attribution taken from a mutable payload field. phobos's prior was that they might be one defect with two symptoms. The measurement says otherwise: this fix is complete without touching where attribution comes from, and `effectiveReviewerIdentity`'s mutability is an independent property of the same collector. Two PRs, and #1534 follows.

## Verification

```
go build ./...                          ok
go vet ./...                            ok
go test -count=1 ./internal/workflow/   ok  94.4s   (full suite, no pre-existing test broke)
go test -count=1 ./internal/cli/        see the pre-merge comment
```

No existing test needed changing, which is itself informative: no test in the suite paired a same-family reviewer and implementer and expected a pass.

Deploy notes: no config, no migration, no schema change. A same-family approval that used to merge will now be refused with a named reason, and an unresolvable family behaves as it does today plus a recorded observation.
