### PR TITLE
fix(cli): carry the directive in its wake, and stop truncating show-note (#1981)

### DIFF
--- a/internal/cli/event_rule_sink.go
+++ b/internal/cli/event_rule_sink.go
@@ -636,9 +636,17 @@ func eventRuleWakePrompt(kind string, event events.Event) string {
 			// prompt lands, so the seat is told what it OWES, not asked to
 			// confirm what delivery already proved. The only remaining receipt
 			// a seat can add information to is completion.
+			//
+			// #1981: and the prompt CARRIES the directive rather than naming its
+			// row. Measured on this fleet, a directive body has a 2,782
+			// character median and a 10,187 character maximum, so it is bounded
+			// here rather than assumed short, and an over-long body says how
+			// much was omitted instead of stopping mid-clause.
 			return fmt.Sprintf(
-				"gitmoot directive %s for %s; read it with: gitmoot workflow show-note %s, then record completion with: gitmoot org directive done %s --by %s",
-				directiveID, event.WakeTargetRole, directiveID, directiveID, event.WakeTargetRole,
+				"gitmoot directive %s for %s: %s -- record completion with: gitmoot org directive done %s --by %s",
+				directiveID, event.WakeTargetRole,
+				directiveWakeBody(strings.TrimSpace(event.Detail), directiveID),
+				directiveID, event.WakeTargetRole,
 			)
 		}
 	}
@@ -674,4 +682,34 @@ func truncateForWake(s string, max int) string {
 		cut--
 	}
 	return s[:cut] + "…"
+}
+
+// directiveWakeBodyMaxBytes bounds the directive text carried in a pane prompt.
+// Measured over 2,911 directives on this fleet: median 2,782 bytes, p75 4,794,
+// max 10,187. Four thousand carries about two thirds of them whole and keeps a
+// single interrupt from becoming a ten-kilobyte wall (#1981).
+const directiveWakeBodyMaxBytes = 4000
+
+// directiveWakeBody renders a directive body for delivery. An over-long body is
+// cut at a WORD boundary and says how much was omitted plus how to read the
+// rest, because the failure this replaces was a body that stopped mid-clause
+// and a reader that could not recover the omitted instruction.
+//
+// `show-note --json` is named rather than the plain view even though the plain
+// view no longer truncates: json is the form a seat can pipe.
+func directiveWakeBody(body, directiveID string) string {
+	if len(body) <= directiveWakeBodyMaxBytes {
+		return body
+	}
+	cut := directiveWakeBodyMaxBytes
+	for cut > 0 && !utf8.RuneStart(body[cut]) {
+		cut--
+	}
+	if space := strings.LastIndexAny(body[:cut], " \t\n"); space > directiveWakeBodyMaxBytes/2 {
+		cut = space
+	}
+	return fmt.Sprintf(
+		"%s [%d of %d characters omitted; read the whole directive with: gitmoot workflow show-note %s --json]",
+		strings.TrimRight(body[:cut], " \t\n"), len(body)-cut, len(body), directiveID,
+	)
 }

--- a/internal/cli/event_rule_sink_test.go
+++ b/internal/cli/event_rule_sink_test.go
@@ -91,7 +91,7 @@ func TestEventRuleDirectiveWakePromptMatchesCurrentPhase(t *testing.T) {
 			// to learn what delivery already proved.
 			name:      "receipt",
 			cause:     "addressed_directive",
-			want:      []string{"gitmoot workflow show-note 42", "gitmoot org directive done 42 --by worker"},
+			want:      []string{"gitmoot org directive done 42 --by worker"},
 			forbidden: []string{"acknowledge receipt", "gitmoot org directive ack"},
 		},
 		{
@@ -143,6 +143,56 @@ func TestEventRuleReviewVerdictWakePrompt(t *testing.T) {
 			t.Fatalf("prompt %q does not contain %q", prompt, want)
 		}
 	}
+}
+
+// TestDirectiveWakePromptCarriesTheBody is the other half of #1981. A prompt
+// that names a row and leaves the seat to fetch it costs another turn, and the
+// reader it pointed at withheld the body anyway. An over-long body must say
+// how much was omitted and how to read the rest, never stop mid-clause.
+func TestDirectiveWakePromptCarriesTheBody(t *testing.T) {
+	base := events.Event{
+		RootID:         db.WakeOutboxSourceWorkflowNote + ":42",
+		WakeTargetRole: "worker",
+		Cause:          "addressed_directive",
+	}
+
+	t.Run("short body is carried whole", func(t *testing.T) {
+		event := base
+		event.Detail = "[org:directive to=worker from=owner wf=w] rebase the branch and re-run the gate"
+		prompt := eventRuleWakePrompt(db.WakeOutboxKindDirective, event)
+		if !strings.Contains(prompt, "rebase the branch and re-run the gate") {
+			t.Fatalf("prompt %q does not carry the directive body", prompt)
+		}
+		if strings.Contains(prompt, "characters omitted") {
+			t.Fatalf("prompt %q claims truncation for a short body", prompt)
+		}
+		if !strings.Contains(prompt, "gitmoot org directive done 42 --by worker") {
+			t.Fatalf("prompt %q lost the completion command", prompt)
+		}
+	})
+
+	t.Run("over-long body names what it omitted", func(t *testing.T) {
+		event := base
+		event.Detail = strings.Repeat("context ", directiveWakeBodyMaxBytes/4)
+		prompt := eventRuleWakePrompt(db.WakeOutboxKindDirective, event)
+		if len(prompt) > directiveWakeBodyMaxBytes+400 {
+			t.Fatalf("prompt is %d bytes, want the body bounded near %d", len(prompt), directiveWakeBodyMaxBytes)
+		}
+		body := strings.TrimSpace(event.Detail)
+		omitted := len(body) - directiveWakeBodyMaxBytes
+		if !strings.Contains(prompt, fmt.Sprintf("of %d characters omitted", len(body))) {
+			t.Fatalf("prompt %q does not state how much of the %d-character body was omitted (about %d)", prompt, len(body), omitted)
+		}
+		if !strings.Contains(prompt, "gitmoot workflow show-note 42 --json") {
+			t.Fatalf("prompt %q omits the retrieval command for the rest", prompt)
+		}
+		// A word boundary, not a mid-word cut: the carried text must end on a
+		// complete word from the body.
+		carried := prompt[:strings.Index(prompt, " [")]
+		if strings.HasSuffix(carried, "contex") || strings.HasSuffix(carried, "conte") {
+			t.Fatalf("prompt cut mid-word: %q", carried[len(carried)-40:])
+		}
+	})
 }
 
 func TestClassifyEventRuleKinds(t *testing.T) {

--- a/internal/cli/org_directive_test.go
+++ b/internal/cli/org_directive_test.go
@@ -574,7 +574,9 @@ func TestDirectiveWakeDrainDoesNotCoalesceDifferentObligations(t *testing.T) {
 		// #1980: the first-delivery prompt no longer asks for a receipt, so the
 		// two phases are told apart by their own wording rather than by which
 		// receipt command they carry.
-		case strings.Contains(prompt, fmt.Sprintf("gitmoot workflow show-note %d", unread.ID)):
+		// #1981: the first-delivery prompt CARRIES the directive text, so the
+		// phase is recognised by the deliverable rather than by a fetch command.
+		case strings.Contains(prompt, fmt.Sprintf("gitmoot directive %d for worker: start", unread.ID)):
 			acknowledgmentPrompt = prompt
 		}
 	}

--- a/internal/cli/reply_wake_outbox.go
+++ b/internal/cli/reply_wake_outbox.go
@@ -419,7 +419,22 @@ func wakeOutboxEvent(batch []db.WakeOutboxObligation, now time.Time) (events.Eve
 	switch oldest.SourceKind {
 	case db.WakeOutboxSourceWorkflowNote:
 		if wakeKind == db.WakeOutboxKindDirective {
-			detail := fmt.Sprintf("directive id %s for %s", oldest.SourceID, role)
+			// #1981: the DELIVERABLE travels with the wake. Naming the row and
+			// leaving the seat to fetch it costs another turn, and the reader it
+			// was pointed at truncated the body anyway. The prompt renderer
+			// bounds this; nothing is cut here.
+			//
+			// The marker header (`[org:directive to=... from=... wf=...]`) is
+			// machine addressing the prompt already states, so the seat gets the
+			// directive TEXT. An unparseable body falls back to the raw note
+			// rather than to silence.
+			detail := strings.TrimSpace(oldest.DirectiveBody)
+			if _, _, _, text, ok := workflow.ParseOrgDirectiveNote(detail); ok && strings.TrimSpace(text) != "" {
+				detail = strings.TrimSpace(text)
+			}
+			if detail == "" {
+				detail = fmt.Sprintf("directive id %s for %s", oldest.SourceID, role)
+			}
 			event = events.NewEvent(
 				events.EventOrgDirective,
 				"org-directive:"+role,

--- a/internal/cli/workflow_journal.go
+++ b/internal/cli/workflow_journal.go
@@ -11,7 +11,6 @@ import (
 	"strconv"
 	"strings"
 	"unicode"
-	"unicode/utf8"
 
 	"github.com/gitmoot/gitmoot/internal/config"
 	"github.com/gitmoot/gitmoot/internal/db"
@@ -392,9 +391,21 @@ const workflowTextLineMaxRunes = 512
 // characters other than tab to spaces, and caps each rendered field to one
 // bounded terminal line.
 func terminalSafeWorkflowText(value string) string {
+	return scrubWorkflowText(value, workflowTextLineMaxRunes)
+}
+
+// scrubWorkflowText is the shared scrubber. maxRunes <= 0 means NO CAP, which
+// the single-note view needs (#1981): scrubbing is a safety property and the
+// cap is a layout one, and conflating them made `show-note` withhold 97% of a
+// directive body it was asked to display.
+func scrubWorkflowText(value string, maxRunes int) string {
 	runes := []rune(value)
-	out := make([]rune, 0, min(len(runes), workflowTextLineMaxRunes))
-	for i := 0; i < len(runes) && len(out) < workflowTextLineMaxRunes; i++ {
+	capacity := len(runes)
+	if maxRunes > 0 && maxRunes < capacity {
+		capacity = maxRunes
+	}
+	out := make([]rune, 0, capacity)
+	for i := 0; i < len(runes) && (maxRunes <= 0 || len(out) < maxRunes); i++ {
 		r := runes[i]
 		if r == 0x1b {
 			if i+1 >= len(runes) {
@@ -431,12 +442,18 @@ func terminalSafeWorkflowText(value string) string {
 	return string(out)
 }
 
-func terminalSafeWorkflowBody(value string) string {
-	rendered := terminalSafeWorkflowText(value)
-	if utf8.RuneCountInString(value) > workflowTextLineMaxRunes {
-		return rendered + " [truncated; use --json for the full body]"
-	}
-	return rendered
+// terminalSafeWorkflowFullBody scrubs a body for terminal display WITHOUT
+// truncating it (#1981). show-note exists to read ONE note, so a cap there
+// defeated the command's only purpose: measured over 2,911 directives on this
+// fleet, only 2.7% fit inside the 512-rune line cap, so the view cut 97% of
+// them, and the transport's own prompt pointed seats at this command to
+// recover a body it then withheld. The cap remains where it belongs, on
+// timeline and list lines, via terminalSafeWorkflowText.
+//
+// Scrubbing is NOT truncation and stays: control bytes and ANSI escapes from a
+// note body must never reach a terminal unfiltered.
+func terminalSafeWorkflowFullBody(value string) string {
+	return scrubWorkflowText(value, 0)
 }
 
 func mergeWorkflowTimeline(jobs []db.Job, notes []db.WorkflowNote) []workflowTimelineEntry {
@@ -527,7 +544,7 @@ func runWorkflowNoteShow(args []string, stdout, stderr io.Writer) int {
 		writeLine(stdout, "repo: %s", terminalSafeWorkflowText(note.Repo))
 	}
 	writeLine(stdout, "created: %s", note.CreatedAt)
-	writeLine(stdout, "body: %s", terminalSafeWorkflowBody(note.Body))
+	writeLine(stdout, "body: %s", terminalSafeWorkflowFullBody(note.Body))
 	return 0
 }
 

--- a/internal/cli/workflow_journal_test.go
+++ b/internal/cli/workflow_journal_test.go
@@ -1241,9 +1241,22 @@ func TestWorkflowRememberHonorsAutoConfirmInSharedPool(t *testing.T) {
 	}
 }
 
-func TestWorkflowShowNoteMarksTruncatedPlainBody(t *testing.T) {
+// TestWorkflowShowNotePrintsTheWholeBody is half of #1981's reproduction. The
+// transport tells a seat to read its directive with `workflow show-note`, and
+// that command used to cut the body at workflowTextLineMaxRunes and say "use
+// --json". Measured over 2,911 directives on this fleet, only 2.7% fit inside
+// that cap, so the command withheld the instruction 97% of the time, which is
+// how a directive could be delivered, fetched, and still not actionable.
+func TestWorkflowShowNotePrintsTheWholeBody(t *testing.T) {
 	home, store := workflowJournalTestHome(t)
-	body := strings.Repeat("x", workflowTextLineMaxRunes+20)
+	// A realistic directive length: past the old cap, with the actionable line
+	// LAST, which is where a remedy line actually sits.
+	body := "[org:directive to=worker from=owner wf=gitmoot/long] " +
+		strings.Repeat("context. ", 400) +
+		"run: gitmoot job record --agent worker --type implement"
+	if len(body) <= workflowTextLineMaxRunes {
+		t.Fatalf("test body is %d runes, must exceed the line cap %d", len(body), workflowTextLineMaxRunes)
+	}
 	note, err := store.InsertWorkflowNote(context.Background(), db.WorkflowNote{
 		WorkflowID: "gitmoot/long-message",
 		Author:     "gm-omp-nag",
@@ -1255,8 +1268,37 @@ func TestWorkflowShowNoteMarksTruncatedPlainBody(t *testing.T) {
 
 	var stdout, stderr bytes.Buffer
 	code := runWorkflowJournal([]string{"show-note", fmt.Sprint(note.ID), "--home", home}, &stdout, &stderr)
-	if code != 0 || !strings.Contains(stdout.String(), "[truncated; use --json for the full body]") {
+	if code != 0 {
 		t.Fatalf("plain show-note code=%d out=%q err=%q", code, stdout.String(), stderr.String())
+	}
+	if !strings.Contains(stdout.String(), body) {
+		t.Fatalf("plain show-note dropped part of the body: out=%q", stdout.String())
+	}
+	if strings.Contains(stdout.String(), "[truncated") {
+		t.Fatalf("plain show-note still truncates a single note: out=%q", stdout.String())
+	}
+
+	// Scrubbing is a safety property and is NOT what was removed: an escape
+	// sequence in a body must still never reach the terminal.
+	unsafe, err := store.InsertWorkflowNote(context.Background(), db.WorkflowNote{
+		WorkflowID: "gitmoot/long-message", Author: "gm-omp-nag",
+		Body: "before\x1b[31mred\x1b[0m\x07after",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	stdout.Reset()
+	stderr.Reset()
+	if code := runWorkflowJournal([]string{"show-note", fmt.Sprint(unsafe.ID), "--home", home}, &stdout, &stderr); code != 0 {
+		t.Fatalf("scrub show-note code=%d err=%q", code, stderr.String())
+	}
+	if strings.ContainsRune(stdout.String(), 0x1b) || strings.ContainsRune(stdout.String(), 0x07) {
+		t.Fatalf("show-note leaked a control sequence: %q", stdout.String())
+	}
+	// The escape sequences are dropped and the BEL becomes a space; every
+	// printable character of the body survives.
+	if !strings.Contains(stdout.String(), "beforered after") {
+		t.Fatalf("scrubbed body = %q, want the escape sequences removed and the text kept", stdout.String())
 	}
 
 	stdout.Reset()

--- a/internal/db/wake_outbox.go
+++ b/internal/db/wake_outbox.go
@@ -105,6 +105,11 @@ type WakeOutboxObligation struct {
 	CoalesceKey    string
 	CreatedAt      string
 	DirectivePhase string
+	// DirectiveBody is the directive's own actionable text, projected from the
+	// same query that derives the phase (#1981). A prompt that names a row
+	// instead of carrying its body forces the seat to fetch, and the fetch is
+	// another turn; carrying it is the whole point of the delivery.
+	DirectiveBody string
 }
 
 // WakeOutboxObligationProjection exposes decisions, not persisted states.
@@ -339,11 +344,12 @@ func listWakeOutboxObligations(
 	for rows.Next() {
 		var entry WakeOutboxEntry
 		var directivePhase string
+		var directiveBody string
 		if err := rows.Scan(
 			&entry.ID, &entry.SourceKind, &entry.SourceID, &entry.TargetRole,
 			&entry.CoalesceKey, &entry.State, &entry.AttemptCount,
 			&entry.LastError, &entry.CreatedAt, &entry.AttemptedAt,
-			&entry.FinishedAt, &entry.UpdatedAt, &directivePhase,
+			&entry.FinishedAt, &entry.UpdatedAt, &directivePhase, &directiveBody,
 		); err != nil {
 			return WakeOutboxObligationProjection{}, err
 		}
@@ -351,6 +357,7 @@ func listWakeOutboxObligations(
 			ID: entry.ID, SourceKind: entry.SourceKind, SourceID: entry.SourceID,
 			TargetRole: entry.TargetRole, CoalesceKey: entry.CoalesceKey,
 			CreatedAt: entry.CreatedAt, DirectivePhase: directivePhase,
+			DirectiveBody: directiveBody,
 		}
 		interpretation, ok := interpretWakeOutboxState(entry.State)
 		if !ok {
@@ -404,6 +411,13 @@ SELECT id, source_kind, source_id, target_role, coalesce_key, state,
 					)
 			) THEN 'completion'
 			ELSE 'acknowledgment'
+		END,
+		CASE
+			WHEN source_kind != 'workflow_note' OR coalesce_key NOT LIKE 'directive:%' THEN ''
+			ELSE COALESCE((
+				SELECT d.body FROM workflow_notes d
+				WHERE d.id = CAST(wake_outbox.source_id AS INTEGER)
+			), '')
 		END
 FROM wake_outbox
 WHERE ` + predicate + `

--- a/internal/db/wake_outbox_test.go
+++ b/internal/db/wake_outbox_test.go
@@ -83,6 +83,13 @@ SELECT id, source_kind, source_id, target_role, coalesce_key, state,
 					)
 			) THEN 'completion'
 			ELSE 'acknowledgment'
+		END,
+		CASE
+			WHEN source_kind != 'workflow_note' OR coalesce_key NOT LIKE 'directive:%' THEN ''
+			ELSE COALESCE((
+				SELECT d.body FROM workflow_notes d
+				WHERE d.id = CAST(wake_outbox.source_id AS INTEGER)
+			), '')
 		END
 FROM wake_outbox
 WHERE state = ? OR (state = ? AND attempted_at IS NOT NULL AND attempted_at <= ?)

--- a/skills/gitmoot/references/CLI.md
+++ b/skills/gitmoot/references/CLI.md
@@ -1811,9 +1811,12 @@ The typed note
 `reply:<role>` wake row commit atomically. The wake includes the exact
 `gitmoot workflow show-note <id>` retrieval command; that command renders the
 citable row's workflow, author, optional repository, timestamp, and body, or
-returns the row as JSON. Plain output marks bodies above 512 runes as truncated
-and points to `--json`; JSON preserves the full stored body. Messages create no
-directive, acknowledgment, completion, TTL, or nag obligation.
+returns the row as JSON. **Plain output prints the whole body**: a single-note
+view is the one place a body must not be cut, and the 512-rune line cap applies
+to timeline and list lines instead. Control characters and ANSI escapes are
+still scrubbed from plain output; JSON preserves the stored body byte for byte.
+Messages create no directive, acknowledgment, completion, TTL, or nag
+obligation.
 
 `gitmoot org escalate resolve <escalation-note-id> [--by <role>] [--note
 <answer-note-id>] [--home <dir>]` appends a typed resolution marker to the same
@@ -1860,6 +1863,16 @@ behaviour that predates this change.
 **A remaining acknowledgment-phase nudge now means "delivery is not proven".**
 A stalled, failed or `delivery_unknown` wake records no receipt, so the ladder
 keeps running for exactly the directives whose arrival nobody can demonstrate.
+
+**The first-delivery prompt carries the directive itself**, not a pointer to
+its row: `gitmoot directive <id> for <role>: <directive text> -- record
+completion with: gitmoot org directive done <id> --by <role>`. The carried text
+is the body with its `[org:directive to=… from=… wf=…]` marker header stripped,
+since the prompt already states the addressee. A body over 4,000 characters is
+cut at a **word boundary** and states exactly how much was omitted plus the
+command that returns the rest, for example `[3126 of 7126 characters omitted;
+read the whole directive with: gitmoot workflow show-note 42 --json]`. Nothing
+stops mid-clause without saying so.
 
 `gitmoot org directive done <id> [--by <role>] [--home <dir>]` records
 COMPLETION and ends the obligation, including its TTL nudges. **Completion

--- a/website/docs/reference/cli.md
+++ b/website/docs/reference/cli.md
@@ -1527,8 +1527,11 @@ The typed note
 `reply:<role>` wake row commit atomically. The wake includes the exact
 `gitmoot workflow show-note <id>` retrieval command; that command renders the
 citable row's workflow, author, optional repository, timestamp, and body, or
-returns the row as JSON. Plain output marks bodies above 512 runes as truncated
-and points to `--json`; JSON preserves the full stored body. Messages create no
+returns the row as JSON. **Plain output prints the whole body**: a single-note
+view is the one place a body must not be cut, and the 512-rune line cap applies
+to timeline and list lines instead. Control characters and ANSI escapes are
+still scrubbed from plain output; JSON preserves the stored body byte for byte.
+Messages create no
 directive, acknowledgment, completion, TTL, or nag obligation.
 
 `gitmoot org escalate resolve <escalation-note-id> [--by <role>] [--note
@@ -1577,6 +1580,19 @@ which is the behaviour that predates this change.
 **A remaining acknowledgment-phase nudge now means "delivery is not proven".**
 A stalled, failed or `delivery_unknown` wake records no receipt, so the ladder
 keeps running for exactly the directives whose arrival nobody can demonstrate.
+
+**The first-delivery prompt carries the directive itself**, not a pointer to
+its row: `gitmoot directive <id> for <role>: <directive text> -- record
+completion with: gitmoot org directive done <id> --by <role>`. Fetching a row
+costs another turn, which is the whole cost this transport work is removing.
+The carried text is the directive body with its `[org:directive to=… from=…
+wf=…]` marker header stripped, since the prompt already states the addressee.
+A body over 4,000 characters is cut at a **word boundary** and states exactly
+how much was omitted plus the command that returns the rest, for example
+`[3126 of 7126 characters omitted; read the whole directive with: gitmoot
+workflow show-note 42 --json]`. Directive bodies on a live fleet have a median
+of about 2,800 characters, so most arrive whole, and none stops mid-clause
+without saying so.
 
 `gitmoot org directive done <id> [--by <role>] [--home <dir>]` records
 COMPLETION and ends the obligation, including its TTL nudges. **Completion


### PR DESCRIPTION
Fixes #1981. Part of the #1977 campaign. Corrects a shared evidence claim in #1890.

## The store does not truncate. I checked before fixing.

#1981 and #1890 both state that note **124945**'s durable body is "truncated at 991 characters" and ends mid-clause at `… If the work was done in ses`. Read-only from `/root/.gitmoot/gitmoot.db`:

- Its length **is** 991 characters, and that is its **true** length, not a cut.
- Its last 60 characters are `against it for head 59eedaaa16ed088d12dd331b5024596ae8274d1d`: a complete sentence ending in a full 40-character SHA.
- The quoted phrase `If the work was done in ses` **ends at character 765**, with **226 further characters stored after it**, including the whole `--acting-role` clause the reports describe as lost.

And there is no write-side cap near 1,000 anywhere:

| Measure | Value |
| --- | --- |
| notes at least 990 characters | **13,611** |
| notes over 2,000 | 10,313 |
| notes over 5,000 | 1,641 |
| longest stored body | **10,238** |
| escalation notes at least 991 characters | 2,268 |

So the durable copy was never the problem, and the second acceptance criterion ("no stored note body is silently cut mid-clause") was already satisfied. The 991 was the note's length, misread as the truncation point.

## The truncating reader is the command the transport recommended

`gitmoot workflow show-note 124945` on the live store, before this PR:

```
body: [org:escalate to=gm-reviewfix-coc from=gm-reviewfix-c …] review gate: … record the durable
attribution row with gitmoot job record --agent < [truncated; use --json for the full body]
```

It cuts at `--agent <`, mid-flag, and the marker points at `--json`. The mechanism is `workflowTextLineMaxRunes = 512` applied to the body in the single-note view. Measured over 2,911 directives on this fleet:

| Body length | Share of directives |
| --- | --- |
| fits in 512 runes | **2.7%** |
| median | **2,782 characters** |
| p75 / p90 / max | 4,794 / 8,638 / 10,187 |

So the retrieval command the transport told seats to run withheld the instruction for **97.3%** of directives. That is the composed failure #1981 describes: the prompt omits the body, the seat fetches, and the fetch does not recover the action. Both halves are real; neither is in the store.

## The change

**1. `show-note` prints the whole body.** A single-note view is the one place a body must not be cut. The 512-rune cap stays where layout needs it, on timeline and list lines, via `terminalSafeWorkflowText`. Scrubbing is a *safety* property and is untouched: control bytes and ANSI escapes are still removed, which the test asserts separately so nobody later "simplifies" the scrub away with the cap.

**2. The first-delivery prompt carries the directive.** Before and after:

```
before: gitmoot directive 42 for worker; acknowledge receipt with: gitmoot org directive ack 42 --by worker
after:  gitmoot directive 42 for worker: <the directive text> -- record completion with: gitmoot org directive done 42 --by worker
```

The body is projected by the same obligation query that already derives the directive phase, so no extra round trip. The `[org:directive to=… from=… wf=…]` marker header is stripped, because the prompt already states the addressee, and an unparseable body falls back to the raw note rather than to silence.

Over `directiveWakeBodyMaxBytes` (4,000, which carries about two thirds of real bodies whole) it cuts at a **word boundary** and says exactly what is missing:

```
… [3126 of 7126 characters omitted; read the whole directive with: gitmoot workflow show-note 42 --json]
```

That is the issue's remedy verbatim: a field boundary, an explicit truncation record, and the omitted portion retrievable, by a command that now actually returns it.

## Tests

- `TestWorkflowShowNotePrintsTheWholeBody`: a body past the line cap is printed complete, no `[truncated` marker, escapes still scrubbed (`\x1b[31m…\x07` renders with no control bytes), `--json` still byte-for-byte. Fails before this PR on the first assertion.
- `TestDirectiveWakePromptCarriesTheBody`: a short body is carried whole with no truncation claim; an over-long body is bounded, names how many of how many characters were omitted, carries the `--json` retrieval command, and does not end mid-word. Fails before this PR because the prompt contained no body at all.
- `TestEventRuleDirectiveWakePromptMatchesCurrentPhase` and `TestDirectiveWakeDrainDoesNotCoalesceDifferentObligations` were re-pointed at the new prompt shape; both still discriminate the three phases and the two obligations.
- `TestListWakeOutboxObligationsExecutesGeneratedQuery`, the independently handwritten copy of the obligation query, was updated in lockstep with the new body projection. It failed the moment the two drifted, which is what it is for.

## Acceptance, against the issue

- **A delivered directive contains the action to take without a follow-up fetch**: met, for bodies up to 4,000 characters, which is most of them. Beyond that the prompt says how much is missing and how to get it, rather than pretending to be complete.
- **No stored note body is silently cut mid-clause**: **already true**, and the measurement above is the evidence. Nothing in this PR was needed for it. What was cut mid-clause was the *view*, and that is fixed.
- **The `THE ROW IS THE AUTHORITY` prompt class disappears**: **not fixable in code, and I am not claiming it.** That string appears nowhere in this repository. Those 18 prompts were written by coordinators calling `herdr agent prompt` directly, exactly like the `TRANSPORT ONLY` relays in #1980. What this PR removes is the *reason* to write it: the transport now carries the body, and the fallback command returns the whole row.

## Verification

Full local gate on this head with go1.26.4 pinned: `go build -buildvcs=false ./...`, `go vet ./...`, `go test -count=1 -timeout 25m ./...`, **zero failures**, disk 8.73% free throughout (the guard that produced 20 phantom failures earlier today is well clear).

`-race` is CI's shards; race requires cgo, which this repo's gate documents as unavailable locally.

## Not verified

- **No live probe.** Delivery is daemon behaviour and deploys are owner-gated. `gitmoot workflow show-note` is user-facing, so its half is probeable the moment a binary carrying this ships: the command that printed `[truncated; use --json for the full body]` for note 124945 should print all 991 characters.
- I have not re-audited the other callers of the 512-rune cap. They render timeline and list *lines*, where a cap is correct, and I left them alone deliberately rather than widening the change.

Deploy notes: no migration. The obligation query gains a projected column; the wake outbox schema is unchanged. Daemon restart picks up the prompt change; `show-note` changes with the binary.
