### PR TITLE
fix(workflow): mark a fan-out announcement in routing telemetry, and refuse #1972's premise (#1972)

### DIFF
--- a/internal/db/cleanup_obligations_test.go
+++ b/internal/db/cleanup_obligations_test.go
@@ -140,21 +140,21 @@ func TestMigrationsUpgradeFromPreviousReleasedVersion(t *testing.T) {
 	// teardown, #1770's Activepieces trigger removal, #1731's escalation_rounds
 	// table, #1754's chat/moot teardown, #1756's preset-delivery removal,
 	// #1753's cockpit/interactive table drop and #1822's findings ledger (plus
-	// its #1850 rebuild) each joined the released prefix, leaving #1967's
-	// jobs.dispatched_by column appended last. Two branches cannot both be
+	// its #1850 rebuild) each joined the released prefix, leaving #1972's
+	// routing_telemetry.fan_out column appended last. Two branches cannot both be
 	// "last", and the ordering that matters is the one a deployed database sees,
 	// which is why this marker MUST be repointed on every branch that appends a
 	// migration, and why the failure reads as "not appended last" rather than as
 	// a merge conflict.
 	//
 	// The marker must name THIS BRANCH'S LAST migration and must be UNIQUE. The
-	// index name is unique to #1534's migration; the bare ALTER would not be,
+	// index name is unique to #1972's migration; the bare ALTER would not be,
 	// because the column name also appears in that migration's own prose.
 	//
 	// It is updated by every branch that appends a migration, which is the point:
 	// the test fails until the new migration is both last and named here, so two
 	// branches cannot each believe theirs is the tail.
-	const branchMigrationMarker = "idx_job_events_runtime"
+	const branchMigrationMarker = "idx_routing_telemetry_fan_out"
 	branchIndex := -1
 	for index, migration := range migrations {
 		if strings.Contains(migration, branchMigrationMarker) {

--- a/internal/db/routing_telemetry.go
+++ b/internal/db/routing_telemetry.go
@@ -36,6 +36,13 @@ type RoutingTelemetry struct {
 	// Approved mirrors the engine's approving-outcome test (approved|implemented|
 	// succeeded) so the summary can report an approval rate without re-deriving it.
 	Approved bool
+	// FanOut marks a row whose Decision is a coordinator's DISPATCH RECORD rather
+	// than a judgement about code (#1972). The engine already draws this line:
+	// ResultIsFanOut keeps a fan-out's decision out of the merge gate's verdict
+	// population. A verdict-rate query that does not exclude these is comparing
+	// announcements with judgements, which is how #1972's 81%-to-17% finding was
+	// produced from 70 announcements.
+	FanOut bool
 	// TestsRun is len(result.tests_run) — a coarse "did the agent exercise tests"
 	// signal. It is NOT a pass/fail count (the agent reports the tests it ran, not
 	// their verdicts); the job state/decision carry the real outcome.
@@ -62,15 +69,19 @@ func (s *Store) InsertRoutingTelemetry(ctx context.Context, t RoutingTelemetry) 
 	if t.Approved {
 		approved = 1
 	}
+	fanOut := 0
+	if t.FanOut {
+		fanOut = 1
+	}
 	_, err := s.db.ExecContext(ctx, `
 INSERT INTO routing_telemetry(
 	job_id, repo, action, phase, runtime, model, agent,
 	template_id, template_commit, job_state, decision, approved,
-	tests_run, duration_ms, input_tokens, output_tokens
-) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+	tests_run, duration_ms, input_tokens, output_tokens, fan_out
+) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 		t.JobID, t.Repo, t.Action, t.Phase, t.Runtime, t.Model, t.Agent,
 		t.TemplateID, t.TemplateCommit, t.JobState, t.Decision, approved,
-		t.TestsRun, t.DurationMS, t.InputTokens, t.OutputTokens)
+		t.TestsRun, t.DurationMS, t.InputTokens, t.OutputTokens, fanOut)
 	return err
 }
 
@@ -82,7 +93,7 @@ func (s *Store) ListRoutingTelemetry(ctx context.Context, filter RoutingTelemetr
 	query := `
 SELECT id, job_id, repo, action, phase, runtime, model, agent,
 	template_id, template_commit, job_state, decision, approved,
-	tests_run, duration_ms, input_tokens, output_tokens, created_at
+	tests_run, duration_ms, input_tokens, output_tokens, created_at, fan_out
 FROM routing_telemetry`
 	var conds []string
 	var args []any
@@ -115,13 +126,18 @@ FROM routing_telemetry`
 	var out []RoutingTelemetry
 	for rows.Next() {
 		var t RoutingTelemetry
-		var approved int
+		var approved, fanOut int
 		if err := rows.Scan(&t.ID, &t.JobID, &t.Repo, &t.Action, &t.Phase, &t.Runtime, &t.Model, &t.Agent,
 			&t.TemplateID, &t.TemplateCommit, &t.JobState, &t.Decision, &approved,
-			&t.TestsRun, &t.DurationMS, &t.InputTokens, &t.OutputTokens, &t.CreatedAt); err != nil {
+			&t.TestsRun, &t.DurationMS, &t.InputTokens, &t.OutputTokens, &t.CreatedAt, &fanOut); err != nil {
 			return nil, err
 		}
 		t.Approved = approved != 0
+		// #1972: a fan-out row is an announcement, not a verdict. Reading it back
+		// is what lets a caller exclude it instead of re-deriving the distinction
+		// from the payload, which is the step every wrong verdict-rate query
+		// skipped.
+		t.FanOut = fanOut != 0
 		out = append(out, t)
 	}
 	return out, rows.Err()

--- a/internal/db/store_migrations.go
+++ b/internal/db/store_migrations.go
@@ -2749,4 +2749,31 @@ CREATE INDEX IF NOT EXISTS idx_jobs_dispatched_by ON jobs(dispatched_by) WHERE d
 ALTER TABLE job_events ADD COLUMN runtime TEXT NOT NULL DEFAULT '';
 CREATE INDEX IF NOT EXISTS idx_job_events_runtime ON job_events(job_id, id) WHERE runtime != '';
 	`,
+	// #1972 fan-out marker on routing telemetry.
+	//
+	// routing_telemetry counted a fan-out COORDINATOR's decision as a verdict
+	// about code. The engine already refuses to: ResultIsFanOut exists precisely
+	// because "a FAN-OUT is a coordinator's dispatch record, not an answer about
+	// the code" (review_threshold.go), and the merge gate excludes those rows
+	// from the verdict population. The telemetry did not, so the one table the
+	// fleet uses to compare reviewer configurations was mixing announcements
+	// with judgements.
+	//
+	// It produced a concrete wrong conclusion. #1972 was filed on the finding
+	// that the review-panel template moves codex from 81% changes_requested to
+	// 17%. Measured: of 93 review-panel rows, 76 were approvals and 70 of those
+	// declared delegations, i.e. announcements. Excluding them leaves 22 real
+	// verdicts at 72.7%, and the panel's own lens children at 77.8%, neither
+	// distinguishable from the untemplated 81.5%. The whole effect was the
+	// artifact.
+	//
+	// DEFAULT 0 preserves every existing row, and existing rows stay unmarked
+	// rather than being guessed at: whether a historical row was an announcement
+	// is recoverable from its payload but not from this column, and back-filling
+	// a judgement call into an evidence table is worse than an honest default.
+	// Append-only tail; migrations are positional.
+	`
+ALTER TABLE routing_telemetry ADD COLUMN fan_out INTEGER NOT NULL DEFAULT 0;
+CREATE INDEX IF NOT EXISTS idx_routing_telemetry_fan_out ON routing_telemetry(action, fan_out);
+	`,
 }

--- a/internal/workflow/routing_telemetry.go
+++ b/internal/workflow/routing_telemetry.go
@@ -79,6 +79,14 @@ func (m Mailbox) recordRoutingTelemetry(ctx context.Context, job db.Job, agent r
 		DurationMS:     durationMS,
 		InputTokens:    inTok,
 		OutputTokens:   outTok,
+		// #1972: mark the announcement so a verdict-rate query can exclude it.
+		// ResultIsFanOut is the SAME predicate the merge gate uses to keep a
+		// coordinator's dispatch record out of its verdict population, so the
+		// telemetry and the gate now agree about what counts as an answer. The
+		// alternative was leaving every consumer to re-derive it from the payload,
+		// which is exactly the step that produced #1972's 81%-to-17% artifact from
+		// 70 coordinator announcements.
+		FanOut: ResultIsFanOut(&result),
 	})
 }
 

--- a/internal/workflow/routing_telemetry_fanout_1972_test.go
+++ b/internal/workflow/routing_telemetry_fanout_1972_test.go
@@ -1,0 +1,120 @@
+package workflow
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/gitmoot/gitmoot/internal/db"
+	"github.com/gitmoot/gitmoot/internal/runtime"
+)
+
+// #1972. routing_telemetry recorded a fan-out COORDINATOR's decision as if it
+// were a verdict about code, and the fleet's one instrument for comparing
+// reviewer configurations was therefore mixing announcements with judgements.
+//
+// THIS IS NOT HYPOTHETICAL: it produced a filed conclusion. #1972 reported that
+// the review-panel template moves codex from 81% changes_requested to 17%.
+// Measured on this box: of 93 review-panel rows, 76 were approvals and 70 of
+// those declared delegations - coordinator dispatch records, not answers.
+// Excluding them leaves 22 real verdicts at 72.7%, and the panel's own lens
+// children at 77.8%, neither distinguishable from the untemplated 81.5% on
+// those sample sizes. The entire effect was the artifact.
+//
+// The engine already draws this line. ResultIsFanOut exists because "a FAN-OUT
+// is a coordinator's dispatch record, not an answer about the code", and the
+// merge gate uses it to keep such rows out of its verdict population. The
+// telemetry did not, so the gate and the instrument disagreed about what counts
+// as an answer. This pins that they now agree.
+func TestRoutingTelemetryMarksAFanOutAsAnAnnouncementNotAVerdict(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	mailbox := NewMailbox(store, UnavailableDeliveryWorktreeResolver("test"))
+
+	for _, tc := range []struct {
+		name   string
+		jobID  string
+		result AgentResult
+		want   bool
+	}{
+		{
+			name:  "a coordinator announcing a fan-out is not a verdict",
+			jobID: "coordinator-row",
+			result: AgentResult{
+				Decision: "approved",
+				Summary:  "dispatched three refutation lenses",
+				Delegations: []Delegation{
+					{ID: "lens-a", Agent: "reviewer", Action: "review", Prompt: "disprove a"},
+					{ID: "lens-b", Agent: "reviewer", Action: "review", Prompt: "disprove b"},
+				},
+			},
+			want: true,
+		},
+		{
+			name:   "an ordinary review verdict is a verdict",
+			jobID:  "verdict-row",
+			result: AgentResult{Decision: "changes_requested", Summary: "found a defect", Severity: "P2"},
+			want:   false,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			job := db.Job{ID: tc.jobID, Agent: "g6-review-sol", Type: "review"}
+			mailbox.recordRoutingTelemetry(ctx, job, runtime.Agent{Runtime: "codex"},
+				JobPayload{Repo: "gitmoot/gitmoot", TemplateID: "review-panel"},
+				tc.result, JobSucceeded, time.Second)
+
+			rows, err := store.ListRoutingTelemetry(ctx, db.RoutingTelemetryFilter{})
+			if err != nil {
+				t.Fatalf("ListRoutingTelemetry: %v", err)
+			}
+			var found *db.RoutingTelemetry
+			for i := range rows {
+				if rows[i].JobID == tc.jobID {
+					found = &rows[i]
+				}
+			}
+			if found == nil {
+				t.Fatalf("no telemetry row for %q", tc.jobID)
+			}
+			if found.FanOut != tc.want {
+				t.Fatalf("fan_out = %v, want %v; a verdict-rate query that cannot tell an announcement from a judgement produced #1972's 81%%-to-17%% finding out of 70 announcements",
+					found.FanOut, tc.want)
+			}
+			// The decision itself is preserved either way: the row still describes
+			// itself, exactly as review_threshold.go returns the raw decision for a
+			// fan-out rather than suppressing it. Marking is not filtering.
+			if found.Decision != tc.result.Decision {
+				t.Fatalf("decision = %q, want %q; marking a row must not rewrite what it recorded", found.Decision, tc.result.Decision)
+			}
+		})
+	}
+}
+
+// The instrument and the gate must not be able to drift apart. If ResultIsFanOut
+// ever changes what counts as a coordinator record, the telemetry has to move
+// with it rather than keeping a second, stale copy of the rule.
+func TestRoutingTelemetryFanOutUsesTheGatesOwnPredicate(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	mailbox := NewMailbox(store, UnavailableDeliveryWorktreeResolver("test"))
+
+	result := AgentResult{
+		Decision:    "approved",
+		Summary:     "fan-out",
+		Delegations: []Delegation{{ID: "lens", Agent: "reviewer", Action: "review", Prompt: "disprove"}},
+	}
+	if !ResultIsFanOut(&result) {
+		t.Fatal("premise broken: the gate no longer classifies this as a fan-out, so this test is asserting nothing")
+	}
+	mailbox.recordRoutingTelemetry(ctx, db.Job{ID: "row", Agent: "a", Type: "review"},
+		runtime.Agent{Runtime: "codex"}, JobPayload{Repo: "r"}, result, JobSucceeded, time.Second)
+
+	rows, err := store.ListRoutingTelemetry(ctx, db.RoutingTelemetryFilter{})
+	if err != nil {
+		t.Fatalf("ListRoutingTelemetry: %v", err)
+	}
+	if len(rows) != 1 || !rows[0].FanOut {
+		t.Fatalf("rows=%d fan_out=%v; the telemetry must agree with ResultIsFanOut, not keep its own copy of the rule",
+			len(rows), len(rows) == 1 && rows[0].FanOut)
+	}
+}


### PR DESCRIPTION
Part of campaign #1966, for #1972. **It does not enable risk tiers, and the measurement is why.**

## #1972's headline finding is an artifact, and I can show the exact mechanism

The issue reports that the `review-panel` template moves codex from **81%** changes_requested to **17%**, same fleet, same runtime, and proposes acting on that.

Re-derived from `routing_telemetry`, the rates reproduce:

| Template | Runtime | Reviews | changes_requested |
| --- | --- | --- | --- |
| *(none)* | codex | 2,327 | 81.5% |
| *(none)* | claude | 759 | 31.6% |
| `review-panel` | codex | 92 | 17.4% |
| *(none)* | kimi | 81 | 24.7% |

**Then the confound.** Of the 93 `review-panel` rows, 76 are approvals, and **70 of those declare delegations**: they are fan-out coordinators announcing a dispatch, not verdicts about code. Every one of the 17 changes_requested rows declares none. The untemplated codex population has **0** rows declaring delegations, so only one side of the comparison is contaminated.

Excluding announcements from both sides:

| Population | Real verdicts | changes_requested |
| --- | --- | --- |
| untemplated codex | 2,327 | **81.5%** |
| `review-panel` codex | 22 | **72.7%** |
| the panel's own lens children | 18 | **77.8%** |

72.7% on n=22 is not distinguishable from 81.5%. **The entire 81-to-17 effect was the artifact.** A second confound compounds it: every `review-panel` row belongs to a single agent, `g6-review-sol`, and per-agent rates span 4.3% to 97.7%, so a one-agent sample measures the agent.

This is not a subtle distinction the codebase had not considered. `ResultIsFanOut` exists because "a FAN-OUT is a coordinator's dispatch record, not an answer about the code", and the merge gate uses it to keep such rows out of its verdict population. **The telemetry did not**, so the gate and the fleet's measurement instrument disagreed about what counts as an answer.

## What DOES reproduce, exactly

The issue's per-agent table, and it is the stronger half of its argument:

| Agent | Verdicts | changes_requested |
| --- | --- | --- |
| `herdres-sol-review` | 564 | 97.7% |
| `keephair-review-sol` | 153 | 88.9% |
| `joltra-sol-review` | 424 | 79.0% |
| `g7-review` | 412 | 69.9% |
| `gm-review-opus` | 401 | 45.1% |
| `lead` | 255 | 4.3% |

`herdres-sol-review` at 97.7% of 564 and `lead` at 4.3% of 255 match the issue's figures exactly, and these are fan-out-free populations. So **"verdict disposition tracks the reviewer rather than the diff" is supported.** What is not supported is that the *template* is the lever, because the only evidence for that was the artifact.

## Risk tiers have never executed, so there is no evidence either way

`dispatchHighRiskReview` mints coordinators with id `review-coordinator/<branch>/<round>` and type `review_coordinator`. Fleet-wide, over the full two-month window:

```
jobs with id LIKE 'review-coordinator/%'  ->  0
jobs with type = 'review_coordinator'     ->  0
```

`risk_tiers_enabled` is absent from this box's config, as the issue says, so the mechanism has never run. **None of the 70 panels came from it** - they are ordinary review jobs run by one agent with that template applied, 48 through daemon fan-out and 20 through CLI dispatch.

So the proposal's step 1 is unmeasured rather than measured-good, and its step 2 has no support left once the artifact is removed. I am not enabling either, which also satisfies the standing rule that fleet config belongs to the owner.

### On capacity, since it was raised

A whole `review-panel` panel averages 0.89 M tokens against 4.22 M for one untemplated review, which looks like panels are cheap. **Do not use that number:** those panels declared 210 lenses, created 179 children, and **165 of them failed** - a 7.3% lens success rate, dominated by a historical `review job for PR #N has no head SHA` failure that no longer appears in September's mix. The panels were cheap because the work did not happen. Panel cost on this fleet is unmeasured, and I would rather say so than quote 0.89.

## The change

One thing, aimed at the defect that produced the wrong conclusion rather than at the conclusion: `routing_telemetry` now records whether a row is a fan-out announcement, using `ResultIsFanOut` - **the gate's own predicate, not a second copy of the rule**.

Marking, not filtering. The row still records its own decision, exactly as `review_threshold.go` returns a fan-out's raw decision rather than suppressing it. Existing rows keep `fan_out = 0` rather than being back-filled, because whether a historical row was an announcement is a judgement this column should not invent.

## Verification

`TestRoutingTelemetryMarksAFanOutAsAnAnnouncementNotAVerdict` drives `recordRoutingTelemetry` and asserts both directions through a real store read, plus that marking does not rewrite the recorded decision. `TestRoutingTelemetryFanOutUsesTheGatesOwnPredicate` asserts its own premise against `ResultIsFanOut` first, so it cannot keep passing if the gate's definition moves.

| Mutant | Result |
| --- | --- |
| telemetry stops marking the announcement | both tests FAIL |
| column written but dropped from the read projection | FAILS - the `root_id` falsely-blank class, guarded here |

Gate: `gofmt` clean, `go build`, `go vet`, and `go test -timeout 25m` on `internal/db` (209s), `internal/workflow` (108s) and `internal/cli` (993s), all **ok**. Disk held at 91% used / 38-40 GiB free throughout and no `DISK GUARD REFUSED` line was emitted, which is the healthy-direction confirmation of the guard diagnosis recorded on #1992. `-race` not run: requires cgo, unavailable in this seat.

## What I recommend instead, with no config changed

1. **Do not enable `risk_tiers_enabled` on the strength of #1972's numbers.** The comparison that motivated it does not survive removing announcements.
2. **The per-agent spread is the real finding** and it is actionable without risk tiers: `herdres-sol-review` at 97.7% of 564 and `lead` at 4.3% of 255 cannot both be calibrated. That is a reviewer-configuration question, measurable per agent, and it does not need a tiering mechanism to address.
3. **Re-measure after this ships.** With `fan_out` recorded, the template comparison becomes answerable for the first time, on rows collected from here on. If someone still wants to know whether templates move verdicts, that is the experiment, and it needs a template applied to more than one agent.
4. **If risk tiers are enabled later, fix the lens path first.** 165 of 179 lens children failed historically; whatever remains of that class should be measured before the highest-risk paths are routed into it.

## Not claimed

- I have not shown that templates do NOT affect verdicts. I have shown the evidence offered for it was announcements. n=22 has almost no power to detect a real effect either way.
- I have not measured the risk-tier mechanism, because it has never run here. Its cost, quality and failure behaviour on this fleet are all unknown.
- No config changed, no backfill, no reviewer retuned.
