### PR TITLE
fix(db,workflow): resolve runtime family from append-only evidence (#1534)

### DIFF
--- a/internal/cli/agent_dispatch.go
+++ b/internal/cli/agent_dispatch.go
@@ -739,7 +739,10 @@ func dispatchLocalAgentJob(ctx context.Context, store *db.Store, request localAg
 	}
 	// Journal runtime selection for every job. Only a real per-job override is
 	// labelled runtime_override; default selection uses effective_runtime.
-	if err := store.AddJobEvent(ctx, db.JobEvent{JobID: job.ID, Kind: jobRuntimeEventKind(overrideRuntime != ""), Message: jobRuntimeOverrideEventMessage(agent.Runtime, effectiveAgent, lockKey)}); err != nil {
+	// Runtime is carried STRUCTURALLY beside the prose (#1534) so a family
+	// resolver reads a column instead of parsing this sentence, and reads an
+	// append-only row instead of a mutable payload field.
+	if err := store.AddJobEvent(ctx, db.JobEvent{JobID: job.ID, Kind: jobRuntimeEventKind(overrideRuntime != ""), Message: jobRuntimeOverrideEventMessage(agent.Runtime, effectiveAgent, lockKey), Runtime: effectiveAgent.Runtime}); err != nil {
 		return localAgentJobOutput{}, err
 	}
 	quotaHooks := newQuotaRoleUnavailableHooks(store, request.Home, io.Discard)

--- a/internal/cli/agent_dispatch_test.go
+++ b/internal/cli/agent_dispatch_test.go
@@ -352,7 +352,7 @@ func TestCLIReviewLoopUnresolvableReviewerFailsClosedBeforeIdentityGuard(t *test
 	fixture := newCLIReviewLoopFixture(t)
 	seedCLIReviewLoopVerdictForAgent(t, fixture.store, "ghost-reviewer", "prior-review", "same-head", "approved")
 
-	family, resolved, err := workflow.ResolveRuntimeFamily(ctx, fixture.store, "ghost-reviewer", "")
+	family, resolved, err := workflow.ResolveRuntimeFamily(ctx, fixture.store, "", "ghost-reviewer", "")
 	if err != nil {
 		t.Fatalf("ResolveRuntimeFamily: %v", err)
 	}

--- a/internal/cli/daemon_worker.go
+++ b/internal/cli/daemon_worker.go
@@ -694,7 +694,11 @@ func (w jobWorker) run(ctx context.Context, job db.Job) error {
 	// Expose the effective runtime (and the session lock it runs under) in job
 	// history for every job. Only an actual override uses runtime_override;
 	// default selection is recorded as effective_runtime.
-	if eventErr := w.Store.AddJobEvent(ctx, db.JobEvent{JobID: job.ID, Kind: jobRuntimeEventKind(overridden), Message: jobRuntimeOverrideEventMessage(defaultRuntime, agent, lockKey)}); eventErr != nil {
+	// Runtime carried STRUCTURALLY beside the prose (#1534): see the sibling
+	// write in agent_dispatch.go. Both run sites must set it or the append-only
+	// tier is only half installed, which is the "correct where installed, absent
+	// at the next call site" shape #1531 warned about.
+	if eventErr := w.Store.AddJobEvent(ctx, db.JobEvent{JobID: job.ID, Kind: jobRuntimeEventKind(overridden), Message: jobRuntimeOverrideEventMessage(defaultRuntime, agent, lockKey), Runtime: agent.Runtime}); eventErr != nil {
 		writeLine(w.Stdout, "job %s effective-runtime event failed: %v", job.ID, eventErr)
 	}
 	// This is the last filesystem authorization check before adapter delivery.

--- a/internal/db/cleanup_obligations_test.go
+++ b/internal/db/cleanup_obligations_test.go
@@ -148,9 +148,13 @@ func TestMigrationsUpgradeFromPreviousReleasedVersion(t *testing.T) {
 	// a merge conflict.
 	//
 	// The marker must name THIS BRANCH'S LAST migration and must be UNIQUE. The
-	// index name is unique to #1967's migration; the bare ALTER would not be,
+	// index name is unique to #1534's migration; the bare ALTER would not be,
 	// because the column name also appears in that migration's own prose.
-	const branchMigrationMarker = "idx_jobs_dispatched_by"
+	//
+	// It is updated by every branch that appends a migration, which is the point:
+	// the test fails until the new migration is both last and named here, so two
+	// branches cannot each believe theirs is the tail.
+	const branchMigrationMarker = "idx_job_events_runtime"
 	branchIndex := -1
 	for index, migration := range migrations {
 		if strings.Contains(migration, branchMigrationMarker) {

--- a/internal/db/store_jobs.go
+++ b/internal/db/store_jobs.go
@@ -1498,7 +1498,8 @@ func (s *Store) RecordRuntimeSessionUsageDelta(ctx context.Context, sessionKey s
 }
 
 func (s *Store) AddJobEvent(ctx context.Context, event JobEvent) error {
-	_, err := s.db.ExecContext(ctx, `INSERT INTO job_events(job_id, kind, message) VALUES (?, ?, ?)`, event.JobID, event.Kind, event.Message)
+	_, err := s.db.ExecContext(ctx, `INSERT INTO job_events(job_id, kind, message, runtime) VALUES (?, ?, ?, ?)`,
+		event.JobID, event.Kind, event.Message, event.Runtime)
 	return err
 }
 
@@ -1506,11 +1507,11 @@ func (s *Store) AddJobEvent(ctx context.Context, event JobEvent) error {
 // existence check and insert share one SQLite statement, so concurrent callers
 // cannot both pass a check-then-insert window.
 func (s *Store) AddJobEventIfAbsent(ctx context.Context, event JobEvent) error {
-	_, err := s.db.ExecContext(ctx, `INSERT INTO job_events(job_id, kind, message)
-		SELECT ?, ?, ?
+	_, err := s.db.ExecContext(ctx, `INSERT INTO job_events(job_id, kind, message, runtime)
+		SELECT ?, ?, ?, ?
 		WHERE NOT EXISTS (
 			SELECT 1 FROM job_events WHERE job_id = ? AND kind = ?
-		)`, event.JobID, event.Kind, event.Message, event.JobID, event.Kind)
+		)`, event.JobID, event.Kind, event.Message, event.Runtime, event.JobID, event.Kind)
 	return err
 }
 
@@ -1707,7 +1708,7 @@ func (s *Store) jobEventsByKindExtreme(ctx context.Context, jobIDs []string, kin
 			args = append(args, jobID)
 		}
 	}
-	query := `SELECT job_id, kind, message, created_at FROM job_events
+	query := `SELECT job_id, kind, message, created_at, runtime FROM job_events
 		WHERE kind = ? AND job_id IN (` + placeholders + `)
 		  AND id IN (SELECT ` + string(pick) + `(id) FROM job_events
 			WHERE kind = ? AND job_id IN (` + placeholders + `) GROUP BY job_id)`
@@ -1718,7 +1719,7 @@ func (s *Store) jobEventsByKindExtreme(ctx context.Context, jobIDs []string, kin
 	defer rows.Close()
 	for rows.Next() {
 		var event JobEvent
-		if err := rows.Scan(&event.JobID, &event.Kind, &event.Message, &event.CreatedAt); err != nil {
+		if err := rows.Scan(&event.JobID, &event.Kind, &event.Message, &event.CreatedAt, &event.Runtime); err != nil {
 			return nil, err
 		}
 		out[event.JobID] = event
@@ -1727,7 +1728,7 @@ func (s *Store) jobEventsByKindExtreme(ctx context.Context, jobIDs []string, kin
 }
 
 func (s *Store) ListJobEvents(ctx context.Context, jobID string) ([]JobEvent, error) {
-	rows, err := s.db.QueryContext(ctx, `SELECT job_id, kind, message, created_at FROM job_events WHERE job_id = ? ORDER BY id`, jobID)
+	rows, err := s.db.QueryContext(ctx, `SELECT job_id, kind, message, created_at, runtime FROM job_events WHERE job_id = ? ORDER BY id`, jobID)
 	if err != nil {
 		return nil, err
 	}
@@ -1736,7 +1737,7 @@ func (s *Store) ListJobEvents(ctx context.Context, jobID string) ([]JobEvent, er
 	var events []JobEvent
 	for rows.Next() {
 		var event JobEvent
-		if err := rows.Scan(&event.JobID, &event.Kind, &event.Message, &event.CreatedAt); err != nil {
+		if err := rows.Scan(&event.JobID, &event.Kind, &event.Message, &event.CreatedAt, &event.Runtime); err != nil {
 			return nil, err
 		}
 		events = append(events, event)
@@ -2512,4 +2513,45 @@ func (s *Store) MaxJobEventID(ctx context.Context) (int64, error) {
 	var id int64
 	err := s.db.QueryRowContext(ctx, maxJobEventIDSQL).Scan(&id)
 	return id, err
+}
+
+// JobRecordedRuntime returns the runtime recorded on a job's append-only
+// runtime-selection event, or "" when none carries one (#1534).
+//
+// THE POINT IS IMMUTABILITY. job_events has no UPDATE and no DELETE anywhere in
+// this package, so a runtime written here cannot later be edited away. The
+// payload's effective_runtime can: it is a field on a row the engine rewrites
+// for other reasons, and it is simply absent on many jobs.
+//
+// It reads the COLUMN and never the message. The message is prose and #1534
+// forbids parsing it, which is why the column exists.
+//
+// THE AGENT IS VERIFIED IN THE SAME QUERY, and this was a defect in my first
+// version that my own bound test caught: the tier read the runtime for a job id
+// while ignoring the agent name it was asked about, so a caller passing a job
+// and an unrelated agent got a confident answer about the wrong one. A resolver
+// that answers a question it was not asked is precisely the proxy-for-property
+// shape this campaign exists to remove. The join makes the answer mean "the
+// runtime THIS AGENT'S job ran on".
+//
+// LATEST WINS, by id, because a job can be re-dispatched within its lifecycle
+// and the last selection is the one that ran.
+func (s *Store) JobRecordedRuntime(ctx context.Context, jobID string, agentName string) (string, error) {
+	id := strings.TrimSpace(jobID)
+	agent := strings.TrimSpace(agentName)
+	if id == "" || agent == "" {
+		return "", nil
+	}
+	var recorded string
+	err := s.db.QueryRowContext(ctx, `SELECT e.runtime FROM job_events e
+		JOIN jobs j ON j.id = e.job_id
+		WHERE e.job_id = ? AND e.runtime != '' AND j.agent = ?
+		ORDER BY e.id DESC LIMIT 1`, id, agent).Scan(&recorded)
+	if errors.Is(err, sql.ErrNoRows) {
+		return "", nil
+	}
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(recorded), nil
 }

--- a/internal/db/store_migrations.go
+++ b/internal/db/store_migrations.go
@@ -2730,4 +2730,23 @@ CREATE INDEX IF NOT EXISTS idx_review_findings_pr ON review_finding_observations
 ALTER TABLE jobs ADD COLUMN dispatched_by TEXT NOT NULL DEFAULT '';
 CREATE INDEX IF NOT EXISTS idx_jobs_dispatched_by ON jobs(dispatched_by) WHERE dispatched_by != '';
 	`,
+	// #1534: runtime attribution moves onto APPEND-ONLY evidence. job_events has
+	// no UPDATE or DELETE anywhere in internal/db, so a runtime recorded here
+	// cannot later be edited away, unlike the payload's effective_runtime field.
+	//
+	// A COLUMN, NOT THE MESSAGE. The event message is prose - "job runs on
+	// runtime shell (agent default codex); session lock ..." - and #1534
+	// explicitly forbids resolving a family by parsing it. Measured on the live
+	// store: 56 review/implement jobs carry a runtime_override event while their
+	// payload field is absent, so today they resolve to the agent's REGISTRY
+	// DEFAULT rather than the runtime that ran. Agent `lead` defaults to claude
+	// and several of those jobs ran on codex.
+	//
+	// DEFAULT '' preserves every pre-migration row: they keep resolving through
+	// the payload field and the registry exactly as before. The partial index
+	// covers only rows that can answer the question.
+	`
+ALTER TABLE job_events ADD COLUMN runtime TEXT NOT NULL DEFAULT '';
+CREATE INDEX IF NOT EXISTS idx_job_events_runtime ON job_events(job_id, id) WHERE runtime != '';
+	`,
 }

--- a/internal/db/store_types.go
+++ b/internal/db/store_types.go
@@ -270,6 +270,12 @@ type JobEvent struct {
 	// ListJobEvents so the web dashboard can order a node's timeline by real
 	// wall-clock time; other readers may leave it zero.
 	CreatedAt string
+	// Runtime is the STRUCTURED, append-only record of the runtime a job ran on
+	// (#1534). Only the two runtime-selection writes set it. It exists because
+	// family attribution previously depended on the payload's effective_runtime,
+	// which is mutable and absent on many jobs, and because the alternative -
+	// parsing the event's prose message - is a fragility trade rather than a fix.
+	Runtime string
 }
 
 // JobGate is one resumable gate row (#682): a single entry from a blocked job's

--- a/internal/workflow/engine_pr_lifecycle.go
+++ b/internal/workflow/engine_pr_lifecycle.go
@@ -837,7 +837,7 @@ func (e Engine) selectNativeReviewFamily(ctx context.Context, reviewers []string
 	dropped := make([]string, 0, len(reviewers))
 	selectedFamily := ""
 	for _, reviewer := range reviewers {
-		family, ok, err := ResolveRuntimeFamily(ctx, e.Store, reviewer, "")
+		family, ok, err := ResolveRuntimeFamily(ctx, e.Store, "", reviewer, "")
 		if err != nil {
 			return nil, nil, "", err
 		}

--- a/internal/workflow/merge_gate.go
+++ b/internal/workflow/merge_gate.go
@@ -1625,6 +1625,11 @@ type implementerIdentity struct {
 	// FromActingRole records that this attribution came from the payload's acting
 	// org role rather than the job's agent column. A role cannot be enqueued.
 	FromActingRole bool
+	// JobID is the implement job this identity came from, kept so the family
+	// resolver can reach that job's append-only runtime evidence (#1534). The
+	// payload field alone is not enough: it is absent on many jobs, and the
+	// registry default then attributes the work to a family that did not run it.
+	JobID string
 	// RecordedRuntime is the implement job's own payload effective_runtime, kept
 	// so the gate can resolve a runtime FAMILY without re-reading the job (#1531).
 	// Empty for a job that predates #1528's recording; ResolveRuntimeFamily then
@@ -1696,7 +1701,7 @@ func collectImplementerAttributionMatching(jobs []db.Job, current JobPayload,
 			// first would attribute every agent's work to its coordinator, make that
 			// coordinator an implementer of everything, and then disqualify it from
 			// reviewing anything.
-			evidence.agents[name] = implementerIdentity{Name: name, RecordedRuntime: payload.EffectiveRuntime}
+			evidence.agents[name] = implementerIdentity{Name: name, JobID: job.ID, RecordedRuntime: payload.EffectiveRuntime}
 		case name != "":
 			// A ROLE NEVER DOWNGRADES AN AGENT ALREADY RECORDED UNDER THE SAME NAME,
 			// AND THAT IS WHY THIS IS A CONDITIONAL WRITE RATHER THAN A PLAIN ONE.
@@ -1712,7 +1717,7 @@ func collectImplementerAttributionMatching(jobs []db.Job, current JobPayload,
 			}
 			// The #1916 shape: implemented in session by an org role, no agent to
 			// name. Attributable, and still subject to the independence check.
-			evidence.agents[name] = implementerIdentity{Name: name, FromActingRole: true, RecordedRuntime: payload.EffectiveRuntime}
+			evidence.agents[name] = implementerIdentity{Name: name, FromActingRole: true, JobID: job.ID, RecordedRuntime: payload.EffectiveRuntime}
 		default:
 			evidence.sawEmptyAgent = true
 		}
@@ -2609,7 +2614,7 @@ func (g PolicyMergeGate) sameRuntimeFamilyAsImplementer(ctx context.Context, rev
 	if g.Store == nil || strings.TrimSpace(reviewer) == "" || len(implementers) == 0 {
 		return false, "", nil
 	}
-	reviewerFamily, ok, err := ResolveRuntimeFamily(ctx, g.Store, reviewer, reviewerRuntime)
+	reviewerFamily, ok, err := ResolveRuntimeFamily(ctx, g.Store, reviewJobID, reviewer, reviewerRuntime)
 	if err != nil {
 		return false, "", err
 	}
@@ -2625,7 +2630,7 @@ func (g PolicyMergeGate) sameRuntimeFamilyAsImplementer(ctx context.Context, rev
 	sort.Strings(names)
 	for _, name := range names {
 		identity := implementers[name]
-		family, ok, err := ResolveRuntimeFamily(ctx, g.Store, name, identity.RecordedRuntime)
+		family, ok, err := ResolveRuntimeFamily(ctx, g.Store, identity.JobID, name, identity.RecordedRuntime)
 		if err != nil {
 			return false, "", err
 		}

--- a/internal/workflow/review_loop_test.go
+++ b/internal/workflow/review_loop_test.go
@@ -205,7 +205,7 @@ func TestResolveRuntimeFamilyPrecedence(t *testing.T) {
 		{name: "empty name without recording", agent: "", recorded: "", want: "", wantOK: false},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			family, ok, err := ResolveRuntimeFamily(ctx, store, tc.agent, tc.recorded)
+			family, ok, err := ResolveRuntimeFamily(ctx, store, "", tc.agent, tc.recorded)
 			if err != nil {
 				t.Fatalf("ResolveRuntimeFamily: %v", err)
 			}

--- a/internal/workflow/runtime_family.go
+++ b/internal/workflow/runtime_family.go
@@ -25,11 +25,36 @@ import (
 // protecting a safety property MUST treat !ok as fail-closed: an unknown
 // family that silently counted as "new" would convert the guard into a way to
 // add unlimited reviews.
-func ResolveRuntimeFamily(ctx context.Context, store *db.Store, agentName string, recordedRuntime string) (family string, ok bool, err error) {
+func ResolveRuntimeFamily(ctx context.Context, store *db.Store, jobID string, agentName string, recordedRuntime string) (family string, ok bool, err error) {
 	if recorded := normalizeRuntimeFamily(recordedRuntime); recorded != "" {
 		return recorded, true, nil
 	}
+	// THE APPEND-ONLY TIER (#1534), consulted before the registry default and
+	// after the payload field.
+	//
+	// Ordered that way on purpose. The payload field, when present, is written by
+	// the same run-phase step that writes the event, so the two agree and reading
+	// the payload first costs no query. When the payload field is ABSENT - 1,813
+	// jobs on the live store carry a runtime event and no payload field - the
+	// registry default is a GUESS about what the agent usually runs, and it is
+	// measurably wrong: 56 review and implement jobs have an override event whose
+	// runtime differs from their agent's registered default, so resolving them
+	// through the registry attributes the execution to a family that did not run
+	// it. Agent `lead` defaults to claude; several of those ran on codex.
+	//
+	// It reads the event COLUMN, never the message. #1534 forbids parsing the
+	// prose, and this campaign has already filed a defect about a pattern that
+	// silently matched nothing.
 	name := strings.TrimSpace(agentName)
+	if jobID != "" && name != "" && store != nil {
+		recorded, readErr := store.JobRecordedRuntime(ctx, jobID, name)
+		if readErr != nil {
+			return "", false, readErr
+		}
+		if family := normalizeRuntimeFamily(recorded); family != "" {
+			return family, true, nil
+		}
+	}
 	if name == "" {
 		return "", false, nil
 	}

--- a/internal/workflow/runtime_family_evidence_1534_test.go
+++ b/internal/workflow/runtime_family_evidence_1534_test.go
@@ -1,0 +1,140 @@
+package workflow
+
+import (
+	"context"
+	"testing"
+
+	"github.com/gitmoot/gitmoot/internal/db"
+)
+
+// #1534: runtime-family attribution depended on a MUTABLE payload field. With
+// `effective_runtime` absent, `ResolveRuntimeFamily` fell back to the agent's
+// REGISTRY DEFAULT, so an execution was attributed to the runtime the agent
+// usually runs rather than the one that ran.
+//
+// MEASURED ON THE LIVE STORE, and this is the number that makes it a defect
+// rather than a theoretical gap: 56 review and implement jobs carry a
+// `runtime_override` event whose runtime DIFFERS from their agent's registered
+// default while their payload field is absent. Verified by eye on a sample:
+// agent `lead` is registered `claude` and those jobs ran on `codex` or `shell`.
+// Separately, 1,813 jobs (1646 ask, 119 implement, 48 review) carry a runtime
+// event and no payload field at all.
+//
+// This compounds directly with #1531, merged earlier as 5ee96763: if `lead`
+// implemented on codex and a codex reviewer approved, the family check would
+// compare codex-reviewer against claude-implementer, find them different, and
+// PASS a same-family approval.
+//
+// The evidence is `job_events.runtime`, a column and not the message. The event
+// message is prose ("job runs on runtime shell (agent default codex); session
+// lock ..."), and #1534 forbids resolving a family by parsing it.
+func TestRuntimeFamilyPrefersAppendOnlyEvidenceOverTheRegistryDefault(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	// The measured shape: registered claude, actually ran codex, payload empty.
+	if err := store.UpsertAgent(ctx, db.Agent{Name: "lead", Runtime: "claude", Capabilities: []string{"implement"}}); err != nil {
+		t.Fatal(err)
+	}
+	insertCompletedJob(t, store, db.Job{ID: "implement-job", Agent: "lead", Type: "implement"}, JobPayload{
+		Repo: "gitmoot/gitmoot", PullRequest: 9,
+	})
+	if err := store.AddJobEvent(ctx, db.JobEvent{
+		JobID:   "implement-job",
+		Kind:    "runtime_override",
+		Message: "job runs on runtime codex (agent default claude); session lock runtime:codex:abc",
+		Runtime: "codex",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	family, ok, err := ResolveRuntimeFamily(ctx, store, "implement-job", "lead", "")
+	if err != nil {
+		t.Fatalf("ResolveRuntimeFamily: %v", err)
+	}
+	if !ok {
+		t.Fatal("family unresolved even though the job's own append-only runtime evidence names it")
+	}
+	if family != "codex" {
+		t.Fatalf("family = %q, want %q; the registry default claude is what the agent USUALLY runs, not what ran", family, "codex")
+	}
+}
+
+// Four bounds. The precedence and the fallbacks all have to keep working, or
+// this trades one misattribution for another.
+func TestRuntimeFamilyEvidencePrecedenceIsBounded(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	if err := store.UpsertAgent(ctx, db.Agent{Name: "lead", Runtime: "claude", Capabilities: []string{"implement"}}); err != nil {
+		t.Fatal(err)
+	}
+	insertCompletedJob(t, store, db.Job{ID: "job-with-event", Agent: "lead", Type: "implement"}, JobPayload{Repo: "r", PullRequest: 1})
+	if err := store.AddJobEvent(ctx, db.JobEvent{JobID: "job-with-event", Kind: "runtime_override", Message: "prose", Runtime: "codex"}); err != nil {
+		t.Fatal(err)
+	}
+
+	// 1. THE PAYLOAD FIELD STILL WINS when present. It is written by the same
+	//    run-phase step as the event, so they agree, and reading it first costs
+	//    no query. Reordering these two would be a behaviour change with no
+	//    measured benefit.
+	family, ok, err := ResolveRuntimeFamily(ctx, store, "job-with-event", "lead", "kimi")
+	if err != nil || !ok {
+		t.Fatalf("payload-first resolution failed: family=%q ok=%v err=%v", family, ok, err)
+	}
+	if family != "kimi" {
+		t.Fatalf("family = %q, want the payload's %q", family, "kimi")
+	}
+
+	// 2. NO JOB ID, NO EVENT TIER. The pre-dispatch caller has no job yet and
+	//    must keep resolving from the registry exactly as before.
+	family, ok, err = ResolveRuntimeFamily(ctx, store, "", "lead", "")
+	if err != nil || !ok || family != "claude" {
+		t.Fatalf("pre-dispatch resolution = (%q, %v, %v), want (claude, true, nil)", family, ok, err)
+	}
+
+	// 3. NO EVIDENCE ANYWHERE STILL FAILS CLOSED. The resolver's contract is that
+	//    an unresolvable family is reported as such, never guessed, because a
+	//    caller protecting a safety property must be able to see the difference.
+	family, ok, err = ResolveRuntimeFamily(ctx, store, "job-with-event", "unregistered-agent", "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if ok {
+		t.Fatalf("family %q was invented for an agent with no evidence and no registration", family)
+	}
+
+	// 4. A JOB WITH NO RUNTIME EVENT falls through to the registry rather than
+	//    failing, so the append-only tier adds a source and removes none.
+	insertCompletedJob(t, store, db.Job{ID: "job-no-event", Agent: "lead", Type: "implement"}, JobPayload{Repo: "r", PullRequest: 2})
+	family, ok, err = ResolveRuntimeFamily(ctx, store, "job-no-event", "lead", "")
+	if err != nil || !ok || family != "claude" {
+		t.Fatalf("eventless resolution = (%q, %v, %v), want (claude, true, nil)", family, ok, err)
+	}
+}
+
+// The evidence must be readable through the LATEST selection, because a job can
+// be re-dispatched inside its lifecycle and the last runtime is the one that ran.
+func TestRuntimeFamilyEvidenceUsesTheLatestRecordedSelection(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	if err := store.UpsertAgent(ctx, db.Agent{Name: "lead", Runtime: "claude", Capabilities: []string{"implement"}}); err != nil {
+		t.Fatal(err)
+	}
+	insertCompletedJob(t, store, db.Job{ID: "job", Agent: "lead", Type: "implement"}, JobPayload{Repo: "r", PullRequest: 3})
+	for _, recorded := range []string{"codex", "shell"} {
+		if err := store.AddJobEvent(ctx, db.JobEvent{JobID: "job", Kind: "runtime_override", Message: "prose", Runtime: recorded}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	// An event with NO runtime must not shadow the ones that carry it.
+	if err := store.AddJobEvent(ctx, db.JobEvent{JobID: "job", Kind: "running", Message: "started"}); err != nil {
+		t.Fatal(err)
+	}
+
+	family, ok, err := ResolveRuntimeFamily(ctx, store, "job", "lead", "")
+	if err != nil || !ok {
+		t.Fatalf("resolution failed: %v %v", ok, err)
+	}
+	if family != "shell" {
+		t.Fatalf("family = %q, want the latest recorded %q", family, "shell")
+	}
+}


### PR DESCRIPTION
Fixes #1534. Runtime-family attribution depended on a **mutable payload field**; it now resolves from append-only evidence.

## The defect, measured

With `payload.effective_runtime` absent, `ResolveRuntimeFamily` fell back to the agent's **registry default**, attributing an execution to the runtime the agent *usually* runs rather than the one that ran.

```sql
-- review/implement jobs with a runtime_override event whose runtime differs
-- from the agent's registered default, and no payload field
-- 56
```

Verified by eye on a sample rather than trusted from the aggregate:

```
type       agent  registry_default  event message
implement  lead   claude            job runs on runtime codex (agent default claude); ...
implement  lead   claude            job runs on runtime shell (agent default claude); ...
implement  lead   claude            job runs on runtime codex (agent default claude); ...
```

Separately, **1,813 jobs** carry a runtime event and no payload field at all (1646 ask, 119 implement, 48 review).

**Note on the measuring query:** it discriminates by matching the agent's runtime inside the event's prose message. That is acceptable for measurement and is exactly what the issue forbids in the *implementation*, which is why the fix adds a column instead. The eyeball check above is what makes the 56 trustworthy rather than the LIKE pattern.

## Why this matters beyond attribution tidiness

It compounds directly with #1531, merged earlier today as `5ee96763`. If `lead` implemented on codex and a codex reviewer approved, the new family check would resolve the implementer to **claude** (its registry default), find it different from the reviewer's codex, and **pass a same-family approval**. The gate I just hardened would have been defeated by the attribution layer beneath it.

## The evidence: a column, not the message

`job_events` has no `UPDATE` and no `DELETE` anywhere in `internal/db`, so a runtime written there cannot later be edited away. The issue's hard constraint is not to string-parse the event message, which is prose (`job runs on runtime shell (agent default codex); session lock ...`), and it names the precedent: this campaign has already filed a defect about a pattern that silently matched nothing.

So the migration adds `job_events.runtime TEXT NOT NULL DEFAULT ''` plus a partial index, and both run sites write it beside the prose they already write.

**Both sites, deliberately.** Setting only one would leave the tier half installed, which is the "correct where installed, absent at the next call site" shape #1531 warned about after seeing it five times.

## Precedence, and why the payload field stays first

```
payload effective_runtime  ->  append-only event evidence  ->  registry default  ->  fail closed
```

The payload field keeps priority because the same run-phase step writes both, so they agree, and reading it costs no query. The new tier only changes what happens when the field is **absent**, which is precisely where the misattribution lived. `DEFAULT ''` preserves every existing row: they resolve exactly as before.

## A defect my own bound test caught

My first version read the runtime for a job id while **ignoring the agent name it was asked about**, so a caller passing a job and an unrelated agent got a confident answer about the wrong one. A resolver that answers a question it was not asked is the proxy-for-property shape this campaign exists to remove. The agent is now verified in the same query as the runtime, and the code comment records the mistake.

## Tests

```
TestRuntimeFamilyPrefersAppendOnlyEvidenceOverTheRegistryDefault
  the measured shape: registered claude, ran codex, payload empty -> resolves codex
TestRuntimeFamilyEvidencePrecedenceIsBounded
  1. the payload field still wins when present
  2. no job id, no event tier (the pre-dispatch caller keeps resolving from the registry)
  3. no evidence anywhere still FAILS CLOSED rather than guessing
  4. a job with no runtime event falls through to the registry, so the tier adds a source and removes none
TestRuntimeFamilyEvidenceUsesTheLatestRecordedSelection
  latest wins, and a runtime-less event does not shadow the ones that carry it
```

Bound 3 is the one that caught the agent-verification defect above.

## Two pre-existing things this touched, both explained rather than quietly changed

1. **`TestMigrationsUpgradeFromPreviousReleasedVersion`** pins the branch's newest migration as last, by design: "the marker must name THIS BRANCH'S LAST migration". It named #1967's index; it now names this one, and I extended its comment to say that every migration-adding branch updates it, which is the point.
2. **A second `job_events` reader** selected four columns while `ListJobEvents` selected five, because my first scan patch landed on the wrong function. Both now select and scan the same five. The db suite caught it as `sql: expected 5 destination arguments in Scan, not 4` across seven tests.

## Scope

The lifecycle-CAS acceptance criteria in #1534 (items 2 through 6: refusal terminality, `finishQueuedJob` generation drift, uncovered blocked-transition branches, detection without remediation) concern the foreground verification seam that #1534 itself says is being **removed** from #1532. They are not attribution defects and I did not fold them in. Criterion 1 (stored evidence absent must not misattribute) and criterion 7 (the guard must not refuse valid work, including whitespace, case, and a differing override ref with a matching runtime) are covered: normalisation is `strings.ToLower(strings.TrimSpace(...))` in the one resolver, and nothing here refuses a dispatch.

## Verification

```
free space 8.67% at start, 0 DISK GUARD refusals in every log
go build ./...                          ok
go vet ./...                            ok
go test -count=1 ./internal/db/         ok  129.5s
go test -count=1 ./internal/workflow/   ok   64.6s
go test -count=1 ./internal/cli/        ok  891.4s
```

Frozen detached worktree at `34b3a9a3`, one suite at a time.

Deploy notes: one additive migration (`ALTER TABLE ... ADD COLUMN ... DEFAULT ''` plus a partial index), no backfill, no config change. Existing rows keep their current resolution path.
