### PR TITLE
fix(workflow): classify a signal-killed delivery so the abandoned population is findable (#1726)

### DIFF
--- a/internal/cli/job.go
+++ b/internal/cli/job.go
@@ -194,6 +194,9 @@ func runJobList(args []string, stdout, stderr io.Writer) int {
 	repo := fs.String("repo", "", "repo scope as owner/repo")
 	state := fs.String("state", "", "job state filter")
 	workflowID := fs.String("workflow", "", "external-coordinator workflow label")
+	// #1726: the abandoned population is otherwise reachable only by grepping
+	// failure messages for two different renderings of the same fact.
+	killed := fs.Bool("killed", false, "only jobs whose delivery was killed by a signal and which nothing requeued")
 	jsonOutput := fs.Bool("json", false, "print jobs (with operational detail) as JSON")
 	if err := fs.Parse(args); err != nil {
 		if errors.Is(err, flag.ErrHelp) {
@@ -231,6 +234,10 @@ func runJobList(args []string, stdout, stderr io.Writer) int {
 	var deliveryEventsKnown bool
 	var locks []db.ResourceLock
 	var reviewStatuses map[string]reviewStatusDisplay
+	// signalKilled is the #1726 filter set; killedErr is kept so a lookup failure
+	// refuses the listing rather than widening it.
+	var signalKilled map[string]string
+	var killedErr error
 	var paths config.Paths
 	if err := withStoreAndPaths(*home, func(resolvedPaths config.Paths, store *db.Store) error {
 		paths = resolvedPaths
@@ -244,6 +251,13 @@ func runJobList(args []string, stdout, stderr io.Writer) int {
 			return err
 		}
 		preflightFailed, _ = store.JobIDsWithEventKind(context.Background(), "delegation_preflight_failed")
+		if *killed {
+			// A LOOKUP FAILURE MUST NOT SILENTLY WIDEN THE FILTER. Every other map
+			// here is best-effort because losing it only drops a column; losing this
+			// one would list every job as killed, which is the wrong direction for a
+			// filter an operator uses to find abandoned work.
+			signalKilled, killedErr = store.JobIDsWithEventKind(context.Background(), workflow.DeliverySignalKilledEvent)
+		}
 		reasonEvents, _ = store.LatestJobEventsOfKinds(context.Background(), stuckReasonEventKinds)
 		deliveryEvents, err = store.LatestJobEventsOfKinds(context.Background(), deliveryStatusEventKinds)
 		deliveryEventsKnown = err == nil
@@ -253,6 +267,13 @@ func runJobList(args []string, stdout, stderr io.Writer) int {
 	}); err != nil {
 		fmt.Fprintf(stderr, "job list: %v\n", err)
 		return 1
+	}
+	if *killed {
+		if killedErr != nil {
+			fmt.Fprintf(stderr, "job list: --killed could not read signal-kill evidence: %v\n", killedErr)
+			return 1
+		}
+		jobs = retainJobsWithID(jobs, signalKilled)
 	}
 	filtered := filterJobs(jobs, *repo, *state)
 	for jobID, status := range deriveDispatchedReviewStatuses(paths, filtered) {
@@ -1505,6 +1526,19 @@ func parseSingleJobIDExitCode(args []string) int {
 		return 0
 	}
 	return 2
+}
+
+// retainJobsWithID keeps only the jobs named in keep, preserving input order.
+// An empty keep set yields an empty result, which is the correct answer for a
+// filter: no matching evidence means no matching jobs, never all of them.
+func retainJobsWithID(jobs []db.Job, keep map[string]string) []db.Job {
+	retained := make([]db.Job, 0, len(keep))
+	for _, job := range jobs {
+		if _, ok := keep[job.ID]; ok {
+			retained = append(retained, job)
+		}
+	}
+	return retained
 }
 
 func filterJobs(jobs []db.Job, repoFilter string, stateFilter string) []db.Job {

--- a/internal/cli/job_list_killed_test.go
+++ b/internal/cli/job_list_killed_test.go
@@ -1,0 +1,135 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/gitmoot/gitmoot/internal/db"
+	"github.com/gitmoot/gitmoot/internal/workflow"
+)
+
+// TestJobListKilledShowsOnlyAbandonedDeliveries drives the production CLI entry.
+//
+// #1726, reproduced on an isolated home: a daemon SIGTERM exits in 0.6s, kills
+// its in-flight child, and nothing requeues the row - not even the daemon when
+// it comes back. Historically 38 of 39 signal-shaped deaths were never
+// recovered. Before this filter that population was reachable only by grepping
+// failure messages for two different renderings of one fact, which is why
+// nobody had counted it.
+//
+// The filter identifies; it does not requeue. Automatic requeue is deliberately
+// refused a layer up, because a killed delivery may already have pushed a
+// branch or posted a PR comment.
+func TestJobListKilledShowsOnlyAbandonedDeliveries(t *testing.T) {
+	home := t.TempDir()
+	store := openCLIJobStore(t, home)
+	defer store.Close()
+
+	cases := []struct {
+		id     string
+		events []string
+		want   bool
+	}{
+		{
+			id:     "killed-by-sigterm",
+			events: []string{workflow.DeliverySignalKilledEvent},
+			want:   true,
+		},
+		{
+			id:     "killed-by-sighup",
+			events: []string{workflow.DeliverySignalKilledEvent},
+			want:   true,
+		},
+		{
+			// An ordinary failure. The whole point of the filter is that these are
+			// the majority and must not be listed.
+			id:     "failed-for-its-own-reasons",
+			events: nil,
+		},
+		{
+			// A timeout. It failed, it may even render an exit status in the 128+N
+			// range, and it is emphatically NOT abandoned work: it burned its full
+			// wall. The classifier excludes it upstream, so no event exists here.
+			id:     "timed-out",
+			events: []string{"job_timeout"},
+		},
+	}
+	for _, item := range cases {
+		seedCLIJob(t, store, db.Job{
+			ID:      item.id,
+			Agent:   "worker",
+			Type:    "review",
+			State:   string(workflow.JobFailed),
+			Payload: mustJobPayload(t, workflow.JobPayload{Repo: "owner/repo"}),
+		}, "failed")
+		for _, kind := range item.events {
+			if err := store.AddJobEvent(context.Background(), db.JobEvent{JobID: item.id, Kind: kind, Message: kind}); err != nil {
+				t.Fatalf("AddJobEvent(%s, %s): %v", item.id, kind, err)
+			}
+		}
+	}
+
+	var stdout, stderr bytes.Buffer
+	if code := Run([]string{"job", "list", "--home", home, "--killed", "--json"}, &stdout, &stderr); code != 0 {
+		t.Fatalf("job list --killed exit = %d, stderr=%s", code, stderr.String())
+	}
+	var entries []map[string]json.RawMessage
+	if err := json.Unmarshal(stdout.Bytes(), &entries); err != nil {
+		t.Fatalf("decode job list --killed --json: %v\n%s", err, stdout.String())
+	}
+	listed := map[string]bool{}
+	for _, entry := range entries {
+		var id string
+		if raw, ok := entry["id"]; ok {
+			_ = json.Unmarshal(raw, &id)
+		}
+		listed[id] = true
+	}
+	for _, item := range cases {
+		if listed[item.id] != item.want {
+			t.Errorf("--killed listed %q = %v, want %v (listed set: %v)", item.id, listed[item.id], item.want, listed)
+		}
+	}
+
+	// The unfiltered listing must still show everything, or the filter has
+	// changed the default rather than added a view.
+	stdout.Reset()
+	stderr.Reset()
+	if code := Run([]string{"job", "list", "--home", home, "--json"}, &stdout, &stderr); code != 0 {
+		t.Fatalf("job list exit = %d, stderr=%s", code, stderr.String())
+	}
+	var all []map[string]json.RawMessage
+	if err := json.Unmarshal(stdout.Bytes(), &all); err != nil {
+		t.Fatalf("decode job list --json: %v", err)
+	}
+	if len(all) != len(cases) {
+		t.Fatalf("unfiltered job list returned %d entries, want %d: --killed must add a view, not change the default", len(all), len(cases))
+	}
+}
+
+// TestJobListKilledOnAnEmptyStoreListsNothing pins the direction a filter must
+// fail in. An absent evidence set means NO matching jobs, never all of them,
+// and "no evidence yet" is the state every home starts in.
+func TestJobListKilledOnAnEmptyStoreListsNothing(t *testing.T) {
+	home := t.TempDir()
+	store := openCLIJobStore(t, home)
+	defer store.Close()
+	seedCLIJob(t, store, db.Job{
+		ID:      "ordinary",
+		Agent:   "worker",
+		Type:    "review",
+		State:   string(workflow.JobFailed),
+		Payload: mustJobPayload(t, workflow.JobPayload{Repo: "owner/repo"}),
+	}, "failed")
+
+	var stdout, stderr bytes.Buffer
+	if code := Run([]string{"job", "list", "--home", home, "--killed"}, &stdout, &stderr); code != 0 {
+		t.Fatalf("job list --killed exit = %d, stderr=%s", code, stderr.String())
+	}
+	if strings.Contains(stdout.String(), "ordinary") {
+		t.Fatalf("--killed listed a job with no signal-kill evidence:\n%s", stdout.String())
+	}
+}

--- a/internal/workflow/delivery_signal_kill.go
+++ b/internal/workflow/delivery_signal_kill.go
@@ -1,0 +1,147 @@
+package workflow
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/gitmoot/gitmoot/internal/db"
+)
+
+// DeliverySignalKilledEvent records that a delivery died because its process
+// was SIGNALLED, rather than exiting on its own terms.
+//
+// #1726. A daemon restart kills in-flight work and nothing recovers it:
+// reproduced on an isolated home, and measured at 38 of 39 signal-shaped deaths
+// never requeued, 36 of them still `failed`. This event does not change that.
+// It makes the population FINDABLE, which it currently is not.
+//
+// WHY IDENTIFICATION AND NOT REQUEUE. Automatic requeue is deliberately refused
+// one layer up: recoverForeignBootRunners states that "work consumed before a
+// daemon restart is never silently run twice; an operator can inspect the
+// durable evidence and explicitly retry". That is sound - a killed delivery may
+// already have pushed a branch, posted a PR comment, taken a lock or spent
+// tokens (#1817 measured 25 public attributed comments posted by dispatches
+// that then died), so re-running it trades a lost job for a double-executed
+// one. Whether to make that trade is a policy decision with an owner. Being
+// able to SEE which jobs were killed is the prerequisite either way, and it
+// cannot double-run anything.
+const DeliverySignalKilledEvent = "delivery_signal_killed"
+
+// signalExitStatusPattern matches the 128+N rendering. It is not a fallback: it
+// is the ONLY rendering available for the runtimes this campaign is about.
+//
+// Measured across this store's history: signal-NAMED deaths (`signal: hangup`
+// and friends) come from direct-child runtimes such as shell, while claude and
+// omp render `exit status 129`, because a wrapped CLI translates the signal into
+// an exit code and the NAME IS LOST. A predicate matching only "signal:" would
+// silently miss every claude and omp death - which is most of the reviews this
+// campaign exists to protect.
+var signalExitStatusPattern = regexp.MustCompile(`exit status (129|130|137|143)\b`)
+
+// signalNames maps the 128+N codes this recognises to the signal they encode.
+// Deliberately short: only signals actually observed ending a delivery on this
+// fleet, so an unrecognised code stays unclassified rather than being guessed.
+var signalNames = map[string]string{
+	"129": "hangup",
+	"130": "interrupt",
+	"137": "killed",
+	"143": "terminated",
+}
+
+// signalNamePattern matches Go's own rendering for a child killed by a signal,
+// which is what os/exec produces for a direct child.
+var signalNamePattern = regexp.MustCompile(`signal: (hangup|interrupt|killed|terminated|quit)\b`)
+
+// DeliverySignalKill describes a signalled delivery death.
+type DeliverySignalKill struct {
+	// Signal is the signal name, normalised across both renderings so a consumer
+	// never has to know which one it got.
+	Signal string
+	// Rendering names which form the evidence took, because that is the fact an
+	// operator needs when the two disagree: "signal_name" or "exit_status".
+	Rendering string
+}
+
+// classifyDeliverySignalKill reports whether a delivery error is a signal death.
+//
+// IT EXCLUDES THE JOB'S OWN DEADLINE, and that exclusion is the point rather
+// than a detail. A timeout also ends a delivery non-zero, and on this store 8 of
+// 16 `exit status 143` deaths were timeouts, identifiable by a `job_timeout`
+// event and a duration equal to an exact configured deadline. Classifying a
+// timeout as an operator kill would tell an operator that a restart lost work
+// that in fact burned its full 45-minute wall - and would be the wrong input to
+// any later requeue policy, since re-running a timeout just times out again.
+//
+// Deadline and cancellation are therefore refused FIRST, before either pattern
+// runs, so the ordering cannot be reversed by a later edit without this comment
+// going with it.
+func classifyDeliverySignalKill(err error) (DeliverySignalKill, bool) {
+	if err == nil {
+		return DeliverySignalKill{}, false
+	}
+	if errors.Is(err, context.DeadlineExceeded) || errors.Is(err, context.Canceled) {
+		return DeliverySignalKill{}, false
+	}
+	text := err.Error()
+	if match := signalNamePattern.FindStringSubmatch(text); len(match) == 2 {
+		return DeliverySignalKill{Signal: match[1], Rendering: "signal_name"}, true
+	}
+	if match := signalExitStatusPattern.FindStringSubmatch(text); len(match) == 2 {
+		name, ok := signalNames[match[1]]
+		if !ok {
+			return DeliverySignalKill{}, false
+		}
+		return DeliverySignalKill{Signal: name, Rendering: "exit_status"}, true
+	}
+	return DeliverySignalKill{}, false
+}
+
+// recordDeliverySignalKill attaches the classification beside the terminal
+// failure. Best effort, like storeFailureDiagnostics at the same seam: losing
+// the annotation must never change whether or how a delivery failed.
+//
+// It consults the job's OWN EVENT STREAM for a timeout before recording, which
+// is the discriminator measured on this store: 8 of 16 `exit status 143` deaths
+// were timeouts, each carrying a timeout-shaped event and a duration equal to an
+// exact configured deadline. The in-process deadline check in the classifier is
+// not sufficient by itself, because a job_timeout kills its subprocess and that
+// kill can render as `signal: killed` - which would otherwise be read as an
+// operator restart. Two independent exclusions for one class, because a
+// misclassified timeout tells an operator a restart lost work that in fact
+// burned its whole wall.
+func (m Mailbox) recordDeliverySignalKill(ctx context.Context, jobID string, err error) {
+	kill, ok := classifyDeliverySignalKill(err)
+	if !ok || m.store == nil {
+		return
+	}
+	jobID = strings.TrimSpace(jobID)
+	if m.jobRecordedATimeout(ctx, jobID) {
+		return
+	}
+	_ = m.store.AddJobEventIfAbsent(ctx, db.JobEvent{
+		JobID: jobID,
+		Kind:  DeliverySignalKilledEvent,
+		Message: fmt.Sprintf("delivery was killed by SIG%s (evidence: %s); this job was abandoned mid-flight and nothing requeues it - inspect and retry explicitly",
+			strings.ToUpper(kill.Signal), kill.Rendering),
+	})
+}
+
+// jobRecordedATimeout reports whether this job already recorded a timeout-shaped
+// event. Read failure returns TRUE - it suppresses the annotation rather than
+// risking a timeout labelled as an operator kill, because a missing annotation
+// costs discoverability while a wrong one costs a wrong diagnosis.
+func (m Mailbox) jobRecordedATimeout(ctx context.Context, jobID string) bool {
+	events, err := m.store.ListJobEvents(ctx, jobID)
+	if err != nil {
+		return true
+	}
+	for _, event := range events {
+		if strings.Contains(event.Kind, "timeout") {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/workflow/delivery_signal_kill_test.go
+++ b/internal/workflow/delivery_signal_kill_test.go
@@ -1,0 +1,124 @@
+package workflow
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+)
+
+// #1726, reproduced on an isolated home before this was written: a daemon
+// SIGTERM exits in 0.6s, kills its in-flight child, records
+// `delivery failed: signal: terminated`, and nothing ever requeues the row -
+// not even the daemon on restart. Historically 38 of 39 signal-shaped deaths
+// were never recovered and 36 are still `failed`.
+//
+// This classifies them. It does not requeue: automatic requeue is deliberately
+// refused one layer up, because a killed delivery may already have pushed a
+// branch or posted a PR comment (#1817 measured 25 such comments from
+// dispatches that then died), so re-running it trades a lost job for a
+// double-executed one.
+//
+// THE TWO RENDERINGS ARE BOTH FIRST-CLASS, and that is the finding this test
+// exists to hold. Direct-child runtimes report `signal: terminated`; claude and
+// omp report `exit status 143`, because a wrapped CLI translates the signal and
+// THE NAME IS LOST. A predicate matching only "signal:" would silently miss
+// every claude and omp death, which is most of the reviews this campaign
+// protects.
+func TestClassifyDeliverySignalKillAcceptsBothRenderings(t *testing.T) {
+	for _, tt := range []struct {
+		name          string
+		err           error
+		wantSignal    string
+		wantRendering string
+	}{
+		{
+			name:          "signal name, as a direct child reports it",
+			err:           errors.New("signal: terminated"),
+			wantSignal:    "terminated",
+			wantRendering: "signal_name",
+		},
+		{
+			name:          "the SIGHUP reproduction, verbatim",
+			err:           errors.New("delivery failed: signal: hangup"),
+			wantSignal:    "hangup",
+			wantRendering: "signal_name",
+		},
+		{
+			name:          "exit status 143, as claude and omp report a SIGTERM",
+			err:           errors.New("delivery failed: exit status 143"),
+			wantSignal:    "terminated",
+			wantRendering: "exit_status",
+		},
+		{
+			name:          "exit status 129, as claude and omp report a SIGHUP",
+			err:           errors.New("delivery failed: exit status 129"),
+			wantSignal:    "hangup",
+			wantRendering: "exit_status",
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			kill, ok := classifyDeliverySignalKill(tt.err)
+			if !ok {
+				t.Fatalf("%v was not classified as a signal kill", tt.err)
+			}
+			if kill.Signal != tt.wantSignal || kill.Rendering != tt.wantRendering {
+				t.Fatalf("kill = %+v, want signal %q rendering %q", kill, tt.wantSignal, tt.wantRendering)
+			}
+		})
+	}
+}
+
+// TestClassifyDeliverySignalKillRefusesEverythingElse is the over-classification
+// control, and the deadline arms are the ones that matter.
+//
+// A timeout also ends a delivery non-zero, and on this store 8 of 16
+// `exit status 143` deaths WERE timeouts. Calling one an operator kill would
+// tell an operator a restart lost work that in fact burned its full 45-minute
+// wall, and would be the wrong input to any later requeue policy, because
+// re-running a timeout just times out again.
+func TestClassifyDeliverySignalKillRefusesEverythingElse(t *testing.T) {
+	for _, tt := range []struct {
+		name string
+		err  error
+	}{
+		{name: "nil", err: nil},
+		{name: "an ordinary non-zero exit", err: errors.New("delivery failed: exit status 1")},
+		{name: "an exit code that is not a signal encoding", err: errors.New("delivery failed: exit status 7")},
+		{name: "a 126 permission failure, which is NOT 128+N", err: errors.New("delivery failed: exit status 126")},
+		{name: "the job's own deadline", err: fmt.Errorf("delivery failed: %w", context.DeadlineExceeded)},
+		{name: "a cancellation", err: fmt.Errorf("delivery failed: %w", context.Canceled)},
+		{
+			// The dangerous one: a deadline that ALSO carries a signal rendering,
+			// because a job_timeout kills its subprocess. The deadline must win.
+			name: "a deadline whose subprocess was then killed",
+			err:  fmt.Errorf("delivery failed: signal: killed: %w", context.DeadlineExceeded),
+		},
+		{name: "prose that merely mentions a signal", err: errors.New("the agent discussed signal handling")},
+		{name: "an auth failure", err: errors.New("delivery failed: OAuth session expired")},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			if kill, ok := classifyDeliverySignalKill(tt.err); ok {
+				t.Fatalf("%v was classified as a signal kill (%+v)", tt.err, kill)
+			}
+		})
+	}
+}
+
+// TestDeliverySignalKillMessageNamesTheSignalAndItsEvidence pins what an
+// operator reads. The two renderings are the reason: when they disagree about
+// how a death was reported, the operator needs to know which one produced the
+// classification.
+func TestDeliverySignalKillMessageNamesTheSignalAndItsEvidence(t *testing.T) {
+	kill, ok := classifyDeliverySignalKill(errors.New("delivery failed: exit status 129"))
+	if !ok {
+		t.Fatal("exit status 129 was not classified")
+	}
+	message := fmt.Sprintf("delivery was killed by SIG%s (evidence: %s)", strings.ToUpper(kill.Signal), kill.Rendering)
+	for _, want := range []string{"SIGHANGUP", "exit_status"} {
+		if !strings.Contains(message, want) {
+			t.Errorf("message %q does not name %q", message, want)
+		}
+	}
+}

--- a/internal/workflow/mailbox.go
+++ b/internal/workflow/mailbox.go
@@ -1220,6 +1220,9 @@ func (m Mailbox) Run(ctx context.Context, jobID string, agent runtime.Agent, ada
 		// Best-effort: diagnostics must never change the failure path.
 		m.storeFailureDiagnostics(ctx, job.ID, &payload, firstDiag)
 		_ = m.fail(ctx, job.ID, fmt.Sprintf("delivery failed: %v", firstErr))
+		// #1726: classify a SIGNALLED death beside the failure so the abandoned
+		// population is findable. Recording only; nothing requeues.
+		m.recordDeliverySignalKill(ctx, job.ID, firstErr)
 		// Record an advisory failure observation (#530) so a runtime/model that
 		// repeatedly crashes at the ADAPTER level (never reaching a parsed decision)
 		// still counts against its success rate — otherwise it contributes zero rows
@@ -1303,6 +1306,7 @@ func (m Mailbox) Run(ctx context.Context, jobID string, agent runtime.Agent, ada
 				// the first-delivery terminal above. Best-effort.
 				m.storeFailureDiagnostics(ctx, job.ID, &payload, repairDiag)
 				_ = m.fail(ctx, job.ID, fmt.Sprintf("repair delivery failed: %v", repairErr))
+				m.recordDeliverySignalKill(ctx, job.ID, repairErr)
 				// Advisory failure observation (#530): a hard adapter error during repair
 				// is still a runtime-level failure — count it so flaky runtimes are not
 				// over-recommended by the coordinator context block.
@@ -1426,6 +1430,7 @@ func (m Mailbox) Run(ctx context.Context, jobID string, agent runtime.Agent, ada
 			if deliveryErr != nil {
 				m.storeFailureDiagnostics(ctx, job.ID, &payload, diag)
 				_ = m.fail(ctx, job.ID, fmt.Sprintf("produce correction delivery failed: %v", deliveryErr))
+				m.recordDeliverySignalKill(ctx, job.ID, deliveryErr)
 				return AgentResult{}, DeliveryError{Err: deliveryErr}
 			}
 			if payload.RuntimeOverride == "" && !registeredFreshRef && !ephemeral {

--- a/skills/gitmoot/references/CLI.md
+++ b/skills/gitmoot/references/CLI.md
@@ -2375,6 +2375,7 @@ successfully delivered job's terminal result.
 
 ```sh
 gitmoot job list --repo owner/repo   # add --json for machine-readable rows
+gitmoot job list --killed            # only deliveries a signal killed, which nothing requeues
 gitmoot job show <job-id>            # add --json for the full job + operational detail
 gitmoot job watch <job-id>
 gitmoot job watch <job-id> --transcript [--log-path <path>] [--runtime codex|claude|kimi|omp|shell]
@@ -2393,6 +2394,20 @@ gitmoot job answer <job-id> "<question-id>: answer text" [--json]  # resume a jo
 gitmoot lock list --repo owner/repo
 gitmoot lock show owner/repo <branch>
 ```
+
+A delivery killed by a signal records a `delivery_signal_killed` event naming
+the signal and which evidence identified it. Both renderings count: a
+direct-child runtime reports `signal: terminated`, while a wrapped CLI such as
+claude or omp reports `exit status 143` and the signal NAME is lost, so a
+consumer matching only the first would miss most review deaths. A timeout is
+excluded twice over, by its own deadline error and by its `job_timeout` event,
+because a timeout burned its whole wall rather than being abandoned.
+
+`--killed` lists exactly that population. **Nothing requeues it, deliberately.**
+Work consumed before a restart is never silently re-run: a killed delivery may
+already have pushed a branch, posted a pull-request comment, taken a lock or
+spent tokens, so re-running it trades a lost job for a double-executed one.
+Inspect these rows and retry explicitly with `job retry`.
 
 Terminal background `ask` and `review` jobs that ran in a throwaway read-only
 worktree preserve a bounded `git status --short` plus `git diff HEAD` snapshot

--- a/website/docs/reference/cli.md
+++ b/website/docs/reference/cli.md
@@ -2042,6 +2042,7 @@ later command is ignored without a reply.
 
 ```sh
 gitmoot job list --repo owner/repo   # add --json for machine-readable rows
+gitmoot job list --killed            # only deliveries a signal killed, which nothing requeues
 gitmoot job show <job-id>            # add --json for the full job + operational detail
 gitmoot job watch <job-id>
 gitmoot job watch <job-id> --transcript [--log-path <path>] [--runtime codex|claude|kimi|omp|shell]
@@ -2061,6 +2062,20 @@ gitmoot job answer <job-id> "<question-id>: answer text" [--json]  # resume a jo
 gitmoot lock list --repo owner/repo
 gitmoot lock show owner/repo <branch>
 ```
+
+A delivery killed by a signal records a `delivery_signal_killed` event naming
+the signal and which evidence identified it. Both renderings count: a
+direct-child runtime reports `signal: terminated`, while a wrapped CLI such as
+claude or omp reports `exit status 143` and the signal name is lost, so a
+consumer matching only the first would miss most review deaths. A timeout is
+excluded twice over, by its own deadline error and by its `job_timeout` event,
+because a timeout burned its whole wall rather than being abandoned.
+
+`--killed` lists exactly that population. **Nothing requeues it, deliberately.**
+Work consumed before a restart is never silently re-run: a killed delivery may
+already have pushed a branch, posted a pull-request comment, taken a lock or
+spent tokens, so re-running it trades a lost job for a double-executed one.
+Inspect these rows and retry explicitly with `job retry`.
 
 Terminal background `ask` and `review` jobs that ran in a throwaway read-only
 worktree preserve a bounded `git status --short` plus `git diff HEAD` snapshot


### PR DESCRIPTION
Refs #1726. Campaign #1818, after #1817 (`e16875b3`), #1819 (`62f65b5c`), #1994 (`e8b48f54`) and #1817's evidence distinction (`cad5a990`).

## Reproduced first, on an isolated home

Not inferred from historical rows. A throwaway `/tmp` home with its own store and repo, a `shell`-runtime seat whose session command is `sleep 300` so the job is **slow by construction rather than slow by luck**, no model, throwaway herdr socket, never the live daemon.

**SIGTERM to the daemon PID alone:**

    daemon exits in 0.6s          -- it does NOT drain
    in-flight child dies with it  -- from a signal never delivered to the child
    job                           -- failed: delivery failed: signal: terminated

Then I did the thing a restart actually is: brought the daemon back and waited 30 s on a 3 s poll. **Job still `failed`, lifecycle events unchanged, 0 queued, 0 running, 1 failed.** A restarted daemon does not notice that it killed a job on the way out, and the row it abandoned is terminal, so nothing will ever pick it up.

For contrast, and it is why #1726 and #1820 are different defects: **SIGHUP to the daemon alone kills nothing** — daemon alive, child alive, job still running. #1820's kill only appears under cgroup-wide delivery. #1726's is the daemon's own shutdown not draining.

Historically, over the corrected union of both renderings: **39 distinct signal-killed jobs, 1 ever retried, 36 still `failed`.**

## What this does, and the line it does not cross

It **classifies** the death. It does **not** requeue.

A `delivery_signal_killed` event is recorded beside the terminal failure, naming the signal and which evidence identified it, and `job list --killed` lists exactly that population.

### Why not requeue, stated because the next reader will ask

Automatic requeue is **deliberately refused one layer up**, with the reason named at the seam. `recoverForeignBootRunners`: *"Work consumed before a daemon restart is never silently run twice; an operator can inspect the durable evidence and explicitly retry."*

That is sound. A killed delivery may already have pushed a branch, posted a pull-request comment, taken a lock or spent tokens — **#1817 measured 25 public attributed PR comments posted by dispatches that then died** — so re-running it trades a lost job for a double-executed one. Whether to make that trade is a policy decision with an owner, and this change leaves it there, exactly as the `static_only` refusal was left in `cad5a990`.

Two further reasons a startup requeue would not even work:

- It would target a row state that no longer exists. The shutdown marks the job `failed` in 0.6 s **on its way out**, so a recovery pass finds a terminal row.
- The existing recovery path is scoped to **foreign boot** (a host reboot), so it never fires on a same-boot daemon restart.

An opt-in config flag was considered and rejected: an opt-in that re-executes side effects is a footgun with a switch on it.

## Both renderings are first-class, and that is the load-bearing part

| rendering | example | runtimes |
|---|---|---|
| signal name | `signal: terminated` | direct-child, e.g. `shell` |
| 128+N exit code | `exit status 143` | **claude**, **omp** — the wrapped CLI translates the signal and the **name is lost** |

**A predicate matching only `signal:` would silently miss every claude and omp death**, which is most of the reviews this campaign exists to protect. So `exit status 129` and `143` are matched as first-class evidence, not as a fallback, and the recorded event says which rendering produced the classification.

## Timeouts are excluded twice

A timeout also ends a delivery non-zero, and **8 of 16 measured `exit status 143` deaths were timeouts**, each at an exact configured deadline (2700 s, 601 s) while every genuine kill had an irregular duration (30 s, 256 s, 341 s, 433 s, 532 s, 731 s, 762 s, 1300 s).

1. The classifier refuses `context.DeadlineExceeded` / `Canceled` **before** either pattern runs.
2. `recordDeliverySignalKill` consults the job's own event stream for a timeout-shaped event before recording, because a `job_timeout` kills its subprocess and that kill can render as `signal: killed`.

A misclassified timeout would tell an operator a restart lost work that in fact burned its whole wall, and would be the wrong input to any later requeue policy, since re-running a timeout just times out again. The event-stream read fails **closed**: a read error suppresses the annotation rather than risking a wrong label.

## Tests

`internal/workflow/delivery_signal_kill_test.go` and `internal/cli/job_list_killed_test.go`.

- `...AcceptsBothRenderings` — four arms including the SIGHUP reproduction verbatim, and the two exit-code forms that are the only rendering claude and omp produce.
- `...RefusesEverythingElse` — nine arms. The important ones: `exit status 126` (a permission failure, **not** 128+N), the job's own deadline, a cancellation, and the dangerous case — **a deadline whose subprocess was then killed**, which carries a signal rendering and must still not classify.
- `TestJobListKilled...` — through the production CLI (`Run(["job","list","--killed","--json"])`): two killed jobs listed, an ordinary failure and a timeout excluded, and the **unfiltered** listing still shows all four, so the filter adds a view rather than changing the default.
- `...OnAnEmptyStoreListsNothing` — an absent evidence set means no matching jobs, never all of them.

### Mutants, each semantic and compiling, each killed by the test that owns it

| mutant | killed by |
|---|---|
| drop the `exit_status` rendering (the claude/omp arm) | `...AcceptsBothRenderings` (2 arms) + the message test |
| check the deadline **after** the patterns instead of before | `...RefusesEverythingElse/a_deadline_whose_subprocess_was_then_killed` |
| let a `--killed` lookup failure widen the filter to every job | both CLI tests |

My first attempt at mutant 2 was a **compile failure**, which #1823's criterion rightly excludes as a mutant; it is redone above as a semantic reordering that compiles. Both files verified sha256-identical after restore.

## Gate

```
go1.26.4 linux/amd64   GOTOOLCHAIN=local   CGO_ENABLED=0
gofmt -l internal/                empty
go build -buildvcs=false ./...    PASS
go vet ./...                      PASS
go generate ./...                 no output, no diff
go test ./internal/workflow/      ok  90.213s
```

Remaining packages posted as a comment. Not run and not claimed: `-race` locally (cgo unavailable), covered by CI's race shards.

## Not verified

Not deployed. I signalled the daemon **directly** rather than through `systemctl`, so a unit restart with its `KillMode` and `TimeoutStopSec` is not reproduced — that could change the timing but not the outcome, since the daemon already kills its own child without help. The runtime attribution of the two renderings is **correlational**, from historical rows rather than a controlled run, because a wrapped-runtime reproduction needs credentials I deliberately kept out of a throwaway home.

Also observed and **not fixed here**: the killed job's read-only worktree was still on disk after the kill and after the restart. That is a separate leak, reported on #1726, and it matters on a host that has crossed the dispatch disk guard three times in one afternoon.
