### PR TITLE
fix(cli): retry a transient wake instead of dropping the obligation (#1982)

### DIFF
--- a/docs/events.md
+++ b/docs/events.md
@@ -237,6 +237,20 @@ A quiet burst tail is flushed by a later daemon tick; it does not require
 another event. If the outbox or its delivery rules cannot be queried, or an
 outbox row cannot be parsed or claimed, the drain is logged as unhealthy and
 retried on a later tick without aborting unrelated repository work.
+A TRANSIENT delivery failure is retried against the same coalesced rows rather
+than dropped: `agent_prompt_stalled` (the pane did not take the prompt) and
+`agent_blocked` (an interactive dialog holds the pane) return the whole claimed
+batch to `pending` with the cause recorded, keeping the attempt count, so the
+next due tick re-coalesces every note into one wake. Delivery is bounded at
+three attempts. When the budget is spent, or when the cause is not transient
+(an unresolved pane binding, `agent_not_found`, a Herdr outage, or an
+unexplained non-delivery), the batch becomes terminal AND a
+`wake_delivery_failed` job event is recorded on `wake-outbox:<id>` naming the
+target role, the cause and the attempts spent, so an undelivered obligation is
+attributable from the store rather than only from a daemon log line.
+`delivery_unknown` remains terminal and is still never retried: a row aged out
+of `attempted` may in fact have been delivered before its outcome write was
+lost, so re-emitting it would risk a duplicate interrupt to prove a negative.
 The wake role's config sets `pane = "<pane-id-or-label>"`: a `wX:pY` value must
 name a currently live pane, while any other value is a unique pane label
 resolved to the current id at wake time (so a recycled pane is still reached).

--- a/internal/cli/event_rule_sink.go
+++ b/internal/cli/event_rule_sink.go
@@ -282,14 +282,31 @@ func (s *eventRuleSink) evaluateRules(ctx context.Context, event events.Event, r
 				slog.Warn("org event wake counter increment failed", "rule_id", rule.ID, "role", rule.WakeRole, "job_id", event.JobID, "error", incrementErr)
 			}
 			ccancel()
-			slog.Info("org event wake stalled", "rule_id", rule.ID, "role", rule.WakeRole, "job_id", event.JobID, "delivered", false)
-			if err := s.finishWakeOutbox(ctx, event, db.WakeOutboxStateStalled, "agent_prompt_stalled"); err != nil {
+			// #1982: a stall is herdr reporting that the pane did not take the
+			// prompt, which is transient by construction, so it earns another
+			// attempt against the same coalesced rows rather than dropping the
+			// obligation. Every one of the 674 undelivered rows measured on the
+			// live store had attempt_count = 1.
+			if err := s.retryOrFailWakeOutbox(
+				ctx, event, rule.WakeRole, db.WakeOutboxStateStalled, "agent_prompt_stalled", wakeDeliveryMaxAttempts,
+			); err != nil {
 				return err
 			}
 		case err != nil:
 			// A Herdr outage is infrastructure failure, not a role ignoring a wake;
 			// it must not falsely increment every role's missed-wake counter.
 			slog.Warn("org event wake failed", "rule_id", rule.ID, "role", rule.WakeRole, "job_id", event.JobID, "error", err)
+			// A pane blocked by an open dialog is the other transient cause: it
+			// clears when the dialog is answered, and 60 of the 108 failed rows
+			// on the live store carry `agent_blocked`.
+			if wakeFailureIsTransient(err) {
+				if retryErr := s.retryOrFailWakeOutbox(
+					ctx, event, rule.WakeRole, db.WakeOutboxStateFailed, err.Error(), wakeDeliveryMaxAttempts,
+				); retryErr != nil {
+					return errors.Join(err, retryErr)
+				}
+				continue
+			}
 			return s.completeWakeOutbox(ctx, event, db.WakeOutboxStateFailed, err.Error(), err)
 		default:
 			// An odd non-delivery is not proof that the role ignored a delivered
@@ -450,6 +467,62 @@ func (s *eventRuleSink) finishWakeOutbox(ctx context.Context, event events.Event
 		slog.Warn("wake outbox state update failed", "job_id", event.JobID, "state", state, "error", err)
 		return fmt.Errorf("finish wake outbox as %s: %w", state, err)
 	}
+	return nil
+}
+
+// wakeDeliveryMaxAttempts bounds re-delivery of a transient failure (#1982).
+// Three attempts across daemon ticks span roughly seven minutes at the
+// observed 143-second median tick gap, which covers a dialog being answered
+// or a pane settling, without turning an unread pane into a permanent
+// retry source.
+const wakeDeliveryMaxAttempts = 3
+
+// wakeFailureIsTransient reports whether a herdr delivery error names a
+// condition that CLEARS ON ITS OWN. Only `agent_blocked` qualifies: the pane
+// exists and holds an interactive dialog, so the same prompt can land once the
+// dialog is answered.
+//
+// Everything else stays terminal on purpose. `agent_not_found` and an
+// unresolved pane binding are configuration, not weather, and retrying them
+// only spends the budget. `agent_prompt_unsubmitted` is deliberately excluded
+// even though it looks transient: the prompt text may already be sitting in
+// the composer, so a re-attempt risks delivering it twice.
+func wakeFailureIsTransient(err error) bool {
+	if err == nil {
+		return false
+	}
+	return strings.Contains(strings.ToLower(err.Error()), "agent_blocked")
+}
+
+// retryOrFailWakeOutbox records a non-delivered outcome for the claimed batch,
+// re-pending it while its budget remains. A row with no outbox ids is an
+// ordinary (non-durable) event and keeps its existing best-effort behaviour.
+func (s *eventRuleSink) retryOrFailWakeOutbox(
+	ctx context.Context,
+	event events.Event,
+	role, state, cause string,
+	budget int,
+) error {
+	if s == nil || s.store == nil || len(event.WakeOutboxIDs) == 0 {
+		return nil
+	}
+	writeCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), db.DurableWriteBudget)
+	defer cancel()
+	retried, attempts, err := s.store.FinishOrRetryWakeOutbox(
+		writeCtx, event.WakeOutboxIDs, state, cause, budget, time.Now().UTC(),
+	)
+	if err != nil {
+		slog.Warn("wake outbox outcome update failed",
+			"job_id", event.JobID, "role", role, "state", state, "error", err)
+		return fmt.Errorf("record wake outbox outcome %s: %w", state, err)
+	}
+	if retried {
+		slog.Info("org event wake retryable",
+			"job_id", event.JobID, "role", role, "cause", cause, "attempts", attempts)
+		return nil
+	}
+	slog.Warn("org event wake undelivered",
+		"job_id", event.JobID, "role", role, "cause", cause, "attempts", attempts, "state", state)
 	return nil
 }
 

--- a/internal/cli/org_directive_test.go
+++ b/internal/cli/org_directive_test.go
@@ -491,7 +491,11 @@ func TestUndeliveredDirectiveRecordsNoReceipt(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	drainReplyWakeAfterAllRowsAreDue(t, store, deliverySink)
+	// A stalled wake is retryable now (#1982), so the drain reports the row as
+	// an outstanding obligation rather than succeeding.
+	if err := drainReplyWakeAfterAllRowsAreDueResult(t, store, deliverySink); err == nil {
+		t.Fatal("stalled directive drain reported healthy; the obligation is outstanding")
+	}
 
 	notes, err := store.ListWorkflowNotes(ctx, "release/unproven", 100)
 	if err != nil {

--- a/internal/cli/reply_wake_outbox.go
+++ b/internal/cli/reply_wake_outbox.go
@@ -191,16 +191,18 @@ func drainReplyWakeOutboxWithHealth(ctx context.Context, store wakeOutboxStore, 
 				ids = append(ids, entry.ID)
 			}
 			// The oldest row SURVIVES as the delivered obligation: it is the one
-			// wakeOutboxEvent identifies as `oldest id`. The rest are recorded
-			// superseded into it rather than each reporting an independent
-			// delivery they never had (#1978).
+			// wakeOutboxEvent identifies as `oldest id`, and ids[0] is that row.
+			// The WHOLE batch travels to the outcome (#1982): a delivered wake
+			// supersedes the rest into the survivor, while a retryable failure
+			// returns them all to pending so the next attempt re-coalesces every
+			// note instead of losing the ones a survivor carried.
 			claimed, err := store.ClaimWakeOutbox(ctx, ids[0], ids[1:], now)
 			if err != nil {
 				return replyWakeOutboxHealth{}, err
 			}
 			if claimed {
 				mutated = true
-				event.WakeOutboxIDs = ids[:1]
+				event.WakeOutboxIDs = ids
 				if err := emitReplyWakeOutboxEvent(ctx, delivery.sink, event, matchingRules); err != nil {
 					return replyWakeOutboxHealth{}, fmt.Errorf("emit claimed %s wake: %w", event.WakeKind, err)
 				}

--- a/internal/cli/reply_wake_outbox_test.go
+++ b/internal/cli/reply_wake_outbox_test.go
@@ -775,6 +775,11 @@ func TestReplyWakeOutboxFleetDrainRunsWithZeroEnabledRepos(t *testing.T) {
 	}
 }
 
+// TestReplyWakeOutboxRecordsExistingDeliveryOutcomeStates pins the outcomes
+// that are NOT retryable. A stalled prompt moved to the retry test in #1982:
+// herdr reporting `agent_prompt_stalled` means the pane did not take the
+// prompt, which is transient, while a transport error or an odd non-delivery
+// is not something a re-attempt can distinguish from a lie.
 func TestReplyWakeOutboxRecordsExistingDeliveryOutcomeStates(t *testing.T) {
 	tests := []struct {
 		name      string
@@ -782,7 +787,6 @@ func TestReplyWakeOutboxRecordsExistingDeliveryOutcomeStates(t *testing.T) {
 		wantState string
 		wantErr   bool
 	}{
-		{name: "stalled", configure: func(w *fakeEventWake) { w.stalled = true }, wantState: db.WakeOutboxStateStalled},
 		{name: "transport failure", configure: func(w *fakeEventWake) { w.promptErr = errors.New("transport down") }, wantState: db.WakeOutboxStateFailed, wantErr: true},
 		{name: "odd non delivery", configure: func(w *fakeEventWake) { w.oddNonDelivery = true }, wantState: db.WakeOutboxStateFailed, wantErr: true},
 	}
@@ -805,6 +809,113 @@ func TestReplyWakeOutboxRecordsExistingDeliveryOutcomeStates(t *testing.T) {
 				t.Fatalf("%s rows = %+v, err=%v", test.wantState, rows, err)
 			}
 		})
+	}
+}
+
+// TestStalledWakeIsRetriedNotDropped is #1982's reproduction. Measured on the
+// live store: 674 of 8,834 wake rows (7.6%) ended in a state that does not
+// establish the target ever received them, and EVERY ONE of them has
+// attempt_count = 1. Nothing was ever retried, so a pane that was momentarily
+// stalled or blocked by an open dialog simply lost its obligation.
+func TestStalledWakeIsRetriedNotDropped(t *testing.T) {
+	store, sink, wake, _ := replyWakeTestHarness(t, []replyWakeTestRole{{"owner", "w1:p1"}})
+	ctx := context.Background()
+	wake.stalled = true
+	for index := range 2 {
+		if _, err := store.InsertWorkflowNote(ctx, db.WorkflowNote{
+			WorkflowID: "release/retry", Author: "worker", Body: fmt.Sprint(index),
+			AddressedTarget: "owner",
+		}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	// First attempt stalls: the rows stay deliverable rather than terminal.
+	if err := drainReplyWakeAfterAllRowsAreDueResult(t, store, sink); err == nil {
+		t.Fatal("stalled drain reported healthy; the obligation is still outstanding")
+	}
+	pending, err := store.ListWakeOutbox(ctx, db.WakeOutboxStatePending)
+	if err != nil || len(pending) != 2 {
+		t.Fatalf("pending after stall = %+v, err=%v, want both rows retryable", pending, err)
+	}
+	for _, row := range pending {
+		if row.AttemptCount != 1 || row.LastError == "" || row.FinishedAt != "" {
+			t.Fatalf("retryable row = %+v, want one recorded attempt, a cause, and no finish stamp", row)
+		}
+	}
+	if stalled, err := store.ListWakeOutbox(ctx, db.WakeOutboxStateStalled); err != nil || len(stalled) != 0 {
+		t.Fatalf("stalled rows = %+v, err=%v, want none while the retry budget remains", stalled, err)
+	}
+
+	// The pane recovers, and the retry re-coalesces BOTH rows into one wake:
+	// the retry must not lose the notes a superseded sibling carried.
+	wake.stalled = false
+	wake.promptCalls = 0
+	drainReplyWakeAfterAllRowsAreDue(t, store, sink)
+	if wake.promptCalls != 1 || !strings.Contains(wake.prompt, "2 new items, oldest id ") {
+		t.Fatalf("retry wake = calls=%d prompt=%q, want one wake naming both notes", wake.promptCalls, wake.prompt)
+	}
+	delivered, err := store.ListWakeOutbox(ctx, db.WakeOutboxStateDelivered)
+	if err != nil || len(delivered) != 1 || delivered[0].AttemptCount != 2 {
+		t.Fatalf("delivered = %+v, err=%v, want one survivor on its second attempt", delivered, err)
+	}
+	superseded, err := store.ListWakeOutbox(ctx, db.WakeOutboxStateSuperseded)
+	if err != nil || len(superseded) != 1 ||
+		superseded[0].LastError != db.WakeOutboxCoalescedDetail(delivered[0].ID) {
+		t.Fatalf("superseded = %+v, err=%v, want the sibling collapsed into the survivor", superseded, err)
+	}
+}
+
+// TestStalledWakeStopsAtItsRetryBudget bounds the retry: an obligation that
+// cannot be delivered becomes an explicit, attributable failure instead of
+// retrying forever against a pane nobody is reading.
+func TestStalledWakeStopsAtItsRetryBudget(t *testing.T) {
+	store, sink, wake, _ := replyWakeTestHarness(t, []replyWakeTestRole{{"owner", "w1:p1"}})
+	ctx := context.Background()
+	wake.stalled = true
+	note, err := store.InsertWorkflowNote(ctx, db.WorkflowNote{
+		WorkflowID: "release/budget", Author: "worker", Body: "never lands",
+		AddressedTarget: "owner",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for attempt := 1; attempt <= wakeDeliveryMaxAttempts; attempt++ {
+		err := drainReplyWakeAfterAllRowsAreDueResult(t, store, sink)
+		if attempt < wakeDeliveryMaxAttempts && err == nil {
+			t.Fatalf("attempt %d reported healthy while the wake was still retryable", attempt)
+		}
+		// The final attempt spends the budget, so the row becomes terminal and
+		// stops being an outstanding obligation. That is the pre-existing
+		// meaning of tick health, which this change deliberately preserves: the
+		// failure is recorded on the row and as a job event instead.
+		if attempt == wakeDeliveryMaxAttempts && err != nil {
+			t.Fatalf("exhausted attempt still reports an obligation: %v", err)
+		}
+	}
+	if wake.promptCalls != wakeDeliveryMaxAttempts {
+		t.Fatalf("prompt calls = %d, want exactly %d attempts", wake.promptCalls, wakeDeliveryMaxAttempts)
+	}
+	stalled, err := store.ListWakeOutbox(ctx, db.WakeOutboxStateStalled)
+	if err != nil || len(stalled) != 1 || stalled[0].AttemptCount != wakeDeliveryMaxAttempts {
+		t.Fatalf("stalled = %+v, err=%v, want one exhausted row", stalled, err)
+	}
+	if stalled[0].FinishedAt == "" || !strings.Contains(stalled[0].LastError, "agent_prompt_stalled") {
+		t.Fatalf("exhausted row = %+v, want a finish stamp and the recorded cause", stalled[0])
+	}
+	// The failure is attributable without reading the daemon log: it names the
+	// role, the cause and how many attempts were spent.
+	events, err := store.ListJobEvents(ctx, fmt.Sprintf("wake-outbox:%d", stalled[0].ID))
+	if err != nil || len(events) != 1 || events[0].Kind != db.WakeOutboxDeliveryFailedEventKind {
+		t.Fatalf("delivery failure events = %+v, err=%v", events, err)
+	}
+	for _, want := range []string{"owner", "agent_prompt_stalled", fmt.Sprintf("attempts=%d", wakeDeliveryMaxAttempts)} {
+		if !strings.Contains(events[0].Message, want) {
+			t.Fatalf("failure event %q does not name %q", events[0].Message, want)
+		}
+	}
+	// And the note itself is still identifiable from the row.
+	if stalled[0].SourceID != fmt.Sprint(note.ID) {
+		t.Fatalf("exhausted row source = %q, want note %d", stalled[0].SourceID, note.ID)
 	}
 }
 

--- a/internal/db/wake_outbox.go
+++ b/internal/db/wake_outbox.go
@@ -26,6 +26,12 @@ const (
 
 const (
 	WakeOutboxDeliveryUnknownEventKind = "wake_delivery_unknown"
+	// WakeOutboxDeliveryFailedEventKind records a wake that will NOT be retried
+	// again: either its cause is not transient or its attempt budget is spent
+	// (#1982). It exists so an undelivered obligation is attributable from the
+	// store, naming role, cause and attempts, rather than only from a daemon
+	// log line nobody reads.
+	WakeOutboxDeliveryFailedEventKind = "wake_delivery_failed"
 
 	WakeOutboxKindReply      = "reply"
 	WakeOutboxKindBlocked    = "blocked"
@@ -508,20 +514,14 @@ WHERE id = ? AND state = 'attempted' AND attempted_at <= ?`,
 // longer pending, none are claimed; this is the cross-daemon mark-before-emit
 // dedup guard.
 //
-// THE BATCH LEAVES THIS CALL AS ONE OBLIGATION, NOT AS N (#1978). `surviving`
-// is the row the emitted wake identifies, and it alone stays `attempted` so
-// that the delivery outcome recorded against it is a real observation. Every
-// `coalesced` row is recorded `superseded`, naming the survivor, because the
-// wake that carries it is the survivor's. Marking them `delivered` instead,
-// which is what happened before this change, reported N deliveries for one
-// delivered wake: 8,806 live rows carried only 250 `superseded` rows and all
-// 250 of those came from directive receipts rather than from coalescing.
-//
-// Superseding here rather than after delivery costs nothing recoverable: every
-// terminal state is terminal, so no wake outbox row is ever re-emitted, and a
-// batch whose delivery then fails records ONE failed obligation, which is the
-// truth. The suppressed rows remain readable and each names the row that
-// carried it.
+// THE BATCH LEAVES THIS CALL AS ONE OBLIGATION, NOT AS N (#1978), but the
+// collapse is recorded at DELIVERY time, not here (#1982). I originally
+// superseded the coalesced rows inside this claim and argued it cost nothing
+// because every terminal state was terminal and no row was ever re-emitted.
+// Retry made that argument false: a stalled batch is now re-attempted, and a
+// row already marked `superseded` could not rejoin the retry, so the notes it
+// carried would vanish from the next wake. The rows therefore stay `attempted`
+// together and FinishWakeOutbox decides their fate from the observed outcome.
 func (s *Store) ClaimWakeOutbox(ctx context.Context, surviving int64, coalesced []int64, at time.Time) (bool, error) {
 	ids := make([]int64, 0, len(coalesced)+1)
 	ids = append(ids, surviving)
@@ -550,32 +550,106 @@ WHERE state = 'pending' AND id IN (`, ids, at)
 	if affected != int64(len(ids)) {
 		return false, tx.Rollback()
 	}
-	if len(coalesced) > 0 {
-		supersede, supersedeArgs, err := wakeOutboxIDUpdate(`
-UPDATE wake_outbox
-SET state = 'superseded', last_error = ?, finished_at = ?, updated_at = ?
-WHERE state = 'attempted' AND id IN (`, coalesced, at, WakeOutboxCoalescedDetail(surviving))
-		if err != nil {
-			return false, err
-		}
-		supersedeResult, err := tx.ExecContext(ctx, supersede, supersedeArgs...)
-		if err != nil {
-			return false, err
-		}
-		supersededRows, err := supersedeResult.RowsAffected()
-		if err != nil {
-			return false, err
-		}
-		if supersededRows != int64(len(coalesced)) {
-			return false, fmt.Errorf(
-				"supersede coalesced wake outbox updated %d rows, want %d", supersededRows, len(coalesced),
-			)
-		}
-	}
 	if err := tx.Commit(); err != nil {
 		return false, err
 	}
 	return true, nil
+}
+
+// FinishOrRetryWakeOutbox records a NON-delivered outcome for one attempted
+// batch (#1982). While `retryBudget` attempts remain and the cause is one the
+// caller judged transient, the batch returns to `pending` with its cause
+// recorded; otherwise it becomes terminal in `state` and the failure is
+// written as a durable, attributable job event naming the target role, the
+// cause and the attempts spent.
+//
+// The decision reads attempt_count inside the same transaction as the write,
+// so two daemons cannot both see budget remaining and re-pend the same batch.
+func (s *Store) FinishOrRetryWakeOutbox(
+	ctx context.Context,
+	ids []int64,
+	state, cause string,
+	retryBudget int,
+	at time.Time,
+) (retried bool, attempts int, err error) {
+	interpretation, ok := interpretWakeOutboxState(state)
+	if !ok || interpretation != wakeOutboxStateTerminal {
+		return false, 0, fmt.Errorf("invalid terminal wake outbox state %q", state)
+	}
+	if len(ids) == 0 {
+		return false, 0, errors.New("wake outbox outcome requires at least one id")
+	}
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return false, 0, err
+	}
+	defer func() { _ = tx.Rollback() }()
+	var role string
+	if err := tx.QueryRowContext(ctx,
+		`SELECT attempt_count, target_role FROM wake_outbox WHERE id = ?`, ids[0],
+	).Scan(&attempts, &role); err != nil {
+		return false, 0, err
+	}
+	if attempts < retryBudget {
+		query, args, err := wakeOutboxIDUpdateStamps(`
+UPDATE wake_outbox
+SET state = 'pending', last_error = ?, attempted_at = NULL, finished_at = NULL,
+	updated_at = ?
+WHERE state = 'attempted' AND id IN (`, ids, at, 1, strings.TrimSpace(cause))
+		if err != nil {
+			return false, attempts, err
+		}
+		if err := execWakeOutboxRowUpdate(ctx, tx, query, args, len(ids), "requeue"); err != nil {
+			return false, attempts, err
+		}
+		if err := tx.Commit(); err != nil {
+			return false, attempts, err
+		}
+		return true, attempts, nil
+	}
+	query, args, err := wakeOutboxIDUpdate(`
+UPDATE wake_outbox
+SET state = ?, last_error = ?, finished_at = ?, updated_at = ?
+WHERE state = 'attempted' AND id IN (`, ids, at, state, strings.TrimSpace(cause))
+	if err != nil {
+		return false, attempts, err
+	}
+	if err := execWakeOutboxRowUpdate(ctx, tx, query, args, len(ids), "finish"); err != nil {
+		return false, attempts, err
+	}
+	message := fmt.Sprintf(
+		"wake delivery failed for %s: %s (attempts=%d, state=%s)",
+		role, strings.TrimSpace(cause), attempts, state,
+	)
+	for _, id := range ids {
+		if _, err := tx.ExecContext(ctx,
+			`INSERT INTO job_events(job_id, kind, message) VALUES (?, ?, ?)`,
+			fmt.Sprintf("wake-outbox:%d", id),
+			WakeOutboxDeliveryFailedEventKind,
+			message,
+		); err != nil {
+			return false, attempts, err
+		}
+	}
+	if err := tx.Commit(); err != nil {
+		return false, attempts, err
+	}
+	return false, attempts, nil
+}
+
+func execWakeOutboxRowUpdate(ctx context.Context, tx *sql.Tx, query string, args []any, want int, op string) error {
+	result, err := tx.ExecContext(ctx, query, args...)
+	if err != nil {
+		return err
+	}
+	affected, err := result.RowsAffected()
+	if err != nil {
+		return err
+	}
+	if affected != int64(want) {
+		return fmt.Errorf("%s wake outbox updated %d rows, want %d", op, affected, want)
+	}
+	return nil
 }
 
 // WakeOutboxCoalescedDetail is the audit text a suppressed wake carries. It
@@ -585,13 +659,29 @@ func WakeOutboxCoalescedDetail(surviving int64) string {
 	return "coalesced into wake outbox row " + strconv.FormatInt(surviving, 10)
 }
 
-// FinishWakeOutbox records the existing event-rule delivery classification for
-// every row in one attempted batch.
+// FinishWakeOutbox records the observed delivery outcome for one attempted
+// batch. ids[0] is the SURVIVING row, the one the emitted wake identifies.
+//
+// On a DELIVERED outcome the survivor is delivered and every row it collapsed
+// is recorded `superseded` naming it, so one delivered wake reports exactly
+// one delivery and the coalescing saving stays countable (#1978). On any other
+// terminal outcome the whole batch carries that outcome, because nothing was
+// delivered on anyone's behalf (#1982).
 func (s *Store) FinishWakeOutbox(ctx context.Context, ids []int64, state, detail string, at time.Time) error {
 	interpretation, ok := interpretWakeOutboxState(state)
 	if !ok || interpretation != wakeOutboxStateTerminal {
 		return fmt.Errorf("invalid terminal wake outbox state %q", state)
 	}
+	if state == WakeOutboxStateDelivered && len(ids) > 1 {
+		if err := s.finishWakeOutboxRows(ctx, ids[1:], WakeOutboxStateSuperseded, WakeOutboxCoalescedDetail(ids[0]), at); err != nil {
+			return err
+		}
+		return s.finishWakeOutboxRows(ctx, ids[:1], state, detail, at)
+	}
+	return s.finishWakeOutboxRows(ctx, ids, state, detail, at)
+}
+
+func (s *Store) finishWakeOutboxRows(ctx context.Context, ids []int64, state, detail string, at time.Time) error {
 	query, args, err := wakeOutboxIDUpdate(`
 UPDATE wake_outbox
 SET state = ?, last_error = ?, finished_at = ?, updated_at = ?
@@ -647,9 +737,24 @@ func wakeOutboxObligationPredicate(attemptedBefore time.Time) (string, []any) {
 	return strings.Join(clauses, " OR "), args
 }
 
+// wakeOutboxIDUpdate builds an `id IN (...)` update whose SET clause takes the
+// `leading` values followed by exactly TWO timestamp placeholders.
 func wakeOutboxIDUpdate(prefix string, ids []int64, at time.Time, leading ...string) (string, []any, error) {
+	return wakeOutboxIDUpdateStamps(prefix, ids, at, 2, leading...)
+}
+
+// wakeOutboxIDUpdateStamps is the same builder with an EXPLICIT number of
+// timestamp placeholders. The count is a parameter because it silently has to
+// match the statement: a SET clause with one stamp and a builder supplying two
+// shifts the id arguments by one, so `id IN (?)` binds a timestamp, the update
+// matches zero rows, and the caller reports "updated 0 rows" for a row that is
+// sitting in exactly the state it asked for (#1982, found by that symptom).
+func wakeOutboxIDUpdateStamps(prefix string, ids []int64, at time.Time, stamps int, leading ...string) (string, []any, error) {
 	if len(ids) == 0 {
 		return "", nil, errors.New("wake outbox update requires at least one id")
+	}
+	if stamps < 0 {
+		return "", nil, fmt.Errorf("invalid wake outbox stamp count %d", stamps)
 	}
 	seen := make(map[int64]struct{}, len(ids))
 	for _, id := range ids {
@@ -662,11 +767,13 @@ func wakeOutboxIDUpdate(prefix string, ids []int64, at time.Time, leading ...str
 		seen[id] = struct{}{}
 	}
 	stamp := at.UTC().Format(BlockedEpisodeTimeLayout)
-	args := make([]any, 0, len(leading)+2+len(ids))
+	args := make([]any, 0, len(leading)+stamps+len(ids))
 	for _, value := range leading {
 		args = append(args, value)
 	}
-	args = append(args, stamp, stamp)
+	for range stamps {
+		args = append(args, stamp)
+	}
 	placeholders := make([]string, 0, len(ids))
 	for _, id := range ids {
 		placeholders = append(placeholders, "?")

--- a/skills/gitmoot/references/CLI.md
+++ b/skills/gitmoot/references/CLI.md
@@ -2046,7 +2046,12 @@ literal pane id. The daemon calls `herdr agent prompt <pane> <text> --wait --tim
 8000` and treats delivered (`result.type = "agent_prompted"`, or a post-delivery
 `error.code = "timeout"`) apart from stalled (`error.code =
 "agent_prompt_stalled"`). Stalls increment the role's consecutive missed-wake
-counter and delivery resets it; transport failures leave it unchanged.
+counter and delivery resets it; transport failures leave it unchanged. A stall
+and an `agent_blocked` pane are **transient**: the claimed rows return to
+`pending` with the cause recorded and are re-delivered as one coalesced wake,
+bounded at three attempts. Any other cause, and an exhausted budget, end the
+rows terminally and record a `wake_delivery_failed` job event on
+`wake-outbox:<id>` naming the role, cause and attempts.
 `attention`, `guard`, `job-terminal`, `review-verdict`, `recycle-overdue`, and
 `pane_input_pending` wakes remain best-effort. With no rule rows this path is
 off. Task episodes due in one evaluator pass produce one oldest-first digest

--- a/website/docs/reference/cli.md
+++ b/website/docs/reference/cli.md
@@ -1763,7 +1763,12 @@ Pass only one of `--match` and `--repo`. The wake role must exist and set
 `pane = "<herdr-pane>"`; Gitmoot resolves that value as an exact pane label first
 and otherwise treats it as a literal pane id.
 Delivery is verified with Herdr's `agent_prompted` versus
-`agent_prompt_stalled` result. `attention`, `guard`, `job-terminal`,
+`agent_prompt_stalled` result. A stall, and an `agent_blocked` pane, are
+**transient**: the claimed rows return to `pending` with the cause recorded and
+are re-delivered as one coalesced wake, bounded at three attempts. Anything
+else, and an exhausted budget, ends the rows terminally and records a
+`wake_delivery_failed` job event on `wake-outbox:<id>` naming the role, cause
+and attempts. `attention`, `guard`, `job-terminal`,
 `review-verdict`, `recycle-overdue`, and `pane_input_pending` wakes remain
 best-effort; zero rules leaves the feature off.
 

--- a/website/docs/reference/event-stream.md
+++ b/website/docs/reference/event-stream.md
@@ -242,6 +242,20 @@ A quiet burst tail is flushed by a later daemon tick; it does not require
 another event. If the outbox or its delivery rules cannot be queried, or an
 outbox row cannot be parsed or claimed, the drain is logged as unhealthy and
 retried on a later tick without aborting unrelated repository work.
+A TRANSIENT delivery failure is retried against the same coalesced rows rather
+than dropped: `agent_prompt_stalled` (the pane did not take the prompt) and
+`agent_blocked` (an interactive dialog holds the pane) return the whole claimed
+batch to `pending` with the cause recorded, keeping the attempt count, so the
+next due tick re-coalesces every note into one wake. Delivery is bounded at
+three attempts. When the budget is spent, or when the cause is not transient
+(an unresolved pane binding, `agent_not_found`, a Herdr outage, or an
+unexplained non-delivery), the batch becomes terminal AND a
+`wake_delivery_failed` job event is recorded on `wake-outbox:<id>` naming the
+target role, the cause and the attempts spent, so an undelivered obligation is
+attributable from the store rather than only from a daemon log line.
+`delivery_unknown` remains terminal and is still never retried: a row aged out
+of `attempted` may in fact have been delivered before its outcome write was
+lost, so re-emitting it would risk a duplicate interrupt to prove a negative.
 The wake role's config sets `pane = "<pane-id-or-label>"`: a `wX:pY` value must
 name a currently live pane, while any other value is a unique pane label
 resolved to the current id at wake time (so a recycled pane is still reached).


### PR DESCRIPTION
Fixes #1982. Part of the #1977 campaign.

## Re-measured, and the numbers moved because of my own earlier slice

Read-only from `/root/.gitmoot/gitmoot.db`, 8,834 rows:

| State | Issue (8,782 rows) | Now (8,834 rows) |
| --- | --- | --- |
| delivered | 7,451 | 7,465 |
| **superseded** | 250 | **599** |
| stalled | 336 | 322 |
| delivery_unknown | **546** | **244** |
| failed | 126 | 108 |
| pending | 94 | 96 |
| **unproven total** | **1,008 (11.5%)** | **674 (7.6%)** |

`superseded` more than doubled and `delivery_unknown` more than halved because #1978 shipped in between: coalescing now collapses rows that previously each held their own claim, and a row that is never claimed alone can never age out alone. That is my own change moving this slice's baseline, so I am stating it rather than presenting 7.6% as an improvement this PR made.

**The finding that matters is not the totals. It is that every single one of those 674 rows has `attempt_count = 1`:**

```
select state, attempt_count, count(*) from wake_outbox
where state in ('delivery_unknown','stalled','failed') group by 1,2;
delivery_unknown|1|244
failed|1|108
stalled|1|322
```

Nothing was ever retried. Causes, verbatim from `last_error`:

| Cause | Rows | Transient? |
| --- | --- | --- |
| `agent_prompt_stalled` | 225 | **yes**, the pane did not take the prompt |
| `role pane binding unresolved` | 97 | no, configuration |
| `agent_blocked: agent … is blocked` | ~60 | **yes**, an interactive dialog holds the pane |
| `agent_not_found` | 9 | no, the pane is gone |
| `agent_prompt_unsubmitted` | 8 | excluded on purpose, see below |
| aged-out claim (`delivery_unknown`) | 244 | no, see below |

So roughly **285 obligations were dropped for reasons that clear on their own**, most of them a dialog being open or a pane not settling within herdr's effect window.

## The change

- **Transient causes retry against the same coalesced rows.** A stall or an `agent_blocked` pane returns the **whole claimed batch** to `pending` with the cause recorded on the rows, keeping the attempt count. The next due tick re-coalesces them into one wake, which is the issue's "retry against the coalesced key rather than emitting a new wake", literally.
- **Bounded at three attempts.** At the observed 143-second median tick gap that spans roughly seven minutes, enough for a dialog to be answered, without turning an unread pane into a permanent retry source.
- **Terminal failures become attributable.** When the budget is spent, or the cause is not transient, the batch goes terminal **and** a `wake_delivery_failed` job event is written on `wake-outbox:<id>` naming the target role, the cause and the attempts. That is the "recorded cause and bounded resolution path" the acceptance asks for, readable from the store rather than from a log line nobody greps.

### This corrects a decision I made in #1978, and that is the interesting part

In #1978 I superseded the coalesced rows inside `ClaimWakeOutbox`, arguing it cost nothing recoverable because every terminal state was terminal and no row was ever re-emitted. **Retry makes that argument false.** A row already marked `superseded` could not rejoin the retry, so the notes it carried would silently vanish from the next wake: exactly the "no wake is silently dropped" property #1978 was built to guarantee.

The collapse therefore moves to `FinishWakeOutbox`: a `delivered` outcome supersedes the siblings into the survivor (so one delivered wake still reports exactly one delivery and the saving stays countable), and any other outcome carries the whole batch. `TestStalledWakeIsRetriedNotDropped` asserts the retry wake says `2 new items` and that the sibling is superseded only after the delivery succeeds, which is the assertion that would have caught the interaction.

### What I deliberately did not do

**`delivery_unknown` stays terminal, against the issue's first acceptance criterion.** The criterion says every wake must end `delivered`, `superseded` or `failed`. I am not implementing that, and the reason is in the code it would change: an aged-out `attempted` row may in fact have been **delivered** before its outcome write was lost. `internal/cli/event_rule_sink.go` documents a measured case: 15 of 167 delivered wakes in one 2h33m window became `delivery_unknown` because a contended SQLite write was abandoned at a 5-second deadline. Re-emitting those would deliver a **duplicate interrupt** in order to prove a negative, in a campaign whose entire subject is interrupt volume. Making it not-terminal is a real improvement only once the lost-outcome case can be told apart from the never-delivered case, which needs a delivery receipt the transport does not currently return.

**`agent_prompt_unsubmitted` is excluded from retry** even though it looks transient: the prompt may already be sitting unsubmitted in the composer, so a re-attempt risks delivering the same text twice.

**Unresolved pane bindings and `agent_not_found` are not retried** because they are configuration, not weather. Retrying them only spends the budget before the same terminal outcome.

## The awaited_facts half, measured

Acceptance item 3 asks that an expiry name what was awaited and from whom. **It already does**, in the row:

```
48|gm-omp-fanout|review_verdict|gitmoot/gitmoot#1783@710e1752…|2026-09-02T18:24:06Z|expired|deadline expired
```

`waiter_role`, `subject_kind`, `subject_key` (repo#pr@sha), `deadline`, `expired_at` and `resolution_detail` are all stored. 40 of 50 expired, 10 satisfied, matching the issue.

But I found something the issue did not: **49 of the 50 `awaited_fact` wake rows are still `pending`, the oldest since 2026-08-02**, and not one has ever been delivered. The cause is not the transport:

```
fact rules exist for: among-friends, among-friends-omp, checkin-builder, deimos, gm-archive,
  gm-findings, gm-integrity, gm-staged, gm-transport, herdr-app-2, keephair-2, memora,
  omp-coc, omp-router, omp-test, phobos, review-loop
pending fact wakes target: apps-coc (22), jarvis (17), aste-screener (6), vetrina (2),
  joltra (1), herdr-app (1)   -- NONE of which has a `fact` route
```

Every role with a pending fact wake has **no `fact` event rule at all**. The routes exist only for roles created by the newer seat-registration path. So the expiry is attributable in the store and silent in the panes, for a configuration reason, and no code change here would deliver them. I am **not** creating fleet routes in a PR; `gitmoot org validate` already reports "roles without enabled wake routes", and surfacing "N obligations with no route, oldest X days" belongs to #1983. Auto-failing routeless rows is also refused on purpose: the drain documents that `pending` is an explicit never-attempted state so a rule added later can still deliver it, and silently erasing 49 obligations to make a state chart tidy would be the opposite of this campaign.

## Tests

- `TestStalledWakeIsRetriedNotDropped`: two notes, first attempt stalls, both rows stay `pending` with a recorded cause and no finish stamp, no `stalled` row exists; the pane recovers and the retry delivers **one** wake naming both notes, the survivor is `delivered` with `attempt_count = 2`, the sibling `superseded` into it.
- `TestStalledWakeStopsAtItsRetryBudget`: exactly three prompt attempts, then one terminal `stalled` row with the cause and a `wake_delivery_failed` job event naming role, cause and `attempts=3`.
- `TestReplyWakeOutboxRecordsExistingDeliveryOutcomeStates` keeps the non-retryable outcomes (transport error, odd non-delivery) terminal on the first attempt.
- `TestUndeliveredDirectiveRecordsNoReceipt` (from #1980) now asserts the drain reports the obligation as outstanding, which is the correct consequence of a retryable stall.

## A bug found while implementing, worth naming

`wakeOutboxIDUpdate` always appended **two** timestamp arguments. A SET clause with one stamp therefore shifted the id arguments by one, so `id IN (?)` bound a timestamp, the update matched zero rows, and the caller reported `requeue wake outbox updated 0 rows, want 1` for a row sitting in exactly the state it required. I found it by dumping the row and seeing `state="attempted"` next to that error. The stamp count is now an explicit parameter with the failure mode recorded in the comment.

## Verification

Full local gate on this head with go1.26.4 pinned: `go build -buildvcs=false ./...`, `go vet ./...`, `go test -count=1 -timeout 25m ./...`, **zero failures**, disk 7.45% free throughout (the dispatch guard that manufactured 20 phantom failures earlier today is clear).

`-race` is CI's shards; race requires cgo, unavailable locally per this repo's gate.

## Not verified

- **No live probe.** Retry is daemon behaviour and deploys are owner-gated. After a deploy the evidence is a wake row with `attempt_count > 1` and a non-empty `last_error` that later reads `delivered`, or a `wake_delivery_failed` job event for one that never lands.
- **The 285 already-dropped obligations are not recovered.** This changes what happens next, not what was lost; those rows stay terminal with their original causes.
- I have not measured how often `agent_blocked` clears within three attempts, only that it is a condition that clears. If it usually does not, the right follow-up is a longer budget or a different escalation, not more retries.

Deploy notes: no migration. `job_events` gains a new `kind` value, which is a free-form column. Daemon restart picks it up.
