### PR TITLE
test(cli): pin the ledger brief after the head-contradiction scan (#1819, #1969)

### DIFF
--- a/internal/cli/agent_dispatch.go
+++ b/internal/cli/agent_dispatch.go
@@ -511,6 +511,38 @@ func dispatchLocalAgentJob(ctx context.Context, store *db.Store, request localAg
 	//
 	// It is additive and fails open: a review with no PR, no head, or no prior
 	// obligations at that head gets a byte-identical prompt.
+	// ORDERING IS LOAD-BEARING AND NOTHING ELSE IN THE TREE RECORDS IT.
+	//
+	// This append MUST stay AFTER dispatchPromptHeadContradictionWarnings above.
+	// #1819 (PR #1991) scans the prompt for commit-shaped tokens that contradict
+	// the dispatch head; promptCommitTokenRE matches 7 to 64 hex characters. This
+	// brief can INJECT such a token: LedgerObligationsAtHead renders
+	// shortHead(obs.HeadSHA) into its reason strings (findings_ledger.go), which
+	// is a 12-character prefix of a PRIOR head, and a finding's own title
+	// routinely cites a commit too.
+	//
+	// The two changes landed within an hour of each other, by different authors,
+	// in the same function, with no textual conflict, so git merged them and CI
+	// never validated the integrated tree. The order that resulted is the safe
+	// one, but it was correct by accident.
+	//
+	// REVERSED, THE COST DEPENDS ON WHOSE HEAD THE BRIEF CITES, and the second
+	// case is much worse than the first. #1819's author confirmed both arms
+	// against origin/main:
+	//
+	//   - A head recorded for THIS pull request, the common case for a re-armed
+	//     finding: the classifier's recorded-head arm allows it, so the result is
+	//     a FALSE "prompt references commit X, but the dispatch head is Y"
+	//     warning against a head no operator wrote. Noisy and misleading.
+	//   - A head belonging to ANOTHER pull request, which happens when a finding
+	//     is re-armed across PRs: that is the FOREIGN arm, and it REFUSES THE
+	//     DISPATCH non-zero, before the job row exists. Every review carrying
+	//     such a brief would fail to dispatch at all.
+	//
+	// "False warning" undersells it, which is why both are named here: a reader
+	// weighing whether this order matters would otherwise weigh the wrong cost.
+	//
+	// TestReviewBriefDoesNotTripTheHeadContradictionScan is the guard.
 	if request.Action == "review" && request.PullRequest > 0 && strings.TrimSpace(request.HeadSHA) != "" {
 		briefEngine := workflow.Engine{
 			Store:           store,

--- a/internal/cli/review_brief_scan_ordering_test.go
+++ b/internal/cli/review_brief_scan_ordering_test.go
@@ -1,0 +1,134 @@
+package cli
+
+import (
+	"context"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/gitmoot/gitmoot/internal/db"
+)
+
+// TestReviewBriefDoesNotTripTheHeadContradictionScan pins an ORDERING that
+// nothing else in the tree records, and that is currently correct by accident.
+//
+// Two changes landed within an hour of each other, by different authors, in the
+// same function, with no textual conflict:
+//
+//	#1819 (PR #1991) classifyPromptCommitCitations + the head-contradiction scan
+//	#1969 (PR #1992) the findings-ledger obligation brief appended to the prompt
+//
+// #1819 scans the prompt for commit-shaped tokens contradicting the dispatch
+// head; promptCommitTokenRE matches 7 to 64 hex characters. The brief can inject
+// exactly that: LedgerObligationsAtHead renders shortHead(obs.HeadSHA), a
+// 12-character prefix of a PRIOR head, into its reason strings, and a finding's
+// own title routinely cites a commit. git merged the two happily and CI never
+// validated the integrated tree, so the safe order was never a decision.
+//
+// REVERSED, the cost splits in two, which is why both arms are here:
+//
+//   - a head recorded for THIS pull request produces a FALSE stale-head warning;
+//   - a head belonging to ANOTHER pull request hits #1819's foreign arm and
+//     REFUSES THE DISPATCH non-zero, before the job row exists.
+//
+// The assertion is deliberately a PROPERTY, not a line number: dispatch succeeds
+// and records zero prompt_head_warning events even though the prompt ends up
+// carrying a real commit that is not the dispatch head. That fails if either
+// author reorders, and it needs no maintenance when the file shifts. The form
+// was suggested by #1819's author.
+func TestReviewBriefDoesNotTripTheHeadContradictionScan(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		// citedHeadIsForeign selects which #1819 arm the injected token would hit
+		// if the ordering regressed: the recorded-head arm (warning) or the
+		// foreign arm (hard dispatch refusal).
+		citedHeadIsForeign bool
+	}{
+		{name: "brief cites a head recorded for this pull request"},
+		{name: "brief cites a head belonging to another pull request", citedHeadIsForeign: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+			store, home := blockerE2EHome(t)
+			checkout, firstHead, secondHead := readonlyReviewWorktreeGitCheckout(t)
+			seedReviewDispatchFixture(t, store, checkout)
+			replaceDiskGuardMeasurement(t, func(string) (diskFilesystemUsage, error) {
+				return diskFilesystemUsage{TotalBytes: 20 << 30, FreeBytes: 10 << 30}, nil
+			})
+
+			// The cited token must be a REAL commit: the scan resolves each token
+			// with RevParse and skips anything git cannot resolve, so an invented
+			// hex string would prove nothing.
+			//
+			// WHICH #1819 ARM IT WOULD HIT depends on whether the commit is a
+			// RECORDED head of this pull request, and recorded heads come from
+			// jobs' payload head_sha for that PR (store_prompt_heads.go:31), not
+			// from findings. So the foreign case needs a real commit that no job
+			// recorded, which is why this makes a third one on a side branch
+			// rather than reusing firstHead.
+			citedCommit := firstHead
+			if tc.citedHeadIsForeign {
+				runGit(t, checkout, "switch", "-c", "unrelated/branch")
+				writeFile(t, filepath.Join(checkout, "unrelated.txt"), "another pull request\n")
+				runGit(t, checkout, "add", "unrelated.txt")
+				runGit(t, checkout, "commit", "-m", "a commit no job recorded for this pr")
+				citedCommit = readonlyWorktreeHead(t, checkout)
+				runGit(t, checkout, "switch", "main")
+			}
+
+			if _, err := store.RecordReviewFindingObservation(ctx, db.ReviewFindingObservation{
+				Repo:        "owner/repo",
+				PullRequest: 12,
+				HeadSHA:     firstHead,
+				ObserverJob: "local-review-prior-round",
+				State:       db.FindingOpen,
+				Severity:    "P1",
+				RoundLabel:  "F1",
+				// A reviewer citing the commit a regression came from is ordinary
+				// prose, and it is the same injection channel as the brief's own
+				// "answered at <shortHead>" reason.
+				Title:            "regression introduced in " + citedCommit[:12],
+				Detail:           "the fix leg pushed before validating the branch",
+				File:             "internal/cli/agent_dispatch.go",
+				Line:             519,
+				EvidenceKind:     db.EvidenceExecuted,
+				ExecutedCommands: []string{"go test ./internal/cli"},
+				ExecutedCount:    1,
+			}); err != nil {
+				t.Fatalf("RecordReviewFindingObservation: %v", err)
+			}
+
+			out, err := dispatchLocalAgentJob(ctx, store, reviewDispatchRequest(home, secondHead))
+			if err != nil {
+				t.Fatalf("dispatch was REFUSED: %v\n\nthat is #1819's foreign arm firing on the brief, which means the brief is now appended before the citation classifier", err)
+			}
+			job, err := store.GetJob(ctx, out.JobID)
+			if err != nil {
+				t.Fatalf("GetJob: %v", err)
+			}
+			payload, err := daemonJobPayload(job)
+			if err != nil {
+				t.Fatalf("daemonJobPayload: %v", err)
+			}
+
+			// PREMISE, asserted rather than assumed: the prompt really does end up
+			// carrying the commit token. Without this the test could pass because
+			// the brief was empty, which is the vacuous version of it.
+			if !strings.Contains(payload.Instructions, citedCommit[:12]) {
+				t.Fatalf("premise broken: the prompt carries no commit token, so the ordering is untested; prompt tail: %q",
+					tailOf(payload.Instructions, 400))
+			}
+
+			events, err := store.ListJobEvents(ctx, job.ID)
+			if err != nil {
+				t.Fatalf("ListJobEvents: %v", err)
+			}
+			for _, event := range events {
+				if event.Kind == "prompt_head_warning" {
+					t.Fatalf("prompt_head_warning recorded: %q\n\nthe ledger brief is being scanned as if the operator had written it; the brief append must stay AFTER the head-contradiction scan",
+						event.Message)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
Guards an ordering between #1819 (PR #1991) and #1969 (PR #1992) that is currently correct **by accident**. Found by applying the base-staleness merge practice retroactively to my own three merges, which is the only reason anyone looked.

## The coupling

Two changes landed within an hour, by different authors, in `dispatchLocalAgentJob`, with no textual conflict. Git merged them and CI never validated the integrated tree.

On `origin/main` today, independently verified by #1819's author:

```
428-430  classifyPromptCommitCitations + reviewPromptTargetMismatchError   #1819 refusal
466      dispatchPromptHeadContradictionWarnings                          #1819 warning scan
519      request.Instructions += brief                                    #1969 append
```

#1819 scans the prompt for commit-shaped tokens that contradict the dispatch head; `promptCommitTokenRE` (`agent_dispatch.go:171`) is `\b[0-9a-fA-F]{7,64}\b`. The #1969 brief **injects exactly that**: `LedgerObligationsAtHead` renders `shortHead(obs.HeadSHA)` into its reason strings (`findings_ledger.go:214`, `:260`), and `shortHead` returns a **12-character** prefix of a *prior* head. A finding's own prose routinely cites a commit too.

Both #1819 sites run before the append, so no scan ever sees the brief. That is the safe order and it was never a decision.

## Reversed, the cost splits in two, and both are proven rather than argued

I reordered the production code and ran the test. Verbatim:

| Cited commit | Result under the reorder |
| --- | --- |
| a head **recorded** for this pull request | `prompt_head_warning recorded: "prompt references commit 918053344301, but the dispatch head is 4dd6992a...; Gitmoot will use dispatch head ..."` |
| a commit **no job recorded** for it | `dispatch was REFUSED: review prompt names a commit outside this pull request's history, so the instructions and the dispatch head describe different trees` |

The second arm is #1819's foreign path: it refuses **non-zero, before the job row exists**. So a future reorder does not add noise, it **blocks review dispatches**, and it does so on precisely the reviews carrying the most ledger history. That distinction came from #1819's author; naming only the warning would have undersold it to whoever next weighs whether this order matters.

## The pin

A **property**, not a line number, because both authors edit this file weekly and a positional assertion rots into a false failure within a month: *dispatch succeeds and records zero `prompt_head_warning` events even though the prompt ends up carrying a real commit that is not the dispatch head.* It survives either half moving.

It asserts its own premise, so it cannot pass by rendering an empty brief. The comment at the append site names both PRs and both consequences, because a test alone tells a future reader they broke something while the comment tells them what it was for.

**A correction I made to my own test before shipping it.** The first version's "foreign" arm reused `firstHead`. That was wrong: recorded heads come from *jobs'* `payload.head_sha` for the pull request (`store_prompt_heads.go:31`), not from findings, so `firstHead` was a recorded head and **both subtests hit the recorded-head arm** and produced identical warnings. It tested one thing twice under two names. The foreign arm now creates a third commit on a side branch that no job recorded, which is what makes the refusal reachable.

## Verification

Both subtests pass; the reorder fails both, with the two distinct messages above.

`gofmt` clean, `go vet ./internal/cli/` clean, `go test ./internal/cli/` **ok 913s**.

One honest caveat. An earlier full-package run failed `TestEphemeralGateTakesNoSessionForANonResumableSpec`, which is not mine and not in the disk-guard family (disk was 92% used, 37 GiB free, no `DISK GUARD REFUSED` line). Three runs discriminate it: **fail** with my test included, **ok 1023s** with only my test skipped, **ok 913s** with it included again, and it passes in isolation on both `main` and this branch. So it is intermittent and not attributable to this change. I am reporting it rather than calling it a known flake, because one failure in three runs is not a root cause. Happy to file it separately if you want it tracked.

`-race` not run: requires cgo, unavailable in this seat.

## Not claimed

- This changes no behaviour. It is a comment and a test.
- I have not audited whether other prompt-mutating call sites in this function have the same coupling. Only the #1969 append is pinned.
