### PR TITLE
fix(db,cli): name the job id a refused insert failed to write (#1559)

### DIFF
--- a/internal/cli/agent_dispatch.go
+++ b/internal/cli/agent_dispatch.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"regexp"
 	"strings"
+	"sync/atomic"
 	"time"
 
 	"github.com/gitmoot/gitmoot/internal/config"
@@ -1916,9 +1917,30 @@ func ensureLocalAgentAccess(ctx context.Context, store *db.Store, agent db.Agent
 	return nil
 }
 
+// localAgentJobID mints a dispatch id for a locally dispatched job.
+//
+// THE TIME COMPONENT IS NOT SUFFICIENT ON ITS OWN (#1559). Two dispatches for
+// the same agent and action can read the same UnixNano - clock resolution is not
+// guaranteed to be a nanosecond, and the observed collision came from four
+// reviews claimed inside one second under [parallel_sessions] - and the insert
+// then fails with SQLITE_CONSTRAINT_PRIMARYKEY, so the job is silently not
+// written while the caller holds an id it believes exists.
+//
+// A PER-PROCESS COUNTER, NOT RANDOMNESS. It makes a same-instant collision
+// UNREACHABLE within a process rather than merely unlikely, and ids stay sortable
+// by their time component, which several operator queries rely on. Randomness
+// would only have made the collision rarer, which is the failure mode this
+// campaign keeps finding: a defect made invisible instead of impossible.
+//
+// Cross-process collision remains possible in principle and is bounded by the
+// same nanosecond clock; it is not addressed here, and the insert now names the
+// id it failed to write so such a case is diagnosable in one step.
 func localAgentJobID(action string, agent string) string {
-	return fmt.Sprintf("local-%s-%s-%x", action, agent, time.Now().UTC().UnixNano())
+	return fmt.Sprintf("local-%s-%s-%x-%x", action, agent, time.Now().UTC().UnixNano(), localAgentJobSequence.Add(1))
 }
+
+// localAgentJobSequence is monotonic for the life of the process.
+var localAgentJobSequence atomic.Uint64
 
 // dispatchReadOnlyWorktreeEligible reports whether a dispatch should allocate a
 // dedicated detached committed-tip worktree for read-only isolation (#739). It is

--- a/internal/cli/local_job_id_1559_test.go
+++ b/internal/cli/local_job_id_1559_test.go
@@ -1,0 +1,70 @@
+package cli
+
+import (
+	"sync"
+	"testing"
+)
+
+// #1559: `local-<action>-<agent>-<hex nanos>` can collide for the same agent and
+// action inside one instant, and the insert then fails with
+// SQLITE_CONSTRAINT_PRIMARYKEY, so the job is silently not written while the
+// caller holds an id it believes exists. Observed with four reviews claimed in
+// one second under `[parallel_sessions]`.
+//
+// A PER-PROCESS COUNTER RATHER THAN RANDOMNESS, so a same-instant collision is
+// UNREACHABLE within a process rather than merely unlikely. Randomness would
+// have made the defect rarer, which is the failure mode this campaign keeps
+// finding: made invisible instead of impossible.
+//
+// The loop is not a probabilistic race hunt. It calls the minter directly and
+// concurrently, so a duplicate is a deterministic property of the id shape
+// rather than something the test has to be lucky to see: without the counter,
+// any two calls that read the same UnixNano produce byte-identical ids.
+func TestLocalAgentJobIDIsUniquePerProcess(t *testing.T) {
+	const workers = 16
+	const perWorker = 200
+
+	var mu sync.Mutex
+	seen := make(map[string]struct{}, workers*perWorker)
+	duplicates := []string{}
+
+	var wg sync.WaitGroup
+	var start sync.WaitGroup
+	start.Add(1)
+	for range workers {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			start.Wait()
+			for range perWorker {
+				id := localAgentJobID("review", "g7-review")
+				mu.Lock()
+				if _, dup := seen[id]; dup {
+					duplicates = append(duplicates, id)
+				}
+				seen[id] = struct{}{}
+				mu.Unlock()
+			}
+		}()
+	}
+	start.Done()
+	wg.Wait()
+
+	if len(duplicates) > 0 {
+		t.Fatalf("%d duplicate dispatch ids minted for one agent (%v...); a colliding id means the job is silently not written while the caller holds an id it believes exists", len(duplicates), duplicates[:1])
+	}
+	if len(seen) != workers*perWorker {
+		t.Fatalf("minted %d distinct ids, want %d", len(seen), workers*perWorker)
+	}
+}
+
+// The id must stay parseable in the established shape: consumers and operator
+// queries key on the `local-<action>-<agent>-` prefix, so adding entropy must
+// extend the id rather than restructure it.
+func TestLocalAgentJobIDKeepsItsPrefix(t *testing.T) {
+	id := localAgentJobID("review", "g7-review")
+	const want = "local-review-g7-review-"
+	if len(id) <= len(want) || id[:len(want)] != want {
+		t.Fatalf("id = %q, want the %q prefix preserved", id, want)
+	}
+}

--- a/internal/db/job_id_conflict_1559_test.go
+++ b/internal/db/job_id_conflict_1559_test.go
@@ -1,0 +1,96 @@
+package db
+
+import (
+	"context"
+	"errors"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// #1559: a job insert that loses a primary-key race surfaced one journal line,
+// `constraint failed: UNIQUE constraint failed: jobs.id (1555)`, naming no id,
+// no agent and no table context beyond the column. 1555 is
+// SQLITE_CONSTRAINT_PRIMARYKEY, so the row was silently not written.
+//
+// The observed instance cost nothing: all four dispatched jobs existed and no
+// leg failed. That is the argument FOR naming it, not against. The same shape on
+// a top-level review means the reviewer does not exist while its coordinator
+// still records a verdict, which is #1557's hollow panel.
+//
+// I hit this shape myself while fixing #1522: the deterministic fix-leg id
+// derives from task and review round, so two objections in one round mint the
+// SAME id and the second advance dies here. That collision is currently the only
+// thing preventing a duplicate writer on the branch, and attributing it took
+// hours precisely because the error named no id.
+func TestJobInsertConflictNamesTheIDItFailedToWrite(t *testing.T) {
+	ctx := context.Background()
+	store, err := openCachedTestStore(t, filepath.Join(t.TempDir(), "gitmoot.db"))
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	job := Job{ID: "local-review-g7-review-18ccc773a42446e8", Agent: "g7-review", Type: "review", State: "queued", Payload: "{}"}
+	if err := store.CreateJob(ctx, job); err != nil {
+		t.Fatalf("first insert: %v", err)
+	}
+
+	err = store.CreateJob(ctx, job)
+	if !errors.Is(err, ErrJobIDConflict) {
+		t.Fatalf("second insert error = %v, want ErrJobIDConflict so a caller can tell a collision from any other failure", err)
+	}
+	if !strings.Contains(err.Error(), job.ID) {
+		t.Fatalf("conflict error %q does not name the id it failed to write; diagnosing it needs an inventory of everything dispatched in that second", err)
+	}
+
+	// The transactional twin must behave identically, or the naming is installed
+	// on one insert path and absent on the next, which is the shape this campaign
+	// keeps finding.
+	err = store.CreateJobWithEvent(ctx, job, JobEvent{Kind: "queued", Message: "queued"})
+	if !errors.Is(err, ErrJobIDConflict) || !strings.Contains(err.Error(), job.ID) {
+		t.Fatalf("CreateJobWithEvent conflict = %v, want a named ErrJobIDConflict", err)
+	}
+
+	// A non-conflict failure must NOT be relabelled: a caller that retries on
+	// ErrJobIDConflict would otherwise retry a permanent error forever.
+	if err := store.CreateJob(ctx, Job{ID: "", Agent: "a", Type: "review", State: "queued", Payload: "{}"}); errors.Is(err, ErrJobIDConflict) {
+		t.Fatalf("a non-conflict insert failure was labelled a conflict: %v", err)
+	}
+}
+
+// The runtime column must travel on the transactional insert too (#1534). It did
+// not: AddJobEvent carried it and createJobWithEventTx dropped it, so a job
+// created together with its runtime-selection event lost the structured value
+// and fell back to the registry default. That is the misattribution #1534 exists
+// to stop, reintroduced through the call site next door, and it is a gap in my
+// own merged change.
+func TestCreateJobWithEventCarriesTheStructuredRuntime(t *testing.T) {
+	ctx := context.Background()
+	store, err := openCachedTestStore(t, filepath.Join(t.TempDir(), "gitmoot.db"))
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	job := Job{ID: "job-1", Agent: "lead", Type: "implement", State: "queued", Payload: "{}"}
+	if err := store.CreateJobWithEvent(ctx, job,
+		JobEvent{Kind: "runtime_override", Message: "job runs on runtime codex (agent default claude)", Runtime: "codex"},
+		JobEvent{Kind: "queued", Message: "queued"},
+	); err != nil {
+		t.Fatalf("CreateJobWithEvent: %v", err)
+	}
+
+	recorded, err := store.JobRecordedRuntime(ctx, "job-1", "lead")
+	if err != nil {
+		t.Fatalf("JobRecordedRuntime: %v", err)
+	}
+	if recorded != "codex" {
+		t.Fatalf("recorded runtime = %q, want %q; the structured value was dropped by the transactional insert", recorded, "codex")
+	}
+
+	// The sibling event carries no runtime and must not shadow the one that does.
+	events, err := store.ListJobEvents(ctx, "job-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(events) != 2 {
+		t.Fatalf("events = %d, want 2", len(events))
+	}
+}

--- a/internal/db/store_jobs.go
+++ b/internal/db/store_jobs.go
@@ -78,7 +78,7 @@ func (s *Store) CreateJob(ctx context.Context, job Job) error {
 		job.ParentJobID, job.DelegationID, job.DelegationDepth, job.DelegatedBy, projection.DispatchedBy,
 		rootIDFromPayload(job.Payload), job.ID, projection.WorkflowID, projection.Repo, projection.PullRequest,
 		projection.BlockerRetryAt, projection.BlockerSuggestedAction)
-	return err
+	return annotateJobInsertConflict(job.ID, err)
 }
 
 func (s *Store) CreateJobWithEvent(ctx context.Context, job Job, event JobEvent, additionalEvents ...JobEvent) error {
@@ -108,17 +108,23 @@ func createJobWithEventTx(ctx context.Context, tx *sql.Tx, s *Store, job Job, ev
 		job.ParentJobID, job.DelegationID, job.DelegationDepth, job.DelegatedBy, projection.DispatchedBy,
 		rootIDFromPayload(job.Payload), job.ID, projection.WorkflowID, projection.Repo, projection.PullRequest,
 		projection.BlockerRetryAt, projection.BlockerSuggestedAction); err != nil {
-		return err
+		return annotateJobInsertConflict(job.ID, err)
 	}
 	if event.JobID == "" {
 		event.JobID = job.ID
 	}
-	if _, err := tx.ExecContext(ctx, `INSERT INTO job_events(job_id, kind, message) VALUES (?, ?, ?)`, event.JobID, event.Kind, event.Message); err != nil {
+	// The runtime column travels here too. Carrying it on AddJobEvent and not on
+	// this transactional twin is the "correct where installed, absent at the next
+	// call site" shape, and it is a gap in my own #1534 change: a caller creating
+	// a job together with its runtime-selection event would have lost the
+	// structured value and fallen back to the registry default, which is the
+	// misattribution #1534 exists to stop.
+	if _, err := tx.ExecContext(ctx, `INSERT INTO job_events(job_id, kind, message, runtime) VALUES (?, ?, ?, ?)`, event.JobID, event.Kind, event.Message, event.Runtime); err != nil {
 		return err
 	}
 	for _, additional := range additionalEvents {
 		additional.JobID = job.ID
-		if _, err := tx.ExecContext(ctx, `INSERT INTO job_events(job_id, kind, message) VALUES (?, ?, ?)`, additional.JobID, additional.Kind, additional.Message); err != nil {
+		if _, err := tx.ExecContext(ctx, `INSERT INTO job_events(job_id, kind, message, runtime) VALUES (?, ?, ?, ?)`, additional.JobID, additional.Kind, additional.Message, additional.Runtime); err != nil {
 			return err
 		}
 	}
@@ -2554,4 +2560,37 @@ func (s *Store) JobRecordedRuntime(ctx context.Context, jobID string, agentName 
 		return "", err
 	}
 	return strings.TrimSpace(recorded), nil
+}
+
+// ErrJobIDConflict reports an insert refused because jobs.id already exists.
+var ErrJobIDConflict = errors.New("job id already exists")
+
+// annotateJobInsertConflict names the id a refused insert was trying to write
+// (#1559).
+//
+// THE RAW ERROR NAMES NOTHING. A dispatch collision surfaced as one journal line
+// - "constraint failed: UNIQUE constraint failed: jobs.id (1555)" - with no id,
+// no agent and no table context beyond the column, so diagnosing it required an
+// inventory of everything dispatched in that second. 1555 is SQLITE_CONSTRAINT_
+// PRIMARYKEY, so the row was silently not written.
+//
+// The severity of the observed instance was zero, and that is the argument FOR
+// naming it rather than against: the same shape on a top-level review means the
+// reviewer does not exist while its coordinator still records a verdict, which
+// is the hollow-panel pattern of #1557. A collision that is benign in one code
+// path is not benign in the path next door.
+//
+// Measured while fixing #1522: the deterministic fix-leg id derives from task
+// and review round, so two objections in one round mint the SAME id and the
+// second advance dies on exactly this error. That collision is currently the
+// only thing preventing a duplicate writer on the branch, and it took hours to
+// attribute because the error named no id.
+func annotateJobInsertConflict(jobID string, err error) error {
+	if err == nil {
+		return nil
+	}
+	if !strings.Contains(err.Error(), "UNIQUE constraint failed: jobs.id") {
+		return err
+	}
+	return fmt.Errorf("%w: %q was not written: %v", ErrJobIDConflict, jobID, err)
 }


### PR DESCRIPTION
Addresses #1559 asks 1 and 2, and ask 3 partially. Full reasoning on the issue at issuecomment-5575369440.

## Ask 2: the error now names the id it failed to write

Base, byte-identical to the journal line in the issue:

```
constraint failed: UNIQUE constraint failed: jobs.id (1555)
```

After:

```
job id already exists: "local-review-g7-review-18ccc773a42446e8" was not written:
constraint failed: UNIQUE constraint failed: jobs.id (1555)
```

`1555` is `SQLITE_CONSTRAINT_PRIMARYKEY`, so the row was silently not written while the caller held an id it believed existed.

Both insert paths are wrapped, `CreateJob` and the transactional `createJobWithEventTx`, because installing it on one and not the other is the "correct where installed, absent at the next call site" shape this campaign keeps finding. A non-conflict failure is deliberately NOT relabelled, with a test for that arm, so a caller retrying on `ErrJobIDConflict` cannot loop on a permanent error.

**Why a zero-cost incident was worth fixing**, using the issue's own framing plus one piece of evidence it did not have: I hit this shape independently while fixing #1522. The deterministic fix-leg id derives from task and review round, so two blocking verdicts in one round mint the **same** id and the second advance dies here. That collision is currently the only thing preventing a duplicate writer on a branch, and attributing it took hours because the error named no id. Recorded on #1533 as its own comment.

## Ask 1: a per-process counter, and a disclosure

`localAgentJobID` becomes `local-<action>-<agent>-<hex nanos>-<hex seq>`.

A counter rather than randomness, deliberately: a counter makes a same-instant collision **unreachable** within a process, while randomness only makes it rarer, which is the failure mode this campaign keeps finding. Ids stay sortable by their time component and keep the prefix operator queries key on, which a second test pins.

**I could not reproduce a `localAgentJobID` collision on this host, so that test passes on base too and is a BOUND, not a reproduction.** 3,200 concurrent mints for one agent produced zero duplicates, and consecutive calls differ by roughly 1,000ns:

```
a=local-review-g7-review-18d323e24ff496b2
b=local-review-g7-review-18d323e24ff49a92
```

I am labelling it rather than presenting a green test as evidence of a fix. The reported collision remains the evidence that the shape is reachable; my measurement says this host's clock granularity is not where it came from, and the temp-session fork path the issue names mints ids by a different route.

**Cross-process collision is not addressed** and I do not claim it is. A per-process counter cannot help two processes minting in the same nanosecond. The named error is what makes that case diagnosable in one step.

## Ask 3, partially

The dispatch boundary does not assert that a returned job id exists. What changed is that the failure is neither silent nor anonymous: the error is typed and names the id, so a caller can distinguish a collision from any other failure. Asserting existence would add a read to every dispatch and belongs with a decision about whether the dispatch path should retry, which is the unimplemented half of ask 1. I would rather that be specified than guessed.

## One defect of my own, fixed here and disclosed rather than folded in

`createJobWithEventTx` dropped the structured `runtime` value that `AddJobEvent` carries, which I added in #1534 (merged as `6d3baefd` a few hours ago). A job created together with its runtime-selection event therefore lost the value and fell back to the agent registry default: exactly the misattribution #1534 exists to stop, reintroduced through the call site next door. Found while reading this insert path, fixed with a test that asserts `JobRecordedRuntime` sees it.

## Verification

```
free space 7.41% at start, 0 DISK GUARD refusals in every log
go build ./...                          ok
go vet ./...                            ok
go test -count=1 ./internal/db/         ok  160.7s
go test -count=1 ./internal/cli/        ok  658.2s
go test -count=1 ./internal/workflow/   ok   92.9s
```

Frozen detached worktree at `3fdc2312`, one suite at a time.

Deploy notes: no config, no migration, no schema change. Dispatch ids gain a trailing sequence component; the `local-<action>-<agent>-` prefix and the time component are unchanged.
