### PR TITLE
feat(cli): report interrupt rate per seat (#1983)

### DIFF
--- a/docs/events.md
+++ b/docs/events.md
@@ -150,7 +150,16 @@ gitmoot org events rule add --on reply --wake operator --scope observer
 gitmoot org events rule list
 gitmoot org events rule set-scope <rule-id> observer
 gitmoot org events rule rm <rule-id>
+gitmoot org interrupts --window 7d
+gitmoot org interrupts --window 24h --json
 ```
+
+`gitmoot org interrupts` reports the interrupt rate the wake transport is
+actually producing: per seat, wakes and wakes per day, the median gap between
+wakes, the share of gaps under five minutes, a source breakdown, delivered
+versus unproven, wakes collapsed by coalescing, pending wakes with no enabled
+route, and completion nags. A collapsed row counts as an interrupt that did not
+happen, so the coalescing saving is readable without hand-written SQL.
 
 Rules default to `--scope addressed`: when an event carries a target role, only
 the matching addressed rule receives it. During rule evaluation,

--- a/internal/cli/org.go
+++ b/internal/cli/org.go
@@ -124,6 +124,8 @@ func runOrg(args []string, stdout, stderr io.Writer) int {
 		return runOrgAwait(args[1:], stdout, stderr)
 	case "events":
 		return runOrgEvents(args[1:], stdout, stderr)
+	case "interrupts":
+		return runOrgInterrupts(args[1:], stdout, stderr)
 	case "seat":
 		return runOrgSeat(args[1:], stdout, stderr)
 	default:
@@ -156,6 +158,7 @@ func printOrgUsage(w io.Writer) {
 	fmt.Fprintln(w, "  gitmoot org events rule list [--home DIR]")
 	fmt.Fprintln(w, "  gitmoot org events rule set-scope [--home DIR] ID observer|addressed")
 	fmt.Fprintln(w, "  gitmoot org events rule rm [--home DIR] ID")
+	fmt.Fprintln(w, "  gitmoot org interrupts [--window 24h|7d|0] [--json] [--home DIR]")
 }
 
 var orgSeatDefaultRouteKinds = []string{"blocked", "directive", "escalation", "fact", "reply"}

--- a/internal/cli/org_interrupts.go
+++ b/internal/cli/org_interrupts.go
@@ -1,0 +1,356 @@
+package cli
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"io"
+	"sort"
+	"strings"
+	"text/tabwriter"
+	"time"
+
+	"github.com/gitmoot/gitmoot/internal/db"
+	"github.com/gitmoot/gitmoot/internal/workflow"
+)
+
+// orgInterruptShortGap is the threshold the campaign measured against: a seat
+// whose wakes arrive closer together than this cannot hold a long piece of
+// work, and the two worst-affected seats sat at a 4.2 and 4.8 minute MEDIAN
+// gap (#1977).
+const orgInterruptShortGap = 5 * time.Minute
+
+const orgInterruptDefaultWindow = 7 * 24 * time.Hour
+
+// orgInterruptSeat is one seat's interrupt profile over the window.
+type orgInterruptSeat struct {
+	Role             string  `json:"role"`
+	Wakes            int     `json:"wakes"`
+	PerDay           float64 `json:"per_day"`
+	MedianGapSeconds float64 `json:"median_gap_seconds"`
+	Gaps             int     `json:"gaps"`
+	GapsUnderShort   int     `json:"gaps_under_short_threshold"`
+	// Collapsed counts wakes this seat did NOT receive because coalescing
+	// carried them on another row. It is the #1978 saving, per seat.
+	Collapsed  int            `json:"collapsed"`
+	Sources    map[string]int `json:"sources"`
+	States     map[string]int `json:"states"`
+	Delivered  int            `json:"delivered"`
+	Unproven   int            `json:"unproven"`
+	Pending    int            `json:"pending"`
+	Routeless  int            `json:"routeless_pending"`
+	OldestRLAt string         `json:"oldest_routeless_at,omitempty"`
+	// CompletionNags is how many completion-phase nudges this seat was sent
+	// for directives created in the window (#1979's population).
+	CompletionNags int `json:"completion_nags"`
+	AckNudges      int `json:"acknowledgment_nudges"`
+}
+
+type orgInterruptReport struct {
+	WindowStart        string             `json:"window_start"`
+	WindowEnd          string             `json:"window_end"`
+	WindowHours        float64            `json:"window_hours"`
+	ShortGapSeconds    float64            `json:"short_gap_threshold_seconds"`
+	Wakes              int                `json:"wakes"`
+	Collapsed          int                `json:"collapsed"`
+	Unproven           int                `json:"unproven"`
+	RoutelessPending   int                `json:"routeless_pending"`
+	Seats              []orgInterruptSeat `json:"seats"`
+	RoutelessByKindLbl map[string]int     `json:"routeless_pending_by_kind,omitempty"`
+}
+
+func runOrgInterrupts(args []string, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("org interrupts", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	home := fs.String("home", "", "home directory to use instead of the current user's home")
+	window := fs.String("window", "7d", "window to report over, for example 24h or 7d; 0 reports every recorded wake")
+	jsonOutput := fs.Bool("json", false, "emit the report as JSON")
+	if err := fs.Parse(args); err != nil {
+		fmt.Fprintf(stderr, "org interrupts: %v\n", err)
+		return 2
+	}
+	span, err := parseOrgInterruptWindow(*window)
+	if err != nil {
+		fmt.Fprintf(stderr, "org interrupts: %v\n", err)
+		return 2
+	}
+	now := time.Now().UTC()
+	since := time.Time{}
+	if span > 0 {
+		since = now.Add(-span)
+	}
+
+	var report orgInterruptReport
+	if err := withStore(*home, func(store *db.Store) error {
+		ctx := context.Background()
+		activity, err := store.ListWakeOutboxActivity(ctx, since)
+		if err != nil {
+			return err
+		}
+		nudges, err := store.ListOrgDirectiveNudges(ctx, since)
+		if err != nil {
+			return err
+		}
+		rules, err := store.ListEventRules(ctx)
+		if err != nil {
+			return err
+		}
+		report = buildOrgInterruptReport(activity, nudges, rules, since, now, span)
+		return nil
+	}); err != nil {
+		fmt.Fprintf(stderr, "org interrupts: %v\n", err)
+		return 1
+	}
+
+	if *jsonOutput {
+		if err := writeJSON(stdout, report); err != nil {
+			fmt.Fprintf(stderr, "org interrupts: %v\n", err)
+			return 1
+		}
+		return 0
+	}
+	writeOrgInterruptText(stdout, report)
+	return 0
+}
+
+func parseOrgInterruptWindow(value string) (time.Duration, error) {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return orgInterruptDefaultWindow, nil
+	}
+	if value == "0" || value == "all" {
+		return 0, nil
+	}
+	if days, ok := strings.CutSuffix(value, "d"); ok {
+		parsed, err := time.ParseDuration(days + "h")
+		if err != nil {
+			return 0, fmt.Errorf("invalid window %q", value)
+		}
+		parsed *= 24
+		if parsed < 0 {
+			return 0, fmt.Errorf("window must not be negative")
+		}
+		return parsed, nil
+	}
+	parsed, err := time.ParseDuration(value)
+	if err != nil {
+		return 0, fmt.Errorf("invalid window %q", value)
+	}
+	if parsed < 0 {
+		return 0, fmt.Errorf("window must not be negative")
+	}
+	return parsed, nil
+}
+
+// buildOrgInterruptReport aggregates the interrupt profile. It is separated
+// from the command so the arithmetic is testable without a store or a home.
+func buildOrgInterruptReport(
+	activity []db.WakeOutboxActivity,
+	nudges []db.OrgDirectiveNudgeRow,
+	rules []db.EventRule,
+	since, now time.Time,
+	span time.Duration,
+) orgInterruptReport {
+	seats := map[string]*orgInterruptSeat{}
+	arrivals := map[string][]time.Time{}
+	routelessByKind := map[string]int{}
+	seat := func(role string) *orgInterruptSeat {
+		role = strings.ToLower(strings.TrimSpace(role))
+		existing, ok := seats[role]
+		if !ok {
+			existing = &orgInterruptSeat{
+				Role:    role,
+				Sources: map[string]int{},
+				States:  map[string]int{},
+			}
+			seats[role] = existing
+		}
+		return existing
+	}
+
+	report := orgInterruptReport{
+		WindowEnd:       now.Format(time.RFC3339),
+		ShortGapSeconds: orgInterruptShortGap.Seconds(),
+	}
+	if !since.IsZero() {
+		report.WindowStart = since.Format(time.RFC3339)
+	}
+	windowHours := span.Hours()
+	for _, row := range activity {
+		entry := seat(row.TargetRole)
+		entry.States[row.State]++
+		if row.Collapsed {
+			// A collapsed row is an interrupt that did NOT happen, so it is
+			// counted separately and never as a wake.
+			entry.Collapsed++
+			report.Collapsed++
+			continue
+		}
+		entry.Wakes++
+		report.Wakes++
+		entry.Sources[row.SourceKind]++
+		switch row.State {
+		case db.WakeOutboxStateDelivered:
+			entry.Delivered++
+		case db.WakeOutboxStateStalled, db.WakeOutboxStateFailed, db.WakeOutboxStateDeliveryUnknown:
+			entry.Unproven++
+			report.Unproven++
+		case db.WakeOutboxStatePending:
+			entry.Pending++
+			if !wakeRowHasRoute(row, rules) {
+				entry.Routeless++
+				report.RoutelessPending++
+				routelessByKind[wakeRowKind(row)]++
+				if entry.OldestRLAt == "" {
+					entry.OldestRLAt = row.CreatedAt
+				}
+			}
+		}
+		if createdAt, err := time.Parse(time.RFC3339Nano, row.CreatedAt); err == nil {
+			arrivals[entry.Role] = append(arrivals[entry.Role], createdAt)
+		}
+	}
+
+	for _, row := range nudges {
+		_, to, _, _, ok := workflow.ParseOrgDirectiveNote(row.Body)
+		if !ok {
+			continue
+		}
+		entry := seat(to)
+		entry.CompletionNags += row.CompletionNudges
+		entry.AckNudges += row.AckNudges
+	}
+
+	for role, entry := range seats {
+		series := arrivals[role]
+		sort.Slice(series, func(i, j int) bool { return series[i].Before(series[j]) })
+		gaps := make([]float64, 0, len(series))
+		for index := 1; index < len(series); index++ {
+			gaps = append(gaps, series[index].Sub(series[index-1]).Seconds())
+		}
+		entry.Gaps = len(gaps)
+		for _, gap := range gaps {
+			if gap < orgInterruptShortGap.Seconds() {
+				entry.GapsUnderShort++
+			}
+		}
+		entry.MedianGapSeconds = medianFloat(gaps)
+		if windowHours > 0 {
+			entry.PerDay = float64(entry.Wakes) / (windowHours / 24)
+		}
+	}
+
+	report.WindowHours = windowHours
+	report.Seats = make([]orgInterruptSeat, 0, len(seats))
+	for _, entry := range seats {
+		report.Seats = append(report.Seats, *entry)
+	}
+	sort.Slice(report.Seats, func(i, j int) bool {
+		if report.Seats[i].Wakes != report.Seats[j].Wakes {
+			return report.Seats[i].Wakes > report.Seats[j].Wakes
+		}
+		return report.Seats[i].Role < report.Seats[j].Role
+	})
+	if len(routelessByKind) > 0 {
+		report.RoutelessByKindLbl = routelessByKind
+	}
+	return report
+}
+
+// wakeRowKind maps a stored row back to the wake kind its delivery rule must
+// name, reusing the drain's own mapping so the report cannot disagree with the
+// component that actually delivers.
+func wakeRowKind(row db.WakeOutboxActivity) string {
+	kind, ok := wakeOutboxKindForSource(row.SourceKind, row.CoalesceKey)
+	if !ok {
+		return row.SourceKind
+	}
+	return kind
+}
+
+// wakeRowHasRoute reports whether an enabled rule exists for this row's kind
+// and target role. A pending row with no route is not waiting for a tick; it is
+// waiting for configuration, and on the live fleet 49 `awaited_fact` rows had
+// been waiting that way since 2026-08-02 (#1982).
+func wakeRowHasRoute(row db.WakeOutboxActivity, rules []db.EventRule) bool {
+	kind := wakeRowKind(row)
+	role := strings.TrimSpace(row.TargetRole)
+	for _, rule := range rules {
+		if !rule.Enabled {
+			continue
+		}
+		if strings.EqualFold(strings.TrimSpace(rule.OnKind), kind) &&
+			strings.EqualFold(strings.TrimSpace(rule.WakeRole), role) {
+			return true
+		}
+	}
+	return false
+}
+
+func medianFloat(values []float64) float64 {
+	if len(values) == 0 {
+		return 0
+	}
+	sorted := append([]float64(nil), values...)
+	sort.Float64s(sorted)
+	middle := len(sorted) / 2
+	if len(sorted)%2 == 1 {
+		return sorted[middle]
+	}
+	return (sorted[middle-1] + sorted[middle]) / 2
+}
+
+func writeOrgInterruptText(stdout io.Writer, report orgInterruptReport) {
+	window := "every recorded wake"
+	if report.WindowStart != "" {
+		window = fmt.Sprintf("%s to %s (%.0fh)", report.WindowStart, report.WindowEnd, report.WindowHours)
+	}
+	fmt.Fprintf(stdout, "Interrupt rate per seat — %s\n", window)
+	fmt.Fprintf(stdout, "%d wake(s) delivered or queued, %d collapsed by coalescing, %d unproven, %d pending with no route\n\n",
+		report.Wakes, report.Collapsed, report.Unproven, report.RoutelessPending)
+	if len(report.Seats) == 0 {
+		fmt.Fprintln(stdout, "no wakes recorded in this window")
+		return
+	}
+	tw := tabwriter.NewWriter(stdout, 0, 2, 2, ' ', 0)
+	fmt.Fprintln(tw, "SEAT\tWAKES\tPER DAY\tMEDIAN GAP\t<5MIN\tNOTE\tESC\tBLK\tFACT\tDELIVERED\tUNPROVEN\tCOLLAPSED\tNO ROUTE\tNAGS")
+	for _, seat := range report.Seats {
+		fmt.Fprintf(tw, "%s\t%d\t%.1f\t%s\t%s\t%d\t%d\t%d\t%d\t%d\t%d\t%d\t%d\t%d\n",
+			seat.Role,
+			seat.Wakes,
+			seat.PerDay,
+			formatInterruptGap(seat.MedianGapSeconds),
+			formatShortGapShare(seat),
+			seat.Sources[db.WakeOutboxSourceWorkflowNote],
+			seat.Sources[db.WakeOutboxSourceEscalation],
+			seat.Sources[db.WakeOutboxSourceBlocked],
+			seat.Sources[db.WakeOutboxSourceAwaitedFact],
+			seat.Delivered,
+			seat.Unproven,
+			seat.Collapsed,
+			seat.Routeless,
+			seat.CompletionNags,
+		)
+	}
+	_ = tw.Flush()
+	for _, seat := range report.Seats {
+		if seat.Routeless > 0 {
+			fmt.Fprintf(stdout, "\n%s has %d pending wake(s) with no enabled route, oldest %s\n",
+				seat.Role, seat.Routeless, seat.OldestRLAt)
+		}
+	}
+}
+
+func formatInterruptGap(seconds float64) string {
+	if seconds <= 0 {
+		return "-"
+	}
+	return time.Duration(seconds * float64(time.Second)).Round(time.Second).String()
+}
+
+func formatShortGapShare(seat orgInterruptSeat) string {
+	if seat.Gaps == 0 {
+		return "-"
+	}
+	return fmt.Sprintf("%d/%d", seat.GapsUnderShort, seat.Gaps)
+}

--- a/internal/cli/org_interrupts_test.go
+++ b/internal/cli/org_interrupts_test.go
@@ -1,0 +1,185 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gitmoot/gitmoot/internal/db"
+	"github.com/gitmoot/gitmoot/internal/workflow"
+)
+
+// TestOrgInterruptReportArithmetic pins the numbers #1983 exists to publish.
+// Before this command the campaign's own table was derived by hand from
+// wake_outbox, which is exactly why a fix in the sibling slices could not be
+// verified and a regression could not be detected.
+func TestOrgInterruptReportArithmetic(t *testing.T) {
+	base := time.Date(2026, 9, 1, 12, 0, 0, 0, time.UTC)
+	at := func(offset time.Duration) string {
+		return base.Add(offset).Format(time.RFC3339Nano)
+	}
+	rules := []db.EventRule{
+		{ID: "reply-busy", OnKind: db.WakeOutboxKindReply, WakeRole: "busy", Enabled: true},
+		{ID: "reply-quiet", OnKind: db.WakeOutboxKindReply, WakeRole: "quiet", Enabled: true},
+		// Deliberately absent: any `fact` route. That is the live condition
+		// behind 49 obligations pending since 2026-08-02 (#1982).
+	}
+	activity := []db.WakeOutboxActivity{
+		// busy: gaps of 1m, 2m, 30m. Median of {60,120,1800} is 120s and two
+		// of the three gaps are under the five-minute threshold.
+		{ID: 1, TargetRole: "busy", SourceKind: db.WakeOutboxSourceWorkflowNote, CoalesceKey: "reply:busy", State: db.WakeOutboxStateDelivered, CreatedAt: at(0)},
+		{ID: 2, TargetRole: "busy", SourceKind: db.WakeOutboxSourceWorkflowNote, CoalesceKey: "reply:busy", State: db.WakeOutboxStateDelivered, CreatedAt: at(time.Minute)},
+		{ID: 3, TargetRole: "busy", SourceKind: db.WakeOutboxSourceEscalation, CoalesceKey: "escalation:busy", State: db.WakeOutboxStateStalled, CreatedAt: at(3 * time.Minute)},
+		{ID: 4, TargetRole: "busy", SourceKind: db.WakeOutboxSourceBlocked, CoalesceKey: "blocked:busy", State: db.WakeOutboxStateDeliveryUnknown, CreatedAt: at(33 * time.Minute)},
+		// A collapsed row is an interrupt that did NOT happen: it must not
+		// count as a wake, and it must not create a gap.
+		{ID: 5, TargetRole: "busy", SourceKind: db.WakeOutboxSourceWorkflowNote, CoalesceKey: "reply:busy", State: db.WakeOutboxStateSuperseded, CreatedAt: at(34 * time.Minute), Collapsed: true},
+		// quiet: one delivered wake, so no gap exists at all.
+		{ID: 6, TargetRole: "quiet", SourceKind: db.WakeOutboxSourceWorkflowNote, CoalesceKey: "reply:quiet", State: db.WakeOutboxStateDelivered, CreatedAt: at(time.Hour)},
+		// stranded: a pending obligation with no route for its kind.
+		{ID: 7, TargetRole: "stranded", SourceKind: db.WakeOutboxSourceAwaitedFact, CoalesceKey: "fact:stranded", State: db.WakeOutboxStatePending, CreatedAt: at(2 * time.Hour)},
+	}
+	nudges := []db.OrgDirectiveNudgeRow{
+		{ID: 10, Body: workflow.FormatOrgDirectiveNote("owner", "busy", "wf", "finish it"), AckNudges: 1, CompletionNudges: 3},
+		{ID: 11, Body: workflow.FormatOrgDirectiveNote("owner", "quiet", "wf", "and this"), CompletionNudges: 0},
+		{ID: 12, Body: "not a directive marker", CompletionNudges: 99},
+	}
+
+	report := buildOrgInterruptReport(activity, nudges, rules, base, base.Add(24*time.Hour), 24*time.Hour)
+
+	if report.Wakes != 6 || report.Collapsed != 1 {
+		t.Fatalf("report wakes=%d collapsed=%d, want 6 and 1", report.Wakes, report.Collapsed)
+	}
+	if report.Unproven != 2 {
+		t.Fatalf("report unproven=%d, want the stalled and delivery_unknown rows", report.Unproven)
+	}
+	if report.RoutelessPending != 1 || report.RoutelessByKindLbl[db.WakeOutboxKindFact] != 1 {
+		t.Fatalf("routeless=%d by kind=%v, want one fact obligation", report.RoutelessPending, report.RoutelessByKindLbl)
+	}
+	byRole := map[string]orgInterruptSeat{}
+	for _, seat := range report.Seats {
+		byRole[seat.Role] = seat
+	}
+	busy := byRole["busy"]
+	if busy.Wakes != 4 || busy.Collapsed != 1 {
+		t.Fatalf("busy wakes=%d collapsed=%d, want 4 and 1", busy.Wakes, busy.Collapsed)
+	}
+	if busy.MedianGapSeconds != 120 {
+		t.Fatalf("busy median gap = %.0fs, want 120s from gaps of 60, 120 and 1800", busy.MedianGapSeconds)
+	}
+	if busy.Gaps != 3 || busy.GapsUnderShort != 2 {
+		t.Fatalf("busy gaps=%d under-threshold=%d, want 3 and 2", busy.Gaps, busy.GapsUnderShort)
+	}
+	if busy.PerDay != 4 {
+		t.Fatalf("busy per day = %.2f, want 4 over a 24h window", busy.PerDay)
+	}
+	if busy.Sources[db.WakeOutboxSourceWorkflowNote] != 2 ||
+		busy.Sources[db.WakeOutboxSourceEscalation] != 1 ||
+		busy.Sources[db.WakeOutboxSourceBlocked] != 1 {
+		t.Fatalf("busy sources = %v, want the four kinds distinguished", busy.Sources)
+	}
+	if busy.Delivered != 2 || busy.Unproven != 2 {
+		t.Fatalf("busy delivered=%d unproven=%d, want 2 and 2", busy.Delivered, busy.Unproven)
+	}
+	if busy.CompletionNags != 3 || busy.AckNudges != 1 {
+		t.Fatalf("busy nags=%d ack=%d, want the persisted ladders", busy.CompletionNags, busy.AckNudges)
+	}
+	quiet := byRole["quiet"]
+	if quiet.Gaps != 0 || quiet.MedianGapSeconds != 0 {
+		t.Fatalf("quiet gaps=%d median=%.0f, want no gap from a single wake", quiet.Gaps, quiet.MedianGapSeconds)
+	}
+	stranded := byRole["stranded"]
+	if stranded.Routeless != 1 || stranded.OldestRLAt != at(2*time.Hour) {
+		t.Fatalf("stranded routeless=%d oldest=%q, want the unrouted obligation named", stranded.Routeless, stranded.OldestRLAt)
+	}
+	// An unparseable directive marker must not be attributed to anyone.
+	for _, seat := range report.Seats {
+		if seat.CompletionNags == 99 {
+			t.Fatalf("seat %q absorbed a malformed directive's nudges", seat.Role)
+		}
+	}
+	if report.Seats[0].Role != "busy" {
+		t.Fatalf("seats = %+v, want the most interrupted seat first", report.Seats)
+	}
+}
+
+// TestOrgInterruptsCommandReportsFromTheStore is the end-to-end path: the
+// command must produce the same numbers from real rows, in text and JSON,
+// without hand-written SQL.
+func TestOrgInterruptsCommandReportsFromTheStore(t *testing.T) {
+	store, sink, _, home := replyWakeTestHarness(t, []replyWakeTestRole{{"owner", "w1:p1"}})
+	ctx := context.Background()
+	for index := range 3 {
+		if _, err := store.InsertWorkflowNote(ctx, db.WorkflowNote{
+			WorkflowID: "release/report", Author: "worker", Body: fmt.Sprint(index),
+			AddressedTarget: "owner",
+		}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	drainReplyWakeAfterAllRowsAreDue(t, store, sink)
+
+	var stdout, stderr bytes.Buffer
+	if code := runOrg([]string{"interrupts", "--home", home, "--window", "24h"}, &stdout, &stderr); code != 0 {
+		t.Fatalf("org interrupts code=%d out=%q err=%q", code, stdout.String(), stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "Interrupt rate per seat") || !strings.Contains(stdout.String(), "owner") {
+		t.Fatalf("text report = %q", stdout.String())
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	if code := runOrg([]string{"interrupts", "--home", home, "--window", "24h", "--json"}, &stdout, &stderr); code != 0 {
+		t.Fatalf("json code=%d err=%q", code, stderr.String())
+	}
+	var report orgInterruptReport
+	if err := json.Unmarshal(stdout.Bytes(), &report); err != nil {
+		t.Fatal(err)
+	}
+	if len(report.Seats) != 1 || report.Seats[0].Role != "owner" {
+		t.Fatalf("json seats = %+v", report.Seats)
+	}
+	// Three notes coalesced into one wake: one delivered interrupt and two
+	// collapsed rows. Reading that from this command rather than from SQL is
+	// the acceptance criterion for the #1978 slice.
+	seat := report.Seats[0]
+	if seat.Wakes != 1 || seat.Collapsed != 2 || seat.Delivered != 1 {
+		t.Fatalf("seat = %+v, want one delivered wake and two collapsed rows", seat)
+	}
+	if report.Collapsed != 2 {
+		t.Fatalf("report collapsed = %d, want 2", report.Collapsed)
+	}
+}
+
+func TestOrgInterruptWindowParsing(t *testing.T) {
+	for _, test := range []struct {
+		value string
+		want  time.Duration
+		bad   bool
+	}{
+		{value: "", want: orgInterruptDefaultWindow},
+		{value: "24h", want: 24 * time.Hour},
+		{value: "7d", want: 7 * 24 * time.Hour},
+		{value: "90m", want: 90 * time.Minute},
+		{value: "0", want: 0},
+		{value: "all", want: 0},
+		{value: "-3h", bad: true},
+		{value: "-2d", bad: true},
+		{value: "soon", bad: true},
+	} {
+		got, err := parseOrgInterruptWindow(test.value)
+		if test.bad {
+			if err == nil {
+				t.Fatalf("window %q parsed as %s, want a refusal", test.value, got)
+			}
+			continue
+		}
+		if err != nil || got != test.want {
+			t.Fatalf("window %q = %s, %v; want %s", test.value, got, err, test.want)
+		}
+	}
+}

--- a/internal/db/wake_outbox.go
+++ b/internal/db/wake_outbox.go
@@ -656,8 +656,12 @@ func execWakeOutboxRowUpdate(ctx context.Context, tx *sql.Tx, query string, args
 // names the row that delivered on its behalf, so the saving is countable:
 // `SELECT count(*) FROM wake_outbox WHERE last_error LIKE 'coalesced into%'`.
 func WakeOutboxCoalescedDetail(surviving int64) string {
-	return "coalesced into wake outbox row " + strconv.FormatInt(surviving, 10)
+	return wakeOutboxCoalescedPrefix + strconv.FormatInt(surviving, 10)
 }
+
+// wakeOutboxCoalescedPrefix is the stable prefix a report matches on to count
+// suppressed wakes without re-deriving the sentence (#1983).
+const wakeOutboxCoalescedPrefix = "coalesced into wake outbox row "
 
 // FinishWakeOutbox records the observed delivery outcome for one attempted
 // batch. ids[0] is the SURVIVING row, the one the emitted wake identifies.

--- a/internal/db/wake_outbox_activity.go
+++ b/internal/db/wake_outbox_activity.go
@@ -1,0 +1,98 @@
+package db
+
+import (
+	"context"
+	"strings"
+	"time"
+)
+
+// WakeOutboxActivity is one wake row reduced to the fields an interrupt-rate
+// report needs (#1983). The report aggregates in Go rather than in SQL because
+// a median gap needs the ordered arrival series per role, not a scalar, and
+// because the rows are already bounded by the window.
+type WakeOutboxActivity struct {
+	ID          int64
+	TargetRole  string
+	SourceKind  string
+	CoalesceKey string
+	State       string
+	CreatedAt   string
+	// Collapsed marks a row that another row's wake carried (#1978). It is the
+	// per-row form of the coalescing saving, so a report can state how many
+	// interrupts were avoided rather than only how many happened.
+	Collapsed bool
+}
+
+// ListWakeOutboxActivity returns every wake row created at or after `since`,
+// oldest first. An empty `since` window returns the whole table.
+func (s *Store) ListWakeOutboxActivity(ctx context.Context, since time.Time) ([]WakeOutboxActivity, error) {
+	query := `
+SELECT id, target_role, source_kind, coalesce_key, state, created_at, last_error
+FROM wake_outbox`
+	var args []any
+	if !since.IsZero() {
+		query += "\nWHERE created_at >= ?"
+		args = append(args, since.UTC().Format(BlockedEpisodeTimeLayout))
+	}
+	query += "\nORDER BY created_at, id"
+	rows, err := s.db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	activity := []WakeOutboxActivity{}
+	for rows.Next() {
+		var entry WakeOutboxActivity
+		var lastError string
+		if err := rows.Scan(
+			&entry.ID, &entry.TargetRole, &entry.SourceKind,
+			&entry.CoalesceKey, &entry.State, &entry.CreatedAt, &lastError,
+		); err != nil {
+			return nil, err
+		}
+		entry.Collapsed = strings.HasPrefix(lastError, wakeOutboxCoalescedPrefix)
+		activity = append(activity, entry)
+	}
+	return activity, rows.Err()
+}
+
+// OrgDirectiveNudgeRow carries the persisted nudge ladders for one directive.
+// The target role lives in the body marker, so the caller parses it with the
+// same parser the evaluator uses instead of a second SQL implementation.
+type OrgDirectiveNudgeRow struct {
+	ID               int64
+	Body             string
+	AckNudges        int
+	CompletionNudges int
+	CreatedAt        string
+}
+
+// ListOrgDirectiveNudges returns directives created at or after `since` with
+// their persisted nudge counts, so a report can state how many completion nags
+// a seat was actually sent (#1979's population) without hand-written SQL.
+func (s *Store) ListOrgDirectiveNudges(ctx context.Context, since time.Time) ([]OrgDirectiveNudgeRow, error) {
+	query := `
+SELECT id, body, directive_nudge_count, directive_done_nudge_count, created_at
+FROM workflow_notes
+WHERE substr(body, 1, length('[org:directive ')) = '[org:directive '`
+	var args []any
+	if !since.IsZero() {
+		query += "\n\tAND created_at >= ?"
+		args = append(args, since.UTC().Format(BlockedEpisodeTimeLayout))
+	}
+	query += "\nORDER BY created_at, id"
+	rows, err := s.db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	out := []OrgDirectiveNudgeRow{}
+	for rows.Next() {
+		var row OrgDirectiveNudgeRow
+		if err := rows.Scan(&row.ID, &row.Body, &row.AckNudges, &row.CompletionNudges, &row.CreatedAt); err != nil {
+			return nil, err
+		}
+		out = append(out, row)
+	}
+	return out, rows.Err()
+}

--- a/skills/gitmoot/references/CLI.md
+++ b/skills/gitmoot/references/CLI.md
@@ -1969,6 +1969,20 @@ removed role as its exact address, leaving delivery failure observable instead
 of making the wait immortal. Fact wakes are delivery only: they require a `fact`
 event rule but create no acknowledgment or completion ceremony.
 
+`gitmoot org interrupts [--window 24h|7d|0] [--json] [--home <dir>]` reports
+**how often each seat is interrupted** (#1983). Per seat, over the window:
+wakes, wakes per day, median gap, share of gaps under five minutes, a breakdown
+by source (`workflow_note`, `escalation`, `blocked`, `awaited_fact`), delivered
+versus unproven, wakes **collapsed** by coalescing, pending wakes with **no
+enabled route** and the oldest such timestamp, and completion nags recorded
+against the seat's directives. `--window` takes a Go duration, `<n>d`, or
+`0`/`all`; default `7d`.
+
+A collapsed row counts as an interrupt that did NOT happen, never as a wake, so
+the coalescing saving is readable here rather than by hand-written SQL. A
+`pending` row whose kind and role have no enabled rule is an obligation waiting
+on configuration rather than on a tick.
+
 Event-rule wakes are separately opt-in:
 
 ```sh

--- a/website/docs/reference/cli.md
+++ b/website/docs/reference/cli.md
@@ -1689,6 +1689,24 @@ removed role as its exact address, leaving delivery failure observable instead
 of making the wait immortal. Fact wakes are delivery only: they require a `fact`
 event rule but create no acknowledgment or completion ceremony.
 
+`gitmoot org interrupts [--window 24h|7d|0] [--json] [--home <dir>]` reports
+**how often each seat is interrupted**, which is the variable that best
+predicted completed work in the transport campaign (#1983). Per seat, over the
+window: wakes, wakes per day, median gap between wakes, the share of gaps under
+five minutes, a breakdown by source (`workflow_note`, `escalation`, `blocked`,
+`awaited_fact`), delivered versus unproven, wakes **collapsed** by coalescing,
+pending wakes with **no enabled route**, and completion nags recorded against
+the seat's directives. `--window` accepts a Go duration, a `<n>d` day count, or
+`0`/`all` for every recorded wake; it defaults to `7d`. `--json` emits the same
+report, including per-kind routeless totals.
+
+Two properties make it a regression check rather than a dashboard. A collapsed
+row is counted as an interrupt that did **not** happen, never as a wake, so the
+coalescing saving is readable directly. And a `pending` row whose kind and role
+have no enabled rule is reported as `NO ROUTE` with its oldest timestamp, which
+is how a fleet discovers obligations that are waiting on configuration rather
+than on a tick.
+
 Event-rule wakes are separately opt-in:
 
 ```sh


### PR DESCRIPTION
Fixes #1983. Last slice of the #1977 campaign.

## What it does

`gitmoot org interrupts [--window 24h|7d|0] [--json] [--home <dir>]`. Smoke-tested against a copy of the live store, 7-day window, verbatim:

```
Interrupt rate per seat — 2026-08-31T21:06:11Z to 2026-09-07T21:06:11Z (168h)
3638 wake(s) delivered or queued, 7 collapsed by coalescing, 504 unproven, 54 pending with no route

SEAT                WAKES  PER DAY  MEDIAN GAP  <5MIN    NOTE  ESC  BLK  FACT  DELIVERED  UNPROVEN  COLLAPSED  NO ROUTE  NAGS
gitmoot             729    104.1    4m5s        405/728  723   0    5    1     568        0         0          5         96
jarvis              670    95.7     5m42s       305/669  490   154  20   6     509        131       0          30        0
gm-reviewfix-coc    478    68.3     4m1s        273/477  478   0    0    0     383        0         0          13        61
apps-coc            289    41.3     9m8s        111/288  285   0    4    0     36         239       0          0         75
gm-reviewfix-c      286    40.9     4m46s       149/285  284   0    2    0     222        0         0          0         20
gm-omp-impl         195    27.9     16m56s      47/194   195   0    0    0     154        0         0          0         87
...
omp-router          65     9.3      1m40s       40/64    65    0    0    0     24         30        0          0         54
```

That reproduces the campaign's hand-derived table independently: `gm-reviewfix-coc` at a **4m1s** median gap against the issue's 4.2 min, and `gm-reviewfix-c` at **4m46s** against 4.8 min. It also surfaces `gitmoot` at **104 wakes/day with 405 of 728 gaps under five minutes**, which the issue's table did not have, and `omp-router` at a **1m40s median**, the worst gap on the fleet.

## Acceptance, item by item

- **One command shows wakes per day and median gap per seat over a chosen window**: yes, `--window` takes a Go duration, an `<n>d` day count, or `0`/`all`, defaulting to `7d`.
- **The report distinguishes `workflow_note`, `escalation`, `blocked` and `awaited_fact`**: the NOTE/ESC/BLK/FACT columns, and the full map in JSON.
- **Before-and-after for the coalescing and nag slices readable from the report**: `COLLAPSED` is #1978's saving per seat, counted as an interrupt that did **not** happen and never as a wake; `NAGS` is the persisted completion-nudge ladder per seat, which is #1979's population; `UNPROVEN` is #1982's.

## Two design choices worth reviewing

**A collapsed row is not a wake.** `wake_outbox` rows superseded into a survivor are counted in `COLLAPSED` and excluded from `WAKES`, gaps and per-day. Otherwise enforcing coalescing would appear to *raise* the interrupt rate, since the rows still exist. The end-to-end test pins it: three notes to one seat produce `wakes=1, collapsed=2`.

**Route matching reuses the drain's own mapping.** `wakeRowKind` calls `wakeOutboxKindForSource`, the same function the drain uses to decide what rule a row needs, so the report cannot disagree with the component that actually delivers. A `NO ROUTE` row is therefore exactly a row the drain would classify inert.

## The scoped routeless list PHOBOS asked for

He measured that 39 of the 49 routeless `awaited_fact` rows are addressed to the retired management layer (`jarvis` 17, `apps-coc` 22) and told me not to propose routes for those. Here are **the ten live-role rows**, and one fact changes the recommendation:

| Row | Role | Age | Awaited | Fact state |
| --- | --- | --- | --- | --- |
| 1692 | aste-screener | 36d | `review_verdict jerryfane/aste-screener#52@372d654` | **satisfied** |
| 1730 | aste-screener | 36d | `#54@4b9fbf0` | **satisfied** |
| 1756 | aste-screener | 35d | `#54@3944026` | **satisfied** |
| 1808 | aste-screener | 35d | `#53@ac8b251` | **satisfied** |
| 1810 | aste-screener | 35d | `#53@4b485b8` | **satisfied** |
| 1824 | aste-screener | 35d | `#54@a19c1d2` | **satisfied** |
| 3391 | joltra | 19d | `jerryfane/joltra#721@d4e405fa` | **satisfied** |
| 4970 | herdr-app | 10d | `jerryfane/herdr#30@a7698211` | **satisfied** |
| 10370 | vetrina | 0d | `jerryfane/vetrina#126@f9a64179` | **satisfied** |
| 10381 | vetrina | 0d | `jerryfane/vetrina#126@6551d202` | **satisfied** |

**All ten are `satisfied`, not `expired`.** They are not missed deadlines; they are notifications that a verdict the seat was waiting for **arrived**, undelivered for up to 36 days. So adding a `fact` route for these four roles would immediately fire ten wakes, nine of them stale news.

My recommendation, for you to decide with the deploy and not for a PR to enact:

1. Add `fact` routes for `aste-screener`, `joltra`, `herdr-app` and `vetrina` **going forward**, so future satisfied and expired facts reach them at all.
2. Do **not** deliver rows 1692, 1730, 1756, 1808, 1810, 1824, 3391 and 4970. A 36-day-old "your verdict arrived" is noise. Supersede those eight explicitly with a recorded cause, as a one-time operator action on identified rows.
3. Rows 10370 and 10381 are from today and are worth delivering.

I am not creating routes and not auto-failing routeless rows, for the reasons in #1982: routes are org config, and code that silently ages out any routeless row would erase obligations a later rule could still deliver.

## Tests

- `TestOrgInterruptReportArithmetic`: fixed arrival series, so the median (120s from gaps of 60/120/1800), the under-threshold share (2 of 3), per-day (4 over 24h), the source split, delivered-versus-unproven, the routeless row with its oldest timestamp, and the nag attribution are all pinned. It also asserts a collapsed row creates neither a wake nor a gap, and that a malformed directive marker is attributed to **nobody** rather than to some seat.
- `TestOrgInterruptsCommandReportsFromTheStore`: the real path, three notes coalesced into one wake, asserting `wakes=1, collapsed=2, delivered=1` in both text and JSON.
- `TestOrgInterruptWindowParsing`: `7d`, `24h`, `90m`, `0`, `all`, and refusals for `-3h`, `-2d`, `soon`.

## Verification

Full local gate on this head with go1.26.4 pinned: `go build -buildvcs=false ./...`, `go vet ./...`, `go test -count=1 -timeout 25m ./...`, **zero failures**, disk 6.21% free (above the 5% dispatch guard). I also re-ran the whole gate on integrated `main` after merging #1982, clean, per the base-staleness practice.

Live smoke test: built the binary and ran the command against a **copy** of the live store on an isolated `/tmp` home. The live store was never written from this seat.

`-race` is CI's shards; race requires cgo, unavailable locally per this repo's gate.

## Not verified

- **Not surfaced in `gitmoot dashboard`.** The issue asks for the dashboard too. I implemented the command and the JSON, which are what make the sibling slices verifiable, and left the dashboard alone deliberately: the dashboard is a separate web surface with its own tests, and bundling a UI change into the measurement slice would make this diff harder to review than the thing it measures. It is a clean follow-up on top of the JSON.
- **No before/after for #1979 from this report.** The nag column is durable, but the *deferral* count is not: a deferred nag writes a daemon log line, not a row. Making it durable would add a write per minute per directive, which I judged worse than the gap. The honest measurement for #1979 remains its test-level reproduction.

Deploy notes: no migration, read-only command. It ships with the binary.
