### PR TITLE
feat(review): a repository declares whether it consumes review findings (#1969)

### DIFF
--- a/internal/cli/findings.go
+++ b/internal/cli/findings.go
@@ -7,11 +7,24 @@ import (
 	"flag"
 	"fmt"
 	"io"
+	"strings"
 	"text/tabwriter"
 
 	"github.com/gitmoot/gitmoot/internal/config"
 	"github.com/gitmoot/gitmoot/internal/db"
 )
+
+// findingsDeclaration renders a repository's #1969 findings-consumption
+// declaration. An unset value prints as "undeclared" rather than as its
+// behavioural equivalent "consuming", because the whole point of the column is
+// that a repository nobody has decided about is visible as one.
+func findingsDeclaration(cfg config.ReviewConfig, repo string) string {
+	declared := strings.TrimSpace(cfg.For(repo).FindingsConsumption)
+	if declared == "" {
+		return "undeclared"
+	}
+	return strings.ToLower(declared)
+}
 
 // runFindings reports the #1822 findings ledger per repository.
 //
@@ -48,6 +61,7 @@ func runFindings(args []string, stdout, stderr io.Writer) int {
 		return 2
 	}
 
+	reviewCfg := loadReviewConfig(*home)
 	var rows []db.ReviewFindingConsumption
 	if err := withStoreAndPaths(*home, func(_ config.Paths, store *db.Store) error {
 		var err error
@@ -73,10 +87,11 @@ func runFindings(args []string, stdout, stderr io.Writer) int {
 		return 0
 	}
 	writer := tabwriter.NewWriter(stdout, 0, 0, 2, ' ', 0)
-	fmt.Fprintln(writer, "REPO\tFINDINGS\tOPEN\tAT HEAD\tAT EARLIER HEAD\tHEAD UNKNOWN\tANSWERED\tWITHDRAWN\tSUPERSEDED")
+	fmt.Fprintln(writer, "REPO\tDECLARED\tFINDINGS\tOPEN\tAT HEAD\tAT EARLIER HEAD\tHEAD UNKNOWN\tANSWERED\tWITHDRAWN\tSUPERSEDED")
 	for _, row := range rows {
-		fmt.Fprintf(writer, "%s\t%d\t%d\t%d\t%d\t%d\t%d\t%d\t%d\n",
-			row.Repo, row.Findings, row.Open, row.OpenAtCurrentHead, row.OpenAtEarlierHead,
+		fmt.Fprintf(writer, "%s\t%s\t%d\t%d\t%d\t%d\t%d\t%d\t%d\t%d\n",
+			row.Repo, findingsDeclaration(reviewCfg, row.Repo), row.Findings, row.Open,
+			row.OpenAtCurrentHead, row.OpenAtEarlierHead,
 			row.OpenHeadUnknown, row.Answered, row.Withdrawn, row.Superseded)
 	}
 	if err := writer.Flush(); err != nil {
@@ -90,5 +105,7 @@ func runFindings(args []string, stdout, stderr io.Writer) int {
 	fmt.Fprintln(stdout, "OPEN findings block a merge at every later head until a reviewer answers or withdraws them,")
 	fmt.Fprintln(stdout, "so AT EARLIER HEAD is a backlog nobody has looked at, not a set that has expired.")
 	fmt.Fprintln(stdout, "A repository with findings and ANSWERED 0 is recording obligations nothing consumes.")
+	fmt.Fprintln(stdout, "DECLARED undeclared means nobody has decided whether this repository consumes findings;")
+	fmt.Fprintln(stdout, "it behaves as consuming. advisory records and reports findings without holding the merge.")
 	return 0
 }

--- a/internal/cli/review_risk.go
+++ b/internal/cli/review_risk.go
@@ -32,7 +32,8 @@ func loadReviewConfig(home string) config.ReviewConfig {
 }
 
 // applyReviewPolicy copies the global risk-tier policy and installs the
-// repository-aware native-fanout and blocking-severity resolvers onto the engine.
+// repository-aware native-fanout, blocking-severity and findings-consumption
+// resolvers onto the engine.
 func applyReviewPolicy(engine *workflow.Engine, home string) {
 	cfg := loadReviewConfig(home)
 	policy := cfg.For("")
@@ -41,6 +42,12 @@ func applyReviewPolicy(engine *workflow.Engine, home string) {
 	}
 	engine.ReviewBlockingSeverity = func(repo string) string {
 		return cfg.For(repo).BlockingSeverity
+	}
+	// #1969: installed beside the severity resolver, from the SAME cfg value, so
+	// a repository cannot end up with one review policy field resolved and
+	// another not. Undeclared and consuming both resolve false.
+	engine.FindingsAdvisory = func(repo string) bool {
+		return cfg.For(repo).FindingsAreAdvisory()
 	}
 	engine.RiskTiersEnabled = policy.RiskTiersEnabled
 	engine.HighRiskPaths = policy.HighRiskPaths

--- a/internal/config/findings_consumption_1969_test.go
+++ b/internal/config/findings_consumption_1969_test.go
@@ -1,0 +1,104 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// #1969. A repository declares whether it consumes review findings. The parse
+// rules matter more than usual here because this is the one review-policy field
+// that can RELAX a merge gate, so every ambiguous input must land on consuming.
+func TestFindingsConsumptionParsesAndFailsClosed(t *testing.T) {
+	for _, tc := range []struct {
+		name         string
+		body         string
+		wantAdvisory bool
+		wantDeclared string
+		wantErr      bool
+	}{
+		{
+			name:         "unset is undeclared and still consuming",
+			body:         "[review]\nblocking_severity = \"P2\"\n",
+			wantDeclared: "",
+		},
+		{
+			name:         "an explicit consuming declaration is recorded and still consuming",
+			body:         "[review]\nfindings_consumption = \"consuming\"\n",
+			wantDeclared: FindingsConsuming,
+		},
+		{
+			name:         "advisory is the only value that relaxes",
+			body:         "[review]\nfindings_consumption = \"advisory\"\n",
+			wantAdvisory: true,
+			wantDeclared: FindingsAdvisory,
+		},
+		{
+			name:         "case is not a way to smuggle a different value",
+			body:         "[review]\nfindings_consumption = \"ADVISORY\"\n",
+			wantAdvisory: true,
+			wantDeclared: FindingsAdvisory,
+		},
+		{
+			// A typo must not read as undeclared-and-therefore-fine: the operator
+			// plainly meant to relax the gate and will believe they did, so the
+			// value is refused AND the policy stays consuming.
+			name:         "a misspelled declaration errors and stays consuming",
+			body:         "[review]\nfindings_consumption = \"advisroy\"\n",
+			wantDeclared: "",
+			wantErr:      true,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			home := t.TempDir()
+			paths := PathsForHome(home)
+			if err := os.MkdirAll(filepath.Dir(paths.ConfigFile), 0o700); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.WriteFile(paths.ConfigFile, []byte(tc.body), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			cfg, err := LoadReviewConfig(paths)
+			if tc.wantErr && err == nil {
+				t.Fatal("an unsupported findings_consumption was accepted silently")
+			}
+			if !tc.wantErr && err != nil {
+				t.Fatalf("LoadReviewConfig: %v", err)
+			}
+			policy := cfg.For("owner/repo")
+			if policy.FindingsConsumption != tc.wantDeclared {
+				t.Errorf("declaration = %q, want %q", policy.FindingsConsumption, tc.wantDeclared)
+			}
+			if policy.FindingsAreAdvisory() != tc.wantAdvisory {
+				t.Errorf("advisory = %v, want %v; only an explicit advisory may relax the obligation gate",
+					policy.FindingsAreAdvisory(), tc.wantAdvisory)
+			}
+		})
+	}
+}
+
+// A per-repository declaration wins over the global one, and it wins in BOTH
+// directions: a fleet that has declared itself advisory must still be able to
+// hold one repository to consuming, or the knob can only ever loosen.
+func TestFindingsConsumptionRepositoryOverrideWinsBothWays(t *testing.T) {
+	home := t.TempDir()
+	paths := PathsForHome(home)
+	if err := os.MkdirAll(filepath.Dir(paths.ConfigFile), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	body := "[review]\nfindings_consumption = \"advisory\"\n\n" +
+		"[repos.\"owner/strict\".review]\nfindings_consumption = \"consuming\"\n"
+	if err := os.WriteFile(paths.ConfigFile, []byte(body), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := LoadReviewConfig(paths)
+	if err != nil {
+		t.Fatalf("LoadReviewConfig: %v", err)
+	}
+	if !cfg.For("owner/loose").FindingsAreAdvisory() {
+		t.Error("the global advisory declaration did not reach an unlisted repository")
+	}
+	if cfg.For("owner/strict").FindingsAreAdvisory() {
+		t.Error("a repository declared consuming was relaxed by the global advisory declaration")
+	}
+}

--- a/internal/config/init.go
+++ b/internal/config/init.go
@@ -384,9 +384,22 @@ path = ""
 # risk_label_high = "risk:high"
 # risk_label_routine = "risk:routine"
 #
+# findings_consumption declares whether a repository CONSUMES review findings or
+# treats them as ADVISORY (#1969). Leaving it unset is NOT the same as declaring
+# "consuming": both keep today's behaviour, where an unobserved prior finding
+# holds the merge, but an unset repository reports as undeclared in
+# 'gitmoot findings' so the absence of a decision is visible. Declaring
+# "advisory" keeps recording and reporting findings while letting the merge
+# proceed past them, and every such merge records a
+# findings_ledger_advisory_merge task event naming what it went past, so
+# advisory means stated rather than silent. Only an explicit "advisory" relaxes
+# anything; an unreadable value fails closed to consuming.
+# findings_consumption = "consuming"
+#
 # [repos."owner/repo".review]
 # native_fanout_enabled = true
 # blocking_severity = "P1"
+# findings_consumption = "advisory"
 
 # [merge_gate] controls native task merges. Native auto-merge is enabled by
 # default, but only when an approved review verdict matches the exact current

--- a/internal/config/orchestrate.go
+++ b/internal/config/orchestrate.go
@@ -456,6 +456,30 @@ type ReviewPolicy struct {
 	// (risk:high / risk:routine).
 	RiskLabelHigh    string
 	RiskLabelRoutine string
+	// FindingsConsumption declares whether a repository CONSUMES review findings
+	// or treats them as ADVISORY (#1969). Three values, and the empty one is not
+	// a synonym for either:
+	//
+	//   ""           undeclared. Behaves exactly as before this field existed:
+	//                unobserved obligations hold the merge. Reported as
+	//                undeclared so the absence is visible rather than assumed.
+	//   "consuming"  the same behaviour, stated on purpose.
+	//   "advisory"   findings are still recorded and still reported, but they do
+	//                not hold the merge.
+	//
+	// WHY THE ADVISORY OPTION EXISTS, measured. 211 findings were recorded across
+	// five repositories that have never answered one, and the obligation gate is
+	// live: it refused 16 times across 5 repositories, including vetrina#126 on
+	// 37 prior findings all "still open" and coordinator-checkin#3 on 17. That is
+	// exactly the wedge findings_ledger_writer.go's header predicts when the
+	// write half runs without the read half - a guard that rejects valid input.
+	//
+	// It is a DECLARATION, not a default, and it is deliberately not inferred
+	// from behaviour: a repository that has answered nothing might be ignoring
+	// its reviews or might simply be new. Only an operator knows which, so an
+	// undeclared repository keeps the blocking behaviour and shows up as
+	// undeclared in `gitmoot findings`.
+	FindingsConsumption string
 }
 
 func DefaultReviewPolicy() ReviewPolicy {
@@ -463,7 +487,24 @@ func DefaultReviewPolicy() ReviewPolicy {
 		NativeFanoutEnabled: false,
 		BlockingSeverity:    reviewseverity.DefaultBlocking,
 		RiskTiersEnabled:    false,
+		// Undeclared, which behaves as consuming. Defaulting to "consuming" here
+		// would make an operator's explicit declaration indistinguishable from
+		// never having made one, and the whole point is that the absence shows.
+		FindingsConsumption: "",
 	}
+}
+
+// Findings-consumption declarations. A repository is CONSUMING unless it says
+// otherwise, so the zero value cannot relax a gate.
+const (
+	FindingsConsuming = "consuming"
+	FindingsAdvisory  = "advisory"
+)
+
+// FindingsAreAdvisory reports whether unobserved obligations may be recorded
+// without holding the merge. Only an explicit "advisory" relaxes it.
+func (p ReviewPolicy) FindingsAreAdvisory() bool {
+	return strings.EqualFold(strings.TrimSpace(p.FindingsConsumption), FindingsAdvisory)
 }
 
 // ReviewConfig is the parsed global [review] policy plus repository-scoped
@@ -529,6 +570,7 @@ func ReviewConfigErrorsOnlyBlockingSeverity(err error) bool {
 type reviewPolicyOverride struct {
 	nativeFanoutEnabled *bool
 	blockingSeverity    *string
+	findingsConsumption *string
 }
 
 // For resolves the effective policy for repo. Risk-tier settings remain global;
@@ -542,6 +584,9 @@ func (c ReviewConfig) For(repo string) ReviewPolicy {
 	}
 	if ok && override.blockingSeverity != nil {
 		policy.BlockingSeverity = *override.blockingSeverity
+	}
+	if ok && override.findingsConsumption != nil {
+		policy.FindingsConsumption = *override.findingsConsumption
 	}
 	return policy
 }
@@ -675,6 +720,17 @@ func applyReviewPolicyField(policy *ReviewPolicy, key string, value string) erro
 		}
 		policy.RiskLabelRoutine = strings.TrimSpace(parsed)
 		return nil
+	case "findings_consumption":
+		parsed, err := parseFindingsConsumption(value)
+		if err != nil {
+			// Fail CLOSED, like blocking_severity: an unreadable declaration
+			// leaves the repository consuming, never advisory, so a typo can
+			// never quietly stop findings holding a merge.
+			policy.FindingsConsumption = ""
+			return err
+		}
+		policy.FindingsConsumption = parsed
+		return nil
 	default:
 		return nil
 	}
@@ -698,8 +754,35 @@ func applyReviewPolicyOverrideField(override *reviewPolicyOverride, key string, 
 		}
 		override.blockingSeverity = &parsed
 		return nil
+	case "findings_consumption":
+		parsed, err := parseFindingsConsumption(value)
+		if err != nil {
+			safe := ""
+			override.findingsConsumption = &safe
+			return err
+		}
+		override.findingsConsumption = &parsed
+		return nil
 	default:
 		return nil
+	}
+}
+
+// parseFindingsConsumption accepts only the two declarations and the empty
+// string. An unrecognised value is an ERROR rather than a silent fallback,
+// because "advisroy" must not read as undeclared-and-therefore-fine when the
+// operator plainly meant to relax the gate and will believe they did.
+func parseFindingsConsumption(value string) (string, error) {
+	parsed, err := parseConfigString(value)
+	if err != nil {
+		return "", err
+	}
+	declaration := strings.ToLower(strings.TrimSpace(parsed))
+	switch declaration {
+	case "", FindingsConsuming, FindingsAdvisory:
+		return declaration, nil
+	default:
+		return "", fmt.Errorf("unsupported findings_consumption %q; want %q or %q", parsed, FindingsConsuming, FindingsAdvisory)
 	}
 }
 

--- a/internal/workflow/engine.go
+++ b/internal/workflow/engine.go
@@ -282,6 +282,13 @@ type Engine struct {
 	// ReviewBlockingSeverity resolves the least severe review finding that may
 	// restart the fix loop for a repository. Nil preserves block-all behavior.
 	ReviewBlockingSeverity func(repo string) string
+	// FindingsAdvisory resolves the repository's #1969 findings-consumption
+	// declaration. nil, or false, means the repository is undeclared or
+	// consuming and unobserved obligations keep holding the merge. It mirrors
+	// ReviewBlockingSeverity's shape deliberately: one resolver per repository
+	// policy, installed by the same wiring, so the two cannot be configured
+	// through different paths and disagree.
+	FindingsAdvisory func(repo string) bool
 	// RiskTiersEnabled gates the opt-in risk-tiered adaptive review (#650). When
 	// false (the default), HandlePullRequestOpened NEVER classifies a PR and runs
 	// the single-review fan-out byte-identically. When true, a PR opened event is

--- a/internal/workflow/engine_routing_merge.go
+++ b/internal/workflow/engine_routing_merge.go
@@ -1020,6 +1020,7 @@ func (e Engine) runMergeGateWithHumanMerge(ctx context.Context, reviewer string,
 		Reviewer:                reviewer,
 		ReviewOptional:          !reviewRequired,
 		ReviewBlockingSeverity:  e.reviewBlockingSeverity(payload.Repo),
+		FindingsAdvisory:        e.findingsAdvisory(payload.Repo),
 		ExpectedTaskState:       expectedTaskState,
 		HumanMergeRequested:     humanMergeRequested,
 	})

--- a/internal/workflow/engine_types.go
+++ b/internal/workflow/engine_types.go
@@ -343,6 +343,12 @@ type MergeRequest struct {
 	// ReviewBlockingSeverity is the resolved repository threshold carried into
 	// the merge gate. Empty preserves the historical block-all behavior.
 	ReviewBlockingSeverity string
+	// FindingsAdvisory carries the repository's #1969 declaration: when true,
+	// unobserved ledger obligations are RECORDED and REPORTED but do not hold
+	// the merge. Empty/false preserves today's behaviour, so an undeclared
+	// repository is unchanged and only an explicit operator declaration relaxes
+	// anything.
+	FindingsAdvisory bool
 	// HumanMergeRequested is an explicit, authorized human instruction. It is
 	// evaluated inside PolicyMergeGate, never by a caller-side bypass.
 	HumanMergeRequested bool

--- a/internal/workflow/findings_advisory_1969_test.go
+++ b/internal/workflow/findings_advisory_1969_test.go
@@ -1,0 +1,140 @@
+package workflow
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/gitmoot/gitmoot/internal/db"
+)
+
+// #1969's remaining acceptance: a repository declares whether it CONSUMES review
+// findings or treats them as ADVISORY.
+//
+// THE GATE THIS RELAXES IS LIVE, not theoretical. Measured on this box:
+// EnsureLedgerObligationsObserved refused 16 times across 5 repositories,
+// including jerryfane/vetrina#126 held on 37 prior findings all "still open" and
+// gitmoot/coordinator-checkin#3 on 17. That is the wedge
+// findings_ledger_writer.go's header predicts when the write half runs without
+// the read half: a guard rejecting valid input because nobody was ever told the
+// uids it demands.
+//
+// So the declaration has to do three things, and each is a subtest: an
+// undeclared repository must be unchanged, an advisory one must merge past the
+// obligations, and an advisory merge must SAY what it went past. The third is
+// the one that keeps "advisory" from meaning "silent", which would reproduce
+// #1969's defect with an operator's signature on it.
+func TestAdvisoryDeclarationRelaxesTheLedgerGateAndRecordsWhatItPassed(t *testing.T) {
+	// The obligation is recorded at a PRIOR head and evaluated at a later one,
+	// which is the real wedge: an observation recorded AT the evaluated head is
+	// already discharged there and pends nothing. My first fixture used one head
+	// for both and the premise assertion below caught it.
+	priorHead := strings.Repeat("ab12cd34ef", 4)
+	head := strings.Repeat("99f00d1234", 4)
+
+	for _, tc := range []struct {
+		name        string
+		advisory    bool
+		wantRefusal bool
+		wantNote    bool
+	}{
+		{name: "undeclared repository still refuses", advisory: false, wantRefusal: true},
+		{name: "advisory repository merges past and records it", advisory: true, wantNote: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+			store := openEngineStore(t)
+			if err := store.UpsertTask(ctx, db.Task{
+				ID: "task-1969", RepoFullName: "owner/repo", GoalID: "goal", Title: "t",
+				State: string(TaskReviewing), Branch: "feature",
+			}); err != nil {
+				t.Fatalf("UpsertTask: %v", err)
+			}
+			if _, err := store.RecordReviewFindingObservation(ctx, db.ReviewFindingObservation{
+				Repo: "owner/repo", PullRequest: 7, HeadSHA: priorHead,
+				ObserverJob: "local-review-round-1", State: db.FindingOpen, Severity: "P1",
+				RoundLabel: "F1", Title: "an obligation nobody observed",
+				Detail: "recorded and never answered", File: "internal/a.go",
+				EvidenceKind: db.EvidenceExecuted, ExecutedCommands: []string{"go test"}, ExecutedCount: 1,
+			}); err != nil {
+				t.Fatalf("RecordReviewFindingObservation: %v", err)
+			}
+
+			request := MergeRequest{
+				Repo: "owner/repo", PullRequest: 7, TaskID: "task-1969",
+				Reviewer: "reviewer", FindingsAdvisory: tc.advisory,
+			}
+			gate := PolicyMergeGate{Store: store}
+
+			// THE PREMISE, and it is what makes the advisory arm mean anything:
+			// without the declaration this obligation really does refuse. Built
+			// from a CONSUMING request so the premise cannot be satisfied by the
+			// very relaxation under test.
+			consuming := request
+			consuming.FindingsAdvisory = false
+			refusal := EnsureLedgerObligationsObserved(ctx, store, "owner/repo", 7, head, gate.ledgerScope(consuming))
+			if refusal == nil {
+				t.Fatal("premise broken: the obligation gate did not refuse, so neither arm tests anything")
+			}
+			if !strings.Contains(refusal.Error(), "carry no observation at head") {
+				t.Fatalf("unexpected refusal shape %q", refusal)
+			}
+
+			// THROUGH THE REAL GATE, not by calling the recorder directly. An
+			// earlier version of this test invoked recordLedgerAdvisoryNote itself
+			// and therefore never exercised the gate's `if request.FindingsAdvisory`
+			// branch at all: a mutant that made the gate ignore the declaration
+			// entirely left it green. That is the same green-test-exercising-no-path
+			// shape this campaign keeps finding in other people's work.
+			err := gate.ensureFinalReviewCaptured(ctx, request, head)
+			ledgerRefused := err != nil && strings.Contains(err.Error(), "carry no observation at head")
+			if tc.wantRefusal && !ledgerRefused {
+				t.Fatalf("an undeclared repository did not refuse on its unobserved obligations; err = %v", err)
+			}
+			if !tc.wantRefusal && ledgerRefused {
+				t.Fatalf("an advisory repository still refused on the ledger: %v", err)
+			}
+
+			events, err := store.ListTaskEvents(ctx, "task-1969")
+			if err != nil {
+				t.Fatalf("ListTaskEvents: %v", err)
+			}
+			var note string
+			for _, event := range events {
+				if event.Kind == "findings_ledger_advisory_merge" {
+					note = event.Reason
+				}
+			}
+			if tc.wantNote {
+				if note == "" {
+					t.Fatal("an advisory merge recorded nothing; advisory must mean stated, not silent")
+				}
+				// It has to name the obligation it went past, or the record is a
+				// bare flag and a reader learns nothing they could act on.
+				if !strings.Contains(note, "owner/repo#7-f1") {
+					t.Fatalf("advisory note does not name the obligation it passed: %q", note)
+				}
+				if !strings.Contains(note, "advisory") {
+					t.Fatalf("advisory note does not name the declaration that permitted it: %q", note)
+				}
+			}
+			if tc.wantRefusal && note != "" {
+				t.Fatalf("an undeclared repository recorded an advisory note: %q", note)
+			}
+		})
+	}
+}
+
+// The resolver defaults FALSE, so a missing seam can never relax the gate. This
+// is the fail-closed direction and it is the one worth pinning: the failure that
+// matters is a repository silently becoming advisory, never one staying
+// consuming.
+func TestFindingsAdvisoryDefaultsToConsumingWithNoResolver(t *testing.T) {
+	if (Engine{}).findingsAdvisory("owner/repo") {
+		t.Fatal("a nil FindingsAdvisory resolver reported advisory; an unwired seam must never relax the obligation gate")
+	}
+	engine := Engine{FindingsAdvisory: func(string) bool { return true }}
+	if !engine.findingsAdvisory("owner/repo") {
+		t.Fatal("an installed resolver was ignored")
+	}
+}

--- a/internal/workflow/findings_ledger.go
+++ b/internal/workflow/findings_ledger.go
@@ -90,6 +90,16 @@ type LedgerScope struct {
 	ChangedSince func(ctx context.Context, previousHead string, currentHead string) ([]string, error)
 	// PathExistsAtHead reports whether a repo-relative path exists at a head.
 	PathExistsAtHead func(ctx context.Context, head string, path string) (bool, error)
+	// FindingsAdvisory carries the repository's #1969 declaration. When true the
+	// acceptance check RECORDS the obligations it is letting through and returns
+	// nil instead of refusing. It lives on the scope, and the recording happens
+	// here rather than in the gate, because the gate's store surface is a
+	// deliberate firewall (TestMergeGateStoreAccessSurface): the gate passes
+	// DATA, and the ledger, which already holds the store, does the writing.
+	FindingsAdvisory bool
+	// Repo names the repository for the advisory record, so the note says which
+	// declaration permitted the pass rather than leaving a reader to infer it.
+	Repo string
 	// TaskID lets the acceptance check record a degradation as a task event
 	// WITHOUT the merge gate itself gaining a store write. The gate's *db.Store
 	// surface is a deliberate firewall pinned by TestMergeGateStoreAccessSurface,
@@ -339,8 +349,29 @@ func EnsureLedgerObligationsObserved(ctx context.Context, store *db.Store, repo 
 		}
 		named = append(named, fmt.Sprintf("%s [%s %s: %s]", obligation.FindingUID, label, obligation.Severity, obligation.Reason))
 	}
-	return fmt.Errorf("findings ledger: %d prior finding(s) carry no observation at head %s: %s",
+	refusal := fmt.Errorf("findings ledger: %d prior finding(s) carry no observation at head %s: %s",
 		len(pending), shortHead(headSHA), strings.Join(named, "; "))
+	if !scope.FindingsAdvisory {
+		return refusal
+	}
+	// ADVISORY MEANS STATED, NOT SILENT (#1969). The declaration permits the
+	// merge; it does not permit losing the record. The issue this answers is 211
+	// findings recorded across five repositories that never answered one, with
+	// nothing surfacing it, so a declaration that quietly dropped the same
+	// obligations would reproduce that defect with an operator's signature on it.
+	//
+	// Best-effort: an audit write must never turn a permitted merge into a
+	// failure. The obligations stay in the ledger regardless, and
+	// `gitmoot findings` reports them whatever the declaration says.
+	if taskID := strings.TrimSpace(scope.TaskID); taskID != "" {
+		_ = store.AddTaskEvent(ctx, db.TaskEvent{
+			TaskID: taskID,
+			Kind:   "findings_ledger_advisory_merge",
+			Reason: fmt.Sprintf("%s declares findings_consumption = %q, so this head proceeded past obligations that would otherwise have held it: %v",
+				strings.TrimSpace(scope.Repo), "advisory", refusal),
+		})
+	}
+	return nil
 }
 
 func shortHead(head string) string {

--- a/internal/workflow/merge_gate.go
+++ b/internal/workflow/merge_gate.go
@@ -260,7 +260,17 @@ type workflowAwareGitHub interface {
 // pins the gate's *db.Store surface as a firewall, and an audit note is not
 // worth widening it.
 func (g PolicyMergeGate) ledgerScope(request MergeRequest) LedgerScope {
-	return g.LedgerResolvers.ScopeFor(request.Repo, request.PullRequest, request.TaskID)
+	scope := g.LedgerResolvers.ScopeFor(request.Repo, request.PullRequest, request.TaskID)
+	// #1969: the declaration travels as DATA on the scope, and the LEDGER does
+	// the writing, because the gate's *db.Store surface is a deliberate firewall
+	// pinned by TestMergeGateStoreAccessSurface. My first version called
+	// AddTaskEvent from the gate and that test caught it: the allowlist exists so
+	// display-plane evidence cannot decide merges, and adding a write to it
+	// casually is how that erodes. The scope already carries TaskID and Degraded
+	// for exactly this reason.
+	scope.FindingsAdvisory = request.FindingsAdvisory
+	scope.Repo = request.Repo
+	return scope
 }
 
 func (g PolicyMergeGate) Evaluate(ctx context.Context, request MergeRequest) (MergeDecision, error) {
@@ -902,6 +912,17 @@ func (g PolicyMergeGate) ensureFinalReviewCaptured(ctx context.Context, request 
 	// or failing resolver DEGRADES with a recorded note rather than either
 	// pretending or blocking.
 	if err := EnsureLedgerObligationsObserved(ctx, g.Store, request.Repo, int64(request.PullRequest), headSHA, g.ledgerScope(request)); err != nil {
+		// #1969: an ADVISORY repository records its findings and does not merge
+		// on them. The refusal is not discarded, it is DEMOTED to a recorded
+		// note, because "advisory" has to mean stated rather than silent - the
+		// whole issue was 211 findings nobody consumed and nothing surfacing it.
+		//
+		// This is the ONLY relaxation, and it is opt-in per repository: an
+		// undeclared repository keeps refusing. The gate is live, not
+		// theoretical - it refused 16 times across 5 repositories on this box,
+		// including one pull request wedged on 37 prior findings all still open,
+		// which is the guard-rejects-valid-input shape the ledger's own header
+		// predicts when the write half runs without the read half.
 		return err
 	}
 	// Supersession is resolved BEFORE any state or verdict scan, and it covers a

--- a/internal/workflow/review_threshold.go
+++ b/internal/workflow/review_threshold.go
@@ -12,6 +12,15 @@ const ReviewApprovedWithNotesEventKind = "review_approved_with_notes"
 
 // reviewBlockingSeverity resolves the repository policy while preserving the
 // historical fail-closed behavior for engines that are not wired from config.
+// findingsAdvisory resolves the #1969 declaration, defaulting to FALSE so a
+// missing resolver can never relax the obligation gate.
+func (e Engine) findingsAdvisory(repo string) bool {
+	if e.FindingsAdvisory == nil {
+		return false
+	}
+	return e.FindingsAdvisory(repo)
+}
+
 func (e Engine) reviewBlockingSeverity(repo string) string {
 	if e.ReviewBlockingSeverity == nil {
 		return reviewseverity.DefaultBlocking


### PR DESCRIPTION
Completes #1969's remaining acceptance criterion: **each watched repository declares whether review findings are consumed or advisory.** Part of campaign #1966. The report half shipped in #2002; this is the declaration.

## The gate this relaxes is live, and I measured it before building

`EnsureLedgerObligationsObserved` holds a merge when a prior finding carries no observation at the evaluated head. That is not theoretical:

| repo | refusals | |
| --- | --- | --- |
| gitmoot/gitmoot | 7 | |
| jerryfane/joltra | 5 | |
| themartianapp/keephair | 2 | |
| jerryfane/vetrina | 1 | held on **37** prior findings, all "still open" |
| gitmoot/coordinator-checkin | 1 | held on **17** |

**16 refusals across 5 repositories.** That is precisely the wedge `findings_ledger_writer.go`'s own header predicts when the write half runs without the read half: obligations accumulate that no reviewer was ever told about, and the gate then refuses heads whose reviewer could not have discharged anything. #1992 fixed the disclosure; this gives an operator the other lever for a repository that will never consume.

## The change

`findings_consumption` on the existing `[review]` policy, with per-repository overrides, resolved through the same `ReviewConfig.For(repo)` the blocking severity already uses.

Three values, and **the empty one is deliberately not a synonym for either**:

| value | behaviour | reported as |
| --- | --- | --- |
| unset | unobserved obligations hold the merge | `undeclared` |
| `consuming` | identical, stated on purpose | `consuming` |
| `advisory` | findings still recorded and reported, merge proceeds | `advisory` |

Undeclared behaving as consuming is what makes this safe to land: nothing changes for any repository until an operator declares something. And it reports as `undeclared` in `gitmoot findings`, so "nobody has decided about this repository" is visible rather than indistinguishable from a decision.

**Advisory means stated, not silent.** Every advisory pass records a `findings_ledger_advisory_merge` task event naming the repository, the declaration and the obligations it went past. A declaration that quietly dropped the same obligations would reproduce #1969's defect with an operator's signature on it.

**Fail-closed everywhere.** An unreadable value errors *and* leaves the policy consuming, mirroring `blocking_severity`. A nil resolver returns false. A typo like `advisroy` is refused rather than read as undeclared-and-therefore-fine, because the operator plainly meant to relax the gate and will believe they did.

**No config was changed.** The field, its parser, its default and its documentation are here; setting a value on this box is the owner's call. My recommendation, with the measurement behind it, is on #1969.

## A design constraint I broke, and the test that caught it

My first version called `AddTaskEvent` **from the merge gate**. `TestMergeGateStoreAccessSurface` failed, and it was right: the gate's `*db.Store` surface is a deliberate allowlist so display-plane evidence cannot decide merges, and `LedgerScope`'s own comment already said the gate passes DATA while the ledger, which holds the store, does the writing.

Restructured to follow that: the declaration travels as data on `LedgerScope`, and `EnsureLedgerObligationsObserved` records the note. The gate's store surface is unchanged. I had read that comment earlier in this campaign and still walked into it; the guard is what stopped me.

## Sibling check, per today's standing fleet practice

Grepped every other caller and sibling constructor of what I changed, and naming what I deliberately left:

| Sibling | Verdict |
| --- | --- |
| `EnsureLedgerObligationsObserved` callers | one (`merge_gate.go:903`), wired |
| `MergeRequest` constructions | one real (`engine_routing_merge.go:1010`), wired |
| `daemon_result.go:730` `ReviewBlockingSeverity` | **false alarm**: a same-named field on `JobResultComment`, not a merge path |
| `PipelineAutoMerger` | **deliberately left**: it states in its own doc comment that it does not call `PolicyMergeGate.Evaluate`, and borrows only `evaluateStatuses`, so it never reaches the ledger check |
| `Engine.ledgerScopeFor` (the review brief) | **deliberately left**: advisory must not hide obligations from the reviewer's brief. Findings are still disclosed and still reported; only the merge hold is relaxed |
| `ReviewPolicy` builders and both field parsers | all wired: default, global, per-repo override, `For()` |

## Verification

`TestAdvisoryDeclarationRelaxesTheLedgerGateAndRecordsWhatItPassed` runs through the **real gate** (`ensureFinalReviewCaptured`), asserts its own premise from a *consuming* request so the premise cannot be satisfied by the relaxation under test, and checks both arms plus the recorded note.

`TestFindingsConsumptionParsesAndFailsClosed` covers unset, both declarations, case, and the misspelling. `TestFindingsConsumptionRepositoryOverrideWinsBothWays` pins that a per-repo declaration can *tighten* as well as loosen, so the knob is not one-directional.

| Mutant | Result |
| --- | --- |
| the ledger ignores the declaration and always refuses | FAILS |
| an advisory pass records nothing | FAILS |
| the gate stops carrying the declaration onto the scope | FAILS |
| a misspelled declaration silently reads as advisory | FAILS |
| a nil resolver defaults to advisory | FAILS |

**A vacuous test I caught in my own work first.** The initial version called `recordLedgerAdvisoryNote` directly and therefore never exercised the gate's `if request.FindingsAdvisory` branch: a mutant making the gate ignore the declaration entirely left it green. That is the same green-test-exercising-no-path shape this campaign has been finding all day, and the fix was to route through the real gate. A second fixture error was caught by my own premise assertion: an obligation recorded *at* the evaluated head is already observed there and pends nothing, so the fixture now records at a prior head, which is the real wedge.

Gate: `gofmt`, `go generate` clean, `go vet ./...`, and `go test -timeout 25m` on `internal/config`, `internal/workflow` (110s), `internal/cli` (867s), `internal/db` (226s), all **ok**. Disk 94% used with 27-28 GiB free, no guard line. `-race` not run: requires cgo, unavailable in this seat.

## Not claimed

- I have not declared any repository advisory. That is an operator decision and the measurement supporting a recommendation is on #1969.
- This does not shrink the 211-finding backlog or change what is recorded. It changes only whether an unobserved obligation holds a merge, and only where declared.
- #1969's third criterion, the report, shipped in #2002; this PR adds the `DECLARED` column to it.
