### PR TITLE
fix(cli): the checkout-identity refusals print a remedy that clears them (#1525)

### DIFF
--- a/internal/cli/daemon_workflow.go
+++ b/internal/cli/daemon_workflow.go
@@ -365,20 +365,56 @@ func implementationFinalizationTargetForRunner(ctx context.Context, store *db.St
 		))
 	}
 	git := jobGitClient(worktreePath, runner)
+	// THE REMEDY IS BUILT ONCE FOR BOTH CHECKOUT-IDENTITY REFUSALS (#1525).
+	//
+	// PR #1521 established the invariant the hard way: a refusal's printed remedy
+	// must be able to CLEAR the refusal it prints. Three defects on that one PR
+	// were variants of violating it. These two refusals - detached HEAD and wrong
+	// branch - were the last of six that ended with no recovery path at all, and
+	// a rule applied to four of six is not yet a rule.
+	//
+	// A CHECKOUT, NOT A RESET. The stale/divergent refusal further down prints
+	// `fetch` plus `reset --hard`, which is right there because the worktree is
+	// behind. Printing it here would be wrong twice over: this refusal fires in
+	// the AFTER-RUN phase too, where a hard reset destroys the work the model just
+	// produced, and the condition is a wrong REF rather than wrong CONTENT. The
+	// dirty-worktree refusal above already returned for an unclean tree, so by
+	// here the checkout is clean and a checkout cannot lose anything.
+	//
+	// WITHOUT A DISPATCH HEAD THERE IS NO REMEDY TO PRINT, AND MY FIRST VERSION
+	// PRINTED ONE ANYWAY. It said `git checkout <branch>`, which fails outright
+	// when the branch does not exist locally - the acceptance test executed it and
+	// it exited 1, which is exactly the defect class #1525 is about, committed
+	// inside #1525's own fix. The tempting repair, `checkout -B <branch> HEAD`,
+	// is worse than useless: it would rebrand whatever commit is sitting there as
+	// the expected branch and clear the refusal by defeating the guard. So the
+	// honest form is the second option the issue allows, the one the
+	// missing-dispatch-head refusal below already uses: say that no verifiable
+	// in-place recovery exists and name the re-dispatch.
+	checkoutRemedy := fmt.Sprintf(
+		"the dispatch head is unknown, so no in-place checkout can be verified; dispatch a new implement job for task %s against the branch's current head",
+		task.ID,
+	)
+	if head := strings.TrimSpace(payload.HeadSHA); head != "" {
+		// With a dispatch head the remedy is exact: it creates or moves the branch
+		// to the commit this job was dispatched against, which is what the head
+		// check further down will then demand.
+		checkoutRemedy = fmt.Sprintf("run `git -C %q checkout -B %s %s` before retrying", worktreePath, branchName, head)
+	}
 	currentBranch, err := git.CurrentBranch(ctx)
 	if err != nil {
 		if phase == implementationFinalizationAfterRun {
 			return implementationFinalizationTarget{}, fmt.Errorf("resolve implementation branch: %w", err)
 		}
 		return implementationFinalizationTarget{}, blockedResultDelivery(fmt.Sprintf(
-			"implementation task %s worktree %q has no usable current branch (%v); expected branch %s; refusing to run or deliver from an unverifiable checkout",
-			task.ID, worktreePath, err, branchName,
+			"implementation task %s worktree %q has no usable current branch (%v); expected branch %s; refusing to run or deliver from an unverifiable checkout; %s",
+			task.ID, worktreePath, err, branchName, checkoutRemedy,
 		))
 	}
 	if currentBranch != branchName {
 		return implementationFinalizationTarget{}, blockedResultDelivery(fmt.Sprintf(
-			"implementation task %s worktree %q is on branch %s, not %s; refusing to run or deliver from the wrong checkout",
-			task.ID, worktreePath, currentBranch, branchName,
+			"implementation task %s worktree %q is on branch %s, not %s; refusing to run or deliver from the wrong checkout; %s",
+			task.ID, worktreePath, currentBranch, branchName, checkoutRemedy,
 		))
 	}
 	if phase == implementationFinalizationBeforeRun {

--- a/internal/cli/refusal_remedy_1525_test.go
+++ b/internal/cli/refusal_remedy_1525_test.go
@@ -1,0 +1,268 @@
+package cli
+
+import (
+	"context"
+	"errors"
+	"os"
+	"os/exec"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/gitmoot/gitmoot/internal/db"
+	"github.com/gitmoot/gitmoot/internal/subprocess"
+	"github.com/gitmoot/gitmoot/internal/workflow"
+)
+
+// #1525: the detached-HEAD and wrong-branch refusals ended at "refusing to run
+// or deliver from the wrong checkout" with no recovery path, leaving the remedy
+// contract enforced on four of six before-run refusals. Both cross-family
+// reviewers on PR #1521 raised it independently.
+//
+// THE ASSERTION THAT MATTERS IS EXECUTION, NOT PRESENCE. PR #1521 produced three
+// separate defects that were all variants of a remedy that could not clear its
+// own refusal, and every one of them would have passed a "does it print
+// something" check: a remedy that moved the worktree to the PR tip when the gate
+// wanted the frozen dispatch head, an unfetched head that returned a raw
+// `fatal: Not a valid commit name`, and a universal recovery that could not
+// clear a force-pushed-away head. So these tests run the printed command
+// verbatim and re-drive the refusal.
+func TestWrongBranchRefusalPrintsARemedyThatClearsIt(t *testing.T) {
+	ctx := context.Background()
+	store := daemonWorkerStore(t)
+	worktree := createDaemonWorkerGitCheckout(t, "feature/task-branch")
+	head := remedyGitOutput(t, worktree, "rev-parse", "HEAD")
+	task := db.Task{ID: "task-1525", RepoFullName: "owner/repo", Branch: "feature/payload-branch", WorktreePath: worktree}
+	if err := store.UpsertTask(ctx, task); err != nil {
+		t.Fatalf("UpsertTask: %v", err)
+	}
+	payload := workflow.JobPayload{
+		Repo: "owner/repo", Branch: "feature/payload-branch", TaskID: "task-1525",
+		PullRequest: 42, HeadSHA: head, FixWorktree: true, WorktreePath: worktree,
+	}
+	job := db.Job{ID: "job-1525", Agent: "lead", Type: "implement"}
+
+	_, err := implementationFinalizationTargetForRunner(ctx, store, job, payload, implementationFinalizationAfterRun, subprocess.ExecRunner{})
+	var blocked workflow.BlockedError
+	if !errors.As(err, &blocked) {
+		t.Fatalf("error = %v, want a result-delivery BlockedError", err)
+	}
+	if !strings.Contains(err.Error(), "refusing to run or deliver from the wrong checkout") {
+		t.Fatalf("error = %q, want the wrong-checkout refusal", err)
+	}
+
+	runPrintedRemedy(t, err.Error())
+
+	if _, err := implementationFinalizationTargetForRunner(ctx, store, job, payload, implementationFinalizationAfterRun, subprocess.ExecRunner{}); err != nil {
+		t.Fatalf("the printed remedy did not clear the refusal it printed; retry still fails: %v", err)
+	}
+}
+
+// THE ARM THAT CAUGHT ME. With no dispatch head there is no command that can be
+// verified to clear this refusal, and my first version printed
+// `git checkout <branch>` anyway. The acceptance test executed it verbatim and
+// it exited 1, because the branch does not exist locally: a remedy that cannot
+// clear its own refusal, committed inside the fix for exactly that defect class.
+//
+// So this arm asserts the OTHER property the issue allows, and asserts the
+// absence of a command rather than only the presence of prose. The tempting
+// repair, `checkout -B <branch> HEAD`, would have cleared the refusal by
+// rebranding whatever commit was sitting there as the expected branch, which
+// defeats the guard instead of satisfying it.
+func TestWrongBranchWithoutADispatchHeadStatesNoInPlaceRecovery(t *testing.T) {
+	ctx := context.Background()
+	store := daemonWorkerStore(t)
+	worktree := createDaemonWorkerGitCheckout(t, "feature/task-branch")
+	task := db.Task{ID: "task-1525n", RepoFullName: "owner/repo", Branch: "feature/payload-branch", WorktreePath: worktree}
+	if err := store.UpsertTask(ctx, task); err != nil {
+		t.Fatalf("UpsertTask: %v", err)
+	}
+	payload := workflow.JobPayload{
+		Repo: "owner/repo", Branch: "feature/payload-branch", TaskID: "task-1525n",
+		FixWorktree: true, WorktreePath: worktree,
+	}
+	_, err := implementationFinalizationTargetForRunner(ctx, store,
+		db.Job{ID: "job-1525n", Agent: "lead", Type: "implement"}, payload,
+		implementationFinalizationAfterRun, subprocess.ExecRunner{})
+	if err == nil {
+		t.Fatal("a wrong-branch worktree was accepted")
+	}
+	if !strings.Contains(err.Error(), "no in-place checkout can be verified") ||
+		!strings.Contains(err.Error(), "dispatch a new implement job") {
+		t.Fatalf("error = %q, want an explicit statement that no in-place recovery exists", err)
+	}
+	if strings.Contains(err.Error(), "`") {
+		t.Fatalf("a refusal with no verifiable remedy still printed a command, which is the defect this issue is about:\n  %s", err)
+	}
+}
+
+// The detached-HEAD arm. `CurrentBranch` cannot name a branch, so the refusal is
+// the "no usable current branch" one, and its remedy must equally clear it.
+func TestDetachedHeadRefusalPrintsARemedyThatClearsIt(t *testing.T) {
+	ctx := context.Background()
+	store := daemonWorkerStore(t)
+	worktree := createDaemonWorkerGitCheckout(t, "feature/payload-branch")
+	head := remedyGitOutput(t, worktree, "rev-parse", "HEAD")
+	runDaemonWorkerGit(t, worktree, "checkout", "--detach", head)
+
+	task := db.Task{ID: "task-1525d", RepoFullName: "owner/repo", Branch: "feature/payload-branch", WorktreePath: worktree}
+	if err := store.UpsertTask(ctx, task); err != nil {
+		t.Fatalf("UpsertTask: %v", err)
+	}
+	payload := workflow.JobPayload{
+		Repo: "owner/repo", Branch: "feature/payload-branch", TaskID: "task-1525d",
+		PullRequest: 42, HeadSHA: head, FixWorktree: true, WorktreePath: worktree,
+	}
+	job := db.Job{ID: "job-1525d", Agent: "lead", Type: "implement"}
+
+	_, err := implementationFinalizationTargetForRunner(ctx, store, job, payload, implementationFinalizationBeforeRun, subprocess.ExecRunner{})
+	if err == nil {
+		t.Fatal("a detached fix worktree was accepted before the model ran")
+	}
+	if !strings.Contains(err.Error(), "no usable current branch") {
+		t.Fatalf("error = %q, want the unverifiable-checkout refusal", err)
+	}
+
+	runPrintedRemedy(t, err.Error())
+
+	if _, err := implementationFinalizationTargetForRunner(ctx, store, job, payload, implementationFinalizationBeforeRun, subprocess.ExecRunner{}); err != nil {
+		t.Fatalf("the printed remedy did not clear the refusal it printed; retry still fails: %v", err)
+	}
+}
+
+// ACCEPTANCE 3, and the one that converts the invariant from a convention into
+// something enforced: EVERY refusal this function can emit must either print a
+// runnable command or state explicitly that no in-place recovery exists.
+//
+// It is a source census rather than a behavioural sweep because the alternative
+// is unreachable: several arms need a git failure, a missing object or a
+// diverged head to fire, and a test that drove only the reachable ones would
+// certify the family while silently skipping members. A new refusal added
+// without either property fails this immediately, which is the property the
+// issue asked for.
+func TestEveryFinalizationRefusalIsActionable(t *testing.T) {
+	source, err := os.ReadFile("daemon_workflow.go")
+	if err != nil {
+		t.Fatalf("read source: %v", err)
+	}
+	body := functionSource(t, string(source), "func implementationFinalizationTargetForRunner(")
+
+	refusals := regexp.MustCompile(`blockedResultDelivery\(fmt\.Sprintf\(\s*\n\s*"((?:[^"\\]|\\.)*)"`).FindAllStringSubmatch(body, -1)
+	if len(refusals) < 9 {
+		t.Fatalf("found %d refusal literals, want at least the 9 this family had when the guard was written; if the count DROPPED the census is matching less than it should", len(refusals))
+	}
+	// "No in-place recovery exists" is the honest second option the issue allows,
+	// and one arm already uses it: the missing-dispatch-head case refuses to guess
+	// a fetch/reset remedy and says to dispatch a new job instead.
+	noInPlaceRecovery := regexp.MustCompile(`dispatch a new|rerun through|refresh pull request`)
+
+	// A refusal may DELEGATE its remedy to a variable and end in "; %s". That is
+	// legitimate and two arms do it, but accepting a bare %s would gut this check,
+	// so every remedy builder in the function is held to the same bar. My first
+	// version accepted the literals and would have passed the broken
+	// `git checkout <branch>` remedy the acceptance test caught.
+	builders := regexp.MustCompile(`(?:checkoutRemedy|recovery)\s*(?::?=)\s*fmt\.Sprintf\(\s*\n?\s*"((?:[^"\\]|\\.)*)"`).FindAllStringSubmatch(body, -1)
+	if len(builders) < 3 {
+		t.Fatalf("found %d remedy builders, want at least 3; a builder renamed out of this pattern would silently stop being checked", len(builders))
+	}
+	for _, builder := range builders {
+		remedy := builder[1]
+		if strings.Contains(remedy, "`") || noInPlaceRecovery.MatchString(remedy) {
+			continue
+		}
+		t.Errorf("remedy builder is neither a runnable command nor a statement that none exists:\n  %s", remedy)
+	}
+
+	for _, refusal := range refusals {
+		message := refusal[1]
+		if strings.Contains(message, "`") || noInPlaceRecovery.MatchString(message) {
+			continue
+		}
+		if strings.HasSuffix(message, "; %s") {
+			// Delegated to a builder, and every builder was just checked.
+			continue
+		}
+		t.Errorf("refusal prints no runnable remedy and does not say that none exists:\n  %s", message)
+	}
+}
+
+// runPrintedRemedy extracts the FIRST backticked command from a refusal and runs
+// it verbatim. Verbatim is the point: a remedy that only works after a human
+// adjusts it has not cleared anything.
+func runPrintedRemedy(t *testing.T, message string) {
+	t.Helper()
+	match := regexp.MustCompile("`([^`]+)`").FindStringSubmatch(message)
+	if match == nil {
+		t.Fatalf("refusal printed no command to run:\n  %s", message)
+	}
+	command := match[1]
+	t.Logf("executing printed remedy: %s", command)
+	fields, err := shellFieldsForRemedy(command)
+	if err != nil {
+		t.Fatalf("cannot parse printed remedy %q: %v", command, err)
+	}
+	if fields[0] != "git" {
+		t.Fatalf("printed remedy is not a git command: %q", command)
+	}
+	output, runErr := exec.Command(fields[0], fields[1:]...).CombinedOutput()
+	if runErr != nil {
+		t.Fatalf("printed remedy %q failed: %v\n%s", command, runErr, output)
+	}
+}
+
+// shellFieldsForRemedy splits a printed command, honouring the %q quoting the
+// refusals use for worktree paths.
+func shellFieldsForRemedy(command string) ([]string, error) {
+	var fields []string
+	var current strings.Builder
+	inQuotes := false
+	for _, r := range command {
+		switch {
+		case r == '"':
+			inQuotes = !inQuotes
+		case r == ' ' && !inQuotes:
+			if current.Len() > 0 {
+				fields = append(fields, current.String())
+				current.Reset()
+			}
+		default:
+			current.WriteRune(r)
+		}
+	}
+	if current.Len() > 0 {
+		fields = append(fields, current.String())
+	}
+	if inQuotes {
+		return nil, errors.New("unbalanced quotes")
+	}
+	if len(fields) == 0 {
+		return nil, errors.New("empty command")
+	}
+	return fields, nil
+}
+
+// functionSource returns one top-level function's body text.
+func functionSource(t *testing.T, source string, signature string) string {
+	t.Helper()
+	start := strings.Index(source, signature)
+	if start < 0 {
+		t.Fatalf("function %q not found; the census is matching nothing", signature)
+	}
+	rest := source[start:]
+	end := strings.Index(rest, "\n}\n")
+	if end < 0 {
+		t.Fatalf("function %q has no closing brace", signature)
+	}
+	return rest[:end]
+}
+
+func remedyGitOutput(t *testing.T, dir string, args ...string) string {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	output, err := cmd.Output()
+	if err != nil {
+		t.Fatalf("git %s: %v", strings.Join(args, " "), err)
+	}
+	return strings.TrimSpace(string(output))
+}


### PR DESCRIPTION
PR opening now. All three acceptance criteria implemented, and criterion 1 caught me committing the exact defect the issue is about.

## What the two refusals now print

```
implementation task T worktree "/path" is on branch X, not Y;
  refusing to run or deliver from the wrong checkout;
  run `git -C "/path" checkout -B Y <dispatch-head>` before retrying
```

A CHECKOUT, NOT A RESET, and the distinction is load-bearing. The stale/divergent refusal further down prints `fetch` plus `reset --hard` because that worktree is BEHIND. Printing the same thing here would be wrong twice over: this refusal also fires in the AFTER-RUN phase, where a hard reset destroys the work the model just produced, and the condition is a wrong REF rather than wrong CONTENT. The dirty-worktree refusal returns earlier in the same function, so by the time these fire the checkout is clean and a checkout cannot lose anything.

## Criterion 1 caught me printing a remedy that does not clear its refusal

My first version printed `git -C "<path>" checkout <branch>` when no dispatch head was available. The acceptance test executed it verbatim:

```
executing printed remedy: git -C "/tmp/.../002" checkout feature/payload-branch
printed remedy ... failed: exit status 1
```

The branch does not exist locally, so the remedy cannot clear the refusal. That is precisely the defect class this issue exists to close, committed inside its own fix, and only the execute-it-for-real assertion found it. A "does it print something" check would have passed, exactly as the issue warned about all three #1521 variants.

The tempting repair is worse than the bug: `checkout -B <branch> HEAD` always succeeds, so it would clear the refusal by **rebranding whatever commit is sitting there as the expected branch**, defeating the guard rather than satisfying it. So that arm now uses the second option this issue allows and states that no verifiable in-place recovery exists, naming the re-dispatch. There is a test asserting it prints NO command in that case, because a refusal that cannot be cleared must not appear to offer a cure.

## Criterion 3, and why it is a source census

`TestEveryFinalizationRefusalIsActionable` enumerates every `blockedResultDelivery` literal in `implementationFinalizationTargetForRunner` and requires each to carry a backticked command or state that no in-place recovery exists.

It is a census rather than a behavioural sweep because several arms need a git failure, a missing object or a diverged head to fire, and a test that drove only the reachable ones would certify the family while silently skipping members.

**A refusal may delegate its remedy to a variable and end in `; %s`.** Two arms do. Accepting a bare `%s` would have gutted the check and would have passed the broken checkout remedy above, so every remedy BUILDER in the function is held to the same bar, and the count of builders is asserted so renaming one out of the pattern fails rather than silently reducing coverage.

## Sibling call sites, per the fleet's standing pre-PR check

`blockedResultDelivery` appears in two files. `internal/workflow/engine_routing_merge.go` is a comment reference only. Inside `internal/cli/daemon_workflow.go` there are **six further remedy-less refusals outside this function**, and I am naming them rather than silently widening scope:

```
:522  push implementation branch failed: ...
:571  open implementation PR failed: ...
:606  validated implementation payload has no pull request number
:617  fix-pass pull request revalidation returned #N, want #M
:620  fix-pass pull request #N is no longer open
:623  fix-pass pull request #N now targets head branch X, not task branch Y
:626  fix-pass pull request #N head belongs to X, not Y
```

They are a different family: post-push and PR-revalidation failures, where the remedy is not a checkout and in several cases is genuinely "re-dispatch". This issue is scoped to the six BEFORE-RUN refusals of `implementationFinalizationTargetFor`, and the census test is scoped to that function deliberately. Extending the contract to the delivery family is worth doing and should be its own issue, specified against what those refusals can actually promise.

Worth noting that `:522` is the push-rejection refusal #1533 is about, whose real gap is not the message but that it is terminal with no rebase, retry or salvage. That half of #1533 remains open.

## Tests, all four failing on base `79baa54a`

```
TestWrongBranchRefusalPrintsARemedyThatClearsIt              base: refusal printed no command to run
TestWrongBranchWithoutADispatchHeadStatesNoInPlaceRecovery   base: no statement that none exists
TestDetachedHeadRefusalPrintsARemedyThatClearsIt             base: refusal printed no command to run
TestEveryFinalizationRefusalIsActionable                     base: found 1 remedy builder, want at least 3
```
