### PR TITLE
fix(db): age a coalesced wake batch out as one obligation (#1982)

### DIFF
--- a/internal/db/wake_outbox.go
+++ b/internal/db/wake_outbox.go
@@ -474,12 +474,34 @@ ORDER BY attempted_at, id`,
 
 	stamp := at.UTC().Format(BlockedEpisodeTimeLayout)
 	const detail = "delivery outcome unknown after attempted wake aged out; not retried"
+	// A CLAIMED BATCH IS ONE WAKE, AND THIS SWEEP IS THE SIBLING SEAM THAT DID
+	// NOT KNOW IT. #1982 moved the coalescing collapse from claim time to
+	// outcome time, which left a whole batch `attempted` until its outcome; this
+	// function is the other writer of a terminal state, so a crashed batch aged
+	// out as N independent `delivery_unknown` rows. One undelivered wake then
+	// counted as N unproven obligations and the record that they were a single
+	// wake was lost.
+	//
+	// The surviving row takes the unknown outcome, because the wake was its own,
+	// and the rows it collapsed are superseded into it: the same accounting a
+	// delivered or failed batch already uses. Rows are ordered by attempted_at
+	// then id, so the first row of each claim group is its survivor.
+	seenSurvivor := map[string]int64{}
 	for _, entry := range entries {
+		group := strings.ToLower(strings.TrimSpace(entry.TargetRole)) + "\x00" +
+			entry.CoalesceKey + "\x00" + entry.AttemptedAt
+		state, rowDetail := WakeOutboxStateDeliveryUnknown, detail
+		survivor, collapsed := seenSurvivor[group]
+		if collapsed {
+			state, rowDetail = WakeOutboxStateSuperseded, WakeOutboxCoalescedDetail(survivor)
+		} else {
+			seenSurvivor[group] = entry.ID
+		}
 		result, err := tx.ExecContext(ctx, `
 UPDATE wake_outbox
 SET state = ?, last_error = ?, finished_at = ?, updated_at = ?
 WHERE id = ? AND state = 'attempted' AND attempted_at <= ?`,
-			WakeOutboxStateDeliveryUnknown, detail, stamp, stamp, entry.ID,
+			state, rowDetail, stamp, stamp, entry.ID,
 			attemptedBefore.UTC().Format(BlockedEpisodeTimeLayout))
 		if err != nil {
 			return nil, err
@@ -490,6 +512,12 @@ WHERE id = ? AND state = 'attempted' AND attempted_at <= ?`,
 		}
 		if affected != 1 {
 			return nil, fmt.Errorf("expire wake outbox row %d updated %d rows, want 1", entry.ID, affected)
+		}
+		if collapsed {
+			// The audit event belongs to the obligation, not to every row it
+			// carried: N events for one undelivered wake is the same
+			// over-counting in the job-event stream.
+			continue
 		}
 		message := fmt.Sprintf(
 			"source=%s:%s target_role=%s attempted_at=%s policy=expire_without_retry",

--- a/internal/db/wake_outbox_test.go
+++ b/internal/db/wake_outbox_test.go
@@ -414,6 +414,82 @@ func TestExpireAgedWakeOutboxRecordsDeliveryUnknownWithoutRetry(t *testing.T) {
 	}
 }
 
+// TestExpireAgedWakeOutboxKeepsACoalescedBatchOneObligation covers the sibling
+// seam of FinishWakeOutbox. #1982 moved the coalescing collapse from claim time
+// to outcome time so a retry could re-coalesce, which left a whole batch
+// `attempted` until its outcome. This function is the OTHER writer of a
+// terminal wake state, and it did not learn that: a crashed batch aged out as
+// N independent `delivery_unknown` rows, so one undelivered wake counted as N
+// unproven obligations and the record that they were a single wake was lost.
+//
+// The surviving row carries the unknown outcome, because the wake was ITS wake;
+// the rest are superseded into it, which is the same accounting a delivered or
+// failed batch already uses.
+func TestExpireAgedWakeOutboxKeepsACoalescedBatchOneObligation(t *testing.T) {
+	store := openWorkflowTestStore(t)
+	ctx := context.Background()
+	for index := range 3 {
+		if _, err := store.InsertWorkflowNote(ctx, WorkflowNote{
+			WorkflowID: "wake/aged-batch", Author: "operator",
+			Body: fmt.Sprint(index), AddressedTarget: "owner",
+		}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	pending, err := store.ListWakeOutbox(ctx, WakeOutboxStatePending)
+	if err != nil || len(pending) != 3 {
+		t.Fatalf("pending = %+v, err=%v", pending, err)
+	}
+	attemptedAt := time.Date(2026, 7, 28, 12, 0, 0, 0, time.UTC)
+	surviving := pending[0].ID
+	coalesced := []int64{pending[1].ID, pending[2].ID}
+	claimed, err := store.ClaimWakeOutbox(ctx, surviving, coalesced, attemptedAt)
+	if err != nil || !claimed {
+		t.Fatalf("claim = %v, err=%v", claimed, err)
+	}
+
+	// The process dies before recording an outcome, so the sweep ages the batch.
+	expired, err := store.ExpireAgedWakeOutbox(ctx, attemptedAt, attemptedAt.Add(time.Minute))
+	if err != nil || len(expired) != 3 {
+		t.Fatalf("expired = %+v, err=%v, want the whole claimed batch", expired, err)
+	}
+	unknown, err := store.ListWakeOutbox(ctx, WakeOutboxStateDeliveryUnknown)
+	if err != nil || len(unknown) != 1 || unknown[0].ID != surviving {
+		t.Fatalf("delivery unknown = %+v, err=%v, want only the surviving row", unknown, err)
+	}
+	if !strings.Contains(unknown[0].LastError, "not retried") || unknown[0].FinishedAt == "" {
+		t.Fatalf("surviving row = %+v, want the unknown-outcome cause and a finish stamp", unknown[0])
+	}
+	superseded, err := store.ListWakeOutbox(ctx, WakeOutboxStateSuperseded)
+	if err != nil || len(superseded) != 2 {
+		t.Fatalf("superseded = %+v, err=%v, want the two collapsed rows", superseded, err)
+	}
+	for _, row := range superseded {
+		if row.LastError != WakeOutboxCoalescedDetail(surviving) {
+			t.Fatalf("collapsed row %d last_error = %q, want the surviving row named", row.ID, row.LastError)
+		}
+		if row.FinishedAt == "" {
+			t.Fatalf("collapsed row %d has no finish stamp: %+v", row.ID, row)
+		}
+	}
+	// One undelivered wake produces ONE audit event, on the row that carried it.
+	events, err := store.ListJobEvents(ctx, fmt.Sprintf("wake-outbox:%d", surviving))
+	if err != nil || len(events) != 1 || events[0].Kind != WakeOutboxDeliveryUnknownEventKind {
+		t.Fatalf("surviving row events = %+v, err=%v", events, err)
+	}
+	for _, id := range coalesced {
+		collapsedEvents, err := store.ListJobEvents(ctx, fmt.Sprintf("wake-outbox:%d", id))
+		if err != nil || len(collapsedEvents) != 0 {
+			t.Fatalf("collapsed row %d events = %+v, err=%v, want none", id, collapsedEvents, err)
+		}
+	}
+	// The sweep must still be idempotent for the whole batch.
+	expired, err = store.ExpireAgedWakeOutbox(ctx, attemptedAt.Add(time.Hour), attemptedAt.Add(2*time.Hour))
+	if err != nil || len(expired) != 0 {
+		t.Fatalf("second expiry = %+v, err=%v", expired, err)
+	}
+}
+
 func TestWakeOutboxSupersededMigrationPreservesRowsAndScopesTerminalMarkers(t *testing.T) {
 	ctx := context.Background()
 	path := filepath.Join(t.TempDir(), "gitmoot.db")


### PR DESCRIPTION
Follow-up to #2010 (#1982). **A regression I introduced tonight, found by the sibling-seam check rather than by a test.**

## The defect

#2010 moved the coalescing collapse from claim time to outcome time, so a retried batch could re-coalesce and no note could vanish from the retry wake. That left a whole claimed batch `attempted` until its outcome was observed.

`ExpireAgedWakeOutbox` is the **other writer of a terminal wake state**, and it did not learn that. A batch whose process died between claim and outcome aged out as **N independent `delivery_unknown` rows**, each with its own `wake_delivery_unknown` audit event. So:

- one undelivered wake counted as **N unproven obligations**, inflating the exact population #1982 exists to measure by the collapse factor,
- the record that those rows were a **single wake** was destroyed, which is the property #1978 was built to hold,
- and `gitmoot org interrupts` (#2013) would have reported the inflated number, because it reads those states.

Before #1982 this was invisible: the siblings were already `superseded` at claim time, so only the survivor could age out.

## Reproduction, written first

`TestExpireAgedWakeOutboxKeepsACoalescedBatchOneObligation`: three notes to one role, claimed as one batch, no outcome recorded, then the sweep runs. Against the code as merged an hour ago:

```
--- FAIL: TestExpireAgedWakeOutboxKeepsACoalescedBatchOneObligation
    delivery unknown = [{ID:1 ... State:delivery_unknown ...}
                        {ID:2 ... State:delivery_unknown ...}
                        {ID:3 ... State:delivery_unknown ...}]
    want only the surviving row
```

Three unproven obligations for one wake.

## The fix

Rows are already selected `ORDER BY attempted_at, id`, so the first row of each `(target_role, coalesce_key, attempted_at)` claim group is its survivor. The survivor takes `delivery_unknown` with the existing cause; the rows it collapsed become `superseded` naming it, which is the same accounting a delivered or failed batch already uses. The audit event belongs to the obligation, so one aged-out wake records one event rather than one per row.

After: one `delivery_unknown` row, two `superseded` rows reading `coalesced into wake outbox row 1`, one job event on the survivor and none on the collapsed rows, and the sweep stays idempotent for the whole batch.

## Sibling seams I checked, and what I left

- `FinishWakeOutbox` and `FinishOrRetryWakeOutbox`: both already batch-aware, they are where #1982 put the split.
- `ClaimWakeOutbox`: claims the batch atomically, no terminal write.
- `supersedeDirectiveWakeOutboxTx`: writes `superseded` for a directive receipt, scoped to `state = 'pending'`, so it can never touch a claimed batch. Left alone deliberately.
- `EventOrgDirective` emitters: exactly two, `buildDirectiveNudgeEvent` and the drain's decoder. #1979's working-seat guard sits on the only nudge emitter, so that fix has no unguarded neighbour.
- Not changed: the `delivery_unknown` policy itself. It stays terminal and unretried for the reason argued in #2010.

## Verification

Full local gate on this head, go1.26.4 pinned: `go build -buildvcs=false ./...`, `go vet ./...`, `go test -count=1 -timeout 25m ./...`, zero failures.

Disk was 5.68% free (24.8 GiB) at the end of that run, which crosses the 25 GiB line phobos set tonight. I reported the level to him and did **not** reclaim anything, per the standing rule, and I am not running further full suites until he says the level is safe. CI on clean runners is unaffected.

## Not verified

- **No live probe.** This path only fires when a daemon dies between claiming a wake and recording its outcome. The production evidence after a deploy is a `delivery_unknown` row whose coalesced siblings read `coalesced into wake outbox row <id>` instead of `delivery_unknown`.
- **Historical rows are not rewritten.** The 244 existing `delivery_unknown` rows keep their current shape; this changes what the sweep does next.
