### PR TITLE
fix(cli): let in-flight jobs finish on shutdown, and split the pool's two contexts (#1726)

### DIFF
--- a/internal/cli/daemon_dispatch_tracked.go
+++ b/internal/cli/daemon_dispatch_tracked.go
@@ -47,13 +47,42 @@ import (
 //   - #570 escalation: an async infra error (job-level failures already resolve
 //     to nil inside worker.run) is recorded per repo and surfaced as the NEXT
 //     tick's error, so a persistent store fault still trips the ceiling.
-//   - graceful shutdown: every dispatched job runs on the tracker's runCtx;
-//     drain() cancels it and waits (bounded) for in-flight jobs to finish.
+//   - graceful shutdown: every dispatched job runs on the tracker's runCtx,
+//     which DELIBERATELY does not descend from the shutdown signal. drain()
+//     waits (bounded) for in-flight jobs and only then cancels them.
+
+// jobContext has TWO production consumers with OPPOSITE cancellation
+// semantics, and nothing else in this file says so, so it is said here:
+//
+//   - job DELIVERY (the per-job goroutines below, and the two
+//     runPoolJobRecovered sites in daemon_scheduler.go) MUST SURVIVE the
+//     shutdown signal, or a job dies mid-flight the moment SIGTERM lands.
+//   - the pool's ACCEPT/REQUERY loop MUST DIE with the signal, or a
+//     shutting-down daemon keeps hunting for work. pool_requery_bound_test.go
+//     pins that, with its own positive control.
+//
+// One context cannot serve both, so the pool pass takes the SIGNAL context and
+// derives the delivery context from the tracker internally. The obvious
+// three-line fix - re-parenting runCtx and handing it to the pool pass - makes
+// the drain tests pass and breaks shutdown, so it looks correct.
+//
+// Re-ordering drain's cancel does NOT substitute for the parentage: the
+// cancellation never came from drain. It came from runCtx's parent.
 
 // daemonShutdownDrainTimeout bounds how long the daemon waits for in-flight
-// dispatched jobs to observe cancellation on shutdown before abandoning them
-// (a truly ctx-deaf subprocess must not block daemon stop forever).
-const daemonShutdownDrainTimeout = 15 * time.Second
+// dispatched jobs to FINISH on shutdown before abandoning them (a truly
+// ctx-deaf subprocess must not block daemon stop forever).
+//
+// 900s buys p90 of measured daemon-dispatched in-flight duration (median 8s,
+// p90 893s, p95 1383s, peak concurrency 3 over 14 days). It is NECESSARY AND
+// NOT SUFFICIENT: systemd truncates it to TimeoutStopSec, and under
+// KillMode=control-group the children are signalled at t=0 and this never runs
+// at all. Both are operator changes.
+var daemonShutdownDrainTimeout = 900 * time.Second
+
+// drainCancelGrace bounds how long a TRUNCATED drain waits after cancelling,
+// so an abandoned job's death is recorded rather than lost to process exit.
+var drainCancelGrace = 5 * time.Second
 
 // heldBackLogInterval throttles the per-job "held back" observability lines
 // (#562 point 5): a job that stays excluded for the same reason re-logs at most
@@ -91,8 +120,17 @@ type inflightJobTracker struct {
 	liveness                   *daemonLivenessSweep
 }
 
+// newInflightJobTracker takes the SUPERVISOR context, which is cancelled by
+// SIGINT/SIGTERM, and deliberately does NOT derive the job run context from
+// it. WithoutCancel (not context.Background) so every VALUE carried on the
+// supervisor context - loggers, tracing, config handles, store references -
+// still reaches in-flight jobs; only the cancellation is dropped.
+//
+// The supervisor context keeps its own job, which is to stop the accept loops,
+// so no new work begins once it is done. That is what makes drain's wait
+// finite.
 func newInflightJobTracker(ctx context.Context) *inflightJobTracker {
-	runCtx, cancel := context.WithCancel(ctx)
+	runCtx, cancel := context.WithCancel(context.WithoutCancel(ctx))
 	return &inflightJobTracker{
 		runCtx:    runCtx,
 		cancelRun: cancel,
@@ -106,9 +144,10 @@ func newInflightJobTracker(ctx context.Context) *inflightJobTracker {
 	}
 }
 
-// jobContext returns the context dispatched jobs must run on: cancelled when
-// the supervisor context is cancelled OR drain() begins. A nil tracker falls
-// back to the caller's context.
+// jobContext returns the context dispatched jobs must run on: cancelled ONLY
+// when drain() spends its budget, never by the shutdown signal itself. A nil
+// tracker falls back to the caller's context, which is what keeps
+// runQueuedJobsForRepoPool byte-identical to the historical pool.
 func (t *inflightJobTracker) jobContext(fallback context.Context) context.Context {
 	if t == nil {
 		return fallback
@@ -518,11 +557,26 @@ func (t *inflightJobTracker) takeErr(repo string) error {
 	return err
 }
 
-// drain cancels every dispatched job's context and waits (bounded) for the
-// in-flight jobs to finish, logging what it had to abandon. Called on
-// supervisor exit so daemon stop cancels + drains in-flight work. From the
-// moment drain starts, begin/tryBeginPool refuse new work, so a worker tick
-// racing the shutdown cannot spawn a job the drain would never see.
+// drain waits (bounded) for in-flight dispatched jobs to FINISH, then cancels
+// them unconditionally. Called on supervisor exit, so daemon stop lets live
+// work COMPLETE instead of killing it. From the moment drain starts,
+// begin/tryBeginPool refuse new work, so a worker tick racing the shutdown
+// cannot spawn a job the drain would never see, which is what bounds the wait.
+//
+// Order matters and the old order was the defect's twin: cancelling first
+// killed exactly the work this exists to preserve. The cancel still happens on
+// EVERY path out, because an abandoned job that keeps running past daemon
+// death orphans a runtime child holding a worktree.
+//
+// The post-cancel grace is not decoration. Without it drain returns while the
+// cancellation is still propagating, and the caller (a deferred call at
+// supervisor exit) lets the process die out from under jobs that were about to
+// unwind cleanly - a smaller version of the bug being fixed here.
+//
+// What a truncated drain leaves behind is a KILLED row, never a silent one:
+// the cancel kills the subprocess, delivery fails on the signal, and #1726's
+// classifier records delivery_signal_killed so `job list --killed` finds
+// exactly what this abandoned.
 func (t *inflightJobTracker) drain(stdout io.Writer, timeout time.Duration) {
 	if t == nil {
 		return
@@ -530,21 +584,38 @@ func (t *inflightJobTracker) drain(stdout io.Writer, timeout time.Duration) {
 	t.mu.Lock()
 	t.draining = true
 	t.mu.Unlock()
-	t.cancelRun()
 	done := make(chan struct{})
 	go func() {
 		t.wg.Wait()
 		close(done)
 	}()
-	timer := time.NewTimer(timeout)
+	// The grace comes OUT of the caller's budget, never on top of it: drain's
+	// total wall time is <= timeout on every path, so one number bounds daemon
+	// stop and an operator's TimeoutStopSec has a single thing to exceed.
+	grace := drainCancelGrace
+	if reserved := timeout / 10; reserved < grace {
+		grace = reserved
+	}
+	timer := time.NewTimer(timeout - grace)
 	defer timer.Stop()
 	select {
 	case <-done:
+		t.cancelRun()
+		return
 	case <-timer.C:
-		t.mu.Lock()
-		remaining := len(t.jobs)
-		t.mu.Unlock()
-		writeLine(stdout, "daemon shutdown: abandoned %d in-flight job(s) still running after %s drain", remaining, timeout)
+	}
+	t.mu.Lock()
+	remaining := len(t.jobs)
+	t.mu.Unlock()
+	writeLine(stdout, "daemon shutdown: abandoning %d in-flight job(s) still running after %s drain; they are recorded as killed", remaining, timeout)
+	t.cancelRun()
+	// Let the cancellation reach the subprocesses so their deaths are RECORDED
+	// before the process exits. This is unwind time, not more work time.
+	graceTimer := time.NewTimer(grace)
+	defer graceTimer.Stop()
+	select {
+	case <-done:
+	case <-graceTimer.C:
 	}
 }
 
@@ -667,10 +738,14 @@ func dispatchQueuedJobsTracked(ctx context.Context, worker jobWorker, limit int,
 	}
 	if worker.UsePool {
 		if tracker.tryBeginPool(repoFilter) {
-			runCtx := tracker.jobContext(ctx)
+			// The SIGNAL context, deliberately: the pool pass's accept/requery
+			// loop must stop when the daemon is shutting down. It derives its
+			// own delivery context from the tracker for the jobs it dispatches.
+			// Handing it the surviving context instead keeps a shutting-down
+			// daemon querying for work (pool_requery_bound_test.go).
 			go func() {
 				defer tracker.endPool(repoFilter)
-				err := runQueuedJobsForRepoPoolTracked(runCtx, worker, limit, hostCap, repoFilter, rootFilter, tracker)
+				err := runQueuedJobsForRepoPoolTracked(ctx, worker, limit, hostCap, repoFilter, rootFilter, tracker)
 				if err != nil && !errors.Is(err, context.Canceled) {
 					tracker.recordErr(repoFilter, err)
 				}

--- a/internal/cli/daemon_dispatch_tracked.go
+++ b/internal/cli/daemon_dispatch_tracked.go
@@ -78,11 +78,11 @@ import (
 // NOT SUFFICIENT: systemd truncates it to TimeoutStopSec, and under
 // KillMode=control-group the children are signalled at t=0 and this never runs
 // at all. Both are operator changes.
-var daemonShutdownDrainTimeout = 900 * time.Second
+const daemonShutdownDrainTimeout = 900 * time.Second
 
 // drainCancelGrace bounds how long a TRUNCATED drain waits after cancelling,
 // so an abandoned job's death is recorded rather than lost to process exit.
-var drainCancelGrace = 5 * time.Second
+const drainCancelGrace = 5 * time.Second
 
 // heldBackLogInterval throttles the per-job "held back" observability lines
 // (#562 point 5): a job that stays excluded for the same reason re-logs at most

--- a/internal/cli/daemon_drain_test.go
+++ b/internal/cli/daemon_drain_test.go
@@ -139,19 +139,28 @@ func TestDrainAbandonsPastItsBudgetAndSaysSo(t *testing.T) {
 		<-release // deaf to cancellation, on purpose
 	}()
 
+	// The budget is derived FROM drainCancelGrace rather than written as a
+	// literal, so widening the grace cannot silently invalidate this bound the
+	// way a hard-coded margin would. A budget well under the grace is also the
+	// interesting case: it forces the reserve-out-of-budget arithmetic to clamp.
+	budget := drainCancelGrace / 100
 	var out bytes.Buffer
 	start := time.Now()
-	tracker.drain(&out, 50*time.Millisecond)
+	tracker.drain(&out, budget)
 	elapsed := time.Since(start)
 	close(release)
 
 	// The invariant is that drain's TOTAL wall time fits the caller's budget:
 	// the post-cancel grace is reserved out of it, never added on top, so one
-	// number bounds daemon stop. A generous slack keeps this from being a
-	// scheduler-timing test while still failing an additive grace, which would
-	// land at seconds against this 50ms budget.
-	if elapsed > time.Second {
-		t.Fatalf("drain took %s against a 50ms budget; the grace is being ADDED to the budget instead of reserved out of it", elapsed)
+	// number bounds daemon stop.
+	//
+	// The slack direction matters (the stall lesson): a scheduling gap makes
+	// elapsed LARGER, so this assertion degrades toward a FALSE FAILURE rather
+	// than a false pass. The slack is therefore generous enough to absorb a
+	// stall, while still far below the grace itself, which is where an additive
+	// grace would land.
+	if limit := budget + drainCancelGrace/5; elapsed > limit {
+		t.Fatalf("drain took %s against a %s budget (limit %s); the grace is being ADDED to the budget instead of reserved out of it", elapsed, budget, limit)
 	}
 	if !strings.Contains(out.String(), "abandoning 1 in-flight job") {
 		t.Fatalf("drain did not report what it abandoned: %q", out.String())

--- a/internal/cli/daemon_drain_test.go
+++ b/internal/cli/daemon_drain_test.go
@@ -1,0 +1,230 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/gitmoot/gitmoot/internal/runtime"
+	"github.com/gitmoot/gitmoot/internal/workflow"
+)
+
+// TARGET SPEC FOR #1726's DRAIN SLICE. These tests FAIL on this commit, on
+// purpose: they describe the behaviour the fix must produce, and they are
+// preserved here rather than re-derived tomorrow.
+//
+// #1726, and the point of these tests is the PARENTAGE, not the wait.
+//
+// drain() has existed, been wired at both supervisor entry points, been
+// deferred and been bounded for a long time. It did not work, because runCtx
+// descended from the supervisor's SIGNAL context: SIGTERM cancelled every
+// in-flight job's context before drain was entered, so the wait returned at
+// once. Measured on an isolated home - the daemon exited in 0.6s and its child
+// died with it. A drain waiting for corpses.
+//
+// Reordering drain's cancel would not have fixed it and that is asserted below,
+// because it is the first thing a reader of drain() would try.
+//
+// THE CONSTRAINT THAT KILLED THE THREE-LINE FIX, and it must be honoured by
+// whatever ships: jobContext has TWO production consumers with OPPOSITE
+// cancellation semantics. daemon_dispatch_tracked.go:783 hands runCtx to the
+// per-job goroutines, which MUST survive the signal so a job can finish;
+// :732 hands the same runCtx to runQueuedJobsForRepoPoolTracked, the pool
+// dispatch and requery loop, which MUST die with the signal or the daemon keeps
+// hunting for work while shutting down. One context cannot serve both, so the
+// pool path needs two threaded through it. Two existing tests hold that line
+// and must pass UNCHANGED:
+//   - daemon_dispatch_tracked_test.go:199 an abandoned job observes cancellation
+//   - pool_requery_bound_test.go:411      a draining daemon stops re-querying
+
+// TestJobContextSurvivesTheShutdownSignal is the fix, stated as the one
+// property everything else depends on.
+func TestJobContextSurvivesTheShutdownSignal(t *testing.T) {
+	supervisor, cancelSupervisor := context.WithCancel(context.Background())
+	tracker := newInflightJobTracker(supervisor)
+	jobCtx := tracker.jobContext(context.Background())
+
+	// The shutdown signal. Before the fix this cancelled jobCtx immediately.
+	cancelSupervisor()
+
+	select {
+	case <-jobCtx.Done():
+		t.Fatal("the job context was cancelled by the shutdown signal; drain can then only wait for work that is already dying")
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	// And it IS still cancellable, by the one thing that should do it.
+	tracker.drain(&bytes.Buffer{}, time.Millisecond)
+	select {
+	case <-jobCtx.Done():
+	case <-time.After(2 * time.Second):
+		t.Fatal("drain did not cancel the job context; an in-flight job would outlive the daemon and orphan its runtime child")
+	}
+}
+
+// TestDrainWaitsForInFlightWorkBeforeCancelling is the behaviour an operator
+// gets: work in flight when the signal arrives is allowed to finish.
+//
+// The fake job observes its own context, so it fails if the context dies while
+// it is still working - which is exactly what the 0.6s measurement was.
+func TestDrainWaitsForInFlightWorkBeforeCancelling(t *testing.T) {
+	supervisor, cancelSupervisor := context.WithCancel(context.Background())
+	tracker := newInflightJobTracker(supervisor)
+
+	if !tracker.beginWithin(0, "job-slow", "owner/repo", "checkout", "runtime") {
+		t.Fatal("beginWithin refused a first job")
+	}
+	jobCtx := tracker.jobContext(context.Background())
+
+	var mu sync.Mutex
+	var cancelledEarly bool
+	finished := make(chan struct{})
+	tracker.wg.Add(1)
+	go func() {
+		defer tracker.wg.Done()
+		defer tracker.end("job-slow")
+		defer close(finished)
+		// Slow BY CONSTRUCTION, like the /tmp probe's `sleep 300`, not slow by
+		// luck. 300ms is long enough that a cancel-first drain would be observed.
+		select {
+		case <-time.After(300 * time.Millisecond):
+		case <-jobCtx.Done():
+			mu.Lock()
+			cancelledEarly = true
+			mu.Unlock()
+		}
+	}()
+
+	// The signal arrives while the job is in flight.
+	cancelSupervisor()
+
+	var out bytes.Buffer
+	tracker.drain(&out, 10*time.Second)
+
+	<-finished
+	mu.Lock()
+	early := cancelledEarly
+	mu.Unlock()
+	if early {
+		t.Fatal("the in-flight job was cancelled before it finished; the drain is still waiting for corpses")
+	}
+	if strings.Contains(out.String(), "abandoned") {
+		t.Fatalf("drain reported abandoning work it should have waited for: %q", out.String())
+	}
+}
+
+// TestDrainAbandonsPastItsBudgetAndSaysSo is the bound. A ctx-deaf subprocess
+// must not block daemon stop forever, and what it leaves behind must be a
+// KILLED row rather than a silent one - the trailing cancel kills the
+// subprocess, the delivery fails on the signal, and #1726's classifier
+// (merged as 246caff8) records it so `job list --killed` finds exactly what
+// was abandoned.
+//
+// It also pins the orphan risk I found in my own first fix: a DEFERRED trailing
+// cancel lets drain return before the cancellation has propagated, so this
+// asserts the context is done by the time drain returns.
+func TestDrainAbandonsPastItsBudgetAndSaysSo(t *testing.T) {
+	tracker := newInflightJobTracker(context.Background())
+	if !tracker.beginWithin(0, "job-deaf", "owner/repo", "checkout", "runtime") {
+		t.Fatal("beginWithin refused a first job")
+	}
+	release := make(chan struct{})
+	tracker.wg.Add(1)
+	go func() {
+		defer tracker.wg.Done()
+		<-release // deaf to cancellation, on purpose
+	}()
+
+	var out bytes.Buffer
+	start := time.Now()
+	tracker.drain(&out, 50*time.Millisecond)
+	elapsed := time.Since(start)
+	close(release)
+
+	// The invariant is that drain's TOTAL wall time fits the caller's budget:
+	// the post-cancel grace is reserved out of it, never added on top, so one
+	// number bounds daemon stop. A generous slack keeps this from being a
+	// scheduler-timing test while still failing an additive grace, which would
+	// land at seconds against this 50ms budget.
+	if elapsed > time.Second {
+		t.Fatalf("drain took %s against a 50ms budget; the grace is being ADDED to the budget instead of reserved out of it", elapsed)
+	}
+	if !strings.Contains(out.String(), "abandoning 1 in-flight job") {
+		t.Fatalf("drain did not report what it abandoned: %q", out.String())
+	}
+	// And it still cancelled on the way out, or the abandoned job would keep
+	// running past daemon death.
+	select {
+	case <-tracker.jobContext(context.Background()).Done():
+	case <-time.After(2 * time.Second):
+		t.Fatal("drain abandoned work WITHOUT cancelling; that orphans a runtime child holding a worktree")
+	}
+}
+
+// TestDrainRefusesNewWorkOnceStarted is what makes the wait finite. Without
+// it a worker tick racing the shutdown could spawn a job the drain never sees,
+// and the bound would be a lie.
+func TestDrainRefusesNewWorkOnceStarted(t *testing.T) {
+	tracker := newInflightJobTracker(context.Background())
+	tracker.drain(&bytes.Buffer{}, time.Millisecond)
+	if tracker.beginWithin(0, "job-late", "owner/repo", "checkout", "runtime") {
+		t.Fatal("a job was admitted after drain started; the drain's wait would never cover it")
+	}
+}
+
+// TestPoolDispatchedJobSurvivesTheShutdownSignal covers the POOL seam, and it
+// exists because a mutation survived without it.
+//
+// The four tests above exercise the tracker directly. Replacing the pool pass's
+// deliveryCtx with its plain (signal) ctx left all of them green, because none
+// of them dispatches through the pool at all - the same "correct where
+// installed, absent at the next call site" shape the fix itself is about, this
+// time in the coverage rather than the code.
+//
+// The adapter here OBEYS its context (the default), so a cancelled delivery
+// context makes Deliver return ctx.Err() and clear `blocked`. Staying blocked
+// across the signal is therefore a positive observation that the job's context
+// outlived it, not an absence of evidence.
+func TestPoolDispatchedJobSurvivesTheShutdownSignal(t *testing.T) {
+	const repo = "owner/repo"
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	store := daemonWorkerStore(t)
+	seedDaemonWorkerRepo(t, store, repo, t.TempDir())
+	seedDaemonWorkerAgent(t, store, "audit", runtime.ShellRuntime, "unused", []string{"ask"}, repo)
+
+	adapter := newWedgeBlockingAdapter("job-a")
+	enqueueDaemonWorkerJob(t, store, workflow.JobRequest{ID: "job-a", Agent: "audit", Action: "ask", Repo: repo, Branch: "main", PullRequest: 1})
+	_, errCh := startTrackedWedgeLoop(t, ctx, store, adapter, 2, true, io.Discard)
+
+	if !waitForCondition(t, 5*time.Second, adapter.stillBlocked) {
+		t.Fatalf("job-a never started delivering through the pool; delivered=%v", adapter.deliveredJobs())
+	}
+
+	// The shutdown signal, delivered to the pass that dispatched the job.
+	cancel()
+
+	// Long enough that a ctx-obeying delivery on a cancelled context would have
+	// returned many times over.
+	time.Sleep(250 * time.Millisecond)
+	if !adapter.stillBlocked() {
+		t.Fatal("the pool-dispatched job observed the shutdown signal; pool delivery is running on the signal context, so drain has nothing left to wait for")
+	}
+
+	// And it can still COMPLETE, which is the whole point of keeping it alive.
+	close(adapter.release)
+	if !waitForCondition(t, 10*time.Second, func() bool {
+		return mustWorkerJob(t, store, "job-a").State == "succeeded"
+	}) {
+		t.Fatalf("the surviving job never completed; state=%s", mustWorkerJob(t, store, "job-a").State)
+	}
+	select {
+	case <-errCh:
+	case <-time.After(10 * time.Second):
+	}
+}

--- a/internal/cli/daemon_scheduler.go
+++ b/internal/cli/daemon_scheduler.go
@@ -2242,6 +2242,17 @@ func runQueuedJobsForRepoPoolTracked(ctx context.Context, worker jobWorker, limi
 		policy = config.ParallelSessionPolicy{SameSession: config.ParallelSessionQueue}
 	}
 
+	// ctx is the SIGNAL context and governs this pass's own accept/requery loop:
+	// on shutdown it must stop selecting, querying and dispatching promptly.
+	//
+	// deliveryCtx governs the JOBS this pass dispatches, and must SURVIVE the
+	// shutdown signal so in-flight work can finish while the tracker's drain
+	// waits for it. Only the two runPoolJobRecovered calls below may use it.
+	//
+	// A nil tracker returns ctx unchanged, which is what keeps the untracked
+	// runQueuedJobsForRepoPool byte-identical to the historical pool.
+	deliveryCtx := tracker.jobContext(ctx)
+
 	type finished struct {
 		jobID        string
 		checkoutKey  string
@@ -2359,8 +2370,9 @@ func runQueuedJobsForRepoPoolTracked(ctx context.Context, worker jobWorker, limi
 		}
 
 		// Stop dispatching promptly on cancellation rather than relying on the next
-		// store query to observe it; in-flight workers return as their own ctx is
-		// cancelled (parity with the barrier's wg.Wait()), then we drain and exit.
+		// store query to observe it. In-flight workers do NOT return here: they run
+		// on deliveryCtx, which survives the signal, so this loop stops accepting
+		// and then waits for them below while the tracker's drain bounds the wait.
 		if firstErr == nil && ctx.Err() != nil {
 			firstErr = ctx.Err()
 		}
@@ -2472,7 +2484,7 @@ func runQueuedJobsForRepoPoolTracked(ctx context.Context, worker jobWorker, limi
 					running++
 					dispatched++
 					go func() {
-						done <- finished{jobID: job.ID, checkoutKey: checkoutKey, runtimeKey: runtimeKey, err: runPoolJobRecovered(ctx, worker, job)}
+						done <- finished{jobID: job.ID, checkoutKey: checkoutKey, runtimeKey: runtimeKey, err: runPoolJobRecovered(deliveryCtx, worker, job)}
 					}()
 				}
 				// #394 part 2: a read-only job left blocked ONLY by a contended same-repo
@@ -2605,7 +2617,7 @@ func runQueuedJobsForRepoPoolTracked(ctx context.Context, worker jobWorker, limi
 					running++
 					dispatched++
 					go func() {
-						done <- finished{jobID: iso.job.ID, checkoutKey: iso.checkoutKey, runtimeKey: iso.runtimeKey, worktreePath: iso.worktreePath, repoCheckout: iso.repoCheckout, runner: iso.runner, payloadBeforeIsolation: payloadBeforeIsolation, err: runPoolJobRecovered(ctx, worker, iso.job)}
+						done <- finished{jobID: iso.job.ID, checkoutKey: iso.checkoutKey, runtimeKey: iso.runtimeKey, worktreePath: iso.worktreePath, repoCheckout: iso.repoCheckout, runner: iso.runner, payloadBeforeIsolation: payloadBeforeIsolation, err: runPoolJobRecovered(deliveryCtx, worker, iso.job)}
 					}()
 				}
 			}


### PR DESCRIPTION
Closes #1726. Campaign #1818, sixth slice, after #1817 (`e16875b3`), #1819 (`62f65b5c`), #1994 (`e8b48f54`), #1817 criterion 2 (`cad5a990`) and #1726's classifier (`246caff8`).

## The defect

The drain **already existed** and was wired at both supervisor entry points, deferred, bounded, with a documented no-new-work flag. It was useless, and not for the reason `drain()` reads like: `runCtx` descended from the **signal** context, so SIGTERM cancelled every in-flight job before drain was entered and the wait returned against goroutines already unwinding. **A drain waiting for corpses.**

Reproduced and re-measured on an isolated `/tmp` home, SIGTERM to the daemon alone, which is what `KillMode=mixed` will deliver:

| | before | after |
|---|---|---|
| daemon exit latency | **0.6 s** | **19 s** |
| in-flight job | `failed: signal: terminated` | **`succeeded`** |
| worktree | leaked | removed, workflow advanced |

**Re-ordering drain's cancel fixes nothing.** That is worth stating because it is the first thing a reader of `drain()` would try; a mutant confirms it. The cancellation never came from drain, it came from `runCtx`'s parent.

## The part that is not the obvious fix

`jobContext` has **two production consumers with opposite cancellation semantics**, and nothing in the tree said so:

- **delivery** (the per-job goroutines, and both `runPoolJobRecovered` sites) **must survive** the signal, or a job dies mid-flight the moment SIGTERM lands.
- the pool's **accept/requery loop must die** with the signal, or a shutting-down daemon keeps hunting for work.

Re-parenting `runCtx` and handing it to the pool pass **makes the drain tests pass and breaks shutdown**. I shipped that version internally yesterday, it broke two existing tests, and I reverted rather than re-pin them. So the pool pass now takes the signal context and derives `deliveryCtx` from the tracker internally, at exactly the two dispatch sites. A nil tracker returns the caller's context unchanged, which is what keeps the untracked `runQueuedJobsForRepoPool` byte-identical to the historical pool, by construction rather than by promise.

That constraint is now a comment at the seam, because the next reader's evidence will be the same three-line fix that appears to work.

## Sibling audit

Per the fleet check, the other callers of everything touched:

| sibling | requires | done |
|---|---|---|
| `runQueuedJobsForRepoPool` (`daemon_scheduler.go:2148`, nil tracker) | unchanged behaviour | `jobContext` falls back to caller ctx; byte-identical |
| non-pool dispatch (`daemon_dispatch_tracked.go:790`) | selection on signal ctx, delivery on surviving ctx | already correctly scoped; untouched |
| `runPoolJobRecovered` sites (2 of 2) | surviving ctx | both switched |
| accept-loop gate (`daemon_scheduler.go:2376`) | signal ctx | kept, and its stale comment corrected: in-flight workers no longer return here |
| 5 `context.WithoutCancel(ctx)` cleanup writes in the same function | unchanged | untouched; the idiom is precedent, not invention |

The audit's second question matters more than the first here: **the neighbour did not want the same answer.** "Checked `:2148`, left unchanged" would have been a true sentence in a PR that broke shutdown.

## Tests

Seven, and the two existing ones pass **unchanged** as required.

```
--- PASS: TestJobContextSurvivesTheShutdownSignal
--- PASS: TestDrainWaitsForInFlightWorkBeforeCancelling
--- PASS: TestDrainAbandonsPastItsBudgetAndSaysSo
--- PASS: TestDrainRefusesNewWorkOnceStarted
--- PASS: TestPoolDispatchedJobSurvivesTheShutdownSignal
--- PASS: TestTrackedLoopShutdownDrainsInFlightJobs          (existing, unchanged)
--- PASS: TestPoolRequeryObserverIsSilentWhileDrainingAfterCancellation (existing, unchanged)
```

Four mutants, all killed:

| mutant | killed by |
|---|---|
| restore the old parentage | `TestJobContextSurvives...`, `TestDrainWaits...` |
| cancel first, then wait | `TestDrainWaits...` |
| hand the pool the surviving ctx | `TestPoolRequeryObserver...` (existing) |
| drop the post-cancel grace | `TestTrackedLoopShutdown...` (existing) |

**`TestPoolDispatchedJobSurvivesTheShutdownSignal` exists because a mutation survived without it.** Every tracker-level test stayed green while the pool seam was broken. That is the same "correct where installed, absent at the next call site" shape as the fix, this time in my coverage rather than in the code. It uses the ctx-**obeying** adapter, so staying blocked across the signal is a positive observation rather than an absence.

The grace being killed by a **pre-existing** test is the useful accident: it proves the grace is load-bearing for a contract older than this change, not decoration I added.

## Not verified, and why

**The local full gate has NOT been run.** Free space is at the dispatch guard and full suites are on hold fleet-wide by `phobos`, so I ran `internal/cli` targeted only, plus `gofmt` and `go vet` clean. **CI is the authority for this PR** until the hold lifts; I am not claiming a local green I did not get. Draft until then.

Not verified: deployed behaviour. Nothing is deployed and no service was restarted.

## Deploy notes

The code change is **necessary and not sufficient**, and the operator half is not mine:

- `KillMode=control-group` signals every process in the cgroup at t=0, so the children die before the daemon can decide anything and this code never runs. Needs `KillMode=mixed`.
- `TimeoutStopSec=90s` truncates the 900 s cap to roughly p60-p70 of in-flight duration. Needs raising alongside the cap.

Both are live-host unit edits for a deploy with **zero jobs in flight**. Signalling the daemon **alone** is the faithful test of the code change, because that is what `mixed` delivers; nobody should later "fix" the test to use `systemctl`.

Signed: **gm-staged**
