### PR TITLE
feat(cli): record a wake nobody can receive, instead of queueing it silently

### DIFF
--- a/docs/events.md
+++ b/docs/events.md
@@ -257,6 +257,19 @@ unexplained non-delivery), the batch becomes terminal AND a
 `wake_delivery_failed` job event is recorded on `wake-outbox:<id>` naming the
 target role, the cause and the attempts spent, so an undelivered obligation is
 attributable from the store rather than only from a daemon log line.
+A wake addressed to a role that CANNOT receive it, because no enabled rule
+exists for that role and kind, records a `wake_unroutable` job event on
+`wake-outbox:<id>` naming the role, the kind, the source and WHICH condition it
+is: `condition=route_removed` when a durable tombstone shows the route was
+deleted after the row existed, which is a retired seat and usually needs no
+remedy, or `condition=never_configured` when no route history exists for that
+role and kind at all, which is the case a route would fix. The record is written
+at most once per row rather than once per tick, because the drain re-classifies
+every tick and a per-tick append is what grows `job_events` without bound. The
+row itself is NOT failed and NOT retried: a wake nobody can receive is not a
+wake that is wrong, and a rule added later still delivers it. The distinction
+rests on the deletion tombstones, so a role retired before that table existed
+reads as never-configured.
 `delivery_unknown` remains terminal and is still never retried: a row aged out
 of `attempted` may in fact have been delivered before its outcome write was
 lost, so re-emitting it would risk a duplicate interrupt to prove a negative.

--- a/internal/cli/org_interrupts.go
+++ b/internal/cli/org_interrupts.go
@@ -47,16 +47,21 @@ type orgInterruptSeat struct {
 }
 
 type orgInterruptReport struct {
-	WindowStart        string             `json:"window_start"`
-	WindowEnd          string             `json:"window_end"`
-	WindowHours        float64            `json:"window_hours"`
-	ShortGapSeconds    float64            `json:"short_gap_threshold_seconds"`
-	Wakes              int                `json:"wakes"`
-	Collapsed          int                `json:"collapsed"`
-	Unproven           int                `json:"unproven"`
-	RoutelessPending   int                `json:"routeless_pending"`
-	Seats              []orgInterruptSeat `json:"seats"`
-	RoutelessByKindLbl map[string]int     `json:"routeless_pending_by_kind,omitempty"`
+	WindowStart      string             `json:"window_start"`
+	WindowEnd        string             `json:"window_end"`
+	WindowHours      float64            `json:"window_hours"`
+	ShortGapSeconds  float64            `json:"short_gap_threshold_seconds"`
+	Wakes            int                `json:"wakes"`
+	Collapsed        int                `json:"collapsed"`
+	Unproven         int                `json:"unproven"`
+	RoutelessPending int                `json:"routeless_pending"`
+	Seats            []orgInterruptSeat `json:"seats"`
+	// RouteHistoryStart is the oldest recorded route deletion. Anything before
+	// it has no route history, so an unroutable row from that era reads as
+	// never-configured even if its seat was retired. Empty means NO route
+	// history is recorded at all.
+	RouteHistoryStart  string         `json:"route_history_start,omitempty"`
+	RoutelessByKindLbl map[string]int `json:"routeless_pending_by_kind,omitempty"`
 }
 
 func runOrgInterrupts(args []string, stdout, stderr io.Writer) int {
@@ -95,7 +100,12 @@ func runOrgInterrupts(args []string, stdout, stderr io.Writer) int {
 		if err != nil {
 			return err
 		}
+		historyStart, err := store.EarliestEventRuleDeletion(ctx)
+		if err != nil {
+			return err
+		}
 		report = buildOrgInterruptReport(activity, nudges, rules, since, now, span)
+		report.RouteHistoryStart = historyStart
 		return nil
 	}); err != nil {
 		fmt.Fprintf(stderr, "org interrupts: %v\n", err)
@@ -333,10 +343,31 @@ func writeOrgInterruptText(stdout io.Writer, report orgInterruptReport) {
 		)
 	}
 	_ = tw.Flush()
+	routeless := false
 	for _, seat := range report.Seats {
 		if seat.Routeless > 0 {
+			routeless = true
 			fmt.Fprintf(stdout, "\n%s has %d pending wake(s) with no enabled route, oldest %s\n",
 				seat.Role, seat.Routeless, seat.OldestRLAt)
+		}
+	}
+	if routeless {
+		// PRINTED WITH THE ROWS, not left in a PR body. Each unroutable row
+		// records a `wake_unroutable` job event whose `condition` says whether
+		// the route was removed (a retired seat) or never configured (a gap).
+		// That categorisation reads the deletion tombstones, and they do not go
+		// back far enough, so history is miscategorised in one direction. A
+		// reader deciding whether these wakes were load-bearing needs to know
+		// that before trusting the split.
+		boundary := report.RouteHistoryStart
+		if boundary == "" {
+			fmt.Fprintf(stdout,
+				"\nNo route deletions are recorded at all, so every unroutable row above reads as %q in its wake_unroutable event whether or not its seat was retired.\n",
+				db.WakeOutboxUnroutableNeverConfigured)
+		} else {
+			fmt.Fprintf(stdout,
+				"\nRoute history begins %s; a role retired before then reads as %q rather than %q in its wake_unroutable event.\n",
+				boundary, db.WakeOutboxUnroutableNeverConfigured, db.WakeOutboxUnroutableRouteRemoved)
 		}
 	}
 }

--- a/internal/cli/org_interrupts_test.go
+++ b/internal/cli/org_interrupts_test.go
@@ -153,6 +153,35 @@ func TestOrgInterruptsCommandReportsFromTheStore(t *testing.T) {
 	if report.Collapsed != 2 {
 		t.Fatalf("report collapsed = %d, want 2", report.Collapsed)
 	}
+
+	// WIRING, not just arithmetic. A mutant that computed the route-history
+	// boundary and never assigned it to the report survived until this existed:
+	// the caveat test set the field by hand, so nothing proved the COMMAND
+	// populates it from the store. Same shape as the #1938 tests that all
+	// passed with the production fix deleted.
+	if err := store.AddEventRule(ctx, db.EventRule{
+		ID: "reply-doomed", OnKind: db.WakeOutboxKindReply, WakeRole: "owner", Enabled: true,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.DeleteEventRule(ctx, "reply-doomed"); err != nil {
+		t.Fatal(err)
+	}
+	stdout.Reset()
+	stderr.Reset()
+	if code := runOrg([]string{"interrupts", "--home", home, "--window", "24h", "--json"}, &stdout, &stderr); code != 0 {
+		t.Fatalf("json code=%d err=%q", code, stderr.String())
+	}
+	var withHistory orgInterruptReport
+	if err := json.Unmarshal(stdout.Bytes(), &withHistory); err != nil {
+		t.Fatal(err)
+	}
+	if strings.TrimSpace(withHistory.RouteHistoryStart) == "" {
+		t.Fatal("command did not carry the recorded route-history boundary into the report")
+	}
+	if _, err := time.Parse(time.RFC3339Nano, withHistory.RouteHistoryStart); err != nil {
+		t.Fatalf("route_history_start = %q, want an RFC3339 timestamp: %v", withHistory.RouteHistoryStart, err)
+	}
 }
 
 func TestOrgInterruptWindowParsing(t *testing.T) {
@@ -181,5 +210,62 @@ func TestOrgInterruptWindowParsing(t *testing.T) {
 		if err != nil || got != test.want {
 			t.Fatalf("window %q = %s, %v; want %s", test.value, got, err, test.want)
 		}
+	}
+}
+
+// TestOrgInterruptTextStatesItsOwnRouteHistoryLimit puts the limitation in the
+// OUTPUT, not only in a PR body (phobos, on gm-integrity's framing: a
+// limitation in a report instead of a record is the same defect class as
+// recording nothing).
+//
+// The retired-versus-gap split in each row's `wake_unroutable` event reads the
+// deletion tombstones. On this fleet they begin 2026-08-30, so every role
+// retired earlier reads as never-configured, including the seven roles with
+// delivered escalations and no current route, which are exactly the rows the
+// question is about.
+func TestOrgInterruptTextStatesItsOwnRouteHistoryLimit(t *testing.T) {
+	base := time.Date(2026, 9, 1, 12, 0, 0, 0, time.UTC)
+	activity := []db.WakeOutboxActivity{{
+		ID: 1, TargetRole: "stranded", SourceKind: db.WakeOutboxSourceAwaitedFact,
+		CoalesceKey: "fact:stranded", State: db.WakeOutboxStatePending,
+		CreatedAt: base.Format(time.RFC3339Nano),
+	}}
+	report := buildOrgInterruptReport(activity, nil, nil, base, base.Add(time.Hour), time.Hour)
+	if report.RoutelessPending != 1 {
+		t.Fatalf("routeless = %d, want the unrouted row", report.RoutelessPending)
+	}
+
+	report.RouteHistoryStart = "2026-08-30T17:27:04Z"
+	var withHistory bytes.Buffer
+	writeOrgInterruptText(&withHistory, report)
+	if !strings.Contains(withHistory.String(), "Route history begins 2026-08-30T17:27:04Z") ||
+		!strings.Contains(withHistory.String(), db.WakeOutboxUnroutableNeverConfigured) {
+		t.Fatalf("report does not state its categorisation limit: %q", withHistory.String())
+	}
+
+	// No tombstones at all is a STRONGER limit, not a missing one: every row
+	// reads as never-configured whatever actually happened.
+	report.RouteHistoryStart = ""
+	var noHistory bytes.Buffer
+	writeOrgInterruptText(&noHistory, report)
+	if !strings.Contains(noHistory.String(), "No route deletions are recorded at all") {
+		t.Fatalf("report with no route history does not say so: %q", noHistory.String())
+	}
+
+	// And the caveat is attached to the rows it qualifies, not printed
+	// unconditionally: a fleet with every route in place should not be told
+	// about a limit that cannot affect it.
+	clean := buildOrgInterruptReport([]db.WakeOutboxActivity{{
+		ID: 2, TargetRole: "owner", SourceKind: db.WakeOutboxSourceWorkflowNote,
+		CoalesceKey: "reply:owner", State: db.WakeOutboxStateDelivered,
+		CreatedAt: base.Format(time.RFC3339Nano),
+	}}, nil, []db.EventRule{{
+		ID: "reply-owner", OnKind: db.WakeOutboxKindReply, WakeRole: "owner", Enabled: true,
+	}}, base, base.Add(time.Hour), time.Hour)
+	clean.RouteHistoryStart = "2026-08-30T17:27:04Z"
+	var cleanOut bytes.Buffer
+	writeOrgInterruptText(&cleanOut, clean)
+	if strings.Contains(cleanOut.String(), "Route history begins") {
+		t.Fatalf("caveat printed with no routeless rows to qualify: %q", cleanOut.String())
 	}
 }

--- a/internal/cli/reply_wake_outbox.go
+++ b/internal/cli/reply_wake_outbox.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"log/slog"
 	"sort"
 	"strings"
 	"time"
@@ -80,6 +81,9 @@ type wakeOutboxStore interface {
 	ExpireAgedWakeOutbox(ctx context.Context, attemptedBefore time.Time, now time.Time) ([]db.WakeOutboxEntry, error)
 	ClaimWakeOutbox(ctx context.Context, surviving int64, coalesced []int64, now time.Time) (bool, error)
 	ListDeletedEventRulesForRoutes(ctx context.Context, routes []db.EventRuleRoute) ([]db.DeletedEventRule, error)
+	// AddJobEventIfAbsent records the unroutable-wake condition at most once per
+	// row, keyed on (job_id, kind) by the store (owner decision 2026-09-08).
+	AddJobEventIfAbsent(ctx context.Context, event db.JobEvent) error
 }
 
 // drainReplyWakeOutboxWithHealth is a store-global daemon operation. It
@@ -263,8 +267,11 @@ func classifyWakeOutboxObligations(
 		return replyWakeOutboxHealth{}, fmt.Errorf("classify wake outbox obligations: %w", err)
 	}
 	type unmatchedWakeObligation struct {
-		event     events.Event
-		createdAt time.Time
+		id         int64
+		sourceKind string
+		sourceID   string
+		event      events.Event
+		createdAt  time.Time
 	}
 	unmatched := make([]unmatchedWakeObligation, 0, len(obligations.Pending))
 	routes := make([]db.EventRuleRoute, 0, len(obligations.Pending))
@@ -293,7 +300,10 @@ func classifyWakeOutboxObligations(
 		if err != nil {
 			return replyWakeOutboxHealth{}, fmt.Errorf("parse wake outbox created_at for row %d: %w", obligation.ID, err)
 		}
-		unmatched = append(unmatched, unmatchedWakeObligation{event: event, createdAt: createdAt})
+		unmatched = append(unmatched, unmatchedWakeObligation{
+			id: obligation.ID, sourceKind: obligation.SourceKind, sourceID: obligation.SourceID,
+			event: event, createdAt: createdAt,
+		})
 		key := wakeRuleRouteKey(event.WakeTargetRole, event.WakeKind)
 		if _, ok := seenRoutes[key]; !ok {
 			seenRoutes[key] = struct{}{}
@@ -310,16 +320,72 @@ func classifyWakeOutboxObligations(
 	}
 	for _, obligation := range unmatched {
 		deletions := deletedRulesAt[wakeRuleRouteKey(obligation.event.WakeTargetRole, obligation.event.WakeKind)]
+		condition := db.WakeOutboxUnroutableNeverConfigured
 		if matchesDeletedWakeRule(deletions, obligation.event, obligation.createdAt) {
+			condition = db.WakeOutboxUnroutableRouteRemoved
 			health.routeRemoved++
-			continue
+		} else {
+			health.inert++
 		}
-		health.inert++
+		recordUnroutableWake(ctx, store, obligation.id, obligation.sourceKind, obligation.sourceID, obligation.event, condition)
 	}
 	if health.pending == 0 && health.routeRemoved == 0 && health.agedAttempted == 0 {
 		return health, nil
 	}
 	return health, fmt.Errorf("wake outbox has outstanding obligations: %s", health)
+}
+
+// recordUnroutableWake makes a dead-ended wake visible in ONE query instead of
+// silently queued (owner decision 2026-09-08, relayed by phobos).
+//
+// It records nothing new about the row's fate: an unroutable row stays pending
+// and is deliberately NOT failed, because a wake nobody can receive is not a
+// wake that is wrong, and a rule added later can still deliver it. What changes
+// is that the condition is attributable: role, kind, source and WHICH condition
+// it is, since a retired seat needs no remedy while a never-configured one
+// needs a route.
+//
+// ONCE PER WAKE, NOT PER TICK. AddJobEventIfAbsent keys on (job_id, kind), and
+// the drain re-classifies every tick, so an unconditional append would add a
+// row per unroutable obligation per tick forever: the mechanism that grew
+// job_events past a million rows.
+//
+// BEST EFFORT. An audit write that fails must not change the drain's verdict,
+// so the failure is logged and the classification stands.
+func recordUnroutableWake(
+	ctx context.Context,
+	store wakeOutboxStore,
+	rowID int64,
+	sourceKind, sourceID string,
+	event events.Event,
+	condition string,
+) {
+	if store == nil || rowID <= 0 {
+		return
+	}
+	source := strings.TrimSpace(sourceKind)
+	// A blocked, escalation or fact source id is a serialized event payload, so
+	// only a workflow-note id is worth rendering into an operator-facing record.
+	if source == db.WakeOutboxSourceWorkflowNote {
+		source += ":" + strings.TrimSpace(sourceID)
+	}
+	message := fmt.Sprintf(
+		"role=%s kind=%s source=%s condition=%s",
+		strings.TrimSpace(event.WakeTargetRole),
+		strings.TrimSpace(event.WakeKind),
+		source,
+		condition,
+	)
+	writeCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), db.DurableWriteBudget)
+	defer cancel()
+	if err := store.AddJobEventIfAbsent(writeCtx, db.JobEvent{
+		JobID:   fmt.Sprintf("wake-outbox:%d", rowID),
+		Kind:    db.WakeOutboxUnroutableEventKind,
+		Message: message,
+	}); err != nil {
+		slog.Warn("unroutable wake record failed",
+			"wake_outbox_row", rowID, "role", event.WakeTargetRole, "kind", event.WakeKind, "error", err)
+	}
 }
 
 type deletedWakeRule struct {

--- a/internal/cli/reply_wake_outbox_test.go
+++ b/internal/cli/reply_wake_outbox_test.go
@@ -952,6 +952,155 @@ func TestReplyWakeOutboxReadFailureLogsUnhealthyWithoutAbortingFleetTick(t *test
 	}
 }
 
+// TestUnroutableWakeIsRecordedOncePerRow covers the owner decision of
+// 2026-09-08: a wake addressed to a role that cannot receive it must be
+// findable in one query rather than sitting silently queued. On the live fleet
+// that silence hid 49 awaited-fact obligations from 2026-08-02 and ten
+// escalations addressed to a coordinator whose wake routes had been removed.
+//
+// Rerouting was deliberately NOT the remedy chosen: it would rebuild the
+// coordinator layer that was just retired. This records, and wakes nobody.
+func TestUnroutableWakeIsRecordedOncePerRow(t *testing.T) {
+	store, sink, wake, _ := replyWakeTestHarness(t, []replyWakeTestRole{
+		{"owner", "w1:p1"},
+		{"stranded", "w1:p2"},
+	})
+	ctx := context.Background()
+	// The harness gives every role a reply rule, so removing this one leaves a
+	// role that is configured, paned, and unreachable for `reply`.
+	if err := store.DeleteEventRule(ctx, "reply-1"); err != nil {
+		t.Fatal(err)
+	}
+	note, err := store.InsertWorkflowNote(ctx, db.WorkflowNote{
+		WorkflowID: "release/unroutable", Author: "worker", Body: "nobody can receive this",
+		AddressedTarget: "stranded",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	pending, err := store.ListWakeOutbox(ctx, db.WakeOutboxStatePending)
+	if err != nil || len(pending) != 1 {
+		t.Fatalf("pending = %+v, err=%v", pending, err)
+	}
+	rowID := pending[0].ID
+	// STAMPED, not left to wall-clock ordering. workflow_notes.created_at has
+	// millisecond precision while event_rule_deletions.deleted_at has
+	// nanosecond precision, so a rule deleted microseconds BEFORE this row can
+	// still compare as deleted after it and read as a retirement. Production
+	// separates the two by seconds or days; a test has to say which it means.
+	setWakeOutboxCreatedAt(t, store.DatabasePath(), fmt.Sprint(note.ID), time.Now().UTC().Add(time.Minute))
+
+	// Two drains: the condition is re-observed every tick, and the record must
+	// not grow with the ticks. A per-tick append is what took job_events past a
+	// million rows.
+	// An INERT row is deliberately not a drain fault (#1758: inert is permanent,
+	// logged once, and an operator adding a rule later resolves it). That is
+	// exactly why it needed a durable record: the tick is healthy and the
+	// obligation is invisible.
+	for range 2 {
+		if err := drainReplyWakeAfterAllRowsAreDueResult(t, store, sink); err != nil {
+			t.Fatalf("inert drain = %v, want a healthy tick; inert is not a fault", err)
+		}
+	}
+	if wake.promptCalls != 0 {
+		t.Fatalf("an unroutable wake reached a pane: %v", wake.prompts)
+	}
+
+	events, err := store.ListJobEvents(ctx, fmt.Sprintf("wake-outbox:%d", rowID))
+	if err != nil || len(events) != 1 {
+		t.Fatalf("unroutable events = %+v, err=%v, want exactly one after two drains", events, err)
+	}
+	if events[0].Kind != db.WakeOutboxUnroutableEventKind {
+		t.Fatalf("event kind = %q, want %q", events[0].Kind, db.WakeOutboxUnroutableEventKind)
+	}
+	for _, want := range []string{
+		"role=stranded",
+		"kind=" + db.WakeOutboxKindReply,
+		fmt.Sprintf("source=%s:%d", db.WakeOutboxSourceWorkflowNote, note.ID),
+		"condition=" + db.WakeOutboxUnroutableNeverConfigured,
+	} {
+		if !strings.Contains(events[0].Message, want) {
+			t.Fatalf("event %q does not name %q", events[0].Message, want)
+		}
+	}
+
+	// The row is NOT failed. A wake nobody can receive is not a wake that is
+	// wrong, and a rule added later must still deliver it (#1983's refusal).
+	stillPending, err := store.ListWakeOutbox(ctx, db.WakeOutboxStatePending)
+	if err != nil || len(stillPending) != 1 || stillPending[0].ID != rowID || stillPending[0].AttemptCount != 0 {
+		t.Fatalf("row after two drains = %+v, err=%v, want it still pending and unattempted", stillPending, err)
+	}
+}
+
+// TestUnroutableWakeDistinguishesARetiredRoleFromAGap pins the distinction the
+// remedy depends on: a role whose route was DELETED after the row existed is a
+// retired seat and usually needs nothing, while a role with no route history
+// at all is the 2026-08-02 gap and needs a route.
+func TestUnroutableWakeDistinguishesARetiredRoleFromAGap(t *testing.T) {
+	store, sink, _, _ := replyWakeTestHarness(t, []replyWakeTestRole{
+		{"owner", "w1:p1"},
+		{"retired", "w1:p2"},
+	})
+	ctx := context.Background()
+	note, err := store.InsertWorkflowNote(ctx, db.WorkflowNote{
+		WorkflowID: "release/retired", Author: "worker", Body: "addressed before the seat retired",
+		AddressedTarget: "retired",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	pending, err := store.ListWakeOutbox(ctx, db.WakeOutboxStatePending)
+	if err != nil || len(pending) != 1 || pending[0].SourceID != fmt.Sprint(note.ID) {
+		t.Fatalf("pending = %+v, err=%v", pending, err)
+	}
+	// The route existed while the row was created and is removed afterwards,
+	// which is exactly the retirement ordering.
+	if err := store.DeleteEventRule(ctx, "reply-1"); err != nil {
+		t.Fatal(err)
+	}
+	if err := drainReplyWakeAfterAllRowsAreDueResult(t, store, sink); err == nil {
+		t.Fatal("drain reported healthy while an obligation was unroutable")
+	}
+	events, err := store.ListJobEvents(ctx, fmt.Sprintf("wake-outbox:%d", pending[0].ID))
+	if err != nil || len(events) != 1 {
+		t.Fatalf("events = %+v, err=%v", events, err)
+	}
+	if !strings.Contains(events[0].Message, "condition="+db.WakeOutboxUnroutableRouteRemoved) {
+		t.Fatalf("event %q, want the retired condition rather than the never-configured gap", events[0].Message)
+	}
+}
+
+// TestRoutableWakeRecordsNoUnroutableEvent is the control. Without it, a
+// recorder that fired for every pending row would pass the tests above and
+// make the new query useless by filling it with rows that are simply waiting.
+func TestRoutableWakeRecordsNoUnroutableEvent(t *testing.T) {
+	store, sink, wake, _ := replyWakeTestHarness(t, []replyWakeTestRole{{"owner", "w1:p1"}})
+	ctx := context.Background()
+	if _, err := store.InsertWorkflowNote(ctx, db.WorkflowNote{
+		WorkflowID: "release/routable", Author: "worker", Body: "deliverable",
+		AddressedTarget: "owner",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	pending, err := store.ListWakeOutbox(ctx, db.WakeOutboxStatePending)
+	if err != nil || len(pending) != 1 {
+		t.Fatalf("pending = %+v, err=%v", pending, err)
+	}
+	drainReplyWakeAfterAllRowsAreDue(t, store, sink)
+	if wake.promptCalls != 1 {
+		t.Fatalf("routable wake calls = %d, want 1", wake.promptCalls)
+	}
+	events, err := store.ListJobEvents(ctx, fmt.Sprintf("wake-outbox:%d", pending[0].ID))
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, event := range events {
+		if event.Kind == db.WakeOutboxUnroutableEventKind {
+			t.Fatalf("a deliverable wake was recorded unroutable: %q", event.Message)
+		}
+	}
+}
+
 func TestReplyWakeOutboxHealthFailsClosedWhenEventRulesAreUnreadable(t *testing.T) {
 	store, _, _, home := replyWakeTestHarness(t, []replyWakeTestRole{{"owner", "w1:p1"}})
 	if _, err := store.InsertWorkflowNote(context.Background(), db.WorkflowNote{
@@ -1531,6 +1680,10 @@ func (s *countingWakeOutboxStore) ListWakeOutboxObligations(ctx context.Context,
 
 func (s *countingWakeOutboxStore) ExpireAgedWakeOutbox(ctx context.Context, attemptedBefore, now time.Time) ([]db.WakeOutboxEntry, error) {
 	return s.inner.ExpireAgedWakeOutbox(ctx, attemptedBefore, now)
+}
+
+func (s *countingWakeOutboxStore) AddJobEventIfAbsent(ctx context.Context, event db.JobEvent) error {
+	return s.inner.AddJobEventIfAbsent(ctx, event)
 }
 
 func (s *countingWakeOutboxStore) ClaimWakeOutbox(ctx context.Context, surviving int64, coalesced []int64, now time.Time) (bool, error) {

--- a/internal/db/event_rules.go
+++ b/internal/db/event_rules.go
@@ -2,6 +2,7 @@ package db
 
 import (
 	"context"
+	"database/sql"
 	"errors"
 	"fmt"
 	"strings"
@@ -165,6 +166,28 @@ func (s *Store) ListEventRules(ctx context.Context) ([]EventRule, error) {
 		rules = append(rules, rule)
 	}
 	return rules, rows.Err()
+}
+
+// EarliestEventRuleDeletion returns the oldest recorded route deletion, or an
+// empty string when none is recorded.
+//
+// It exists so a report can state the LIMIT OF ITS OWN CATEGORISATION rather
+// than implying route history it does not have. Anything that classifies an
+// unroutable wake as "retired" versus "never configured" reads these
+// tombstones, so a role retired before the oldest one reads as
+// never-configured. On this fleet that boundary is 2026-08-30, which
+// miscategorises every role retired in the month before it.
+func (s *Store) EarliestEventRuleDeletion(ctx context.Context) (string, error) {
+	var earliest sql.NullString
+	if err := s.db.QueryRowContext(ctx,
+		`SELECT MIN(deleted_at) FROM event_rule_deletions`,
+	).Scan(&earliest); err != nil {
+		return "", err
+	}
+	if !earliest.Valid {
+		return "", nil
+	}
+	return strings.TrimSpace(earliest.String), nil
 }
 
 // ListDeletedEventRulesForRoutes returns enabled tombstones for the exact

--- a/internal/db/wake_outbox.go
+++ b/internal/db/wake_outbox.go
@@ -33,6 +33,32 @@ const (
 	// log line nobody reads.
 	WakeOutboxDeliveryFailedEventKind = "wake_delivery_failed"
 
+	// WakeOutboxUnroutableEventKind records a wake addressed to a role that
+	// CANNOT RECEIVE IT, because no enabled event rule exists for that role and
+	// kind. Such a row is not wrong and is not retried: it waits, correctly, for
+	// a rule that may never come. What was missing is that it waited SILENTLY,
+	// so 49 awaited-fact obligations sat pending from 2026-08-02 and ten
+	// escalations addressed to a retired coordinator dead-ended unobserved.
+	//
+	// Owner decision of 2026-09-08, relayed by phobos, chose making the
+	// dead-end LOUD over rerouting it: rerouting would rebuild the coordinator
+	// layer that was just retired. This event is the loudness, and it wakes
+	// nobody.
+	WakeOutboxUnroutableEventKind = "wake_unroutable"
+	// WakeOutboxUnroutableRouteRemoved marks a role whose route once existed and
+	// was deleted after the row was created: a RETIRED seat, which is usually
+	// correct and needs no remedy.
+	WakeOutboxUnroutableRouteRemoved = "route_removed"
+	// WakeOutboxUnroutableNeverConfigured marks a role with no recorded route
+	// history for this kind at all: the 2026-08-02 gap, where the remedy is a
+	// route. The two are separated because the remedy differs.
+	//
+	// LIMIT OF THE DISTINCTION, stated because it is not visible from the
+	// record: it rests on the event_rule_deletions tombstones, and that table
+	// has no rows before 2026-08-30. A role retired before then reads as
+	// never-configured.
+	WakeOutboxUnroutableNeverConfigured = "never_configured"
+
 	WakeOutboxKindReply      = "reply"
 	WakeOutboxKindBlocked    = "blocked"
 	WakeOutboxKindEscalation = "escalation"

--- a/skills/gitmoot/references/CLI.md
+++ b/skills/gitmoot/references/CLI.md
@@ -1983,6 +1983,11 @@ the coalescing saving is readable here rather than by hand-written SQL. A
 `pending` row whose kind and role have no enabled rule is an obligation waiting
 on configuration rather than on a tick.
 
+A pending row whose kind and role have no enabled rule additionally records a
+`wake_unroutable` job event once per row, naming role, kind, source and whether
+the route was removed (a retired seat) or never configured (a gap a route would
+close), so `NO ROUTE` here has a durable, queryable counterpart.
+
 Event-rule wakes are separately opt-in:
 
 ```sh

--- a/website/docs/reference/cli.md
+++ b/website/docs/reference/cli.md
@@ -1707,6 +1707,11 @@ have no enabled rule is reported as `NO ROUTE` with its oldest timestamp, which
 is how a fleet discovers obligations that are waiting on configuration rather
 than on a tick.
 
+A pending row whose kind and role have no enabled rule additionally records a
+`wake_unroutable` job event once per row, naming role, kind, source and whether
+the route was removed (a retired seat) or never configured (a gap a route would
+close), so `NO ROUTE` here has a durable, queryable counterpart.
+
 Event-rule wakes are separately opt-in:
 
 ```sh

--- a/website/docs/reference/event-stream.md
+++ b/website/docs/reference/event-stream.md
@@ -253,6 +253,19 @@ unexplained non-delivery), the batch becomes terminal AND a
 `wake_delivery_failed` job event is recorded on `wake-outbox:<id>` naming the
 target role, the cause and the attempts spent, so an undelivered obligation is
 attributable from the store rather than only from a daemon log line.
+A wake addressed to a role that CANNOT receive it, because no enabled rule
+exists for that role and kind, records a `wake_unroutable` job event on
+`wake-outbox:<id>` naming the role, the kind, the source and WHICH condition it
+is: `condition=route_removed` when a durable tombstone shows the route was
+deleted after the row existed, which is a retired seat and usually needs no
+remedy, or `condition=never_configured` when no route history exists for that
+role and kind at all, which is the case a route would fix. The record is written
+at most once per row rather than once per tick, because the drain re-classifies
+every tick and a per-tick append is what grows `job_events` without bound. The
+row itself is NOT failed and NOT retried: a wake nobody can receive is not a
+wake that is wrong, and a rule added later still delivers it. The distinction
+rests on the deletion tombstones, so a role retired before that table existed
+reads as never-configured.
 `delivery_unknown` remains terminal and is still never retried: a row aged out
 of `attempted` may in fact have been delivered before its outcome write was
 lost, so re-emitting it would risk a duplicate interrupt to prove a negative.


### PR DESCRIPTION
Owner decision, 2026-09-08, relayed by phobos: make the dead-end **loud** rather than reroute it. Follows the #1977 campaign; no issue of its own yet.

## What was dead-ending

Measured after my route census: 365 escalation wakes fleet-wide, 286 of them addressed to `jarvis`, and **ten since the 14:40 retirement still addressed to `jarvis`**, which can no longer be woken because its wake routes were removed. Separately, 49 `awaited_fact` obligations have been pending since as early as 2026-08-02 for roles that have no `fact` route at all.

Both conditions were invisible: the rows sit `pending`, which is the correct state, and nothing recorded that nobody could receive them.

Rerouting was rejected for a reason worth keeping: routing them to phobos or to the owner rebuilds the coordinator layer that was just retired, one variant with phobos in the chair.

## The change

A pending wake whose role has no enabled rule for its kind records a `wake_unroutable` job event on `wake-outbox:<id>`:

```
role=stranded kind=reply source=workflow_note:1 condition=never_configured
```

It creates no route, changes no wiring, and wakes nobody.

**The discriminator is not a new definition.** It is the drain's existing classification: a pending row with no matching rule is already counted `inert` or `route_removed`, and `matchesDeletedWakeRule` already distinguishes them. Reusing it means the record cannot disagree with the component that decides deliverability, which is the same reason `org interrupts` calls `wakeOutboxKindForSource` rather than re-deriving kinds.

**The two conditions are separated because the remedy differs.** `route_removed` means a tombstone shows the route was deleted after the row existed: a retired seat, usually correct, no action. `never_configured` means no route history at all: the 2026-08-02 gap, where a route is the fix.

**Limit of that distinction, recorded at the constant rather than left for someone to discover:** it rests on `event_rule_deletions`, and that table has no rows before 2026-08-30, so a role retired before then reads as `never_configured`.

**Once per row, not once per tick.** `AddJobEventIfAbsent` keys on `(job_id, kind)`. The drain re-classifies every tick, so an unconditional append is precisely the mechanism gm-integrity identified behind `job_events` reaching 1.8M rows.

**The row is not failed and not retried.** That refusal stands from #1983.

## Tests, and the four mutants that prove they discriminate

- `TestUnroutableWakeIsRecordedOncePerRow`: two drains produce exactly one event naming role, kind, source and `never_configured`; no pane is woken; the row is still `pending` with `attempt_count = 0`.
- `TestUnroutableWakeDistinguishesARetiredRoleFromAGap`: a route deleted *after* the row exists records `route_removed`.
- `TestRoutableWakeRecordsNoUnroutableEvent`: the control. Without it, a recorder that fired for every pending row would pass both tests above and fill the new query with rows that are merely waiting.

| Mutant | Result |
| --- | --- |
| recorder made a no-op | both recording tests fail |
| condition collapsed to one value | the distinction test fails |
| per-tick unique job id | once-per-row test fails, events not findable by row |
| stable id, non-idempotent append | fails with **two identical events for one row**, which is the exact defect the assertion exists for |

The first and third attempts at mutants 1 and 3 did not compile, so they proved nothing; I re-ran both build-valid. A mutant that fails to build is not evidence.

One test detail worth naming because it bit me: `workflow_notes.created_at` has millisecond precision while `event_rule_deletions.deleted_at` has nanosecond precision, so a rule deleted microseconds *before* a row can still compare as deleted after it and read as a retirement. Production separates the two by seconds or days; the test stamps the ordering explicitly rather than trusting the wall clock.

## Verification

```
head c81f69b3 on main 939537c1 (base == main, so the branch tree is the merge result)
go build ./...   exit=0
go vet ./...     exit=0
go test -count=1 ./...   TEST EXIT=0
ok 41   FAIL 0   panics 0   DISK GUARD refusals 0
```

Exit status captured rather than inferred from a filter, per the habit gm-findings and I arrived at independently tonight.

## Not verified

- **No live probe.** After a deploy the query is `select message from job_events where kind = 'wake_unroutable'`, and the ten jarvis escalations plus the 49 fact obligations are what should appear first.
- **Whether those escalations were load-bearing is the whole point and cannot be known yet.** In a week this says whether anything important dead-ended: if nothing did, the retirement is vindicated in data; if something did, we will know which seat and which kind, and a route becomes an evidence-backed decision instead of a guess.


## Added after phobos's review, and a gap it exposed in my own tests

**The categorisation limit is now in the OUTPUT, not only in this PR body.** Each unroutable row's `condition` is derived from the deletion tombstones, so a role retired before the oldest one reads as `never_configured`. `gitmoot org interrupts` now states that limit itself, with the boundary **measured from the store** rather than hardcoded:

```
Route history begins 2026-08-30T17:27:04Z; a role retired before then reads as
"never_configured" rather than "route_removed" in its wake_unroutable event.
```

With no deletions recorded at all it says so instead, because that is a stronger limit rather than a missing one. The line is attached to the routeless rows it qualifies rather than printed unconditionally, and `route_history_start` is in the JSON. On this fleet the boundary is 2026-08-30, which miscategorises the seven roles that have delivered escalations and no current route: exactly the rows the load-bearing question is about.

**The gap this exposed was mine.** My first version of that test set `report.RouteHistoryStart` by hand, so a mutant that computed the boundary and never assigned it to the report **survived**. That is the same shape I criticised in #1938 an hour earlier: the mechanism tested, the wiring not. The command test now creates a real tombstone and asserts the JSON carries an RFC3339 boundary, which kills that mutant; a build-valid unconditional-caveat mutant is killed by the control.

**On the deploy note above:** the running binary is **`e8b48f54`**, which I verified with `/root/.local/bin/gitmoot version` rather than taking it on report. gm-integrity's addition sharpens why the sha matters: its #1534 migration is also undeployed, so anyone reasoning about live behaviour from a merged commit is reasoning about a database column production does not have.

## Smoke test on real data, read-only

Built at this head and run against a **copy** of the live store (`396996608` bytes copied; the live daemon was not touched), `gitmoot org interrupts --window 7d` now names the condition in one command:

```
gitmoot has 5 pending wake(s) with no enabled route, oldest 2026-09-07T14:25:48.214Z
jarvis has 30 pending wake(s) with no enabled route, oldest 2026-09-02T02:34:44.345Z
gm-reviewfix-coc has 13 pending wake(s) with no enabled route, oldest 2026-09-07T14:25:48.228Z
vetrina has 2 pending wake(s) with no enabled route, oldest 2026-09-06T23:21:02.092Z
owner has 3 pending wake(s) with no enabled route, oldest 2026-09-03T16:07:41.065Z
joltra-2 has 1 pending wake(s) with no enabled route, oldest 2026-09-04T21:50:07.548Z

Route history begins 2026-08-30T17:27:04.389303823Z; a role retired before then reads as
"never_configured" rather than "route_removed" in its wake_unroutable event.
```

54 routeless wakes across six roles, previously visible only by hand-written SQL. The boundary line is read from `event_rule_deletions` at run time, not hardcoded, and it is the same value I measured when I raised the caveat.

**What this smoke test does NOT prove:** the `wake_unroutable` job event itself, because recording one requires a write and I will not write to the live store. That path is proven by the three tests and the four killed mutants above.

## CI note

The `e2e (tagged)` check failed on this head in `internal/workflow` at `escalation_guarded_writes_test.go:645`, in a file my diff does not touch. I reproduced it on demand: 5 of 5 passes clean, **8 of 8 failures with 250ms SIGSTOP/SIGCONT stalls injected**, identical message. It is gm-findings' #2017 class, test two of their four, fixed in #2020. Their correction to my framing, which I accept: this is not environmental. The runner is behaving legitimately; the test cannot survive a scheduling gap, because it needs two consecutive lease renewals to land inside a fixed 450ms window. This branch carries the unfixed test, so it clears when #2020 lands and this branch is rebased, not by re-running.
