### PR TITLE
test(workflow): derive heartbeat lease margins from one lease (#2017)

### DIFF
--- a/internal/workflow/escalation_guarded_writes_test.go
+++ b/internal/workflow/escalation_guarded_writes_test.go
@@ -342,6 +342,29 @@ func TestOwnershipLostBeforeRenewalAppliesNothing(t *testing.T) {
 	}
 }
 
+// shortRecoveryLeaseTTL is the lease the heartbeat tests below shorten to, and every
+// hold and margin in those tests is expressed as a FRACTION OF IT rather than as its own
+// literal. Scattered literals are what let the relationship drift out of view.
+//
+// #2017: at 300ms the derived margins were 150ms to 200ms, which is smaller than the
+// scheduling stall a contended CI runner produces, so these tests passed on a quiet box
+// and failed on a loaded one. Measured by injecting 250ms SIGSTOP/SIGCONT stalls into
+// the test process, 5 runs each: KeepsOwnershipAcrossASlowPreEffect 5 failures,
+// RenewalErrorsCancelAtTheConfirmedExpiry 5, RenewalErrorsAfterSuccessesStillCompleteTheRun
+// 5, ExpiryIsReArmedAfterEachConfirmedRenewal 1.
+//
+// THE DEFECT WAS NEVER THE CONSTANT, it was the relationship between the lease and the
+// work held against it. Four other tests in this file shorten the same lease and hold
+// work past it, and survived the identical stalls without a single failure, because what
+// they assert is the outcome a DELAY MAKES MORE LIKELY - an expiry that must already have
+// happened, or a cancellation with seconds of budget. CancelsThePassOnAuthoritativeLoss,
+// LateRenewalDoesNotExtendAuthorityPastThePersistedExpiry,
+// StalledRenewalStopsPreEffectsAtThePersistedExpiry and StalledRenewalDoesNotStallTheResolution
+// are therefore deliberately left at their own values: widening them would buy nothing and
+// would only cost wall time. Sharing a constant is not the defect; the direction the
+// assertion leans under load is.
+const shortRecoveryLeaseTTL = 1500 * time.Millisecond
+
 // TestHeartbeatKeepsOwnershipAcrossASlowPreEffect is the test the round-3 verdict said
 // did not exist: nothing shrank escalationRecoveryLeaseTTL, so the ticker (TTL/3 = 40s)
 // never fired in any checked-in test, and deleting the heartbeat loop left them all
@@ -361,7 +384,8 @@ func TestHeartbeatKeepsOwnershipAcrossASlowPreEffect(t *testing.T) {
 	manager := pausedImplementEscalation(t, store, &engine)
 
 	originalTTL := escalationRecoveryLeaseTTL
-	escalationRecoveryLeaseTTL = 300 * time.Millisecond
+	escalationRecoveryLeaseTTL = shortRecoveryLeaseTTL
+	ttl := escalationRecoveryLeaseTTL
 	t.Cleanup(func() { escalationRecoveryLeaseTTL = originalTTL })
 
 	round, ok := unsettledRound(t, store, "parent-job")
@@ -373,7 +397,7 @@ func TestHeartbeatKeepsOwnershipAcrossASlowPreEffect(t *testing.T) {
 	// keep this pass's ownership alive.
 	var competitorTook atomic.Bool
 	manager.onAdd = func() {
-		time.Sleep(900 * time.Millisecond)
+		time.Sleep(3 * ttl)
 		now := time.Now().UTC()
 		taken, err := store.AcquireEscalationRecoveryLease(context.Background(), "parent-job", round.RoundID,
 			"competitor", now.Add(time.Minute), now)
@@ -540,7 +564,7 @@ func TestRenewalErrorsCancelAtTheConfirmedExpiry(t *testing.T) {
 	manager := pausedImplementEscalation(t, store, &engine)
 
 	originalTTL := escalationRecoveryLeaseTTL
-	escalationRecoveryLeaseTTL = 300 * time.Millisecond
+	escalationRecoveryLeaseTTL = shortRecoveryLeaseTTL
 	// ttl is captured for use inside the hooks below. They run on the heartbeat's own
 	// goroutine, which can outlive this test body now that shutdown is bounded, so a
 	// closure reading the package var would race this cleanup.
@@ -567,7 +591,7 @@ func TestRenewalErrorsCancelAtTheConfirmedExpiry(t *testing.T) {
 		select {
 		case <-effectCtx.Done():
 			// (a) cancelled, and cancelled no later than the confirmed expiry.
-			if !time.Now().UTC().After(deadline.Add(150 * time.Millisecond)) {
+			if !time.Now().UTC().After(deadline.Add(ttl / 2)) {
 				cancelledBeforeExpiry.Store(true)
 			}
 		case <-time.After(3 * time.Second):
@@ -619,7 +643,8 @@ func TestRenewalErrorsAfterSuccessesStillCompleteTheRun(t *testing.T) {
 	manager := pausedImplementEscalation(t, store, &engine)
 
 	originalTTL := escalationRecoveryLeaseTTL
-	escalationRecoveryLeaseTTL = 300 * time.Millisecond
+	escalationRecoveryLeaseTTL = shortRecoveryLeaseTTL
+	ttl := escalationRecoveryLeaseTTL
 	t.Cleanup(func() { escalationRecoveryLeaseTTL = originalTTL })
 
 	// The first two renewals succeed - each advancing the confirmed expiry - and only
@@ -633,7 +658,7 @@ func TestRenewalErrorsAfterSuccessesStillCompleteTheRun(t *testing.T) {
 	t.Cleanup(func() { escalationRenewFaultHook = nil })
 
 	// Work that spans several ticks, so the late errors are genuinely reached.
-	manager.onAdd = func() { time.Sleep(450 * time.Millisecond) }
+	manager.onAdd = func() { time.Sleep(3 * ttl / 2) }
 
 	if err := engine.ResolveEscalation(ctx, "parent-job", ResumeRetry, ""); err != nil {
 		t.Fatalf("ResolveEscalation: %v", err)
@@ -817,7 +842,7 @@ func TestExpiryIsReArmedAfterEachConfirmedRenewal(t *testing.T) {
 	manager := pausedImplementEscalation(t, store, &engine)
 
 	originalTTL := escalationRecoveryLeaseTTL
-	escalationRecoveryLeaseTTL = 300 * time.Millisecond
+	escalationRecoveryLeaseTTL = shortRecoveryLeaseTTL
 	// ttl is captured for use inside the hooks below. They run on the heartbeat's own
 	// goroutine, which can outlive this test body now that shutdown is bounded, so a
 	// closure reading the package var would race this cleanup.
@@ -843,7 +868,7 @@ func TestExpiryIsReArmedAfterEachConfirmedRenewal(t *testing.T) {
 	var cancelledEventually atomic.Bool
 	manager.onAddCtx = func(effectCtx context.Context) {
 		// Past the ORIGINAL expiry, the pass must still be alive: renewals were healthy.
-		time.Sleep(ttl + 60*time.Millisecond)
+		time.Sleep(ttl + ttl/3)
 		if effectCtx.Err() == nil {
 			survivedFirstExpiry.Store(true)
 		}


### PR DESCRIPTION
Closes #2017.

## The issue I filed was wrong in both directions, and I found that by measuring rather than by re-reading it

I filed #2017 naming three unaudited siblings at `:364`, `:414` and `:543`. Auditing them as PHOBOS directed, for the hold-past-lease RELATIONSHIP rather than the shared constant:

- there are **seven** tests in the file that shorten the lease, not four. My census stopped at the test that fired, so `:673`, `:747` and `:820` were never named.
- **`:414` is fine.** It is one of the three I filed.
- **`:820` is defective and my issue never mentioned it.**

So the audit removed one of my three and added one I had not seen.

## The discriminator is the direction the assertion leans, not the constant

Reporting "three more tests share 300ms" would have been the false positive PHOBOS warned about. Holding work past the lease is not sufficient either, because four tests do exactly that and are correct. The real split:

**Load-sensitive.** The assertion needs something to happen ON TIME, so a stall pushes it toward failure.

| Test | Line | Margin |
| --- | --- | --- |
| `HeartbeatKeepsOwnershipAcrossASlowPreEffect` | 364 | 900ms held against a 300ms lease; ~9 consecutive renewals must each land, 200ms slack apiece |
| `RenewalErrorsCancelAtTheConfirmedExpiry` | 543 | one-shot 150ms budget after the confirmed expiry |
| `RenewalErrorsAfterSuccessesStillCompleteTheRun` | 622 | 450ms held against 300ms; the one that fired |
| `ExpiryIsReArmedAfterEachConfirmedRenewal` | 820 | **two-sided**: a 360ms sleep must land after the 300ms original expiry AND before the ~500ms re-armed one, a 200ms window |

**Load-tolerant.** The assertion is the outcome a delay makes MORE likely, or the budget is 10x to 20x.

| Test | Line | Why |
| --- | --- | --- |
| `HeartbeatCancelsThePassOnAuthoritativeLoss` | 414 | 2s to observe a 100ms ticker, 20x |
| `LateRenewalDoesNotExtendAuthorityPastThePersistedExpiry` | 673 | 3s for a 300ms expiry, 10x |
| `StalledRenewalStopsPreEffectsAtThePersistedExpiry` | 747 | sleeps, then asserts expiry ALREADY happened: a longer sleep makes it pass |
| `StalledRenewalDoesNotStallTheResolution` | 892 | asserts elapsed under 6s against ~600ms of work, 10x |

## Reproduction

Ordinary contention does not reproduce it, which is why it reads as an unattributable flake. Measured, 10 runs of each of the eight:

- box load 13 on 12 logical cores: **80 pass, 0 fail**
- pinned to a single core with `taskset -c 0`: **80 pass, 0 fail**

The condition is not load, it is a STALL. Injecting 250ms `SIGSTOP`/`SIGCONT` pauses into the test process, confined to that one process and adding nothing to the box, 5 runs each:

```
BEFORE                                                     after
KeepsOwnershipAcrossASlowPreEffect       0 pass  5 fail    5 pass  0 fail
CancelsThePassOnAuthoritativeLoss        5 pass  0 fail    5 pass  0 fail
RenewalErrorsCancelAtTheConfirmedExpiry  0 pass  5 fail    5 pass  0 fail
AfterSuccessesStillCompleteTheRun        0 pass  5 fail    5 pass  0 fail
LateRenewalDoesNotExtendAuthority        5 pass  0 fail    5 pass  0 fail
StalledRenewalStopsPreEffects            5 pass  0 fail    5 pass  0 fail
ExpiryIsReArmedAfterEachConfirmedRenewal 4 pass  1 fail    5 pass  0 fail
StalledRenewalDoesNotStallTheResolution  5 pass  0 fail    5 pass  0 fail
```

16 failures before, 0 after. The positive control is the known one: `AfterSuccesses` failed 5 of 5 with the exact CI message, `resume jobs = 0, want exactly 1: late renewal errors cancelled a run that held its lease`.

I wrote the classification down BEFORE running this, as a prediction of which four would fail. It matched on all eight, including the one my own issue had cleared and the one it had never named.

### Independently reproduced by a second seat, from the prose and not from the script

`gm-transport` hit this same assertion on the e2e check of an unrelated PR (#2019) whose diff touches no file in `internal/workflow`. Rather than asserting attribution it proved it, building a stall injector **from the written description alone, having never seen my script**: without stalls 5 of 5 pass, with 250ms stalls **8 of 8 fail** with the identical message.

Two independent implementations agreeing is stronger than a shared script agreeing, because a shared script can share a bug. Their 8 of 8 is the better citation for that row than my 5 of 5, and it is an argument for describing an instrument in words rather than only shipping it.

They also placed the test in the right bucket from the discriminator alone, separating "needs N consecutive renewals to land" from "sleeps then asserts an expiry already happened", which is the check that the rule is usable by someone who did not derive it.

**One framing correction, theirs adopted:** this is not "environmental". The runner is behaving legitimately. It is a test-design defect that only a stalled scheduler exposes, and calling it environmental invites someone to go fix the runner.

## The fix

One named `shortRecoveryLeaseTTL`, and every hold and margin derived from it as a fraction. Scattered literals are what let the relationship drift out of view in the first place, so the durable half is single-sourcing it, not the value.

The four load-tolerant tests are left exactly as they are. Widening them would buy nothing and cost wall time.

## Wider margins must not make a test blind, so I mutated the production loop

| Mutant | 364 | 543 | 622 | 820 |
| --- | --- | --- | --- | --- |
| heartbeat issues no renewal | FAIL | FAIL | FAIL | FAIL |
| drop `expiry.Reset` after a confirmed renewal | pass | pass | pass | FAIL |
| expiry timer never cancels the pass | pass | FAIL | pass | FAIL |

Every one of the four still dies to its own documented reversion, and the kills are specific rather than blanket, which is what says the tests still discriminate.

**One of these mutants did not apply on my first attempt and I nearly reported its output.** My anchor `\t\t\tcase <-expiry.C:` matched twice, because a second site at 5 tabs contains the 3 tab string, so the count guard tripped and the file was never modified. The shell continued and printed four PASS rows against UNMUTATED code. Had I asserted only "count > 0" instead of "count == 1", or omitted the guard, I would have published four survivals as evidence the tests were vacuous. Re-anchored on the following comment line, applied, and the real result is the table above.

## Cost, stated rather than buried

`internal/workflow` goes from 100.0s to 113.7s. The eight tests go from 5.19s to 14.91s; the four untouched ones moved by at most 0.03s, which is the control confirming the change reaches only what it intends.

That is a real 10 percent on every gate this fleet runs. It buys removing a failure mode that costs a full gate plus an investigation each time it fires, which happened once tonight and cost far more than 9.7 seconds.

## Not claimed

- I have not proven the four fixed tests survive an arbitrarily long stall. Nothing wall-clock based can. They survive 250ms stalls with 2x to 4x headroom where they previously failed outright.
- An injected clock would remove the wall-time dependence entirely, and it would mean changing production timing code to fix a test defect. I did not do that, and I would want it reviewed as its own change if anyone wants it.
- `-race` not run: requires cgo, unavailable in this seat.
