### PR TITLE
fix(cli): record why a queued job is waiting, not just that it is (#1553)

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -387,6 +387,15 @@ gitmoot daemon status
 gitmoot agent list
 ```
 
+A queued job that is waiting rather than starting records
+`dispatch_held_back` (#1553). Every dispatch pass that examines the job and
+declines to claim it writes one, naming the reason: an admission-budget
+refusal, a checkout held by an in-flight job, a runtime session lock and its
+holder, or - when the pass cannot attribute the wait - the bare fact that the
+job was not selected this pass. That reason previously reached daemon stdout
+only, so `gitmoot job events` could not distinguish a long wait from an
+imminent start. One row per job per distinct reason every five minutes.
+
 Fixes:
 
 - Check `[parallel_sessions]`. The default is `same_session = "fork_temp_session"`,

--- a/internal/cli/daemon_dispatch_tracked.go
+++ b/internal/cli/daemon_dispatch_tracked.go
@@ -634,7 +634,33 @@ var (
 // warnJobHeldBack emits ONE throttled line explaining why a queued job was not
 // dispatched this tick (#562 point 5: these exclusions used to be silent). The
 // wording reuses the #552 why-stuck vocabulary where it applies.
-func warnJobHeldBack(stdout io.Writer, jobID string, reason string) {
+// warnJobHeldBack records that a queued job could not be claimed, and why.
+//
+// IT WRITES TO job_events AS WELL AS THE LOG (#1553). A job that is
+// queued-and-unclaimable was indistinguishable from one that is
+// queued-and-about-to-run: measured on jobs since 2026-08-15, 395 waited more
+// than ten minutes between being queued and starting, 99 waited more than
+// thirty, and the worst waited 120.2 minutes. 366 of the 395 carried no event of
+// any deferral, refusal, quota or admission kind, so nothing an operator can
+// read said why.
+//
+// The reason existed the whole time and went only to daemon stdout, which is not
+// where anyone looks: `gitmoot job events <id>` showed the four-to-eight rows
+// written at the instant of dispatch and nothing about the interval before it.
+// So this is not new instrumentation, it is the existing reason reaching the
+// record. The engine already proves the shape is wanted - runtime_lock_wait and
+// dispatch_refused_disk_guard both record a wait against the job that is waiting.
+//
+// THE THROTTLE IS THE EXISTING ONE, DELIBERATELY. The event is written only past
+// the same job+reason guard that gates the log line, so its volume equals the
+// log's: at most one row per job per distinct reason per heldBackLogInterval,
+// five minutes. Writing it unthrottled is the mistake the pool's own comments
+// already record twice - an unbounded skip row became one every two seconds per
+// blocked job, and job_events reached ~1.8M rows.
+//
+// Recording is best-effort: a job held back is already a degraded path and
+// failing to describe it must not change the dispatch decision.
+func warnJobHeldBack(ctx context.Context, store *db.Store, stdout io.Writer, jobID string, reason string) {
 	if strings.TrimSpace(reason) == "" {
 		return
 	}
@@ -658,7 +684,19 @@ func warnJobHeldBack(stdout io.Writer, jobID string, reason string) {
 	heldBackWarnByJob[jobID] = heldBackWarnState{reason: reason, at: now}
 	heldBackWarnMu.Unlock()
 	writeLine(stdout, "job %s held back: %s", jobID, reason)
+	if store != nil && strings.TrimSpace(jobID) != "" {
+		_ = store.AddJobEvent(ctx, db.JobEvent{
+			JobID:   jobID,
+			Kind:    dispatchHeldBackEventKind,
+			Message: reason,
+		})
+	}
 }
+
+// dispatchHeldBackEventKind marks a queued job the dispatcher looked at and
+// could not claim. Its presence is what distinguishes a job that is waiting from
+// one that is about to run.
+const dispatchHeldBackEventKind = "dispatch_held_back"
 
 // admissionSkipReason describes an admission-budget refusal (#365) for the
 // held-back log, distinguishing a transient "does not fit right now" from a
@@ -682,14 +720,11 @@ func explainHeldBackJobs(ctx context.Context, worker jobWorker, tracker *infligh
 	for _, job := range remaining {
 		checkoutKey := queuedJobCheckoutKey(ctx, worker.Store, job)
 		if holder := tracker.holderOf(checkoutKey); holder != "" && holder != job.ID {
-			warnJobHeldBack(worker.Stdout, job.ID, fmt.Sprintf("waiting on checkout %s (held by in-flight job %s)", checkoutKey, holder))
+			warnJobHeldBack(ctx, worker.Store, worker.Stdout, job.ID, fmt.Sprintf("waiting on checkout %s (held by in-flight job %s)", checkoutKey, holder))
 			continue
 		}
 		runtimeKey := queuedJobRuntimeResourceKey(ctx, worker.Store, job)
-		if runtimeKey == "" {
-			continue
-		}
-		if lock, err := worker.Store.GetResourceLock(ctx, runtimeKey); err == nil {
+		if lock, err := worker.Store.GetResourceLock(ctx, runtimeKey); runtimeKey != "" && err == nil {
 			reason := fmt.Sprintf("waiting on runtime session lock %s", runtimeKey)
 			if owner := strings.TrimSpace(lock.OwnerJobID); owner != "" && owner != job.ID {
 				reason += fmt.Sprintf(" (held by job %s)", owner)
@@ -697,8 +732,22 @@ func explainHeldBackJobs(ctx context.Context, worker jobWorker, tracker *infligh
 			if expires := strings.TrimSpace(lock.ExpiresAt); expires != "" {
 				reason += fmt.Sprintf(", lease expires %s", expires)
 			}
-			warnJobHeldBack(worker.Stdout, job.ID, reason)
+			warnJobHeldBack(ctx, worker.Store, worker.Stdout, job.ID, reason)
+			continue
 		}
+		// THE TWO BARE `continue`s THIS REPLACES ARE #1553 (no runtime key at all,
+		// and a runtime key with no readable lock row). Both left a job that the
+		// selector had just declined with nothing recorded anywhere, which is the
+		// silence the issue is about: measured on jobs since 2026-08-15, 398 waited
+		// over ten minutes between enqueue and first `running`, 99 over thirty, worst
+		// 120.2, and 363 of the 398 carried no event of any deferral, refusal, quota,
+		// admission or wait kind.
+		//
+		// A job reaching here is still queued after a pass that examined it, so the
+		// fact of the wait is certain even when the cause is not. Saying that beats
+		// saying nothing: the reader's question is "is this job waiting or about to
+		// run", and only the specific cause was ever missing, not the answer.
+		warnJobHeldBack(ctx, worker.Store, worker.Stdout, job.ID, "queued and not selected this dispatch pass (no checkout or runtime holder identified)")
 	}
 }
 
@@ -797,7 +846,7 @@ func dispatchQueuedJobsTracked(ctx context.Context, worker jobWorker, limit int,
 	for _, job := range queued {
 		job := job
 		if !worker.Admission.Reserve(job.ID, func() admissionEstimate { return worker.admissionEstimate(ctx, job) }) {
-			warnJobHeldBack(worker.Stdout, job.ID, admissionSkipReason(worker.Admission, worker.admissionEstimate(ctx, job)))
+			warnJobHeldBack(ctx, worker.Store, worker.Stdout, job.ID, admissionSkipReason(worker.Admission, worker.admissionEstimate(ctx, job)))
 			continue
 		}
 		checkoutKey := queuedJobCheckoutKey(ctx, worker.Store, job)

--- a/internal/cli/daemon_scheduler.go
+++ b/internal/cli/daemon_scheduler.go
@@ -2464,7 +2464,7 @@ func runQueuedJobsForRepoPoolTracked(ctx context.Context, worker jobWorker, limi
 					// failed/dropped. A nil budget always admits ⇒ byte-identical default.
 					if !worker.Admission.Reserve(job.ID, func() admissionEstimate { return worker.admissionEstimate(ctx, job) }) {
 						if tracker != nil {
-							warnJobHeldBack(worker.Stdout, job.ID, admissionSkipReason(worker.Admission, worker.admissionEstimate(ctx, job)))
+							warnJobHeldBack(ctx, worker.Store, worker.Stdout, job.ID, admissionSkipReason(worker.Admission, worker.admissionEstimate(ctx, job)))
 						}
 						continue
 					}
@@ -2534,7 +2534,7 @@ func runQueuedJobsForRepoPoolTracked(ctx context.Context, worker jobWorker, limi
 					// isolation worktree so a deferred job leaves no orphan worktree behind.
 					if !worker.Admission.Reserve(job.ID, func() admissionEstimate { return worker.admissionEstimate(ctx, job) }) {
 						if tracker != nil {
-							warnJobHeldBack(worker.Stdout, job.ID, admissionSkipReason(worker.Admission, worker.admissionEstimate(ctx, job)))
+							warnJobHeldBack(ctx, worker.Store, worker.Stdout, job.ID, admissionSkipReason(worker.Admission, worker.admissionEstimate(ctx, job)))
 						}
 						continue
 					}

--- a/internal/cli/held_back_event_1553_test.go
+++ b/internal/cli/held_back_event_1553_test.go
@@ -1,0 +1,180 @@
+package cli
+
+import (
+	"context"
+	"io"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/gitmoot/gitmoot/internal/config"
+	"github.com/gitmoot/gitmoot/internal/db"
+	"github.com/gitmoot/gitmoot/internal/runtime"
+	"github.com/gitmoot/gitmoot/internal/workflow"
+)
+
+// #1553: a queued job the dispatcher looked at and refused to claim recorded the
+// reason only on daemon stdout. `gitmoot job events <id>` showed the rows written
+// at the INSTANT of dispatch and nothing about the interval before it, so a job
+// waiting 120 minutes and a job about to run in one second read identically.
+//
+// The two arms below are the whole property. The refusal arm alone would pass
+// against a version that recorded the event unconditionally, which is why the
+// control arm dispatches a job that is NOT held back and requires silence.
+func heldBackEvents(t *testing.T, store *db.Store, jobID string) []db.JobEvent {
+	t.Helper()
+	events, err := store.ListJobEvents(context.Background(), jobID)
+	if err != nil {
+		t.Fatalf("ListJobEvents(%s): %v", jobID, err)
+	}
+	var held []db.JobEvent
+	for _, event := range events {
+		if event.Kind == dispatchHeldBackEventKind {
+			held = append(held, event)
+		}
+	}
+	return held
+}
+
+func TestHeldBackJobRecordsItsReasonInJobEvents(t *testing.T) {
+	resetHeldBackWarnState()
+	ctx := context.Background()
+	store := daemonWorkerStore(t)
+	seedDaemonWorkerRepo(t, store, "owner/repo", t.TempDir())
+	seedDaemonWorkerAgent(t, store, "coder", runtime.CodexRuntime, "session-1", []string{"ask"}, "owner/repo")
+	enqueueDaemonWorkerJob(t, store, workflow.JobRequest{ID: "job-big", Agent: "coder", Action: "ask", Repo: "owner/repo", Branch: "main", PullRequest: 1})
+
+	worker := poolSchedulerWorker(t, store, &cliWorkerFakeAdapter{output: poolSchedulerAskResult}, false)
+	// Cap below the smallest estimate: the job is refused, and stays queued.
+	worker.Admission = newAdmissionBudget(config.AdmissionPolicy{MaxMemoryGB: 0.1})
+	tracker := newInflightJobTracker(ctx)
+
+	if err := dispatchQueuedJobsTracked(ctx, worker, 2, 2, "owner/repo", "", tracker); err != nil {
+		t.Fatalf("dispatchQueuedJobsTracked: %v", err)
+	}
+	if job, _ := store.GetJob(ctx, "job-big"); job.State != string(workflow.JobQueued) {
+		t.Fatalf("job-big state = %q, want queued (the fixture must actually refuse it)", job.State)
+	}
+	held := heldBackEvents(t, store, "job-big")
+	if len(held) != 1 {
+		t.Fatalf("dispatch_held_back events = %d, want 1; a refused job must say why in its own record", len(held))
+	}
+	if !strings.Contains(held[0].Message, "NEVER fit") || !strings.Contains(held[0].Message, "max_memory_gb") {
+		t.Fatalf("held-back message = %q, want the admission cap named; an event that does not carry the reason\nis the same silence in a new row", held[0].Message)
+	}
+
+	// THE BOUND, and it is why the event rides the existing log throttle rather
+	// than every skip: an unthrottled per-pass append is what grew job_events to
+	// ~1.8M rows. A second pass inside the window must add nothing.
+	if err := dispatchQueuedJobsTracked(ctx, worker, 2, 2, "owner/repo", "", tracker); err != nil {
+		t.Fatalf("dispatchQueuedJobsTracked (second pass): %v", err)
+	}
+	if held := heldBackEvents(t, store, "job-big"); len(held) != 1 {
+		t.Fatalf("dispatch_held_back events after a second refusing pass = %d, want 1 (throttle regressed)", len(held))
+	}
+}
+
+// The control. Without it the assertion above is satisfied by a version that
+// records the event on every dispatch, which would restore the original defect
+// in the opposite direction: an event that is always present distinguishes
+// nothing either.
+func TestDispatchedJobRecordsNoHeldBackEvent(t *testing.T) {
+	resetHeldBackWarnState()
+	ctx := context.Background()
+	store := daemonWorkerStore(t)
+	seedDaemonWorkerRepo(t, store, "owner/repo", t.TempDir())
+	seedDaemonWorkerAgent(t, store, "coder", runtime.CodexRuntime, "session-1", []string{"ask"}, "owner/repo")
+	enqueueDaemonWorkerJob(t, store, workflow.JobRequest{ID: "job-ok", Agent: "coder", Action: "ask", Repo: "owner/repo", Branch: "main", PullRequest: 1})
+
+	worker := poolSchedulerWorker(t, store, &cliWorkerFakeAdapter{output: poolSchedulerAskResult}, false)
+	tracker := newInflightJobTracker(ctx)
+
+	if err := dispatchQueuedJobsTracked(ctx, worker, 2, 2, "owner/repo", "", tracker); err != nil {
+		t.Fatalf("dispatchQueuedJobsTracked: %v", err)
+	}
+	tracker.drain(io.Discard, 10*time.Second)
+	if job, _ := store.GetJob(ctx, "job-ok"); job.State == string(workflow.JobQueued) {
+		t.Fatalf("job-ok is still queued; the control must dispatch, or its silence proves nothing")
+	}
+	if held := heldBackEvents(t, store, "job-ok"); len(held) != 0 {
+		t.Fatalf("dispatch_held_back events on a job that ran = %d, want 0; msg=%q", len(held), held[0].Message)
+	}
+}
+
+// The pool path (#1553 second half). A job the SELECTOR declines - it is scanned,
+// it is runnable-looking, but an in-flight job holds the repo checkout - reaches
+// the bottom of the dispatch loop through a bare `continue` and parks on the
+// re-query bound. This is the shape behind the 120-minute worst case.
+func TestPoolWaitRecordsTheHeldBackJob(t *testing.T) {
+	resetHeldBackWarnState()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	store := daemonWorkerStore(t)
+	seedDaemonWorkerRepo(t, store, "owner/repo", t.TempDir())
+	seedDaemonWorkerAgent(t, store, "audit", runtime.ShellRuntime, "unused", []string{"ask"}, "owner/repo")
+
+	adapter := newWedgeBlockingAdapter("job-a")
+	enqueueDaemonWorkerJob(t, store, workflow.JobRequest{ID: "job-a", Agent: "audit", Action: "ask", Repo: "owner/repo", Branch: "main", PullRequest: 1})
+	worker := poolSchedulerWorker(t, store, adapter, false)
+	worker.Stdout = io.Discard
+	live := newDaemonReloadableConfig(30*time.Second, 2, false)
+	var checkoutLock sync.Mutex
+	tracker := newInflightJobTracker(ctx)
+	t.Cleanup(func() { tracker.drain(io.Discard, 5*time.Second) })
+	_ = startSingleRepoWorkerLoop(ctx, 5*time.Millisecond, store, worker, live, &checkoutLock, tracker, "owner/repo", "", io.Discard)
+
+	if !waitForCondition(t, 5*time.Second, adapter.stillBlocked) {
+		t.Fatalf("job-a never started delivering")
+	}
+	enqueueDaemonWorkerJob(t, store, workflow.JobRequest{ID: "job-b", Agent: "audit", Action: "ask", Repo: "owner/repo", Branch: "main", PullRequest: 2})
+
+	if !waitForCondition(t, 5*time.Second, func() bool { return len(heldBackEvents(t, store, "job-b")) > 0 }) {
+		t.Fatalf("job-b waited behind job-a and its record never said so")
+	}
+	held := heldBackEvents(t, store, "job-b")
+	t.Logf("held-back rows for job-b: %d; first message = %q", len(held), held[0].Message)
+	if len(held) != 1 {
+		t.Fatalf("dispatch_held_back rows = %d, want exactly 1; the named refusal and the wait record must not both file", len(held))
+	}
+	close(adapter.release)
+	if got := waitForJobState(t, store, "job-b", string(workflow.JobSucceeded), 10*time.Second); got != string(workflow.JobSucceeded) {
+		t.Fatalf("job-b state = %q after release, want succeeded", got)
+	}
+}
+
+// The fallback arm. explainHeldBackJobs walked the declined jobs and returned
+// silently for the two cases it could not attribute: a job with no runtime key,
+// and one whose lock row will not read. Those jobs were declined by the selector
+// - the wait is certain - so silence there is the defect, not caution.
+func TestUnattributableHeldBackJobStillRecordsTheWait(t *testing.T) {
+	resetHeldBackWarnState()
+	ctx := context.Background()
+	store := daemonWorkerStore(t)
+	seedDaemonWorkerRepo(t, store, "owner/repo", t.TempDir())
+	seedDaemonWorkerAgent(t, store, "audit", runtime.ShellRuntime, "unused", []string{"ask"}, "owner/repo")
+	enqueueDaemonWorkerJob(t, store, workflow.JobRequest{ID: "job-mute", Agent: "audit", Action: "ask", Repo: "owner/repo", Branch: "main", PullRequest: 1})
+
+	worker := poolSchedulerWorker(t, store, &cliWorkerFakeAdapter{output: poolSchedulerAskResult}, false)
+	worker.Stdout = io.Discard
+	// No in-flight job holds anything, and no runtime session lock exists: both
+	// attribution attempts miss, which is precisely the silent path.
+	tracker := newInflightJobTracker(ctx)
+	job, err := store.GetJob(ctx, "job-mute")
+	if err != nil {
+		t.Fatalf("GetJob: %v", err)
+	}
+	if holder := tracker.holderOf(queuedJobCheckoutKey(ctx, store, job)); holder != "" {
+		t.Fatalf("fixture holds checkout %q; the unattributable arm would not be exercised", holder)
+	}
+
+	explainHeldBackJobs(ctx, worker, tracker, []db.Job{job})
+
+	held := heldBackEvents(t, store, "job-mute")
+	if len(held) != 1 {
+		t.Fatalf("dispatch_held_back rows for an unattributable wait = %d, want 1", len(held))
+	}
+	if !strings.Contains(held[0].Message, "not selected this dispatch pass") {
+		t.Fatalf("message = %q, want the fact of the wait recorded even without a cause", held[0].Message)
+	}
+}

--- a/skills/gitmoot/references/CLI.md
+++ b/skills/gitmoot/references/CLI.md
@@ -613,6 +613,16 @@ cannot be established or a floor is breached. The guard applies only to normal
 agent-job dispatch; daemon maintenance/reconciliation remains runnable so an
 internal reclaim pass can free space.
 
+A queued job that the dispatcher examined and could not claim records a
+`dispatch_held_back` job event naming the reason: an admission-budget refusal
+(including the never-fit case, which names the cap), a checkout key held by an
+in-flight job, a runtime session lock with its holder and lease expiry, or - when
+the pass cannot attribute the wait - the bare fact that the job was not selected
+this pass. Before this the reason reached daemon stdout only, so
+`gitmoot job events <job-id>` could not distinguish a job waiting two hours from
+one about to start. The event is throttled to one row per job per distinct reason
+every five minutes, matching the log line it accompanies.
+
 Claude runtime auth is independent of daemon restarts. Use `gitmoot auth set
 claude` to rotate the owner-only `runtime-auth.env`; the next delivery observes
 it. Use `gitmoot auth unset claude` to write the explicit-empty state. Do not

--- a/website/docs/operations/troubleshooting.md
+++ b/website/docs/operations/troubleshooting.md
@@ -288,6 +288,17 @@ gitmoot agent show <agent>
 gitmoot lock list --repo owner/repo
 ```
 
+A job that is simply WAITING now says so in its own record (#1553). Every
+dispatch pass that examines a queued job and declines to claim it writes a
+`dispatch_held_back` event naming the reason: an admission-budget refusal, a
+checkout held by an in-flight job, a runtime session lock and its holder, or -
+when the pass cannot attribute the wait - the bare fact that the job was not
+selected this pass. Before this, that reason went only to daemon stdout, so
+`gitmoot job events` could not tell a job waiting two hours from one about to
+start. The event is throttled to one row per job per distinct reason every five
+minutes, so a long wait produces a readable handful of rows rather than one per
+tick.
+
 `gitmoot job list` appends a `WHY:` column and `gitmoot job show` prints a
 `why_stuck:` line for queued/blocked jobs (#552) — e.g. a runtime-session lock
 wait (naming the holder), `blocked: awaiting human`, `auth failing: …`,

--- a/website/docs/reference/cli.md
+++ b/website/docs/reference/cli.md
@@ -467,6 +467,16 @@ cannot be established or a floor is breached. The guard applies only to normal
 agent-job dispatch; daemon maintenance/reconciliation remains runnable so an
 internal reclaim pass can free space.
 
+A queued job that the dispatcher examined and could not claim records a
+`dispatch_held_back` job event naming the reason: an admission-budget refusal
+(including the never-fit case, which names the cap), a checkout key held by an
+in-flight job, a runtime session lock with its holder and lease expiry, or - when
+the pass cannot attribute the wait - the bare fact that the job was not selected
+this pass. Before this the reason reached daemon stdout only, so
+`gitmoot job events <job-id>` could not distinguish a job waiting two hours from
+one about to start. The event is throttled to one row per job per distinct reason
+every five minutes, matching the log line it accompanies.
+
 ### Claude Runtime Auth
 
 Claude runtime auth lives in owner-only (0600) `runtime-auth.env` and is re-read


### PR DESCRIPTION
Fixes #1553.

## The defect, re-measured before touching code

Jobs created since 2026-08-15, wait = first `running` event minus `created_at`:

| | |
|---|---|
| waits over 10 minutes | **398** |
| waits over 30 minutes | **99** |
| worst wait | **120.2 minutes** |
| of the 398, carrying no deferral / refusal / quota / admission / wait event | **363** |

My handoff note said 395 / 99 / 120.2 / 366. The population moved by three jobs
overnight; the shape is unchanged.

## The reason was never missing, it was in the wrong place

`warnJobHeldBack` already computed a precise cause at six call sites and wrote it
to daemon stdout. `gitmoot job events <id>` showed the four to eight rows written
at the INSTANT of dispatch and nothing about the interval before it, so a job
waiting two hours and a job about to start in one second read identically.

So this is not new instrumentation. It is an existing reason reaching the record.
The engine already proves the shape is wanted: `runtime_lock_wait` and
`dispatch_refused_disk_guard` both record a wait against the job that is waiting.

Two changes, one seam each:

1. `warnJobHeldBack` also writes a `dispatch_held_back` job event. All six call
   sites get it from one place, rather than the "correct where installed, absent
   at the next call site" shape this campaign keeps finding. The two edits in
   `daemon_scheduler.go` are the signature change and nothing else - no logic in
   the dispatch loop moved.
2. `explainHeldBackJobs` had two bare `continue`s for jobs it could not attribute
   (no runtime key, or a lock row that will not read). Those jobs had just been
   declined by the selector, so the fact of the wait is certain even when the
   cause is not. They now record that fact.

**Volume is the existing throttle's, deliberately.** The event is written only
past the same job+reason guard that gates the log line: at most one row per job
per distinct reason per five minutes. An unbounded per-pass append is the mistake
the pool's own comments already record twice, and `job_events` stands at ~1.8M
rows.

## Not covered, and named rather than hidden

A pass whose slot budget is zero never scans the queue, so a job enqueued against
a saturated repo is invisible to it and records nothing. Restoring that scan is
precisely the store read the `slots > 0` guard exists to avoid. I did not measure
the split between "examined and refused" and "never examined", because the pass's
historical slot budget is not recorded anywhere - I can say what I could not
measure, not guess it. What I can measure: of the 363 unexplained waits, **337**
were queued while another job in the same repo was running, and **26** were not,
so the predicate is not tautological.

## Tests

Four arms in `internal/cli/held_back_event_1553_test.go`. Base control run in a
detached worktree at `origin/main` with the event kind spelled literally, because
the constant does not exist on base and a build failure proves nothing:

| test | base | branch |
|---|---|---|
| `TestHeldBackJobRecordsItsReasonInJobEvents` | FAIL (`events = 0, want 1`) | PASS |
| `TestPoolWaitRecordsTheHeldBackJob` | FAIL (record never said so) | PASS |
| `TestUnattributableHeldBackJobStillRecordsTheWait` | FAIL (`rows = 0, want 1`) | PASS |
| `TestDispatchedJobRecordsNoHeldBackEvent` | PASS | PASS |

The fourth is a control and passes on base by design. Without it the other three
are satisfied by a version that records the event unconditionally, which restores
the original defect pointing the other way: an event that is always present
distinguishes nothing either. Stating that explicitly because "a test that fails
before and passes after" is true of three of these four, not all of them.

`TestPoolWaitRecordsTheHeldBackJob` asserts **exactly one** row, which is the
interaction check: the named refusal and the fallback must not both file. Its log
line records which one won - the specific reason, `waiting on checkout
repo:owner/repo (held by in-flight job job-a)`.

## Instrument controls

- The 337/26 split above is the positive control on the coverage query: it
  demonstrably returns both values.
- The base run's three failures are read failures, which per the fleet taxonomy
  audit themselves. The one result here that needed a deliberate control is the
  green fourth arm, and it has one: it fails if the job does not actually
  dispatch (`job-ok is still queued; the control must dispatch, or its silence
  proves nothing`).

## Docs

Both trees, as required: `docs/troubleshooting.md` and
`website/docs/operations/troubleshooting.md`.

Deploy notes: no config, no migration, no schema change. One new job-event kind.
