### PR TITLE
feat(cli): a capability refusal blocks instead of failing into the same wall (#1821)

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -437,6 +437,18 @@ Fixes:
   (a failing probe extends the hold without spending a retry). Over `[events]`
   the deferral is a first-class `job.deferred` emitted instead of `job.failed`.
   Only act when the retry budget is spent and the job stays failed.
+- A job `blocked` with class `runtime_unavailable` will NOT recover on its own
+  (#1821). That class means the runtime could not be executed at all: its
+  binary is absent from the seat's `PATH`, or resolves to a published
+  unavailable shim that exits 126 (#1974), or the sandbox could not resolve the
+  target. It is the only operational class that does not defer, because it is
+  the only one whose condition does not clear without an operator. The job
+  records a `blocker_runtime_unavailable` event carrying the remedy and no
+  retry instant. **Do not retry it unchanged** - fix or re-stage the runtime, or
+  dispatch to an agent on a runtime that works. Before this existed the same
+  condition recorded `failed`, and 25 of 29 measured refusal deaths were
+  re-dispatched into the identical wall, one agent eleven times. Find them with
+  `gitmoot job list --state blocked`.
 - A read-only seat (every `review`/`ask` job under the read-only autonomy
   policy) does NOT authenticate with the ambient credential: it stages a
   SNAPSHOT of its runtime config dir (`payload.runtime_config_dir`, else the

--- a/internal/cli/job_blocker.go
+++ b/internal/cli/job_blocker.go
@@ -118,13 +118,41 @@ const blockerBlockedEventKind = "blocker_runtime_unavailable"
 //     target binary cannot be resolved inside the seat.
 //   - "runtime unavailable" is the daemon's staging refusal.
 //
+// The last three close a gap found in review of this change (#2022 P2): a
+// refusal that happens AFTER execLookPath already resolved the target is not
+// an unresolved-target failure and matched none of the first four. The sandbox
+// ends in a bare `syscall.Exec` (internal/sandbox/exec_linux.go), which returns
+// an UNWRAPPED errno, so these are the renderings that reach the delivery seam:
+//
+//   - "exec format error" is ENOEXEC: the target resolved and is not
+//     executable - a truncated or corrupt shim, or a text file where a binary
+//     was expected.
+//   - "apply strict landlock ruleset" and "landlock abi" are the sandbox's own
+//     wrapped refusals to start at all. Deliberately strict with no BestEffort
+//     downgrade, so they are capability facts rather than warnings.
+//
+// TWO RENDERINGS ARE DELIBERATELY REFUSED, and the reason is the same one that
+// excludes a bare "126": "permission denied" (EACCES) and "no such file or
+// directory" (ENOENT) also reach this seam from a genuine capability refusal,
+// and they ALSO reach it from an agent's own file operations, a denied cache
+// directory, a missing repository path. This predicate decides a TERMINAL
+// state, so a signature that is right about the cause only some of the time is
+// worse than a miss: a miss keeps today's behaviour, a false positive blocks
+// work that would have succeeded on retry. Those two cases stay UNCOVERED and
+// TestRuntimeUnavailableRefusesAmbiguousErrnoText pins that, so a later reader
+// closing "the rest of the gap" has to argue with a test rather than a comment.
+//
 // A bare "126" is deliberately NOT a signature: it appears in SHAs, job ids and
-// token counts, and this predicate decides a terminal state.
+// token counts, and measured store-wide a loose "%126%" match returns 234
+// events against 13 for "exit status 126", an 18x inflation.
 var runtimeUnavailableSignatures = []string{
 	"exit status 126",
 	"executable file not found in $path",
 	"resolve sandbox target",
 	"runtime unavailable",
+	"exec format error",
+	"apply strict landlock ruleset",
+	"landlock abi",
 }
 
 // isRuntimeUnavailableMessage reports whether text names a capability refusal.
@@ -633,8 +661,25 @@ func (w jobWorker) deferOperationalBlockerPreTerminal(ctx context.Context, jobID
 func (w jobWorker) blockOnRuntimeUnavailable(ctx context.Context, jobID string, payload workflow.JobPayload, classification blockerClassification) (bool, error) {
 	payload.BlockerClass = string(classification.Class)
 	payload.BlockerSuggestedAction = classification.SuggestedAction
-	// No RetryAt and no attempt increment: nothing is going to retry this, and a
-	// recorded retry instant would be a promise the engine does not keep.
+	// No RetryAt and no attempt increment: the OPERATIONAL-BLOCKER actuator will
+	// not re-dispatch this job, and a recorded retry instant would be a promise
+	// this layer does not keep.
+	//
+	// THAT CLAIM IS SCOPED TO THIS LAYER, and review of this change (#2022)
+	// established the boundary rather than letting the comment overstate it: for
+	// a DELEGATION CHILD, requeueDelegation gates purely on the delegation
+	// edge's own d.Retry against the child's RetryCount
+	// (internal/workflow/engine_delegation.go) with zero awareness of blocker
+	// class, and JobBlocked has been a settled state since #632. So a blocked
+	// child on an edge declaring Retry > 0 CAN be re-dispatched by the DAG, into
+	// the same wall, up to that edge's budget.
+	//
+	// Not fixed here, deliberately: teaching requeueDelegation about blocker
+	// class is a change to the delegation engine, not to this classifier, and it
+	// would be the wrong thing to smuggle into a slice whose subject is the
+	// terminal state. What this layer guarantees is that the job is BLOCKED with
+	// a recorded cause and a remedy, which is what makes the DAG's retry visible
+	// as a repeat rather than a first attempt.
 	payload.BlockerRetryAt = ""
 	payload.BlockerPreDelivery = false
 	encoded, err := json.Marshal(payload)

--- a/internal/cli/job_blocker.go
+++ b/internal/cli/job_blocker.go
@@ -69,6 +69,26 @@ const (
 	// exponential backoff) or a dirty/wrong-head checkout (usually needs a human;
 	// defers with a suggested_action surfaced through the #552 stuck surface).
 	blockerClassCheckoutContention blockerClass = "checkout_contention"
+	// blockerClassRuntimeUnavailable (#1821, #1823) classifies a CAPABILITY
+	// refusal: the runtime the job needs could not be executed at all, because
+	// its binary is absent from the seat's PATH, or resolves to a published
+	// unavailable shim that exits 126, or the sandbox could not resolve the
+	// target.
+	//
+	// It is the ONLY class that does not defer, because it is the only one whose
+	// condition does not clear on its own. The other four wait out a provider
+	// window, an outage or a lock; a missing executable waits for an operator.
+	// Re-dispatching it walks into the same wall: measured over this store's
+	// history, 29 refusal deaths, ZERO recorded blocked, and 25 of the 29 belong
+	// to an agent hit more than once - gm-review-opus eleven times.
+	//
+	// So it terminates the job BLOCKED. Nothing was wrong with the job, which is
+	// why `failed` was the wrong state: `failed` invites the identical
+	// re-dispatch, and eleven of them happened. This is the same judgement as
+	// #1817's dispatch-time refusal (e16875b3), applied at the delivery seam
+	// that #1817 cannot see - a published 126 shim RESOLVES on PATH, so an
+	// absent-binary predicate at dispatch is silent about it.
+	blockerClassRuntimeUnavailable blockerClass = "runtime_unavailable"
 )
 
 // blockerDeferredEventKind is the job_event kind recorded when a failed job is
@@ -80,6 +100,43 @@ const blockerDeferredEventKind = "blocker_deferred"
 // the auto-retry budget is spent; the job stays terminally failed and this event
 // documents why no further auto-retry happened.
 const blockerExhaustedEventKind = "blocker_retries_exhausted"
+
+// blockerBlockedEventKind is recorded when a capability refusal terminates a job
+// BLOCKED instead of failed. A #552 stuck-reason kind, so `job list`/`job show`
+// explain a job an operator has to unblock rather than retry.
+const blockerBlockedEventKind = "blocker_runtime_unavailable"
+
+// runtimeUnavailableSignatures are the renderings a capability refusal actually
+// produces on this host. Measured, not guessed - every one of them appears in
+// this store's job_events:
+//
+//   - "exit status 126" is POSIX "found but not executable", and is what a
+//     published unavailable shim returns by design (#1974).
+//   - "executable file not found in $PATH" is exec.LookPath's wording, which
+//     killed two #1910 review legs.
+//   - "resolve sandbox target" is the sandbox wrapper's own failure when the
+//     target binary cannot be resolved inside the seat.
+//   - "runtime unavailable" is the daemon's staging refusal.
+//
+// A bare "126" is deliberately NOT a signature: it appears in SHAs, job ids and
+// token counts, and this predicate decides a terminal state.
+var runtimeUnavailableSignatures = []string{
+	"exit status 126",
+	"executable file not found in $path",
+	"resolve sandbox target",
+	"runtime unavailable",
+}
+
+// isRuntimeUnavailableMessage reports whether text names a capability refusal.
+// Case-folded once by the caller.
+func isRuntimeUnavailableMessage(text string) bool {
+	for _, sig := range runtimeUnavailableSignatures {
+		if strings.Contains(text, sig) {
+			return true
+		}
+	}
+	return false
+}
 
 // maxOperationalBlockerRetries hard-bounds automatic re-dispatches per job. It
 // counts classified deferrals over the job's lifetime (persisted in the payload
@@ -188,6 +245,23 @@ func classifyOperationalBlocker(cause error, now time.Time) (blockerClassificati
 		}, true
 	case "auth failing":
 		return blockerClassification{Class: blockerClassRuntimeAuth, RetryAt: now.Add(authBlockerRetryDelay), Detail: detail}, true
+	}
+	// CAPABILITY refusal (#1821): the runtime could not be executed at all.
+	// Checked AFTER auth/quota so a 401/429 keeps its more specific class, and
+	// BEFORE the network arm because neither predicate should be able to claim
+	// the other's text.
+	//
+	// RetryAt is deliberately ZERO. Every other class returns an instant to wait
+	// until; this one has nothing to wait for, and the zero value is what
+	// deferOperationalBlockerPreTerminal reads to route it to a terminal block
+	// instead of a re-queue.
+	if isRuntimeUnavailableMessage(strings.ToLower(text)) {
+		return blockerClassification{
+			Class:  blockerClassRuntimeUnavailable,
+			Detail: detail,
+			SuggestedAction: "the runtime this job needs is not executable in the seat: install or re-stage it, " +
+				"or dispatch to an agent on a runtime that is. Retrying this job unchanged will hit the same wall.",
+		}, true
 	}
 	// Network / GitHub outage that surfaced through the delivery seam: the agent's
 	// own `gh` subprocess printed a transport/DNS/5xx signature to stderr (which
@@ -458,6 +532,31 @@ func (w jobWorker) deferOperationalBlockerPreTerminal(ctx context.Context, jobID
 	if !ok {
 		return false, nil
 	}
+	// CAPABILITY REFUSAL (#1821): terminate BLOCKED instead of re-queueing.
+	//
+	// Placed BEFORE the retry guards below on purpose, and the difference is not
+	// cosmetic. Those guards exist to protect an at-least-once RE-RUN: a stored
+	// result, a delegation child owned by the DAG's retry policy, persisted raw
+	// outputs proving side effects. This path re-runs NOTHING, so none of those
+	// hazards apply to it.
+	//
+	// A delegation child in particular MUST reach this branch. A child that
+	// cannot execute its runtime is precisely the staged-review failure #1823
+	// names, and a blocked child lands in the merge gate's parked arm, where
+	// ensureDelegatedReviewEvidence already refuses the parent. That is the
+	// non-fallback clause - strong reviewer unavailable must never degrade to
+	// cheap reviewer approved - enforced by the row's STATE rather than by a
+	// rule anyone has to remember.
+	//
+	// The one guard that does apply is a stored Result: if the agent answered,
+	// this is a product outcome and the runtime plainly executed, whatever the
+	// error text says.
+	if classification.Class == blockerClassRuntimeUnavailable {
+		if payload.Result != nil {
+			return false, nil
+		}
+		return w.blockOnRuntimeUnavailable(ctx, jobID, payload, classification)
+	}
 	// A stored result means the agent answered: decision=failed is a PRODUCT
 	// failure and is never auto-retried. Delegation children keep the DAG's own
 	// retry/failure-policy path (#409 machinery), untouched by this slice.
@@ -518,6 +617,43 @@ func (w jobWorker) deferOperationalBlockerPreTerminal(ctx context.Context, jobID
 		// directly, with no preceding failed→deferred flap. Best-effort and nil-safe
 		// when [events] is OFF, mirroring the daemon's other emits.
 		emitDaemonTerminalEvent(ctx, w.eventSink(), w.Store, jobID, daemonTerminalDeferred, string(workflow.JobQueued), message)
+	}
+	return transitioned, nil
+}
+
+// blockOnRuntimeUnavailable terminates a RUNNING job BLOCKED because the runtime
+// it needs could not be executed. It is the capability-refusal arm of
+// deferOperationalBlockerPreTerminal and returns the same (tookOwnership, err)
+// contract, so Mailbox.Run skips m.fail and no job.failed is emitted first.
+//
+// It writes the payload BEFORE the transition, in one call, for the reason the
+// deferral path documents: a crash between the two would otherwise leave a
+// blocked job with no recorded reason, which is the silent row this whole slice
+// exists to abolish.
+func (w jobWorker) blockOnRuntimeUnavailable(ctx context.Context, jobID string, payload workflow.JobPayload, classification blockerClassification) (bool, error) {
+	payload.BlockerClass = string(classification.Class)
+	payload.BlockerSuggestedAction = classification.SuggestedAction
+	// No RetryAt and no attempt increment: nothing is going to retry this, and a
+	// recorded retry instant would be a promise the engine does not keep.
+	payload.BlockerRetryAt = ""
+	payload.BlockerPreDelivery = false
+	encoded, err := json.Marshal(payload)
+	if err != nil {
+		return false, err
+	}
+	message := fmt.Sprintf("%s: %s (no automatic retry; the condition does not clear on its own): %s",
+		classification.Class, classification.SuggestedAction, classification.Detail)
+	transitioned, err := w.Store.TransitionJobStatePayloadWithEvent(ctx, jobID,
+		string(workflow.JobRunning), string(workflow.JobBlocked), string(encoded), db.JobEvent{
+			JobID:   jobID,
+			Kind:    blockerBlockedEventKind,
+			Message: message,
+		})
+	if err != nil {
+		return false, err
+	}
+	if transitioned {
+		emitDaemonTerminalEvent(ctx, w.eventSink(), w.Store, jobID, daemonTerminalBlocked, string(workflow.JobBlocked), message)
 	}
 	return transitioned, nil
 }

--- a/internal/cli/job_blocker_runtime_unavailable_test.go
+++ b/internal/cli/job_blocker_runtime_unavailable_test.go
@@ -47,6 +47,48 @@ func TestClassifyRuntimeUnavailableRecognisesTheRenderingsThatActuallyOccur(t *t
 	}
 }
 
+// These four close the gap review found in this change (#2022 P2): a refusal
+// that happens AFTER execLookPath resolved the target. The sandbox ends in a
+// bare syscall.Exec, so the errno reaches the delivery seam unwrapped.
+func TestClassifyRuntimeUnavailableCoversPostResolutionRefusals(t *testing.T) {
+	now := time.Now().UTC()
+	for _, text := range []string{
+		"delivery failed: exec format error",
+		"delivery failed: apply strict Landlock ruleset: invalid argument",
+		"delivery failed: Landlock ABI v2 is unavailable; v3 or newer is required",
+	} {
+		got, ok := classifyOperationalBlocker(workflow.DeliveryError{Err: errors.New(text)}, now)
+		if !ok || got.Class != blockerClassRuntimeUnavailable {
+			t.Fatalf("a post-resolution capability refusal was classified as %q (ok=%v): %q", got.Class, ok, text)
+		}
+	}
+}
+
+// TestRuntimeUnavailableRefusesAmbiguousErrnoText pins a DELIBERATE gap.
+//
+// EACCES and ENOENT reach this seam from a genuine capability refusal AND from
+// an agent's own file operations, a denied cache directory, a missing
+// repository path. This predicate decides a TERMINAL state, so a signature
+// right only some of the time is worse than a miss: a miss keeps today's
+// behaviour, a false positive blocks work that would have succeeded.
+//
+// This test exists so that closing "the rest of the gap" means arguing with a
+// test rather than editing a comment.
+func TestRuntimeUnavailableRefusesAmbiguousErrnoText(t *testing.T) {
+	now := time.Now().UTC()
+	for _, text := range []string{
+		"delivery failed: permission denied",
+		"delivery failed: open /tmp/gitmoot-go-build-cache: permission denied",
+		"delivery failed: no such file or directory",
+		"delivery failed: stat /root/repo/missing.go: no such file or directory",
+	} {
+		got, ok := classifyOperationalBlocker(workflow.DeliveryError{Err: errors.New(text)}, now)
+		if ok && got.Class == blockerClassRuntimeUnavailable {
+			t.Fatalf("ambiguous errno text was read as a capability refusal, which would BLOCK work that may succeed on retry: %q", text)
+		}
+	}
+}
+
 // The specific classes must not be able to steal each other's text. Ordering is
 // a property here, not an implementation detail: an auth or quota failure that
 // happens to mention an exit code keeps its own, more actionable class.

--- a/internal/cli/job_blocker_runtime_unavailable_test.go
+++ b/internal/cli/job_blocker_runtime_unavailable_test.go
@@ -1,0 +1,247 @@
+package cli
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gitmoot/gitmoot/internal/db"
+	"github.com/gitmoot/gitmoot/internal/workflow"
+)
+
+// #1821, #1823. A capability refusal is the one operational blocker whose
+// condition does NOT clear on its own, so it must terminate the job BLOCKED
+// rather than be re-queued into the same wall.
+//
+// Measured over this store's history before writing any of this: 29 refusal
+// deaths, ZERO recorded blocked, and 25 of the 29 belonged to an agent hit more
+// than once - gm-review-opus eleven times.
+
+func TestClassifyRuntimeUnavailableRecognisesTheRenderingsThatActuallyOccur(t *testing.T) {
+	now := time.Now().UTC()
+	// Every string here was taken from a real job_events row on this host.
+	for _, text := range []string{
+		"delivery failed: exit status 126",
+		`delivery failed: exec: "claude": executable file not found in $PATH`,
+		`sandbox-exec: resolve sandbox target "kimi": exec: "kimi": executable file not found in $PATH`,
+		"gitmoot: runtime unavailable: no daemon-staged artifact exists: exit status 126",
+	} {
+		got, ok := classifyOperationalBlocker(workflow.DeliveryError{Err: errors.New(text)}, now)
+		if !ok {
+			t.Fatalf("a real capability refusal was not classified at all: %q", text)
+		}
+		if got.Class != blockerClassRuntimeUnavailable {
+			t.Fatalf("capability refusal %q classified as %q, want %q", text, got.Class, blockerClassRuntimeUnavailable)
+		}
+		// The absent RetryAt is what routes this to a terminal block instead of a
+		// re-queue, so it is part of the contract, not an incidental zero.
+		if !got.RetryAt.IsZero() {
+			t.Fatalf("capability refusal %q carries RetryAt %s; a retry instant is a promise the engine does not keep", text, got.RetryAt)
+		}
+		if strings.TrimSpace(got.SuggestedAction) == "" {
+			t.Fatalf("capability refusal %q has no suggested action; an operator has to know what to do with a blocked job", text)
+		}
+	}
+}
+
+// The specific classes must not be able to steal each other's text. Ordering is
+// a property here, not an implementation detail: an auth or quota failure that
+// happens to mention an exit code keeps its own, more actionable class.
+func TestClassifyRuntimeUnavailableDoesNotStealAuthOrQuota(t *testing.T) {
+	now := time.Now().UTC()
+	for _, tc := range []struct {
+		name string
+		text string
+		want blockerClass
+	}{
+		{"quota wins", "Claude AI usage limit reached, try again in 3 hours (exit status 126)", blockerClassRuntimeQuota},
+		{"auth wins", "invalid API key, authentication_error (exit status 126)", blockerClassRuntimeAuth},
+	} {
+		got, ok := classifyOperationalBlocker(workflow.DeliveryError{Err: errors.New(tc.text)}, now)
+		if !ok || got.Class != tc.want {
+			t.Fatalf("%s: classified %q as %q (ok=%v), want %q", tc.name, tc.text, got.Class, ok, tc.want)
+		}
+	}
+}
+
+// A bare "126" must never trigger this. It appears in SHAs, job ids and token
+// counts, and this predicate decides a terminal state.
+func TestClassifyRuntimeUnavailableRefusesIncidentalNumbers(t *testing.T) {
+	now := time.Now().UTC()
+	for _, text := range []string{
+		"delivery failed: job local-review-gm-review-opus-18d126ab produced no result",
+		"delivery failed: 126 findings exceeded the cap",
+		"delivery failed: contract parse error at offset 126",
+	} {
+		got, ok := classifyOperationalBlocker(workflow.DeliveryError{Err: errors.New(text)}, now)
+		if ok && got.Class == blockerClassRuntimeUnavailable {
+			t.Fatalf("an incidental number was read as a capability refusal: %q", text)
+		}
+	}
+}
+
+// The DeliveryError gate is load-bearing for this class exactly as it is for
+// auth and quota: an agent-authored summary that DISCUSSES an exit-126 wall is
+// a product output, not a capability refusal, and must not block the job.
+func TestClassifyRuntimeUnavailableRequiresTheDeliverySeam(t *testing.T) {
+	now := time.Now().UTC()
+	text := "review summary: the implementer's runtime exits with exit status 126 on this host"
+	if got, ok := classifyOperationalBlocker(errors.New(text), now); ok {
+		t.Fatalf("agent-authored text was classified as %q; only the delivery seam may produce this class", got.Class)
+	}
+}
+
+// The end of the contract: a running job whose delivery hit a capability refusal
+// is BLOCKED, carries its reason, and is NOT queued for another identical run.
+func TestCapabilityRefusalBlocksInsteadOfRequeueing(t *testing.T) {
+	ctx := context.Background()
+	store := daemonWorkerStore(t)
+	seedDaemonWorkerRepo(t, store, "owner/repo", t.TempDir())
+	seedDaemonWorkerAgent(t, store, "audit", "shell", "unused", []string{"ask"}, "owner/repo")
+	enqueueDaemonWorkerJob(t, store, workflow.JobRequest{
+		ID: "cap-job", Agent: "audit", Action: "ask", Repo: "owner/repo", Branch: "main", PullRequest: 1,
+	})
+	if _, err := store.TransitionJobState(ctx, "cap-job", string(workflow.JobQueued), string(workflow.JobRunning)); err != nil {
+		t.Fatalf("claim job: %v", err)
+	}
+
+	worker := jobWorker{Store: store}
+	took, err := worker.deferOperationalBlockerPreTerminal(ctx,
+		"cap-job", workflow.DeliveryError{Err: errors.New(`exec: "claude": executable file not found in $PATH`)})
+	if err != nil {
+		t.Fatalf("pre-terminal seam returned an error: %v", err)
+	}
+	if !took {
+		t.Fatal("the seam declined a capability refusal, so Mailbox.Run would fail the job and invite the identical re-dispatch")
+	}
+
+	job, err := store.GetJob(ctx, "cap-job")
+	if err != nil {
+		t.Fatalf("get job: %v", err)
+	}
+	if job.State != string(workflow.JobBlocked) {
+		t.Fatalf("job state is %q, want %q: `failed` is what produced eleven re-dispatches into one wall", job.State, workflow.JobBlocked)
+	}
+	payload, err := daemonJobPayload(job)
+	if err != nil {
+		t.Fatalf("payload: %v", err)
+	}
+	if payload.BlockerClass != string(blockerClassRuntimeUnavailable) {
+		t.Fatalf("blocker_class is %q, want %q", payload.BlockerClass, blockerClassRuntimeUnavailable)
+	}
+	if strings.TrimSpace(payload.BlockerSuggestedAction) == "" {
+		t.Fatal("a blocked job carries no suggested action; nothing tells an operator what to fix")
+	}
+	if strings.TrimSpace(payload.BlockerRetryAt) != "" {
+		t.Fatalf("blocked job carries retry_at %q; nothing is going to retry it", payload.BlockerRetryAt)
+	}
+	if payload.BlockerAttempts != 0 {
+		t.Fatalf("blocked job counted %d retry attempts against a budget it never uses", payload.BlockerAttempts)
+	}
+
+	events, err := store.ListJobEvents(ctx, "cap-job")
+	if err != nil {
+		t.Fatalf("events: %v", err)
+	}
+	var haveBlocked, haveDeferred bool
+	for _, e := range events {
+		switch e.Kind {
+		case blockerBlockedEventKind:
+			haveBlocked = true
+		case blockerDeferredEventKind:
+			haveDeferred = true
+		}
+	}
+	if !haveBlocked {
+		t.Fatalf("no %s event: the blocked job would be unexplained on the stuck surface", blockerBlockedEventKind)
+	}
+	if haveDeferred {
+		t.Fatal("a capability refusal recorded a DEFERRAL; that is the re-dispatch this slice removes")
+	}
+}
+
+// The should-succeed arm, which every guard in this campaign is required to
+// have: a self-clearing blocker still defers. A guard that blocks valid work is
+// its own defect.
+func TestSelfClearingBlockerStillDefers(t *testing.T) {
+	ctx := context.Background()
+	store := daemonWorkerStore(t)
+	seedDaemonWorkerRepo(t, store, "owner/repo", t.TempDir())
+	seedDaemonWorkerAgent(t, store, "audit", "shell", "unused", []string{"ask"}, "owner/repo")
+	enqueueDaemonWorkerJob(t, store, workflow.JobRequest{
+		ID: "quota-job", Agent: "audit", Action: "ask", Repo: "owner/repo", Branch: "main", PullRequest: 1,
+	})
+	if _, err := store.TransitionJobState(ctx, "quota-job", string(workflow.JobQueued), string(workflow.JobRunning)); err != nil {
+		t.Fatalf("claim job: %v", err)
+	}
+	worker := jobWorker{Store: store}
+	took, err := worker.deferOperationalBlockerPreTerminal(ctx,
+		"quota-job", workflow.DeliveryError{Err: errors.New("Claude AI usage limit reached, try again in 3 hours")})
+	if err != nil {
+		t.Fatalf("pre-terminal seam returned an error: %v", err)
+	}
+	if !took {
+		t.Fatal("a quota blocker was not deferred; this slice must not change the self-clearing path")
+	}
+	job, err := store.GetJob(ctx, "quota-job")
+	if err != nil {
+		t.Fatalf("get job: %v", err)
+	}
+	if job.State != string(workflow.JobQueued) {
+		t.Fatalf("quota blocker left the job %q, want %q: the deferral path is unchanged by this slice", job.State, workflow.JobQueued)
+	}
+}
+
+// A stored result means the agent ANSWERED, so the runtime plainly executed
+// whatever the error text says. That is a product outcome and must keep the
+// terminal failure path.
+func TestAnsweredJobIsNeverBlockedOnRuntimeText(t *testing.T) {
+	ctx := context.Background()
+	store := daemonWorkerStore(t)
+	seedDaemonWorkerRepo(t, store, "owner/repo", t.TempDir())
+	seedDaemonWorkerAgent(t, store, "audit", "shell", "unused", []string{"ask"}, "owner/repo")
+	enqueueDaemonWorkerJob(t, store, workflow.JobRequest{
+		ID: "answered-job", Agent: "audit", Action: "ask", Repo: "owner/repo", Branch: "main", PullRequest: 1,
+	})
+	job, err := store.GetJob(ctx, "answered-job")
+	if err != nil {
+		t.Fatalf("get job: %v", err)
+	}
+	payload, err := daemonJobPayload(job)
+	if err != nil {
+		t.Fatalf("payload: %v", err)
+	}
+	payload.Result = &workflow.AgentResult{Decision: "failed", Summary: "could not finish"}
+	raw, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	encoded := string(raw)
+	if err := store.UpdateJobPayload(ctx, "answered-job", encoded); err != nil {
+		t.Fatalf("update payload: %v", err)
+	}
+	if _, err := store.TransitionJobState(ctx, "answered-job", string(workflow.JobQueued), string(workflow.JobRunning)); err != nil {
+		t.Fatalf("claim job: %v", err)
+	}
+	worker := jobWorker{Store: store}
+	took, err := worker.deferOperationalBlockerPreTerminal(ctx,
+		"answered-job", workflow.DeliveryError{Err: errors.New("exit status 126")})
+	if err != nil {
+		t.Fatalf("pre-terminal seam returned an error: %v", err)
+	}
+	if took {
+		t.Fatal("a job that produced a result was blocked on runtime text; a product outcome must stay terminal")
+	}
+	after, err := store.GetJob(ctx, "answered-job")
+	if err != nil {
+		t.Fatalf("get job: %v", err)
+	}
+	if after.State != string(workflow.JobRunning) {
+		t.Fatalf("the seam moved an answered job to %q; it must leave the terminal path alone", after.State)
+	}
+}
+
+var _ = db.JobEvent{}

--- a/internal/cli/job_stuck.go
+++ b/internal/cli/job_stuck.go
@@ -22,6 +22,7 @@ var authWordRe = regexp.MustCompile(`\bauth\b`)
 // row keeps its existing shape.
 var stuckReasonEventKinds = []string{
 	blockerDeferredEventKind,
+	blockerBlockedEventKind,
 	"runtime_lock_wait",
 	"advance_blocked",
 	"advance_awaiting_human",

--- a/skills/gitmoot/references/CLI.md
+++ b/skills/gitmoot/references/CLI.md
@@ -2837,6 +2837,20 @@ a retry. So a job that "failed then reappeared as queued" is the deferral
 working, not a bug. Product failures (the agent answered with a `gitmoot_result`,
 including `decision=failed`) are never auto-retried.
 
+A **capability refusal is the one class that does not retry** (#1821). When a
+delivery fails because the runtime could not be executed at all - its binary is
+absent from the seat's `PATH`, or resolves to a published unavailable shim that
+exits 126, or the sandbox could not resolve the target - the job terminates
+**`blocked`** with class `runtime_unavailable`, a
+`blocker_runtime_unavailable` event carrying the remedy, and **no** retry
+instant or attempt count. It is the only operational class whose condition does
+not clear on its own: the other four wait out a provider window, an outage or a
+lock, while a missing executable waits for an operator. Measured before it was
+built: 29 refusal deaths in this store, zero recorded `blocked`, and 25 of the
+29 belonged to an agent dispatched into the same wall more than once - one of
+them eleven times. `failed` invited that; `blocked` does not. Find them with
+`gitmoot job list --state blocked`.
+
 When a runtime session ends **without** producing a `gitmoot_result` envelope —
 the CLI process crashed, exited non-zero, was signal-killed, or completed but
 never emitted a valid envelope even after repair attempts — the job records

--- a/website/docs/reference/cli.md
+++ b/website/docs/reference/cli.md
@@ -2445,6 +2445,18 @@ until the earliest retry time. `gitmoot job show --json` carries the
 [event stream](event-stream.md)). A job that "failed then reappeared as queued"
 is the deferral working, not a bug.
 
+A **capability refusal is the one class that does not retry** (#1821). When a
+delivery fails because the runtime could not be executed at all - its binary is
+absent from the seat's `PATH`, or resolves to a published unavailable shim that
+exits 126, or the sandbox could not resolve the target - the job terminates
+**`blocked`** with class `runtime_unavailable` and a
+`blocker_runtime_unavailable` event carrying the remedy, and it records **no**
+retry instant or attempt count. It is the only operational class whose
+condition does not clear on its own: the others wait out a provider window, an
+outage or a lock, while a missing executable waits for an operator, so
+re-dispatching it walks into the same wall. List them with `gitmoot job list
+--state blocked`.
+
 When a runtime session ends **without** producing a `gitmoot_result` envelope —
 the CLI process crashed, exited non-zero, was signal-killed, or completed but
 never emitted a valid envelope even after repair attempts — the job records


### PR DESCRIPTION
Refs #1821, #1823. First slice of the staged review, campaign #1818, after #1817 (`e16875b3`), #1819 (`62f65b5c`), #1994 (`e8b48f54`), #1817 criterion 2 (`cad5a990`), #1726's classifier (`246caff8`) and #1726's drain (`b7a5e1da`).

## The one piece the design said had to be built

My design on #1821 found that five of #1823's six conditions are already enforced or become free once staging uses parent-plus-delegation-child, because `ensureDelegatedReviewEvidence` is a defended chokepoint. **One clause had no analogue:** *"a refused escalation must be `blocked`, not `failed`."* This is that clause.

## Measured before writing code

Jobs whose events name a capability refusal (`exit status 126`, `executable file not found in $PATH`, `resolve sandbox target`, `runtime unavailable`), over this store's full history, grouped by the `jobs.agent` **column**:

| | |
|---|---|
| refusal jobs | **35** (29 `failed`, 6 `succeeded`) |
| recorded `blocked` | **0** |
| distinct agents | 11 |
| agents hit more than once | 5 |
| worst single agent | `gm-review-opus`, **15 jobs / 17 events** |

`failed` is what invited that. It reads as "try again", and on one agent somebody did fifteen times.

**An earlier version of this body said eleven, derived by parsing agent names out of job ids.** That was the weaker instrument: `rsplit` on a job id mangles ephemeral and delegation-child ids, which is why it reported 9 agents where the column reports 11. The column numbers above supersede it.

**A caution about the predicate, because it is the reason one of the tests exists.** A loose `%126%` match returns **234** events store-wide against **13** for `exit status 126`, an 18x inflation, and every loose match inspected on the worst-looking agent turned out to be a commit SHA (`b112653207...`). That agent, `keephair-review-sol`, has **zero** `exit status 126` events and its real terminal failures are timeouts, dirty checkouts and head mismatches. So a bare `126` is not a signature here, and `TestClassifyRuntimeUnavailableRefusesIncidentalNumbers` is what keeps it from becoming one.

**Do not read the absence of recent refusals as evidence for this PR.** There have been no `exit status 126` events since the 06:15 deploy, and that is the #1974 runtime repair plus low dispatch volume, not this change, which is not merged.

## Why this class does not defer

The existing four operational classes all **defer** with a retry instant, because a provider window, a network outage or a branch lock clears on its own. A missing executable clears when an operator fixes it. So this is the only class that terminates, and it terminates `blocked`: nothing was wrong with the job, which is exactly why `failed` was the wrong state.

It reuses the **same injected pre-terminal seam** the deferral path already owns, so there is one classifier, one hook, and one place that decides between defer and block. No second definition of the predicate, which is how two rules drift.

It records the class, a suggested action naming the remedy, and a `blocker_runtime_unavailable` event registered as a #552 stuck reason. It deliberately records **no retry instant and no attempt count** - nothing is going to retry it, and a recorded retry instant would be a promise the engine does not keep.

**Placed before the deferral guards on purpose.** Those guards protect an at-least-once *re-run*: a stored result, a DAG-owned delegation child, persisted raw outputs proving side effects. This path re-runs nothing, so none of those hazards apply. A delegation child in particular **must** reach it, because a `blocked` child lands in the merge gate's `parked` arm where `ensureDelegatedReviewEvidence` already refuses the parent. That is #1821's non-fallback clause - *strong reviewer unavailable must never degrade to cheap reviewer approved* - enforced by the row's **state** rather than by a rule anyone has to remember. The one guard that does apply is a stored `Result`: if the agent answered, the runtime plainly executed, whatever the error text says.

## E2E, which is the proof for engine-feature work

Two isolated `/tmp` homes, each with its own store, repo and daemon. Same `shell` agent whose session command exits 126, same probe. No model, per the design note.

| | `origin/main` `b7a5e1da` | this change |
|---|---|---|
| job state | **`failed`** | **`blocked`** |
| terminal event | `delivery failed: exit status 126` | `blocker_runtime_unavailable` + remedy |
| `blocker_class` | `null` | `runtime_unavailable` |
| `blocker_retry_at` | - | `null` |
| `blocker_attempts` | - | `null` |
| deferral / retry events | - | **0** |

Both arms ran against a real daemon, and the after-arm was checked with a negative control (zero `blocker_deferred`/`retry_queued`) and a positive control (the block event query returns 1, so the zero is a real zero).

## Tests and mutants

Seven tests. Four mutants, all killed:

| mutant | killed by |
|---|---|
| add bare `"126"` as a signature | `...RefusesIncidentalNumbers` |
| check capability before auth/quota | `...DoesNotStealAuthOrQuota` |
| route the class to the deferral path | `TestCapabilityRefusalBlocksInsteadOfRequeueing` |
| drop the `DeliveryError` gate | `...RequiresTheDeliverySeam` |

The should-**succeed** arm is explicit, because a guard that blocks valid work is its own defect and that is the failure mode I hit twice building #1817 and #1819: `TestSelfClearingBlockerStillDefers` proves a quota blocker still defers, and `TestAnsweredJobIsNeverBlockedOnRuntimeText` proves a job that produced a result keeps the terminal path.

The signature list is measured, not guessed: every string in it appears in a real `job_events` row on this host. A bare `126` is deliberately excluded because it occurs in SHAs, job ids and token counts, and this predicate decides a terminal state.

## Local verification was deliberately partial

**Build, vet, gofmt, `go generate` clean, `-run` filtered tests, and the isolated-home E2E. No untargeted package runs.** That is a decision, not an omission: free space was at the dispatch guard when this started, and the coordinator holds full suites fleet-wide. **CI is the full gate**, including the 8 `internal/cli` race shards a seat cannot run at all because race requires cgo and the sandbox denies the C header. What is lost locally is the pre-CI catch, not the gate.

## Not verified

Deployed behaviour. Nothing deployed, no service restarted.

## Docs

Skill CLI reference, website CLI reference, and troubleshooting all state that this class does not recover on its own and must not be retried unchanged.

Signed: **gm-staged**

