### PR TITLE
fix(db): give every wake bookkeeping write the store's own budget (#1911)

### DIFF
--- a/internal/cli/daemon_drain_write_budget_order_test.go
+++ b/internal/cli/daemon_drain_write_budget_order_test.go
@@ -1,0 +1,70 @@
+package cli
+
+import (
+	"testing"
+
+	"github.com/gitmoot/gitmoot/internal/db"
+)
+
+// TestShutdownDrainOutlastsEveryDurableWriteBudget pins the RELATIVE ORDER of
+// two constants in two packages, which is the whole point (#1911, #2028).
+//
+// THE DEFECT CLASS, third instance. #1836 was "two constants in two packages
+// whose relative order nothing enforced": a caller bounded a wake-outbox write
+// below the store's own busy wait. #1911's second half was the same shape one
+// level up: a budget sized for one lock acquisition, used by writes that take
+// the lock twice. This is that shape again, across a package boundary.
+//
+// A wake bookkeeping write DETACHES the caller's cancellation on purpose,
+// because it records a delivery that already happened. So on shutdown the drain
+// bound, not the caller, decides whether that write survives. If the drain were
+// shorter than the write's own floor, the daemon would exit with the write in
+// flight, the row would stay `attempted`, and the age-out sweep would later
+// relabel it `delivery_unknown` - the exact symptom #1911 and #1958 are about,
+// produced by the fix for them.
+//
+// THE ORDER IS ALREADY CORRECT AND THIS TEST DOES NOT CHANGE IT. #2018 raised
+// the drain to 900s, so the 33s write floor sits inside it with 867s of
+// headroom. This exists because I measured the mismatch at 18-vs-15 against a
+// tree that was one merge stale, which is exactly how an unenforced relation
+// gets lost: the fetch had already happened and the decisive line was still
+// read from the wrong ref.
+//
+// WHY THE 900s CANNOT BE DERIVED FROM ANYTHING IN internal/db, recorded so the
+// next reader with a tidier instinct does not re-propose what I proposed and
+// gm-staged refused. It is a MEASUREMENT, not a round number: p90 of
+// daemon-dispatched in-flight duration over 14 days, median 8s, p90 893s, p95
+// 1383s, peak concurrency 3. `db.DurableWriteBudgetFor(2)` plus a margin is
+// about 36s, which is 25x smaller, so deriving one from the other would
+// reintroduce the defect #2018 fixed: a drain that returns while real work is
+// still running. The general rule this is an instance of: single-sourcing a
+// constant is the right instinct, and it is WRONG when the two values are not
+// the same quantity. A shared constant is a fix only when the thing shared is
+// one fact. Here one value answers how long a MODEL RUN may take and the other
+// how long a LOCK ACQUISITION may take.
+//
+// The drain must also stay UNDER systemd's TimeoutStopSec, currently 930s. 900s
+// was chosen against it with the 5s post-cancel grace reserved OUT of the
+// budget rather than added to it, so the worst case is 905s. That upper bound
+// is NOT asserted here because it lives in a unit file this test cannot read;
+// naming it is the most a Go test can honestly do, and it is the reason raising
+// the drain is today's hazard where lowering it was yesterday's.
+//
+// This test lives in internal/cli, though its subject is an internal/db budget,
+// because `daemonShutdownDrainTimeout` is UNEXPORTED: an internal/db test
+// cannot read it at all. The location is forced, not preferred.
+//
+// The VALUES are deliberately not asserted. Pinning 15s or 33s or 900s would
+// need editing whenever someone tunes a timeout, which is how a relation drifts
+// while both halves keep passing their own tests. The ORDER is the invariant.
+func TestShutdownDrainOutlastsEveryDurableWriteBudget(t *testing.T) {
+	// The largest acquisition count any wake bookkeeping write declares
+	// (internal/db: a transaction's first contended write plus its COMMIT).
+	const maxWakeWriteAcquisitions = 2
+	floor := db.DurableWriteBudgetFor(maxWakeWriteAcquisitions)
+	if daemonShutdownDrainTimeout <= floor {
+		t.Fatalf("daemonShutdownDrainTimeout = %s, want more than the largest durable write budget %s: "+
+			"a detached bookkeeping write would outlive the drain and be abandoned with the daemon",
+			daemonShutdownDrainTimeout, floor)
+	}
+}

--- a/internal/db/durable_write_test.go
+++ b/internal/db/durable_write_test.go
@@ -1,0 +1,219 @@
+package db
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// holdWriteLock takes this store's write lock from a SECOND connection and holds
+// it for `hold`, then releases. It returns a wait function.
+//
+// It PROVES THE LOCK IS HELD before returning rather than assuming a BEGIN
+// IMMEDIATE won it: an instrument that silently failed to take the lock would
+// make every test below pass for the wrong reason (#1911's own lesson, and the
+// fleet rule about asserting your instrument's shape before comparing).
+func holdWriteLock(t *testing.T, path string, hold time.Duration) func() {
+	t.Helper()
+	holder, err := sql.Open("sqlite", "file:"+path+"?_pragma=busy_timeout(15000)")
+	if err != nil {
+		t.Fatalf("open holder: %v", err)
+	}
+	tx, err := holder.BeginTx(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("holder begin: %v", err)
+	}
+	if _, err := tx.ExecContext(context.Background(),
+		`INSERT INTO org_role_missed_wakes(role, consecutive, updated_at) VALUES ('lock-holder', 1, '')`,
+	); err != nil {
+		t.Fatalf("holder write: %v", err)
+	}
+
+	// Positive control: a competing write with a deadline far below busy_timeout
+	// MUST fail right now. If it succeeds the lock is not held and no result
+	// from this harness means anything.
+	probeCtx, probeCancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer probeCancel()
+	if _, err := holder.ExecContext(probeCtx, `SELECT 1`); err == nil {
+		// A read is allowed in WAL; only prove the WRITE path is blocked.
+		_ = err
+	}
+	probe, err := sql.Open("sqlite", "file:"+path+"?_pragma=busy_timeout(50)")
+	if err != nil {
+		t.Fatalf("open probe: %v", err)
+	}
+	defer probe.Close()
+	if _, err := probe.ExecContext(context.Background(),
+		`INSERT INTO org_role_missed_wakes(role, consecutive, updated_at) VALUES ('probe', 1, '')`,
+	); err == nil {
+		t.Fatal("instrument failure: the write lock is NOT held, so nothing measured here is about contention")
+	}
+
+	done := make(chan struct{})
+	go func() {
+		time.Sleep(hold)
+		_ = tx.Commit()
+		_ = holder.Close()
+		close(done)
+	}()
+	return func() { <-done }
+}
+
+// TestBookkeepingCounterWriteOutlastsAShortCallerDeadline is #1911 mechanism (a).
+//
+// Three call sites bounded these SQLite writes at eventRuleProbeTimeout (5s), a
+// constant documented for herdr SUBPROCESS PROBES, while this store's driver
+// waits sqliteBusyTimeoutMillis (15s) for the write lock. Under contention
+// longer than the caller's deadline the write was abandoned and the missed-wake
+// counter silently kept a stale value - which is what a coordinator reads to
+// decide whether a seat is alive.
+//
+// The budget belongs AT THE WRITE, not at each caller: #1836 fixed one caller
+// and its neighbours in the same file were never fixed.
+func TestBookkeepingCounterWriteOutlastsAShortCallerDeadline(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "gitmoot.db")
+	store, err := openCachedTestStore(t, path)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+
+	// Both durations are DERIVED FROM THE BUDGET, never literals: a literal
+	// margin does not scale when someone widens the busy timeout (#2017).
+	hold := DurableWriteBudget / 18
+	callerBudget := hold / 5
+	wait := holdWriteLock(t, path, hold)
+	defer wait()
+
+	ctx, cancel := context.WithTimeout(context.Background(), callerBudget)
+	defer cancel()
+	if err := store.IncrementRoleMissedWake(ctx, "worker", time.Now().UTC()); err != nil {
+		t.Fatalf("IncrementRoleMissedWake under %s contention with a %s caller deadline: %v",
+			hold, callerBudget, err)
+	}
+
+	// Destination evidence, not a nil error: the row must actually be there.
+	missed, err := store.ListRoleMissedWakes(context.Background())
+	if err != nil {
+		t.Fatalf("ListRoleMissedWakes: %v", err)
+	}
+	var found bool
+	for _, row := range missed {
+		if row.Role == "worker" && row.Consecutive == 1 {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("counter rows = %+v, want worker at 1", missed)
+	}
+}
+
+// TestBookkeepingCounterResetOutlastsAShortCallerDeadline covers the reset
+// neighbour, which is a SEPARATE call site (event_rule_sink.go:362) and would
+// stay broken if only the increment were given a floor.
+func TestBookkeepingCounterResetOutlastsAShortCallerDeadline(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "gitmoot.db")
+	store, err := openCachedTestStore(t, path)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+	if err := store.IncrementRoleMissedWake(context.Background(), "worker", time.Now().UTC()); err != nil {
+		t.Fatalf("seed IncrementRoleMissedWake: %v", err)
+	}
+
+	hold := DurableWriteBudget / 18
+	callerBudget := hold / 5
+	wait := holdWriteLock(t, path, hold)
+	defer wait()
+
+	ctx, cancel := context.WithTimeout(context.Background(), callerBudget)
+	defer cancel()
+	if err := store.ResetRoleMissedWake(ctx, "worker"); err != nil {
+		t.Fatalf("ResetRoleMissedWake under %s contention with a %s caller deadline: %v",
+			hold, callerBudget, err)
+	}
+	missed, err := store.ListRoleMissedWakes(context.Background())
+	if err != nil {
+		t.Fatalf("ListRoleMissedWakes: %v", err)
+	}
+	for _, row := range missed {
+		if row.Role == "worker" {
+			t.Fatalf("worker counter survived the reset: %+v", missed)
+		}
+	}
+}
+
+// TestDurableWriteBudgetCoversEveryLockAcquisition is the invariant that would
+// have caught my own #1978/#1982 regression.
+//
+// TestDurableWriteBudgetExceedsBusyTimeout pins the two CONSTANTS' order. It
+// does not pin that the budget covers the NUMBER OF TIMES the write actually
+// takes the lock, and #1978 made the delivered finish issue two independent
+// statements under a budget derived for one, so a legitimately contended write
+// could need 30s against an 18s ceiling.
+func TestDurableWriteBudgetCoversEveryLockAcquisition(t *testing.T) {
+	busy := time.Duration(sqliteBusyTimeoutMillis) * time.Millisecond
+	for acquisitions := 1; acquisitions <= 4; acquisitions++ {
+		got := DurableWriteBudgetFor(acquisitions)
+		floor := time.Duration(acquisitions) * busy
+		if got <= floor {
+			t.Fatalf("DurableWriteBudgetFor(%d) = %s, want more than %d full busy waits (%s)",
+				acquisitions, got, acquisitions, floor)
+		}
+	}
+	if DurableWriteBudgetFor(1) != DurableWriteBudget {
+		t.Fatalf("DurableWriteBudgetFor(1) = %s, want the single-acquisition budget %s",
+			DurableWriteBudgetFor(1), DurableWriteBudget)
+	}
+}
+
+// TestDeliveredFinishNeverLeavesCollapsedRowsSupersededAlone is #1911 mechanism
+// (b), and it is a defect in my own #1978.
+//
+// The delivered path supersedes the collapsed siblings and then delivers the
+// survivor in TWO separate statements. If the survivor's write does not land,
+// the siblings stay `superseded` with no delivered row carrying their
+// obligation - the exact outcome #1978 promised could not happen ("no wake is
+// silently dropped"). Two statements are also two lock acquisitions, which is
+// how the same bug produces mechanism (b)'s timeout.
+func TestDeliveredFinishNeverLeavesCollapsedRowsSupersededAlone(t *testing.T) {
+	store := openWorkflowTestStore(t)
+	ctx := context.Background()
+	now := time.Now().UTC()
+
+	var ids []int64
+	for index, state := range []string{"pending", "attempted", "attempted"} {
+		res, err := store.db.ExecContext(ctx, `
+INSERT INTO wake_outbox(source_kind, source_id, target_role, coalesce_key, state,
+	attempt_count, created_at, updated_at)
+VALUES ('workflow_note', ?, 'worker', 'reply:worker', ?, 1, ?, ?)`,
+			fmt.Sprint(index+1), state,
+			now.Format(BlockedEpisodeTimeLayout), now.Format(BlockedEpisodeTimeLayout))
+		if err != nil {
+			t.Fatalf("seed row %d: %v", index, err)
+		}
+		id, err := res.LastInsertId()
+		if err != nil {
+			t.Fatalf("seed id %d: %v", index, err)
+		}
+		ids = append(ids, id)
+	}
+
+	// The survivor (ids[0]) is `pending`, so the second statement cannot update
+	// it and the whole finish must fail.
+	if err := store.FinishWakeOutbox(ctx, ids, WakeOutboxStateDelivered, "", now); err == nil {
+		t.Fatal("FinishWakeOutbox succeeded with a survivor that was not attempted")
+	}
+
+	rows, err := store.ListWakeOutbox(ctx, WakeOutboxStateSuperseded)
+	if err != nil {
+		t.Fatalf("ListWakeOutbox: %v", err)
+	}
+	if len(rows) != 0 {
+		t.Fatalf("collapsed rows were superseded by a finish that failed: %+v", rows)
+	}
+}

--- a/internal/db/durable_write_test.go
+++ b/internal/db/durable_write_test.go
@@ -17,6 +17,17 @@ import (
 // make every test below pass for the wrong reason (#1911's own lesson, and the
 // fleet rule about asserting your instrument's shape before comparing).
 func holdWriteLock(t *testing.T, path string, hold time.Duration) func() {
+	return holdWriteLockThen(t, path, hold, true)
+}
+
+// holdWriteLockThen holds the write lock and either COMMITS or ROLLS BACK.
+//
+// The distinction is load-bearing, not tidiness. A committing holder moves the
+// WAL, so a transaction that already took a read snapshot fails its write
+// upgrade with plain SQLITE_BUSY however long its budget is - a different
+// mechanism. A rolling-back holder blocks the write for exactly as long without
+// invalidating anyone's snapshot, which isolates the DEADLINE being tested.
+func holdWriteLockThen(t *testing.T, path string, hold time.Duration, commit bool) func() {
 	t.Helper()
 	holder, err := sql.Open("sqlite", "file:"+path+"?_pragma=busy_timeout(15000)")
 	if err != nil {
@@ -55,7 +66,11 @@ func holdWriteLock(t *testing.T, path string, hold time.Duration) func() {
 	done := make(chan struct{})
 	go func() {
 		time.Sleep(hold)
-		_ = tx.Commit()
+		if commit {
+			_ = tx.Commit()
+		} else {
+			_ = tx.Rollback()
+		}
 		_ = holder.Close()
 		close(done)
 	}()
@@ -216,4 +231,81 @@ VALUES ('workflow_note', ?, 'worker', 'reply:worker', ?, 1, ?, ?)`,
 	if len(rows) != 0 {
 		t.Fatalf("collapsed rows were superseded by a finish that failed: %+v", rows)
 	}
+}
+
+// TestTransactionalWakeWritesOutlastAShortCallerDeadline drives the DEADLINE
+// PATH of the transactional writers, which nothing did before.
+//
+// Every statement inside these transactions must run on the write's own floor,
+// not the caller's context. Flooring only BeginTx leaves the inner statements
+// bounded by the caller, which is the same half-applied fix this issue is
+// about - and it happened inside FinishOrRetryWakeOutbox, where two calls still
+// passed `ctx` after BeginTx had been converted. A review caught it; no test
+// did, so here is the test.
+func TestTransactionalWakeWritesOutlastAShortCallerDeadline(t *testing.T) {
+	for _, test := range []struct {
+		name string
+		call func(store *Store, ctx context.Context, ids []int64, at time.Time) error
+	}{
+		{name: "claim", call: func(store *Store, ctx context.Context, ids []int64, at time.Time) error {
+			_, err := store.ClaimWakeOutbox(ctx, ids[0], ids[1:], at)
+			return err
+		}},
+		{name: "delivered-coalesced-finish", call: func(store *Store, ctx context.Context, ids []int64, at time.Time) error {
+			return store.FinishWakeOutbox(ctx, ids, WakeOutboxStateDelivered, "", at)
+		}},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "gitmoot.db")
+			store, err := openCachedTestStore(t, path)
+			if err != nil {
+				t.Fatalf("Open: %v", err)
+			}
+			t.Cleanup(func() { _ = store.Close() })
+			now := time.Now().UTC()
+			state := "attempted"
+			if test.name == "claim" {
+				state = "pending"
+			}
+			ids := seedWakeOutboxRows(t, store, state, 2)
+
+			hold := DurableWriteBudget / 18
+			callerBudget := hold / 5
+			wait := holdWriteLock(t, path, hold)
+			defer wait()
+
+			ctx, cancel := context.WithTimeout(context.Background(), callerBudget)
+			defer cancel()
+			if err := test.call(store, ctx, ids, now); err != nil {
+				t.Fatalf("%s under %s contention with a %s caller deadline: %v",
+					test.name, hold, callerBudget, err)
+			}
+		})
+	}
+}
+
+func seedWakeOutboxRows(t *testing.T, store *Store, state string, count int) []int64 {
+	t.Helper()
+	now := time.Now().UTC().Format(BlockedEpisodeTimeLayout)
+	attempted := "NULL"
+	if state == "attempted" {
+		attempted = "'" + now + "'"
+	}
+	var ids []int64
+	for index := 0; index < count; index++ {
+		res, err := store.db.ExecContext(context.Background(), `
+INSERT INTO wake_outbox(source_kind, source_id, target_role, coalesce_key, state,
+	attempt_count, created_at, updated_at, attempted_at)
+VALUES ('workflow_note', ?, 'worker', 'reply:worker', ?, 1, ?, ?, `+attempted+`)`,
+			fmt.Sprint(index+1), state, now, now)
+		if err != nil {
+			t.Fatalf("seed row %d: %v", index, err)
+		}
+		id, err := res.LastInsertId()
+		if err != nil {
+			t.Fatalf("seed id %d: %v", index, err)
+		}
+		ids = append(ids, id)
+	}
+	return ids
 }

--- a/internal/db/org_role_missed_wakes.go
+++ b/internal/db/org_role_missed_wakes.go
@@ -18,7 +18,13 @@ func (s *Store) IncrementRoleMissedWake(ctx context.Context, role string, at tim
 	if role == "" {
 		return errors.New("org role is required")
 	}
-	_, err := s.db.ExecContext(ctx, `INSERT INTO org_role_missed_wakes(role, consecutive, updated_at)
+	// #1911: three call sites bounded this write at eventRuleProbeTimeout (5s),
+	// a constant documented for herdr SUBPROCESS PROBES, while the driver waits
+	// 15s for the write lock. The floor belongs here, where no future caller can
+	// get it wrong, rather than at each call site.
+	writeCtx, cancel := s.durableWriteContext(ctx, 1)
+	defer cancel()
+	_, err := s.db.ExecContext(writeCtx, `INSERT INTO org_role_missed_wakes(role, consecutive, updated_at)
 		VALUES (?, 1, ?)
 		ON CONFLICT(role) DO UPDATE SET
 			consecutive = consecutive + 1,
@@ -31,7 +37,9 @@ func (s *Store) ResetRoleMissedWake(ctx context.Context, role string) error {
 	if role == "" {
 		return errors.New("org role is required")
 	}
-	_, err := s.db.ExecContext(ctx, `DELETE FROM org_role_missed_wakes WHERE role = ?`, role)
+	writeCtx, cancel := s.durableWriteContext(ctx, 1)
+	defer cancel()
+	_, err := s.db.ExecContext(writeCtx, `DELETE FROM org_role_missed_wakes WHERE role = ?`, role)
 	return err
 }
 

--- a/internal/db/store.go
+++ b/internal/db/store.go
@@ -87,6 +87,49 @@ const sqliteBusyTimeoutMillis = 15000
 // execute the write it just won the lock for.
 const DurableWriteBudget = sqliteBusyTimeoutMillis*time.Millisecond + 3*time.Second
 
+// DurableWriteBudgetFor is DurableWriteBudget for a write that takes the write
+// lock more than once.
+//
+// WHY THIS EXISTS (#1911). DurableWriteBudget covers ONE contended lock
+// acquisition. Nothing said so, and nothing checked it, so callers grew that
+// acquire the lock repeatedly under the same ceiling: a coalesced delivered
+// finish issued two independent UPDATE statements, and a retry-or-fail write
+// runs a transaction whose first statement and whose COMMIT can each wait. Two
+// legitimate 15s waits do not fit in an 18s budget, so contention that the
+// store was still handling correctly surfaced as `context deadline exceeded`
+// and the write was lost.
+//
+// TestDurableWriteBudgetExceedsBusyTimeout pins the two CONSTANTS' order;
+// TestDurableWriteBudgetCoversEveryLockAcquisition pins this, which is the
+// invariant the constants' order does not imply.
+func DurableWriteBudgetFor(acquisitions int) time.Duration {
+	if acquisitions < 1 {
+		acquisitions = 1
+	}
+	return time.Duration(acquisitions)*sqliteBusyTimeoutMillis*time.Millisecond + 3*time.Second
+}
+
+// durableWriteContext gives a durability write its OWN floor instead of
+// trusting the caller's deadline.
+//
+// #1836 fixed one caller by widening the deadline at the call site, and the
+// three neighbours in that same file were never fixed: they still bound a
+// SQLite write with a constant documented for herdr subprocess probes. A floor
+// enforced at the write cannot be got wrong by the next call site, which is the
+// difference between fixing an instance and fixing the class.
+//
+// The caller's cancellation is deliberately detached, matching what the call
+// sites already did explicitly: a bookkeeping write that records a delivery
+// that ALREADY HAPPENED must not be abandoned because the wake path moved on.
+// A caller that already allows more than the floor keeps its own deadline.
+func (s *Store) durableWriteContext(ctx context.Context, acquisitions int) (context.Context, context.CancelFunc) {
+	floor := DurableWriteBudgetFor(acquisitions)
+	if deadline, ok := ctx.Deadline(); ok && time.Until(deadline) >= floor {
+		return context.WithCancel(ctx)
+	}
+	return context.WithTimeout(context.WithoutCancel(ctx), floor)
+}
+
 func Open(path string) (*Store, error) {
 	store, err := openWritable(path)
 	if err != nil {

--- a/internal/db/wake_outbox.go
+++ b/internal/db/wake_outbox.go
@@ -665,7 +665,7 @@ WHERE state = 'attempted' AND id IN (`, ids, at, 1, strings.TrimSpace(cause))
 		if err != nil {
 			return false, attempts, err
 		}
-		if err := execWakeOutboxRowUpdate(ctx, tx, query, args, len(ids), "requeue"); err != nil {
+		if err := execWakeOutboxRowUpdate(writeCtx, tx, query, args, len(ids), "requeue"); err != nil {
 			return false, attempts, err
 		}
 		if err := tx.Commit(); err != nil {
@@ -680,7 +680,7 @@ WHERE state = 'attempted' AND id IN (`, ids, at, state, strings.TrimSpace(cause)
 	if err != nil {
 		return false, attempts, err
 	}
-	if err := execWakeOutboxRowUpdate(ctx, tx, query, args, len(ids), "finish"); err != nil {
+	if err := execWakeOutboxRowUpdate(writeCtx, tx, query, args, len(ids), "finish"); err != nil {
 		return false, attempts, err
 	}
 	message := fmt.Sprintf(

--- a/internal/db/wake_outbox.go
+++ b/internal/db/wake_outbox.go
@@ -460,13 +460,17 @@ ORDER BY created_at, id`, args
 // them. Each transition and its audit event share one transaction, so a crash
 // cannot silently resolve the obligation without recording the policy outcome.
 func (s *Store) ExpireAgedWakeOutbox(ctx context.Context, attemptedBefore, at time.Time) ([]WakeOutboxEntry, error) {
-	tx, err := s.db.BeginTx(ctx, nil)
+	// #1911: a transaction's contended waits are its first write and its COMMIT,
+	// so its budget is two acquisitions, not one.
+	writeCtx, cancel := s.durableWriteContext(ctx, 2)
+	defer cancel()
+	tx, err := s.db.BeginTx(writeCtx, nil)
 	if err != nil {
 		return nil, err
 	}
 	defer func() { _ = tx.Rollback() }()
 
-	rows, err := tx.QueryContext(ctx, `
+	rows, err := tx.QueryContext(writeCtx, `
 SELECT id, source_kind, source_id, target_role, coalesce_key, state,
 	attempt_count, last_error, created_at, COALESCE(attempted_at, ''),
 	COALESCE(finished_at, ''), updated_at
@@ -523,7 +527,7 @@ ORDER BY attempted_at, id`,
 		} else {
 			seenSurvivor[group] = entry.ID
 		}
-		result, err := tx.ExecContext(ctx, `
+		result, err := tx.ExecContext(writeCtx, `
 UPDATE wake_outbox
 SET state = ?, last_error = ?, finished_at = ?, updated_at = ?
 WHERE id = ? AND state = 'attempted' AND attempted_at <= ?`,
@@ -549,7 +553,7 @@ WHERE id = ? AND state = 'attempted' AND attempted_at <= ?`,
 			"source=%s:%s target_role=%s attempted_at=%s policy=expire_without_retry",
 			entry.SourceKind, entry.SourceID, entry.TargetRole, entry.AttemptedAt,
 		)
-		if _, err := tx.ExecContext(ctx,
+		if _, err := tx.ExecContext(writeCtx,
 			`INSERT INTO job_events(job_id, kind, message) VALUES (?, ?, ?)`,
 			fmt.Sprintf("wake-outbox:%d", entry.ID),
 			WakeOutboxDeliveryUnknownEventKind,
@@ -588,12 +592,16 @@ WHERE state = 'pending' AND id IN (`, ids, at)
 	if err != nil {
 		return false, err
 	}
-	tx, err := s.db.BeginTx(ctx, nil)
+	// #1911: a transaction's contended waits are its first write and its COMMIT,
+	// so its budget is two acquisitions, not one.
+	writeCtx, cancel := s.durableWriteContext(ctx, 2)
+	defer cancel()
+	tx, err := s.db.BeginTx(writeCtx, nil)
 	if err != nil {
 		return false, err
 	}
 	defer func() { _ = tx.Rollback() }()
-	result, err := tx.ExecContext(ctx, query, args...)
+	result, err := tx.ExecContext(writeCtx, query, args...)
 	if err != nil {
 		return false, err
 	}
@@ -633,13 +641,17 @@ func (s *Store) FinishOrRetryWakeOutbox(
 	if len(ids) == 0 {
 		return false, 0, errors.New("wake outbox outcome requires at least one id")
 	}
-	tx, err := s.db.BeginTx(ctx, nil)
+	// #1911: a transaction's contended waits are its first write and its COMMIT,
+	// so its budget is two acquisitions, not one.
+	writeCtx, cancel := s.durableWriteContext(ctx, 2)
+	defer cancel()
+	tx, err := s.db.BeginTx(writeCtx, nil)
 	if err != nil {
 		return false, 0, err
 	}
 	defer func() { _ = tx.Rollback() }()
 	var role string
-	if err := tx.QueryRowContext(ctx,
+	if err := tx.QueryRowContext(writeCtx,
 		`SELECT attempt_count, target_role FROM wake_outbox WHERE id = ?`, ids[0],
 	).Scan(&attempts, &role); err != nil {
 		return false, 0, err
@@ -676,7 +688,7 @@ WHERE state = 'attempted' AND id IN (`, ids, at, state, strings.TrimSpace(cause)
 		role, strings.TrimSpace(cause), attempts, state,
 	)
 	for _, id := range ids {
-		if _, err := tx.ExecContext(ctx,
+		if _, err := tx.ExecContext(writeCtx,
 			`INSERT INTO job_events(job_id, kind, message) VALUES (?, ?, ?)`,
 			fmt.Sprintf("wake-outbox:%d", id),
 			WakeOutboxDeliveryFailedEventKind,
@@ -731,15 +743,53 @@ func (s *Store) FinishWakeOutbox(ctx context.Context, ids []int64, state, detail
 		return fmt.Errorf("invalid terminal wake outbox state %q", state)
 	}
 	if state == WakeOutboxStateDelivered && len(ids) > 1 {
-		if err := s.finishWakeOutboxRows(ctx, ids[1:], WakeOutboxStateSuperseded, WakeOutboxCoalescedDetail(ids[0]), at); err != nil {
+		// ONE TRANSACTION, for two independent reasons that happen to share a
+		// remedy (#1911).
+		//
+		// Correctness: as two separate statements, a survivor write that did
+		// not land left the collapsed rows `superseded` naming a row that was
+		// never delivered - wakes dropped with nothing carrying their
+		// obligation, which is exactly what #1978 promised could not happen.
+		//
+		// Budget: two statements are two contended lock acquisitions, and
+		// DurableWriteBudget covers one. A transaction takes the lock at its
+		// first write and holds it to COMMIT, so the contended waits are the
+		// first statement and the commit rather than one per statement.
+		writeCtx, cancel := s.durableWriteContext(ctx, 2)
+		defer cancel()
+		tx, err := s.db.BeginTx(writeCtx, nil)
+		if err != nil {
 			return err
 		}
-		return s.finishWakeOutboxRows(ctx, ids[:1], state, detail, at)
+		defer func() { _ = tx.Rollback() }()
+		if err := finishWakeOutboxRowsTx(writeCtx, tx, ids[1:], WakeOutboxStateSuperseded, WakeOutboxCoalescedDetail(ids[0]), at); err != nil {
+			return err
+		}
+		if err := finishWakeOutboxRowsTx(writeCtx, tx, ids[:1], state, detail, at); err != nil {
+			return err
+		}
+		return tx.Commit()
 	}
 	return s.finishWakeOutboxRows(ctx, ids, state, detail, at)
 }
 
 func (s *Store) finishWakeOutboxRows(ctx context.Context, ids []int64, state, detail string, at time.Time) error {
+	writeCtx, cancel := s.durableWriteContext(ctx, 1)
+	defer cancel()
+	return finishWakeOutboxRowsExec(writeCtx, s.db, ids, state, detail, at)
+}
+
+func finishWakeOutboxRowsTx(ctx context.Context, tx *sql.Tx, ids []int64, state, detail string, at time.Time) error {
+	return finishWakeOutboxRowsExec(ctx, tx, ids, state, detail, at)
+}
+
+// wakeOutboxExecer is the shared shape of *sql.DB and *sql.Tx, so the finish
+// statement has ONE definition whether or not it runs inside a transaction.
+type wakeOutboxExecer interface {
+	ExecContext(ctx context.Context, query string, args ...any) (sql.Result, error)
+}
+
+func finishWakeOutboxRowsExec(ctx context.Context, execer wakeOutboxExecer, ids []int64, state, detail string, at time.Time) error {
 	query, args, err := wakeOutboxIDUpdate(`
 UPDATE wake_outbox
 SET state = ?, last_error = ?, finished_at = ?, updated_at = ?
@@ -747,7 +797,7 @@ WHERE state = 'attempted' AND id IN (`, ids, at, state, strings.TrimSpace(detail
 	if err != nil {
 		return err
 	}
-	result, err := s.db.ExecContext(ctx, query, args...)
+	result, err := execer.ExecContext(ctx, query, args...)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Fixes #1911.

## Reproduced before fixed, three tests, four killed mutants

`internal/db` only. Build and test are authorised for this package alone at the current disk level, so **the three `internal/cli` call sites are deliberately untouched** and the fix is placed where it does not need them.

### Before the fix

```
--- FAIL: TestBookkeepingCounterWriteOutlastsAShortCallerDeadline (1.22s)
    IncrementRoleMissedWake under 1s contention with a 200ms caller deadline: context deadline exceeded
--- FAIL: TestBookkeepingCounterResetOutlastsAShortCallerDeadline (1.21s)
    ResetRoleMissedWake under 1s contention with a 200ms caller deadline: context deadline exceeded
--- FAIL: TestDeliveredFinishNeverLeavesCollapsedRowsSupersededAlone (0.06s)
    collapsed rows were superseded by a finish that failed:
    [{ID:2 State:superseded LastError:coalesced into wake outbox row 1}
     {ID:3 State:superseded LastError:coalesced into wake outbox row 1}]
```

### After

`go vet` exit 0, `go test ./internal/db/` **exit 0**, ok=1 FAIL=0 (exit status captured, not inferred from a grep).

## The two mechanisms

**(a) The neighbours of #1836 were never fixed.** #1836 established that a durability write bounded shorter than the store's own `busy_timeout` turns contention into a lost write, and fixed it by widening the deadline **at one call site**. Three call sites in that same file still bound a SQLite write at `eventRuleProbeTimeout` = 5s, a constant whose own doc says it bounds herdr **subprocess probes**, with a comment 140 lines below explaining why that is a bug:

- `event_rule_sink.go:362` `ResetRoleMissedWake`
- `event_rule_sink.go:373` `IncrementRoleMissedWake`
- `event_rule_sink.go:496` `IncrementRoleMissedWake`

That accounts for the counter half of the reported lines: 42 reset plus 8 increment of 140 in 6h. The missed-wake counter is what a coordinator reads to decide whether a seat is alive, so a silently stale value is not cosmetic.

**Census, including what I left and why.** Seven probe-bounded contexts exist. Three are the store writes above. The other four are genuine herdr subprocess probes and are **deliberately unchanged**: `event_rule_sink.go:304` (`wake.Available`), `:702` (`ResolvePaneByLabel`), `org_role_unavailable.go:153` and `:161`. Cutting a hung subprocess early is what that constant is for.

`InsertWakeOutbox` is also **deliberately left** without a floor. It is the enqueue side, not a bookkeeping write: its caller can propagate the error to whoever asked for the wake, whereas a bookkeeping write records a delivery that already happened and has nobody to report to.

**(b) The budget covered one lock acquisition and my own changes made callers take it repeatedly.** This half is a regression I introduced in #1978 and #1982. `DurableWriteBudget` = `busy_timeout + 3s` = 18s is sized for **one** contended acquisition. `FinishWakeOutbox` on the coalesced delivered path issued **two independent UPDATE statements**, and the retry-or-fail and claim writes run transactions whose first statement and whose COMMIT can each wait. Two legitimate waits do not fit in 18s.

`TestDurableWriteBudgetExceedsBusyTimeout` pins the two constants' **order**. Nothing pinned that the budget covers the **number of times the write takes the lock**, which is why my own regression passed. `TestDurableWriteBudgetCoversEveryLockAcquisition` pins it now.

## The correctness defect inside (b)

As two separate statements, a survivor write that did not land left the collapsed rows `superseded` naming a row that was **never delivered**, with nothing carrying their obligation. That is exactly the outcome #1978's acceptance said could not happen ("no wake is silently dropped"). The delivered split is now one transaction, so it is atomic as well as within budget.

## The driver ceiling, measured here rather than quoted

#1889 says the committed 13.67s figure is WAL-specific and variable. I measured it myself rather than copying that report, because replacing a wrong measured number with an unverified one repeats the defect:

| journal mode | contended write returns after |
| --- | --- |
| WAL (this store's mode) | 14.67s, 14.82s, 14.92s |
| rollback journal | 15.08s, 15.10s, 15.17s |

**The committed 13.67s is below every one of those six samples**, including the lowest WAL reading, by a full second. This is the third independent measurement and it agrees with #1889's reviewer (WAL 13.81 to 14.64s, rollback ~15.05s) rather than with the comment.

It also validates the arithmetic here against a measured worst case rather than a nominal one: `DurableWriteBudgetFor(2)` = 33s against 2 x 15.17s = 30.34s leaves 2.66s of margin.

**#1889 is NOT fixed in this PR.** Its one sentence lives in `internal/cli/event_rule_sink.go:535`, outside the package authorised for this pass, so it is deferred to the follow-up rather than edited unverified. The measurement above is what should go into it.

## Mutants, all build-valid, each killed by its own test

| Mutant | Killed by |
| --- | --- |
| increment loses its floor | `TestBookkeepingCounterWriteOutlastsAShortCallerDeadline` |
| reset loses its floor | `TestBookkeepingCounterResetOutlastsAShortCallerDeadline` |
| delivered split back to two statements | `TestDeliveredFinishNeverLeavesCollapsedRowsSupersededAlone` |
| budget ignores the acquisition count | `TestDurableWriteBudgetCoversEveryLockAcquisition` |

Reverting all four returns the package to green, so no mutant was a compile failure passing as a kill.

## What I could NOT measure, stated rather than implied

**The live 140-per-6h rate is not re-derivable right now, and the zero is about the condition, not the code.** The live daemon is pid 961972, up 1.82h, so a 6h window on it is not a 6h rate. In that window there are exactly 10 `context deadline exceeded` lines and **zero** are wake bookkeeping: all are merge-gate GitHub lookups, a network class. Dispatch is paused fleet-wide, so the concurrent writers that produced the contention are not running. Positive control run first: the journal for that pid does return lines (505 with `--lines=all`, checked that 500 was not a cap). The defect is therefore proven by construction, and a live rate tonight would have measured the pause.

The test harness makes the same check about itself: `holdWriteLock` proves a competing write is actually blocked before any assertion runs, because an instrument that silently failed to take the lock would make every test here pass for the wrong reason.

Both test durations are derived from the budget rather than written as literals, so they scale if anyone widens `busy_timeout`.

## Deploy notes

No migration. The running binary is `e8b48f54`, so this changes nothing in production until a deploy.

`internal/cli` is not built or tested in this pass by instruction. Its three call sites need no change for this fix to work, which is the point of putting the floor at the write, but the package is unverified here.

## Related

#1958 is the same lost write seen from the read side; I will report on it against this fix rather than assume it is covered. #1889 is deferred as described above.


## Added after review, including a claim of mine that was wrong

**Review caught two calls this change had missed, and no test drove them.** `FinishOrRetryWakeOutbox` still passed the CALLER's context to `execWakeOutboxRowUpdate` at both of its write sites after its `BeginTx` had been converted. That is the same half-applied shape this PR is about, inside the function this PR had just edited: flooring the transaction's start while its statements keep the caller's deadline. Fixed, and `TestTransactionalWakeWritesOutlastAShortCallerDeadline` now drives the deadline path instead of leaving it to inspection.

**A third mechanism, and it corrects something I claimed above.** Writing that test produced two failures I first attributed to a stale WAL snapshot. That hypothesis was wrong, and a rolling-back holder refuted it, so I timed the call itself rather than the subtest:

| transaction shape | elapsed before SQLITE_BUSY |
| --- | --- |
| write-first | 14.93s (busy handler ran) |
| read-then-write | **0s** (busy handler never ran) |

SQLite will not run the busy handler for a write upgrade inside a transaction that already holds a read lock. So for `ExpireAgedWakeOutbox` and `FinishOrRetryWakeOutbox`, which both read before they write, **the floor this PR adds is correct but INERT under contention**: the write never waits, so no budget changes anything. I am not claiming this PR fixes those two under contention. Filed as #2028 with the measurement and a proposed fix that preserves `FinishOrRetryWakeOutbox`'s same-transaction read invariant.

That also answers a question #1911 explicitly left open: its deadline class and its BUSY class do **not** share a root cause.

**One instrument error of my own in that diagnosis:** I read "the write waited 1.1s then failed" off the SUBTEST duration, which includes deferred cleanup, in this case a holder the test waits out. The write had failed immediately. Timing the call rather than the test is what produced the 0s figure.

## Full gate, on the integrated tree

Authorised by phobos at this disk level and run once:

```
build exit=0
vet exit=0
generate clean=0
TEST EXIT=0
ok=41 FAIL=0
cache 1600MiB -> 2310MiB   free 27.96GiB -> 25.82GiB
```

Exit statuses captured rather than inferred from a grep, after last night's lesson that an `ok`-arm filter can hide the verdict.


## Parked: local full verification pending a disk constraint, CI is the gate

This is a decision, not an omission, and the state is specific rather than "unverified".

**A full `./...` gate DID pass on this exact head**, `c72c711d`: `build exit=0`, `vet exit=0`, `generate clean`, `TEST EXIT=0`, `ok=41 FAIL=0`. What is missing is the **integrated** gate, because `main` moved to `b7a5e1da` (#2018) afterwards, so the tree I gated is no longer the merge result and my own condition 7 applies.

Fleet disk is at ~24.5 GiB against a ~21.8 GiB floor where all dispatch pauses, so the owner has stopped granting new gate windows rather than deleting another seat's scratch without its reply. I am not merging on CI alone, and phobos has been told.

**What is already known about the integrated tree**, from a scratch detached worktree at `b7a5e1da` using only package-scoped runs (removed afterwards):

- both commits cherry-pick with **no conflict**
- `gofmt` clean, `go vet` clean on `internal/cli` and `internal/db`
- the four `internal/db` tests pass
- the order pin for #2028's sibling constant passes there (900s against a 33s budget) and fails against **both** mutants: drain lowered to 15s, and drain left alone with the write budget raised 15 minutes

So the remaining unknown is narrow: the untargeted portion of `./...` on the rebased tree. CI is the gate for it.

**Still to be added when a window opens:** `internal/cli/daemon_drain_write_budget_order_test.go`, the order pin, agreed directly with gm-staged (whose package it lives in, because `daemonShutdownDrainTimeout` is unexported and an `internal/db` test cannot read it). It is written and validated, and is deliberately not pushed onto this branch while the branch's base still carries the pre-#2018 15s value, where it would be red for a reason that no longer exists.
