### PR TITLE
feat(workflow): a staged verdict cannot exceed its own preflight (#1821)

### DIFF
--- a/internal/workflow/engine_run_budgets.go
+++ b/internal/workflow/engine_run_budgets.go
@@ -1206,6 +1206,11 @@ func (e Engine) delegationRequest(ctx context.Context, job db.Job, payload JobPa
 		// Inherit the coordinator's resolved risk tier (#650) so a high-risk lens
 		// child carries it for explainable escalation. Empty for every non-risk tree.
 		RiskTier: strings.TrimSpace(payload.RiskTier),
+		// #1821: a staged review's verdict child inherits the preflight's evidence
+		// as a CEILING. Prefer the parent's own recorded result, which is the
+		// preflight finding; fall back to the parent's own inherited ceiling so a
+		// deeper chain cannot launder the constraint by adding a hop.
+		InheritedEvidence: delegationInheritedEvidence(payload),
 		// #1277: inherit the skip-native-review-fanout intent. Without this the
 		// intent survived exactly one hop — the dispatched coordinator — and died
 		// at the first engine-initiated hop, so a coordinator dispatched with
@@ -1217,6 +1222,28 @@ func (e Engine) delegationRequest(ctx context.Context, job db.Job, payload JobPa
 		// job that happened to receive the flag.
 		SkipNativeReviewFanout: payload.SkipNativeReviewFanout,
 	}
+}
+
+// delegationInheritedEvidence resolves the evidence ceiling a delegation child
+// inherits (#1821).
+//
+// The parent's OWN result wins when it declared one, because that is the
+// preflight finding this child is being dispatched under. When the parent
+// declared nothing, the parent's own inherited ceiling carries forward: without
+// that fallback a chain could launder the constraint by inserting one silent
+// hop between the preflight and the verdict, which is the same
+// survives-exactly-one-hop defect #1277 fixed for the review-fanout intent.
+//
+// A parent that declared EXECUTED imposes no ceiling: normalizeInheritedEvidence
+// keeps the value, and ApplyInheritedEvidenceCeiling only ever clamps downward
+// from static_only.
+func delegationInheritedEvidence(payload JobPayload) string {
+	if payload.Result != nil && EvidenceWasDeclared(*payload.Result) {
+		if declared := normalizeInheritedEvidence(payload.Result.Evidence); declared != "" {
+			return declared
+		}
+	}
+	return normalizeInheritedEvidence(payload.InheritedEvidence)
 }
 
 // delegationHeadSHA resolves the head a delegated REVIEW child will be pinned

--- a/internal/workflow/inherited_evidence_test.go
+++ b/internal/workflow/inherited_evidence_test.go
@@ -1,0 +1,267 @@
+package workflow
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/gitmoot/gitmoot/internal/runtime"
+)
+
+// #1821. A staged review's preflight is decoration unless its finding CONSTRAINS
+// the verdict stage. These tests are about the direction of that constraint,
+// which is the only interesting thing about it: it moves evidence downward,
+// never upward, and it cannot be laundered by adding a hop.
+
+func TestInheritedEvidenceCeilingClampsAnExecutedClaim(t *testing.T) {
+	result := AgentResult{Decision: "approved", Evidence: EvidenceExecuted, EvidenceDeclared: true}
+	if !ApplyInheritedEvidenceCeiling(&result, EvidenceStaticOnly) {
+		t.Fatal("an executed claim under a static_only preflight was not clamped; the preflight would be decoration")
+	}
+	if result.Evidence != EvidenceStaticOnly {
+		t.Fatalf("evidence is %q after clamping, want %q", result.Evidence, EvidenceStaticOnly)
+	}
+	// #1817's flag must keep meaning "the producer spoke". An overruled producer
+	// still spoke, and a consumer that cannot tell it apart from a silent one
+	// loses the distinction that field was built for.
+	if !EvidenceWasDeclared(result) {
+		t.Fatal("clamping cleared evidence_declared; an overruled producer is not a silent one")
+	}
+	if EvidenceWasExecuted(result) {
+		t.Fatal("EvidenceWasExecuted still reports true after a clamp; the gate would read the unclamped claim")
+	}
+}
+
+// The ceiling must never manufacture a stronger claim than the row itself made.
+// The child is the row whose verdict the gate consumes, so its own modesty wins.
+func TestInheritedEvidenceCeilingNeverUpgrades(t *testing.T) {
+	result := AgentResult{Decision: "approved", Evidence: EvidenceStaticOnly, EvidenceDeclared: true}
+	if ApplyInheritedEvidenceCeiling(&result, EvidenceExecuted) {
+		t.Fatal("a static_only child was reported as clamped under an executed preflight")
+	}
+	if result.Evidence != EvidenceStaticOnly {
+		t.Fatalf("an executed preflight upgraded its child to %q; the ceiling only moves downward", result.Evidence)
+	}
+}
+
+// This case exists because a mutation SURVIVED without it. Swapping the clamp
+// for "executed becomes static_only, everything else becomes executed" left
+// every other test here green, because TestInheritedEvidenceCeilingNeverUpgrades
+// passes an EXECUTED ceiling and returns before the mutated branch.
+//
+// The uncovered shape is the most common one a staged review will produce: an
+// honest static_only child under a static_only preflight. Upgrading it would
+// manufacture an execution claim out of two admissions that nothing ran, which
+// is worse than the gap this whole slice closes.
+func TestInheritedEvidenceCeilingLeavesAnAlreadyStaticVerdictAlone(t *testing.T) {
+	result := AgentResult{Decision: "changes_requested", Evidence: EvidenceStaticOnly, EvidenceDeclared: true}
+	if ApplyInheritedEvidenceCeiling(&result, EvidenceStaticOnly) {
+		t.Fatal("a static_only verdict under a static_only ceiling reported a clamp; there was nothing to clamp")
+	}
+	if result.Evidence != EvidenceStaticOnly {
+		t.Fatalf("evidence became %q; two admissions that nothing ran cannot add up to an execution claim", result.Evidence)
+	}
+	if EvidenceWasExecuted(result) {
+		t.Fatal("EvidenceWasExecuted reports true for a static_only verdict under a static_only ceiling")
+	}
+}
+
+// Every job outside a staged review must be untouched, which is what makes this
+// safe to land while nothing dispatches two stages yet.
+func TestInheritedEvidenceCeilingIgnoresEveryNonStagedShape(t *testing.T) {
+	for _, inherited := range []string{"", "   ", "executed", "nonsense", "STATIC_ONLY"} {
+		result := AgentResult{Decision: "approved", Evidence: EvidenceExecuted, EvidenceDeclared: true}
+		if ApplyInheritedEvidenceCeiling(&result, inherited) {
+			t.Fatalf("inherited %q clamped an executed verdict; only a declared static_only ceiling may", inherited)
+		}
+		if result.Evidence != EvidenceExecuted {
+			t.Fatalf("inherited %q altered evidence to %q", inherited, result.Evidence)
+		}
+	}
+}
+
+func TestInheritedEvidenceCeilingToleratesANilResult(t *testing.T) {
+	if ApplyInheritedEvidenceCeiling(nil, EvidenceStaticOnly) {
+		t.Fatal("a nil result reported a clamp")
+	}
+}
+
+// The inheritance resolution, which is where a chain could cheat.
+func TestDelegationInheritedEvidencePrefersTheParentsOwnFinding(t *testing.T) {
+	payload := JobPayload{Result: &AgentResult{Evidence: EvidenceStaticOnly, EvidenceDeclared: true}}
+	if got := delegationInheritedEvidence(payload); got != EvidenceStaticOnly {
+		t.Fatalf("child inherited %q, want the parent's declared %q", got, EvidenceStaticOnly)
+	}
+}
+
+// The laundering case, and the reason the fallback exists: without it a chain
+// closes the constraint by inserting one silent hop between the preflight and
+// the verdict. That is the same survives-exactly-one-hop defect #1277 fixed for
+// the review-fanout intent.
+func TestDelegationInheritedEvidenceSurvivesASilentHop(t *testing.T) {
+	silentHop := JobPayload{InheritedEvidence: EvidenceStaticOnly}
+	if got := delegationInheritedEvidence(silentHop); got != EvidenceStaticOnly {
+		t.Fatalf("a hop that declared nothing dropped the ceiling (%q); the constraint would survive exactly one hop", got)
+	}
+	// And with a result that declared nothing, the same fallback must hold: an
+	// undeclared result is silence, not permission.
+	undeclared := JobPayload{
+		InheritedEvidence: EvidenceStaticOnly,
+		Result:            &AgentResult{Evidence: EvidenceExecuted},
+	}
+	if got := delegationInheritedEvidence(undeclared); got != EvidenceStaticOnly {
+		t.Fatalf("an UNDECLARED executed result overrode the inherited ceiling (%q); silence is not permission", got)
+	}
+}
+
+func TestDelegationInheritedEvidenceIsEmptyForAnOrdinaryParent(t *testing.T) {
+	if got := delegationInheritedEvidence(JobPayload{}); got != "" {
+		t.Fatalf("an ordinary parent imposed a ceiling of %q", got)
+	}
+	declaredExecuted := JobPayload{Result: &AgentResult{Evidence: EvidenceExecuted, EvidenceDeclared: true}}
+	if got := delegationInheritedEvidence(declaredExecuted); got != EvidenceExecuted {
+		t.Fatalf("a parent that executed passed down %q, want %q carried verbatim", got, EvidenceExecuted)
+	}
+}
+
+// The payload must serialize byte-identically for every job that is not a staged
+// review, or this field is a migration rather than an addition.
+func TestInheritedEvidenceIsAbsentFromAnOrdinaryPayload(t *testing.T) {
+	raw, err := json.Marshal(JobPayload{Repo: "owner/repo", Branch: "main"})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if strings.Contains(string(raw), "inherited_evidence") {
+		t.Fatalf("an ordinary payload carries the field: %s", raw)
+	}
+	staged, err := json.Marshal(JobPayload{Repo: "owner/repo", InheritedEvidence: EvidenceStaticOnly})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if !strings.Contains(string(staged), `"inherited_evidence":"static_only"`) {
+		t.Fatalf("a staged payload does not carry the ceiling: %s", staged)
+	}
+}
+
+// An unrecognised ceiling must not be stored, so a future reader never has to
+// interpret a value the validator would reject.
+func TestNormalizeInheritedEvidenceDropsUnrecognisedValues(t *testing.T) {
+	for _, in := range []string{"", "  ", "EXECUTED", "static-only", "partial", "no"} {
+		if got := normalizeInheritedEvidence(in); got != "" {
+			t.Fatalf("normalize(%q) = %q, want empty", in, got)
+		}
+	}
+	if got := normalizeInheritedEvidence("  " + EvidenceStaticOnly + " "); got != EvidenceStaticOnly {
+		t.Fatalf("normalize did not accept a padded declared value: %q", got)
+	}
+}
+
+// The PRODUCTION-ENTRY test, and the only one here that proves the wiring
+// rather than the arithmetic. The helpers above can all pass while nothing
+// calls them, which is the shape that let a pool-seam mutation survive on my
+// last slice.
+//
+// A real Mailbox.Run, a real store, an agent returning a real gitmoot_result
+// that claims EXECUTED, under a payload carrying a static_only ceiling.
+func TestMailboxRunClampsAVerdictToItsPreflightCeiling(t *testing.T) {
+	ctx := context.Background()
+	store := openTestStore(t)
+	mailbox := Mailbox{store: store, resolveDeliveryWorktree: ExcludedDeliveryWorktreeResolver("test_explicit_no_worktree")}
+	agent := runtime.Agent{Name: "verdict", Runtime: runtime.ShellRuntime, RuntimeRef: "printf ok", RepoScope: "owner/repo", Role: "reviewer"}
+	adapter := &fakeDelivery{outputs: []string{
+		`{"gitmoot_result":{"decision":"approved","summary":"looks fine","evidence":"executed",` +
+			`"tests_run":["go test ./..."],"findings":[],"changes_made":[],"needs":[],"delegations":[]}}`,
+	}}
+
+	if _, err := mailbox.Enqueue(ctx, JobRequest{
+		ID: "verdict-job", Agent: "verdict", Action: "review", Repo: "owner/repo",
+		InheritedEvidence: EvidenceStaticOnly,
+	}); err != nil {
+		t.Fatalf("Enqueue returned error: %v", err)
+	}
+	result, err := mailbox.Run(ctx, "verdict-job", agent, adapter)
+	if err != nil {
+		t.Fatalf("Run returned error: %v", err)
+	}
+
+	// The returned value.
+	if result.Evidence != EvidenceStaticOnly {
+		t.Fatalf("Run returned evidence %q; a verdict claiming execution under a static_only preflight was not clamped", result.Evidence)
+	}
+	// And the STORED value, which is what every later consumer and the merge gate
+	// actually read. Asserting only the return would miss a clamp applied after
+	// the payload was written.
+	job, err := store.GetJob(ctx, "verdict-job")
+	if err != nil {
+		t.Fatalf("GetJob: %v", err)
+	}
+	var stored JobPayload
+	if err := json.Unmarshal([]byte(job.Payload), &stored); err != nil {
+		t.Fatalf("unmarshal payload: %v", err)
+	}
+	if stored.Result == nil {
+		t.Fatal("no stored result")
+	}
+	if stored.Result.Evidence != EvidenceStaticOnly {
+		t.Fatalf("STORED evidence is %q, want %q", stored.Result.Evidence, EvidenceStaticOnly)
+	}
+	if EvidenceWasExecuted(*stored.Result) {
+		t.Fatal("the stored result still reports executed evidence to the gate")
+	}
+	if !EvidenceWasDeclared(*stored.Result) {
+		t.Fatal("the stored result lost evidence_declared; an overruled producer still spoke")
+	}
+
+	// The audit trail. A clamp that leaves no record makes an overruled producer
+	// indistinguishable from an honest static_only one, which is the exact
+	// distinction #1817 built that flag for.
+	events, err := store.ListJobEvents(ctx, "verdict-job")
+	if err != nil {
+		t.Fatalf("ListJobEvents: %v", err)
+	}
+	var clamped bool
+	for _, e := range events {
+		if e.Kind == InheritedEvidenceClampedEvent {
+			clamped = true
+		}
+	}
+	if !clamped {
+		t.Fatalf("no %s event recorded for a clamped verdict", InheritedEvidenceClampedEvent)
+	}
+}
+
+// The should-SUCCEED arm: an ordinary review with no ceiling keeps its executed
+// claim and records no clamp. A guard that quietly downgrades honest evidence
+// would be worse than the gap it closes.
+func TestMailboxRunLeavesAnUnstagedVerdictAlone(t *testing.T) {
+	ctx := context.Background()
+	store := openTestStore(t)
+	mailbox := Mailbox{store: store, resolveDeliveryWorktree: ExcludedDeliveryWorktreeResolver("test_explicit_no_worktree")}
+	agent := runtime.Agent{Name: "verdict", Runtime: runtime.ShellRuntime, RuntimeRef: "printf ok", RepoScope: "owner/repo", Role: "reviewer"}
+	adapter := &fakeDelivery{outputs: []string{
+		`{"gitmoot_result":{"decision":"approved","summary":"ran it","evidence":"executed",` +
+			`"tests_run":["go test ./..."],"findings":[],"changes_made":[],"needs":[],"delegations":[]}}`,
+	}}
+	if _, err := mailbox.Enqueue(ctx, JobRequest{
+		ID: "plain-job", Agent: "verdict", Action: "review", Repo: "owner/repo",
+	}); err != nil {
+		t.Fatalf("Enqueue returned error: %v", err)
+	}
+	result, err := mailbox.Run(ctx, "plain-job", agent, adapter)
+	if err != nil {
+		t.Fatalf("Run returned error: %v", err)
+	}
+	if result.Evidence != EvidenceExecuted {
+		t.Fatalf("an unstaged verdict was downgraded to %q", result.Evidence)
+	}
+	events, err := store.ListJobEvents(ctx, "plain-job")
+	if err != nil {
+		t.Fatalf("ListJobEvents: %v", err)
+	}
+	for _, e := range events {
+		if e.Kind == InheritedEvidenceClampedEvent {
+			t.Fatal("an unstaged verdict recorded a clamp event")
+		}
+	}
+}

--- a/internal/workflow/mailbox.go
+++ b/internal/workflow/mailbox.go
@@ -338,6 +338,17 @@ type JobRequest struct {
 	// and the dashboard can explain an escalation. Empty (the default) for every
 	// job outside the opt-in risk-tiered path.
 	RiskTier string
+	// InheritedEvidence carries a STAGED review's preflight verdict about what
+	// could actually be executed (#1821) from the parent stage into its verdict
+	// child. It is one of the declared evidence values, normally
+	// EvidenceStaticOnly, and it is a CEILING: a child cannot claim it executed
+	// work its own preflight already found unrunnable in the same worktree.
+	//
+	// Empty for every non-staged job, so the enqueued payload is byte-identical
+	// by default. It exists because the parent-to-child boundary already carries
+	// repo, pull_request, head_sha, task_id and the review scope, and this was
+	// the one field a staged review needs that no delegation carried.
+	InheritedEvidence string
 	// OrchestrateStage marks a #758 pipeline orchestrate stage job: the stage's agent
 	// runs as a bounded sub-tree COORDINATOR, so its delegations[] are NOT stripped by
 	// the pipeline-sender leaf strip (they fan out as children owned by this stage
@@ -536,6 +547,15 @@ type JobPayload struct {
 	// byte-identically. It is stamped on a high-risk review coordinator and
 	// inherited by its lens children for explainable escalation.
 	RiskTier string `json:"risk_tier,omitempty"`
+	// InheritedEvidence is the staged-review preflight ceiling (#1821) this job
+	// was dispatched under: one of the declared evidence values, carried from the
+	// parent stage. A verdict stage cannot report EXECUTED evidence when the
+	// preflight that shared its worktree recorded static_only, because nothing
+	// about the worktree changed between the stages.
+	//
+	// Additive/omitempty, so every job outside a staged review serializes
+	// byte-identically.
+	InheritedEvidence string `json:"inherited_evidence,omitempty"`
 	// Operational-blocker deferral context (#532, additive — all omitempty, so a
 	// job that never hit a classified blocker serializes byte-identically).
 	// BlockerClass is the last classified blocker (e.g. "runtime_auth",
@@ -774,6 +794,7 @@ func (m Mailbox) prepareEnqueue(ctx context.Context, request JobRequest) (db.Job
 		Ephemeral:              request.Ephemeral,
 		HumanAnswer:            request.HumanAnswer,
 		RiskTier:               strings.TrimSpace(request.RiskTier),
+		InheritedEvidence:      normalizeInheritedEvidence(request.InheritedEvidence),
 		OrchestrateStage:       request.OrchestrateStage,
 		WritablePaths:          compactStrings(request.WritablePaths),
 		ReadablePaths:          compactStrings(request.ReadablePaths),
@@ -1503,6 +1524,16 @@ func (m Mailbox) Run(ctx context.Context, jobID string, agent runtime.Agent, ada
 		// and a child is a non-pipeline-sender job (Sender = the coordinator agent,
 		// ParentJobID = this stage job), so this strip never touches it.
 		result.HumanQuestions = nil
+	}
+	// #1821: clamp a staged verdict to what its preflight found runnable, BEFORE
+	// the result is stored, so no consumer ever reads the unclamped claim. The
+	// event is the audit trail: an overruled producer is a different thing from
+	// one that declared static_only itself, and a merge decision that later
+	// leans on this evidence should be able to tell them apart.
+	if ApplyInheritedEvidenceCeiling(&result, payload.InheritedEvidence) {
+		_ = m.addEvent(ctx, job.ID, InheritedEvidenceClampedEvent, fmt.Sprintf(
+			"declared %s evidence was clamped to %s: the preflight stage sharing this worktree and head recorded %s, so nothing here could have run",
+			EvidenceExecuted, EvidenceStaticOnly, EvidenceStaticOnly))
 	}
 	payload.Result = &result
 	if strings.EqualFold(strings.TrimSpace(job.Type), "implement") {

--- a/internal/workflow/result.go
+++ b/internal/workflow/result.go
@@ -448,6 +448,62 @@ func EvidenceWasDeclared(r AgentResult) bool {
 	return r.EvidenceDeclared
 }
 
+// InheritedEvidenceClampedEvent records that a staged verdict's EXECUTED claim
+// was overruled by its own preflight stage (#1821). It is the audit trail for a
+// clamp, because a producer that was overruled and one that declared
+// static_only itself are different facts with the same stored value.
+const InheritedEvidenceClampedEvent = "inherited_evidence_clamped"
+
+// normalizeInheritedEvidence keeps only a DECLARED evidence value as a ceiling.
+// Anything unrecognised - including the empty string every non-staged job
+// carries - normalizes away, so a staged review is the only shape that can
+// constrain its child and no other job's payload changes.
+func normalizeInheritedEvidence(value string) string {
+	trimmed := strings.TrimSpace(value)
+	if !ValidEvidence(trimmed) {
+		return ""
+	}
+	return trimmed
+}
+
+// ApplyInheritedEvidenceCeiling clamps a verdict stage's declared evidence to
+// what its preflight stage found runnable (#1821), and reports whether it
+// clamped.
+//
+// WHY THIS IS SOUND, and it rests on a property of the shape rather than on
+// trust: the two stages share one worktree and one head, asserted at child
+// dispatch. So the preflight's finding that a declared verification command
+// cannot execute is a fact about the tree the child is looking at, not a
+// pessimistic guess about a different one. Nothing between the stages can make
+// an unrunnable command runnable.
+//
+// It only ever moves evidence DOWNWARD. A preflight that executed does not
+// license a child to claim execution: a static_only child under an executed
+// preflight keeps its own more modest claim, because the child is the row whose
+// verdict the gate consumes and its own honesty about itself is the point.
+//
+// This is the #1823 condition "a declared verification command cannot execute"
+// made mechanical. Without it the preflight is decoration: stage 1 could find
+// nothing runnable and stage 2 could still return an executed verdict that the
+// merge gate consumes as proof work ran.
+func ApplyInheritedEvidenceCeiling(result *AgentResult, inherited string) bool {
+	if result == nil {
+		return false
+	}
+	ceiling := normalizeInheritedEvidence(inherited)
+	if ceiling != EvidenceStaticOnly {
+		return false
+	}
+	if strings.TrimSpace(result.Evidence) != EvidenceExecuted {
+		return false
+	}
+	result.Evidence = EvidenceStaticOnly
+	// The producer DID declare a value; it was overruled rather than defaulted,
+	// and #1817's declared flag must keep meaning "the producer spoke".
+	result.EvidenceDeclared = true
+	return true
+}
+
 // authorityGrantingResultFields are AgentResult fields an agent may NEVER supply,
 // because setting them GRANTS the job authority it would not otherwise have (#1673).
 //

--- a/skills/gitmoot/references/RESULT_CONTRACT.md
+++ b/skills/gitmoot/references/RESULT_CONTRACT.md
@@ -53,6 +53,17 @@ refused `static_only` would today refuse 93% of all reviews**, almost none of
 which made the claim. Declaring the field is what makes your verdict
 distinguishable from silence, so declare it.
 
+**A staged review's verdict cannot exceed its own preflight (#1821).** When a
+review runs as two stages sharing one worktree and one head, the preflight
+stage's evidence is carried to the verdict stage as a **ceiling**. If the
+preflight recorded `static_only`, a verdict declaring `executed` is clamped back
+to `static_only` before it is stored, and an `inherited_evidence_clamped` event
+records that the producer was overruled rather than silent. Nothing between the
+stages can make an unrunnable command runnable, so the clamp is a fact about the
+tree, not a penalty. The ceiling only ever moves evidence **downward**: a
+preflight that executed does not license the verdict stage to claim execution,
+and an honest `static_only` verdict stays `static_only`.
+
 **No check fails a static-only review.** The distinction a merge decision needs
 is carried by the stored field, not by refusing the verdict. An earlier version
 of this feature failed every static-only review, which under


### PR DESCRIPTION
Refs #1821, #1823. Second slice of the staged review, campaign #1818, after #2022 (capability refusal blocks).

## What this closes

#2022 made a refused escalation `blocked`. This makes the **preflight mean something**, which is the piece that decides whether a two-stage shape is worth having at all.

The gap, confirmed by reading the boundary rather than assuming it: `delegationRequest` already carries `repo`, `pull_request`, `head_sha`, `task_id`, review scope, risk tier and the fanout intent - and **not** evidence. So stage 1 could find that nothing in the worktree can be executed and stage 2 could still return an `executed` verdict that the merge gate consumes as proof work ran. Without this, the preflight is decoration and #1823's condition *"a declared verification command cannot execute"* has no mechanism.

## The shape

- `JobRequest.InheritedEvidence` / `JobPayload.inherited_evidence` carry the preflight finding as a **ceiling**. Both additive and `omitempty`, so every job outside a staged review serializes byte-identically - this is an addition, not a migration, and a test asserts it.
- `delegationInheritedEvidence` prefers the parent's own **declared** result and falls back to the parent's own inherited ceiling. **The fallback is the point:** without it a chain launders the constraint by inserting one silent hop between preflight and verdict, which is the survives-exactly-one-hop defect #1277 fixed for the review-fanout intent. An *undeclared* result is silence, not permission.
- `ApplyInheritedEvidenceCeiling` clamps at the mailbox seam **before** the result is stored, so no consumer ever reads the unclamped claim, and records `inherited_evidence_clamped`.

**Why the clamp is sound rather than pessimistic.** The two stages share one worktree and one head, asserted at child dispatch, so the preflight's finding is a fact about the tree the child is looking at. Nothing between the stages can make an unrunnable command runnable.

**It only moves evidence downward.** A preflight that executed does not license the child to claim execution, and an honest `static_only` verdict stays `static_only` - the child is the row whose verdict the gate consumes, so its own modesty wins. The clamp keeps `evidence_declared` **true**, because #1817 built that flag to separate a producer that spoke from one that was silent, and an overruled producer still spoke.

## The test that exists because a mutant survived

Swapping the clamp for *"executed becomes static_only, everything else becomes executed"* left **every other test green**. `TestInheritedEvidenceCeilingNeverUpgrades` passes an `executed` ceiling and returns before the mutated branch, so the uncovered shape was the most common one a staged review will produce: an honest `static_only` child under a `static_only` preflight. The mutant **upgraded** it, manufacturing an execution claim out of two admissions that nothing ran.

`TestInheritedEvidenceCeilingLeavesAnAlreadyStaticVerdictAlone` closes it. This is the second slice in a row where running the mutant at a sibling seam found a coverage hole rather than a code defect.

## Tests and mutants

Twelve tests. Five mutants, all killed:

| mutant | killed by |
|---|---|
| never clamp | `...ClampsAnExecutedClaim`, production-entry test |
| clamp upward | `...LeavesAnAlreadyStaticVerdictAlone` (**the one that survived first**) |
| drop the silent-hop fallback | `...SurvivesASilentHop` |
| remove the clamp call from the mailbox seam | production-entry test |
| clear `evidence_declared` on clamp | `...ClampsAnExecutedClaim`, production-entry test |

The **production-entry** test drives a real `Mailbox.Run` against a real store and asserts the **stored payload**, not just the returned value, because a clamp applied after the payload was written would pass a return-value assertion. The mutant that removes the wiring entirely is killed only by that test - every helper-level test passes while the feature is dead code, which is exactly the shape that let a pool-seam mutation survive on my previous slice.

Should-succeed arms are explicit: `TestMailboxRunLeavesAnUnstagedVerdictAlone` proves an ordinary review keeps its `executed` claim and records no clamp, and `TestInheritedEvidenceCeilingIgnoresEveryNonStagedShape` covers empty, whitespace, unrecognised and wrong-case ceilings.

## Local verification was deliberately partial

Build, vet, `gofmt`, `go generate` clean, and `-run` filtered tests across `internal/workflow`, `internal/prompts` and `skills`. **No untargeted package run**, by agreement with the coordinator while free space is thin. **CI is the full gate**, including the race shards a seat cannot run at all.

The contract-drift guard passes because this adds no `AgentResult` JSON field - the ceiling is engine state on the payload, never something an agent supplies.

## Not verified

Deployed behaviour. Nothing deployed, no service restarted. Nothing dispatches two stages yet, which is the next slice; this lands the constraint first so the dispatch has something to be constrained by.

Signed: **gm-staged**
