### PR TITLE
fix(workflow): resolve a synthetic agent's runtime family from its parent (#2004)

### DIFF
--- a/internal/workflow/runtime_family.go
+++ b/internal/workflow/runtime_family.go
@@ -25,7 +25,28 @@ import (
 // protecting a safety property MUST treat !ok as fail-closed: an unknown
 // family that silently counted as "new" would convert the guard into a way to
 // add unlimited reviews.
+//
+// SYNTHETIC AGENTS RESOLVE THROUGH THEIR PARENT (#2004). Temp and ephemeral
+// agents are deliberately absent from the registry, so the three tiers above
+// cannot name a family for them and the merge gate had to fall through to a
+// name comparison rather than fail closed. Measured on review and implement
+// jobs since 2026-08-25: 119 of 1,903 resolve through none of the three tiers,
+// and 102 of those 119 are recoverable from a parent - 86 temp rows whose
+// parent agent is in the registry (86/86) and 16 ephemeral rows whose parent
+// job's agent is (16/16). The remaining 17 are 11 rows with no agent at all and
+// 6 naming agents that are simply not registered, neither of which has a parent
+// to recover.
 func ResolveRuntimeFamily(ctx context.Context, store *db.Store, jobID string, agentName string, recordedRuntime string) (family string, ok bool, err error) {
+	family, ok, err = resolveRuntimeFamilyDirect(ctx, store, jobID, agentName, recordedRuntime)
+	if ok || err != nil {
+		return family, ok, err
+	}
+	return resolveRuntimeFamilyViaParent(ctx, store, jobID, agentName)
+}
+
+// resolveRuntimeFamilyDirect is the three-tier resolution that does not leave
+// the job it is asked about.
+func resolveRuntimeFamilyDirect(ctx context.Context, store *db.Store, jobID string, agentName string, recordedRuntime string) (family string, ok bool, err error) {
 	if recorded := normalizeRuntimeFamily(recordedRuntime); recorded != "" {
 		return recorded, true, nil
 	}
@@ -67,6 +88,104 @@ func ResolveRuntimeFamily(ctx context.Context, store *db.Store, jobID string, ag
 	}
 	if family := normalizeRuntimeFamily(agent.Runtime); family != "" {
 		return family, true, nil
+	}
+	return "", false, nil
+}
+
+// maxSyntheticParentHops bounds the walk. A temp worker forked from an
+// ephemeral delegation child is two hops, so four leaves headroom while making
+// a cycle in parent_job_id terminate instead of hanging the caller.
+const maxSyntheticParentHops = 4
+
+// tempAgentInfix and ephemeralAgentInfix are the two synthetic shapes.
+// daemon_worker.go mints `<parent-agent>-temp-<parent-job-id>`, so the parent
+// AGENT is the prefix and needs no store read. ephemeralAgentName mints
+// `<slug(delegation-id)>-ephemeral-<shortHash(parent-job+delegation)>`, which
+// HASHES the parent job: nothing in that name recovers it, so the parent comes
+// from the job row's parent_job_id column instead.
+//
+// #2004 as filed claimed the parent job is recoverable from the name in both
+// shapes. That is true of temp and false of ephemeral; the hash is one-way. The
+// column is the reason the ephemeral half works at all.
+const (
+	tempAgentInfix      = "-temp-"
+	ephemeralAgentInfix = "-ephemeral-"
+)
+
+// splitTempAgentName recovers the parent agent from a temp worker's name.
+// It splits at the FIRST infix because the prefix is a registered agent name
+// and the suffix is a job id, which is where a second "-temp-" could appear.
+func splitTempAgentName(name string) (parentAgent string, ok bool) {
+	index := strings.Index(name, tempAgentInfix)
+	if index <= 0 {
+		return "", false
+	}
+	parent := strings.TrimSpace(name[:index])
+	if parent == "" || parent == name {
+		return "", false
+	}
+	return parent, true
+}
+
+// resolveRuntimeFamilyViaParent walks up from a synthetic agent to one that can
+// name a family. Each hop resolves the parent through the same three tiers, so
+// a parent that ran on an override attributes to what it actually ran rather
+// than to its registered default.
+func resolveRuntimeFamilyViaParent(ctx context.Context, store *db.Store, jobID string, agentName string) (string, bool, error) {
+	if store == nil {
+		return "", false, nil
+	}
+	name := strings.TrimSpace(agentName)
+	currentJobID := strings.TrimSpace(jobID)
+	for range maxSyntheticParentHops {
+		parentAgent, parentJobID := "", ""
+		if parent, ok := splitTempAgentName(name); ok {
+			parentAgent = parent
+		} else if strings.Contains(name, ephemeralAgentInfix) && currentJobID != "" {
+			job, err := store.GetJob(ctx, currentJobID)
+			if err != nil {
+				if errors.Is(err, sql.ErrNoRows) {
+					return "", false, nil
+				}
+				return "", false, err
+			}
+			parentJobID = strings.TrimSpace(job.ParentJobID)
+		}
+		if parentAgent == "" && parentJobID == "" {
+			// Not a synthetic name, or an ephemeral row with no parent recorded.
+			// Either way there is nothing above this job to ask.
+			return "", false, nil
+		}
+		if parentJobID != "" {
+			parent, err := store.GetJob(ctx, parentJobID)
+			if err != nil {
+				if errors.Is(err, sql.ErrNoRows) {
+					return "", false, nil
+				}
+				return "", false, err
+			}
+			if parentJobID == currentJobID {
+				// A self-parent would spin the walk against one row.
+				return "", false, nil
+			}
+			parentAgent = strings.TrimSpace(parent.Agent)
+			currentJobID = parentJobID
+		} else {
+			// A temp name identifies its parent agent but not a parent job whose
+			// own recorded runtime we may read, so the next hop is name-only.
+			currentJobID = ""
+		}
+		if parentAgent == "" {
+			return "", false, nil
+		}
+		family, ok, err := resolveRuntimeFamilyDirect(ctx, store, currentJobID, parentAgent, "")
+		if err != nil {
+			return "", false, err
+		}
+		if ok {
+			return family, true, nil
+		}
+		name = parentAgent
 	}
 	return "", false, nil
 }

--- a/internal/workflow/runtime_family.go
+++ b/internal/workflow/runtime_family.go
@@ -115,16 +115,21 @@ const (
 // splitTempAgentName recovers the parent agent from a temp worker's name.
 // It splits at the FIRST infix because the prefix is a registered agent name
 // and the suffix is a job id, which is where a second "-temp-" could appear.
-func splitTempAgentName(name string) (parentAgent string, ok bool) {
+func splitTempAgentName(name string) (parentAgent string, parentJobID string, ok bool) {
 	index := strings.Index(name, tempAgentInfix)
 	if index <= 0 {
-		return "", false
+		return "", "", false
 	}
 	parent := strings.TrimSpace(name[:index])
 	if parent == "" || parent == name {
-		return "", false
+		return "", "", false
 	}
-	return parent, true
+	// The suffix is the parent JOB id, and carrying it matters for the chained
+	// case: a temp worker forked from an ephemeral delegation child resolves its
+	// parent agent by name, but that agent is itself synthetic and its own parent
+	// lives in a job row. Dropping the suffix here would strand that second hop
+	// with no job to read, so the documented two-hop path would not exist.
+	return parent, strings.TrimSpace(name[index+len(tempAgentInfix):]), true
 }
 
 // resolveRuntimeFamilyViaParent walks up from a synthetic agent to one that can
@@ -139,8 +144,22 @@ func resolveRuntimeFamilyViaParent(ctx context.Context, store *db.Store, jobID s
 	currentJobID := strings.TrimSpace(jobID)
 	for range maxSyntheticParentHops {
 		parentAgent, parentJobID := "", ""
-		if parent, ok := splitTempAgentName(name); ok {
+		if parent, parentJob, ok := splitTempAgentName(name); ok {
 			parentAgent = parent
+			// Resolve the parent agent by name, but keep the parent JOB for the next
+			// hop and for its own recorded runtime. A job id that names no row simply
+			// leaves the walk on the name-only path.
+			if parentJob != "" {
+				if _, err := store.GetJob(ctx, parentJob); err == nil {
+					currentJobID = parentJob
+				} else if !errors.Is(err, sql.ErrNoRows) {
+					return "", false, err
+				} else {
+					currentJobID = ""
+				}
+			} else {
+				currentJobID = ""
+			}
 		} else if strings.Contains(name, ephemeralAgentInfix) && currentJobID != "" {
 			job, err := store.GetJob(ctx, currentJobID)
 			if err != nil {
@@ -170,10 +189,6 @@ func resolveRuntimeFamilyViaParent(ctx context.Context, store *db.Store, jobID s
 			}
 			parentAgent = strings.TrimSpace(parent.Agent)
 			currentJobID = parentJobID
-		} else {
-			// A temp name identifies its parent agent but not a parent job whose
-			// own recorded runtime we may read, so the next hop is name-only.
-			currentJobID = ""
 		}
 		if parentAgent == "" {
 			return "", false, nil

--- a/internal/workflow/runtime_family_parent_2004_test.go
+++ b/internal/workflow/runtime_family_parent_2004_test.go
@@ -91,7 +91,23 @@ func TestEphemeralAgentDoesNotResolveWithoutItsJob(t *testing.T) {
 func TestUnregisteredPlainNameStillDoesNotResolve(t *testing.T) {
 	ctx := context.Background()
 	store := openEngineStore(t)
-	insertCompletedJob(t, store, db.Job{ID: "job-plain", Agent: "gm-omp-nag", Type: "implement"}, JobPayload{})
+	// DELIBERATELY NOT insertCompletedJob: that helper registers a fixture agent
+	// (#2004), which would register the very agent this control needs absent and
+	// turn the assertion vacuous. The failure mode is the point of the control, so
+	// it must not be fed by the helper that defeats it.
+	encoded, err := marshalPayload(JobPayload{})
+	if err != nil {
+		t.Fatalf("marshalPayload: %v", err)
+	}
+	if err := store.CreateJobWithEvent(ctx, db.Job{
+		ID: "job-plain", Agent: "gm-omp-nag", Type: "implement",
+		State: string(JobSucceeded), Payload: encoded,
+	}, db.JobEvent{Kind: string(JobSucceeded), Message: "done"}); err != nil {
+		t.Fatalf("CreateJobWithEvent: %v", err)
+	}
+	if _, err := store.GetAgent(ctx, "gm-omp-nag"); err == nil {
+		t.Fatal("gm-omp-nag is registered; this control cannot detect a resolver that invents a family")
+	}
 
 	family, ok, err := ResolveRuntimeFamily(ctx, store, "job-plain", "gm-omp-nag", "")
 	if err != nil {
@@ -117,5 +133,32 @@ func TestParentWalkTerminatesOnASelfParent(t *testing.T) {
 	}
 	if ok {
 		t.Fatalf("self-parent resolved to %q, want no family and a terminating walk", family)
+	}
+}
+
+// The chained shape, and the reason splitTempAgentName returns the suffix job id
+// rather than only the parent agent: a temp worker forked from an ephemeral
+// delegation child needs TWO hops. Hop one resolves the temp name's parent agent
+// by name, but that agent is itself synthetic and unregistered; hop two can only
+// continue because the temp name's suffix gave the walk a job row to read a
+// parent_job_id from. Drop the suffix and this resolves to nothing while the
+// single-hop tests stay green, which is why the bound needed its own case.
+func TestParentWalkResolvesATempWorkerForkedFromAnEphemeralChild(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	seedReviewLoopAgent(t, store, "coordinator", "kimi", "k2")
+
+	insertCompletedJob(t, store, db.Job{ID: "job-coord", Agent: "coordinator", Type: "review"}, JobPayload{})
+	ephemeral := ephemeralAgentName("lens-chain", "job-coord")
+	insertCompletedJob(t, store, db.Job{ID: "job-eph", Agent: ephemeral, Type: "review", ParentJobID: "job-coord"}, JobPayload{})
+	tempOfEphemeral := ephemeral + "-temp-" + "job-eph"
+	insertCompletedJob(t, store, db.Job{ID: "job-temp-chain", Agent: tempOfEphemeral, Type: "review"}, JobPayload{})
+
+	family, ok, err := ResolveRuntimeFamily(ctx, store, "job-temp-chain", tempOfEphemeral, "")
+	if err != nil {
+		t.Fatalf("ResolveRuntimeFamily: %v", err)
+	}
+	if !ok || family != "kimi" {
+		t.Fatalf("chained temp-of-ephemeral resolved to (%q, %v), want (\"kimi\", true)", family, ok)
 	}
 }

--- a/internal/workflow/runtime_family_parent_2004_test.go
+++ b/internal/workflow/runtime_family_parent_2004_test.go
@@ -1,0 +1,121 @@
+package workflow
+
+import (
+	"context"
+	"testing"
+
+	"github.com/gitmoot/gitmoot/internal/db"
+)
+
+// #2004: temp and ephemeral agents are deliberately absent from the agent
+// registry, so ResolveRuntimeFamily could not name a family for them and the
+// merge gate's independence check had to fall through to a name comparison.
+// Measured on review and implement jobs since 2026-08-25: 119 of 1,903 resolved
+// to no family, 86 of them temp-shaped and 16 ephemeral-shaped.
+//
+// The two shapes recover differently and that is the point of testing both.
+// A temp name CARRIES its parent agent as a prefix. An ephemeral name does not
+// carry its parent at all - ephemeralAgentName hashes the parent job id - so it
+// recovers through the job row's parent_job_id column instead. #2004 as filed
+// claimed both were name-recoverable; only one is.
+func TestRuntimeFamilyResolvesATempAgentThroughItsNamedParent(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	seedReviewLoopAgent(t, store, "g7-review", "codex", "gpt-5.6-sol")
+
+	// The live shape, verbatim from daemon_worker.go: base + "-temp-" + job.
+	// The parent JOB id also contains dashes and the agent's own name, which is
+	// why the split must take the FIRST infix.
+	const tempAgent = "g7-review-temp-local-review-g7-review-18d0d354"
+	insertCompletedJob(t, store, db.Job{ID: "job-temp", Agent: tempAgent, Type: "review"}, JobPayload{})
+
+	family, ok, err := ResolveRuntimeFamily(ctx, store, "job-temp", tempAgent, "")
+	if err != nil {
+		t.Fatalf("ResolveRuntimeFamily: %v", err)
+	}
+	if !ok || family != "codex" {
+		t.Fatalf("temp agent resolved to (%q, %v), want (\"codex\", true); the parent agent is the name's own prefix", family, ok)
+	}
+}
+
+func TestRuntimeFamilyResolvesAnEphemeralAgentThroughItsParentJob(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	seedReviewLoopAgent(t, store, "coordinator", "claude", "sonnet")
+
+	insertCompletedJob(t, store, db.Job{ID: "job-parent", Agent: "coordinator", Type: "review"}, JobPayload{})
+	// ephemeralAgentName(delegationID, parentJobID) - the parent job survives only
+	// as a hash, so nothing in this string identifies job-parent.
+	ephemeral := ephemeralAgentName("lens-db-path", "job-parent")
+	insertCompletedJob(t, store, db.Job{ID: "job-lens", Agent: ephemeral, Type: "review", ParentJobID: "job-parent"}, JobPayload{})
+
+	family, ok, err := ResolveRuntimeFamily(ctx, store, "job-lens", ephemeral, "")
+	if err != nil {
+		t.Fatalf("ResolveRuntimeFamily: %v", err)
+	}
+	if !ok || family != "claude" {
+		t.Fatalf("ephemeral agent resolved to (%q, %v), want (\"claude\", true)", family, ok)
+	}
+}
+
+// THE CONSUMER GUARD (#2004 acceptance 2). selectNativeReviewFamily asks about a
+// configured reviewer NAME with no job id, and treats an unresolved family as a
+// drop. If an ephemeral name resolved without a job, that call would start
+// admitting reviewers it drops today. It cannot: the parent lives in the job row
+// this call does not have.
+//
+// Measured alongside: of the 49 distinct reviewer names ever recorded in job
+// payloads on this host, 0 are temp-shaped and 1 is ephemeral-shaped, so the
+// fanout consumer sees no change either in principle or in this population.
+func TestEphemeralAgentDoesNotResolveWithoutItsJob(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	seedReviewLoopAgent(t, store, "coordinator", "claude", "sonnet")
+	insertCompletedJob(t, store, db.Job{ID: "job-parent", Agent: "coordinator", Type: "review"}, JobPayload{})
+	ephemeral := ephemeralAgentName("lens-db-path", "job-parent")
+	insertCompletedJob(t, store, db.Job{ID: "job-lens", Agent: ephemeral, Type: "review", ParentJobID: "job-parent"}, JobPayload{})
+
+	family, ok, err := ResolveRuntimeFamily(ctx, store, "", ephemeral, "")
+	if err != nil {
+		t.Fatalf("ResolveRuntimeFamily: %v", err)
+	}
+	if ok {
+		t.Fatalf("ephemeral name resolved to %q with no job id; the fanout consumer would change behaviour", family)
+	}
+}
+
+// The control. Parent recovery must not become "everything resolves": the
+// remaining residue is 11 rows with no agent and 6 naming an agent that is not
+// registered, and neither has a parent to recover. Without this arm the two
+// tests above are satisfied by a resolver that invents a family.
+func TestUnregisteredPlainNameStillDoesNotResolve(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	insertCompletedJob(t, store, db.Job{ID: "job-plain", Agent: "gm-omp-nag", Type: "implement"}, JobPayload{})
+
+	family, ok, err := ResolveRuntimeFamily(ctx, store, "job-plain", "gm-omp-nag", "")
+	if err != nil {
+		t.Fatalf("ResolveRuntimeFamily: %v", err)
+	}
+	if ok {
+		t.Fatalf("unregistered plain name resolved to %q; parent recovery must not invent a family", family)
+	}
+}
+
+// A parent_job_id pointing at its own row is the cheap way to hang a walk that
+// trusts the column. The hop bound is what stops it, and a bound with no test
+// is a comment.
+func TestParentWalkTerminatesOnASelfParent(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	ephemeral := ephemeralAgentName("lens-loop", "job-loop")
+	insertCompletedJob(t, store, db.Job{ID: "job-loop", Agent: ephemeral, Type: "review", ParentJobID: "job-loop"}, JobPayload{})
+
+	family, ok, err := ResolveRuntimeFamily(ctx, store, "job-loop", ephemeral, "")
+	if err != nil {
+		t.Fatalf("ResolveRuntimeFamily: %v", err)
+	}
+	if ok {
+		t.Fatalf("self-parent resolved to %q, want no family and a terminating walk", family)
+	}
+}


### PR DESCRIPTION
First half of #2004: acceptance 1 and 2. Acceptance 3 is measured and held back
deliberately, see the end.

## Re-measured before touching code

Review and implement jobs since 2026-08-25, resolution by tier:

```
implement  recorded 251   registry 191   unresolvable 22
review     recorded 1121  registry 221   unresolvable 97
```

119 unresolvable, matching the issue's 22 and 97 exactly. Split by shape:

```
unresolvable  empty_agent  temp_shape  ephemeral_shape  plain_name  has_parent_job_id
119           11           86          16               6           16
```

## The issue was wrong about one of the two shapes, and it matters

#2004 says "the parent job is recoverable from the name in both shapes". That is
true of temp and **false of ephemeral**:

- `daemon_worker.go` mints `<parent-agent>-temp-<parent-job-id>`, so the parent
  agent is the prefix. Split at the FIRST infix: the suffix is a job id that can
  contain the agent's own name, e.g.
  `g6-review-sol-temp-local-review-g6-review-sol-18d285edb0a0dfc8`.
- `ephemeralAgentName(delegationID, parentJobID)` returns
  `slug(delegationID)-ephemeral-shortHash(parentJobID+delegationID)`. The parent
  job is inside a hash. Nothing in that name recovers it.

So the ephemeral half works through the job row's `parent_job_id` column, not the
name. Measured: **16/16** ephemeral rows carry one. And **86/86** temp rows have
their parent agent in the registry with a runtime.

Ceiling: 102 of 119 recovered. Residue 17 = 11 rows with no agent + 6 naming an
unregistered agent. Neither has a parent to recover, which is why they stay.

## Acceptance 2, measured not assumed

The other consumer is `selectNativeReviewFamily`, which asks about a configured
reviewer NAME with `jobID == ""` and drops a reviewer whose family will not
resolve. A temp name would newly resolve there. Of the **49** distinct reviewer
names ever recorded in job payloads on this host, **0** are temp-shaped and **1**
is ephemeral-shaped - and an ephemeral name cannot resolve without the job row,
so that one is unchanged too.

**Zero rows change at that consumer**, and `TestEphemeralAgentDoesNotResolveWithoutItsJob`
pins the no-job-id behaviour so a later change cannot quietly alter the fanout.

Full `Family|MergeGate|Merge|ReviewLoop|Fanout|NativeReview` suite passes
unchanged with this commit applied, which is the regression evidence.

## Tests

| test | base | branch |
|---|---|---|
| `TestRuntimeFamilyResolvesATempAgentThroughItsNamedParent` | FAIL (`("", false)`) | PASS |
| `TestRuntimeFamilyResolvesAnEphemeralAgentThroughItsParentJob` | FAIL (`("", false)`) | PASS |
| `TestEphemeralAgentDoesNotResolveWithoutItsJob` | PASS | PASS |
| `TestUnregisteredPlainNameStillDoesNotResolve` | PASS | PASS |
| `TestParentWalkTerminatesOnASelfParent` | PASS | PASS |

Three pass on base by design and I am saying so rather than implying five
reproductions. They are the controls: without them the two failing arms are
satisfied by a resolver that invents a family for anything, which would be a
worse defect than the one being fixed. The self-parent arm is the bound on the
hop limit, because a bound with no test is a comment.

## Acceptance 3 is written, measured, and held back

Making `sameRuntimeFamilyAsImplementer` fail closed turns **74** existing tests
red through **one** shared cause: their fixtures never register the reviewer
agent, so `audit` resolves to no family and every gate decision blocks. The
production exposure is much smaller and I measured it separately: the 11
empty-agent rows cannot reach that function at all
(`collectImplementerAttributionMatching` routes them to `sawEmptyAgent`), leaving
**6 implement rows naming unregistered agents, none on an open pull request**.

That is a contract change with a 74-test fixture consequence, and it belongs in
its own reviewable PR rather than under a resolver change. Filing it next.

Deploy notes: no config, no migration, no schema change. Resolution is strictly
additive - every row that resolves today resolves to the same family.
