### PR TITLE
fix(workflow): resolve a review row's identity through one rule, not six copies (#2008)

### DIFF
--- a/internal/db/awaited_facts.go
+++ b/internal/db/awaited_facts.go
@@ -210,7 +210,11 @@ type reviewVerdictPayload struct {
 	// report-only and is therefore never re-interpreted against repository
 	// severity policy.
 	Sender string `json:"sender"`
-	Result *struct {
+	// ActingOrgRole is read so a session review authored by a role rather than an
+	// agent survives to the caller, which resolves the two into one identity
+	// (#2008). Folding stays in workflow.ReviewerIdentity, not here.
+	ActingOrgRole string `json:"acting_org_role"`
+	Result        *struct {
 		Decision string `json:"decision"`
 		Severity string `json:"severity,omitempty"`
 		// Delegations and FanOut are the canonical fan-out classification, decoded
@@ -249,6 +253,12 @@ type SucceededReviewVerdict struct {
 	// recorded it (#1528). Empty for jobs that predate that recording; callers
 	// resolving a runtime family fall back to the agent registry default.
 	EffectiveRuntime string
+	// ActingOrgRole is the role an externally driven session review recorded IN
+	// PLACE OF an agent. It is carried RAW and deliberately not folded here:
+	// workflow depends on db and never the reverse, so the Agent-first rule lives
+	// in workflow.ReviewerIdentity and this layer must not keep a second copy of
+	// it (#2008). A caller reading Agent alone silently drops such a row.
+	ActingOrgRole string
 }
 
 // SucceededReviewVerdicts returns stable approved or changes-requested review
@@ -302,6 +312,7 @@ ORDER BY updated_at DESC, id DESC`, repo, pullRequest)
 			Decision:         decision,
 			Severity:         strings.ToUpper(strings.TrimSpace(decoded.Result.Severity)),
 			EffectiveRuntime: strings.ToLower(strings.TrimSpace(decoded.EffectiveRuntime)),
+			ActingOrgRole:    strings.TrimSpace(decoded.ActingOrgRole),
 		})
 	}
 	if err := rows.Err(); err != nil {

--- a/internal/proof/project.go
+++ b/internal/proof/project.go
@@ -27,14 +27,19 @@ type PRReceipt struct {
 }
 
 type payloadProjection struct {
-	Repo               string                      `json:"repo"`
-	PullRequest        int                         `json:"pull_request"`
-	HeadSHA            string                      `json:"head_sha"`
-	WorkflowID         string                      `json:"workflow_id"`
-	RuntimeOverride    string                      `json:"runtime_override"`
-	RuntimeOverrideRef string                      `json:"runtime_override_ref"`
-	Result             *workflow.AgentResult       `json:"result"`
-	ResultObservation  *workflow.ResultObservation `json:"result_observation"`
+	Repo               string `json:"repo"`
+	PullRequest        int    `json:"pull_request"`
+	HeadSHA            string `json:"head_sha"`
+	WorkflowID         string `json:"workflow_id"`
+	RuntimeOverride    string `json:"runtime_override"`
+	RuntimeOverrideRef string `json:"runtime_override_ref"`
+	// ActingOrgRole is the role an externally driven session job records IN PLACE
+	// OF an agent. internal/proof previously had zero references to it and read
+	// bare job.Agent, so a role-authored review rendered its author as "-" and its
+	// independence stayed unknown rather than being computed (#2008).
+	ActingOrgRole     string                      `json:"acting_org_role"`
+	Result            *workflow.AgentResult       `json:"result"`
+	ResultObservation *workflow.ResultObservation `json:"result_observation"`
 }
 
 type projector struct {
@@ -149,8 +154,15 @@ func (p *projector) buildSession(jobID string) string {
 	defer delete(p.visiting, jobID)
 
 	projection, payloadParseable := parsePayloadWithStatus(job.Payload)
+	// Resolved by the same rule as the review node below, and NOT left bare, for
+	// consistency WITHIN one manifest: the review node reports its implementer as
+	// a resolved identity, so leaving this one on the raw column would render the
+	// same job's author two different ways in the same document. Measured on this
+	// box: 11 rows carry a role with no agent (10 implement, 1 ask), which is the
+	// implementer side of exactly that comparison (#2008).
+	authorName, _ := workflow.ReviewerIdentity(job.Agent, projection.ActingOrgRole)
 	attrs := map[string]string{
-		"agent": job.Agent, "job_type": job.Type, "state": job.State,
+		"agent": authorName, "job_type": job.Type, "state": job.State,
 		"input_tokens":  strconv.Itoa(job.InputTokens),
 		"output_tokens": strconv.Itoa(job.OutputTokens),
 		"as_of":         job.UpdatedAt,
@@ -245,8 +257,9 @@ func (p *projector) factNodes(job db.Job, projection payloadProjection, result *
 	}
 
 	if job.Type == "review" {
+		reviewerName, _ := workflow.ReviewerIdentity(job.Agent, projection.ActingOrgRole)
 		attrs := map[string]string{
-			"job_id": job.ID, "agent": job.Agent, "as_of": job.UpdatedAt,
+			"job_id": job.ID, "agent": reviewerName, "as_of": job.UpdatedAt,
 			"reviewed_ref": emptyDash(p.reviewedRef(job, headSHA)),
 		}
 		claims := []Claim{}
@@ -257,12 +270,17 @@ func (p *projector) factNodes(job db.Job, projection payloadProjection, result *
 				claims = append(claims, reportedClaim("review.decision", job, job.UpdatedAt))
 			}
 			implementer, known := p.implementer[job.ID]
-			implementerAgent := strings.TrimSpace(implementer.Agent)
-			reviewerAgent := strings.TrimSpace(job.Agent)
-			comparable := known && implementerAgent != "" && reviewerAgent != ""
-			independent := comparable && implementerAgent != reviewerAgent
+			// BOTH SIDES resolve through the same rule the merge gate uses, because an
+			// independence claim comparing a resolved name against a bare column is
+			// comparing two different things. The gate records a role implementer and
+			// holds it "still subject to the independence check", so reporting that
+			// pair as not comparable was incomplete rather than conservative (#2008).
+			implementerProjection, _ := parsePayloadWithStatus(implementer.Payload)
+			implementerAgent, _ := workflow.ReviewerIdentity(implementer.Agent, implementerProjection.ActingOrgRole)
+			comparable := known && implementerAgent != "" && reviewerName != ""
+			independent := comparable && implementerAgent != reviewerName
 			if known {
-				attrs["implementer_agent"] = implementer.Agent
+				attrs["implementer_agent"] = implementerAgent
 			}
 			if comparable {
 				attrs["independent"] = strconv.FormatBool(independent)

--- a/internal/proof/role_authored_review_2008_test.go
+++ b/internal/proof/role_authored_review_2008_test.go
@@ -1,0 +1,121 @@
+package proof
+
+import (
+	"testing"
+
+	"github.com/gitmoot/gitmoot/internal/workflow"
+)
+
+// TestRoleAuthoredReviewIsAttributedAndComparable pins #2008's agent-keyed half
+// for internal/proof, which read bare job.Agent with zero ActingOrgRole
+// references.
+//
+// An externally driven session review persists the acting org role IN PLACE OF
+// an agent, so the review row's Agent column is empty by design. Reading it
+// alone rendered the author as "-" and left the independence attribute absent,
+// which reads as "not comparable" rather than as "nobody looked".
+//
+// Both assertions are about what a CONSUMER sees in the manifest, not about
+// which helper computed it.
+func TestRoleAuthoredReviewIsAttributedAndComparable(t *testing.T) {
+	root, jobs, results, receipts, events := proofFixture(t, false)
+
+	// Turn the review row into a session review: no agent, an acting role
+	// instead. Nothing else about the fixture changes.
+	for i, job := range jobs {
+		if job.Type != "review" {
+			continue
+		}
+		payload := workflow.JobPayload{
+			Repo: "owner/repo", PullRequest: 42, HeadSHA: "abc123", WorkflowID: "proof/42",
+			RootJobID: "root", ParentJobID: "root", DelegationID: "review", DelegationDepth: 1,
+			DelegatedBy: "implementer", ActingOrgRole: " ReVieWer ", Result: results["review-job"],
+		}
+		jobs[i].Agent = ""
+		jobs[i].Payload = proofPayload(t, payload)
+		jobs[i].ResultHash = resultHashForPayload(t, jobs[i].Payload)
+	}
+
+	manifest := Project(root, jobs, results, receipts, events)
+	if err := VerifyManifest(manifest); err != nil {
+		t.Fatalf("VerifyManifest: %v", err)
+	}
+
+	var review *Node
+	for id := range manifest.Nodes {
+		node := manifest.Nodes[id]
+		if node.Kind == KindReview {
+			review = &node
+			break
+		}
+	}
+	if review == nil {
+		t.Fatal("no review node in the manifest")
+	}
+
+	// The role is normalized by the same rule the merge gate uses, so the
+	// surrounding whitespace and casing above must not survive into the author.
+	if got := review.Attrs["agent"]; got != "reviewer" {
+		t.Errorf("review author = %q, want %q: a role-authored review renders no author", got, "reviewer")
+	}
+
+	// The implementer is "implementer" and the reviewer resolves to "reviewer",
+	// so this pair IS comparable and IS independent. Before the fix the attribute
+	// was absent entirely, which is indistinguishable from a pair nobody could
+	// compare.
+	if _, ok := review.Attrs["independent"]; !ok {
+		t.Fatalf("independent attribute absent: a role-authored reviewer was reported as not comparable")
+	}
+	if got := review.Attrs["independent"]; got != "true" {
+		t.Errorf("independent = %q, want true", got)
+	}
+}
+
+// TestRoleAuthoredSelfReviewIsNotIndependent is the other direction, and it is
+// the one that matters for a merge decision: resolving the identity must be able
+// to REFUSE independence, not only grant it. A rule that only ever produced
+// "true" would satisfy the test above while destroying the attribute's meaning.
+func TestRoleAuthoredSelfReviewIsNotIndependent(t *testing.T) {
+	root, jobs, results, receipts, events := proofFixture(t, false)
+
+	for i, job := range jobs {
+		switch {
+		case job.Type == "review":
+			payload := workflow.JobPayload{
+				Repo: "owner/repo", PullRequest: 42, HeadSHA: "abc123", WorkflowID: "proof/42",
+				RootJobID: "root", ParentJobID: "root", DelegationID: "review", DelegationDepth: 1,
+				DelegatedBy: "implementer", ActingOrgRole: "gitmoot", Result: results["review-job"],
+			}
+			jobs[i].Agent = ""
+			jobs[i].Payload = proofPayload(t, payload)
+			jobs[i].ResultHash = resultHashForPayload(t, jobs[i].Payload)
+		case job.ID == "root":
+			// The implementer records the SAME role, also with no agent.
+			payload := workflow.JobPayload{
+				Repo: "owner/repo", PullRequest: 42, HeadSHA: "abc123", WorkflowID: "proof/42",
+				RootJobID: "root", ActingOrgRole: "gitmoot", Result: results["root"],
+			}
+			jobs[i].Agent = ""
+			jobs[i].Payload = proofPayload(t, payload)
+			jobs[i].ResultHash = resultHashForPayload(t, jobs[i].Payload)
+			root = jobs[i]
+		}
+	}
+
+	manifest := Project(root, jobs, results, receipts, events)
+
+	var review *Node
+	for id := range manifest.Nodes {
+		node := manifest.Nodes[id]
+		if node.Kind == KindReview {
+			review = &node
+			break
+		}
+	}
+	if review == nil {
+		t.Fatal("no review node in the manifest")
+	}
+	if got := review.Attrs["independent"]; got != "false" {
+		t.Errorf("independent = %q, want false: one role reviewing its own work is not independent", got)
+	}
+}

--- a/internal/workflow/engine_routing_merge.go
+++ b/internal/workflow/engine_routing_merge.go
@@ -14,6 +14,15 @@ import (
 	"github.com/gitmoot/gitmoot/internal/runtime"
 )
 
+// reviewDecisionAgent resolves the identity a review row's decision is credited
+// to. It is the funnel for three of #2008's agent-keyed consumers -
+// reviewLegsAtHead, followUpReviewScopes and the approval scan below - which is
+// why the fallback lives here rather than at each of those call sites.
+//
+// The re-delegation case stays FIRST and stays ahead of the identity rule: a
+// runtime_session_busy hand-off records the delegate in job.Agent, so resolving
+// the stored fields first would still return that delegate and credit the leg to
+// it rather than to the agent whose slot it fills.
 func reviewDecisionAgent(job db.Job, payload JobPayload) string {
 	if job.Type == "review" &&
 		payload.DelegationReason == "runtime_session_busy" &&
@@ -21,7 +30,11 @@ func reviewDecisionAgent(job db.Job, payload JobPayload) string {
 		strings.TrimSpace(payload.OriginalAgent) != "" {
 		return payload.OriginalAgent
 	}
-	return job.Agent
+	// An externally driven session review persists ActingOrgRole IN PLACE OF an
+	// agent, so bare job.Agent returned "" and every caller's non-empty check then
+	// dropped the row from the legs, scopes and approvals it belonged in.
+	name, _ := ReviewerIdentity(job.Agent, payload.ActingOrgRole)
+	return name
 }
 
 func (e Engine) jobPayload(ctx context.Context, jobID string) (db.Job, JobPayload, error) {

--- a/internal/workflow/merge_gate.go
+++ b/internal/workflow/merge_gate.go
@@ -2205,10 +2205,29 @@ func effectiveReviewerIdentityName(job db.Job, payload JobPayload) string {
 // already recorded under the same name); what it no longer keeps is a second copy
 // of how an identity is DERIVED.
 func effectiveReviewerIdentity(job db.Job, payload JobPayload) (string, bool) {
-	if agent := strings.TrimSpace(job.Agent); agent != "" {
-		return agent, false
+	return ReviewerIdentity(job.Agent, payload.ActingOrgRole)
+}
+
+// ReviewerIdentity is that same rule as a pure function of the two STORED
+// fields, exported so consumers outside this package resolve an identity the
+// same way instead of keeping a third copy (#2008).
+//
+// It exists because the comment above this function already named two consumers
+// that were deliberately left on bare job.Agent for routing: review_loop.go's
+// FindRepeatedReviewers, which could not see a role because db.SucceededReviewVerdict
+// carried only Agent, and internal/proof, which had zero ActingOrgRole references
+// and therefore reported a role-authored review as not comparable. Both now call
+// this, so the count in that comment is no longer two and is deliberately not
+// restated here - quoting a count is the habit #1950 F5 ended.
+//
+// The db layer does NOT call this and must not: workflow depends on db and never
+// the reverse, so db.SucceededReviewVerdict carries the role RAW and the folding
+// happens here. That keeps one rule rather than one rule and one lowercase.
+func ReviewerIdentity(agent, actingOrgRole string) (string, bool) {
+	if trimmed := strings.TrimSpace(agent); trimmed != "" {
+		return trimmed, false
 	}
-	if role := NormalizeActingOrgRole(payload.ActingOrgRole); role != "" {
+	if role := NormalizeActingOrgRole(actingOrgRole); role != "" {
 		return role, true
 	}
 	return "", false

--- a/internal/workflow/review_loop.go
+++ b/internal/workflow/review_loop.go
@@ -86,7 +86,13 @@ func FindRepeatedReviewers(ctx context.Context, store *db.Store, repo string, pu
 			if verdict.HeadSHA != headSHA {
 				continue
 			}
-			agent := strings.ToLower(strings.TrimSpace(verdict.Agent))
+			// A session review persists ActingOrgRole IN PLACE OF an agent, so the
+			// bare Agent column indexed it under "" and this check then dropped it.
+			// That made a role's own verdict unmatchable by a requester named for
+			// that same role (#1950 F2, #2008). The verdict carries the role RAW and
+			// the fold stays in one place.
+			name, _ := ReviewerIdentity(verdict.Agent, verdict.ActingOrgRole)
+			agent := strings.ToLower(name)
 			if agent == "" {
 				continue
 			}
@@ -119,9 +125,12 @@ func FindRepeatedReviewers(ctx context.Context, store *db.Store, repo string, pu
 				continue
 			}
 		}
+		// Reported as the RESOLVED identity for the same reason it is indexed as
+		// one: a match whose author renders empty names nobody.
+		evidenceAgent, _ := ReviewerIdentity(evidence.Agent, evidence.ActingOrgRole)
 		match := ReviewLoopMatch{
 			JobID:       evidence.JobID,
-			Agent:       evidence.Agent,
+			Agent:       evidenceAgent,
 			Repo:        repo,
 			PullRequest: pullRequest,
 			HeadSHA:     headSHA,

--- a/internal/workflow/role_authored_verdict_2008_test.go
+++ b/internal/workflow/role_authored_verdict_2008_test.go
@@ -1,0 +1,122 @@
+package workflow
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/gitmoot/gitmoot/internal/db"
+)
+
+// seedRoleAuthoredVerdict seeds the shape OpenExternalJob persists for a session
+// review: NO agent column, an acting org role in the payload instead.
+func seedRoleAuthoredVerdict(t *testing.T, store *db.Store, jobID, role, headSHA, decision string) {
+	t.Helper()
+	encoded, err := marshalPayload(JobPayload{
+		Repo: "owner/repo", Branch: "main", PullRequest: 227, HeadSHA: headSHA,
+		TaskID: "review-pr-227", ReviewRound: "review-1",
+		ActingOrgRole: role,
+		Result:        &AgentResult{Decision: decision, Summary: "session review"},
+	})
+	if err != nil {
+		t.Fatalf("marshalPayload(%s): %v", jobID, err)
+	}
+	if err := store.CreateJobWithEvent(context.Background(), db.Job{
+		ID: jobID, Agent: "", Type: "review", State: string(JobSucceeded), Payload: encoded,
+	}, db.JobEvent{Kind: string(JobSucceeded), Message: decision}); err != nil {
+		t.Fatalf("CreateJobWithEvent(%s): %v", jobID, err)
+	}
+	job, err := store.GetJob(context.Background(), jobID)
+	if err != nil {
+		t.Fatalf("GetJob(%s): %v", jobID, err)
+	}
+	if strings.TrimSpace(job.Agent) != "" {
+		t.Fatalf("fixture drifted: seeded agent = %q, want empty; this test is about the empty-agent row", job.Agent)
+	}
+}
+
+// TestFindRepeatedReviewersSeesARoleAuthoredVerdict pins #2008's agent-keyed
+// half at the consumer the merge gate's own comment named as deliberately left
+// on bare job.Agent: db.SucceededReviewVerdict carried only Agent, so a verdict
+// authored by a ROLE was indexed under "" and dropped.
+//
+// The consequence was #1950 F2: a role's own objection could not be answered by
+// a requester named for that same role, because the loop detector could not see
+// that the role had already reviewed this head.
+func TestFindRepeatedReviewersSeesARoleAuthoredVerdict(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	seedRoleAuthoredVerdict(t, store, "session-review-1", " GitMoot ", "head-a", "changes_requested")
+
+	matches, err := FindRepeatedReviewers(ctx, store, "owner/repo", 227, "head-a", []string{"gitmoot"})
+	if err != nil {
+		t.Fatalf("FindRepeatedReviewers: %v", err)
+	}
+	if len(matches) != 1 {
+		t.Fatalf("matches = %+v, want 1: a role's own verdict at this head is invisible to the role", matches)
+	}
+	// The match must NAME the role. Reporting the raw empty column here would
+	// produce a diagnostic that blames nobody.
+	if matches[0].Agent != "gitmoot" {
+		t.Errorf("match agent = %q, want %q", matches[0].Agent, "gitmoot")
+	}
+	if matches[0].JobID != "session-review-1" {
+		t.Errorf("match job = %q, want session-review-1", matches[0].JobID)
+	}
+}
+
+// TestFindRepeatedReviewersStillIgnoresAnUnrelatedRole is the negative control
+// that keeps the test above from passing under a rule that simply matches
+// everything. A role that has not reviewed this head must remain eligible.
+func TestFindRepeatedReviewersStillIgnoresAnUnrelatedRole(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	seedRoleAuthoredVerdict(t, store, "session-review-1", "gitmoot", "head-a", "changes_requested")
+
+	matches, err := FindRepeatedReviewers(ctx, store, "owner/repo", 227, "head-a", []string{"phobos"})
+	if err != nil {
+		t.Fatalf("FindRepeatedReviewers: %v", err)
+	}
+	if len(matches) != 0 {
+		t.Fatalf("matches = %+v, want none: a role with no verdict at this head is eligible", matches)
+	}
+}
+
+// TestReviewDecisionAgentResolvesARoleButNotOverADelegate covers the funnel
+// three more of #2008's agent-keyed consumers share - reviewLegsAtHead,
+// followUpReviewScopes and the approval scan - and pins the ORDER inside it.
+//
+// The re-delegation branch must stay ahead of the identity rule. A
+// runtime_session_busy hand-off records the DELEGATE in job.Agent, so a version
+// that resolved the stored fields first would credit the leg to the delegate
+// rather than to the agent whose reviewer slot it fills.
+func TestReviewDecisionAgentResolvesARoleButNotOverADelegate(t *testing.T) {
+	roleAuthored := reviewDecisionAgent(
+		db.Job{Type: "review", Agent: ""},
+		JobPayload{ActingOrgRole: " GitMoot "},
+	)
+	if roleAuthored != "gitmoot" {
+		t.Errorf("role-authored review credited to %q, want %q", roleAuthored, "gitmoot")
+	}
+
+	agentWins := reviewDecisionAgent(
+		db.Job{Type: "review", Agent: "g7-review"},
+		JobPayload{ActingOrgRole: "gitmoot"},
+	)
+	if agentWins != "g7-review" {
+		t.Errorf("agent column lost to a role: got %q, want g7-review", agentWins)
+	}
+
+	delegated := reviewDecisionAgent(
+		db.Job{Type: "review", Agent: "busy-delegate"},
+		JobPayload{
+			DelegationReason: "runtime_session_busy",
+			DelegatedAgent:   "busy-delegate",
+			OriginalAgent:    "g7-review",
+			ActingOrgRole:    "gitmoot",
+		},
+	)
+	if delegated != "g7-review" {
+		t.Errorf("re-delegated leg credited to %q, want the original agent g7-review", delegated)
+	}
+}


### PR DESCRIPTION
Part of #2008. The agent-keyed group only.

## This is the SMALLEST of the three classes, and the number is one

Stated first because a PR that oversells its population is how the next reader concludes #2008 is handled.

Re-derived read-only against `/root/.gitmoot/gitmoot.db`:

| | |
| --- | --- |
| session review rows (`externally_driven=1`, `type='review'`) | 41 |
| with an empty `payload.head_sha` | **41** |
| with an empty `job.Agent` | **1** |
| rows with neither an agent nor a role, still unattributable and correctly so | **0** |

**The head is the dominant discriminator by a factor of forty and this PR does not touch it.** Per PHOBOS's ruling on #2008, head-keyed consumers keep their behaviour: a session verdict may not bind to a head, and nothing here records one. The 41-of-41 class remains open as a visibility slice.

The reason to do the small class first is not its size. It is that the resolver already existed, so this is a real slice rather than a design question, and it clears the group that cannot be argued about before the group that can.

## What was wrong

An externally driven session review persists `ActingOrgRole` **in place of** an agent, so `job.Agent` is empty by design. Six consumers read that column alone, indexed the row under `""`, and dropped it.

The Agent-first/normalized-role rule already existed in the merge gate, and **its own comment named two of these consumers as deliberately left on the bare column for routing**:

> - review_loop.go's FindRepeatedReviewers drops a role-authored verdict, because db.SucceededReviewVerdict carries only Agent and would need the role plumbed through awaited_facts.go's query first;
> - proof/project.go reports a role-authored review as not comparable, so its independence attribute stays unknown rather than being computed.

Both blockers are removed here, so that comment's list is now empty. It deliberately does not restate a count, per #1950 F5.

## One rule, not six correct copies

`workflow.ReviewerIdentity(agent, actingOrgRole)` is the existing rule exported as a pure function of the two stored fields. `effectiveReviewerIdentity` now calls it, so the gate's behaviour is byte-identical.

| Consumer | How it is reached |
| --- | --- |
| `reviewLegsAtHead` | via `reviewDecisionAgent` |
| `followUpReviewScopes` | via `reviewDecisionAgent` |
| approval scan, `engine_routing_merge.go:399` | via `reviewDecisionAgent` |
| `FindRepeatedReviewers` | directly, on the new verdict field |
| `proof` review author and independence | directly |
| `proof` job-node author | directly |

**`db` deliberately does not call it.** `workflow` depends on `db` and never the reverse, so `SucceededReviewVerdict.ActingOrgRole` carries the role **raw** and the folding stays in `workflow`. One rule, not one rule and one lowercase.

**Order inside `reviewDecisionAgent` is load-bearing.** The `runtime_session_busy` re-delegation branch stays ahead of the identity rule, because such a hand-off records the DELEGATE in `job.Agent`; resolving the stored fields first would credit the leg to the delegate rather than to the agent whose slot it fills. That ordering is pinned by a test.

## Sibling check

`reviewDecisionAgent` has **seven** call sites, not the three #2008 enumerated. I read the other four rather than assuming they were unaffected:

- `engine_run_budgets.go:820`, `engine_routing_merge.go:588` and `:676` pass the result to `dispatchFix`, which uses it as `Sender` and in the instruction text. It is **attribution, not a dispatch target** (the fix leg goes to `leadAgent()`), so a resolved role improves the record and cannot route work to a non-existent agent.
- `engine_routing_merge.go:399` is the enumerated approval scan.

**One sibling I added beyond the enumeration, with its reason.** `proof/project.go`'s generic job node also read bare `job.Agent`. I fixed it because otherwise **this PR itself would introduce an inconsistency**: the review node now reports its implementer as a resolved identity, so leaving the job node bare would render the same job's author two different ways in one manifest. Measured: 12 rows carry a role with no agent (10 implement, 1 ask, 1 review), and the 10 implement rows are exactly the implementer side of that comparison.

**Deliberately left:** everything head-keyed and round-keyed, and the proof tree's structural self-rooting, all per the ruling.

## Tests, and six mutants

Five tests across two packages. Every assertion is about what a consumer observes, not which helper computed it.

| Mutant | 364-style consumer hit |
| --- | --- |
| `reviewDecisionAgent` returns bare `job.Agent` | only `TestReviewDecisionAgentResolvesARoleButNotOverADelegate` FAILS |
| `review_loop` indexes by `verdict.Agent` only | only `TestFindRepeatedReviewersSeesARoleAuthoredVerdict` FAILS |
| `db` stops carrying the role | only `TestFindRepeatedReviewersSeesARoleAuthoredVerdict` FAILS |
| `proof` reads bare `job.Agent` on both sides | both proof tests FAIL |

Each mutant kills exactly its own consumer rather than everything, which is what says the tests discriminate. **The negative control survives all six**: `TestFindRepeatedReviewersStillIgnoresAnUnrelatedRole` keeps a role with no verdict at this head eligible, so the suite cannot pass under a rule that simply matches everything.

`TestRoleAuthoredSelfReviewIsNotIndependent` is the other required direction: resolving an identity must be able to REFUSE independence, not only grant it. A rule that only ever produced `true` would satisfy the positive test while destroying the attribute's meaning.

## Verification

| Check | Result |
| --- | --- |
| `go build ./...` | ok |
| `go vet` on all three changed packages | ok |
| `gofmt -l internal/` | clean |
| `internal/proof` | ok 0.043s |
| `internal/db` | ok 297.827s |
| `internal/workflow` | ok 157.830s |
| `internal/cli` | **ok 848.282s** |

`internal/cli` was run because `internal/proof` is surfaced through the CLI and it is the only package outside the three changed ones that can observe this. Cache grew 1.3 GiB to 1.9 GiB across that run; no `DISK GUARD` line.

`-race` not run: requires cgo, unavailable in this seat. Covered by CI's race shards.

## Not claimed

- **No user-visible impact is claimed for most of these consumers.** One review row of 41 is affected today. The value is structural: one definition instead of six, so the class stops recurring.
- The `proof` over-attribution at `project.go:206` is head-keyed and untouched. It remains the only false-positive claim in #2008's enumeration rather than an omission.
- Independence for a role-vs-agent pair is now computed rather than reported unknown. That matches the merge gate, whose collector records a role implementer and holds it "still subject to the independence check". If that policy is wrong, it is wrong in the gate first and should be changed there.
