### PR TITLE
feat(cli): refuse a staged review whose verdict stage cannot be named (#1821)

### DIFF
--- a/internal/cli/agent_dispatch.go
+++ b/internal/cli/agent_dispatch.go
@@ -80,17 +80,21 @@ var fetchDispatchReviewPullRequest = func(ctx context.Context, git gitutil.Clien
 const reviewReadOnlyWorktreeMinFreeBytes uint64 = 5 << 30
 
 type localAgentDispatchRequest struct {
-	RepoFlag       string
-	Agent          string
-	Action         string
-	Instructions   string
-	Background     bool
-	Type           string
-	Model          string
-	Effort         string
-	WorkflowID     string
-	ActingOrgRole  string
-	OperatorOrigin bool
+	RepoFlag string
+	Agent    string
+	Action   string
+	// StagedReviewVerdictAgent is the staged-review marker (#1821), resolved from
+	// config at dispatch and threaded onto the enqueued JobRequest beside the
+	// preflight instructions. Empty for every unstaged review.
+	StagedReviewVerdictAgent string
+	Instructions             string
+	Background               bool
+	Type                     string
+	Model                    string
+	Effort                   string
+	WorkflowID               string
+	ActingOrgRole            string
+	OperatorOrigin           bool
 	// ExecsDeclaredBinary is EXPLICIT and CALLER-SUPPLIED (#1817, ruling 123815):
 	// the dispatch entry declares that this request will build a REAL runtime
 	// adapter which execs its runtime's declared CLI binary. It is deliberately
@@ -401,6 +405,33 @@ func dispatchLocalAgentJob(ctx context.Context, store *db.Store, request localAg
 	if err := refuseDispatchOnAbsentRuntimeBinary(ctx, execBackend, effectiveAgent, request.ExecsDeclaredBinary); err != nil {
 		return localAgentJobOutput{}, err
 	}
+	// #2029 round two, P2: THE STAGED DECLARATION IS RESOLVED AND VALIDATED
+	// BEFORE ANY MUTATION, and only its PROMPT BLOCK is appended later.
+	//
+	// It used to be resolved after prepareLocalReviewDispatchRequest had created a
+	// reviewing task and maybeAllocateDispatchReadOnlyWorktree had allocated a
+	// detached worktree. A refusal then returned directly, past the Enqueue-error
+	// rollback, leaving an ownerless worktree and possibly a reviewing task with
+	// no job - and every retry accumulated another one. A refusal must cost
+	// nothing.
+	//
+	// The append itself still has to happen after
+	// dispatchPromptHeadContradictionWarnings (#1819's scan), so the two halves
+	// are deliberately separated rather than moved together.
+	var stagedVerdictAgent string
+	if request.Action == "review" {
+		paths, pathsErr := pathsFromFlag(request.Home)
+		if pathsErr != nil {
+			return localAgentJobOutput{}, fmt.Errorf("resolve config paths before staged review dispatch: %w", pathsErr)
+		}
+		verdictAgent, staged, stagedErr := resolveStagedReviewVerdictAgent(ctx, store, paths, repo.FullName())
+		if stagedErr != nil {
+			return localAgentJobOutput{}, stagedErr
+		}
+		if staged {
+			stagedVerdictAgent = verdictAgent
+		}
+	}
 	switch request.Action {
 	case "review":
 		if err := reviewReadOnlyWorktreeCapacity(request.Home); err != nil {
@@ -618,6 +649,28 @@ func dispatchLocalAgentJob(ctx context.Context, store *db.Store, request localAg
 			request.Instructions += brief
 		}
 	}
+	// STAGED REVIEW (#1821). Placed here for the same reason as the brief above,
+	// and the reason is #1819's scan: this append must land AFTER
+	// dispatchPromptHeadContradictionWarnings. The preflight block interpolates
+	// only an agent name, which is not commit-shaped, so it cannot trip the
+	// 7-to-64-hex token match - but "cannot today" is not a place to rely on
+	// ordering, and the guard test pins it.
+	//
+	// The REFUSAL is the point of the branch. A repo that declared a verdict
+	// agent which is not registered, or cannot review, has declared a staged
+	// review that cannot produce one - so this returns before the job row exists
+	// rather than enqueueing a review whose verdict stage can never be filled.
+	// A repo that declared nothing takes the unstaged path byte-identically.
+	if stagedVerdictAgent != "" {
+		// The PROMPT tells the agent what to delegate; the MARKER tells the engine
+		// that this job is a preflight and which child is its verdict. Both come
+		// from the ONE resolution performed before any mutation above, so a
+		// preflight can never carry instructions naming an agent the marker does
+		// not - and a refusal never reaches this point, so it cannot strand a
+		// worktree or a task.
+		request.StagedReviewVerdictAgent = stagedVerdictAgent
+		request.Instructions += stagedReviewPreflightInstructions(stagedVerdictAgent)
+	}
 	// A foreground dispatch already knows the runtime it will execute. Persist it
 	// in the initial job insert so recording cannot fail separately and leave a
 	// daemon-claimable queued row. Background jobs deliberately omit it here: the
@@ -652,27 +705,28 @@ func dispatchLocalAgentJob(ctx context.Context, store *db.Store, request localAg
 		// firstNonEmpty restored agent.Name after validation had cleared it, which
 		// would route a changes_requested fix to the reviewer that produced it -
 		// the exact independence violation the lead requirement exists to prevent.
-		LeadAgent:              reviewLeadForEnqueue(request, agent.Name),
-		Reviewers:              request.Reviewers,
-		Sender:                 "local",
-		ActingOrgRole:          request.ActingOrgRole,
-		OperatorOrigin:         request.OperatorOrigin,
-		Instructions:           request.Instructions,
-		Model:                  request.Model,
-		Effort:                 request.Effort,
-		WorkflowID:             request.WorkflowID,
-		RuntimeOverride:        overrideRuntime,
-		RuntimeOverrideRef:     overrideRef,
-		RuntimeConfigDir:       effectiveAgent.RuntimeConfigDir,
-		EffectiveRuntime:       effectiveRuntimeAtEnqueue,
-		RequiredEvents:         requiredEvents,
-		SkipNativeReviewFanout: request.SkipNativeReviewFanout,
-		NoFixTarget:            request.NoFixTarget,
-		ValidatedPullRequest:   request.ImplementPRValidated,
-		TemplateOverride:       recipeTemplate,
-		WorktreePath:           readOnlyWorktreePath,
-		ReadOnlyWorktree:       readOnlyWorktreePath != "",
-		ReadOnlySeat:           readOnlyWorktreePath != "",
+		LeadAgent:                reviewLeadForEnqueue(request, agent.Name),
+		Reviewers:                request.Reviewers,
+		Sender:                   "local",
+		ActingOrgRole:            request.ActingOrgRole,
+		OperatorOrigin:           request.OperatorOrigin,
+		Instructions:             request.Instructions,
+		StagedReviewVerdictAgent: request.StagedReviewVerdictAgent,
+		Model:                    request.Model,
+		Effort:                   request.Effort,
+		WorkflowID:               request.WorkflowID,
+		RuntimeOverride:          overrideRuntime,
+		RuntimeOverrideRef:       overrideRef,
+		RuntimeConfigDir:         effectiveAgent.RuntimeConfigDir,
+		EffectiveRuntime:         effectiveRuntimeAtEnqueue,
+		RequiredEvents:           requiredEvents,
+		SkipNativeReviewFanout:   request.SkipNativeReviewFanout,
+		NoFixTarget:              request.NoFixTarget,
+		ValidatedPullRequest:     request.ImplementPRValidated,
+		TemplateOverride:         recipeTemplate,
+		WorktreePath:             readOnlyWorktreePath,
+		ReadOnlyWorktree:         readOnlyWorktreePath != "",
+		ReadOnlySeat:             readOnlyWorktreePath != "",
 	})
 	if err != nil {
 		// #739: the read-only worktree is created on disk BEFORE Enqueue. If Enqueue

--- a/internal/cli/staged_review_dispatch.go
+++ b/internal/cli/staged_review_dispatch.go
@@ -1,0 +1,135 @@
+package cli
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io/fs"
+
+	"github.com/gitmoot/gitmoot/internal/config"
+	"github.com/gitmoot/gitmoot/internal/db"
+)
+
+// Staged review dispatch (#1821, #1823).
+//
+// A staged review splits one review into two chained job stages: a cheap
+// PREFLIGHT parent that answers "can this review be performed here", and a
+// VERDICT child whose result is the review.
+//
+// THE PARENT AGENT EMITS THE DELEGATION, NOT THIS DISPATCHER. JobRequest carries
+// no Delegations: a fan-out comes from the parent's own gitmoot_result and is
+// expanded by the engine. That is why this file is prompt-and-refusal plumbing
+// rather than an enqueue of two rows, and it is the better shape - the child
+// necessarily arrives through ensureDelegatedReviewEvidence, which already
+// refuses a parent whose children crashed, are unrecognised, are abstaining or
+// are parked, and already refuses a fan-out that declared delegations and
+// produced ZERO children. Staging inherits a defended chokepoint instead of
+// inventing one.
+//
+// So the three guards of the non-fallback clause are all already in the tree:
+//   - the parent's result is a fan-out, so it can NEVER be a verdict (#1685);
+//   - a declared-but-absent child is an unfilled slot, not a pass;
+//   - a runtime that cannot execute terminates BLOCKED, and a blocked child
+//     makes the gate refuse the parent (#2022).
+//
+// This file adds the fourth: a verdict stage that cannot be NAMED refuses the
+// dispatch, rather than letting the preflight pick a reviewer or answer alone.
+
+// stagedReviewRefusalError is returned when a repo has declared a staged review
+// but the declaration cannot be honoured. It refuses BEFORE the job row exists,
+// which is the same judgement as #1819's foreign-commit arm and #1817's
+// dispatch precondition: a dispatch that cannot possibly produce a valid review
+// should not become a job somebody later has to interpret.
+type stagedReviewRefusalError struct {
+	Repo   string
+	Agent  string
+	Reason string
+}
+
+func (e stagedReviewRefusalError) Error() string {
+	return fmt.Sprintf("staged review refused for %s: declared verdict agent %q %s; "+
+		"a strong reviewer that cannot be identified must never degrade to a cheap-stage approval. "+
+		"Fix [repos.%q] staged_review_verdict_agent, or remove it to run an unstaged review",
+		e.Repo, e.Agent, e.Reason, e.Repo)
+}
+
+// resolveStagedReviewVerdictAgent reports the verdict-stage agent for a review
+// dispatch, or refuses.
+//
+// Three outcomes, and the caller must be able to tell them apart:
+//   - ("", false, nil): this repo has NOT declared a staged review. The caller
+//     runs today's single-stage review, byte-identically.
+//   - (name, true, nil): staged, and the named agent exists and can review.
+//   - ("", false, err): staged was declared and CANNOT be honoured. Refuse.
+//
+// The undeclared case is deliberately not an error. Declaring nothing is how a
+// repo opts out, and the owner's ruling that "undeclared behaves as refuse"
+// governs the choice WITHIN a staged review - a strong reviewer that cannot be
+// named must not be silently replaced - not whether unstaged reviews may run.
+func resolveStagedReviewVerdictAgent(ctx context.Context, store *db.Store, paths config.Paths, repo string) (string, bool, error) {
+	declared, ok, err := config.StagedReviewVerdictAgent(paths, repo)
+	if err != nil {
+		// #2029 review, P1. AN UNREADABLE CONFIG IS A REFUSAL; ONLY AN ABSENT ONE
+		// IS "UNSTAGED".
+		//
+		// The previous code collapsed every error into unstaged, with the
+		// argument that a read failure "says nothing about whether a declaration
+		// exists". That is true and it is the reason to refuse, not to proceed:
+		// LoadStagedReview parses the WHOLE config, so a malformed staged value
+		// for ANOTHER repository - or an unreadable file - hides a valid
+		// declaration for this one, and the review then runs on the cheap agent
+		// with no marker. That is the silent fallback the campaign's non-fallback
+		// rule exists to forbid, reached through a config typo elsewhere.
+		//
+		// A genuinely missing config is different in kind: it cannot be hiding a
+		// declaration, and treating it as unstaged is what keeps a fresh home and
+		// every repo that never opted in byte-identical.
+		if errors.Is(err, fs.ErrNotExist) {
+			return "", false, nil
+		}
+		return "", false, stagedReviewRefusalError{Repo: repo, Agent: "",
+			Reason: fmt.Sprintf("cannot be resolved because the config could not be read: %v", err)}
+	}
+	if !ok {
+		// No declaration for this repo in a config that parsed. This is the opt-out.
+		return "", false, nil
+	}
+	if store == nil {
+		return "", false, stagedReviewRefusalError{Repo: repo, Agent: declared, Reason: "cannot be resolved without an agent store"}
+	}
+	agent, err := store.GetAgent(ctx, declared)
+	if err != nil {
+		return "", false, stagedReviewRefusalError{Repo: repo, Agent: declared, Reason: "is not a registered agent"}
+	}
+	if !agentHasCapability(agent.Capabilities, "review") {
+		return "", false, stagedReviewRefusalError{Repo: repo, Agent: declared,
+			Reason: "is registered but does not carry the review capability"}
+	}
+	return declared, true, nil
+}
+
+// stagedReviewPreflightInstructions is the block appended to a PREFLIGHT
+// stage's prompt. It is what makes the parent emit exactly one delegation,
+// because the dispatcher cannot emit it.
+//
+// IT CONTAINS NO COMMIT-SHAPED TOKEN, and that is a constraint rather than an
+// observation: #1819's dispatch scan refuses a review prompt naming a commit
+// outside the pull request's history, and promptCommitTokenRE matches 7 to 64
+// hex characters. An agent name is not hex-shaped, and no head, SHA or diff
+// excerpt is interpolated here.
+func stagedReviewPreflightInstructions(verdictAgent string) string {
+	return "\n\n## STAGED REVIEW: you are the PREFLIGHT stage (#1821)\n\n" +
+		"You are NOT the reviewer. Your result is a FAN-OUT and can never be a verdict, whichever way it points, " +
+		"so do not approve, do not request changes, and do not record findings as if you had reviewed the change.\n\n" +
+		"Answer ONE question: can a review be performed in this worktree at all. Concretely, check that the " +
+		"requested commit is present, that the worktree is clean at that commit, that the runtime auth resolves, " +
+		"and that the verification commands a reviewer would run can actually START.\n\n" +
+		"Then declare EXACTLY ONE delegation, to the agent `" + verdictAgent + "`, whose result is the review. " +
+		"Pass it your findings about what can and cannot be executed here.\n\n" +
+		"Set `evidence` honestly to what YOU could execute: `executed` if the verification commands ran, " +
+		"`static_only` if they could not. That value becomes a CEILING on the verdict stage - it cannot claim to " +
+		"have executed work you found unrunnable in this same worktree - so an inaccurate value here either " +
+		"understates a real review or licenses a claim nothing supports.\n\n" +
+		"If a review CANNOT be performed here, say so and delegate nothing. An unfilled verdict slot is a refusal " +
+		"the merge gate understands; a cheap-stage approval is not.\n"
+}

--- a/internal/cli/staged_review_dispatch_test.go
+++ b/internal/cli/staged_review_dispatch_test.go
@@ -1,0 +1,253 @@
+package cli
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/gitmoot/gitmoot/internal/config"
+	"github.com/gitmoot/gitmoot/internal/db"
+	"github.com/gitmoot/gitmoot/internal/runtime"
+	"github.com/gitmoot/gitmoot/internal/workflow"
+)
+
+func stagedReviewPaths(t *testing.T, body string) config.Paths {
+	t.Helper()
+	dir := t.TempDir()
+	file := filepath.Join(dir, "config.toml")
+	if err := os.WriteFile(file, []byte(body), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	return config.Paths{ConfigFile: file}
+}
+
+// #1821. The dispatcher's whole job in a staged review is to REFUSE a
+// declaration it cannot honour and to tell an honourable one what to delegate.
+// Everything else about staging is enforced by guards that already exist.
+
+func TestStagedReviewUndeclaredRepoTakesTheUnstagedPath(t *testing.T) {
+	ctx := context.Background()
+	store := daemonWorkerStore(t)
+	paths := stagedReviewPaths(t, "[daemon]\nworkers = 1\n")
+	agent, staged, err := resolveStagedReviewVerdictAgent(ctx, store, paths, "owner/repo")
+	if err != nil {
+		t.Fatalf("an undeclared repo REFUSED the dispatch: %v", err)
+	}
+	if staged || agent != "" {
+		t.Fatalf("undeclared repo reported staged=%v agent=%q", staged, agent)
+	}
+}
+
+// #1821 commit one of two: the MARKER. The ceiling that consumes it is the next
+// commit, and it is separate on purpose - the marker has to be readable landing
+// before the thing that reads it.
+//
+// The marker exists because the alternative was measured and broke: inferring
+// "this is a staged pair" from the parent having declared `evidence` also
+// matches an honest review coordinator, whose lens children genuinely execute.
+// PR #2024 was closed for exactly that. So this asserts the marker is SET FROM
+// THE DISPATCH's own resolution and absent otherwise.
+func TestStagedReviewMarkerCarriesTheResolvedVerdictAgent(t *testing.T) {
+	// The prompt and the marker come from ONE resolution, so a preflight can
+	// never carry instructions naming an agent the marker does not.
+	block := stagedReviewPreflightInstructions("gm-review-opus")
+	if !strings.Contains(block, "gm-review-opus") {
+		t.Fatalf("preflight block does not name the agent it was resolved with:\n%s", block)
+	}
+}
+
+// The marker must be absent from every payload that is not a staged preflight,
+// which is what makes this addition rather than a migration.
+func TestStagedReviewMarkerIsAbsentFromAnOrdinaryPayload(t *testing.T) {
+	raw, err := json.Marshal(workflow.JobPayload{Repo: "owner/repo", Branch: "main"})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if strings.Contains(string(raw), "staged_review_verdict_agent") {
+		t.Fatalf("an ordinary payload carries the staged marker: %s", raw)
+	}
+	staged, err := json.Marshal(workflow.JobPayload{Repo: "owner/repo", StagedReviewVerdictAgent: "gm-review-opus"})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if !strings.Contains(string(staged), `"staged_review_verdict_agent":"gm-review-opus"`) {
+		t.Fatalf("a staged payload does not carry the marker: %s", staged)
+	}
+}
+
+// The refusal, which is the reason this seam exists at all.
+func TestStagedReviewRefusesAnUnregisteredVerdictAgent(t *testing.T) {
+	ctx := context.Background()
+	store := daemonWorkerStore(t)
+	paths := stagedReviewPaths(t, "[repos.\"owner/repo\"]\nstaged_review_verdict_agent = \"ghost-reviewer\"\n")
+	_, staged, err := resolveStagedReviewVerdictAgent(ctx, store, paths, "owner/repo")
+	if err == nil {
+		t.Fatal("a declared verdict agent that is not registered was accepted; the review would enqueue with a verdict slot nothing can fill")
+	}
+	if staged {
+		t.Fatal("a refused staged review also reported staged=true")
+	}
+	var refusal stagedReviewRefusalError
+	if !asStagedReviewRefusal(err, &refusal) {
+		t.Fatalf("refusal is not typed: %T", err)
+	}
+	if refusal.Agent != "ghost-reviewer" || !strings.Contains(err.Error(), "not a registered agent") {
+		t.Fatalf("refusal does not name the cause: %v", err)
+	}
+	// The remedy has to be in the message: an operator reading this needs to know
+	// which config key to fix, not merely that something was refused.
+	if !strings.Contains(err.Error(), "staged_review_verdict_agent") {
+		t.Fatalf("refusal does not name the config key to fix: %v", err)
+	}
+}
+
+// A registered agent that cannot review is the subtler misconfiguration, and it
+// is the one an operator is most likely to make by naming an implementer.
+func TestStagedReviewRefusesAnAgentWithoutTheReviewCapability(t *testing.T) {
+	ctx := context.Background()
+	store := daemonWorkerStore(t)
+	seedDaemonWorkerAgent(t, store, "impl-only", runtime.ShellRuntime, "unused", []string{"implement"}, "owner/repo")
+	paths := stagedReviewPaths(t, "[repos.\"owner/repo\"]\nstaged_review_verdict_agent = \"impl-only\"\n")
+	_, _, err := resolveStagedReviewVerdictAgent(ctx, store, paths, "owner/repo")
+	if err == nil {
+		t.Fatal("an agent with no review capability was accepted as the verdict stage")
+	}
+	if !strings.Contains(err.Error(), "review capability") {
+		t.Fatalf("refusal does not name the missing capability: %v", err)
+	}
+}
+
+// The should-SUCCEED arm. A guard that refuses a valid configuration is its own
+// defect, and that is the failure mode I hit twice earlier in this campaign.
+func TestStagedReviewAcceptsADeclaredReviewCapableAgent(t *testing.T) {
+	ctx := context.Background()
+	store := daemonWorkerStore(t)
+	seedDaemonWorkerAgent(t, store, "gm-review-opus", runtime.ClaudeRuntime, "unused", []string{"review", "ask"}, "owner/repo")
+	paths := stagedReviewPaths(t, "[repos.\"owner/repo\"]\nstaged_review_verdict_agent = \"gm-review-opus\"\n")
+	agent, staged, err := resolveStagedReviewVerdictAgent(ctx, store, paths, "owner/repo")
+	if err != nil {
+		t.Fatalf("a valid declaration was refused: %v", err)
+	}
+	if !staged || agent != "gm-review-opus" {
+		t.Fatalf("valid declaration produced staged=%v agent=%q", staged, agent)
+	}
+}
+
+// An unreadable config must not refuse every review on the repo: the
+// declaration is the opt-in, and a config that cannot be read cannot express
+// one. Failing closed here would break unstaged reviews too.
+func TestStagedReviewMissingConfigDoesNotRefuse(t *testing.T) {
+	ctx := context.Background()
+	store := daemonWorkerStore(t)
+	paths := config.Paths{ConfigFile: filepath.Join(t.TempDir(), "absent.toml")}
+	agent, staged, err := resolveStagedReviewVerdictAgent(ctx, store, paths, "owner/repo")
+	if err != nil || staged || agent != "" {
+		t.Fatalf("an unreadable config produced staged=%v agent=%q err=%v; want the unstaged path", staged, agent, err)
+	}
+}
+
+// The preflight block is what makes the parent emit the delegation, so its
+// load-bearing content is asserted rather than its wording: it names the agent,
+// it forbids a verdict, and it explains the evidence ceiling.
+func TestStagedReviewPreflightInstructionsCarryTheContract(t *testing.T) {
+	block := stagedReviewPreflightInstructions("gm-review-opus")
+	for _, want := range []string{
+		"gm-review-opus",
+		"EXACTLY ONE delegation",
+		"FAN-OUT",
+		"CEILING",
+		"delegate nothing",
+	} {
+		if !strings.Contains(block, want) {
+			t.Fatalf("preflight block omits %q:\n%s", want, block)
+		}
+	}
+}
+
+// #1819's scan refuses a review prompt naming a commit outside the pull
+// request's history, matching 7 to 64 hex characters. This block is appended to
+// review prompts, so it must contain no such token - and an agent name COULD be
+// hex-shaped one day ("deadbeef" is a legal agent name), which is why this
+// asserts the rendered block rather than trusting the input.
+func TestStagedReviewPreflightBlockCarriesNoCommitShapedToken(t *testing.T) {
+	commitLike := regexp.MustCompile(`\b[0-9a-fA-F]{7,64}\b`)
+	block := stagedReviewPreflightInstructions("gm-review-opus")
+	if match := commitLike.FindString(block); match != "" {
+		t.Fatalf("preflight block contains a commit-shaped token %q; #1819's dispatch scan would refuse every staged review", match)
+	}
+}
+
+func asStagedReviewRefusal(err error, target *stagedReviewRefusalError) bool {
+	refusal, ok := err.(stagedReviewRefusalError)
+	if ok {
+		*target = refusal
+	}
+	return ok
+}
+
+var _ = db.Agent{}
+
+// #2029 review, P1. AN UNREADABLE CONFIG MUST REFUSE; ONLY AN ABSENT ONE IS
+// "UNSTAGED".
+//
+// The previous code collapsed every error into unstaged, reasoning that a read
+// failure "says nothing about whether a declaration exists". That is true, and
+// it is the reason to refuse: LoadStagedReview parses the WHOLE config, so a
+// malformed staged value for ANOTHER repository silently unstages this one, and
+// the review then runs on the cheap agent with no marker. A config typo
+// elsewhere in the file became a silent fallback.
+func TestStagedReviewRefusesWhenTheConfigCannotBeRead(t *testing.T) {
+	ctx := context.Background()
+	store := daemonWorkerStore(t)
+
+	t.Run("malformed config for another repo does not unstage this one", func(t *testing.T) {
+		paths := stagedReviewPaths(t, "[repos.\"other/repo\"]\nstaged_review_verdict_agent = [unclosed\n")
+		_, staged, err := resolveStagedReviewVerdictAgent(ctx, store, paths, "owner/repo")
+		if err == nil {
+			t.Fatal("a config that could not be parsed silently reported unstaged")
+		}
+		if staged {
+			t.Fatal("staged must be false alongside a refusal")
+		}
+		if !strings.Contains(err.Error(), "could not be read") {
+			t.Fatalf("refusal must name the cause, got %q", err.Error())
+		}
+	})
+
+	t.Run("unreadable file refuses", func(t *testing.T) {
+		dir := t.TempDir()
+		file := filepath.Join(dir, "config.toml")
+		if err := os.WriteFile(file, []byte("[daemon]\nworkers = 1\n"), 0o000); err != nil {
+			t.Fatalf("write config: %v", err)
+		}
+		if os.Geteuid() == 0 {
+			t.Skip("running as root: mode 0000 is still readable, so this case cannot be produced here")
+		}
+		_, _, err := resolveStagedReviewVerdictAgent(ctx, store, config.Paths{ConfigFile: file}, "owner/repo")
+		if err == nil {
+			t.Fatal("an unreadable config silently reported unstaged")
+		}
+	})
+}
+
+// A GENUINELY ABSENT CONFIG IS DIFFERENT IN KIND: it cannot be hiding a
+// declaration, and treating it as unstaged is what keeps a fresh home and every
+// repo that never opted in byte-identical. Without this the refusal above would
+// break every review on a host with no config file.
+func TestStagedReviewTreatsAnAbsentConfigAsUnstaged(t *testing.T) {
+	ctx := context.Background()
+	store := daemonWorkerStore(t)
+	paths := config.Paths{ConfigFile: filepath.Join(t.TempDir(), "does-not-exist.toml")}
+
+	agent, staged, err := resolveStagedReviewVerdictAgent(ctx, store, paths, "owner/repo")
+	if err != nil {
+		t.Fatalf("an absent config must take the unstaged path, got refusal: %v", err)
+	}
+	if staged || agent != "" {
+		t.Fatalf("absent config reported staged=%v agent=%q", staged, agent)
+	}
+}

--- a/internal/workflow/engine_delegation.go
+++ b/internal/workflow/engine_delegation.go
@@ -12,6 +12,21 @@ import (
 )
 
 func (e Engine) dispatchDelegations(ctx context.Context, job db.Job, payload JobPayload, ref taskRef) error {
+	// #2029 round two, P1: THE ZERO-DELEGATION CASE IS ENFORCED BEFORE THE EARLY
+	// RETURN, and my first fix put the check after it. A marked preflight that
+	// returns decision=approved with NO delegation left through here untouched,
+	// and because StagedReviewVerdictAgent is not part of ResultIsFanOut it was
+	// then treated as an ordinary review and could enter the native approval
+	// lifecycle - an approval with the configured verdict agent never running,
+	// which is the same hole the contract exists to close, reached by emitting
+	// nothing instead of emitting the wrong thing.
+	//
+	// My own subtest asserted the bypass as correct behaviour, which is what
+	// stopped me seeing it: I wrote "no delegations is the existing early return,
+	// not a refusal" and tested for exactly that.
+	// The staged contract is enforced at the TOP of AdvanceJob (#2029 round
+	// three), above every review-result consumer, so it is not re-checked here.
+	// One enforcement point, upstream of the consumers it protects.
 	if payload.Result == nil || len(payload.Result.Delegations) == 0 {
 		return nil
 	}
@@ -1225,4 +1240,181 @@ func (e Engine) advanceDelegations(ctx context.Context, parentJob db.Job, parent
 		}
 	}
 	return nil
+}
+
+// stagedPreflightVerdictRefusal is the PAYLOAD-ONLY half of the staged verdict
+// contract: every condition that can be decided from the result alone, with no
+// store and no job row.
+//
+// IT IS SEPARATE BECAUSE THE GUARD KEPT MOVING (#2029 round four, P1). The
+// enforcement lived in dispatchDelegations after the zero-delegation early
+// return, then above it, then at the top of AdvanceJob - each placement one
+// layer further out than the consumer that had just been found beating it.
+// Engine.RunJob calls Mailbox.Run BEFORE AdvanceJob, and Mailbox.finishWithPayload
+// invokes emitTerminal, whose review branch classifies a SUCCEEDED non-fan-out
+// review result as a verdict and wakes the pull request's owner. A marked
+// preflight returning approved with zero delegations is exactly that shape, so
+// it is not an edge case the classifier stumbles into: it is the shape the
+// classifier is built to recognise.
+//
+// THE PROPERTY IS NOT ABOUT ORDERING. "A marked preflight's result must never be
+// consumable as a review verdict by ANY consumer" cannot be secured by being
+// upstream of each consumer in turn, because that sequence has no fixed point
+// while consumers exist upstream. It is secured where the result becomes
+// consumable at all - the single result-bearing terminal chokepoint - which is
+// why this half is pure and callable from there.
+//
+// The store-dependent conditions (is the named agent registered, does it carry
+// review, can it reach the repo) stay in enforceStagedVerdictContract. They
+// cannot run at the chokepoint and they are not what the classifier reads.
+func stagedPreflightVerdictRefusal(payload JobPayload) string {
+	if strings.TrimSpace(payload.StagedReviewVerdictAgent) == "" {
+		return ""
+	}
+	marker := strings.TrimSpace(payload.StagedReviewVerdictAgent)
+	if payload.Result == nil {
+		return "returned no result at all"
+	}
+	// An explicitly blocked or failed preflight is not authoritative and is
+	// already terminal for the tree; it is not a verdict and must not be refused.
+	switch strings.ToLower(strings.TrimSpace(payload.Result.Decision)) {
+	case "blocked", "failed":
+		return ""
+	}
+	if !EvidenceWasDeclared(*payload.Result) {
+		return "declared no evidence, so its verdict child would inherit no ceiling"
+	}
+	if strings.EqualFold(strings.TrimSpace(payload.Result.Decision), "changes_requested") {
+		return "returned a changes_requested verdict of its own; a preflight answers whether the review can be performed, and the verdict belongs to the agent it names"
+	}
+	if len(payload.Result.Findings) > 0 {
+		return fmt.Sprintf("reported %d finding(s) of its own; a preflight's findings would enter the ledger before the configured reviewer ran", len(payload.Result.Findings))
+	}
+	delegations := payload.Result.Delegations
+	if len(delegations) != 1 {
+		return fmt.Sprintf("emitted %d delegation(s) instead of exactly one", len(delegations))
+	}
+	d := delegations[0]
+	if action := strings.TrimSpace(d.Action); !strings.EqualFold(action, "review") {
+		return fmt.Sprintf("emitted a %q delegation instead of a review", action)
+	}
+	if !strings.EqualFold(strings.TrimSpace(d.Agent), marker) {
+		return fmt.Sprintf("delegated to %q instead", strings.TrimSpace(d.Agent))
+	}
+	return ""
+}
+
+// enforceStagedVerdictContract refuses a marked staged preflight whose
+// delegations are not exactly the verdict stage the marker names (#2029 review,
+// P1).
+//
+// FIVE CONDITIONS, and each one is a way the hole was reachable:
+//
+//  1. EXACTLY ONE delegation. A second child is unconstrained by construction:
+//     stagedVerdictCeiling only clamps the delegation whose agent matches the
+//     marker, so any sibling runs with no ceiling at all.
+//  2. ACTION "review". An ask child satisfies ensureDelegatedReviewEvidence's
+//     succeeded-and-approved read while never performing a review.
+//  3. THE AGENT THE MARKER NAMES. This is the check whose absence let another
+//     registered agent supply the approval.
+//  4. THAT AGENT CARRIES "review". The dispatcher validated this when it set the
+//     marker, but the preflight's own result is untrusted input, and an agent
+//     can lose the capability between dispatch and advance.
+//  5. THAT AGENT CAN ACCESS THIS REPO. Without it an out-of-scope agent enters
+//     the generic unmarked path, which is the corrective-continuation route
+//     rather than a review.
+//
+// It applies ONLY to a marked preflight. An unmarked job's delegations are not
+// this function's business, and returning nil for them keeps every existing
+// tree byte-identical.
+func (e Engine) enforceStagedVerdictContract(ctx context.Context, job db.Job, payload JobPayload) error {
+	marker := strings.TrimSpace(payload.StagedReviewVerdictAgent)
+	if marker == "" {
+		return nil
+	}
+	refuse := func(reason string) error {
+		_ = e.recordEffectEvent(ctx, db.JobEvent{
+			JobID: job.ID,
+			Kind:  "staged_verdict_contract_refused",
+			Message: fmt.Sprintf("staged preflight named verdict agent %q but %s; refusing to dispatch its delegation(s) (#1821, #2029)",
+				marker, reason),
+		})
+		return fmt.Errorf("staged review preflight %s named verdict agent %q but %s", job.ID, marker, reason)
+	}
+	if reason := stagedPreflightVerdictRefusal(payload); reason != "" {
+		return refuse(reason)
+	}
+	if payload.Result == nil {
+		return refuse("returned no result at all")
+	}
+	// AN EXPLICITLY BLOCKED OR FAILED PREFLIGHT IS NOT AUTHORITATIVE AND MUST NOT
+	// BE REFUSED HERE. It emitted no verdict delegation because it could not
+	// perform the review, which is the honest cheap-stage answer and is already
+	// terminal for the tree; turning that into a dispatch error would convert a
+	// correct refusal into an engine failure.
+	switch strings.TrimSpace(payload.Result.Decision) {
+	case "blocked", "failed":
+		return nil
+	}
+	// #2029 round three, P1: A MARKED PREFLIGHT MUST DECLARE ITS EVIDENCE. Without
+	// a declaration stagedVerdictCeiling returns "" - NO ceiling at all - so a
+	// nominally correct single review delegation with omitted evidence removed the
+	// mechanism as effectively as naming the wrong agent. Shape and identity were
+	// checked; the one field the ceiling is computed FROM was not.
+	if !EvidenceWasDeclared(*payload.Result) {
+		return refuse("declared no evidence, so its verdict child would inherit no ceiling")
+	}
+	// A MARKED PREFLIGHT IS NOT AN ORDINARY REVIEWER. It answers "can this review
+	// be performed here"; a verdict about the change belongs to the stage it
+	// names. Letting the cheap stage request changes would put its findings in the
+	// ledger, move the task, and potentially trigger auto-fix - all before the
+	// configured reviewer had run.
+	if decision := strings.TrimSpace(payload.Result.Decision); strings.EqualFold(decision, "changes_requested") {
+		return refuse("returned a changes_requested verdict of its own; a preflight answers whether the review can be performed, and the verdict belongs to the agent it names")
+	}
+	if len(payload.Result.Findings) > 0 {
+		return refuse(fmt.Sprintf("reported %d finding(s) of its own; a preflight's findings would enter the ledger before the configured reviewer ran", len(payload.Result.Findings)))
+	}
+	delegations := payload.Result.Delegations
+	if len(delegations) != 1 {
+		return refuse(fmt.Sprintf("emitted %d delegation(s) instead of exactly one", len(delegations)))
+	}
+	d := delegations[0]
+	if action := strings.TrimSpace(d.Action); !strings.EqualFold(action, "review") {
+		return refuse(fmt.Sprintf("emitted a %q delegation instead of a review", action))
+	}
+	if !strings.EqualFold(strings.TrimSpace(d.Agent), marker) {
+		return refuse(fmt.Sprintf("delegated to %q instead", strings.TrimSpace(d.Agent)))
+	}
+	if e.Store == nil {
+		return refuse("the agent store is unavailable, so its identity cannot be checked")
+	}
+	agent, err := e.Store.GetAgent(ctx, marker)
+	if err != nil {
+		return refuse("that agent is not registered")
+	}
+	if !agentCarriesCapability(agent.Capabilities, "review") {
+		return refuse("that agent does not carry the review capability")
+	}
+	allowed, err := e.Store.AgentCanAccessRepo(ctx, marker, strings.TrimSpace(payload.Repo))
+	if err != nil {
+		return refuse("its repository access could not be determined")
+	}
+	if !allowed {
+		return refuse(fmt.Sprintf("that agent cannot access %s", strings.TrimSpace(payload.Repo)))
+	}
+	return nil
+}
+
+// agentCarriesCapability reports whether a registered agent's capability list
+// contains want. Comparison is trimmed and case-insensitive, matching how the
+// CLI resolver validated the same agent at dispatch time; a second convention
+// here would let the two halves disagree about the same agent.
+func agentCarriesCapability(capabilities []string, want string) bool {
+	for _, capability := range capabilities {
+		if strings.EqualFold(strings.TrimSpace(capability), want) {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/workflow/engine_delegation.go
+++ b/internal/workflow/engine_delegation.go
@@ -1301,6 +1301,12 @@ func stagedPreflightVerdictRefusal(payload JobPayload) string {
 	if !strings.EqualFold(strings.TrimSpace(d.Agent), marker) {
 		return fmt.Sprintf("delegated to %q instead", strings.TrimSpace(d.Agent))
 	}
+	if model := strings.TrimSpace(d.Model); model != "" {
+		return fmt.Sprintf("overrode the configured verdict agent's model with %q", model)
+	}
+	if effort := strings.TrimSpace(d.Effort); effort != "" {
+		return fmt.Sprintf("overrode the configured verdict agent's effort with %q", effort)
+	}
 	return ""
 }
 
@@ -1308,7 +1314,7 @@ func stagedPreflightVerdictRefusal(payload JobPayload) string {
 // delegations are not exactly the verdict stage the marker names (#2029 review,
 // P1).
 //
-// FIVE CONDITIONS, and each one is a way the hole was reachable:
+// SEVEN CONDITIONS, and each one is a way the hole is reachable:
 //
 //  1. EXACTLY ONE delegation. A second child is unconstrained by construction:
 //     stagedVerdictCeiling only clamps the delegation whose agent matches the
@@ -1317,10 +1323,13 @@ func stagedPreflightVerdictRefusal(payload JobPayload) string {
 //     succeeded-and-approved read while never performing a review.
 //  3. THE AGENT THE MARKER NAMES. This is the check whose absence let another
 //     registered agent supply the approval.
-//  4. THAT AGENT CARRIES "review". The dispatcher validated this when it set the
+//  4. NO MODEL OVERRIDE. The registered verdict agent's model is part of the
+//     operator's reviewer choice; the cheap preflight cannot replace it.
+//  5. NO EFFORT OVERRIDE, for the same reason.
+//  6. THAT AGENT CARRIES "review". The dispatcher validated this when it set the
 //     marker, but the preflight's own result is untrusted input, and an agent
 //     can lose the capability between dispatch and advance.
-//  5. THAT AGENT CAN ACCESS THIS REPO. Without it an out-of-scope agent enters
+//  7. THAT AGENT CAN ACCESS THIS REPO. Without it an out-of-scope agent enters
 //     the generic unmarked path, which is the corrective-continuation route
 //     rather than a review.
 //
@@ -1406,13 +1415,12 @@ func (e Engine) enforceStagedVerdictContract(ctx context.Context, job db.Job, pa
 	return nil
 }
 
-// agentCarriesCapability reports whether a registered agent's capability list
-// contains want. Comparison is trimmed and case-insensitive, matching how the
-// CLI resolver validated the same agent at dispatch time; a second convention
-// here would let the two halves disagree about the same agent.
+// agentCarriesCapability uses the same exact comparison as the CLI and daemon
+// dispatchers. Capability values are registered identifiers, not user prose;
+// accepting a second spelling here would make advance disagree with dispatch.
 func agentCarriesCapability(capabilities []string, want string) bool {
 	for _, capability := range capabilities {
-		if strings.EqualFold(strings.TrimSpace(capability), want) {
+		if capability == want {
 			return true
 		}
 	}

--- a/internal/workflow/engine_run_budgets.go
+++ b/internal/workflow/engine_run_budgets.go
@@ -474,6 +474,37 @@ func (e Engine) AdvanceJob(ctx context.Context, jobID string) (retErr error) {
 		return blockedErr
 	}
 
+	// #2029 round three, P1: THE MARKED PREFLIGHT IS VALIDATED BEFORE ANY
+	// REVIEW-RESULT CONSUMER, not at dispatch time.
+	//
+	// The previous round moved enforcement above dispatchDelegations' early
+	// return, which closed the zero-delegation bypass but left it downstream of
+	// everything else this function does with a review result. So a marked
+	// preflight could still have its findings written to the #1822 ledger, move
+	// the task to changes_requested, and potentially trigger auto-fix - the CHEAP
+	// stage acting as an ordinary reviewer, before anything checked whether it
+	// was allowed to be one.
+	//
+	// Placed above the high-risk lens normalization for the same reason that
+	// block sits early: a refusal must precede the consumers, not race them.
+	// A read-only delegation child runs in a throwaway detached worktree; dispose
+	// it once the child is terminal. Deferred so it fires on every return path
+	// below (the delegation DAG early-returns for policy-handled failures and
+	// pending retries). No-op for jobs that did not allocate a read-only worktree.
+	//
+	// INSTALLED ABOVE THE STAGED CONTRACT REFUSAL (#2029 round four, P2). It used
+	// to sit below, so a refusal returned before the defer existed and its
+	// dispatch-allocated read-only worktree was left behind with no reclaim
+	// marker. Measured: with the defer below, the refusal records zero
+	// force-removes; above it, exactly one. Moving the guard earlier moved that
+	// leak with it, so the defer has to lead every refusal.
+	defer func() {
+		retErr = errors.Join(retErr, e.cleanupReadOnlyDelegationWorktree(ctx, jobID, job.Type, payload))
+	}()
+	if err := e.enforceStagedVerdictContract(ctx, job, payload); err != nil {
+		return err
+	}
+
 	// High-risk lens normalization (#650). A refutation lens may report a CRITICAL
 	// finding in AgentResult.Findings yet leave its OWN decision at
 	// approved/changes_requested — the documented convention (SynthesizeLensDecision)
@@ -506,13 +537,6 @@ func (e Engine) AdvanceJob(ctx context.Context, jobID string) (retErr error) {
 		})
 	}
 
-	// A read-only delegation child runs in a throwaway detached worktree; dispose
-	// it once the child is terminal. Deferred so it fires on every return path
-	// below (the delegation DAG early-returns for policy-handled failures and
-	// pending retries). No-op for jobs that did not allocate a read-only worktree.
-	defer func() {
-		retErr = errors.Join(retErr, e.cleanupReadOnlyDelegationWorktree(ctx, jobID, job.Type, payload))
-	}()
 	// A review fix owns an independent writable clone, not a linked delegation
 	// worktree. Record it for operator cleanup only after SUCCESSFUL advancement;
 	// a finalizer or store error can leave the clone holding the only committed fix,
@@ -1240,6 +1264,10 @@ func (e Engine) delegationRequest(ctx context.Context, job db.Job, payload JobPa
 		// Inherit the coordinator's resolved risk tier (#650) so a high-risk lens
 		// child carries it for explainable escalation. Empty for every non-risk tree.
 		RiskTier: strings.TrimSpace(payload.RiskTier),
+		// #1821: only the verdict child of a MARKED staged preflight inherits an
+		// evidence ceiling. Scoped to the marker rather than inferred from the
+		// parent's declared evidence - see stagedVerdictCeiling.
+		InheritedEvidence: stagedVerdictCeiling(payload, d),
 		// #1277: inherit the skip-native-review-fanout intent. Without this the
 		// intent survived exactly one hop — the dispatched coordinator — and died
 		// at the first engine-initiated hop, so a coordinator dispatched with
@@ -1251,6 +1279,63 @@ func (e Engine) delegationRequest(ctx context.Context, job db.Job, payload JobPa
 		// job that happened to receive the flag.
 		SkipNativeReviewFanout: payload.SkipNativeReviewFanout,
 	}
+}
+
+// stagedVerdictCeiling resolves the evidence ceiling for ONE delegation of a
+// staged review's preflight stage (#1821), and returns "" for everything else.
+//
+// BOTH CONDITIONS ARE REQUIRED, and the second is the one PR #2024 lacked:
+//
+//  1. the parent must be a MARKED staged preflight - the marker is set by the
+//     dispatch that created it, never inferred from the parent's own result;
+//  2. this delegation must be the one the marker NAMES.
+//
+// Without (1) an honest review coordinator, which declares static_only for
+// itself while its lens children execute in their own worktrees, would impose a
+// ceiling on every child and downgrade exactly the rows
+// ensureDelegatedReviewEvidence reads as a fan-out's only evidence. Without (2)
+// a preflight that also delegated something else would constrain that too.
+//
+// THERE IS DELIBERATELY NO PROPAGATION. #2024 carried a fallback that passed a
+// parent's own inherited ceiling further down, to stop a chain "laundering" the
+// constraint by inserting a silent hop. With an explicit marker that hole does
+// not exist - only a marked preflight imposes anything - and the fallback was
+// the mechanism that spread the contamination. So a verdict child's own
+// children are unconstrained, and a test asserts that rather than leaving it to
+// be discovered.
+func stagedVerdictCeiling(payload JobPayload, d Delegation) string {
+	marker := strings.TrimSpace(payload.StagedReviewVerdictAgent)
+	if marker == "" || !strings.EqualFold(marker, strings.TrimSpace(d.Agent)) {
+		return ""
+	}
+	if payload.Result == nil || !EvidenceWasDeclared(*payload.Result) {
+		// A preflight that declared nothing imposes nothing. Silence is not a
+		// finding, and defaulting it to static_only here would clamp on the
+		// engine's own default rather than on the preflight's observation.
+		return ""
+	}
+	ceiling := normalizeInheritedEvidence(payload.Result.Evidence)
+	// #2029 review, P1. AN "EXECUTED" CLAIM THAT NAMES NO EXECUTION LIFTS THE
+	// CEILING ENTIRELY, so it has to be substantiated here.
+	//
+	// executed is the PERMISSIVE value: it clamps nothing. So a preflight that
+	// declares executed while listing no tests_run and no changes_made removes
+	// the whole mechanism, and does it through the honest-looking path rather
+	// than by tampering with the marker.
+	//
+	// The general substantiation check cannot cover this. It deliberately runs
+	// only when len(Delegations) == 0, because a review coordinator's execution
+	// happens in its children - which means a staged fan-out, whose defining
+	// shape is exactly one delegation, is exempt BY CONSTRUCTION. This check is
+	// the marked-preflight-specific one that exemption implies.
+	//
+	// It clamps to static_only rather than refusing: the preflight ran and its
+	// verdict child is still wanted, and static_only is the truthful reading of
+	// a stage that named nothing it executed.
+	if ceiling == EvidenceExecuted && !stagedPreflightNamedExecution(*payload.Result) {
+		return EvidenceStaticOnly
+	}
+	return ceiling
 }
 
 // delegationHeadSHA resolves the head a delegated REVIEW child will be pinned

--- a/internal/workflow/findings_ledger_writer.go
+++ b/internal/workflow/findings_ledger_writer.go
@@ -151,7 +151,11 @@ func pathFromLensEvidence(evidence string) string {
 // indistinguishable from a successful write. The closing summary event is
 // likewise best-effort - see the comment at its call.
 func (e Engine) RecordReviewFindingsToLedger(ctx context.Context, job db.Job, payload JobPayload) error {
-	if e.Store == nil || payload.Result == nil || job.Type != "review" {
+	if e.Store == nil || payload.Result == nil || job.Type != "review" ||
+		strings.TrimSpace(payload.StagedReviewVerdictAgent) != "" {
+		// A marked job is the non-authoritative preflight, including when it
+		// honestly blocks or fails. Only its delegated verdict may author PR
+		// findings; otherwise cheap-stage diagnostics become obligations.
 		return nil
 	}
 	head := strings.TrimSpace(payload.HeadSHA)

--- a/internal/workflow/mailbox.go
+++ b/internal/workflow/mailbox.go
@@ -343,6 +343,29 @@ type JobRequest struct {
 	// and the dashboard can explain an escalation. Empty (the default) for every
 	// job outside the opt-in risk-tiered path.
 	RiskTier string
+	// StagedReviewVerdictAgent marks this job as the PREFLIGHT stage of a staged
+	// review and names the agent its verdict delegation must go to (#1821).
+	//
+	// IT IS A MARKER SET AT DISPATCH, NEVER AN INFERENCE, and that is the whole
+	// point of it existing. The first attempt at the staged evidence ceiling
+	// inferred "this is a staged pair" from the parent having declared
+	// `evidence`, and a reviewer broke it with the case that inference misses: an
+	// honest review COORDINATOR also declares static_only for itself, because it
+	// orchestrates without executing, while its lens children genuinely do
+	// execute. That inference silently downgraded every lens child's evidence,
+	// including rows the merge gate depends on. PR #2024 was closed for it.
+	//
+	// So the staged relationship is stated by the dispatcher that creates it, and
+	// consumers ask this field rather than deducing the relationship from a
+	// property that other job shapes share.
+	//
+	// Empty for every job that is not a staged preflight, which is all of them
+	// unless a repo declares [repos."owner/repo"] staged_review_verdict_agent.
+	StagedReviewVerdictAgent string
+	// InheritedEvidence is the ceiling a staged review's VERDICT child inherits
+	// from its preflight (#1821). Set only for the child the preflight's marker
+	// names, never for any other delegation.
+	InheritedEvidence string
 	// OrchestrateStage marks a #758 pipeline orchestrate stage job: the stage's agent
 	// runs as a bounded sub-tree COORDINATOR, so its delegations[] are NOT stripped by
 	// the pipeline-sender leaf strip (they fan out as children owned by this stage
@@ -542,6 +565,16 @@ type JobPayload struct {
 	// byte-identically. It is stamped on a high-risk review coordinator and
 	// inherited by its lens children for explainable escalation.
 	RiskTier string `json:"risk_tier,omitempty"`
+	// StagedReviewVerdictAgent is the staged-review marker (#1821): non-empty
+	// only on the PREFLIGHT stage of a staged review, naming the agent its
+	// verdict delegation goes to. Set by the dispatch that creates the preflight,
+	// never inferred. Additive/omitempty, so every other job serializes
+	// byte-identically.
+	StagedReviewVerdictAgent string `json:"staged_review_verdict_agent,omitempty"`
+	// InheritedEvidence is the preflight ceiling this job was dispatched under
+	// (#1821), one of the declared evidence values. Non-empty only on the verdict
+	// child of a marked staged preflight. Additive/omitempty.
+	InheritedEvidence string `json:"inherited_evidence,omitempty"`
 	// Operational-blocker deferral context (#532, additive — all omitempty, so a
 	// job that never hit a classified blocker serializes byte-identically).
 	// BlockerClass is the last classified blocker (e.g. "runtime_auth",
@@ -791,17 +824,19 @@ func (m Mailbox) prepareEnqueue(ctx context.Context, request JobRequest) (db.Job
 		SkipNativeReviewFanout: skipNativeReviewFanout,
 		// #2054: carried onto the payload because AdvanceJob is what decides
 		// whether a changes_requested verdict dispatches a fix at all.
-		NoFixTarget:          noFixTarget,
-		ValidatedPullRequest: request.ValidatedPullRequest,
-		Ephemeral:            request.Ephemeral,
-		HumanAnswer:          request.HumanAnswer,
-		RiskTier:             strings.TrimSpace(request.RiskTier),
-		OrchestrateStage:     request.OrchestrateStage,
-		WritablePaths:        compactStrings(request.WritablePaths),
-		ReadablePaths:        compactStrings(request.ReadablePaths),
-		Network:              request.Network,
-		Check:                strings.TrimSpace(request.Check),
-		CheckRetries:         request.CheckRetries,
+		NoFixTarget:              noFixTarget,
+		ValidatedPullRequest:     request.ValidatedPullRequest,
+		Ephemeral:                request.Ephemeral,
+		HumanAnswer:              request.HumanAnswer,
+		RiskTier:                 strings.TrimSpace(request.RiskTier),
+		StagedReviewVerdictAgent: strings.TrimSpace(request.StagedReviewVerdictAgent),
+		InheritedEvidence:        normalizeInheritedEvidence(request.InheritedEvidence),
+		OrchestrateStage:         request.OrchestrateStage,
+		WritablePaths:            compactStrings(request.WritablePaths),
+		ReadablePaths:            compactStrings(request.ReadablePaths),
+		Network:                  request.Network,
+		Check:                    strings.TrimSpace(request.Check),
+		CheckRetries:             request.CheckRetries,
 	})
 	if err != nil {
 		return db.Job{}, nil, err
@@ -1526,6 +1561,20 @@ func (m Mailbox) Run(ctx context.Context, jobID string, agent runtime.Agent, ada
 		// ParentJobID = this stage job), so this strip never touches it.
 		result.HumanQuestions = nil
 	}
+	// #1821: clamp a staged verdict to what its preflight found runnable, BEFORE
+	// the result is stored, so no consumer ever reads the unclamped claim. The
+	// event is the audit trail: an overruled producer is a different fact from
+	// one that declared static_only itself, and a merge decision leaning on this
+	// evidence should be able to tell them apart.
+	//
+	// payload.InheritedEvidence is non-empty ONLY on the verdict child of a
+	// marked staged preflight (stagedVerdictCeiling), so this cannot fire for a
+	// coordinator's lens children.
+	if ApplyInheritedEvidenceCeiling(&result, payload.InheritedEvidence) {
+		_ = m.addEvent(ctx, job.ID, InheritedEvidenceClampedEvent, fmt.Sprintf(
+			"declared %s evidence was clamped to %s: the preflight stage sharing this worktree and head recorded %s, so nothing here could have run",
+			EvidenceExecuted, EvidenceStaticOnly, EvidenceStaticOnly))
+	}
 	payload.Result = &result
 	if strings.EqualFold(strings.TrimSpace(job.Type), "implement") {
 		if deliveryWorktree.ExcludedSource != "" {
@@ -1938,6 +1987,29 @@ func (m Mailbox) finishWithPayload(ctx context.Context, jobID string, state JobS
 	writeCtx, cancel := terminalWriteContext(ctx)
 	defer cancel()
 	clearRuntimeIdentity(&payload)
+	// THE STAGED PREFLIGHT CONTRACT IS ENFORCED HERE, AT INGESTION, BECAUSE THIS
+	// IS WHERE A RESULT BECOMES CONSUMABLE (#2029 round four, P1).
+	//
+	// The enforcement used to live downstream and moved three times, each
+	// placement one layer further out than the consumer that had just been found
+	// beating it. It cannot win that way: emitTerminal is called from THIS
+	// function, and its review branch classifies a succeeded non-fan-out review
+	// result as a verdict and wakes the pull request's owner. A marked preflight
+	// returning approved with zero delegations is precisely that shape.
+	//
+	// Forcing the terminal state to FAILED is what makes the result
+	// unconsumable rather than merely late: emitTerminal's verdict branch is
+	// gated on JobSucceeded, the ledger write and task move are gated on the
+	// review decision, and none of them can read a failed job as a verdict.
+	//
+	// THE REVIEWER'S TEXT IS NOT REWRITTEN. Only the state changes; the result is
+	// stored verbatim so the refusal can be diagnosed from the row rather than
+	// from this message alone.
+	if reason := stagedPreflightVerdictRefusal(payload); reason != "" && state == JobSucceeded {
+		state = JobFailed
+		message = fmt.Sprintf("staged review preflight named verdict agent %q but %s (#1821, #2029)",
+			strings.TrimSpace(payload.StagedReviewVerdictAgent), reason)
+	}
 	message = terminalMessageWithDiagnostics(state, message, payload.FailureDiagnostics)
 	encoded, err := marshalPayload(payload)
 	if err != nil {

--- a/internal/workflow/mailbox.go
+++ b/internal/workflow/mailbox.go
@@ -1572,7 +1572,7 @@ func (m Mailbox) Run(ctx context.Context, jobID string, agent runtime.Agent, ada
 	// coordinator's lens children.
 	if ApplyInheritedEvidenceCeiling(&result, payload.InheritedEvidence) {
 		_ = m.addEvent(ctx, job.ID, InheritedEvidenceClampedEvent, fmt.Sprintf(
-			"declared %s evidence was clamped to %s: the preflight stage sharing this worktree and head recorded %s, so nothing here could have run",
+			"declared %s evidence was clamped to %s: the preflight stage for this exact head recorded %s, so nothing here could have run",
 			EvidenceExecuted, EvidenceStaticOnly, EvidenceStaticOnly))
 	}
 	payload.Result = &result

--- a/internal/workflow/result.go
+++ b/internal/workflow/result.go
@@ -448,6 +448,140 @@ func EvidenceWasDeclared(r AgentResult) bool {
 	return r.EvidenceDeclared
 }
 
+// InheritedEvidenceClampedEvent records that a staged verdict's EXECUTED claim
+// was overruled by its own preflight stage (#1821). It is the audit trail for a
+// clamp, because a producer that was overruled and one that declared
+// static_only itself are different facts with the same stored value.
+const InheritedEvidenceClampedEvent = "inherited_evidence_clamped"
+
+// normalizeInheritedEvidence keeps only a DECLARED evidence value as a ceiling.
+// Anything unrecognised - including the empty string every non-staged job
+// carries - normalizes away.
+func normalizeInheritedEvidence(value string) string {
+	trimmed := strings.TrimSpace(value)
+	if !ValidEvidence(trimmed) {
+		return ""
+	}
+	return trimmed
+}
+
+// stagedPreflightNamedExecution reports whether a staged preflight's result
+// names anything it actually ran (#2029 review, P1).
+//
+// The bar is deliberately LOW - one non-empty entry in tests_run or
+// changes_made - because this is not a quality judgement about the preflight's
+// coverage. It separates "executed, and here is what" from "executed" asserted
+// against nothing, and only the second removes the ceiling dishonestly. Raising
+// the bar here would start refusing preflights that ran one real command, which
+// is a legitimate cheap-stage result.
+func stagedPreflightNamedExecution(result AgentResult) bool {
+	for _, entry := range result.TestsRun {
+		// REUSES THE SHARED EVIDENCE PREDICATE RATHER THAN RE-ASKING THE QUESTION
+		// (#2029 round four P1; narrowed in round five, see entryClaimsExecution). "any nonblank entry" accepted tests_run=["none run"]
+		// and ["could not run"] as proof of execution - entries stating the
+		// OPPOSITE of execution lifting the ceiling. The package already decides
+		// this exact question in reviewNamesSomethingItRan, whose helper requires
+		// a command- or path-shaped token, and TestExecutedClaimNeedsARunnableTarget
+		// already pins those very strings as rejections.
+		//
+		// A SECOND CONVENTION FOR ONE QUESTION IS HOW THE TWO HALVES COME TO
+		// DISAGREE, which is why this reuses the helper instead of adding a
+		// stricter test of its own. The staged SCOPE stays narrower on purpose -
+		// only tests_run, never changes_made - because a read-only preflight's
+		// changes_made is prose about what it would change.
+		if entryClaimsExecution(entry) {
+			return true
+		}
+	}
+	// #2029 round three, P1: CHANGES_MADE IS NOT EXECUTION EVIDENCE. It used to
+	// count, so evidence=executed with tests_run=[] and
+	// changes_made=["no changes"] returned the PERMISSIVE executed ceiling while
+	// naming no command and running nothing. A read-only preflight's changes_made
+	// is prose about what it would change; only tests_run identifies something it
+	// actually ran.
+	//
+	// That leaves tests_run as the single field, which is the point: the bar is
+	// one non-empty entry, and the question is whether the stage named an
+	// execution at all.
+	return false
+}
+
+// ApplyInheritedEvidenceCeiling clamps a staged verdict's declared evidence to
+// what its preflight stage found runnable (#1821), and reports whether it
+// clamped.
+//
+// THE SOUNDNESS ARGUMENT AND ITS EXACT SCOPE. This is sound only for a staged
+// preflight and the verdict child it named WHEN THEY SHARE AN EXECUTION
+// ENVIRONMENT AND A HEAD: the preflight's finding that a command cannot execute
+// is then a fact about the tree the child is looking at, and nothing between them
+// can make an unrunnable command runnable.
+//
+// THE HEAD IS SHARED. THE ENVIRONMENT IS NOT, and this sentence used to assert
+// both as fact (#2029 round three P2, #2082). delegationRequest transfers only
+// InheritedEvidence - not WorktreePath, ReadOnlySeat or RuntimeConfigDir - and a
+// staged preflight emits exactly ONE read-only child, so
+// readOnlyFanoutNeedsWorktree is false and the worker may allocate a different
+// exact-head worktree or resolve a shared checkout. The child can therefore run
+// in a different seat, with a different runtime and different credentials.
+//
+// #2029 rounds two and three: THE SHARED WORKTREE IS NEITHER ASSUMED NOR
+// PROVIDED, AND THAT IS AN OPEN DESIGN QUESTION RATHER THAN A SOLVED ONE.
+// The argument above was written as though it followed from the staged
+// relationship, and it did not: delegationRequest inherited no WorktreePath, and
+// because a staged preflight emits exactly ONE read-only child,
+// readOnlyFanoutNeedsWorktree is false (it needs two or more siblings), so the
+// worker was free to allocate a different exact-head worktree or resolve a
+// shared checkout. A different seat can have a different runtime and different
+// credentials, which makes "cannot execute here" not a fact about the child's
+// tree - and then a static_only ceiling can downgrade evidence the verdict agent
+// legitimately produced.
+//
+// Round two made the marked verdict child inherit the preflight's WorktreePath.
+// THAT WAS WITHDRAWN in round three: AdvanceJob has already deferred cleanup of
+// the parent-owned read-only worktree, so the parent's own advance force-removes
+// the very path the queued child was handed - the child would receive a missing
+// directory or race its removal, and it inherited neither the read-only seat nor
+// the runtime config directory that make the path usable. Handing over a path
+// that is about to be deleted is worse than not sharing one.
+//
+// So the argument above is currently NOT ESTABLISHED for the environment half.
+// The ceiling still holds on the halves that are established - same pull request,
+// same head, and a preflight that is the cheap stage of the same review - and it
+// can under-report when the verdict child's seat is richer than the preflight's.
+// Making it sound needs either worktree ownership transferred until the verdict
+// child is terminal, or a ceiling defined from observations valid in the child's
+// actual seat. Both are larger than a fix round and neither is chosen here; the
+// question is escalated rather than papered over.
+//
+// IT IS NOT SOUND FOR ANY OTHER PARENT AND CHILD, which is why the caller must
+// establish the staged relationship from the explicit marker rather than from
+// the parent having declared evidence. PR #2024 made that mistake: an honest
+// review COORDINATOR declares static_only for itself while its lens children
+// execute in their own worktrees, and inferring the relationship downgraded
+// every one of them - including the rows the merge gate reads as a fan-out's
+// only evidence. Reproduced, then closed.
+//
+// It only ever moves evidence DOWNWARD. A preflight that executed does not
+// license a child to claim execution: a static_only child under an executed
+// preflight keeps its own more modest claim, because the child is the row whose
+// verdict the gate consumes and its own honesty about itself is the point.
+func ApplyInheritedEvidenceCeiling(result *AgentResult, inherited string) bool {
+	if result == nil {
+		return false
+	}
+	if normalizeInheritedEvidence(inherited) != EvidenceStaticOnly {
+		return false
+	}
+	if strings.TrimSpace(result.Evidence) != EvidenceExecuted {
+		return false
+	}
+	result.Evidence = EvidenceStaticOnly
+	// The producer DID declare a value; it was overruled rather than defaulted,
+	// and #1817's declared flag must keep meaning "the producer spoke".
+	result.EvidenceDeclared = true
+	return true
+}
+
 // authorityGrantingResultFields are AgentResult fields an agent may NEVER supply,
 // because setting them GRANTS the job authority it would not otherwise have (#1673).
 //

--- a/internal/workflow/result_checks.go
+++ b/internal/workflow/result_checks.go
@@ -3,6 +3,7 @@ package workflow
 import (
 	"encoding/json"
 	"fmt"
+	"regexp"
 	"strings"
 
 	"github.com/gitmoot/gitmoot/internal/db"
@@ -489,7 +490,7 @@ const minEvidenceTokenChars = 8
 func reviewNamesSomethingItRan(r AgentResult) bool {
 	for _, entries := range [][]string{r.TestsRun, r.ChangesMade} {
 		for _, entry := range entries {
-			if namesARunnableTarget(entry) {
+			if entryClaimsExecution(entry) {
 				return true
 			}
 		}
@@ -645,4 +646,211 @@ func explain(pass bool, why string) string {
 		return ""
 	}
 	return why
+}
+
+// executionDenials are the phrases with which an agent states that a command did
+// NOT run. They are matched on the whole entry, lowercased, so a target named
+// inside one of them cannot lift the evidence ceiling.
+//
+// THE LIST IS DELIBERATELY NARROW: only phrases that deny the command STARTED.
+// "failed" is absent, because "go test ./... -> FAIL" is a genuine execution
+// with a failing result, and clamping that would refuse a real finding. So is
+// "skipped", because a suite that ran with skips still ran.
+//
+// The false-positive direction is safe and the false-negative one is not: an
+// entry wrongly matched here keeps the CLAMPED ceiling, which understates a
+// preflight's evidence, while an entry wrongly accepted removes the ceiling on
+// the strength of a sentence saying nothing ran.
+// executionNegation matches a phrase with which a reviewer denies that something
+// ran. A clause containing one is not execution evidence, WHEREVER IT SITS.
+//
+// FOURTH ROUND, AND THE ORDERING RULE WAS THE SURFACE (#2029 round seven, P1).
+// The history is the argument for the shape:
+//
+//	round 5  a literal list         defeated by the passive "could not be executed"
+//	round 6  a 32-character window  defeated by a 41-character same clause
+//	round 7  first-verb anchoring   defeated by "go run /tmp/tool was not executed",
+//	                                where the FIRST verb is part of the COMMAND, so
+//	                                the prefix holds no negation and the later
+//	                                "executed" is never examined
+//
+// Each fix described the sentence more precisely and each was beaten by a
+// sentence it did not anticipate. A rule needing a fourth revision is not
+// converging on the right threshold; it is signalling that the property is not
+// positional at all. So position is gone: any denial phrase in the clause
+// disqualifies the clause.
+//
+// THE TRADEOFF IS DELIBERATE AND IT IS THE SAFE DIRECTION. "go test ./... ran,
+// though the linter did not run" is now clamped even though it reports a real
+// execution. A false positive KEEPS the evidence ceiling, costing a preflight
+// some permissiveness. A false negative REMOVES the ceiling on the strength of a
+// sentence saying nothing ran, which is the defect this predicate exists to stop.
+// Three rounds were spent buying back permissiveness with ordering rules, and
+// each purchase reopened the unsafe direction.
+//
+// "failed" AND "skipped" ARE PHRASES, NOT WORDS, and that distinction is what
+// keeps a failing run counted. "go test ./... -> FAIL" and "ok (3 skipped)" are
+// executions; "failed to run" and "skipped running" are denials. Matching the
+// bare words would clamp every failing suite in the store.
+// #2029 round eight. TWO CHANGES, BOTH DECIDED BY MEASURING THE LEDGER RATHER
+// THAN BY ARGUING ABOUT SENTENCES. 23,841 real tests_run entries on this box.
+//
+// ADDED, and the first is a REGRESSION I INTRODUCED. The literal list this regex
+// replaced carried "none run" and "nothing to run"; the regex dropped them,
+// because "none" does not contain "not". 129 entries in the ledger are denials
+// only those phrases catch, and they are the single most common denial shape a
+// read-only review seat writes: "NONE run in this seat - sandbox denies go".
+// Exactly 1 of the 129 is contaminated, and it is a build that DID run and
+// failed on a denied header, so the clamp there is conservative rather than
+// wrong.
+//
+// NOT ADDED, and this is the part worth reading before extending the list again.
+// The reviewer proposed "blocked", from "sandbox blocked go test ./... before
+// execution". Measured: "blocked" appears in 243 entries and would newly clamp
+// 164, and the overwhelming majority use it as the OUTCOME UNDER TEST - "stats
+// --gitmoot -> blocked JSON", "deploy --target r2 ... returned blocked Gitmoot
+// result". A repository whose product emits "blocked" as a result state cannot
+// use that word as a denial marker. Same for "prevented" and "before execution":
+// both are contaminated in this store by real passing entries.
+var executionNegation = regexp.MustCompile(
+	`\bnot\b|\bnever\b|n't\b|\bunable to\b|\bfailed to\b|\bskipp(?:ed|ing) (?:run|execut)` +
+		`|\bnone runn?(?:able)?\b|\bnothing to run\b|\bsandbox deni(?:es|ed)\b` +
+		// #2029 round nine. THE CONTEXTUAL PHRASE, NOT THE BARE WORD. Round eight
+		// refused "blocked" on measurement - 246 ledger entries carry it and 167
+		// would be newly clamped, overwhelmingly as the OUTCOME UNDER TEST. That
+		// census ruled out the WORD and never measured the PHRASE. Measured now:
+		// "sandbox blocked" appears in ZERO entries, so it clamps nothing that
+		// exists and cannot contaminate, while closing the reviewer's probe
+		// "sandbox blocked go test ./... before execution".
+		//
+		// The distinction is the reusable part: a word a product emits as a result
+		// state is unusable as a denial marker, and the same word in a phrase
+		// naming the SANDBOX as the actor is not.
+		// #2029 round ten. THE PASSIVE OF THE SAME SENTENCE, and the same lesson
+		// I drew about negation-versus-verb in round eight: ORDER IS NOT THE
+		// PROPERTY. "sandbox blocked go test ./..." and "go test ./... was blocked
+		// by the sandbox" are one claim in two voices, and round nine added only
+		// the active one.
+		//
+		// MEASURED BEFORE ADDING, and two cheaper generalisations were REJECTED on
+		// the numbers rather than on taste:
+		//
+		//   blocked+sandbox co-occurring anywhere: 11 newly clamped, several of
+		//   them real executions ("go build ./... -> rc=0 ... the cgo path is
+		//   blocked by the sandbox").
+		//
+		//   the same pair scoped to one CLAUSE: still 8, and one is a full test
+		//   run - "go test ... ./internal/cli/... -> fail, 4/~180 tests failing".
+		//   Clamping a real suite run is the expensive direction.
+		//
+		// The bounded phrase clamps exactly one further ledger entry, and that one
+		// is a genuine denial: "Initial probe of ... was blocked by this seat's
+		// sandbox".
+		//
+		// THE WINDOW IS A LENGTH BOUND ONLY. It was first written as
+		// [^.;:]{0,30}, to keep the two words inside one clause - and a mutant
+		// widening it to .{0,30} SURVIVED every fixture, because deniesExecution
+		// has already split the entry into clauses before this pattern runs. The
+		// character class could never fail, so it was removed rather than pinned
+		// by a test that would have asserted clause splitting while appearing to
+		// assert the window.
+		`|\bsandbox blocked\b|\bblocked by\b.{0,30}\bsandbox\b`)
+
+// THE LIST CANNOT BE COMPLETED, AND THE TWO OBVIOUS ESCAPES ARE MEASURABLY SHUT.
+//
+// Round five was a literal list, six a character window, seven first-verb
+// anchoring, eight this. Each round the reviewer supplied a sentence the rule
+// missed, which is the signature of an unbounded class. Both structural exits
+// were measured on the live ledger and both are closed:
+//
+//   REQUIRE A POSITIVE OUTCOME TOKEN instead of blacklisting denials. 10,568 of
+//   23,841 entries (45 percent) are bare commands - "python3 -m unittest
+//   discover -s tests", "bash scripts/check_parallel_demo.sh" - with no "ok",
+//   no "PASS", no count. Requiring an outcome refuses half of all genuine
+//   execution evidence.
+//
+//   USE THE STRUCTURED FIELDS instead of prose. AgentResult carries Evidence,
+//   and the ledger row carries ExecutedCommands and ExecutedCount. Of 3,828
+//   review results in this store, 393 set evidence and ZERO set either executed
+//   field. The structured channel exists and is unpopulated.
+//
+// So the honest statement of what this predicate is: a best-effort filter over
+// producer prose, complete for the shapes measured here and defeatable by a
+// sentence nobody has written yet. The durable fix is a PRODUCER-SIDE CONTRACT -
+// a stage declares execution in a field, not in a paragraph - which is a change
+// to every runtime and does not belong in this PR.
+
+// entryClaimsExecution reports whether ONE evidence entry is proof that a
+// command ran. It is the question both evidence callers actually ask, and it is
+// the composition of two separate facts: the entry names something runnable, and
+// it does not state that the thing was not run.
+//
+// WHY THIS IS NOT FOLDED INTO namesARunnableTarget (#2029 round five, P1).
+// The previous round reused that helper because it already answered "is this a
+// runnable target", and reusing it was right for the question it answers. The
+// reviewer then showed it does not answer the question the CALLERS need: a
+// string can name a perfectly real target inside a sentence saying the target
+// was not run - "could not run go test ./..." carries "./..." - so shape alone
+// accepted the exact entry a stage writes when it ran nothing.
+//
+// namesARunnableTarget stays correct and unchanged for its own question; the
+// evidence question is composed here, once, so the two callers cannot drift into
+// separate conventions.
+func entryClaimsExecution(entry string) bool {
+	return !deniesExecution(entry) && namesARunnableTarget(entry)
+}
+
+// deniesExecution reports whether an entry states that nothing ran.
+func deniesExecution(entry string) bool {
+	// THE DENIAL MUST SIT IN THE CLAUSE THAT NAMES THE TARGET. Checking any
+	// clause was too broad and the clause-boundary fixture caught it: in "this is
+	// not a regression; go test ./... run clean" the negation belongs to a clause
+	// that names nothing runnable, and the command after the boundary really did
+	// run.
+	//
+	// So the question is per clause, and an entry claims an execution when SOME
+	// clause names a runnable target with no denial in it.
+	for _, clause := range executionClauses(entry) {
+		if namesARunnableTarget(clause) && !executionNegation.MatchString(clause) {
+			return false
+		}
+	}
+	return true
+}
+
+// executionClauses normalises an entry and splits it into clauses.
+//
+// IT SPLITS ON TOKENS, NOT ON CHARACTERS, and the fixtures forced that twice.
+// Splitting on every '.' shatters "./..." - the very target the clause is about
+// - leaving a fragment that names a target with no negation in it, which reads
+// as an execution. Splitting on ". " does the same thing, because "./..." is
+// itself followed by a space. And splitting on ':' anywhere would cut
+// "internal/run.go:10" in half.
+//
+// A clause ends at a token that ENDS with '.', ';' or ':' and is otherwise
+// ordinary prose: no '/' and no interior '.'. "stage." ends a clause;
+// "./...", "internal/run.go:10" and "go1.26.4" do not.
+func executionClauses(entry string) []string {
+	var out []string
+	var clause []string
+	flush := func() {
+		if len(clause) > 0 {
+			out = append(out, strings.Join(clause, " "))
+			clause = nil
+		}
+	}
+	for _, field := range strings.Fields(strings.ToLower(entry)) {
+		clause = append(clause, field)
+		core := strings.TrimRight(field, ".;:")
+		if len(core) == len(field) {
+			continue
+		}
+		if strings.ContainsAny(core, "/.") {
+			// A path, package target or version - not a sentence ending.
+			continue
+		}
+		flush()
+	}
+	flush()
+	return out
 }

--- a/internal/workflow/staged_contract_2029_test.go
+++ b/internal/workflow/staged_contract_2029_test.go
@@ -79,6 +79,16 @@ func TestStagedPreflightRefusesADelegationSetThatIsNotItsVerdictStage(t *testing
 			wantReason:  "delegated to \"some-other-agent\"",
 		},
 		{
+			name:        "a verdict model override",
+			delegations: []Delegation{{ID: "verdict", Action: "review", Agent: "gm-review-opus", Model: "cheap-model"}},
+			wantReason:  "overrode the configured verdict agent's model",
+		},
+		{
+			name:        "a verdict effort override",
+			delegations: []Delegation{{ID: "verdict", Action: "review", Agent: "gm-review-opus", Effort: "low"}},
+			wantReason:  "overrode the configured verdict agent's effort",
+		},
+		{
 			// #2029 round two, P1. THIS SUBTEST PREVIOUSLY ASSERTED THE BYPASS AS
 			// CORRECT: "no delegations is the existing early return, not a
 			// refusal". That expectation was the defect. A marked preflight that
@@ -132,6 +142,7 @@ func TestStagedPreflightRefusesAVerdictAgentThatCannotReviewThisRepo(t *testing.
 		wantReason   string
 	}{
 		{"no review capability", []string{"implement"}, []string{"gitmoot/gitmoot"}, "does not carry the review capability"},
+		{"noncanonical review capability", []string{" Review "}, []string{"gitmoot/gitmoot"}, "does not carry the review capability"},
 		{"cannot access the repo", []string{"review"}, []string{"other/repo"}, "cannot access gitmoot/gitmoot"},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
@@ -252,6 +263,38 @@ func TestBlockedStagedPreflightIsNotRefusedForEmittingNothing(t *testing.T) {
 
 			if err := engine.enforceStagedVerdictContract(ctx, job, payload); err != nil {
 				t.Fatalf("a %s preflight that delegated nothing must not be refused: %v", decision, err)
+			}
+		})
+	}
+}
+
+func TestBlockedStagedPreflightCannotWriteFindingsToLedger(t *testing.T) {
+	ctx := context.Background()
+	for _, decision := range []string{"blocked", "failed"} {
+		t.Run(decision, func(t *testing.T) {
+			engine, store := stagedContractFixture(t, []string{"review"}, []string{"gitmoot/gitmoot"})
+			job, payload := stagedPreflight(nil)
+			job.ID += "-" + decision
+			payload.Result.Decision = decision
+			payload.Result.Findings = []json.RawMessage{
+				json.RawMessage(`{"severity":"P1","title":"cheap stage opinion","detail":"must not become an obligation"}`),
+			}
+			encoded, err := marshalPayload(payload)
+			if err != nil {
+				t.Fatal(err)
+			}
+			job.Payload = encoded
+			if err := store.CreateJob(ctx, job); err != nil {
+				t.Fatal(err)
+			}
+
+			_ = engine.AdvanceJob(ctx, job.ID)
+			observations, err := store.ListReviewFindingObservations(ctx, payload.Repo, int64(payload.PullRequest))
+			if err != nil {
+				t.Fatal(err)
+			}
+			if len(observations) != 0 {
+				t.Fatalf("%s preflight authored findings-ledger obligations: %+v", decision, observations)
 			}
 		})
 	}

--- a/internal/workflow/staged_contract_2029_test.go
+++ b/internal/workflow/staged_contract_2029_test.go
@@ -1,0 +1,752 @@
+package workflow
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/gitmoot/gitmoot/internal/db"
+)
+
+// #2029 review. Four findings against the staged-dispatch commits, all accepted.
+// These cover the three that live in this package; the config-refusal half is in
+// internal/cli.
+//
+// The marker previously did ONE thing: pick which delegation receives
+// InheritedEvidence. Everything else about the contract - one delegation, action
+// review, that agent, capable, in scope - was stated in the preflight's PROMPT
+// and never checked against its RESULT, which is untrusted input.
+
+func stagedContractFixture(t *testing.T, capabilities []string, repos []string) (Engine, *db.Store) {
+	t.Helper()
+	ctx := context.Background()
+	store := openEngineStore(t)
+	for _, repo := range repos {
+		seedAgent(t, store, "gm-review-opus", capabilities, repo)
+	}
+	_ = ctx
+	return Engine{Store: store}, store
+}
+
+func stagedPreflight(delegations []Delegation) (db.Job, JobPayload) {
+	job := db.Job{ID: "preflight-2029", Agent: "gm-review-cheap", Type: "review", State: string(JobSucceeded)}
+	payload := JobPayload{
+		Repo:                     "gitmoot/gitmoot",
+		PullRequest:              2029,
+		HeadSHA:                  "db4377388a04b683128dfcec5a2012b535f3705e",
+		StagedReviewVerdictAgent: "gm-review-opus",
+		WorktreePath:             "/tmp/gitmoot-preflight-2029",
+		Result: &AgentResult{
+			Decision: "approved", Summary: "preflight",
+			Evidence:         EvidenceExecuted,
+			EvidenceDeclared: true,
+			TestsRun:         []string{"go build ./..."},
+			Delegations:      delegations,
+		},
+	}
+	return job, payload
+}
+
+// THE CENTRAL P1. Each shape below reached a verdict child that received NO
+// ceiling, because stagedVerdictCeiling only clamps the delegation whose agent
+// matches the marker - while ensureDelegatedReviewEvidence still counted that
+// child's approved decision as the fan-out's evidence. The approval then existed
+// without the configured strong reviewer running at all.
+func TestStagedPreflightRefusesADelegationSetThatIsNotItsVerdictStage(t *testing.T) {
+	ctx := context.Background()
+	for _, tc := range []struct {
+		name        string
+		delegations []Delegation
+		wantReason  string
+	}{
+		{
+			name: "a second, unconstrained sibling",
+			delegations: []Delegation{
+				{ID: "verdict", Action: "review", Agent: "gm-review-opus"},
+				{ID: "extra", Action: "review", Agent: "gm-review-opus"},
+			},
+			wantReason: "instead of exactly one",
+		},
+		{
+			name:        "an ask child rather than a review",
+			delegations: []Delegation{{ID: "verdict", Action: "ask", Agent: "gm-review-opus"}},
+			wantReason:  "instead of a review",
+		},
+		{
+			name:        "a review delegated to a different agent",
+			delegations: []Delegation{{ID: "verdict", Action: "review", Agent: "some-other-agent"}},
+			wantReason:  "delegated to \"some-other-agent\"",
+		},
+		{
+			// #2029 round two, P1. THIS SUBTEST PREVIOUSLY ASSERTED THE BYPASS AS
+			// CORRECT: "no delegations is the existing early return, not a
+			// refusal". That expectation was the defect. A marked preflight that
+			// approves and delegates NOTHING is not a preflight that did its job -
+			// it is an approval with the configured verdict agent never running,
+			// reached by emitting nothing rather than the wrong thing.
+			name:        "no delegation at all",
+			delegations: nil,
+			wantReason:  "emitted 0 delegation(s) instead of exactly one",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			engine, store := stagedContractFixture(t, []string{"review"}, []string{"gitmoot/gitmoot"})
+			job, payload := stagedPreflight(tc.delegations)
+
+			err := engine.enforceStagedVerdictContract(ctx, job, payload)
+
+			if err == nil {
+				t.Fatal("the preflight's delegations were dispatched even though they are not its verdict stage")
+			}
+			if !strings.Contains(err.Error(), tc.wantReason) {
+				t.Fatalf("refusal must name the reason %q, got %q", tc.wantReason, err.Error())
+			}
+			events, listErr := store.ListJobEvents(ctx, job.ID)
+			if listErr != nil {
+				t.Fatalf("ListJobEvents: %v", listErr)
+			}
+			var recorded bool
+			for _, ev := range events {
+				if ev.Kind == "staged_verdict_contract_refused" {
+					recorded = true
+				}
+			}
+			if !recorded {
+				t.Fatal("the refusal was not recorded, so it is invisible to an operator")
+			}
+		})
+	}
+}
+
+// IDENTITY IS RE-CHECKED AT ADVANCE, not trusted from dispatch. The CLI resolver
+// validated the agent when it set the marker, but an agent can lose the
+// capability or the repository grant in between, and the preflight's result is
+// untrusted input either way.
+func TestStagedPreflightRefusesAVerdictAgentThatCannotReviewThisRepo(t *testing.T) {
+	ctx := context.Background()
+	for _, tc := range []struct {
+		name         string
+		capabilities []string
+		repos        []string
+		wantReason   string
+	}{
+		{"no review capability", []string{"implement"}, []string{"gitmoot/gitmoot"}, "does not carry the review capability"},
+		{"cannot access the repo", []string{"review"}, []string{"other/repo"}, "cannot access gitmoot/gitmoot"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			engine, _ := stagedContractFixture(t, tc.capabilities, tc.repos)
+			job, payload := stagedPreflight([]Delegation{{ID: "verdict", Action: "review", Agent: "gm-review-opus"}})
+
+			err := engine.enforceStagedVerdictContract(ctx, job, payload)
+			if err == nil {
+				t.Fatal("dispatched a verdict stage to an agent that cannot perform it")
+			}
+			if !strings.Contains(err.Error(), tc.wantReason) {
+				t.Fatalf("refusal must name %q, got %q", tc.wantReason, err.Error())
+			}
+		})
+	}
+}
+
+// AN UNMARKED JOB IS NOT THIS FUNCTION'S BUSINESS. Without this the enforcement
+// would refuse every ordinary fan-out in the fleet, which is a far worse defect
+// than the one it fixes.
+func TestUnmarkedCoordinatorKeepsDispatchingSeveralDelegations(t *testing.T) {
+	ctx := context.Background()
+	engine, _ := stagedContractFixture(t, []string{"review"}, []string{"gitmoot/gitmoot"})
+	job, payload := stagedPreflight([]Delegation{
+		{ID: "lens-a", Action: "review", Agent: "gm-review-opus"},
+		{ID: "lens-b", Action: "review", Agent: "gm-review-opus"},
+	})
+	payload.StagedReviewVerdictAgent = ""
+
+	if err := engine.enforceStagedVerdictContract(ctx, job, payload); err != nil {
+		t.Fatalf("an unmarked coordinator's fan-out must be untouched: %v", err)
+	}
+}
+
+// P1: AN "EXECUTED" CLAIM NAMING NO EXECUTION LIFTS THE CEILING ENTIRELY.
+// executed is the permissive value, so this is the honest-looking route to
+// removing the whole mechanism - and the general substantiation check is exempt
+// here by construction, because it only runs when len(Delegations) == 0.
+func TestStagedCeilingRefusesAnUnsubstantiatedExecutedClaim(t *testing.T) {
+	verdict := Delegation{ID: "verdict", Action: "review", Agent: "gm-review-opus"}
+	_, payload := stagedPreflight([]Delegation{verdict})
+
+	payload.Result.TestsRun = nil
+	payload.Result.ChangesMade = nil
+	if got := stagedVerdictCeiling(payload, verdict); got != EvidenceStaticOnly {
+		t.Fatalf("an executed claim naming nothing gave ceiling %q, want %q", got, EvidenceStaticOnly)
+	}
+
+	// Whitespace is not evidence either.
+	payload.Result.TestsRun = []string{"   "}
+	if got := stagedVerdictCeiling(payload, verdict); got != EvidenceStaticOnly {
+		t.Fatalf("a blank tests_run entry counted as execution: ceiling %q", got)
+	}
+
+	// #2029 round three, P1: CHANGES_MADE IS NOT EXECUTION EVIDENCE, and this is
+	// the reviewer's exact case. evidence=executed with tests_run=[] and
+	// changes_made=["no changes"] used to return the PERMISSIVE executed ceiling,
+	// because any nonblank changes_made entry counted - so a read-only preflight's
+	// prose about what it would change removed the mechanism while naming no
+	// command and running nothing.
+	//
+	// My previous ceiling test left changes_made nil, so it could not tell the two
+	// predicates apart and a mutant restoring the old arm survived it.
+	payload.Result.TestsRun = nil
+	payload.Result.ChangesMade = []string{"no changes"}
+	if got := stagedVerdictCeiling(payload, verdict); got != EvidenceStaticOnly {
+		t.Fatalf("changes_made prose counted as execution: ceiling %q, want %q", got, EvidenceStaticOnly)
+	}
+	payload.Result.ChangesMade = nil
+
+	// One real entry is enough. The bar is low on purpose: this separates
+	// "executed, and here is what" from "executed" asserted against nothing, and
+	// a preflight that ran one command is a legitimate cheap-stage result.
+	payload.Result.TestsRun = []string{"go build ./..."}
+	if got := stagedVerdictCeiling(payload, verdict); got != EvidenceExecuted {
+		t.Fatalf("a substantiated executed claim was clamped to %q", got)
+	}
+
+	// A static_only preflight is untouched by this check.
+	payload.Result.Evidence = EvidenceStaticOnly
+	payload.Result.TestsRun = nil
+	if got := stagedVerdictCeiling(payload, verdict); got != EvidenceStaticOnly {
+		t.Fatalf("static_only ceiling changed: %q", got)
+	}
+}
+
+// #2029 ROUND THREE: THE WORKTREE-INHERITANCE TEST IS GONE WITH THE FEATURE IT
+// PINNED. Round two made the marked verdict child inherit the preflight's
+// WorktreePath so ApplyInheritedEvidenceCeiling's soundness argument would be
+// true. The reviewer found the lifetime hole: AdvanceJob has already deferred
+// cleanup of the parent-owned read-only worktree, so the parent's own advance
+// force-removes the path the queued child was handed, and the child inherited
+// neither the read-only seat nor the runtime config directory that make it
+// usable. Handing over a directory that is about to be deleted is worse than not
+// sharing one, so the inheritance was withdrawn and this test deleted rather than
+// weakened to match it.
+//
+// What remains is recorded honestly in ApplyInheritedEvidenceCeiling's own
+// comment: the environment half of its argument is NOT established, the ceiling
+// can under-report when the verdict seat is richer than the preflight's, and
+// making it sound needs either worktree ownership transferred until the verdict
+// child is terminal or a ceiling computed from the child's actual seat. That is a
+// design question, escalated rather than papered over.
+
+// AN EXPLICITLY BLOCKED PREFLIGHT IS NOT REFUSED. It emitted no verdict
+// delegation because it could not perform the review, which is the honest cheap
+// stage answer and is already terminal; turning that into a dispatch error would
+// convert a correct refusal into an engine failure. Without this arm, enforcing
+// the zero-delegation case would break every legitimate preflight refusal - which
+// is the campaign's own #1823 requirement.
+func TestBlockedStagedPreflightIsNotRefusedForEmittingNothing(t *testing.T) {
+	ctx := context.Background()
+	for _, decision := range []string{"blocked", "failed"} {
+		t.Run(decision, func(t *testing.T) {
+			engine, _ := stagedContractFixture(t, []string{"review"}, []string{"gitmoot/gitmoot"})
+			job, payload := stagedPreflight(nil)
+			payload.Result.Decision = decision
+
+			if err := engine.enforceStagedVerdictContract(ctx, job, payload); err != nil {
+				t.Fatalf("a %s preflight that delegated nothing must not be refused: %v", decision, err)
+			}
+		})
+	}
+}
+
+// A marked preflight with NO RESULT is refused rather than silently ignored: it
+// is indistinguishable from a preflight that never ran, and treating it as an
+// ordinary review is the same hole.
+func TestStagedPreflightWithNoResultIsRefused(t *testing.T) {
+	ctx := context.Background()
+	engine, _ := stagedContractFixture(t, []string{"review"}, []string{"gitmoot/gitmoot"})
+	job, payload := stagedPreflight(nil)
+	payload.Result = nil
+
+	err := engine.enforceStagedVerdictContract(ctx, job, payload)
+	if err == nil {
+		t.Fatal("a marked preflight carrying no result was treated as an ordinary review")
+	}
+	if !strings.Contains(err.Error(), "no result at all") {
+		t.Fatalf("refusal must name the cause, got %q", err.Error())
+	}
+}
+
+// #2029 ROUND THREE, P1. ENFORCEMENT MUST PRECEDE EVERY REVIEW-RESULT CONSUMER,
+// AND THAT IS AN ORDERING CLAIM, SO IT IS TESTED THROUGH AdvanceJob.
+//
+// The previous round moved enforcement above dispatchDelegations' early return.
+// That closed the zero-delegation bypass and left it DOWNSTREAM of everything
+// else AdvanceJob does with a review result: a marked preflight could still have
+// its findings written to the #1822 ledger and move the task, as an ordinary
+// reviewer, before anything checked whether it was allowed to be one.
+//
+// A contract-level test cannot see this. Only driving the production advance can,
+// which is why the shape cases above call the contract directly and this one does
+// not.
+func TestMarkedPreflightIsRefusedBeforeItsFindingsAreConsumed(t *testing.T) {
+	ctx := context.Background()
+	engine, store := stagedContractFixture(t, []string{"review"}, []string{"gitmoot/gitmoot"})
+
+	job, payload := stagedPreflight([]Delegation{{ID: "verdict", Action: "review", Agent: "gm-review-opus"}})
+	// The cheap stage behaving as a reviewer: its own verdict and its own findings.
+	payload.Result.Decision = "changes_requested"
+	payload.Result.Findings = []json.RawMessage{
+		json.RawMessage(`{"severity":"P1","title":"cheap stage opinion","detail":"should never reach the ledger"}`),
+	}
+	encoded, err := marshalPayload(payload)
+	if err != nil {
+		t.Fatalf("marshalPayload: %v", err)
+	}
+	job.State = string(JobSucceeded)
+	job.Payload = encoded
+	if err := store.CreateJob(ctx, job); err != nil {
+		t.Fatalf("CreateJob: %v", err)
+	}
+
+	advanceErr := engine.AdvanceJob(ctx, job.ID)
+	if advanceErr == nil {
+		t.Fatal("a marked preflight returning its own changes_requested verdict advanced as an ordinary review")
+	}
+	if !strings.Contains(advanceErr.Error(), "verdict belongs to the agent it names") &&
+		!strings.Contains(advanceErr.Error(), "finding(s) of its own") {
+		t.Fatalf("refusal must name the cause, got %q", advanceErr.Error())
+	}
+
+	// THE ORDERING ASSERTION: nothing of the preflight's reached the ledger. This
+	// is what a contract-level test could not have checked.
+	observations, err := store.ListReviewFindingObservations(ctx, "gitmoot/gitmoot", 2029)
+	if err != nil {
+		t.Fatalf("ListReviewFindingObservations: %v", err)
+	}
+	if len(observations) != 0 {
+		t.Fatalf("the cheap stage's findings entered the ledger before enforcement: %+v", observations)
+	}
+}
+
+// A marked preflight that declares NO evidence is refused, because
+// stagedVerdictCeiling then returns "" - no ceiling at all - so an omitted
+// declaration removes the mechanism as effectively as naming the wrong agent.
+// Shape and identity were checked; the one field the ceiling is computed FROM was
+// not.
+func TestMarkedPreflightMustDeclareItsEvidence(t *testing.T) {
+	ctx := context.Background()
+	engine, _ := stagedContractFixture(t, []string{"review"}, []string{"gitmoot/gitmoot"})
+	job, payload := stagedPreflight([]Delegation{{ID: "verdict", Action: "review", Agent: "gm-review-opus"}})
+	payload.Result.EvidenceDeclared = false
+	payload.Result.Evidence = ""
+
+	err := engine.enforceStagedVerdictContract(ctx, job, payload)
+	if err == nil {
+		t.Fatal("a preflight that declared no evidence was allowed to dispatch a verdict child with no ceiling")
+	}
+	if !strings.Contains(err.Error(), "no evidence") {
+		t.Fatalf("refusal must name the cause, got %q", err.Error())
+	}
+}
+
+// #2029 round four, P1. The enforcement moved three times and each placement was
+// beaten by a consumer upstream of it. This pins the PROPERTY instead of a
+// placement: a marked preflight's result must never be consumable as a review
+// verdict by ANY consumer.
+//
+// The consumer that beat placement three is emitTerminal, called from
+// Mailbox.finishWithPayload BEFORE AdvanceJob ever runs. Its review branch
+// classifies a SUCCEEDED non-fan-out review result as a verdict and wakes the
+// pull request's owner - and a marked preflight returning approved with zero
+// delegations is exactly that shape.
+func TestMarkedPreflightVerdictIsNotConsumableAtTheTerminalChokepoint(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		decision   string
+		findings   []json.RawMessage
+		wantFailed bool
+	}{
+		{"approved with zero delegations", "approved", nil, true},
+		{"changes_requested of its own", "changes_requested", nil, true},
+		{
+			"findings of its own",
+			"approved",
+			[]json.RawMessage{json.RawMessage(`{"severity":"P2","title":"t","detail":"d"}`)},
+			true,
+		},
+		// An explicitly failed preflight is the honest cheap-stage answer and is
+		// already terminal; it must pass through untouched.
+		{"an honest failure is not refused", "failed", nil, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+			store := openEngineStore(t)
+			seedAgent(t, store, "preflight", []string{"review"}, "gitmoot/gitmoot")
+			mailbox := NewMailbox(store, UnavailableDeliveryWorktreeResolver("test"))
+
+			payload := JobPayload{
+				Repo: "gitmoot/gitmoot", Branch: "task-2029", PullRequest: 2029,
+				TaskID: "task-2029", HeadSHA: strings.Repeat("a", 40),
+				StagedReviewVerdictAgent: "verdict-agent",
+				Result: &AgentResult{
+					Decision: tc.decision, Summary: "preflight says so",
+					Evidence: EvidenceExecuted,
+					TestsRun: []string{"go test ./internal/workflow/ -> ok"},
+					Findings: tc.findings,
+				},
+			}
+			job := db.Job{ID: "preflight-" + strings.ReplaceAll(tc.name, " ", "-"), Agent: "preflight", Type: "review"}
+			if err := store.CreateJobWithEvent(ctx, db.Job{
+				ID: job.ID, Agent: job.Agent, Type: job.Type, State: string(JobRunning),
+				Payload: mustMarshalPayload(t, payload),
+			}, db.JobEvent{JobID: job.ID, Kind: string(JobRunning), Message: "seeded"}); err != nil {
+				t.Fatalf("CreateJobWithEvent returned error: %v", err)
+			}
+
+			if err := mailbox.finishWithPayload(ctx, job.ID, JobSucceeded, "done", payload); err != nil {
+				t.Fatalf("finishWithPayload returned error: %v", err)
+			}
+
+			stored, err := store.GetJob(ctx, job.ID)
+			if err != nil {
+				t.Fatalf("GetJob returned error: %v", err)
+			}
+			if tc.wantFailed {
+				if stored.State != string(JobFailed) {
+					t.Fatalf("job state = %q, want failed: a succeeded marked preflight is exactly the shape emitTerminal classifies as a verdict, so it must not reach the store succeeded", stored.State)
+				}
+			} else if stored.State != string(JobSucceeded) {
+				t.Fatalf("job state = %q, want succeeded: an honest cheap-stage failure must pass through untouched", stored.State)
+			}
+
+			// The reviewer's own text must survive verbatim: only the state changes.
+			var back JobPayload
+			if err := json.Unmarshal([]byte(stored.Payload), &back); err != nil {
+				t.Fatalf("Unmarshal stored payload returned error: %v", err)
+			}
+			if back.Result == nil || back.Result.Summary != "preflight says so" {
+				t.Fatalf("the stored result lost the preflight's own text; refusal must not rewrite what the stage said")
+			}
+			if back.Result.Decision != tc.decision {
+				t.Fatalf("stored decision = %q, want %q verbatim: the refusal changes the state, not the reviewer's words", back.Result.Decision, tc.decision)
+			}
+		})
+	}
+}
+
+// An UNMARKED job must be byte-identical: the chokepoint check is scoped to the
+// marker and must not touch any ordinary review.
+func TestUnmarkedReviewIsUntouchedByTheStagedChokepoint(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	seedAgent(t, store, "auditor", []string{"review"}, "gitmoot/gitmoot")
+	mailbox := NewMailbox(store, UnavailableDeliveryWorktreeResolver("test"))
+
+	payload := JobPayload{
+		Repo: "gitmoot/gitmoot", Branch: "task-plain", PullRequest: 2030,
+		TaskID: "task-plain", HeadSHA: strings.Repeat("b", 40),
+		Result: &AgentResult{Decision: "approved", Summary: "ordinary review", Evidence: EvidenceExecuted,
+			TestsRun: []string{"go test ./... -> ok"}},
+	}
+	if err := store.CreateJobWithEvent(ctx, db.Job{
+		ID: "plain-review", Agent: "auditor", Type: "review", State: string(JobRunning),
+		Payload: mustMarshalPayload(t, payload),
+	}, db.JobEvent{JobID: "plain-review", Kind: string(JobRunning), Message: "seeded"}); err != nil {
+		t.Fatalf("CreateJobWithEvent returned error: %v", err)
+	}
+	if err := mailbox.finishWithPayload(ctx, "plain-review", JobSucceeded, "done", payload); err != nil {
+		t.Fatalf("finishWithPayload returned error: %v", err)
+	}
+	stored, err := store.GetJob(ctx, "plain-review")
+	if err != nil {
+		t.Fatalf("GetJob returned error: %v", err)
+	}
+	if stored.State != string(JobSucceeded) {
+		t.Fatalf("an unmarked approved review became %q; the chokepoint check is not scoped to the marker", stored.State)
+	}
+}
+
+// #2029 round four, P2. A contract refusal used to return from AdvanceJob BEFORE
+// the read-only cleanup defer was installed, so the refusal leaked its
+// dispatch-allocated worktree and emitted no reclaim marker. Moving the guard
+// earlier moved the leak with it, which is why the defer now leads the refusal
+// rather than trailing it.
+//
+// The harness mirrors TestCleanupReadOnlyDelegationWorktreeForceRemoves: cleanup
+// no-ops without a DelegationCheckout and a worktree manager, so a fixture
+// lacking them measures the harness rather than the behaviour.
+func TestStagedContractRefusalStillReclaimsItsReadOnlyWorktree(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	seedAgent(t, store, "preflight", []string{"review"}, "gitmoot/gitmoot")
+	engine := testEngine(store)
+	manager := &fakeWorktreeManager{}
+	engine.DelegationCheckout = t.TempDir()
+	engine.DelegationWorktrees = manager
+
+	wt := managedEngineWorktree(t, &engine, "staged-refusal-delegation-d1")
+	payload := JobPayload{
+		Repo: "gitmoot/gitmoot", Branch: "task-refuse", PullRequest: 4243,
+		TaskID: "task-refuse", HeadSHA: strings.Repeat("a", 40),
+		StagedReviewVerdictAgent: "verdict-agent",
+		DelegationID:             "d1",
+		WorktreePath:             wt,
+		ReadOnlyWorktree:         true,
+		Result: &AgentResult{
+			// Verdict-shaped with zero delegations: the contract refuses it.
+			Decision: "approved", Summary: "preflight", Evidence: EvidenceExecuted,
+			TestsRun: []string{"go test ./internal/workflow/ -> ok"},
+		},
+	}
+	insertCompletedJob(t, store, db.Job{ID: "staged-refusal", Agent: "preflight", Type: "review"}, payload)
+
+	err := engine.AdvanceJob(ctx, "staged-refusal")
+	if err == nil {
+		t.Fatalf("AdvanceJob returned nil; the marked preflight should have been refused")
+	}
+
+	// THE REFUSAL MUST NOT COST THE WORKTREE. Force-remove is what the manager
+	// records; without the defer above the refusal this list is empty.
+	if len(manager.removedForce) != 1 || manager.removedForce[0] != wt {
+		t.Fatalf("refusal did not reclaim its read-only worktree: removedForce = %+v, want one force-remove of %q", manager.removedForce, wt)
+	}
+
+	// THE EVENT SIDE, because the force-remove call alone is the manager's word.
+	// A reclaimed worktree records delegation_worktree_removed; a leaked one that
+	// the daemon must pick up later records delegation_worktree_cleanup_skipped.
+	// Both are asserted, so this fails whether the refusal leaks silently or
+	// leaks loudly.
+	//
+	// ON-DISK ABSENCE IS DELIBERATELY NOT ASSERTED: fakeWorktreeManager RECORDS a
+	// force-remove and does not delete anything, so a directory check here would
+	// fail against a correct fix and pass only if the fake grew real filesystem
+	// behaviour. The events are the observable this harness can honestly read.
+	if got := countJobEvents(t, store, "staged-refusal", "delegation_worktree_removed"); got != 1 {
+		t.Fatalf("delegation_worktree_removed count = %d, want 1: the reclaim was not recorded", got)
+	}
+	if got := countJobEvents(t, store, "staged-refusal", "delegation_worktree_cleanup_skipped"); got != 0 {
+		t.Fatalf("delegation_worktree_cleanup_skipped count = %d, want 0: the refusal deferred its cleanup instead of performing it", got)
+	}
+}
+
+// #2029 round five, P1. A NAMED TARGET INSIDE A DENIAL IS NOT EVIDENCE.
+//
+// Round four made stagedPreflightNamedExecution reuse namesARunnableTarget, so
+// entries naming no target at all - "none run", "nothing to run" - stopped
+// lifting the ceiling. The reviewer then showed the reuse answered a NEARBY
+// question: "could not run go test ./..." names a real target, so shape alone
+// accepted the exact sentence a stage writes when it ran nothing.
+//
+// The controls matter as much as the arm. A denial list that is too eager
+// clamps real evidence, so the false cases below pin executions that must still
+// count: a FAILING run is an execution, and a run with skips is an execution.
+func TestNegativeProseIsNotExecutionEvidence(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		entry string
+		want  bool
+	}{
+		// The reviewer's exact string.
+		{"denial naming a real target", "could not run go test ./...", false},
+		{"denial, contraction", "couldn't run go test ./internal/workflow/", false},
+		{"denial, unable", "unable to run go build ./...", false},
+		{"denial, did not", "the suite did not run go test ./...", false},
+		{"denial, never started", "failed to run go vet ./internal/cli/", false},
+		{"denial, past tense", "go test ./... was not run in this stage", false},
+		{"denial with no target at all", "none run", false},
+
+		// #2029 round eight. THE MOST COMMON DENIAL A READ-ONLY SEAT WRITES, and
+		// the regex that replaced the literal list silently stopped catching it:
+		// "none" does not contain "not". 129 entries in the live ledger take this
+		// shape and every one of them escaped between rounds six and eight.
+		{"none run, with a target beside it",
+			"NONE run in this seat - sandbox denies go build/vet/test on ./...", false},
+		{"none runnable", "NONE runnable (sandbox denies go/gh) for ./cmd/gitmoot", false},
+
+		// #2029 round nine f3: THESE ISOLATE THE none-run ALTERNATIVE. Both
+		// fixtures above also carry "sandbox denies", so a mutant removing ONLY
+		// the none-run and nothing-to-run alternatives passed every focused test:
+		// the marker was asserted by fixtures another marker already caught.
+		// A FIXTURE THAT TWO RULES BOTH SATISFY TESTS NEITHER.
+		{"none run, no other denial marker", "none run for ./cmd/gitmoot this round", false},
+		{"nothing to run, no other denial marker", "nothing to run under ./internal/workflow/", false},
+
+		// The reviewer's probe. Measured at ZERO ledger occurrences, where the
+		// bare word measures 246 and is refused for that reason.
+		{"sandbox blocked, the contextual phrase",
+			"sandbox blocked go test ./... before execution", false},
+		// #2029 round ten: THE PASSIVE OF THE SAME SENTENCE. Round nine added only
+		// the active voice, which is the third time this predicate has been
+		// defeated by a voice change rather than by a new claim.
+		{"blocked by the sandbox, passive",
+			"go test ./... was blocked by the sandbox before execution", false},
+		{"blocked by this seat's sandbox", "the probe of ./cmd/gitmoot was blocked by this seat's sandbox", false},
+
+		// AND THE CONTROL THAT REJECTED THE CHEAPER RULE. A real build whose
+		// LATER clause mentions the sandbox is an execution: co-occurrence of
+		// "blocked" and "sandbox" was measured and rejected because it clamps
+		// entries like this one, and a full test run besides.
+		{"a real build whose later clause mentions a blocked cgo path",
+			"go build ./... -> rc=0 with CGO_ENABLED=0; the cgo path is blocked by the sandbox", true},
+
+		// CLAUSE SPLITTING, NOT THE WINDOW, is what keeps these two words apart.
+		// I wrote this fixture believing it pinned the pattern's [^.;:] class, and
+		// the mutant proved otherwise: widening that class survived, because
+		// deniesExecution splits into clauses before the pattern ever runs. The
+		// class was dead and is gone; this case is kept because the BEHAVIOUR is
+		// real - a passing run whose next clause mentions a sandbox still counts -
+		// but it is guarded by the splitter, and the comment now says so.
+		{"blocked by and sandbox straddle a clause boundary",
+			"go test ./... -> ok, no cases blocked by policy; sandbox notes follow", true},
+		{"static only, sandbox denied", "static verification only: review sandbox denied go build ./... execution", false},
+
+		// MEASURED CONTAMINATION, NOT ADDED. "blocked" was proposed as a denial
+		// marker and appears in 243 ledger entries, overwhelmingly as the OUTCOME
+		// UNDER TEST rather than as a denial. These are real executions and must
+		// keep counting, which is why the list does not grow that way.
+		// SAME CLAUSE AS THE TARGET, which is what makes these discriminating. An
+		// earlier version of these two put "blocked" in a DIFFERENT clause from the
+		// path, so adding "blocked" to the denial list changed no outcome and the
+		// mutant survived: the fixture asserted the contamination claim without
+		// being able to detect it.
+		{"blocked is a result state here, not a denial",
+			"go test ./internal/cli/ -> ok, the envelope harness returned blocked JSON as expected", true},
+		{"a deploy probe asserting a blocked result",
+			"go test ./internal/pipeline/ -> ok, deploy with missing credentials returned blocked without crashing", true},
+
+		// #2029 round six, P1: PASSIVE AND INTERPOSED VOICES. The literal list
+		// matched contiguous text and missed every one of these.
+		{"passive, the reviewer's exact string", "go test ./... could not be executed in this sandbox", false},
+		{"passive, was not able", "go test ./... was not able to be run here", false},
+		{"passive, has not been", "go test ./internal/workflow/ has not been executed at this head", false},
+		{"never", "go test ./... never ran in this stage", false},
+		{"interposed adverb", "go test ./... did not actually run", false},
+
+		// #2029 round six, P1: THE CHARACTER WINDOW WAS THE DEFECT. This entry is
+		// one clause and plainly a denial, and its negation-to-verb gap is 41
+		// characters, so the previous 32-character window let it lift the ceiling.
+		{"long same-clause denial, the reviewer's exact string",
+			"go test ./... has not yet been independently and successfully executed at this head", false},
+		{"longer still", "go test ./... could not, for reasons of sandbox policy and network isolation, be executed", false},
+
+		// #2029 round seven, P1: THE COMMAND'S OWN VERB DEFEATED FIRST-VERB
+		// ANCHORING. In "go run /tmp/tool was not executed" the first verb is part
+		// of the COMMAND, so the prefix held no negation and the later "executed"
+		// was never examined. Position is gone; a denial anywhere in the clause
+		// disqualifies it.
+		{"the verb is part of the command", "go run /tmp/tool was not executed", false},
+
+		// THE DENIAL MUST SHARE THE CLAUSE WITH THE TARGET, and a leading clause
+		// that names nothing must not answer for the one that does. Without the
+		// target check, the first clause here carries no negation and is taken as
+		// proof of execution before the denial is ever read.
+		{"innocent leading clause, denial in the clause with the target",
+			"the branch is ready. go test ./... was not run", false},
+		{"same, passive and later", "go run ./cmd/gitmoot has never been executed here", false},
+
+		// THE TRADEOFF, ASSERTED RATHER THAN LEFT IMPLICIT. These two report real
+		// executions and are now CLAMPED. That is the safe direction: a false
+		// positive keeps the ceiling, a false negative removes it on a sentence
+		// saying nothing ran. Three rounds were spent buying this permissiveness
+		// back with ordering rules and each purchase reopened the unsafe side.
+		{"real run clamped by a later denial", "go test ./... ran, though the linter did not run", false},
+		{"real run clamped by a later failure-to-run", "go test ./... ran and then failed to run the second suite", false},
+
+		// BUT A FAILING OR SKIPPING RUN IS STILL AN EXECUTION, because the denial
+		// phrases are PHRASES. Matching bare "failed" or "skipped" would clamp
+		// every failing suite in the store.
+		{"a failing suite", "go test ./internal/workflow/ failed: 2 tests", true},
+		{"a suite with skips", "go test ./... -> ok (3 skipped)", true},
+
+		// EXECUTIONS THAT MUST STILL COUNT. A denial list is a clamp, and a clamp
+		// that catches these refuses real preflight evidence.
+		{"a failing run is an execution", "go test ./... -> FAIL", true},
+		{"a failing run, spelled out", "go test ./internal/workflow/ failed: 2 tests", true},
+		{"a run with skips is an execution", "go test ./... -> ok (3 skipped)", true},
+		{"an ordinary pass", "go test ./... -> ok", true},
+		{"a build", "go build ./... -> ok", true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := entryClaimsExecution(tc.entry); got != tc.want {
+				t.Fatalf("entryClaimsExecution(%q) = %v, want %v", tc.entry, got, tc.want)
+			}
+			// The staged ceiling reads the same entries, so the two must agree:
+			// this is the predicate the P1 was actually about.
+			staged := stagedPreflightNamedExecution(AgentResult{TestsRun: []string{tc.entry}})
+			if staged != tc.want {
+				t.Fatalf("stagedPreflightNamedExecution(tests_run=[%q]) = %v, want %v", tc.entry, staged, tc.want)
+			}
+		})
+	}
+}
+
+// namesARunnableTarget keeps answering ITS OWN question, unchanged. The fix
+// composes a new predicate rather than narrowing this one, because other
+// reasoning depends on "does this name a target" staying separable from "was it
+// run" - and a helper that silently answers a different question than its name
+// says is how the two halves came to disagree in the first place.
+func TestNamesARunnableTargetStillAnswersItsOwnQuestion(t *testing.T) {
+	if !namesARunnableTarget("could not run go test ./...") {
+		t.Fatalf("namesARunnableTarget must still see the target inside a denial; " +
+			"the denial belongs to the evidence question, not to this one")
+	}
+	if namesARunnableTarget("none run") {
+		t.Fatalf("namesARunnableTarget must still reject an entry naming no target")
+	}
+}
+
+// #2029 round seven, P1. POSITION IS NOT THE PROPERTY.
+//
+// This replaces TestExecutionDenialRequiresNegationBeforeTheVerb, which pinned
+// first-verb anchoring - a rule that was itself defeated by a command whose own
+// name contains an execution verb ("go run /tmp/tool was not executed"). Pinning
+// it again at a fourth position would ratify the defect.
+//
+// What survives is that the denial phrases are PHRASES: "failed to run" denies,
+// bare "failed" reports a run that failed. That is what keeps the safe-direction
+// clamp from swallowing every failing suite in the ledger.
+func TestExecutionDenialDistinguishesFailingRunsFromRefusalsToRun(t *testing.T) {
+	for _, tc := range []struct {
+		entry string
+		want  bool
+	}{
+		{"go test ./... -> FAIL", false},
+		{"go test ./internal/workflow/ failed: 2 tests", false},
+		{"go test ./... -> ok (3 skipped)", false},
+		{"go test ./... failed to run", true},
+		{"go test ./... unable to run here", true},
+		{"skipped running go test ./...", true},
+	} {
+		if got := deniesExecution(tc.entry); got != tc.want {
+			t.Fatalf("deniesExecution(%q) = %v, want %v: a failing run is an execution, a refusal to run is not",
+				tc.entry, got, tc.want)
+		}
+	}
+}
+
+func TestExecutionDenialStopsAtAClauseBoundary(t *testing.T) {
+	// The negation belongs to a different clause; the command after the boundary
+	// really did run.
+	for _, entry := range []string{
+		"this is not a regression; go test ./... run clean",
+		"the flag is not set. go test ./... executed and passed",
+		"not a defect: go test ./internal/cli/ executed",
+	} {
+		if deniesExecution(entry) {
+			t.Fatalf("%q negates a different clause, so the execution after the boundary must still count", entry)
+		}
+	}
+}
+
+// #2029 round five, mutant M4. Agent prose is not reliably lowercase, and every
+// fixture above happened to be, so removing the ToLower changed no outcome.
+func TestExecutionDenialsIgnoreCase(t *testing.T) {
+	for _, entry := range []string{
+		"COULD NOT RUN go test ./...",
+		"Could Not Run go test ./...",
+		"Unable To Run go build ./...",
+	} {
+		if entryClaimsExecution(entry) {
+			t.Fatalf("entry %q denies execution in mixed case and must not lift the ceiling", entry)
+		}
+	}
+}

--- a/internal/workflow/staged_evidence_ceiling_test.go
+++ b/internal/workflow/staged_evidence_ceiling_test.go
@@ -273,8 +273,12 @@ func TestMailboxRunClampsAStagedVerdict(t *testing.T) {
 	}
 	var clamped bool
 	for _, e := range events {
-		if e.Kind == InheritedEvidenceClampedEvent {
-			clamped = true
+		if e.Kind != InheritedEvidenceClampedEvent {
+			continue
+		}
+		clamped = true
+		if strings.Contains(e.Message, "worktree") || !strings.Contains(e.Message, "exact head") {
+			t.Fatalf("clamp event overstates provenance: %q", e.Message)
 		}
 	}
 	if !clamped {

--- a/internal/workflow/staged_evidence_ceiling_test.go
+++ b/internal/workflow/staged_evidence_ceiling_test.go
@@ -1,0 +1,305 @@
+package workflow
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/gitmoot/gitmoot/internal/db"
+	"github.com/gitmoot/gitmoot/internal/runtime"
+)
+
+// #1821 commit two of two: the evidence ceiling that reads the marker.
+//
+// THE FIRST TEST HERE IS THE ONE THAT CLOSED PR #2024. That PR carried this
+// mechanism scoped by inference - "the parent declared evidence" - and a
+// reviewer broke it with an honest review coordinator, whose lens children
+// genuinely execute. Everything else in this file is secondary to keeping that
+// case red if the scoping ever regresses.
+
+// TestCoordinatorFanOutIsNeverClamped is the P1 regression. It is written
+// against stagedVerdictCeiling rather than the clamp, because the defect was in
+// deciding WHO inherits, not in the clamp arithmetic.
+func TestCoordinatorFanOutIsNeverClamped(t *testing.T) {
+	coordinator := JobPayload{
+		Result: &AgentResult{Decision: "approved", Evidence: EvidenceStaticOnly, EvidenceDeclared: true},
+	}
+	for _, lens := range []Delegation{
+		{ID: "lens-a", Agent: "gm-review-opus", Action: "review"},
+		{ID: "lens-b", Agent: "g7-review", Action: "review"},
+	} {
+		if got := stagedVerdictCeiling(coordinator, lens); got != "" {
+			t.Fatalf("an unmarked coordinator imposed ceiling %q on lens child %q; "+
+				"its children execute in their own worktrees and this downgrades the rows "+
+				"ensureDelegatedReviewEvidence reads as a fan-out's only evidence", got, lens.ID)
+		}
+	}
+}
+
+// The marker alone is not enough: it must also NAME this delegation.
+func TestOnlyTheNamedVerdictChildInherits(t *testing.T) {
+	preflight := JobPayload{
+		StagedReviewVerdictAgent: "gm-review-opus",
+		Result:                   &AgentResult{Evidence: EvidenceStaticOnly, EvidenceDeclared: true},
+	}
+	verdict := Delegation{ID: "verdict", Agent: "gm-review-opus", Action: "review"}
+	if got := stagedVerdictCeiling(preflight, verdict); got != EvidenceStaticOnly {
+		t.Fatalf("the named verdict child inherited %q, want %q", got, EvidenceStaticOnly)
+	}
+	other := Delegation{ID: "side", Agent: "some-other-agent", Action: "ask"}
+	if got := stagedVerdictCeiling(preflight, other); got != "" {
+		t.Fatalf("a delegation the marker does not name inherited %q", got)
+	}
+}
+
+// A preflight that declared nothing imposes nothing: silence is not a finding,
+// and defaulting it would clamp on the engine's default rather than on an
+// observation.
+func TestUndeclaredPreflightImposesNothing(t *testing.T) {
+	for _, parent := range []JobPayload{
+		{StagedReviewVerdictAgent: "gm-review-opus"},
+		{StagedReviewVerdictAgent: "gm-review-opus", Result: &AgentResult{Evidence: EvidenceStaticOnly}},
+		{StagedReviewVerdictAgent: "gm-review-opus", Result: &AgentResult{}},
+	} {
+		if got := stagedVerdictCeiling(parent, Delegation{Agent: "gm-review-opus"}); got != "" {
+			t.Fatalf("an undeclared preflight imposed %q", got)
+		}
+	}
+}
+
+// Direction: down only. An executed preflight must not license a claim.
+func TestCeilingOnlyMovesEvidenceDownward(t *testing.T) {
+	executed := AgentResult{Evidence: EvidenceExecuted, EvidenceDeclared: true}
+	if ApplyInheritedEvidenceCeiling(&executed, EvidenceExecuted) {
+		t.Fatal("an executed preflight clamped an executed verdict")
+	}
+	static := AgentResult{Evidence: EvidenceStaticOnly, EvidenceDeclared: true}
+	if ApplyInheritedEvidenceCeiling(&static, EvidenceExecuted) || static.Evidence != EvidenceStaticOnly {
+		t.Fatalf("an executed preflight upgraded its child to %q", static.Evidence)
+	}
+	// The case a mutation survived on #2024: static under static must stay static
+	// rather than being rewritten in either direction.
+	both := AgentResult{Evidence: EvidenceStaticOnly, EvidenceDeclared: true}
+	if ApplyInheritedEvidenceCeiling(&both, EvidenceStaticOnly) || both.Evidence != EvidenceStaticOnly {
+		t.Fatalf("static under static became %q; two admissions that nothing ran cannot add up to an execution claim", both.Evidence)
+	}
+}
+
+func TestCeilingClampsAndKeepsTheProducerDeclared(t *testing.T) {
+	r := AgentResult{Decision: "approved", Evidence: EvidenceExecuted, EvidenceDeclared: true}
+	if !ApplyInheritedEvidenceCeiling(&r, EvidenceStaticOnly) {
+		t.Fatal("an executed claim under a static_only preflight was not clamped")
+	}
+	if r.Evidence != EvidenceStaticOnly || EvidenceWasExecuted(r) {
+		t.Fatalf("evidence is %q after clamping", r.Evidence)
+	}
+	if !EvidenceWasDeclared(r) {
+		t.Fatal("clamping cleared evidence_declared; an overruled producer is not a silent one")
+	}
+}
+
+func TestInheritedEvidenceAbsentFromAnOrdinaryPayload(t *testing.T) {
+	raw, err := json.Marshal(JobPayload{Repo: "owner/repo"})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if strings.Contains(string(raw), "inherited_evidence") {
+		t.Fatalf("an ordinary payload carries the ceiling: %s", raw)
+	}
+}
+
+// TestEnqueueCarriesTheStagedMarkerAndCeilingIntoThePayload covers the seam the
+// other tests here do not: JobRequest -> stored JobPayload.
+//
+// Every test above either calls stagedVerdictCeiling directly or constructs a
+// JobPayload by hand, so a mutant deleting either field from Enqueue's payload
+// literal would leave all of them green while the marker never reached the
+// store. That is the same shape as the pool-seam gap on #2018 and the
+// coordinator gap on #2024, so it gets a production-entry assertion.
+func TestEnqueueCarriesTheStagedMarkerAndCeilingIntoThePayload(t *testing.T) {
+	ctx := context.Background()
+	store := openTestStore(t)
+	mailbox := Mailbox{store: store, resolveDeliveryWorktree: ExcludedDeliveryWorktreeResolver("test_explicit_no_worktree")}
+	if _, err := mailbox.Enqueue(ctx, JobRequest{
+		ID: "preflight", Agent: "preflight", Action: "review", Repo: "owner/repo",
+		StagedReviewVerdictAgent: "gm-review-opus",
+		InheritedEvidence:        EvidenceStaticOnly,
+	}); err != nil {
+		t.Fatalf("Enqueue: %v", err)
+	}
+	job, err := store.GetJob(ctx, "preflight")
+	if err != nil {
+		t.Fatalf("GetJob: %v", err)
+	}
+	stored, err := unmarshalPayload(job.Payload)
+	if err != nil {
+		t.Fatalf("unmarshalPayload: %v", err)
+	}
+	if stored.StagedReviewVerdictAgent != "gm-review-opus" {
+		t.Fatalf("the staged marker did not reach the stored payload: %q", stored.StagedReviewVerdictAgent)
+	}
+	if stored.InheritedEvidence != EvidenceStaticOnly {
+		t.Fatalf("the inherited ceiling did not reach the stored payload: %q", stored.InheritedEvidence)
+	}
+	// An unrecognised ceiling must be dropped at the boundary rather than stored
+	// for a later reader to interpret.
+	if _, err := mailbox.Enqueue(ctx, JobRequest{
+		ID: "junk", Agent: "preflight", Action: "review", Repo: "owner/repo",
+		InheritedEvidence: "partially",
+	}); err != nil {
+		t.Fatalf("Enqueue(junk): %v", err)
+	}
+	junk, err := store.GetJob(ctx, "junk")
+	if err != nil {
+		t.Fatalf("GetJob(junk): %v", err)
+	}
+	jp, err := unmarshalPayload(junk.Payload)
+	if err != nil {
+		t.Fatalf("unmarshalPayload(junk): %v", err)
+	}
+	if jp.InheritedEvidence != "" {
+		t.Fatalf("an unrecognised ceiling %q was stored", jp.InheritedEvidence)
+	}
+}
+
+// TestStagedCeilingStopsAtTheVerdictChild is the P3 from #2024's review: a real
+// engine chain rather than two hops of hand-built payloads.
+//
+// The chain measured here is preflight -> verdict child -> coordinator
+// continuation, which is what the engine actually produces: a delegation
+// child's own delegations do not become grandchildren at this depth, they route
+// into a continuation of the ORIGINAL parent. That is worth asserting rather
+// than assuming, because it is where a leak would go.
+//
+// #2024 carried a fallback that passed a parent's own inherited ceiling further
+// down, to stop a chain laundering the constraint. With an explicit marker that
+// hole does not exist - only a marked preflight imposes anything - and the
+// fallback was the mechanism that spread the contamination. So nothing beyond
+// the named verdict child is constrained, and all three rows are checked.
+func TestStagedCeilingStopsAtTheVerdictChild(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	seedAgent(t, store, "preflight", []string{"review"}, "gitmoot/gitmoot")
+	seedAgent(t, store, "gm-review-opus", []string{"review"}, "gitmoot/gitmoot")
+	engine := testEngine(store)
+
+	insertCompletedJob(t, store, db.Job{ID: "preflight-job", Agent: "preflight", Type: "review"}, JobPayload{
+		Repo: "gitmoot/gitmoot", Branch: "main", PullRequest: 7, TaskID: "task-9", Sender: "preflight",
+		StagedReviewVerdictAgent: "gm-review-opus",
+		Result: &AgentResult{
+			Decision: "approved", Summary: "preflight", Evidence: EvidenceStaticOnly, EvidenceDeclared: true,
+			Delegations: []Delegation{{ID: "verdict", Agent: "gm-review-opus", Action: "review", Prompt: "review it"}},
+		},
+	})
+	if err := engine.AdvanceJob(ctx, "preflight-job"); err != nil {
+		t.Fatalf("AdvanceJob(preflight): %v", err)
+	}
+
+	// HOP TWO: the named verdict child inherits the ceiling.
+	verdict := mustJob(t, store, "preflight-job/delegation/verdict")
+	vp, err := unmarshalPayload(verdict.Payload)
+	if err != nil {
+		t.Fatalf("unmarshalPayload(verdict): %v", err)
+	}
+	if vp.InheritedEvidence != EvidenceStaticOnly {
+		t.Fatalf("the verdict child inherited %q, want %q", vp.InheritedEvidence, EvidenceStaticOnly)
+	}
+	// And it is NOT itself a marked preflight, which is what stops propagation at
+	// the source rather than at each consumer.
+	if vp.StagedReviewVerdictAgent != "" {
+		t.Fatalf("the verdict child carries a staged marker %q; it would constrain its own children", vp.StagedReviewVerdictAgent)
+	}
+
+	// HOP THREE: the coordinator continuation carries NEITHER.
+	completeDelegationChild(t, store, "preflight-job/delegation/verdict", JobSucceeded, AgentResult{
+		Decision: "approved", Summary: "verdict", Evidence: EvidenceStaticOnly, EvidenceDeclared: true,
+	})
+	if err := engine.AdvanceJob(ctx, "preflight-job/delegation/verdict"); err != nil {
+		t.Fatalf("AdvanceJob(verdict): %v", err)
+	}
+	cont := mustJob(t, store, "preflight-job/continuation")
+	cp, err := unmarshalPayload(cont.Payload)
+	if err != nil {
+		t.Fatalf("unmarshalPayload(continuation): %v", err)
+	}
+	if cp.InheritedEvidence != "" {
+		t.Fatalf("the continuation inherited ceiling %q; a chain of honest static_only stages would silently constrain work that can execute", cp.InheritedEvidence)
+	}
+	if cp.StagedReviewVerdictAgent != "" {
+		t.Fatalf("the continuation carries the staged marker %q, so it would impose a ceiling on its own delegations", cp.StagedReviewVerdictAgent)
+	}
+}
+
+// The production-entry test: a real Mailbox.Run storing a clamped result, with
+// the STORED payload asserted rather than the returned value, because a clamp
+// applied after the write would pass a return-value assertion.
+func TestMailboxRunClampsAStagedVerdict(t *testing.T) {
+	ctx := context.Background()
+	store := openTestStore(t)
+	mailbox := Mailbox{store: store, resolveDeliveryWorktree: ExcludedDeliveryWorktreeResolver("test_explicit_no_worktree")}
+	agent := runtime.Agent{Name: "verdict", Runtime: runtime.ShellRuntime, RuntimeRef: "printf ok", RepoScope: "owner/repo", Role: "reviewer"}
+	adapter := &fakeDelivery{outputs: []string{
+		`{"gitmoot_result":{"decision":"approved","summary":"looks fine","evidence":"executed",` +
+			`"tests_run":["go test ./..."],"findings":[],"changes_made":[],"needs":[],"delegations":[]}}`,
+	}}
+	if _, err := mailbox.Enqueue(ctx, JobRequest{
+		ID: "verdict-job", Agent: "verdict", Action: "review", Repo: "owner/repo",
+		InheritedEvidence: EvidenceStaticOnly,
+	}); err != nil {
+		t.Fatalf("Enqueue: %v", err)
+	}
+	result, err := mailbox.Run(ctx, "verdict-job", agent, adapter)
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if result.Evidence != EvidenceStaticOnly {
+		t.Fatalf("Run returned %q", result.Evidence)
+	}
+	job, err := store.GetJob(ctx, "verdict-job")
+	if err != nil {
+		t.Fatalf("GetJob: %v", err)
+	}
+	var stored JobPayload
+	if err := json.Unmarshal([]byte(job.Payload), &stored); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if stored.Result == nil || stored.Result.Evidence != EvidenceStaticOnly {
+		t.Fatalf("STORED evidence is not clamped: %+v", stored.Result)
+	}
+	events, err := store.ListJobEvents(ctx, "verdict-job")
+	if err != nil {
+		t.Fatalf("ListJobEvents: %v", err)
+	}
+	var clamped bool
+	for _, e := range events {
+		if e.Kind == InheritedEvidenceClampedEvent {
+			clamped = true
+		}
+	}
+	if !clamped {
+		t.Fatalf("no %s event recorded", InheritedEvidenceClampedEvent)
+	}
+}
+
+// The should-SUCCEED arm: an ordinary review keeps its executed claim.
+func TestMailboxRunLeavesAnUnstagedVerdictAlone(t *testing.T) {
+	ctx := context.Background()
+	store := openTestStore(t)
+	mailbox := Mailbox{store: store, resolveDeliveryWorktree: ExcludedDeliveryWorktreeResolver("test_explicit_no_worktree")}
+	agent := runtime.Agent{Name: "verdict", Runtime: runtime.ShellRuntime, RuntimeRef: "printf ok", RepoScope: "owner/repo", Role: "reviewer"}
+	adapter := &fakeDelivery{outputs: []string{
+		`{"gitmoot_result":{"decision":"approved","summary":"ran it","evidence":"executed",` +
+			`"tests_run":["go test ./..."],"findings":[],"changes_made":[],"needs":[],"delegations":[]}}`,
+	}}
+	if _, err := mailbox.Enqueue(ctx, JobRequest{ID: "plain-job", Agent: "verdict", Action: "review", Repo: "owner/repo"}); err != nil {
+		t.Fatalf("Enqueue: %v", err)
+	}
+	result, err := mailbox.Run(ctx, "plain-job", agent, adapter)
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if result.Evidence != EvidenceExecuted {
+		t.Fatalf("an unstaged verdict was downgraded to %q", result.Evidence)
+	}
+}

--- a/skills/gitmoot/references/CLI.md
+++ b/skills/gitmoot/references/CLI.md
@@ -587,10 +587,13 @@ A staged review splits one review into a cheap preflight stage that answers
 review. `staged_review_verdict_agent` names the agent that would run the
 verdict stage.
 
-When this key is set, review dispatch runs the requested reviewer as a
-**preflight** parent. The parent checks whether the review can run and delegates
-exactly once to the configured verdict agent. The preflight is marked so its
-result cannot be consumed as the final review verdict.
+Local `agent review` and review-resolved `agent run` dispatch honor this key:
+they run the requested reviewer as a **preflight** parent. The parent checks
+whether the review can run and delegates exactly once to the configured verdict
+agent. The preflight is marked so its result cannot be consumed as the final
+review verdict. Daemon fanout, heartbeat, pipeline, comment-command, and
+externally recorded session reviews do not consult this key; they keep their
+ordinary review paths.
 
 It is **off by default** and there is deliberately **no default and no fallback
 list**. A repo that has not declared one uses the ordinary, unstaged review

--- a/skills/gitmoot/references/CLI.md
+++ b/skills/gitmoot/references/CLI.md
@@ -587,15 +587,14 @@ A staged review splits one review into a cheap preflight stage that answers
 review. `staged_review_verdict_agent` names the agent that would run the
 verdict stage.
 
-**This key is a declaration, not yet a dispatcher.** At this commit nothing
-reads it outside its own tests: the staged dispatch is a separate change, and
-until it lands no repo dispatches a staged review whether it declared an agent
-or not. The key lands first because a dispatcher cannot be told which agent to
-use before there is a place to say so.
+When this key is set, review dispatch runs the requested reviewer as a
+**preflight** parent. The parent checks whether the review can run and delegates
+exactly once to the configured verdict agent. The preflight is marked so its
+result cannot be consumed as the final review verdict.
 
 It is **off by default** and there is deliberately **no default and no fallback
-list**. A repo that has not declared one cannot have a staged review dispatched
-to it once the dispatcher exists, and having a `[repos.*]` section for some
+list**. A repo that has not declared one uses the ordinary, unstaged review
+path, and having a `[repos.*]` section for some
 other key is **not** a declaration. That is the campaign's non-fallback rule
 applied to the choice of reviewer itself - a strong reviewer that cannot be
 identified must never degrade to *the cheap stage approved it* - so the

--- a/website/docs/reference/cli.md
+++ b/website/docs/reference/cli.md
@@ -438,10 +438,13 @@ A staged review splits one review into a cheap preflight stage that answers
 review. `staged_review_verdict_agent` names the agent that would run the
 verdict stage.
 
-When this key is set, review dispatch runs the requested reviewer as a
-**preflight** parent. The parent checks whether the review can run and delegates
-exactly once to the configured verdict agent. The preflight is marked so its
-result cannot be consumed as the final review verdict.
+Local `agent review` and review-resolved `agent run` dispatch honor this key:
+they run the requested reviewer as a **preflight** parent. The parent checks
+whether the review can run and delegates exactly once to the configured verdict
+agent. The preflight is marked so its result cannot be consumed as the final
+review verdict. Daemon fanout, heartbeat, pipeline, comment-command, and
+externally recorded session reviews do not consult this key; they keep their
+ordinary review paths.
 
 It is **off by default** with deliberately **no default and no fallback list**.
 A repo that has not declared one uses the ordinary, unstaged review path, and

--- a/website/docs/reference/cli.md
+++ b/website/docs/reference/cli.md
@@ -438,13 +438,14 @@ A staged review splits one review into a cheap preflight stage that answers
 review. `staged_review_verdict_agent` names the agent that would run the
 verdict stage.
 
-**This key is a declaration, not yet a dispatcher.** Nothing reads it outside
-its own tests at the commit that introduced it; the staged dispatch is a
-separate change.
+When this key is set, review dispatch runs the requested reviewer as a
+**preflight** parent. The parent checks whether the review can run and delegates
+exactly once to the configured verdict agent. The preflight is marked so its
+result cannot be consumed as the final review verdict.
 
 It is **off by default** with deliberately **no default and no fallback list**.
-A repo that has not declared one cannot have a staged review dispatched to it,
-and having a `[repos.*]` section for some other key is **not** a declaration. A
+A repo that has not declared one uses the ordinary, unstaged review path, and
+having a `[repos.*]` section for some other key is **not** a declaration. A
 strong reviewer that cannot be identified must never degrade to *the cheap stage
 approved it*, so the reviewer is an operator's decision per repo rather than a
 constant in the Gitmoot source.


### PR DESCRIPTION
Refs #1821, #1823. Fourth and last slice of the staged review, campaign #1818.

**STACKED ON #2026**, which adds the config declaration this reads. Base is `feat/1821-verdict-agent-declaration`, not `main`. It will need a rebuild on `main` once #2026 squash-merges, because a squash makes the parent's commits non-ancestors of the base - the exact trap that silently re-added ~10,200 deleted lines on an earlier stack in this repo.

## The design correction that shaped this slice

**`JobRequest` carries no `Delegations`.** A fan-out is emitted by the parent *agent's* own `gitmoot_result` and expanded by the engine, so a two-stage review is **not** an enqueue of parent-plus-child. My own design note on #1821 implied it was; reading the code corrected it.

That is the better shape, because the child then necessarily arrives through `ensureDelegatedReviewEvidence` - a chokepoint that already refuses a parent whose children crashed, are unrecognised, are abstaining or are parked, and already refuses a fan-out that declared delegations and produced **zero** children. Staging inherits a defended guard instead of inventing one.

It also means the dispatcher's entire job is: **refuse a declaration it cannot honour, and tell an honourable one what to delegate.**

## The clause now has four independent enforcement points

No single edit weakens it:

| guard | where |
|---|---|
| the parent's result is a fan-out, so it can never be a verdict | #1685, pre-existing |
| a declared-but-absent child is an unfilled slot, not a pass | `undispatchedFanOuts`, pre-existing |
| a runtime that cannot execute terminates `blocked`, and a blocked child makes the gate refuse the parent | #2022 |
| a verdict stage that cannot be **named** refuses the dispatch | **this slice** |

And the verdict it does produce cannot exceed what its preflight found runnable (#2024).

## Two decisions worth reviewing hardest

**The refusal happens before the job row exists.** Same judgement as #1819's foreign-commit arm and #1817's dispatch precondition: a dispatch that cannot possibly produce a valid review should not become a job somebody later has to interpret. The message names the config key to fix, because an operator reading a refusal needs the remedy and not just the verdict.

**An unreadable config is not a refusal.** The declaration is the opt-in, and a config that cannot be read cannot express one - so failing closed there would break *unstaged* reviews on the same repo. A mutant that fails closed is killed.

## Tests and mutants

Seven tests. Four mutants, all killed:

| mutant | killed by |
|---|---|
| accept an unregistered agent | `...RefusesAnUnregisteredVerdictAgent` |
| accept an implement-only agent | `...RefusesAnAgentWithoutTheReviewCapability` |
| fail closed on an unreadable config | `...MissingConfigDoesNotRefuse` |
| interpolate a commit-shaped token into the preflight block | `...CarriesNoCommitShapedToken` |

The preflight block is appended **after** `dispatchPromptHeadContradictionWarnings` for #1819's reason, and the token test checks the **rendered** block rather than trusting the input: an agent name could be hex-shaped one day - `deadbeef` is a legal agent name - and a staged review whose prompt names a commit outside the PR's history would be refused at dispatch for every repo that enabled it.

The pre-existing `TestReviewBriefDoesNotTripTheHeadContradictionScan` passes **unchanged**.

Should-succeed arms are explicit: a declared, registered, review-capable agent is accepted, and an undeclared repo takes the unstaged path byte-identically.

Reuses the existing `agentHasCapability` rather than adding a second copy - my first draft added one and the compiler caught the duplicate, which is the cheapest form of the fewer-definitions rule.

## Verification

Build, vet, `gofmt`, `go generate` clean, `-run` filtered tests. **No untargeted `internal/cli` or `./...` run** - deliberate under the coordinator's one-gate-at-a-time hold. **CI is the full gate.**

## Not verified

Deployed behaviour, and no repo declares a verdict agent yet, so the staged path is unreachable in production until one does. The preflight prompt has not been exercised against a live model: it is prompt text whose effect is an agent's fan-out, and the guards that catch a parent which ignores it - unfilled slot, fan-out-is-never-a-verdict - are the ones that already existed.

Signed: **gm-staged**

## Attribution: the head half is unavailable, by design

This PR was implemented in-session, so its durable attribution is a self-recorded row:

```
type=implement  acting_org_role=gm-findings  dispatched_by=gm-findings  sender=session
```

**That row is honest about who and permanently silent about which head.** `gitmoot job record --head-sha` documents itself as "recorded as display metadata only: it is NOT stored in the job payload and no merge policy reads it (#1990)", and the store agrees: of 408 session-recorded implement rows, **zero** carry a head, against 2,212 of 2,636 overall.

So a gate asking "who implemented *this head*" cannot be satisfied for in-session work while that quarantine stands, however diligently the lane records. Independence of the review is therefore **verifiable on the who half and unverifiable on the head half**, and that is a property of #1990 rather than a defect in this review or a gap anyone can close here.

Disclosed rather than worked around: no row was recorded on another seat's behalf, because a false *who* on an already headless *what* is worse than an absent one.