### PR TITLE
feat(workflow): make a head-bound exclusion legible without binding a head (#2008)

### DIFF
--- a/internal/db/awaited_facts.go
+++ b/internal/db/awaited_facts.go
@@ -259,6 +259,14 @@ type SucceededReviewVerdict struct {
 	// in workflow.ReviewerIdentity and this layer must not keep a second copy of
 	// it (#2008). A caller reading Agent alone silently drops such a row.
 	ActingOrgRole string
+	// ExternallyDriven is carried RAW for the same reason and with a sharper one:
+	// HEADLESS DOES NOT IMPLY SESSION. Measured on this box, 211 review rows have
+	// no head - 41 externally driven, 156 failed, 10 cancelled, and 4 ephemeral
+	// ask-delegation children (#1962, #1895). A consumer that reports every
+	// headless row as a self-rooted session row would commit an over-attribution
+	// while trying to improve honesty, so the distinction must reach the caller
+	// that phrases the exclusion (#2008).
+	ExternallyDriven bool
 }
 
 // SucceededReviewVerdicts returns stable approved or changes-requested review
@@ -276,7 +284,7 @@ func (s *Store) SucceededReviewVerdicts(ctx context.Context, repo string, pullRe
 		return nil, errors.New("review verdict pull request must be positive")
 	}
 	rows, err := s.db.QueryContext(ctx, `
-SELECT id, agent, payload
+SELECT id, agent, payload, externally_driven
 FROM jobs
 WHERE type = 'review' AND state = 'succeeded' AND lower(repo) = ? AND pull_request = ?
 ORDER BY updated_at DESC, id DESC`, repo, pullRequest)
@@ -288,7 +296,8 @@ ORDER BY updated_at DESC, id DESC`, repo, pullRequest)
 	verdicts := make([]SucceededReviewVerdict, 0)
 	for rows.Next() {
 		var jobID, agent, payload string
-		if err := rows.Scan(&jobID, &agent, &payload); err != nil {
+		var externallyDriven bool
+		if err := rows.Scan(&jobID, &agent, &payload, &externallyDriven); err != nil {
 			return nil, err
 		}
 		var decoded reviewVerdictPayload
@@ -313,6 +322,7 @@ ORDER BY updated_at DESC, id DESC`, repo, pullRequest)
 			Severity:         strings.ToUpper(strings.TrimSpace(decoded.Result.Severity)),
 			EffectiveRuntime: strings.ToLower(strings.TrimSpace(decoded.EffectiveRuntime)),
 			ActingOrgRole:    strings.TrimSpace(decoded.ActingOrgRole),
+			ExternallyDriven: externallyDriven,
 		})
 	}
 	if err := rows.Err(); err != nil {

--- a/internal/workflow/head_bound_exclusion.go
+++ b/internal/workflow/head_bound_exclusion.go
@@ -1,0 +1,85 @@
+package workflow
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/gitmoot/gitmoot/internal/db"
+)
+
+// HeadBoundExclusionEventKind records that a consumer excluded a row from a
+// HEAD-BOUND decision, and why.
+const HeadBoundExclusionEventKind = "head_bound_exclusion"
+
+// Stable reason strings. They are constants rather than formatted text because
+// the recorder's at-most-once guarantee is keyed on the exact message; see
+// RecordHeadBoundExclusion.
+const (
+	// HeadBoundExclusionSessionRow is the #2008 class: an externally driven
+	// session review self-roots and legitimately carries no head, because a head
+	// on a review verdict must be ENGINE-OBSERVED and never caller-asserted
+	// (#1990). Excluding it from a head-bound decision is CORRECT.
+	HeadBoundExclusionSessionRow = "session row, self-rooted, no engine-observed head"
+	// HeadBoundExclusionNoHeadRecorded covers every other headless row. It says
+	// strictly less, on purpose.
+	HeadBoundExclusionNoHeadRecorded = "no engine-observed head recorded on the row"
+)
+
+// HeadBoundExclusion reports whether a row must be excluded from a decision
+// keyed on a head, and the reason to state when it is.
+//
+// THE REASONS ARE DIFFERENT BECAUSE HEADLESS DOES NOT IMPLY SESSION, and that is
+// measured rather than assumed. On this box 211 review rows carry no head: 41
+// externally driven, 156 failed, 10 cancelled, and 4 ephemeral ask-delegation
+// children with pull_request=0 (#1962, #1895). Reporting all 211 as self-rooted
+// session rows would be an over-attribution committed BY the change meant to
+// improve honesty - the same defect class as proof's reviewed_ref reporting a
+// head its row never recorded.
+//
+// It takes the two STORED fields rather than a job, so the db layer can carry
+// them raw and this package can stay the only place the rule lives. workflow
+// depends on db and never the reverse, so a predicate db could call does not
+// exist; a copy inside db would be a second definition of the same rule and
+// would still need the same column.
+func HeadBoundExclusion(externallyDriven bool, headSHA string) (string, bool) {
+	if strings.TrimSpace(headSHA) != "" {
+		return "", false
+	}
+	if externallyDriven {
+		return HeadBoundExclusionSessionRow, true
+	}
+	return HeadBoundExclusionNoHeadRecorded, true
+}
+
+// RecordHeadBoundExclusion makes one consumer's exclusion legible on the row it
+// excluded, without changing whether the row is excluded.
+//
+// THE MESSAGE MUST STAY STABLE. ClaimJobEvent is at-most-once on the EXACT
+// (job_id, kind, message) triple, so a message carrying anything variable - the
+// evaluated head, a timestamp, a count of siblings - defeats the guarantee and
+// appends one row per call. advanceReviewingPullRequest runs on every daemon
+// poll tick, so that is not a slow leak: it is the mechanism that grew
+// job_events to over a million rows. Consumer name and reason only.
+//
+// IT MUST NOT WRITE A HEAD, AND THAT IS THE WHOLE TRAP OF THIS CAMPAIGN. Making
+// an exclusion legible and making the row head-bound are opposite fixes that
+// look identical from a distance: both make the row stop vanishing. A consumer
+// that "fixes" its silence by recording a head on a session row has bound a
+// caller-asserted head into engine-observed evidence, which is exactly what
+// #1990 established must never happen. This function records an EVENT beside the
+// row and touches no payload.
+func RecordHeadBoundExclusion(ctx context.Context, store *db.Store, jobID, consumer, reason string) error {
+	jobID = strings.TrimSpace(jobID)
+	consumer = strings.TrimSpace(consumer)
+	reason = strings.TrimSpace(reason)
+	if store == nil || jobID == "" || consumer == "" || reason == "" {
+		return nil
+	}
+	_, err := store.ClaimJobEvent(ctx, db.JobEvent{
+		JobID:   jobID,
+		Kind:    HeadBoundExclusionEventKind,
+		Message: fmt.Sprintf("%s: excluded from a head-bound decision (%s)", consumer, reason),
+	})
+	return err
+}

--- a/internal/workflow/head_bound_exclusion_2008_test.go
+++ b/internal/workflow/head_bound_exclusion_2008_test.go
@@ -1,0 +1,191 @@
+package workflow
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/gitmoot/gitmoot/internal/db"
+)
+
+// seedHeadlessReviewVerdict seeds a succeeded review verdict with NO head.
+// externallyDriven selects the two populations #2008 must tell apart.
+func seedHeadlessReviewVerdict(t *testing.T, store *db.Store, jobID, agent string, externallyDriven bool) {
+	t.Helper()
+	ctx := context.Background()
+	encoded, err := marshalPayload(JobPayload{
+		Repo: "owner/repo", Branch: "main", PullRequest: 227, HeadSHA: "",
+		TaskID: "review-pr-227", ReviewRound: "review-1",
+		Result: &AgentResult{Decision: "changes_requested", Summary: "headless verdict"},
+	})
+	if err != nil {
+		t.Fatalf("marshalPayload(%s): %v", jobID, err)
+	}
+	job := db.Job{ID: jobID, Agent: agent, Type: "review", State: string(JobSucceeded), Payload: encoded}
+	event := db.JobEvent{Kind: string(JobSucceeded), Message: "changes_requested"}
+	if externallyDriven {
+		if err := store.CreateExternallyDrivenJobWithEvent(ctx, job, event); err != nil {
+			t.Fatalf("CreateExternallyDrivenJobWithEvent(%s): %v", jobID, err)
+		}
+	} else if err := store.CreateJobWithEvent(ctx, job, event); err != nil {
+		t.Fatalf("CreateJobWithEvent(%s): %v", jobID, err)
+	}
+}
+
+func headBoundExclusionEvents(t *testing.T, store *db.Store, jobID string) []string {
+	t.Helper()
+	events, err := store.ListJobEvents(context.Background(), jobID)
+	if err != nil {
+		t.Fatalf("ListJobEvents(%s): %v", jobID, err)
+	}
+	var out []string
+	for _, event := range events {
+		if event.Kind == HeadBoundExclusionEventKind {
+			out = append(out, event.Message)
+		}
+	}
+	return out
+}
+
+// TestHeadBoundExclusionSaysWhichPopulationItExcluded pins the distinction the
+// measurement forced: 211 review rows on this box carry no head and only 41 are
+// session rows, so one reason string for all of them would be an
+// over-attribution committed by the change meant to improve honesty.
+func TestHeadBoundExclusionSaysWhichPopulationItExcluded(t *testing.T) {
+	if reason, excluded := HeadBoundExclusion(true, "abc123"); excluded || reason != "" {
+		t.Errorf("a row WITH a head must not be excluded: reason=%q excluded=%v", reason, excluded)
+	}
+	if reason, excluded := HeadBoundExclusion(true, ""); !excluded || reason != HeadBoundExclusionSessionRow {
+		t.Errorf("session row reason = %q (excluded=%v), want %q", reason, excluded, HeadBoundExclusionSessionRow)
+	}
+	if reason, excluded := HeadBoundExclusion(false, ""); !excluded || reason != HeadBoundExclusionNoHeadRecorded {
+		t.Errorf("non-session headless reason = %q (excluded=%v), want %q", reason, excluded, HeadBoundExclusionNoHeadRecorded)
+	}
+	if HeadBoundExclusionSessionRow == HeadBoundExclusionNoHeadRecorded {
+		t.Fatal("the two reasons are identical, so the distinction the measurement forced does not exist")
+	}
+}
+
+// TestFindRepeatedReviewersRecordsWhyItExcludedAHeadlessRow is the seam: the row
+// stays excluded and the exclusion becomes legible.
+func TestFindRepeatedReviewersRecordsWhyItExcludedAHeadlessRow(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	seedReviewLoopAgent(t, store, "g7-review", "codex", "gpt-5.6-sol")
+	seedHeadlessReviewVerdict(t, store, "session-review-1", "g7-review", true)
+
+	matches, err := FindRepeatedReviewers(ctx, store, "owner/repo", 227, "head-a", []string{"g7-review"})
+	if err != nil {
+		t.Fatalf("FindRepeatedReviewers: %v", err)
+	}
+
+	// BEHAVIOUR UNCHANGED: a headless row still does not satisfy a head-bound
+	// decision. If this ever passes, the visibility change has become a
+	// head-binding change.
+	if len(matches) != 0 {
+		t.Fatalf("matches = %+v, want none: a headless row must not satisfy a decision keyed on head-a", matches)
+	}
+
+	messages := headBoundExclusionEvents(t, store, "session-review-1")
+	if len(messages) != 1 {
+		t.Fatalf("exclusion events = %d (%v), want exactly 1: the row was dropped silently", len(messages), messages)
+	}
+	if !strings.Contains(messages[0], HeadBoundExclusionSessionRow) {
+		t.Errorf("exclusion message = %q, want it to carry %q", messages[0], HeadBoundExclusionSessionRow)
+	}
+	if !strings.Contains(messages[0], "review_loop.FindRepeatedReviewers") {
+		t.Errorf("exclusion message = %q, want it to name the consumer that excluded the row", messages[0])
+	}
+}
+
+// TestHeadBoundExclusionRecordDoesNotGrowPerCall pins the at-most-once
+// guarantee at the CALLER's level rather than trusting ClaimJobEvent in the
+// abstract. That primitive is at-most-once on the exact (job_id, kind, message)
+// triple, so a message carrying anything variable would defeat it. The consumer
+// that motivates this runs on every daemon poll tick, which is the mechanism
+// that grew job_events past a million rows.
+func TestHeadBoundExclusionRecordDoesNotGrowPerCall(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	seedReviewLoopAgent(t, store, "g7-review", "codex", "gpt-5.6-sol")
+	seedHeadlessReviewVerdict(t, store, "session-review-1", "g7-review", true)
+
+	for i := range 5 {
+		if _, err := FindRepeatedReviewers(ctx, store, "owner/repo", 227, "head-a", []string{"g7-review"}); err != nil {
+			t.Fatalf("FindRepeatedReviewers call %d: %v", i, err)
+		}
+	}
+	if messages := headBoundExclusionEvents(t, store, "session-review-1"); len(messages) != 1 {
+		t.Fatalf("exclusion events after 5 calls = %d, want 1: the message is not stable and appends per call", len(messages))
+	}
+}
+
+// TestMakingTheExclusionLegibleNeverWritesAHead IS THE TRAP, as a test rather
+// than as a warning in a PR body.
+//
+// Making an exclusion legible and making the row head-bound are opposite fixes
+// that look identical from a distance, because both stop the row vanishing. A
+// consumer that "fixed" its silence by recording a head on a session row would
+// satisfy every visibility assertion above while binding a caller-asserted head
+// into engine-observed evidence, which #1990 established must never happen.
+//
+// So this asserts the row's STORED head is still empty afterwards. Every later
+// slice in #2008 inherits it.
+func TestMakingTheExclusionLegibleNeverWritesAHead(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	seedReviewLoopAgent(t, store, "g7-review", "codex", "gpt-5.6-sol")
+	seedHeadlessReviewVerdict(t, store, "session-review-1", "g7-review", true)
+
+	if _, err := FindRepeatedReviewers(ctx, store, "owner/repo", 227, "head-a", []string{"g7-review"}); err != nil {
+		t.Fatalf("FindRepeatedReviewers: %v", err)
+	}
+
+	job, err := store.GetJob(ctx, "session-review-1")
+	if err != nil {
+		t.Fatalf("GetJob: %v", err)
+	}
+	payload, err := unmarshalPayload(job.Payload)
+	if err != nil {
+		t.Fatalf("unmarshalPayload: %v", err)
+	}
+	if strings.TrimSpace(payload.HeadSHA) != "" {
+		t.Fatalf("head_sha = %q, want empty: the exclusion was made legible by BINDING A HEAD, which is the opposite fix", payload.HeadSHA)
+	}
+	// And the row must still be reported by the store as headless, so no later
+	// consumer can read a head that no engine observed.
+	verdicts, err := store.SucceededReviewVerdicts(ctx, "owner/repo", 227)
+	if err != nil {
+		t.Fatalf("SucceededReviewVerdicts: %v", err)
+	}
+	for _, verdict := range verdicts {
+		if verdict.JobID == "session-review-1" && verdict.HeadSHA != "" {
+			t.Fatalf("stored verdict head = %q, want empty", verdict.HeadSHA)
+		}
+	}
+}
+
+// TestHeadlessNonSessionRowGetsTheWeakerReason is the negative control for the
+// population split. Without it the suite passes under a rule that labels every
+// headless row a session row, which is the over-attribution this design exists
+// to avoid.
+func TestHeadlessNonSessionRowGetsTheWeakerReason(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	seedReviewLoopAgent(t, store, "g7-review", "codex", "gpt-5.6-sol")
+	seedHeadlessReviewVerdict(t, store, "ordinary-review-1", "g7-review", false)
+
+	if _, err := FindRepeatedReviewers(ctx, store, "owner/repo", 227, "head-a", []string{"g7-review"}); err != nil {
+		t.Fatalf("FindRepeatedReviewers: %v", err)
+	}
+	messages := headBoundExclusionEvents(t, store, "ordinary-review-1")
+	if len(messages) != 1 {
+		t.Fatalf("exclusion events = %d, want 1", len(messages))
+	}
+	if strings.Contains(messages[0], HeadBoundExclusionSessionRow) {
+		t.Errorf("message = %q: a row that is NOT externally driven was reported as a self-rooted session row", messages[0])
+	}
+	if !strings.Contains(messages[0], HeadBoundExclusionNoHeadRecorded) {
+		t.Errorf("message = %q, want the weaker reason %q", messages[0], HeadBoundExclusionNoHeadRecorded)
+	}
+}

--- a/internal/workflow/review_loop.go
+++ b/internal/workflow/review_loop.go
@@ -84,6 +84,18 @@ func FindRepeatedReviewers(ctx context.Context, store *db.Store, repo string, pu
 	if headSHA != "" {
 		for _, verdict := range verdicts {
 			if verdict.HeadSHA != headSHA {
+				// BEHAVIOUR IS UNCHANGED: the row is still excluded, and no head is
+				// written to it. Only the SILENCE changes. A headless verdict
+				// vanished from this index with no trace, so a reader counting
+				// at-head verdicts could not tell an absent row from an excluded
+				// one (#2008). A row at a DIFFERENT head is not this class - it has
+				// an engine-observed head and simply is not this one - so only the
+				// headless case is recorded.
+				if reason, excluded := HeadBoundExclusion(verdict.ExternallyDriven, verdict.HeadSHA); excluded {
+					if err := RecordHeadBoundExclusion(ctx, store, verdict.JobID, "review_loop.FindRepeatedReviewers", reason); err != nil {
+						return nil, err
+					}
+				}
 				continue
 			}
 			// A session review persists ActingOrgRole IN PLACE OF an agent, so the


### PR DESCRIPTION
Part of #2008. **Slice 1 of 5: the foundation.** Head-keyed group.

## Behaviour is unchanged and no row gains a head

Stated first because the whole hazard of this campaign is that the correct fix and the catastrophic one look identical from a distance.

The ten head-keyed consumers exclude a headless review row from decisions keyed on a head. **They are right to.** A review verdict's head must be engine-observed, never caller-asserted (#1990), and a session review self-roots and legitimately carries none. What is wrong is that they exclude it **silently**, so the row vanishes from counts and surfaces with no trace.

**THE TRAP: making the exclusion legible and making the row head-bound are opposite fixes, and the second looks like the first from a distance.** Both stop the row vanishing. No consumer may start recording a head to make its exclusion readable. This PR makes that a test, not a warning (below).

## Headless does not imply session, and that decided the design

Re-derived read-only. **211 review rows carry no head, not 41:**

| Population | Rows |
| --- | --- |
| `externally_driven = 1` (session) | 41 |
| failed | 156 |
| cancelled | 10 |
| ephemeral ask-delegation children, `pull_request=0` (#1962, #1895) | 4 |
| **unexplained residue** | **0** |

#2008 counted the session population; I read that as the population of the drop. They are not the same, and the issue has been corrected.

This is not a footnote, it decided the seam. Emitting `session row, self-rooted, no engine-observed head` for all 211 would be **an over-attribution committed by the change meant to improve honesty** - the same defect class as `proof`'s `reviewed_ref` reporting a head its row never recorded, which is why slice 5 was moved up. So the predicate carries two reasons and the weaker one says strictly less.

It also settles the campaign's open design question. `db` cannot call a workflow predicate (imports run one way), so either `db` expresses the rule or it reports and the caller decides. **Report-and-decide is forced, not chosen:** the distinction needs `externally_driven`, so a copy inside `db` would be a second definition of the same rule *and* would still need the same column. The anti-duplication argument alone would have been taste; this is measurement.

## What this slice adds

- `workflow.HeadBoundExclusion(externallyDriven, headSHA) (reason, excluded)` - one definition, taking the two stored fields so `db` can carry them raw.
- Two **stable** reason constants.
- `workflow.RecordHeadBoundExclusion` - at-most-once through the existing `ClaimJobEvent`, which `review_loop` already uses. No new surface, no new throttle.
- `db.SucceededReviewVerdict.ExternallyDriven`, carried raw. The query selected `id, agent, payload` and could not tell the populations apart.
- Wired into **exactly one** consumer, `review_loop.FindRepeatedReviewers`, to prove the seam.

**The message must stay stable.** `ClaimJobEvent` is at-most-once on the exact `(job_id, kind, message)` triple, so a message carrying the evaluated head, a timestamp or a count defeats the guarantee and appends per call. `advanceReviewingPullRequest` runs every poll tick, so that is not a slow leak: it is the mechanism that grew `job_events` past a million rows. Consumer name and reason only.

## Five mutants, and the most useful result is a negative one

| Mutant | What it kills |
| --- | --- |
| M1 record nothing (the pre-fix silence) | seam, no-growth, weaker-reason |
| M2 one reason for every headless row | population-split, weaker-reason |
| M3 message carries a timestamp | no-growth **only** |
| M4 headless row adopts the head **in memory** | seam **only** |
| M5 headless row gets a head **persisted** | all four store-backed tests, **including the trap** |

M3 and M4 each killing exactly one test is what says these are independent instruments rather than four views of one assertion.

### The trap test was vacuous as shipped, and a mutant column found it

`TestMakingTheExclusionLegibleNeverWritesAHead` is the test this campaign most wanted. **It survived M1 through M4 without ever failing**, because the consumer it is wired into writes no payload, so "the stored head is still empty" could not fail there. It had already passed a design review, a written spec, and explicit praise from the person who specified it.

It was found by a mechanical check rather than by insight: **after a mutation round, list which tests each mutant killed, and treat an empty column as a suspect rather than a pass.** M5 - a consumer that makes the exclusion legible by *persisting* a head - is the mutant that makes it real. It stops being an artificial mutation at slices 3 and 4, whose consumers genuinely write.

## Verification

| Check | Result |
| --- | --- |
| `go build ./...` | ok |
| `go vet` on both changed packages | ok |
| `gofmt -l internal/` | clean |
| `internal/workflow` | ok 106.262s |
| `internal/db` | ok 169.818s |

Cache unchanged at 3.2 GiB across the run; disk unchanged at 28 GiB; no `DISK GUARD` line. `internal/cli` deliberately not run: nothing here reaches it, and it is the expensive one under the current disk constraint.

`-race` not run: requires cgo, unavailable in this seat. Covered by CI's race shards.

## Slicing, so a reviewer can redirect it now rather than after

1. **this PR** - predicate, record, one consumer
2. `proof:206` - moved up, because it is an over-attribution (a false claim) while the other nine are omissions
3. `review_loop`'s remaining two
4. engine decision path: `merge_gate:872`, `engine_routing_merge:529` and `:603`, `engine_pr_lifecycle:900`. **Splittable**: `:872` can come out alone if review prefers, since it is closest to the gate
5. `db` + `daemon` together, because they share the import constraint above and separating them would decide the same seam twice

## Not claimed

- **No behaviour changes for any consumer.** One consumer gains an event; nine still exclude silently and are addressed by later slices.
- Round-keyed consumers and the proof tree's structural self-rooting are untouched.
- The four ask-delegation rows are two months stale and belong to #1962/#1895. This slice only carries the column so they can be told apart.
