### PR TITLE
fix(proof): a headless review must not borrow the pull request's head (#2008)

### DIFF
--- a/internal/proof/project.go
+++ b/internal/proof/project.go
@@ -216,6 +216,20 @@ func (p *projector) factNodes(job db.Job, projection payloadProjection, result *
 	}
 	receipt := p.receipts[prKey(repo, prNumber)]
 	headSHA := firstNonBlank(projection.HeadSHA, receipt.HeadSHA)
+	if job.Type == "review" {
+		// A REVIEW ROW MAY NOT BORROW THE RECEIPT'S HEAD FOR ANY EVIDENCE NODE
+		// (#2008). The receipt fallback is legitimate for a job that CONTRIBUTED
+		// the change the pull request landed; a review contributed nothing, so a
+		// head it never recorded is not evidence about it, it is an invention.
+		//
+		// Applied to the whole local rather than only to reviewed_ref, because
+		// the commit node below is fed by the same value: fixing one and not the
+		// other would leave one manifest reporting two different heads for one
+		// row, and this change is what would have created that divergence.
+		//
+		// This is the head SOURCE only. What a commit node means is unchanged.
+		headSHA = strings.TrimSpace(projection.HeadSHA)
+	}
 
 	if result != nil && (len(result.ChangesMade) > 0 || job.ResultHash != "" || headSHA != "") {
 		attrs := map[string]string{"job_id": job.ID, "as_of": job.UpdatedAt}
@@ -586,6 +600,24 @@ func (p *projector) indexImplementers() {
 	}
 }
 
+// reviewedRef reports the ref a review row actually examined.
+//
+// IT MUST BE GIVEN A HEAD THE ROW ITSELF RECORDED (#2008). factNodes now
+// refuses the receipt fallback for review rows before this is called, so the
+// value it receives is already the row's own.
+// That local is firstNonBlank(projection.HeadSHA, receipt.HeadSHA), so for a
+// review row carrying no head it resolves to the PULL REQUEST RECEIPT's head -
+// a commit the row never recorded - and this attribute then asserted that the
+// review examined it. That is an over-attribution: the other nine head-keyed
+// consumers in #2008 OMIT a headless row, and this one INVENTED a fact about it.
+//
+// The distinction matters more than the count. A missing fact makes a reader ask
+// a question; a false one makes them stop asking, and a proof manifest is the
+// artifact people cite when they want to know what was verified.
+//
+// The receipt fallback stays legitimate for the commit node above, which is
+// evidence about the change that landed rather than a claim about what a
+// reviewer looked at.
 func (p *projector) reviewedRef(job db.Job, headSHA string) string {
 	if headSHA != "" {
 		return headSHA

--- a/internal/proof/reviewed_ref_2008_test.go
+++ b/internal/proof/reviewed_ref_2008_test.go
@@ -1,0 +1,197 @@
+package proof
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/gitmoot/gitmoot/internal/workflow"
+)
+
+const receiptHead = "abc123"
+
+// headlessReviewFixture is proofFixture with the review row's own head removed
+// and everything else left alone. The PR receipt still records receiptHead, so
+// the receipt fallback is live and the wrong answer is reachable.
+func headlessReviewFixture(t *testing.T) Manifest {
+	t.Helper()
+	root, jobs, results, receipts, events := proofFixture(t, false)
+	var patched bool
+	for i, job := range jobs {
+		if job.Type != "review" {
+			continue
+		}
+		payload := workflow.JobPayload{
+			Repo: "owner/repo", PullRequest: 42, WorkflowID: "proof/42",
+			RootJobID: "root", ParentJobID: "root", DelegationID: "review", DelegationDepth: 1,
+			DelegatedBy: "implementer", ActingOrgRole: "gitmoot", Result: results["review-job"],
+		}
+		jobs[i].Agent = ""
+		jobs[i].Payload = proofPayload(t, payload)
+		jobs[i].ResultHash = resultHashForPayload(t, jobs[i].Payload)
+		patched = true
+	}
+	if !patched {
+		t.Fatal("fixture has no review row to make headless")
+	}
+	// The hazard only exists while the receipt carries a head to borrow.
+	var receiptHasHead bool
+	for _, receipt := range receipts {
+		if receipt.HeadSHA == receiptHead {
+			receiptHasHead = true
+		}
+	}
+	if !receiptHasHead {
+		t.Fatalf("fixture receipt does not record %q, so this test cannot observe the over-attribution", receiptHead)
+	}
+	return Project(root, jobs, results, receipts, events)
+}
+
+func reviewNode(t *testing.T, manifest Manifest) Node {
+	t.Helper()
+	for id := range manifest.Nodes {
+		if node := manifest.Nodes[id]; node.Kind == KindReview {
+			return node
+		}
+	}
+	t.Fatal("no review node in the manifest")
+	return Node{}
+}
+
+// TestHeadlessReviewDoesNotBorrowThePullRequestHead is the #2008 over-attribution.
+//
+// IT ASSERTS THE ABSENCE OF THE WRONG ANSWER, not the presence of a right one.
+// This slice fixes a FALSE CLAIM rather than an omission, and a test that only
+// proves the new value leaves the old claim provable by nobody: any later change
+// that reintroduces the receipt fallback would satisfy "reviewed_ref is
+// non-empty" perfectly well.
+func TestHeadlessReviewDoesNotBorrowThePullRequestHead(t *testing.T) {
+	review := reviewNode(t, headlessReviewFixture(t))
+
+	got := review.Attrs["reviewed_ref"]
+	if got == receiptHead {
+		t.Fatalf("reviewed_ref = %q, which is the PULL REQUEST RECEIPT's head: the row records no head and this asserts it reviewed that commit", got)
+	}
+	if strings.Contains(got, receiptHead) {
+		t.Fatalf("reviewed_ref = %q still carries the receipt head %q", got, receiptHead)
+	}
+}
+
+// TestHeadlessReviewStillReportsAnHonestRef is the other half. Refusing the
+// borrowed head must not turn the attribute into a blank: the row genuinely has
+// a ref to name, the implementer result hash it was delegated from, and an
+// over-correction that reported nothing would replace a false claim with a
+// missing one.
+func TestHeadlessReviewStillReportsAnHonestRef(t *testing.T) {
+	review := reviewNode(t, headlessReviewFixture(t))
+
+	got := review.Attrs["reviewed_ref"]
+	if got == "" || got == "-" {
+		t.Fatalf("reviewed_ref = %q: refusing the borrowed head must not erase the honest ref", got)
+	}
+	if !strings.HasPrefix(got, hashPrefix) {
+		t.Errorf("reviewed_ref = %q, want the implementer result-hash ref (%s...)", got, hashPrefix)
+	}
+}
+
+// TestReviewWithItsOwnHeadIsUnchanged is the control that keeps the two tests
+// above from passing under a rule that simply stops reporting heads. A review
+// row that DID record a head must still report exactly that head.
+func TestReviewWithItsOwnHeadIsUnchanged(t *testing.T) {
+	root, jobs, results, receipts, events := proofFixture(t, false)
+	review := reviewNode(t, Project(root, jobs, results, receipts, events))
+
+	if got := review.Attrs["reviewed_ref"]; got != receiptHead {
+		t.Fatalf("reviewed_ref = %q, want %q: a row that recorded its own head must still report it", got, receiptHead)
+	}
+}
+
+func commitNodes(manifest Manifest) []Node {
+	var out []Node
+	for id := range manifest.Nodes {
+		if node := manifest.Nodes[id]; node.Kind == KindCommit {
+			out = append(out, node)
+		}
+	}
+	return out
+}
+
+// TestHeadlessReviewCommitNodeDoesNotCarryTheBorrowedHead is the same
+// over-attribution wearing a different node type, fed by the identical local.
+//
+// A commit node on a job asserts that the commit is part of the evidence for
+// that job. A review row that never recorded the head did not review it, so the
+// receipt's head is not evidence about that row.
+//
+// NOTE THE SHAPE THIS TEST HAS TO TAKE. The fixture's review row carries a
+// ResultHash, which independently justifies a commit node, so the honest
+// assertion is that the node must not CARRY the borrowed head - not that no node
+// exists. The pure "acquired from the receipt alone" case is the test below.
+func TestHeadlessReviewCommitNodeDoesNotCarryTheBorrowedHead(t *testing.T) {
+	for _, node := range commitNodes(headlessReviewFixture(t)) {
+		if node.Attrs["job_id"] != "review-job" {
+			continue
+		}
+		if node.Attrs["head_sha"] == receiptHead {
+			t.Fatalf("review commit node head_sha = %q, the receipt's head: the row never recorded it", receiptHead)
+		}
+		if node.Ref == receiptHead {
+			t.Fatalf("review commit node Ref = %q, the receipt's head", receiptHead)
+		}
+	}
+}
+
+// TestReviewWithNoOwnEvidenceAcquiresNoCommitNode is the pure case: strip the
+// ResultHash too, so the ONLY thing that could create a commit node is the
+// borrowed head. Before the fix the receipt manufactured one.
+func TestReviewWithNoOwnEvidenceAcquiresNoCommitNode(t *testing.T) {
+	root, jobs, results, receipts, events := proofFixture(t, false)
+	for i, job := range jobs {
+		if job.Type != "review" {
+			continue
+		}
+		payload := workflow.JobPayload{
+			Repo: "owner/repo", PullRequest: 42, WorkflowID: "proof/42",
+			RootJobID: "root", ParentJobID: "root", DelegationID: "review", DelegationDepth: 1,
+			DelegatedBy: "implementer", ActingOrgRole: "gitmoot",
+			Result: &workflow.AgentResult{Decision: "approved", Summary: "no changes, no tests"},
+		}
+		jobs[i].Agent = ""
+		jobs[i].Payload = proofPayload(t, payload)
+		jobs[i].ResultHash = ""
+		results["review-job"] = payload.Result
+	}
+	for _, node := range commitNodes(Project(root, jobs, results, receipts, events)) {
+		if node.Attrs["job_id"] == "review-job" {
+			t.Fatalf("a review row with no head and no result hash acquired a commit node from the receipt: %+v", node.Attrs)
+		}
+	}
+}
+
+// TestImplementerKeepsTheReceiptFallback is the control that stops the two above
+// from passing under a rule that simply deletes the receipt fallback. A job that
+// CONTRIBUTED the change the pull request landed still resolves its evidence
+// head from the receipt when it recorded none itself.
+func TestImplementerKeepsTheReceiptFallback(t *testing.T) {
+	root, jobs, results, receipts, events := proofFixture(t, false)
+	for i, job := range jobs {
+		if job.ID != "child-job" {
+			continue
+		}
+		payload := workflow.JobPayload{
+			Repo: "owner/repo", PullRequest: 42, WorkflowID: "proof/42",
+			RootJobID: "root", ParentJobID: "root", DelegationID: "child", DelegationDepth: 1,
+			DelegatedBy: "implementer", Result: results["child-job"],
+		}
+		jobs[i].Payload = proofPayload(t, payload)
+		jobs[i].ResultHash = resultHashForPayload(t, jobs[i].Payload)
+	}
+	var sawBorrowed bool
+	for _, node := range commitNodes(Project(root, jobs, results, receipts, events)) {
+		if node.Attrs["job_id"] == "child-job" && node.Attrs["head_sha"] == receiptHead {
+			sawBorrowed = true
+		}
+	}
+	if !sawBorrowed {
+		t.Fatal("an implement job that recorded no head lost the receipt fallback: the fix removed a legitimate path, not just the borrowed one")
+	}
+}


### PR DESCRIPTION
Part of #2008. **Slice 2 of 5: the over-attribution.** Head-keyed group.

## This slice removes a FALSE CLAIM, which is why it was moved ahead of the omissions

`factNodes` computes

```go
headSHA := firstNonBlank(projection.HeadSHA, receipt.HeadSHA)
```

and passed that to `reviewedRef`. For a review row carrying no head it resolves to the **pull request receipt's** head, so the manifest asserted that the review examined a commit **the row never recorded**.

The other nine head-keyed consumers in #2008 **omit** a headless row. This one **invents a fact about it**. That is the whole reason it jumped the queue: a missing fact makes a reader ask a question, a false one makes them stop asking, and a proof manifest is the artifact people cite when they want to know what was verified.

## The fix, applied to the LOCAL rather than to one attribute

For a review row, `headSHA` resolves to the row's own recorded head and nothing else. When that is empty, `reviewedRef` falls through to the pre-existing honest chain: the implementer's result hash, then the implementer's id.

**It covers the commit node too, and that was a review correction rather than my own reading.** The same local feeds `head_sha` and `Ref` on the commit node, so a review row could acquire a commit node purely because the receipt supplied a head. A commit node on a job asserts that the commit is evidence for that job; a review that never recorded the head did not review it, which is this slice's whole premise. It is the identical over-attribution wearing a different node type.

Fixing only `reviewed_ref` would have left one manifest reporting two different heads for one row, and **this change is what would have created that divergence** - the same criterion that pulled the job-node fix into #2027.

**The receipt fallback is unchanged for a job that CONTRIBUTED the change the pull request landed.** This is the head source only. What a commit node means is untouched.

## The test asserts the ABSENCE of the wrong answer

Per review direction, and it matters for this slice specifically: a fix to an over-attribution that only proves the new value leaves the old claim **provable by nobody**. Any later change reintroducing the receipt fallback would satisfy "reviewed_ref is non-empty" perfectly well.

So the regression asserts `reviewed_ref != receiptHead` and does not contain it. The fixture asserts up front that the receipt **does** carry that head, because a test for a borrowed value proves nothing if there was nothing to borrow.

| Mutant | Kills |
| --- | --- |
| M1 restore the receipt fallback in `reviewedRef` | absence, honest-ref |
| M2 over-correct: report nothing when the row has no head | honest-ref **only** |
| M3 stop reporting any head at all | own-head control **only** |
| M4 restore the receipt fallback for review rows (pre-fix, both nodes) | absence, honest-ref, both commit-node tests |
| M5 over-correct: drop the receipt fallback for **every** job type | implementer control **only** |

Every test has at least one mutant that kills it. **No empty column**, which is the check slice 1 added after its trap test turned out to be vacuous, applied here rather than treated as a one-off.

M2, M3 and M5 are the three over-corrections this fix could plausibly have been: replacing a false claim with a missing one, throwing out the correct head-reporting path along with the borrowed one, and removing the receipt fallback from the jobs that legitimately use it. Each is refused by a test rather than by care.

### On the shape the commit-node test had to take

The fixture's review row carries a `ResultHash`, which independently justifies a commit node, so the honest assertion is that the node must not **carry** the borrowed head rather than that no node exists. The pure "acquired from the receipt alone" case is a separate test that strips the `ResultHash` too, leaving the borrowed head as the only thing that could create the node.

## Sibling check

`reviewedRef` has exactly one caller, and it is the one fixed.

**The commit node was flagged in the first version of this PR as an open question and is now fixed.** I had left it, reasoning that a commit node is evidence about a change that landed. Review pointed out that the question answers itself: a commit node asserts the commit is evidence **for that job**, and a review that never recorded the head did not review it. It is the same defect fed by the same local, and my own partial fix would have been the thing that made the manifest inconsistent.

## Verification

| Check | Result |
| --- | --- |
| `go build ./...` | ok |
| `go vet ./internal/proof/` | ok |
| `gofmt -l internal/` | clean |
| `internal/proof` (full package) | ok 0.016s |

No gate consumed: `internal/proof` runs in well under a second and touches no cache of consequence.

`-race` not run: requires cgo, unavailable in this seat. Covered by CI's race shards.

## Not claimed

- **No count of affected manifests.** The population depends on which proof trees get rendered, not on a stored column, so I did not manufacture a number for it. What is measured is that 211 review rows carry no head and any of them rendered in a proof tree with a PR receipt would have borrowed that head.
- Stacked on nothing: this branches from `main` and is independent of slice 1 (#2031). They touch different files.
