### PR TITLE
feat(workflow): review_loop's two remaining head-keyed consumers say why they excluded a row (#2008)

### DIFF
--- a/internal/db/awaited_facts.go
+++ b/internal/db/awaited_facts.go
@@ -259,6 +259,14 @@ type SucceededReviewVerdict struct {
 	// in workflow.ReviewerIdentity and this layer must not keep a second copy of
 	// it (#2008). A caller reading Agent alone silently drops such a row.
 	ActingOrgRole string
+	// ExternallyDriven is carried RAW for the same reason and with a sharper one:
+	// HEADLESS DOES NOT IMPLY SESSION. Measured on this box, 211 review rows have
+	// no head - 41 externally driven, 156 failed, 10 cancelled, and 4 ephemeral
+	// ask-delegation children (#1962, #1895). A consumer that reports every
+	// headless row as a self-rooted session row would commit an over-attribution
+	// while trying to improve honesty, so the distinction must reach the caller
+	// that phrases the exclusion (#2008).
+	ExternallyDriven bool
 }
 
 // SucceededReviewVerdicts returns stable approved or changes-requested review
@@ -276,7 +284,7 @@ func (s *Store) SucceededReviewVerdicts(ctx context.Context, repo string, pullRe
 		return nil, errors.New("review verdict pull request must be positive")
 	}
 	rows, err := s.db.QueryContext(ctx, `
-SELECT id, agent, payload
+SELECT id, agent, payload, externally_driven
 FROM jobs
 WHERE type = 'review' AND state = 'succeeded' AND lower(repo) = ? AND pull_request = ?
 ORDER BY updated_at DESC, id DESC`, repo, pullRequest)
@@ -288,7 +296,8 @@ ORDER BY updated_at DESC, id DESC`, repo, pullRequest)
 	verdicts := make([]SucceededReviewVerdict, 0)
 	for rows.Next() {
 		var jobID, agent, payload string
-		if err := rows.Scan(&jobID, &agent, &payload); err != nil {
+		var externallyDriven bool
+		if err := rows.Scan(&jobID, &agent, &payload, &externallyDriven); err != nil {
 			return nil, err
 		}
 		var decoded reviewVerdictPayload
@@ -313,6 +322,7 @@ ORDER BY updated_at DESC, id DESC`, repo, pullRequest)
 			Severity:         strings.ToUpper(strings.TrimSpace(decoded.Result.Severity)),
 			EffectiveRuntime: strings.ToLower(strings.TrimSpace(decoded.EffectiveRuntime)),
 			ActingOrgRole:    strings.TrimSpace(decoded.ActingOrgRole),
+			ExternallyDriven: externallyDriven,
 		})
 	}
 	if err := rows.Err(); err != nil {

--- a/internal/workflow/engine_pr_lifecycle.go
+++ b/internal/workflow/engine_pr_lifecycle.go
@@ -226,7 +226,11 @@ func (e Engine) HandlePullRequestOpened(ctx context.Context, event PullRequestEv
 	// and re-fired it every poll. Skipping on identity is the idempotent answer.
 	// FindRepeatedReviewers cannot serve this: it queries succeeded verdicts only, so
 	// it never sees a queued, running or failed leg.
-	if existing := reviewLegsAtHead(reviewJobs, event, reviewRound); len(existing) > 0 {
+	existing, err := e.reviewLegsAtHead(ctx, reviewJobs, event, reviewRound)
+	if err != nil {
+		return err
+	}
+	if len(existing) > 0 {
 		remaining := make([]string, 0, len(reviewers))
 		for _, reviewer := range reviewers {
 			if _, dispatched := existing[strings.ToLower(strings.TrimSpace(reviewer))]; !dispatched {

--- a/internal/workflow/head_bound_exclusion.go
+++ b/internal/workflow/head_bound_exclusion.go
@@ -1,0 +1,85 @@
+package workflow
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/gitmoot/gitmoot/internal/db"
+)
+
+// HeadBoundExclusionEventKind records that a consumer excluded a row from a
+// HEAD-BOUND decision, and why.
+const HeadBoundExclusionEventKind = "head_bound_exclusion"
+
+// Stable reason strings. They are constants rather than formatted text because
+// the recorder's at-most-once guarantee is keyed on the exact message; see
+// RecordHeadBoundExclusion.
+const (
+	// HeadBoundExclusionSessionRow is the #2008 class: an externally driven
+	// session review self-roots and legitimately carries no head, because a head
+	// on a review verdict must be ENGINE-OBSERVED and never caller-asserted
+	// (#1990). Excluding it from a head-bound decision is CORRECT.
+	HeadBoundExclusionSessionRow = "session row, self-rooted, no engine-observed head"
+	// HeadBoundExclusionNoHeadRecorded covers every other headless row. It says
+	// strictly less, on purpose.
+	HeadBoundExclusionNoHeadRecorded = "no engine-observed head recorded on the row"
+)
+
+// HeadBoundExclusion reports whether a row must be excluded from a decision
+// keyed on a head, and the reason to state when it is.
+//
+// THE REASONS ARE DIFFERENT BECAUSE HEADLESS DOES NOT IMPLY SESSION, and that is
+// measured rather than assumed. On this box 211 review rows carry no head: 41
+// externally driven, 156 failed, 10 cancelled, and 4 ephemeral ask-delegation
+// children with pull_request=0 (#1962, #1895). Reporting all 211 as self-rooted
+// session rows would be an over-attribution committed BY the change meant to
+// improve honesty - the same defect class as proof's reviewed_ref reporting a
+// head its row never recorded.
+//
+// It takes the two STORED fields rather than a job, so the db layer can carry
+// them raw and this package can stay the only place the rule lives. workflow
+// depends on db and never the reverse, so a predicate db could call does not
+// exist; a copy inside db would be a second definition of the same rule and
+// would still need the same column.
+func HeadBoundExclusion(externallyDriven bool, headSHA string) (string, bool) {
+	if strings.TrimSpace(headSHA) != "" {
+		return "", false
+	}
+	if externallyDriven {
+		return HeadBoundExclusionSessionRow, true
+	}
+	return HeadBoundExclusionNoHeadRecorded, true
+}
+
+// RecordHeadBoundExclusion makes one consumer's exclusion legible on the row it
+// excluded, without changing whether the row is excluded.
+//
+// THE MESSAGE MUST STAY STABLE. ClaimJobEvent is at-most-once on the EXACT
+// (job_id, kind, message) triple, so a message carrying anything variable - the
+// evaluated head, a timestamp, a count of siblings - defeats the guarantee and
+// appends one row per call. advanceReviewingPullRequest runs on every daemon
+// poll tick, so that is not a slow leak: it is the mechanism that grew
+// job_events to over a million rows. Consumer name and reason only.
+//
+// IT MUST NOT WRITE A HEAD, AND THAT IS THE WHOLE TRAP OF THIS CAMPAIGN. Making
+// an exclusion legible and making the row head-bound are opposite fixes that
+// look identical from a distance: both make the row stop vanishing. A consumer
+// that "fixes" its silence by recording a head on a session row has bound a
+// caller-asserted head into engine-observed evidence, which is exactly what
+// #1990 established must never happen. This function records an EVENT beside the
+// row and touches no payload.
+func RecordHeadBoundExclusion(ctx context.Context, store *db.Store, jobID, consumer, reason string) error {
+	jobID = strings.TrimSpace(jobID)
+	consumer = strings.TrimSpace(consumer)
+	reason = strings.TrimSpace(reason)
+	if store == nil || jobID == "" || consumer == "" || reason == "" {
+		return nil
+	}
+	_, err := store.ClaimJobEvent(ctx, db.JobEvent{
+		JobID:   jobID,
+		Kind:    HeadBoundExclusionEventKind,
+		Message: fmt.Sprintf("%s: excluded from a head-bound decision (%s)", consumer, reason),
+	})
+	return err
+}

--- a/internal/workflow/head_bound_exclusion_2008_test.go
+++ b/internal/workflow/head_bound_exclusion_2008_test.go
@@ -1,0 +1,191 @@
+package workflow
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/gitmoot/gitmoot/internal/db"
+)
+
+// seedHeadlessReviewVerdict seeds a succeeded review verdict with NO head.
+// externallyDriven selects the two populations #2008 must tell apart.
+func seedHeadlessReviewVerdict(t *testing.T, store *db.Store, jobID, agent string, externallyDriven bool) {
+	t.Helper()
+	ctx := context.Background()
+	encoded, err := marshalPayload(JobPayload{
+		Repo: "owner/repo", Branch: "main", PullRequest: 227, HeadSHA: "",
+		TaskID: "review-pr-227", ReviewRound: "review-1",
+		Result: &AgentResult{Decision: "changes_requested", Summary: "headless verdict"},
+	})
+	if err != nil {
+		t.Fatalf("marshalPayload(%s): %v", jobID, err)
+	}
+	job := db.Job{ID: jobID, Agent: agent, Type: "review", State: string(JobSucceeded), Payload: encoded}
+	event := db.JobEvent{Kind: string(JobSucceeded), Message: "changes_requested"}
+	if externallyDriven {
+		if err := store.CreateExternallyDrivenJobWithEvent(ctx, job, event); err != nil {
+			t.Fatalf("CreateExternallyDrivenJobWithEvent(%s): %v", jobID, err)
+		}
+	} else if err := store.CreateJobWithEvent(ctx, job, event); err != nil {
+		t.Fatalf("CreateJobWithEvent(%s): %v", jobID, err)
+	}
+}
+
+func headBoundExclusionEvents(t *testing.T, store *db.Store, jobID string) []string {
+	t.Helper()
+	events, err := store.ListJobEvents(context.Background(), jobID)
+	if err != nil {
+		t.Fatalf("ListJobEvents(%s): %v", jobID, err)
+	}
+	var out []string
+	for _, event := range events {
+		if event.Kind == HeadBoundExclusionEventKind {
+			out = append(out, event.Message)
+		}
+	}
+	return out
+}
+
+// TestHeadBoundExclusionSaysWhichPopulationItExcluded pins the distinction the
+// measurement forced: 211 review rows on this box carry no head and only 41 are
+// session rows, so one reason string for all of them would be an
+// over-attribution committed by the change meant to improve honesty.
+func TestHeadBoundExclusionSaysWhichPopulationItExcluded(t *testing.T) {
+	if reason, excluded := HeadBoundExclusion(true, "abc123"); excluded || reason != "" {
+		t.Errorf("a row WITH a head must not be excluded: reason=%q excluded=%v", reason, excluded)
+	}
+	if reason, excluded := HeadBoundExclusion(true, ""); !excluded || reason != HeadBoundExclusionSessionRow {
+		t.Errorf("session row reason = %q (excluded=%v), want %q", reason, excluded, HeadBoundExclusionSessionRow)
+	}
+	if reason, excluded := HeadBoundExclusion(false, ""); !excluded || reason != HeadBoundExclusionNoHeadRecorded {
+		t.Errorf("non-session headless reason = %q (excluded=%v), want %q", reason, excluded, HeadBoundExclusionNoHeadRecorded)
+	}
+	if HeadBoundExclusionSessionRow == HeadBoundExclusionNoHeadRecorded {
+		t.Fatal("the two reasons are identical, so the distinction the measurement forced does not exist")
+	}
+}
+
+// TestFindRepeatedReviewersRecordsWhyItExcludedAHeadlessRow is the seam: the row
+// stays excluded and the exclusion becomes legible.
+func TestFindRepeatedReviewersRecordsWhyItExcludedAHeadlessRow(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	seedReviewLoopAgent(t, store, "g7-review", "codex", "gpt-5.6-sol")
+	seedHeadlessReviewVerdict(t, store, "session-review-1", "g7-review", true)
+
+	matches, err := FindRepeatedReviewers(ctx, store, "owner/repo", 227, "head-a", []string{"g7-review"})
+	if err != nil {
+		t.Fatalf("FindRepeatedReviewers: %v", err)
+	}
+
+	// BEHAVIOUR UNCHANGED: a headless row still does not satisfy a head-bound
+	// decision. If this ever passes, the visibility change has become a
+	// head-binding change.
+	if len(matches) != 0 {
+		t.Fatalf("matches = %+v, want none: a headless row must not satisfy a decision keyed on head-a", matches)
+	}
+
+	messages := headBoundExclusionEvents(t, store, "session-review-1")
+	if len(messages) != 1 {
+		t.Fatalf("exclusion events = %d (%v), want exactly 1: the row was dropped silently", len(messages), messages)
+	}
+	if !strings.Contains(messages[0], HeadBoundExclusionSessionRow) {
+		t.Errorf("exclusion message = %q, want it to carry %q", messages[0], HeadBoundExclusionSessionRow)
+	}
+	if !strings.Contains(messages[0], "review_loop.FindRepeatedReviewers") {
+		t.Errorf("exclusion message = %q, want it to name the consumer that excluded the row", messages[0])
+	}
+}
+
+// TestHeadBoundExclusionRecordDoesNotGrowPerCall pins the at-most-once
+// guarantee at the CALLER's level rather than trusting ClaimJobEvent in the
+// abstract. That primitive is at-most-once on the exact (job_id, kind, message)
+// triple, so a message carrying anything variable would defeat it. The consumer
+// that motivates this runs on every daemon poll tick, which is the mechanism
+// that grew job_events past a million rows.
+func TestHeadBoundExclusionRecordDoesNotGrowPerCall(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	seedReviewLoopAgent(t, store, "g7-review", "codex", "gpt-5.6-sol")
+	seedHeadlessReviewVerdict(t, store, "session-review-1", "g7-review", true)
+
+	for i := range 5 {
+		if _, err := FindRepeatedReviewers(ctx, store, "owner/repo", 227, "head-a", []string{"g7-review"}); err != nil {
+			t.Fatalf("FindRepeatedReviewers call %d: %v", i, err)
+		}
+	}
+	if messages := headBoundExclusionEvents(t, store, "session-review-1"); len(messages) != 1 {
+		t.Fatalf("exclusion events after 5 calls = %d, want 1: the message is not stable and appends per call", len(messages))
+	}
+}
+
+// TestMakingTheExclusionLegibleNeverWritesAHead IS THE TRAP, as a test rather
+// than as a warning in a PR body.
+//
+// Making an exclusion legible and making the row head-bound are opposite fixes
+// that look identical from a distance, because both stop the row vanishing. A
+// consumer that "fixed" its silence by recording a head on a session row would
+// satisfy every visibility assertion above while binding a caller-asserted head
+// into engine-observed evidence, which #1990 established must never happen.
+//
+// So this asserts the row's STORED head is still empty afterwards. Every later
+// slice in #2008 inherits it.
+func TestMakingTheExclusionLegibleNeverWritesAHead(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	seedReviewLoopAgent(t, store, "g7-review", "codex", "gpt-5.6-sol")
+	seedHeadlessReviewVerdict(t, store, "session-review-1", "g7-review", true)
+
+	if _, err := FindRepeatedReviewers(ctx, store, "owner/repo", 227, "head-a", []string{"g7-review"}); err != nil {
+		t.Fatalf("FindRepeatedReviewers: %v", err)
+	}
+
+	job, err := store.GetJob(ctx, "session-review-1")
+	if err != nil {
+		t.Fatalf("GetJob: %v", err)
+	}
+	payload, err := unmarshalPayload(job.Payload)
+	if err != nil {
+		t.Fatalf("unmarshalPayload: %v", err)
+	}
+	if strings.TrimSpace(payload.HeadSHA) != "" {
+		t.Fatalf("head_sha = %q, want empty: the exclusion was made legible by BINDING A HEAD, which is the opposite fix", payload.HeadSHA)
+	}
+	// And the row must still be reported by the store as headless, so no later
+	// consumer can read a head that no engine observed.
+	verdicts, err := store.SucceededReviewVerdicts(ctx, "owner/repo", 227)
+	if err != nil {
+		t.Fatalf("SucceededReviewVerdicts: %v", err)
+	}
+	for _, verdict := range verdicts {
+		if verdict.JobID == "session-review-1" && verdict.HeadSHA != "" {
+			t.Fatalf("stored verdict head = %q, want empty", verdict.HeadSHA)
+		}
+	}
+}
+
+// TestHeadlessNonSessionRowGetsTheWeakerReason is the negative control for the
+// population split. Without it the suite passes under a rule that labels every
+// headless row a session row, which is the over-attribution this design exists
+// to avoid.
+func TestHeadlessNonSessionRowGetsTheWeakerReason(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	seedReviewLoopAgent(t, store, "g7-review", "codex", "gpt-5.6-sol")
+	seedHeadlessReviewVerdict(t, store, "ordinary-review-1", "g7-review", false)
+
+	if _, err := FindRepeatedReviewers(ctx, store, "owner/repo", 227, "head-a", []string{"g7-review"}); err != nil {
+		t.Fatalf("FindRepeatedReviewers: %v", err)
+	}
+	messages := headBoundExclusionEvents(t, store, "ordinary-review-1")
+	if len(messages) != 1 {
+		t.Fatalf("exclusion events = %d, want 1", len(messages))
+	}
+	if strings.Contains(messages[0], HeadBoundExclusionSessionRow) {
+		t.Errorf("message = %q: a row that is NOT externally driven was reported as a self-rooted session row", messages[0])
+	}
+	if !strings.Contains(messages[0], HeadBoundExclusionNoHeadRecorded) {
+		t.Errorf("message = %q, want the weaker reason %q", messages[0], HeadBoundExclusionNoHeadRecorded)
+	}
+}

--- a/internal/workflow/review_loop.go
+++ b/internal/workflow/review_loop.go
@@ -264,7 +264,11 @@ func (e Engine) reviewScopeUnavailableRecorded(ctx context.Context, taskID strin
 // Re-attempting a HELD leg is the worker's path — the row stays queued and is
 // re-dispatched — and nothing here silently retries a terminal verdict, which is the
 // pre-existing contract.
-func reviewLegsAtHead(jobs []db.Job, event PullRequestEvent, round string) map[string]string {
+//
+// IT IS AN ENGINE METHOD RATHER THAN A PURE FUNCTION so it can record why it
+// dropped a row (#2008). The alternative was to re-derive the dropped set in the
+// caller, which would be a second copy of this filter and would drift from it.
+func (e Engine) reviewLegsAtHead(ctx context.Context, jobs []db.Job, event PullRequestEvent, round string) (map[string]string, error) {
 	current := JobPayload{Repo: event.Repo, PullRequest: event.PullRequest, TaskID: event.TaskID}
 	head := strings.TrimSpace(event.HeadSHA)
 	round = strings.TrimSpace(round)
@@ -283,13 +287,22 @@ func reviewLegsAtHead(jobs []db.Job, event PullRequestEvent, round string) map[s
 			continue
 		}
 		if strings.TrimSpace(payload.HeadSHA) != head || strings.TrimSpace(payload.ReviewRound) != round {
+			// BEHAVIOUR UNCHANGED, and no head is written. Only the head-keyed
+			// reason is recorded: a row at a DIFFERENT head has an engine-observed
+			// head and is simply not this one. A row that is also roundless stays a
+			// round-keyed matter, which is a separate slice.
+			if reason, excluded := HeadBoundExclusion(job.ExternallyDriven, payload.HeadSHA); excluded {
+				if err := RecordHeadBoundExclusion(ctx, e.Store, job.ID, "review_loop.reviewLegsAtHead", reason); err != nil {
+					return nil, err
+				}
+			}
 			continue
 		}
 		if agent := strings.ToLower(strings.TrimSpace(reviewDecisionAgent(job, payload))); agent != "" {
 			legs[agent] = job.State
 		}
 	}
-	return legs
+	return legs, nil
 }
 
 // reviewScopeForRoutine resolves the scope for a ROUTINE (non-lens) round. It reads
@@ -398,6 +411,18 @@ func (e Engine) followUpReviewScopes(ctx context.Context, event PullRequestEvent
 		}
 		previousHead := strings.TrimSpace(payload.HeadSHA)
 		if previousHead == "" || previousHead == strings.TrimSpace(event.HeadSHA) {
+			// Same split as reviewLegsAtHead, and the split is enforced by the
+			// SHARED PREDICATE rather than by a local guard here. An earlier
+			// version wrapped this in `if previousHead == ""`, which was dead
+			// code: HeadBoundExclusion already refuses a non-empty head. It was
+			// found by its own test having no mutant that could kill it, and it
+			// is worth removing rather than keeping, because a second copy of a
+			// rule that currently agrees is what this whole campaign is about.
+			if reason, excluded := HeadBoundExclusion(job.ExternallyDriven, previousHead); excluded {
+				if err := RecordHeadBoundExclusion(ctx, e.Store, job.ID, "review_loop.followUpReviewScopes", reason); err != nil {
+					return nil, err
+				}
+			}
 			continue
 		}
 		findings := namedReviewFindings(*payload.Result)

--- a/internal/workflow/review_loop.go
+++ b/internal/workflow/review_loop.go
@@ -84,6 +84,18 @@ func FindRepeatedReviewers(ctx context.Context, store *db.Store, repo string, pu
 	if headSHA != "" {
 		for _, verdict := range verdicts {
 			if verdict.HeadSHA != headSHA {
+				// BEHAVIOUR IS UNCHANGED: the row is still excluded, and no head is
+				// written to it. Only the SILENCE changes. A headless verdict
+				// vanished from this index with no trace, so a reader counting
+				// at-head verdicts could not tell an absent row from an excluded
+				// one (#2008). A row at a DIFFERENT head is not this class - it has
+				// an engine-observed head and simply is not this one - so only the
+				// headless case is recorded.
+				if reason, excluded := HeadBoundExclusion(verdict.ExternallyDriven, verdict.HeadSHA); excluded {
+					if err := RecordHeadBoundExclusion(ctx, store, verdict.JobID, "review_loop.FindRepeatedReviewers", reason); err != nil {
+						return nil, err
+					}
+				}
 				continue
 			}
 			// A session review persists ActingOrgRole IN PLACE OF an agent, so the

--- a/internal/workflow/review_loop_visibility_2008_test.go
+++ b/internal/workflow/review_loop_visibility_2008_test.go
@@ -1,0 +1,226 @@
+package workflow
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/gitmoot/gitmoot/internal/db"
+)
+
+// legsAtHeadForTest keeps the existing reviewLegsAtHead call sites readable now
+// that it is an Engine method.
+//
+// Those call sites pass UNPERSISTED fixture rows, which would be unlike
+// production if the recorder fired for them - job_events carries no foreign key,
+// so an orphan write would succeed silently rather than failing loudly. It never
+// fires: every one of those fixtures records a head, and HeadBoundExclusion
+// refuses a non-empty head. That is ASSERTED here rather than reasoned about,
+// so a future fixture that drops its head cannot start writing orphan events
+// unnoticed.
+func legsAtHeadForTest(t *testing.T, jobs []db.Job, event PullRequestEvent, round string) map[string]string {
+	t.Helper()
+	store := openEngineStore(t)
+	engine := testEngine(store)
+	legs, err := engine.reviewLegsAtHead(context.Background(), jobs, event, round)
+	if err != nil {
+		t.Fatalf("reviewLegsAtHead: %v", err)
+	}
+	for _, job := range jobs {
+		if events := headBoundExclusionEvents(t, store, job.ID); len(events) != 0 {
+			t.Fatalf("job %s: recorded %v against an unpersisted fixture row; persist the row or give it a head", job.ID, events)
+		}
+	}
+	return legs
+}
+
+func seedHeadlessReviewJob(t *testing.T, store *db.Store, jobID string, externallyDriven bool, round string) db.Job {
+	t.Helper()
+	encoded, err := marshalPayload(JobPayload{
+		Repo: "owner/repo", PullRequest: 227, TaskID: "review-pr-227",
+		HeadSHA: "", ReviewRound: round,
+		Result: &AgentResult{Decision: "changes_requested", Summary: "headless"},
+	})
+	if err != nil {
+		t.Fatalf("marshalPayload: %v", err)
+	}
+	job := db.Job{ID: jobID, Agent: "audit", Type: "review", State: string(JobSucceeded), Payload: encoded}
+	event := db.JobEvent{Kind: string(JobSucceeded), Message: "changes_requested"}
+	if externallyDriven {
+		if err := store.CreateExternallyDrivenJobWithEvent(context.Background(), job, event); err != nil {
+			t.Fatalf("CreateExternallyDrivenJobWithEvent: %v", err)
+		}
+	} else if err := store.CreateJobWithEvent(context.Background(), job, event); err != nil {
+		t.Fatalf("CreateJobWithEvent: %v", err)
+	}
+	stored, err := store.GetJob(context.Background(), jobID)
+	if err != nil {
+		t.Fatalf("GetJob: %v", err)
+	}
+	// The predicate reads ExternallyDriven off the row, so a read path that did
+	// not select the column would silently give every session row the weaker
+	// reason. ListJobs uses jobColumns, which includes it; asserted here so a
+	// future projection change cannot make this test quietly meaningless.
+	if stored.ExternallyDriven != externallyDriven {
+		t.Fatalf("stored ExternallyDriven = %v, want %v: the read path does not carry the column", stored.ExternallyDriven, externallyDriven)
+	}
+	return stored
+}
+
+// TestReviewLegsAtHeadRecordsWhyItDroppedAHeadlessRow: behaviour unchanged, the
+// silence removed.
+func TestReviewLegsAtHeadRecordsWhyItDroppedAHeadlessRow(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	engine := testEngine(store)
+	job := seedHeadlessReviewJob(t, store, "session-review-1", true, "review-1")
+	event := PullRequestEvent{Repo: "owner/repo", PullRequest: 227, TaskID: "review-pr-227", HeadSHA: "head-a"}
+
+	legs, err := engine.reviewLegsAtHead(ctx, []db.Job{job}, event, "review-1")
+	if err != nil {
+		t.Fatalf("reviewLegsAtHead: %v", err)
+	}
+	if len(legs) != 0 {
+		t.Fatalf("legs = %v, want none: a headless row must not be seen as a leg at head-a", legs)
+	}
+	messages := headBoundExclusionEvents(t, store, "session-review-1")
+	if len(messages) != 1 {
+		t.Fatalf("exclusion events = %d (%v), want 1", len(messages), messages)
+	}
+	if !strings.Contains(messages[0], "review_loop.reviewLegsAtHead") {
+		t.Errorf("message = %q, want it to name the consumer", messages[0])
+	}
+	if !strings.Contains(messages[0], HeadBoundExclusionSessionRow) {
+		t.Errorf("message = %q, want the session reason", messages[0])
+	}
+}
+
+// TestReviewLegsAtHeadStaysSilentForARowAtAnotherHead is the arm that keeps the
+// record meaningful. A row WITH an engine-observed head that simply is not this
+// one was never the #2008 class, and recording it would bury the 41 rows that
+// are among thousands that are not.
+func TestReviewLegsAtHeadStaysSilentForARowAtAnotherHead(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	engine := testEngine(store)
+	encoded, err := marshalPayload(JobPayload{
+		Repo: "owner/repo", PullRequest: 227, TaskID: "review-pr-227",
+		HeadSHA: "head-b", ReviewRound: "review-1",
+		Result: &AgentResult{Decision: "approved", Summary: "other head"},
+	})
+	if err != nil {
+		t.Fatalf("marshalPayload: %v", err)
+	}
+	job := db.Job{ID: "other-head-review", Agent: "audit", Type: "review", State: string(JobSucceeded), Payload: encoded}
+	if err := store.CreateJobWithEvent(ctx, job, db.JobEvent{Kind: string(JobSucceeded), Message: "approved"}); err != nil {
+		t.Fatalf("CreateJobWithEvent: %v", err)
+	}
+	stored, err := store.GetJob(ctx, "other-head-review")
+	if err != nil {
+		t.Fatalf("GetJob: %v", err)
+	}
+	event := PullRequestEvent{Repo: "owner/repo", PullRequest: 227, TaskID: "review-pr-227", HeadSHA: "head-a"}
+
+	if _, err := engine.reviewLegsAtHead(ctx, []db.Job{stored}, event, "review-1"); err != nil {
+		t.Fatalf("reviewLegsAtHead: %v", err)
+	}
+	if messages := headBoundExclusionEvents(t, store, "other-head-review"); len(messages) != 0 {
+		t.Fatalf("exclusion events = %v, want none: this row has an engine-observed head and is simply not this one", messages)
+	}
+}
+
+// TestFollowUpReviewScopesRecordsWhyItDroppedAHeadlessRow is the second consumer
+// in this slice. Its drop is the `previousHead == ""` arm.
+func TestFollowUpReviewScopesRecordsWhyItDroppedAHeadlessRow(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	engine := testEngine(store)
+	job := seedHeadlessReviewJob(t, store, "session-review-2", true, "review-1")
+	event := PullRequestEvent{Repo: "owner/repo", PullRequest: 227, TaskID: "review-pr-227", HeadSHA: "head-a"}
+
+	scopes, err := engine.followUpReviewScopes(ctx, event, []string{"audit"}, []db.Job{job})
+	if err != nil {
+		t.Fatalf("followUpReviewScopes: %v", err)
+	}
+	if len(scopes) != 0 {
+		t.Fatalf("scopes = %v, want none: a headless row must not scope a follow-up round", scopes)
+	}
+	messages := headBoundExclusionEvents(t, store, "session-review-2")
+	if len(messages) != 1 {
+		t.Fatalf("exclusion events = %d (%v), want 1", len(messages), messages)
+	}
+	if !strings.Contains(messages[0], "review_loop.followUpReviewScopes") {
+		t.Errorf("message = %q, want it to name the consumer", messages[0])
+	}
+}
+
+// TestFollowUpReviewScopesStaysSilentForTheCurrentHead is the same discipline on
+// the other consumer: a row AT the evaluated head is skipped because it is not a
+// previous round, not for want of a head.
+func TestFollowUpReviewScopesStaysSilentForTheCurrentHead(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	engine := testEngine(store)
+	encoded, err := marshalPayload(JobPayload{
+		Repo: "owner/repo", PullRequest: 227, TaskID: "review-pr-227",
+		HeadSHA: "head-a", ReviewRound: "review-1",
+		Result: &AgentResult{Decision: "approved", Summary: "current head"},
+	})
+	if err != nil {
+		t.Fatalf("marshalPayload: %v", err)
+	}
+	job := db.Job{ID: "current-head-review", Agent: "audit", Type: "review", State: string(JobSucceeded), Payload: encoded}
+	if err := store.CreateJobWithEvent(ctx, job, db.JobEvent{Kind: string(JobSucceeded), Message: "approved"}); err != nil {
+		t.Fatalf("CreateJobWithEvent: %v", err)
+	}
+	stored, err := store.GetJob(ctx, "current-head-review")
+	if err != nil {
+		t.Fatalf("GetJob: %v", err)
+	}
+	event := PullRequestEvent{Repo: "owner/repo", PullRequest: 227, TaskID: "review-pr-227", HeadSHA: "head-a"}
+
+	if _, err := engine.followUpReviewScopes(ctx, event, []string{"audit"}, []db.Job{stored}); err != nil {
+		t.Fatalf("followUpReviewScopes: %v", err)
+	}
+	if messages := headBoundExclusionEvents(t, store, "current-head-review"); len(messages) != 0 {
+		t.Fatalf("exclusion events = %v, want none", messages)
+	}
+}
+
+// TestBothReviewLoopConsumersRecordSeparately proves the record identifies WHICH
+// consumer excluded the row rather than merely that something did. Two consumers
+// dropping one row must leave two distinguishable records, and the at-most-once
+// key must not collapse them into one.
+func TestBothReviewLoopConsumersRecordSeparately(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	engine := testEngine(store)
+	job := seedHeadlessReviewJob(t, store, "session-review-3", true, "review-1")
+	event := PullRequestEvent{Repo: "owner/repo", PullRequest: 227, TaskID: "review-pr-227", HeadSHA: "head-a"}
+
+	for range 3 {
+		if _, err := engine.reviewLegsAtHead(ctx, []db.Job{job}, event, "review-1"); err != nil {
+			t.Fatalf("reviewLegsAtHead: %v", err)
+		}
+		if _, err := engine.followUpReviewScopes(ctx, event, []string{"audit"}, []db.Job{job}); err != nil {
+			t.Fatalf("followUpReviewScopes: %v", err)
+		}
+	}
+
+	messages := headBoundExclusionEvents(t, store, "session-review-3")
+	if len(messages) != 2 {
+		t.Fatalf("exclusion events = %d (%v), want exactly 2: one per consumer, stable across repeats", len(messages), messages)
+	}
+	var sawLegs, sawScopes bool
+	for _, message := range messages {
+		if strings.Contains(message, "review_loop.reviewLegsAtHead") {
+			sawLegs = true
+		}
+		if strings.Contains(message, "review_loop.followUpReviewScopes") {
+			sawScopes = true
+		}
+	}
+	if !sawLegs || !sawScopes {
+		t.Fatalf("messages = %v, want one from each consumer", messages)
+	}
+}

--- a/internal/workflow/review_scope_identity_test.go
+++ b/internal/workflow/review_scope_identity_test.go
@@ -366,18 +366,18 @@ func TestReviewLegsAtHeadKeysOnIdentity(t *testing.T) {
 	}
 	for _, state := range []JobState{JobQueued, JobRunning, JobFailed, JobSucceeded, JobCancelled, JobBlocked} {
 		jobs := []db.Job{{ID: "leg", Agent: "audit", Type: "review", State: string(state), Payload: string(payload)}}
-		if _, held := reviewLegsAtHead(jobs, event, "review-2")["audit"]; !held {
+		if _, held := legsAtHeadForTest(t, jobs, event, "review-2")["audit"]; !held {
 			t.Fatalf("state %s: leg not recognised at this head and round", state)
 		}
 	}
 	jobs := []db.Job{{ID: "leg", Agent: "audit", Type: "review", State: string(JobQueued), Payload: string(payload)}}
 	// A different round at the same head is different work.
-	if _, held := reviewLegsAtHead(jobs, event, "review-3")["audit"]; held {
+	if _, held := legsAtHeadForTest(t, jobs, event, "review-3")["audit"]; held {
 		t.Fatal("a leg from another round was treated as this round's work")
 	}
 	// A different head in the same round is different work.
 	otherHead := reviewRefanoutEvent("head-three")
-	if _, held := reviewLegsAtHead(jobs, otherHead, "review-2")["audit"]; held {
+	if _, held := legsAtHeadForTest(t, jobs, otherHead, "review-2")["audit"]; held {
 		t.Fatal("a leg at another head was treated as this head's work")
 	}
 }


### PR DESCRIPTION
Part of #2008, head-keyed group. **`review_loop`'s two remaining consumers.**

**Stacked on #2031** (the foundation), which supplies `HeadBoundExclusion` and `RecordHeadBoundExclusion`. Review that one first. If #2031 is squash-merged, this branch must be rebuilt on the new base before it lands: a squash makes the parent's commits non-ancestors, so a stale stack can silently re-add or drop work.

## Behaviour is unchanged and no row gains a head

`reviewLegsAtHead` and `followUpReviewScopes` drop a review row carrying no head. **They are right to** - a verdict's head must be engine-observed, never caller-asserted (#1990). They did it silently, so a headless row vanished from the leg index and from follow-up scoping with no trace.

## Only the headless arm is recorded

Both consumers drop on a compound condition. Only the head-keyed part is a #2008 exclusion:

- **`reviewLegsAtHead`**: a row at a **different** head has an engine-observed head and simply is not this one. Not recorded.
- **`followUpReviewScopes`**: a row at the **current** head is skipped because it is not a previous round. Not recorded.

Recording those would bury the headless rows among thousands that are not.

**Round-keyed exclusions are untouched.** A headless row that is also roundless still gets only the head reason here; the round is a separate slice.

## `reviewLegsAtHead` becomes an Engine method

It was a pure function with no store, so it could not record. The alternative was re-deriving the dropped set in the caller, which would be **a second copy of this filter** and would drift from it. Three existing test call sites move to a helper; no assertion changed.

## The read path was verified, not assumed

The predicate reads `job.ExternallyDriven`. Had the read path not selected that column, every session row would have silently received the **weaker** reason - a misattribution in the opposite direction from the one the foundation was built to avoid. `nextReviewRound` reads through `ListJobs`, which uses `jobColumns`, which includes `externally_driven`. The fixture also asserts the flag survives the round trip, so a future projection change cannot make these tests quietly meaningless.

### Orphan events are refused rather than tolerated

The three moved call sites pass **unpersisted** fixture rows. `job_events` has no foreign key, so a recorder firing there would write an orphan **silently** rather than failing loudly - unlike production, and exactly the kind of permissiveness a test should not lean on.

It never fires, because every one of those fixtures records a head and the predicate refuses a non-empty head. The helper now **asserts** that rather than relying on it, so a future fixture that drops its head cannot start writing orphan events unnoticed.

The tests written for this slice persist real rows through `CreateJobWithEvent` / `CreateExternallyDrivenJobWithEvent` and read them back with `GetJob`.

## Six mutants, and one of them found dead code

| Mutant | Kills |
| --- | --- |
| M1 `reviewLegsAtHead` records nothing | its own test, both-consumers |
| M2 `followUpReviewScopes` records nothing | its own test, both-consumers |
| M3 record for **any** head mismatch, not only headless | legs-stays-silent **only** |
| M4 both consumers record under one name | follow-up-records, both-consumers |
| M5 `followUpReviewScopes` records for **both** arms | **nothing** |
| M6 the shared predicate stops refusing a non-empty head | both stays-silent tests, and the predicate's own test |

**M4 is the at-most-once arm.** `ClaimJobEvent` keys on the exact `(job_id, kind, message)` triple, so two consumers recording under one name collapse into a single event and the row loses which consumer excluded it.

### M5 killed nothing, and that was the useful result

`TestFollowUpReviewScopesStaysSilentForTheCurrentHead` had **no mutant that could kill it** - the empty column that slice 1 added as a control. Investigating rather than declaring it covered: the local `if previousHead == ""` guard I had written was **dead code**, because `HeadBoundExclusion` already refuses a non-empty head. The test could not fail because the protection lived somewhere else entirely.

The guard is removed rather than kept. **A second copy of a rule that currently agrees is the exact defect this campaign exists to remove**, and I had just written one. M6 breaks the real protection and kills both silence tests, so the column is filled by the mechanism that actually protects the behaviour.

## Verification

| Check | Result |
| --- | --- |
| `go build ./...` | ok |
| `go vet ./internal/workflow/` | ok |
| `gofmt -l internal/` | clean |
| filtered runs: every `review_loop`, review-scope, review-decision and head-bound family, plus the three pre-existing call sites moved | all pass |

**Local full verification is pending a disk constraint; CI is the gate.** Untargeted package runs are held fleet-wide while free space sits near the dispatch guard floor, so `go test ./internal/workflow/` was not run for this branch. That is a decision, not an omission. Filtered runs cover every test in the touched families including the pre-existing ones whose call sites changed.

`-race` not run: requires cgo, unavailable in this seat.

## Not claimed

- No count of rows this makes visible in production. The consumers run on daemon polls, so the population depends on traffic rather than on a stored column.
- Seven consumers in this group remain silent: `merge_gate:872`, `engine_routing_merge:529` and `:603`, `engine_pr_lifecycle:900`, `awaited_facts:191`, `daemon:2243`. `proof:206` is handled separately in #2032.
