### PR TITLE
fix(workflow): fail closed on an unresolvable runtime family (#2004)

### DIFF
--- a/internal/cli/daemon_merge_gate_active_job_test.go
+++ b/internal/cli/daemon_merge_gate_active_job_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/gitmoot/gitmoot/internal/config"
 	"github.com/gitmoot/gitmoot/internal/daemon"
 	"github.com/gitmoot/gitmoot/internal/db"
+	"github.com/gitmoot/gitmoot/internal/db/dbtest"
 	"github.com/gitmoot/gitmoot/internal/github"
 	"github.com/gitmoot/gitmoot/internal/github/githubtest"
 	"github.com/gitmoot/gitmoot/internal/subprocess"
@@ -743,6 +744,11 @@ func daemonMergeGateActiveJobFixture(t *testing.T, seedReview ...bool) (*db.Stor
 
 func seedDaemonMergeGateJob(t *testing.T, store *db.Store, job db.Job, payload workflow.JobPayload) {
 	t.Helper()
+	// #2004: the gate resolves a runtime family for the reviewer and every
+	// recorded implementer and fails closed when it cannot. These fixtures name
+	// an agent and never registered one, because nothing read a registration
+	// before. Production always has it.
+	dbtest.SeedGateFixtureAgent(t, store, job.Agent)
 	raw, err := json.Marshal(payload)
 	if err != nil {
 		t.Fatal(err)

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -1734,6 +1734,13 @@ func newSkippedFanoutPendingGateDaemon(t *testing.T, initialState workflow.TaskS
 	t.Helper()
 	ctx := context.Background()
 	store := testStore(t)
+	// #2004: the merge gate resolves a runtime FAMILY for the reviewer and every
+	// recorded implementer and fails closed when it cannot. This fixture names an
+	// agent and never registered one, which is a shape production does not have.
+	// Seeded here rather than at testStore, because a package-wide seed also
+	// registers agents for tests that deliberately model an ABSENT or unscoped
+	// one - measured: it turned four unrelated poll tests red.
+	dbtest.SeedGateFixtureAgent(t, store, "audit")
 	repo := github.Repository{Owner: "gitmoot", Name: "gitmoot"}
 	if err := store.UpsertTask(ctx, db.Task{
 		ID:           "task-7",

--- a/internal/daemon/external_merge_reconcile_test.go
+++ b/internal/daemon/external_merge_reconcile_test.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/gitmoot/gitmoot/internal/db"
+	"github.com/gitmoot/gitmoot/internal/db/dbtest"
 	"github.com/gitmoot/gitmoot/internal/github"
 	"github.com/gitmoot/gitmoot/internal/subprocess"
 	"github.com/gitmoot/gitmoot/internal/workflow"
@@ -317,6 +318,11 @@ func runBranchlessQueuedMergeTerminalPolls(t *testing.T, terminal github.PullReq
 		AutoMerge: true, Store: store, GitHub: client, Git: postMergeGit,
 		Worktrees: worktrees, NextTasks: nextTasks,
 	}
+	// #2004: the merge gate resolves a runtime FAMILY and fails closed when it
+	// cannot. Seeded here rather than at testStore, because a package-wide seed
+	// also registers agents for tests that model an ABSENT or unscoped one -
+	// measured: it turned four unrelated poll tests red.
+	dbtest.SeedGateFixtureAgent(t, store, "reviewer")
 	engine := workflow.Engine{Store: store, MergeGate: gate, RequiredReviewers: []string{"reviewer"}}
 	daemon := Daemon{Repo: repo, Store: store, GitHub: client, Workflow: &engine}
 

--- a/internal/daemon/merge_gate_transient_exit_test.go
+++ b/internal/daemon/merge_gate_transient_exit_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/gitmoot/gitmoot/internal/db"
+	"github.com/gitmoot/gitmoot/internal/db/dbtest"
 	"github.com/gitmoot/gitmoot/internal/github"
 	"github.com/gitmoot/gitmoot/internal/workflow"
 )
@@ -48,6 +49,15 @@ func seedBlockedReviewTask(t *testing.T, store *db.Store, repo github.Repository
 
 func seedBlockedReviewTaskAttributed(t *testing.T, store *db.Store, repo github.Repository, class workflow.MergeBlockClass, reason string, attribute bool) github.PullRequest {
 	t.Helper()
+	// #2004: the merge gate resolves a runtime FAMILY for the reviewer and every
+	// recorded implementer and fails closed when it cannot. This fixture names an
+	// agent and never registered one, a shape production does not have. Seeded at
+	// the fixture rather than at testStore: a package-wide seed also registers
+	// agents for tests that model an ABSENT or unscoped one, measured as four
+	// unrelated poll tests turning red.
+	for _, name := range []string{"audit", "reviewer", "implementer"} {
+		dbtest.SeedGateFixtureAgent(t, store, name)
+	}
 	ctx := context.Background()
 	if err := store.UpsertTask(ctx, db.Task{
 		ID:           "review-pr-1699-3f3a1026",

--- a/internal/daemon/poll_path_projection_test.go
+++ b/internal/daemon/poll_path_projection_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/gitmoot/gitmoot/internal/db"
+	"github.com/gitmoot/gitmoot/internal/db/dbtest"
 	"github.com/gitmoot/gitmoot/internal/github"
 	"github.com/gitmoot/gitmoot/internal/workflow"
 )
@@ -35,6 +36,10 @@ func seedLargeNonReviewJob(t *testing.T, store *db.Store) {
 
 func seedReviewJob(t *testing.T, store *db.Store, repo, id, headSHA string, state workflow.JobState, result *workflow.AgentResult) {
 	t.Helper()
+	// #2004: see the note in dbtest.SeedGateFixtureAgent - the merge gate now
+	// needs a resolvable runtime family for the agents a fixture names.
+	dbtest.SeedGateFixtureAgent(t, store, "audit")
+	dbtest.SeedGateFixtureAgent(t, store, "lead")
 	payload, err := json.Marshal(workflow.JobPayload{
 		Repo:        repo,
 		Branch:      "task-7",

--- a/internal/db/dbtest/dbtest.go
+++ b/internal/db/dbtest/dbtest.go
@@ -10,6 +10,7 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 	"testing"
 
@@ -186,4 +187,64 @@ func copyTemplateSnapshotIfMissing(snapshot []byte, path string) error {
 	}
 	complete = true
 	return nil
+}
+
+// gate fixture agents (#2004)
+//
+// The merge gate resolves a runtime FAMILY for the reviewer and every recorded
+// implementer, and fails closed when it cannot. Fixtures written before that
+// check existed name an agent and never register one, because nothing read a
+// registration. Production does not have that shape: a dispatched job's agent is
+// registered, or is a temp/ephemeral name derived from one that is.
+//
+// THIS LIVES HERE RATHER THAN IN EACH PACKAGE'S TEST FILES because internal/cli,
+// internal/daemon and internal/workflow all drive PolicyMergeGate and all three
+// already import dbtest. Three package-local copies would make the next change
+// to this contract cost three edits, and the third one gets missed - which is
+// the defect class the #1520 campaign exists to remove, arriving in test
+// infrastructure instead of production code.
+const (
+	tempAgentInfix      = "-temp-"
+	ephemeralAgentInfix = "-ephemeral-"
+)
+
+// SeedGateFixtureAgent registers a fixture agent on a runtime family of its own,
+// which is what every name-only gate expectation already assumed: two
+// differently-named agents are independent.
+//
+// It REFUSES synthetic names, because production refuses them. Temp workers
+// (`<parent>-temp-<job>`, minted in the daemon worker) and ephemeral delegation
+// agents (`<slug>-ephemeral-<hash>`, minted in the workflow result path) are
+// deliberately absent from the registry and resolve through their parent
+// instead. Registering one here resolves it directly and silently retires the
+// parent-walk tests that cover that path.
+//
+// Idempotent, so a fixture that wants two agents to SHARE a family can upsert
+// them onto one runtime itself and this will not overwrite it.
+func SeedGateFixtureAgent(t *testing.T, store *db.Store, name string) {
+	t.Helper()
+	name = strings.TrimSpace(name)
+	if name == "" || store == nil {
+		return
+	}
+	if index := strings.Index(name, tempAgentInfix); index > 0 {
+		return
+	}
+	if strings.Contains(name, ephemeralAgentInfix) {
+		return
+	}
+	if _, err := store.GetAgent(context.Background(), name); err == nil {
+		return
+	}
+	if err := store.UpsertAgent(context.Background(), db.Agent{
+		Name:           name,
+		Role:           "agent",
+		Runtime:        "rt-" + name,
+		RepoScope:      "gitmoot/gitmoot",
+		Capabilities:   []string{"review", "implement"},
+		AutonomyPolicy: "auto",
+		HealthStatus:   "ok",
+	}); err != nil {
+		t.Fatalf("SeedGateFixtureAgent(%s): %v", name, err)
+	}
 }

--- a/internal/workflow/changes_requested_wedge_test.go
+++ b/internal/workflow/changes_requested_wedge_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/gitmoot/gitmoot/internal/db"
+	"github.com/gitmoot/gitmoot/internal/db/dbtest"
 	"github.com/gitmoot/gitmoot/internal/github"
 )
 
@@ -83,6 +84,9 @@ func seedWedgedTask(t *testing.T, store *db.Store) {
 
 func seedReviewJob(t *testing.T, store *db.Store, id, agent, head, decision string, state JobState) {
 	t.Helper()
+	// #2004: the gate resolves a runtime family for this reviewer and fails closed
+	// when it cannot. This fixture names an agent and never registered one.
+	dbtest.SeedGateFixtureAgent(t, store, agent)
 	payload := JobPayload{
 		Repo:        "gitmoot/gitmoot",
 		Branch:      "task-9",

--- a/internal/workflow/engine_test.go
+++ b/internal/workflow/engine_test.go
@@ -3427,6 +3427,13 @@ func enableAutoFix(t *testing.T, store *db.Store, pullRequest int) {
 
 func insertCompletedJob(t *testing.T, store *db.Store, job db.Job, payload JobPayload) {
 	t.Helper()
+	// #2004: the merge gate now resolves a runtime FAMILY and fails closed when it
+	// cannot. These fixtures predate that and name agents without registering
+	// them, which is a shape production does not have - a dispatched job's agent
+	// is registered, or is a temp/ephemeral name derived from one that is.
+	// Registering each on a family of its own preserves what every name-only
+	// expectation in this suite already assumed.
+	seedMergeGateFixtureAgent(t, store, job.Agent)
 	encoded, err := marshalPayload(payload)
 	if err != nil {
 		t.Fatalf("marshalPayload returned error: %v", err)

--- a/internal/workflow/merge_gate.go
+++ b/internal/workflow/merge_gate.go
@@ -2693,6 +2693,19 @@ func (g PolicyMergeGate) sameRuntimeFamilyAsImplementer(ctx context.Context, rev
 	sort.Strings(names)
 	for _, name := range names {
 		identity := implementers[name]
+		// THE SAME DOMAIN EXCLUSION, ON THE IMPLEMENTER SIDE. A role-attributed
+		// implementer (#1916) is a human session, not a runtime agent, so it has no
+		// family to share and comparing one is the same category error as on the
+		// reviewer side. Keyed on the recorded flag, never on an empty family,
+		// because an unregistered AGENT implementer looks identical and must keep
+		// failing closed.
+		//
+		// A role that implemented and then approved its own work is still refused:
+		// the caller tests implementingAgents[reviewer] by name before reaching
+		// here, and both sides normalize to the same role string.
+		if identity.FromActingRole {
+			continue
+		}
 		family, ok, err := ResolveRuntimeFamily(ctx, g.Store, identity.JobID, name, identity.RecordedRuntime)
 		if err != nil {
 			return false, "", err

--- a/internal/workflow/merge_gate.go
+++ b/internal/workflow/merge_gate.go
@@ -1227,7 +1227,7 @@ func (g PolicyMergeGate) ensureFinalReviewCaptured(ctx context.Context, request 
 			// unattributed and refused it BEFORE the independence check ever ran, so a
 			// role could never approve anything - and the role's own self-approval was
 			// never even tested for. Agent still wins whenever present.
-			reviewer := effectiveReviewerIdentityName(review.job, review.payload)
+			reviewer, reviewerFromRole := effectiveReviewerIdentity(review.job, review.payload)
 			if JobState(review.job.State) != JobSucceeded {
 				return fmt.Errorf("reviewer %s at evaluated head has unusable job state %s (job %s)", reviewer, review.job.State, review.job.ID)
 			}
@@ -1274,7 +1274,7 @@ func (g PolicyMergeGate) ensureFinalReviewCaptured(ctx context.Context, request 
 						selfApprovalReason = fmt.Sprintf("latest review round's approval was authored by %s, the implementing agent; an independent reviewer is required", reviewer)
 					}
 					if selfApprovalReason == "" {
-						sameFamily, familyReason, err := g.sameRuntimeFamilyAsImplementer(ctx, review.job.ID, reviewer, review.payload.EffectiveRuntime, implementingAgents)
+						sameFamily, familyReason, err := g.sameRuntimeFamilyAsImplementer(ctx, review.job.ID, reviewer, reviewerFromRole, review.payload.EffectiveRuntime, implementingAgents)
 						if err != nil {
 							return err
 						}
@@ -1351,7 +1351,7 @@ func (g PolicyMergeGate) ensureFinalReviewCaptured(ctx context.Context, request 
 		if effectiveReviewDecisionForPayload(payload, request.ReviewBlockingSeverity) == "approved" {
 			// Same rule, same helper (#1950 F4): the latest-round arm resolved identity
 			// separately, which is the fourth copy that ruling 126350 removes.
-			reviewerAgent := effectiveReviewerIdentityName(job, payload)
+			reviewerAgent, reviewerFromRole := effectiveReviewerIdentity(job, payload)
 			switch {
 			case reviewerAgent == "":
 				if unattributedReviewerReason == "" {
@@ -1370,7 +1370,7 @@ func (g PolicyMergeGate) ensureFinalReviewCaptured(ctx context.Context, request 
 					}
 					continue
 				}
-				sameFamily, familyReason, err := g.sameRuntimeFamilyAsImplementer(ctx, job.ID, reviewerAgent, payload.EffectiveRuntime, implementingAgents)
+				sameFamily, familyReason, err := g.sameRuntimeFamilyAsImplementer(ctx, job.ID, reviewerAgent, reviewerFromRole, payload.EffectiveRuntime, implementingAgents)
 				if err != nil {
 					return err
 				}
@@ -2654,8 +2654,25 @@ func parseRepoFullName(value string) (github.Repository, error) {
 // whose runtime nothing records cannot be shown not to. The observation row is
 // still written, so the reason survives past the decision.
 func (g PolicyMergeGate) sameRuntimeFamilyAsImplementer(ctx context.Context, reviewJobID string, reviewer string,
-	reviewerRuntime string, implementers map[string]implementerIdentity) (bool, string, error) {
+	reviewerFromActingRole bool, reviewerRuntime string, implementers map[string]implementerIdentity) (bool, string, error) {
 	if g.Store == nil || strings.TrimSpace(reviewer) == "" || len(implementers) == 0 {
+		return false, "", nil
+	}
+	// A ROLE IS OUTSIDE THIS PREDICATE'S DOMAIN, NOT AN UNRESOLVED VALUE WITHIN IT
+	// (#2004). A role-authored review is a human session (#1916): there is no
+	// runtime family to share with anyone, so comparing families is a category
+	// error rather than a missing measurement.
+	//
+	// THE FLAG IS PLUMBED EXPLICITLY AND IS NEVER INFERRED FROM AN EMPTY FAMILY.
+	// An unregistered AGENT also resolves to no family, and that case must keep
+	// failing closed; deciding this on "the family came back empty" would collapse
+	// the two and reopen the hole this change closes.
+	//
+	// This is a domain exclusion rather than an exemption because every other
+	// independence check still binds a role: the caller tests
+	// implementingAgents[reviewer] BEFORE reaching here, so a role approving its
+	// own implementation is still refused on identity. That arm has its own test.
+	if reviewerFromActingRole {
 		return false, "", nil
 	}
 	reviewerFamily, ok, err := ResolveRuntimeFamily(ctx, g.Store, reviewJobID, reviewer, reviewerRuntime)

--- a/internal/workflow/merge_gate.go
+++ b/internal/workflow/merge_gate.go
@@ -2634,21 +2634,25 @@ func parseRepoFullName(value string) (github.Repository, error) {
 // falls back to the agent registry default, so an override-run job attributes
 // correctly even after its agent's default later changes.
 //
-// UNRESOLVABLE IS NOT SILENTLY CLEAN, AND IT IS ALSO NOT A BLOCK. This is the
-// tension #1531's own comment warns about: "doing (2) without (1) produces a
-// gate that silently passes whenever the field is absent". Re-measured on jobs
-// since 2026-08-25, resolution now covers 1335 of 1432 reviews and 427 of 449
-// implement jobs once the registry fallback is counted - 93 to 95 percent, up
-// from the 11 percent that made the issue defer this. The residue is dominated
-// by EPHEMERAL and TEMP agents, which are deliberately absent from the registry,
-// plus rows with an empty agent column.
+// UNRESOLVABLE NOW BLOCKS (#2004). #1531 shipped this falling through to the
+// name check, because refusing then would have blocked the native review
+// fanout: its lens legs are ephemeral by construction and ephemeral agents are
+// deliberately absent from the registry. #2004 removed that objection by
+// teaching the shared resolver to recover a synthetic agent's family from its
+// parent, so the residue no longer contains the thing the fall-through was
+// protecting.
 //
-// Refusing on that residue would block the native review fanout, whose lens legs
-// are ephemeral by construction, so an unresolved family falls through to the
-// name check exactly as before AND records why it could not be compared. That
-// keeps the gate's behaviour unchanged where it cannot see, while never claiming
-// a check it did not perform. Making the residue resolvable - temp agent names
-// embed their parent - is the follow-up that would let this fail closed.
+// Measured on review and implement jobs since 2026-08-25, after parent
+// recovery: 17 of 1,903 rows resolve to no family. Eleven have an empty agent
+// column and CANNOT REACH THIS FUNCTION - collectImplementerAttributionMatching
+// routes them to sawEmptyAgent and its own attribution reason - so the exposure
+// is the six rows naming an agent that is simply not registered, all implement
+// rows, none of them on an open pull request.
+//
+// Blocking is the honest answer for those six: the gate's property is that the
+// approver did not share a runtime family with an implementer, and an agent
+// whose runtime nothing records cannot be shown not to. The observation row is
+// still written, so the reason survives past the decision.
 func (g PolicyMergeGate) sameRuntimeFamilyAsImplementer(ctx context.Context, reviewJobID string, reviewer string,
 	reviewerRuntime string, implementers map[string]implementerIdentity) (bool, string, error) {
 	if g.Store == nil || strings.TrimSpace(reviewer) == "" || len(implementers) == 0 {
@@ -2659,9 +2663,11 @@ func (g PolicyMergeGate) sameRuntimeFamilyAsImplementer(ctx context.Context, rev
 		return false, "", err
 	}
 	if !ok {
-		g.recordFamilyUnresolved(ctx, reviewJobID, fmt.Sprintf(
-			"runtime family unresolved for reviewer %q; independence was decided on agent name alone", reviewer))
-		return false, "", nil
+		reason := fmt.Sprintf(
+			"runtime family unresolved for reviewer %q, so cross-family independence cannot be shown; register the agent with a runtime, or re-run the review on an agent whose runtime is recorded",
+			reviewer)
+		g.recordFamilyUnresolved(ctx, reviewJobID, reason)
+		return true, reason, nil
 	}
 	names := make([]string, 0, len(implementers))
 	for name := range implementers {
@@ -2675,9 +2681,11 @@ func (g PolicyMergeGate) sameRuntimeFamilyAsImplementer(ctx context.Context, rev
 			return false, "", err
 		}
 		if !ok {
-			g.recordFamilyUnresolved(ctx, reviewJobID, fmt.Sprintf(
-				"runtime family unresolved for implementer %q; independence was decided on agent name alone", name))
-			continue
+			reason := fmt.Sprintf(
+				"runtime family unresolved for implementer %q, so cross-family independence cannot be shown; register the agent with a runtime, or record the runtime the implement job ran on",
+				name)
+			g.recordFamilyUnresolved(ctx, reviewJobID, reason)
+			return true, reason, nil
 		}
 		if family == reviewerFamily {
 			return true, fmt.Sprintf(

--- a/internal/workflow/merge_gate_family_1531_test.go
+++ b/internal/workflow/merge_gate_family_1531_test.go
@@ -107,14 +107,22 @@ func TestMergeGateRecordsAnUnresolvableFamilyRatherThanClaimingAClean(t *testing
 	})
 	gate := PolicyMergeGate{Store: store}
 
-	// The reviewer is an ephemeral agent: not in the registry, no recorded runtime.
-	same, _, err := gate.sameRuntimeFamilyAsImplementer(ctx, "review-job", "lens-ephemeral-abc", "",
+	// The reviewer is an ephemeral agent with no parent recorded: not in the
+	// registry, no recorded runtime, and nothing for #2004's parent recovery to
+	// walk to. #1531 shipped this falling THROUGH to the name check because
+	// refusing then would have blocked the native review fanout. #2004 removed
+	// that objection by making the fanout's own ephemeral legs resolvable, so what
+	// remains here is a genuinely unknown family, and the gate now refuses it.
+	same, reason, err := gate.sameRuntimeFamilyAsImplementer(ctx, "review-job", "lens-ephemeral-abc", "",
 		map[string]implementerIdentity{"wave-impl": {Name: "wave-impl", RecordedRuntime: "codex"}})
 	if err != nil {
 		t.Fatalf("sameRuntimeFamilyAsImplementer: %v", err)
 	}
-	if same {
-		t.Fatal("an unresolvable family was reported as a same-family match; absence is not evidence")
+	if !same {
+		t.Fatal("an unresolvable family did not block; independence that cannot be shown must not be assumed")
+	}
+	if !strings.Contains(reason, "lens-ephemeral-abc") {
+		t.Fatalf("block reason = %q, want the unresolvable reviewer named", reason)
 	}
 	events, err := store.ListJobEvents(ctx, "review-job")
 	if err != nil {

--- a/internal/workflow/merge_gate_family_1531_test.go
+++ b/internal/workflow/merge_gate_family_1531_test.go
@@ -36,7 +36,7 @@ func TestMergeGateRefusesASameFamilyApprovalWithADifferentAgentName(t *testing.T
 	implementers := map[string]implementerIdentity{
 		"wave-impl": {Name: "wave-impl", RecordedRuntime: "codex"},
 	}
-	same, reason, err := gate.sameRuntimeFamilyAsImplementer(ctx, "review-job", "g7-review", "codex", implementers)
+	same, reason, err := gate.sameRuntimeFamilyAsImplementer(ctx, "review-job", "g7-review", false, "codex", implementers)
 	if err != nil {
 		t.Fatalf("sameRuntimeFamilyAsImplementer: %v", err)
 	}
@@ -59,7 +59,7 @@ func TestMergeGateAcceptsACrossFamilyApproval(t *testing.T) {
 	seedFamilyAgent(t, store, "gm-review-opus", "claude")
 	gate := PolicyMergeGate{Store: store}
 
-	same, reason, err := gate.sameRuntimeFamilyAsImplementer(ctx, "review-job", "gm-review-opus", "claude",
+	same, reason, err := gate.sameRuntimeFamilyAsImplementer(ctx, "review-job", "gm-review-opus", false, "claude",
 		map[string]implementerIdentity{"wave-impl": {Name: "wave-impl", RecordedRuntime: "codex"}})
 	if err != nil {
 		t.Fatalf("sameRuntimeFamilyAsImplementer: %v", err)
@@ -80,7 +80,7 @@ func TestMergeGateUsesTheRuntimeAJobActuallyRanOn(t *testing.T) {
 	seedFamilyAgent(t, store, "g7-review", "codex")
 	gate := PolicyMergeGate{Store: store}
 
-	same, _, err := gate.sameRuntimeFamilyAsImplementer(ctx, "review-job", "g7-review", "kimi",
+	same, _, err := gate.sameRuntimeFamilyAsImplementer(ctx, "review-job", "g7-review", false, "kimi",
 		map[string]implementerIdentity{"wave-impl": {Name: "wave-impl", RecordedRuntime: "codex"}})
 	if err != nil {
 		t.Fatalf("sameRuntimeFamilyAsImplementer: %v", err)
@@ -113,7 +113,7 @@ func TestMergeGateRecordsAnUnresolvableFamilyRatherThanClaimingAClean(t *testing
 	// refusing then would have blocked the native review fanout. #2004 removed
 	// that objection by making the fanout's own ephemeral legs resolvable, so what
 	// remains here is a genuinely unknown family, and the gate now refuses it.
-	same, reason, err := gate.sameRuntimeFamilyAsImplementer(ctx, "review-job", "lens-ephemeral-abc", "",
+	same, reason, err := gate.sameRuntimeFamilyAsImplementer(ctx, "review-job", "lens-ephemeral-abc", false, "",
 		map[string]implementerIdentity{"wave-impl": {Name: "wave-impl", RecordedRuntime: "codex"}})
 	if err != nil {
 		t.Fatalf("sameRuntimeFamilyAsImplementer: %v", err)

--- a/internal/workflow/merge_gate_role_domain_2004_test.go
+++ b/internal/workflow/merge_gate_role_domain_2004_test.go
@@ -1,0 +1,85 @@
+package workflow
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/gitmoot/gitmoot/internal/db"
+)
+
+// #2004 acceptance 3, ruling (b): a role-authored reviewer is OUTSIDE the
+// runtime-family predicate's domain rather than an unresolved value inside it.
+//
+// The three arms below are one property, and arm 2 is the one that earns arm 1.
+// An exclusion that switched off the family check would be indistinguishable
+// from an exemption if nothing else still bound a role. Arm 2 shows something
+// does: a role approving its own implementation is refused on IDENTITY, before
+// the family check is ever reached. Arm 3 shows the exclusion did not leak to
+// the case that must keep failing closed - an unregistered AGENT also resolves
+// to no family, and inferring the exclusion from an empty family rather than
+// from the plumbed flag would collapse the two.
+
+func seedRoleDomainImplementer(t *testing.T, store *db.Store, agent string, runtime string) {
+	t.Helper()
+	if runtime != "" {
+		seedFamilyAgent(t, store, agent, runtime)
+	}
+	insertCompletedJob(t, store, db.Job{ID: "implement-" + agent, Agent: agent, Type: "implement"}, JobPayload{
+		Repo: "gitmoot/gitmoot", PullRequest: 9,
+	})
+}
+
+// Arm 1: the family check does not apply to a role, so a role-authored approval
+// by someone who did not implement is not blocked. A human session has no
+// runtime family to share.
+func TestRoleAuthoredApprovalIsOutsideTheFamilyCheck(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	seedRoleDomainImplementer(t, store, "wave-impl", "codex")
+	gate := PolicyMergeGate{Store: store}
+
+	same, reason, err := gate.sameRuntimeFamilyAsImplementer(ctx, "review-job", "reviewer", true, "",
+		map[string]implementerIdentity{"wave-impl": {Name: "wave-impl", RecordedRuntime: "codex"}})
+	if err != nil {
+		t.Fatalf("sameRuntimeFamilyAsImplementer: %v", err)
+	}
+	if same {
+		t.Fatalf("a role-authored approval was blocked on runtime family: %q; a role has no family to share", reason)
+	}
+}
+
+// ARM 2 IS NOT WRITTEN HERE, ON PURPOSE. It already exists and already drives
+// the real Evaluate path: TestPolicyMergeGateReachesIndependenceForARoleAuthoredApproval
+// carries the table case "the SAME role that implemented cannot approve its own
+// work", expecting zero merges with the reason "the implementing agent". That is
+// the arm that makes arm 1 a domain exclusion instead of an exemption, and its
+// reason string is the proof the refusal comes from IDENTITY rather than from a
+// family a role does not have.
+//
+// Re-asserting it here would be a second, weaker copy: my first draft checked the
+// same implementer map twice and never reached Evaluate, which would have passed
+// against a gate that let a role self-approve a merge. What matters is that the
+// pre-existing case still passes WITH the exclusion applied, and it does.
+
+// Arm 3: the exclusion is keyed on the plumbed flag, never on an empty family.
+// An unregistered AGENT produces exactly the same empty family and must keep
+// failing closed.
+func TestUnregisteredAgentReviewerStillFailsClosed(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	seedRoleDomainImplementer(t, store, "wave-impl", "codex")
+	gate := PolicyMergeGate{Store: store}
+
+	same, reason, err := gate.sameRuntimeFamilyAsImplementer(ctx, "review-job", "gm-omp-nag", false, "",
+		map[string]implementerIdentity{"wave-impl": {Name: "wave-impl", RecordedRuntime: "codex"}})
+	if err != nil {
+		t.Fatalf("sameRuntimeFamilyAsImplementer: %v", err)
+	}
+	if !same {
+		t.Fatal("an unregistered agent reviewer did not fail closed; its family is as empty as a role's and it is not a role")
+	}
+	if !strings.Contains(reason, "gm-omp-nag") {
+		t.Fatalf("block reason = %q, want the unresolvable reviewer named", reason)
+	}
+}

--- a/internal/workflow/merge_gate_role_domain_2004_test.go
+++ b/internal/workflow/merge_gate_role_domain_2004_test.go
@@ -83,3 +83,45 @@ func TestUnregisteredAgentReviewerStillFailsClosed(t *testing.T) {
 		t.Fatalf("block reason = %q, want the unresolvable reviewer named", reason)
 	}
 }
+
+// The implementer side of arm 1, which CI found and my filtered run could not:
+// TestRoleImplementedTaskIsAttributable lives outside every pattern I ran. A
+// role-attributed implementer (#1916) is a human session with no runtime family,
+// so an agent reviewing its work is independent and must not be blocked.
+func TestRoleAttributedImplementerIsOutsideTheFamilyCheck(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	seedFamilyAgent(t, store, "g7-review", "codex")
+	gate := PolicyMergeGate{Store: store}
+
+	same, reason, err := gate.sameRuntimeFamilyAsImplementer(ctx, "review-job", "g7-review", false, "codex",
+		map[string]implementerIdentity{"gitmoot": {Name: "gitmoot", FromActingRole: true}})
+	if err != nil {
+		t.Fatalf("sameRuntimeFamilyAsImplementer: %v", err)
+	}
+	if same {
+		t.Fatalf("an agent reviewer was blocked against a ROLE implementer: %q; a role has no family to share", reason)
+	}
+}
+
+// And its control: an implementer that is an unregistered AGENT, not a role,
+// produces the identical empty family and must still fail closed. Without this
+// the arm above is satisfied by skipping every unresolvable implementer.
+func TestUnregisteredAgentImplementerStillFailsClosed(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	seedFamilyAgent(t, store, "g7-review", "codex")
+	gate := PolicyMergeGate{Store: store}
+
+	same, reason, err := gate.sameRuntimeFamilyAsImplementer(ctx, "review-job", "g7-review", false, "codex",
+		map[string]implementerIdentity{"gm-omp-nag": {Name: "gm-omp-nag"}})
+	if err != nil {
+		t.Fatalf("sameRuntimeFamilyAsImplementer: %v", err)
+	}
+	if !same {
+		t.Fatal("an unregistered agent implementer did not fail closed; it is not a role and its family is unknown")
+	}
+	if !strings.Contains(reason, "gm-omp-nag") {
+		t.Fatalf("block reason = %q, want the unresolvable implementer named", reason)
+	}
+}

--- a/internal/workflow/merge_gate_test.go
+++ b/internal/workflow/merge_gate_test.go
@@ -98,7 +98,7 @@ func seedMergeGateFixtureAgent(t *testing.T, store *db.Store, name string) {
 	// the production registry by design, and #2004's parent recovery is the thing
 	// that resolves them; a fixture that registers one resolves it directly and
 	// silently stops exercising the walk.
-	if _, isTemp := splitTempAgentName(name); isTemp || strings.Contains(name, ephemeralAgentInfix) {
+	if _, _, isTemp := splitTempAgentName(name); isTemp || strings.Contains(name, ephemeralAgentInfix) {
 		return
 	}
 	if _, err := store.GetAgent(context.Background(), name); err == nil {

--- a/internal/workflow/merge_gate_test.go
+++ b/internal/workflow/merge_gate_test.go
@@ -19,6 +19,7 @@ import (
 
 func insertIndependentMergeGateReview(t *testing.T, store *db.Store, reviewJob db.Job, reviewPayload JobPayload) {
 	t.Helper()
+	seedMergeGateFixtureAgent(t, store, reviewJob.Agent)
 	implementingAgent := "implementer"
 	if strings.TrimSpace(reviewJob.Agent) == implementingAgent {
 		implementingAgent = "different-implementer"
@@ -26,6 +27,7 @@ func insertIndependentMergeGateReview(t *testing.T, store *db.Store, reviewJob d
 	implementPayload := reviewPayload
 	implementPayload.ReviewRound = ""
 	implementPayload.Result = &AgentResult{Decision: "implemented", Summary: "implemented"}
+	seedMergeGateFixtureAgent(t, store, implementingAgent)
 	insertCompletedJob(t, store, db.Job{
 		ID:    reviewJob.ID + "-implement-author",
 		Agent: implementingAgent,
@@ -77,8 +79,47 @@ func newMergeGateQuorumScenario(t *testing.T) (*db.Store, *fakeMergeGateGitHub, 
 	return store, gh, gate, request
 }
 
+// seedMergeGateFixtureAgent registers a fixture agent on a runtime family OF ITS
+// OWN (#2004). These tests were written against a gate that compared agent
+// NAMES, so they implicitly assume two differently-named agents are independent.
+// Once the gate resolves families and fails closed on an unresolvable one, that
+// assumption has to be stated rather than implied: one family per name preserves
+// every existing expectation, while an unregistered agent would now block.
+//
+// Deliberately idempotent and name-derived, so a test that wants a SHARED family
+// still gets one by upserting the two agents onto the same runtime itself.
+func seedMergeGateFixtureAgent(t *testing.T, store *db.Store, name string) {
+	t.Helper()
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return
+	}
+	// Never register a SYNTHETIC agent. Temp and ephemeral agents are absent from
+	// the production registry by design, and #2004's parent recovery is the thing
+	// that resolves them; a fixture that registers one resolves it directly and
+	// silently stops exercising the walk.
+	if _, isTemp := splitTempAgentName(name); isTemp || strings.Contains(name, ephemeralAgentInfix) {
+		return
+	}
+	if _, err := store.GetAgent(context.Background(), name); err == nil {
+		return
+	}
+	if err := store.UpsertAgent(context.Background(), db.Agent{
+		Name:           name,
+		Role:           "agent",
+		Runtime:        "rt-" + name,
+		RepoScope:      "gitmoot/gitmoot",
+		Capabilities:   []string{"review", "implement"},
+		AutonomyPolicy: "auto",
+		HealthStatus:   "ok",
+	}); err != nil {
+		t.Fatalf("UpsertAgent(%s) returned error: %v", name, err)
+	}
+}
+
 func insertMergeGateReviewFixture(t *testing.T, store *db.Store, fixture mergeGateReviewFixture) {
 	t.Helper()
+	seedMergeGateFixtureAgent(t, store, fixture.agent)
 	state := fixture.state
 	if state == "" {
 		state = JobSucceeded
@@ -6497,6 +6538,8 @@ func TestPolicyMergeGateAdmitsCLIReviewsAndRefusesAtHeadFanOut(t *testing.T) {
 			id: "review-approval", agent: "audit", decision: "approved", hasResult: true,
 		})
 		mailbox := Mailbox{store: store, resolveDeliveryWorktree: ExcludedDeliveryWorktreeResolver("test_explicit_no_worktree")}
+		// #2004: the gate resolves a runtime family for this reviewer.
+		seedMergeGateFixtureAgent(t, store, "returning-reviewer")
 		if _, err := mailbox.OpenExternalJob(ctx, JobRequest{
 			ID: "cli-session-objection", Agent: "returning-reviewer", Action: "review",
 			Repo: "gitmoot/gitmoot", PullRequest: 9, TaskID: "task-9", Sender: "session",
@@ -6629,6 +6672,8 @@ func TestPolicyMergeGateAdmitsCLIReviewsAndRefusesAtHeadFanOut(t *testing.T) {
 			id: "review-approval", agent: "audit", decision: "approved", hasResult: true,
 		})
 		mailbox := Mailbox{store: store, resolveDeliveryWorktree: ExcludedDeliveryWorktreeResolver("test_explicit_no_worktree")}
+		// #2004: the gate resolves a runtime family for this reviewer.
+		seedMergeGateFixtureAgent(t, store, "asym-reviewer")
 		if _, err := mailbox.OpenExternalJob(ctx, JobRequest{
 			ID: "asym-objection", Agent: "asym-reviewer", Action: "review",
 			Repo: "gitmoot/gitmoot", PullRequest: 9, TaskID: "task-9", Sender: "session",
@@ -6774,6 +6819,8 @@ func TestPolicyMergeGateProvenanceScopeMatrix(t *testing.T) {
 				id: "review-approval", agent: "audit", decision: "approved", hasResult: true,
 			})
 			mailbox := Mailbox{store: store, resolveDeliveryWorktree: ExcludedDeliveryWorktreeResolver("test_explicit_no_worktree")}
+			// #2004: the gate resolves a runtime family for this reviewer.
+			seedMergeGateFixtureAgent(t, store, "matrix-reviewer")
 			if _, err := mailbox.OpenExternalJob(ctx, JobRequest{
 				ID: "matrix-objection", Agent: "matrix-reviewer", Action: "review",
 				Repo: "gitmoot/gitmoot", PullRequest: 9, TaskID: "task-9", Sender: "session",

--- a/internal/workflow/merge_gate_test.go
+++ b/internal/workflow/merge_gate_test.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/gitmoot/gitmoot/internal/db"
+	"github.com/gitmoot/gitmoot/internal/db/dbtest"
 	"github.com/gitmoot/gitmoot/internal/github"
 	"github.com/gitmoot/gitmoot/internal/reviewseverity"
 	"github.com/gitmoot/gitmoot/internal/subprocess"
@@ -79,42 +80,14 @@ func newMergeGateQuorumScenario(t *testing.T) (*db.Store, *fakeMergeGateGitHub, 
 	return store, gh, gate, request
 }
 
-// seedMergeGateFixtureAgent registers a fixture agent on a runtime family OF ITS
-// OWN (#2004). These tests were written against a gate that compared agent
-// NAMES, so they implicitly assume two differently-named agents are independent.
-// Once the gate resolves families and fails closed on an unresolvable one, that
-// assumption has to be stated rather than implied: one family per name preserves
-// every existing expectation, while an unregistered agent would now block.
-//
-// Deliberately idempotent and name-derived, so a test that wants a SHARED family
-// still gets one by upserting the two agents onto the same runtime itself.
+// seedMergeGateFixtureAgent delegates to the SHARED helper (#2004). It stays as
+// a one-line wrapper only because this package's fixtures call it in a dozen
+// places; the rule itself - one family per name, and never register a synthetic
+// agent - lives in dbtest, so internal/cli and internal/daemon get the same one
+// instead of a third copy that drifts.
 func seedMergeGateFixtureAgent(t *testing.T, store *db.Store, name string) {
 	t.Helper()
-	name = strings.TrimSpace(name)
-	if name == "" {
-		return
-	}
-	// Never register a SYNTHETIC agent. Temp and ephemeral agents are absent from
-	// the production registry by design, and #2004's parent recovery is the thing
-	// that resolves them; a fixture that registers one resolves it directly and
-	// silently stops exercising the walk.
-	if _, _, isTemp := splitTempAgentName(name); isTemp || strings.Contains(name, ephemeralAgentInfix) {
-		return
-	}
-	if _, err := store.GetAgent(context.Background(), name); err == nil {
-		return
-	}
-	if err := store.UpsertAgent(context.Background(), db.Agent{
-		Name:           name,
-		Role:           "agent",
-		Runtime:        "rt-" + name,
-		RepoScope:      "gitmoot/gitmoot",
-		Capabilities:   []string{"review", "implement"},
-		AutonomyPolicy: "auto",
-		HealthStatus:   "ok",
-	}); err != nil {
-		t.Fatalf("UpsertAgent(%s) returned error: %v", name, err)
-	}
+	dbtest.SeedGateFixtureAgent(t, store, name)
 }
 
 func insertMergeGateReviewFixture(t *testing.T, store *db.Store, fixture mergeGateReviewFixture) {


### PR DESCRIPTION
Acceptance 3 of #2004, under phobos's ruling (b). **Stacked on #2025** - review
that first; this PR's diff against `main` includes it.

> **Local full verification pending a disk constraint, CI is the gate.** An
> untargeted package run is unavailable under the current fleet disk hold. What
> ran here: `go build ./...`, `go vet ./internal/workflow/`, `gofmt`, and a
> filtered `Family|MergeGate|Merge|RoleAuthored|Unregistered|RuntimeFamily|ParentWalk`
> run, green in 36s. **A filtered run cannot detect a change to a shared
> fixture**, and this PR changes one (`insertCompletedJob`), so that gap is real
> and stated rather than omitted.

## What changes

`PolicyMergeGate.sameRuntimeFamilyAsImplementer` now **blocks** when a reviewer's
or an implementer's runtime family cannot be resolved, instead of falling through
to the agent-name comparison. #1531 shipped the fall-through because refusing
then would have blocked the native review fanout, whose lens legs are ephemeral
by construction. #2025 removed that objection.

## A role is outside the predicate, an unknown agent is not

A role-authored review is a human session (#1916). It has no runtime family to
share, so comparing families is a **category error**, not a missing measurement.
The gate skips the family check for it.

That is a domain exclusion rather than an exemption only because everything else
still binds a role, and the acceptance for it was three arms:

| arm | where |
|---|---|
| 1. role approval, role != implementer, family check not applied | `TestRoleAuthoredApprovalIsOutsideTheFamilyCheck` |
| 2. role approval, role == implementer, **REFUSED on identity** | already existed: `TestPolicyMergeGateReachesIndependenceForARoleAuthoredApproval`, case "the SAME role that implemented cannot approve its own work" |
| 3. unregistered **agent**, identically empty family, **still fails closed** | `TestUnregisteredAgentReviewerStillFailsClosed` |

**Arm 2 needed no new test and I deleted the one I wrote.** It already exists,
already drives the real `Evaluate` path, expects zero merges, and cites "the
implementing agent" - identity, not family - and it passes with the exclusion
applied, which is the proof. My draft replacement asserted on the same
implementer map twice and never reached `Evaluate`; it would have passed against
a gate that lets a role self-approve its own merge. An extra green test costs
nothing visible, which is exactly why it had to go.

**Arm 3 is what keeps this honest later.** `gm-omp-nag` is an unregistered agent
whose family is as empty as a role's. Anyone who "simplifies" the exclusion into
a family-emptiness test turns that arm red. The flag is plumbed explicitly from
`effectiveReviewerIdentity` through both call sites and is **never** inferred
from an empty family.

## The 74 red tests, and what they were

One shared cause: fixtures name a reviewer agent and never register it, a shape
production does not have. Seeded at the three shared insertion points plus the
three `OpenExternalJob` sites that build a `JobRequest` and bypass all three,
each agent on a runtime family of its own - which is what every name-only
expectation in that suite already assumed. **No predicate was narrowed to buy a
test back.**

Two follow-on corrections, both mine, both caught here:

- The seeder must **refuse synthetic names**. Registering a temp or ephemeral
  agent - which production never does - resolves it directly and silently retires
  #2025's parent-walk tests. My own new tests, passing for the wrong reason.
- `TestUnregisteredPlainNameStillDoesNotResolve` was fed the very agent it was
  controlling for. It now bypasses the helper and asserts the agent is absent
  **first**, so it cannot pass vacuously.

`TestMergeGateRecordsAnUnresolvableFamilyRatherThanClaimingAClean` is re-pinned
to the new contract. It asserted the behaviour this change deliberately removes,
so re-pinning is correct handling rather than wording churn.

## Measured exposure

On review and implement jobs since 2026-08-25, after #2025's parent recovery,
**17 of 1,903** rows resolve to no family. Eleven have an empty agent column and
**cannot reach this function at all** -
`collectImplementerAttributionMatching` routes them to `sawEmptyAgent` and its own
attribution reason - leaving **6 implement rows naming unregistered agents, none
on an open pull request**.

Plus exactly **one** role-authored review in the whole store: an approval, no
payload runtime, no runtime event. Option (a), blocking it, would have broken a
path the product advertises to protect one historical row. Recorded here so
nobody reopens (a) as an oversight.

Deploy notes: no config, no migration, no schema change.
