### PR TITLE
fix(db): take the write lock with the first statement in the wake transactions (#2028)

### DIFF
--- a/internal/db/wake_outbox.go
+++ b/internal/db/wake_outbox.go
@@ -470,6 +470,39 @@ func (s *Store) ExpireAgedWakeOutbox(ctx context.Context, attemptedBefore, at ti
 	}
 	defer func() { _ = tx.Rollback() }()
 
+	// WRITE-FIRST BY CONSTRUCTION (#2028), in two statements rather than one,
+	// both on the write's own budget (#1911).
+	//
+	// This transaction used to open with the SELECT below, which took a read
+	// lock and left the write to UPGRADE into one - and SQLite will not run the
+	// busy handler for a write attempted inside a transaction that already
+	// holds a read lock, because waiting there could deadlock. Measured under a
+	// held write lock: a write-first transaction waits 14.50s, a read-then-write
+	// transaction is refused at 0s. So the sweep forfeited its wait entirely and
+	// no context budget could help it: #1911's floor was correct here and inert.
+	//
+	// The obvious single-statement form, UPDATE ... RETURNING, was tried and
+	// REJECTED: RETURNING has no defined row order, while the survivor
+	// selection below depends on `ORDER BY attempted_at, id` - and no test can
+	// discriminate that, because the grouping key contains attempted_at, so
+	// intra-group order is by id and RETURNING happens to emit rowid order. A
+	// correctness property that only holds by coincidence of the query plan, with
+	// no test able to catch its loss, is worse than an extra statement.
+	//
+	// So the lock is taken by a stamping UPDATE and the read stays exactly the
+	// ordered SELECT it was. Stamping updated_at is a real change, not a no-op
+	// to grab the lock: these rows are being processed now, and each one this
+	// transaction returns gets its terminal state below. The second statement
+	// costs nothing in contention terms - the write lock is already held.
+	if _, err := tx.ExecContext(writeCtx, `
+UPDATE wake_outbox
+SET updated_at = ?
+WHERE state = 'attempted' AND attempted_at IS NOT NULL AND attempted_at <= ?`,
+		at.UTC().Format(BlockedEpisodeTimeLayout),
+		attemptedBefore.UTC().Format(BlockedEpisodeTimeLayout),
+	); err != nil {
+		return nil, err
+	}
 	rows, err := tx.QueryContext(writeCtx, `
 SELECT id, source_kind, source_id, target_role, coalesce_key, state,
 	attempt_count, last_error, created_at, COALESCE(attempted_at, ''),
@@ -650,9 +683,23 @@ func (s *Store) FinishOrRetryWakeOutbox(
 		return false, 0, err
 	}
 	defer func() { _ = tx.Rollback() }()
+	// WRITE-FIRST BY CONSTRUCTION (#2028). This read decides the outcome and
+	// must stay inside the same transaction as the write - that is the invariant
+	// documented above, so two daemons cannot both see budget remaining. But as
+	// a SELECT it took a read lock first, and SQLite will not run the busy
+	// handler for a write attempted inside a transaction that already holds one,
+	// so this transaction forfeited its wait entirely: measured under a held
+	// write lock, write-first waits 14.50s while read-then-write is refused at
+	// 0s. Reading through an UPDATE ... RETURNING keeps the read in the
+	// transaction AND takes the write lock with the first statement.
+	//
+	// Stamping updated_at is a real change: this row's outcome is being decided
+	// now, and every path below writes it again in the same transaction.
 	var role string
 	if err := tx.QueryRowContext(writeCtx,
-		`SELECT attempt_count, target_role FROM wake_outbox WHERE id = ?`, ids[0],
+		`UPDATE wake_outbox SET updated_at = ? WHERE id = ?
+RETURNING attempt_count, target_role`,
+		at.UTC().Format(BlockedEpisodeTimeLayout), ids[0],
 	).Scan(&attempts, &role); err != nil {
 		return false, 0, err
 	}

--- a/internal/db/wake_outbox_contention_test.go
+++ b/internal/db/wake_outbox_contention_test.go
@@ -1,0 +1,99 @@
+package db
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// This file's contention helper was collapsed into durable_write_test.go's
+// holdWriteLock when #2023 landed, as its own note said it would be: the
+// duplication was deliberate and temporary, and forking a second convention
+// permanently was never the plan.
+
+func seedAttemptedWakeRows(t *testing.T, store *Store, count int, attemptedAt time.Time) []int64 {
+	t.Helper()
+	stamp := attemptedAt.UTC().Format(BlockedEpisodeTimeLayout)
+	var ids []int64
+	for index := 0; index < count; index++ {
+		res, err := store.db.ExecContext(context.Background(), `
+INSERT INTO wake_outbox(source_kind, source_id, target_role, coalesce_key, state,
+	attempt_count, created_at, updated_at, attempted_at)
+VALUES ('workflow_note', ?, 'worker', 'reply:worker', 'attempted', 1, ?, ?, ?)`,
+			index+1, stamp, stamp, stamp)
+		if err != nil {
+			t.Fatalf("seed row %d: %v", index, err)
+		}
+		id, err := res.LastInsertId()
+		if err != nil {
+			t.Fatalf("seed id %d: %v", index, err)
+		}
+		ids = append(ids, id)
+	}
+	return ids
+}
+
+// TestWakeTransactionsWaitForTheWriteLockInsteadOfBeingRefused is #2028.
+//
+// MEASURED, with another connection holding the write lock and a caller
+// deadline far above the store's busy timeout so the caller is never the limit:
+//
+//	write-first transaction                  waits 14.50s then SQLITE_BUSY
+//	read-then-write transaction              refused at 0s
+//	first statement UPDATE ... RETURNING     waits 14.22s then SQLITE_BUSY
+//
+// SQLite will not run the busy handler for a write attempted inside a
+// transaction that already holds a read lock, because waiting there could
+// deadlock. So a transaction that reads before it writes forfeits the wait
+// entirely, and NO context budget can help it - which is why #1911's budget
+// floor is correct but inert for these two writers.
+//
+// Both of these transactions must therefore acquire the write lock with their
+// FIRST statement. The test asserts the observable consequence: under a lock
+// held for less than the store's budget, the call WAITS and then succeeds,
+// rather than failing immediately.
+func TestWakeTransactionsWaitForTheWriteLockInsteadOfBeingRefused(t *testing.T) {
+	for _, test := range []struct {
+		name string
+		call func(store *Store, ctx context.Context, ids []int64, at time.Time) error
+	}{
+		{name: "aged-sweep", call: func(store *Store, ctx context.Context, ids []int64, at time.Time) error {
+			_, err := store.ExpireAgedWakeOutbox(ctx, at.Add(time.Hour), at)
+			return err
+		}},
+		{name: "finish-or-retry", call: func(store *Store, ctx context.Context, ids []int64, at time.Time) error {
+			_, _, err := store.FinishOrRetryWakeOutbox(ctx, ids, WakeOutboxStateFailed, "transport down", 3, at)
+			return err
+		}},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "gitmoot.db")
+			store, err := openCachedTestStore(t, path)
+			if err != nil {
+				t.Fatalf("Open: %v", err)
+			}
+			t.Cleanup(func() { _ = store.Close() })
+			now := time.Now().UTC()
+			ids := seedAttemptedWakeRows(t, store, 2, now)
+
+			// The hold is a fraction of the store's own budget rather than a
+			// literal, so it still means "less than the store will wait" if
+			// anyone widens the busy timeout.
+			hold := DurableWriteBudget / 18
+			wait := holdWriteLock(t, path, hold)
+			defer wait()
+
+			started := time.Now()
+			if err := test.call(store, context.Background(), ids, now); err != nil {
+				t.Fatalf("%s under a %s held write lock: %v", test.name, hold, err)
+			}
+			// A call that returned before the lock was released did not wait for
+			// it, so a pass would not mean what the test claims.
+			if waited := time.Since(started); waited < hold/2 {
+				t.Fatalf("%s returned after %s, less than half the %s hold: it did not wait for the write lock",
+					test.name, waited, hold)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Fixes #2028. Found while fixing #1911, and it is a **different mechanism from that issue's deadline class**, not the same bug seen twice.

## Reproduced before fixed

```
--- FAIL: TestWakeTransactionsWaitForTheWriteLockInsteadOfBeingRefused/aged-sweep
    aged-sweep under a 1s held write lock: database is locked (5) (SQLITE_BUSY)
--- FAIL: TestWakeTransactionsWaitForTheWriteLockInsteadOfBeingRefused/finish-or-retry
    finish-or-retry under a 1s held write lock: database is locked (5) (SQLITE_BUSY)
```

Both now pass, and the test asserts the call **waited** rather than merely returned without error: a call that came back in under half the hold did not wait for the lock, so a pass would not mean what the test claims.

## The mechanism, measured

With another connection holding the write lock and a 30s caller deadline, so the caller is never the limit:

| transaction shape | elapsed before `SQLITE_BUSY` |
| --- | --- |
| write-first | **14.50s** (busy handler ran) |
| read-then-write | **0s** (busy handler never ran) |
| first statement `UPDATE ... RETURNING` | **14.22s** (busy handler ran) |

SQLite will not run the busy handler for a write attempted inside a transaction that already holds a read lock, because waiting there could deadlock. So a transaction that reads before it writes **forfeits the wait entirely**, and no context budget can help it. That is why #1911's floor is correct but **inert** for these two writers, which I said in that PR rather than letting the fix imply coverage.

Store defaults confirmed first rather than assumed: `journal_mode = wal`, `busy_timeout = 15000`, on both the cached test store and a production `Open`.

## Two writers, two different shapes of fix

**`ExpireAgedWakeOutbox`: a stamping UPDATE, then the ordered SELECT unchanged.**

The single-statement `UPDATE ... RETURNING` form was tried and **rejected**. `RETURNING` has no defined row order, while the survivor selection below it depends on `ORDER BY attempted_at, id` - the grouping comment says so explicitly. Worse, **no test can discriminate that loss**: the grouping key contains `attempted_at`, so intra-group order is by `id`, and `RETURNING` happens to emit rowid order. I first "fixed" that with a defensive Go sort, and a mutant removing the sort **survived**, which is what told me the property held only by coincidence of the query plan with nothing able to catch its loss.

An extra statement inside a transaction that already holds the write lock costs nothing in contention terms. A correctness property that depends on a query plan does.

**`FinishOrRetryWakeOutbox`: reads through `UPDATE ... RETURNING`.**

Its read decides the outcome and must stay in the same transaction as its write - the two-daemon invariant its own doc comment names, so this could not be fixed by moving the read out. Reading through `UPDATE ... RETURNING` keeps the read inside the transaction and makes the first statement a write. It returns one row by id, so row order does not arise.

Stamping `updated_at` in both is a real change rather than a no-op taken to grab the lock: those rows are being processed now, and every row either statement returns is written again in the same transaction.

## Mutants

| Mutant | Result |
| --- | --- |
| sweep back to a `SELECT` (read-first) | **killed** |
| finish-or-retry back to a `SELECT` | **killed** |
| remove the stamping UPDATE, sweep read-first again | **killed** |
| defensive Go sort removed (earlier RETURNING design) | **survived** - which is why that design was abandoned |
| stamping UPDATE kept but made to match nothing (`WHERE 0`) | **survived, and this one is a finding** |

The last is not a test gap. It shows a zero-match `UPDATE` still acquires the write lock, so **the sweep is write-first even when nothing has aged out** - the fix does not depend on rows matching. I am recording it rather than adding an assertion about `updated_at`, which is incidental: those rows are rewritten later in the same transaction anyway.

## Verification, and what is NOT verified

`go build ./...` exit 0, `go vet ./internal/db` exit 0, and every wake-related test by name filter (`WakeOutbox|Wake|Expire|Finish|Claim|Requeue|Directive|Coalesc`) passes.

**Local full verification is pending a disk constraint; CI is the gate.** The owner has stopped granting `./...` windows while free space sits near the fleet dispatch floor, and reviews are now counted against that too. This is a decision, not an omission: no untargeted package run and no `./...` was performed here, and I am not merging on CI alone.

**The live rate is not re-derivable right now.** #1911's evidence records 91 `SQLITE_BUSY` lines in 6h, bursty, with 67 in one hour. Dispatch is paused fleet-wide, so the concurrent writers that produce that contention are not running. The defect is proven by construction and by contended tests instead.

**Not claimed:** how much of that 91 comes from these two writers versus the five other subsystems #1911's third comment names (`delegation_worktree_ttl reclaim`, `worker tick` across five repos, `task lane lock reclaim`, `blocked_since role live presence persist`). Those may share this transaction shape or may not; each needs its own read, and this PR does not touch them.

## Relationship to #2023

#2023 (#1911's deadline class) is parked behind the same disk constraint. This branch is based on `main` rather than stacked on it, so it is independently mergeable in either order.

One consequence: `internal/db/wake_outbox_contention_test.go` carries a `holdContendedWriteLock` helper equivalent to the one #2023 adds in `durable_write_test.go`. That duplication is deliberate and temporary, named distinctly so the two cannot collide, and it collapses into the single helper when whichever lands second is rebased. I am not forking a second convention permanently.
