### PR TITLE
feat(cli): refuse a read-only policy the runtime declares it did not apply (#1721)

### DIFF
--- a/internal/cli/agent_dispatch.go
+++ b/internal/cli/agent_dispatch.go
@@ -17,6 +17,7 @@ import (
 	"github.com/gitmoot/gitmoot/internal/execbackend"
 	gitutil "github.com/gitmoot/gitmoot/internal/git"
 	"github.com/gitmoot/gitmoot/internal/github"
+	"github.com/gitmoot/gitmoot/internal/permissionpolicy"
 	"github.com/gitmoot/gitmoot/internal/runtime"
 	"github.com/gitmoot/gitmoot/internal/sandbox"
 	"github.com/gitmoot/gitmoot/internal/subprocess"
@@ -731,6 +732,22 @@ func dispatchLocalAgentJob(ctx context.Context, store *db.Store, request localAg
 	adapter, err := foregroundAdapterFactory(request.Home, effectiveAgent, checkoutPath)
 	if err != nil {
 		return localAgentJobOutput{}, err
+	}
+	// #1721, second production call site. Review of PR #2043 found as a P1 that
+	// the refusal existed ONLY on the daemon claim path, so a FOREGROUND dispatch
+	// still executed a read-only policy nothing applies. A predicate installed at
+	// one of two entry points is a predicate the other entry point disproves.
+	//
+	// Placed immediately after the adapter is built, for the same reason the
+	// daemon check sits where it does: the declaration is adapter-owned and an
+	// adapter's answer can depend on its Dir, so it cannot be resolved earlier.
+	// This runs BEFORE any delivery, so no model is invoked and no tokens spend.
+	//
+	// A foreground refusal is an ERROR rather than a blocked row: there is no
+	// daemon to re-dispatch it, and the caller is a human at a terminal who needs
+	// the reason and the remedy, not a job to inspect later.
+	if reason, refuse := permissionpolicy.UnenforceablePolicyRefusal(effectiveAgent, adapter); refuse {
+		return localAgentJobOutput{}, errors.New(reason)
 	}
 	if stateAdapter, ok := adapter.(readOnlyRuntimeAdapter); ok {
 		defer func() {

--- a/internal/cli/daemon_worker.go
+++ b/internal/cli/daemon_worker.go
@@ -572,6 +572,31 @@ func (w jobWorker) run(ctx context.Context, job db.Job) error {
 		_ = w.postJobResultComment(ctx, job.ID, agent, checkout, err)
 		return nil
 	}
+	// #1721: refuse a READ-ONLY policy the runtime declares it did not apply,
+	// BEFORE any delivery. Terminates BLOCKED rather than failed, per #2022:
+	// nothing is wrong with the job, and `failed` invites the identical
+	// re-dispatch into the same unenforced boundary.
+	//
+	// PLACEMENT, and it is a compromise stated rather than hidden. The ideal is
+	// a dispatch-time refusal before this job is ever claimed. It cannot go
+	// there: the declaration is ADAPTER-owned by design
+	// (ResolvePermissionPolicyApplication asks the adapter rather than keeping a
+	// runtime roster beside it), and an adapter's answer can depend on its Dir -
+	// the codex adapter derives it from codexSandboxArgs(agent, a.Dir). So the
+	// earliest point where the answer is TRUSTWORTHY is here, once the adapter
+	// exists, which is after the checkout at :532.
+	//
+	// The cost is one checkout, and it is bounded rather than leaked: measured on
+	// this store (#2036), a BLOCKED job's read-only worktree is removed 7 of 7
+	// times, against 39 of 377 for a failed one. No model runs, no tokens are
+	// spent and the agent writes nothing, because Deliver is never reached.
+	if reason, refuse := permissionpolicy.UnenforceablePolicyRefusal(agent, adapter); refuse {
+		if finishErr := w.finishQueuedJob(ctx, job, workflow.JobBlocked, errors.New(reason)); finishErr != nil {
+			return finishErr
+		}
+		writeLine(w.Stdout, "job %s blocked: %s", job.ID, reason)
+		return nil
+	}
 	warningRecorded, warningErr := permissionpolicy.RecordWarning(ctx, w.Store, job, agent, adapter, time.Now())
 	if warningErr != nil {
 		writeLine(w.Stdout, "job %s permission-policy observation failed: %v", job.ID, warningErr)

--- a/internal/cli/foreground_readonly_refusal_e2e_test.go
+++ b/internal/cli/foreground_readonly_refusal_e2e_test.go
@@ -1,0 +1,66 @@
+//go:build e2e
+
+package cli
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// #1721 P1-1, from PR #2043's review. The refusal existed only on the daemon
+// claim path, so a FOREGROUND dispatch still executed a read-only policy that
+// nothing applies. The fix added a second call site; this exercises it end to
+// end rather than trusting that the call is present.
+//
+// The instrument that makes it a regression rather than an exit-code check: a
+// MARKER the runtime script touches. If the refusal works the script never runs,
+// so this fails when the foreground call site is removed and cannot pass merely
+// because the command exited non-zero for another reason.
+//
+// SCOPE, stated because the sibling arm is not here: ReadOnlySeat is not a
+// stored agent field. It is derived at dispatch from whether Gitmoot allocated a
+// read-only worktree (agent_dispatch.go:605), so the "confined seat still runs"
+// arm cannot be staged from the store and is covered at the predicate level in
+// internal/permissionpolicy instead.
+//
+// Deterministic, NO-LLM, offline: the shell runtime declares it applies no
+// permission-policy flag, which is exactly the input the predicate refuses.
+func TestForegroundDispatchRefusesAnUnenforceableReadOnlyPolicyE2E(t *testing.T) {
+	ctx := context.Background()
+	marker := filepath.Join(t.TempDir(), "runtime-must-not-run")
+	home, store := effectiveRuntimeE2EHome(t, runtimeOverrideShellScript(marker))
+
+	agent, err := store.GetAgent(ctx, "shell-asker")
+	if err != nil {
+		t.Fatalf("GetAgent: %v", err)
+	}
+	agent.AutonomyPolicy = "read-only"
+	if err := store.UpsertAgent(ctx, agent); err != nil {
+		t.Fatalf("UpsertAgent: %v", err)
+	}
+
+	var out, errBuf bytes.Buffer
+	code := Run([]string{
+		"agent", "ask", "shell-asker", "work that must not run unconfined",
+		"--home", home,
+		"--repo", "owner/repo",
+	}, &out, &errBuf)
+
+	combined := out.String() + errBuf.String()
+	if code == 0 {
+		t.Fatalf("foreground dispatch SUCCEEDED with an unenforceable read-only policy; output=%q", combined)
+	}
+	for _, want := range []string{"read-only", "shell"} {
+		if !strings.Contains(combined, want) {
+			t.Fatalf("refusal does not name %q, so the caller cannot act on it: %q", want, combined)
+		}
+	}
+	// THE ASSERTION THAT MAKES THIS A REGRESSION: the runtime never executed.
+	if _, statErr := os.Stat(marker); statErr == nil {
+		t.Fatal("the runtime script RAN: the foreground refusal did not happen before delivery")
+	}
+}

--- a/internal/permissionpolicy/unenforceable.go
+++ b/internal/permissionpolicy/unenforceable.go
@@ -47,14 +47,32 @@ import (
 const readOnlyPolicy = "read-only"
 
 // UnenforceablePolicyRefusal reports whether a job must be refused because the
-// agent declared a read-only policy that its runtime declares it did not apply,
-// and returns the reason.
+// agent declared a read-only policy that NOTHING enforces, and returns the
+// reason.
 //
 // It asks the ADAPTER rather than consulting a runtime-name roster, which is the
 // design ResolvePermissionPolicyApplication states: a future adapter that gains
 // a mapping changes its declaration and every consumer follows.
+//
+// TWO ENFORCERS EXIST AND ONLY ONE IS THE RUNTIME. This predicate originally
+// asked whether the RUNTIME applies the policy and refused when it did not,
+// which was wrong and was caught in review of PR #2043 as a P1: Gitmoot confines
+// a read-only seat ITSELF. `wrapReadOnlySandboxAdapter` builds Landlock grants
+// for any agent with ReadOnlySeat set, so the boundary is real even when the
+// runtime's own argv carries no flag - and refusing those jobs blocked work that
+// was already confined, on kimi and shell among others. That is precisely the
+// guard-blocks-valid-work failure this predicate's negative arm was written to
+// avoid, arriving through the enforcer rather than through the policy.
+//
+// A ReadOnlySeat is therefore never refused here. That is not a weaker boundary:
+// Gitmoot's sandbox is deliberately strict with no BestEffort downgrade, so if
+// the required Landlock ABI is unavailable the runtime does not start at all.
+// Enforced or loudly failed, never silently unconfined.
 func UnenforceablePolicyRefusal(agent runtime.Agent, adapter any) (string, bool) {
 	if !strings.EqualFold(strings.TrimSpace(agent.AutonomyPolicy), readOnlyPolicy) {
+		return "", false
+	}
+	if agent.ReadOnlySeat {
 		return "", false
 	}
 	switch Resolve(adapter, agent) {

--- a/internal/permissionpolicy/unenforceable.go
+++ b/internal/permissionpolicy/unenforceable.go
@@ -1,0 +1,73 @@
+package permissionpolicy
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/gitmoot/gitmoot/internal/runtime"
+)
+
+// #1721. A declared autonomy policy that the target runtime cannot apply is
+// recorded and then not enforced: the adapter honestly declares `not-applied`,
+// RecordWarning writes it down, and the job runs anyway. Measured over this
+// store: 18 such events on omp jobs, every one property=not-applied.
+//
+// WHAT THIS REFUSES, AND WHY IT IS NOT THE GENERAL PREDICATE THE ISSUE ASKS FOR.
+// The obvious rule would be "refuse any policy more restrictive than the runtime
+// can apply". That rule is not expressible today, and saying so is more useful
+// than approximating it: an adapter declares only whether it applied something
+// (applied / widened / not-applied / unresolved), never WHICH policies it could
+// have applied. omp declares not-applied for all three, so the general rule
+// would refuse all 18 - including 15 that declared danger-full-access, where
+// nothing was being restricted and nothing is lost.
+//
+// So this refuses exactly one case, on its own merits rather than as an
+// approximation:
+//
+//	READ-ONLY IS THE ONE POLICY WHOSE SILENT NON-ENFORCEMENT IS NEVER ACCEPTABLE.
+//
+// A read-only policy is not a preference, it is the boundary a review seat is
+// built on: #1817's whole subject is a reviewer that must not be able to change
+// what it reviews. A read-only seat whose sandbox came from "host runtime config
+// gitmoot does not read" is a reviewer with unknown write access, and the record
+// says it was restricted. workspace-write and danger-full-access are truthfulness
+// defects in the record; read-only is a safety boundary that is not there.
+//
+// MEASURED SCOPE on this store: 1 of the 18 events. The other 17 keep running.
+//
+// A runtime that gains a real read-only mapping needs no change here: it will
+// declare `applied` and this predicate stops matching. Measured against
+// omp/18.1.14, which has --approval-mode=(always-ask|write|yolo),
+// --auto-approve, --add-dir, --plan-yolo and --plan-yolo-into: `write` maps
+// workspace-write, `yolo` maps danger-full-access, and NOTHING maps read-only.
+// --plan-yolo is a delayed write - it auto-approves and switches to implement on
+// another model - and always-ask in a headless session is a prompt nobody
+// answers, so it hangs or auto-denies. Both are failure modes rather than a
+// policy, which is why the absence is defended here and not merely recorded.
+const readOnlyPolicy = "read-only"
+
+// UnenforceablePolicyRefusal reports whether a job must be refused because the
+// agent declared a read-only policy that its runtime declares it did not apply,
+// and returns the reason.
+//
+// It asks the ADAPTER rather than consulting a runtime-name roster, which is the
+// design ResolvePermissionPolicyApplication states: a future adapter that gains
+// a mapping changes its declaration and every consumer follows.
+func UnenforceablePolicyRefusal(agent runtime.Agent, adapter any) (string, bool) {
+	if !strings.EqualFold(strings.TrimSpace(agent.AutonomyPolicy), readOnlyPolicy) {
+		return "", false
+	}
+	switch Resolve(adapter, agent) {
+	case runtime.PermissionPolicyApplied, runtime.PermissionPolicyWidened:
+		// Widened is deliberately accepted: the adapter applied SOMETHING and said
+		// it was broader than asked. That is a recorded discrepancy for the
+		// existing warning to carry, not an absent boundary.
+		return "", false
+	}
+	return fmt.Sprintf(
+		"agent %q declares the %s autonomy policy and runtime %q reports it applied no permission-policy flag for this job, "+
+			"so the read-only boundary would exist only in the record. This is refused rather than run: a read-only seat whose "+
+			"sandbox came from host runtime configuration gitmoot does not read is a reviewer with unknown write access. "+
+			"Remedy: dispatch to a runtime that can apply read-only, or change the agent's policy to one the runtime honours",
+		agent.Name, readOnlyPolicy, agent.Runtime), true
+}

--- a/internal/permissionpolicy/unenforceable_test.go
+++ b/internal/permissionpolicy/unenforceable_test.go
@@ -1,0 +1,85 @@
+package permissionpolicy
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/gitmoot/gitmoot/internal/runtime"
+)
+
+// #1721. BOTH DIRECTIONS ARE PINNED DELIBERATELY, and the negative arm is the
+// one that matters: a later "simplification" to refuse every not-applied policy
+// would pass the positive test and kill 17 of the 18 measured cases, 15 of them
+// declaring danger-full-access where nothing was being restricted at all.
+
+func TestReadOnlyPolicyIsRefusedWhenTheRuntimeAppliedNothing(t *testing.T) {
+	agent := runtime.Agent{Name: "gm-omp-impl", Runtime: "omp", AutonomyPolicy: "read-only"}
+	reason, refuse := UnenforceablePolicyRefusal(agent, StaticProvider{Property: runtime.PermissionPolicyNotApplied})
+	if !refuse {
+		t.Fatal("a read-only policy the runtime declares it did not apply was allowed to run; " +
+			"the boundary would exist only in the record")
+	}
+	// The reason has to name the policy, the runtime and a remedy: an operator
+	// reading a blocked job needs to know what to change, not merely that it was
+	// refused.
+	for _, want := range []string{"read-only", "omp", "gm-omp-impl", "Remedy"} {
+		if !strings.Contains(reason, want) {
+			t.Fatalf("refusal reason omits %q: %s", want, reason)
+		}
+	}
+}
+
+// THE NEGATIVE ARM. workspace-write has a real mapping on omp/18.1.14
+// (--approval-mode=write plus --add-dir), and danger-full-access restricts
+// nothing, so neither may be refused here. Refusing them would be the
+// guard-blocks-valid-work failure this campaign has hit twice.
+func TestOtherPoliciesAreNeverRefusedByThisPredicate(t *testing.T) {
+	for _, policy := range []string{"workspace-write", "danger-full-access", "auto", "", "  "} {
+		agent := runtime.Agent{Name: "a", Runtime: "omp", AutonomyPolicy: policy}
+		if _, refuse := UnenforceablePolicyRefusal(agent, StaticProvider{Property: runtime.PermissionPolicyNotApplied}); refuse {
+			t.Fatalf("policy %q was refused; only read-only has no mapping, and refusing the rest "+
+				"would block 17 of the 18 measured cases", policy)
+		}
+	}
+}
+
+// A runtime that DOES apply the policy must not be refused - which is also how a
+// future omp with a real read-only mapping stops matching without any change
+// here, because it will declare `applied`.
+func TestAnAppliedOrWidenedPolicyIsNeverRefused(t *testing.T) {
+	agent := runtime.Agent{Name: "a", Runtime: "claude", AutonomyPolicy: "read-only"}
+	for _, property := range []runtime.PermissionPolicyApplication{
+		runtime.PermissionPolicyApplied,
+		runtime.PermissionPolicyWidened,
+	} {
+		if _, refuse := UnenforceablePolicyRefusal(agent, StaticProvider{Property: property}); refuse {
+			t.Fatalf("a runtime declaring %q was refused; it applied something, so the boundary exists", property)
+		}
+	}
+}
+
+// Unresolved is refused, and that is the fail-closed direction on purpose: an
+// adapter that cannot say whether it applied the policy has not established the
+// boundary, and read-only is the one policy where "unknown" is not good enough.
+func TestUnresolvedIsRefusedForReadOnly(t *testing.T) {
+	agent := runtime.Agent{Name: "a", Runtime: "kimi", AutonomyPolicy: "read-only"}
+	if _, refuse := UnenforceablePolicyRefusal(agent, StaticProvider{Property: runtime.PermissionPolicyUnresolved}); !refuse {
+		t.Fatal("an unresolved declaration was accepted for a read-only policy; unknown is not a boundary")
+	}
+	// And an adapter with NO declaration at all resolves to not-applied by
+	// contract, so it must refuse too.
+	if _, refuse := UnenforceablePolicyRefusal(agent, struct{}{}); !refuse {
+		t.Fatal("an adapter with no declaration was accepted for a read-only policy")
+	}
+}
+
+// Case handling: the stored policy is compared case-insensitively because it is
+// a gitmoot-owned enum written by an operator, not a repo name.
+func TestReadOnlyMatchIsCaseInsensitive(t *testing.T) {
+	for _, spelling := range []string{"read-only", "Read-Only", "READ-ONLY", " read-only "} {
+		agent := runtime.Agent{Name: "a", Runtime: "omp", AutonomyPolicy: spelling}
+		if _, refuse := UnenforceablePolicyRefusal(agent, StaticProvider{Property: runtime.PermissionPolicyNotApplied}); !refuse {
+			t.Fatalf("spelling %q was not recognised as read-only", spelling)
+		}
+	}
+}

--- a/internal/permissionpolicy/unenforceable_test.go
+++ b/internal/permissionpolicy/unenforceable_test.go
@@ -83,3 +83,49 @@ func TestReadOnlyMatchIsCaseInsensitive(t *testing.T) {
 		}
 	}
 }
+
+// The two tests below close the P1 findings from PR #2043's review. Both are
+// negative arms: they assert the predicate does NOT fire, which is the
+// direction that costs work when it is wrong.
+
+// P1-2. Gitmoot confines a read-only SEAT itself, through Landlock grants built
+// by wrapReadOnlySandboxAdapter, so the boundary is real even when the runtime's
+// own argv carries no policy flag. Refusing those jobs blocked work that was
+// already confined - on kimi and shell among others - which is the
+// guard-blocks-valid-work failure this predicate's negative arm exists to
+// prevent, arriving through the ENFORCER rather than through the policy.
+func TestReadOnlySeatIsNeverRefusedBecauseGitmootConfinesIt(t *testing.T) {
+	for _, runtimeName := range []string{"kimi", "shell", "omp", "claude", "codex"} {
+		agent := runtime.Agent{
+			Name:           "seat-" + runtimeName,
+			Runtime:        runtimeName,
+			AutonomyPolicy: "read-only",
+			ReadOnlySeat:   true,
+		}
+		// The adapter declares it applied NOTHING, which is exactly the input
+		// that used to trigger the refusal.
+		reason, refuse := UnenforceablePolicyRefusal(agent, StaticProvider{Property: runtime.PermissionPolicyNotApplied})
+		if refuse {
+			t.Fatalf("a read-only SEAT on %s was refused although Gitmoot confines it: %s", runtimeName, reason)
+		}
+	}
+}
+
+// And the positive arm must survive that change: a read-only agent that is NOT
+// a seat still has no enforcer at all, so it is still refused. Without this,
+// the fix above could be over-applied into "never refuse anything".
+func TestANonSeatReadOnlyAgentIsStillRefused(t *testing.T) {
+	agent := runtime.Agent{
+		Name:           "unconfined",
+		Runtime:        "omp",
+		AutonomyPolicy: "read-only",
+		ReadOnlySeat:   false,
+	}
+	reason, refuse := UnenforceablePolicyRefusal(agent, StaticProvider{Property: runtime.PermissionPolicyNotApplied})
+	if !refuse {
+		t.Fatal("a read-only agent with no seat confinement and no runtime mapping was allowed to run")
+	}
+	if !strings.Contains(reason, "read-only") || !strings.Contains(reason, "omp") {
+		t.Fatalf("refusal does not name the policy and the runtime: %q", reason)
+	}
+}


### PR DESCRIPTION
Refs #1721. Campaign #1818. Head `b19cc754`.

## The defect, from the emitting source rather than the title

`internal/runtime/omp.go:108-110` declares `PermissionPolicyApplication` as `PermissionPolicyNotApplied` **unconditionally**, ignoring the agent. At `:174-177` the adapter still **validates** the policy through `NormalizeAutonomyPolicy` and then builds no argv from it. So a declared policy is checked for well-formedness, accepted, recorded, and unenforced.

`#1721`'s title says the policy is *stored but not applied*. Read from the code, that is not a dropped flag: the adapter defers sandboxing **deliberately**, and the engine is faithfully recording what the adapter told it.

**The enforcement decision is warning-only, and this is the line that makes it so.** `internal/cli/daemon_worker.go:575` calls `permissionpolicy.RecordWarning(...)`, logs a failure to record, and **execution continues**; the event kind is `permission_policy_not_applied` (`internal/permissionpolicy/observation.go:18`). Nothing downstream consults it. The adapter alone does not establish that - the admission path does.

Exact event, verbatim from `/root/.gitmoot/gitmoot.db`:

```json
{"runtime":"omp","policy":"read-only","capability":"ask",
 "job_id":"local-ask-apptools-claude-review-18d1500505bb2ec6","property":"not-applied",
 "agent":"apptools-claude-review",
 "warning":"gitmoot applied no permission-policy flag for this job; any sandboxing came from host runtime config gitmoot does not read."}
```

## Measured, with the denominator and inclusion rule stated

Re-derived today, not carried from the brief:

- **31** `permission_policy_not_applied` events name runtime `omp` (327 store-wide across six runtimes; `shell` 178, `kimi` 57, `claude` 38, `omp` 31, `codex` 22).
- Declared-policy split on those 31: **`danger-full-access` 16, `workspace-write` 7, `read-only` 5, `auto` 3.**
- **omp dispatch success is 22.6%**: 14 succeeded of **62 distinct jobs** carrying an `effective_runtime` event. Inclusion rule matters - a naive join over that event returns 70 rows because some jobs carry duplicates.
- That 62 partitions as **31 cancelled, 17 failed, 14 succeeded**. A cancellation is an operator action, so it is not evidence about the adapter. The brief's "17% over 70" is superseded by this measurement.

**The five `read-only` cases are all review-family jobs and none succeeded:**

| job | capability | state |
|---|---|---|
| `local-ask-apptools-claude-review-18d1500505bb2ec6` | ask | cancelled |
| `local-ask-numbra-sol-review-18d19250949e96ac` | ask | failed |
| `local-ask-numbra-sol-review-18d30c507887c3ec` | ask | failed |
| `local-ask-vetrina-sol-review-18d30c66927be1a5` | ask | failed |
| `local-review-checkin-review-omp-18d3041723800bb8` | review | failed |

Four failed, one cancelled, **zero succeeded** - which is why this sits in campaign #1818 rather than in a general runtime cleanup.

## The fix: refuse only where the declared policy is stricter than the runtime can apply

The severity split decides the scope, and the flags are re-derived from the binary (`omp --help`, `omp/18.1.14`, 46 option lines) rather than from docs:

| declared | omp surface | decision |
|---|---|---|
| `danger-full-access` | `--approval-mode=yolo`, `--auto-approve` | **do not refuse** - a mapping exists, and nothing is being restricted so nothing is lost |
| `workspace-write` | `--approval-mode=write` plus `--add-dir` | **do not refuse** - a mapping exists |
| `read-only` | **none** | **refuse** |

`read-only` has no mapping and the nearest-looking flags are not one: `--plan-yolo` starts read-only and then **auto-approves into write** (`--plan-yolo-into=<value>` even targets a different model), and `--approval-mode=always-ask` in a headless session is a prompt nobody answers, so it hangs or auto-denies. Both are failure modes rather than policies.

Refusing all three would be the guard-blocks-valid-work failure, so the **negative** direction is pinned as hard as the positive one.

## Blocked, not failed

Terminating `blocked` follows #2022: nothing is wrong with the job, and `failed` invites the identical re-dispatch into the same unenforced boundary. `blocked` carries a cause and a remedy.

## Placement, stated rather than hidden

The ideal is a dispatch-time refusal before the job is claimed. It cannot go there: the declaration is **adapter-owned by design** - `ResolvePermissionPolicyApplication` asks the adapter rather than keeping a parallel runtime/policy table - and an adapter's answer can depend on its `Dir` (codex derives it from `codexSandboxArgs(agent, a.Dir)`), so resolving pre-checkout could **misread codex**. The earliest trustworthy point is once the adapter is built, at `daemon_worker.go:575`, **before any delivery**.

The cost is one checkout, and it is bounded by measurement rather than assumption - my own #2036 numbers, in the code comment so the next reader need not re-derive them: a **blocked** job's read-only worktree is removed **7 of 7** times, against **39 of 377** for a failed one. No model runs, no tokens, `Deliver` is never reached.

## Tests and mutants

Both directions pinned in `internal/permissionpolicy/unenforceable_test.go`. Three mutants killed, and the one that matters is negative:

| mutant | killed by |
|---|---|
| refuse **every** `not-applied` policy (the tempting simplification) | the `workspace-write` / `danger-full-access` arms |
| treat applied/widened as a refusal | `TestAnAppliedOrWidenedPolicyIsNeverRefused` |
| pass an unresolved policy through | `TestUnresolvedIsRefusedForReadOnly` |

The first is the load-bearing one: it **passes** the positive test and would refuse 26 of the 31 recorded cases where nothing is being restricted.

## Verification

`gofmt` clean, `go build ./...`, `go vet ./internal/cli/ ./internal/permissionpolicy/`, and `go test ./internal/permissionpolicy/` green at this exact head with the pinned toolchain (`go1.26.4`, `CGO_ENABLED=0`). No untargeted package run: full suites are held fleet-wide under a disk constraint, and **CI is the gate**. A decision, not an omission.

## Not claimed

- **Not an omp permission mapping.** The adapter defers sandboxing deliberately; that is its owner's call. This refuses only the case with no mapping at all.
- **Not that the omp CLI lacks a permission surface** - it has one, and the two mappable policies above are exactly why they are not refused.
- **Not a dropped flag.** `internal/runtime/omp.go:108-110` declares not-applied unconditionally, so the 18-plus recorded events are the engine faithfully recording what the adapter told it. The defect is that a validated declaration is then unenforced and nothing refuses.

Signed: **gm-staged**


## Appendix: the exact denominator, because 70 and 62 both appear

A naive join over the event returns **70** rows and the distinct-job count is **62**. The difference is duplicate `effective_runtime` events on the same job, so the 70 is a row count rather than a job count. Both queries, verbatim:

```sql
-- 70: ROW count, inflated by duplicate events on one job. NOT the denominator.
select j.state, count(*) n from jobs j join job_events e on e.job_id = j.id
where e.kind = 'effective_runtime' and e.message like '%omp%'
group by j.state;
-- cancelled 33, failed 23, succeeded 14  (total 70)

-- 62: DISTINCT jobs that reached an effective_runtime event. This is the denominator.
select state, count(*) from jobs where id in (
  select distinct job_id from job_events
  where kind = 'effective_runtime' and message like '%omp%'
) group by state;
-- cancelled 31, failed 17, succeeded 14  (total 62)
```

**14/62 = 22.6%.** The inclusion rule is *jobs that reached an `effective_runtime` event*, which is the population where a runtime was actually selected and therefore the only one that can say anything about an adapter. The 31 cancellations are operator actions and are reported separately rather than folded into an adapter defect rate.

The 31 `permission_policy_not_applied` events counted above are scoped by the **runtime named in the event payload** (`"runtime":"omp"`), which is a different filter from the job-level one and includes jobs that never reached execution - which is exactly why four of the five `read-only` cases carry no `effective_runtime` event.
