### PR TITLE
fix(db): resolve an aged wake against destination evidence, not its columns (#1958)

### DIFF
--- a/docs/events.md
+++ b/docs/events.md
@@ -257,6 +257,18 @@ unexplained non-delivery), the batch becomes terminal AND a
 `wake_delivery_failed` job event is recorded on `wake-outbox:<id>` naming the
 target role, the cause and the attempts spent, so an undelivered obligation is
 attributable from the store rather than only from a daemon log line.
+An aged-out row whose delivery the store can PROVE is recorded as `delivered`
+rather than `delivery_unknown`, with a `wake_delivered` job event on
+`wake-outbox:<id>` carrying `policy=resolved_by_destination_evidence`. The proof
+is DESTINATION EVIDENCE: a note in the directive's own workflow that
+acknowledges it (`[org:directive-ack id=<id> ...]`) or records its delivery
+(`[org:directive-delivered id=<id> ...]`). Without that check the sweep recorded
+a negative the store could disprove: a directive acknowledged two minutes after
+its row was created was still flagged undelivered 78 minutes later, and every
+instrument built on `state` and `attempt_count` then reported delivered work as
+an outstanding obligation. The evidence must name THAT row's directive and live
+in the directive's own workflow; a reply-class row has no equivalent marker, so
+it keeps the unknown outcome rather than being laundered by an absent check.
 A wake addressed to a role that CANNOT receive it, because no enabled rule
 exists for that role and kind, records a `wake_unroutable` job event on
 `wake-outbox:<id>` naming the role, the kind, the source and WHICH condition it

--- a/internal/cli/reply_wake_outbox.go
+++ b/internal/cli/reply_wake_outbox.go
@@ -119,10 +119,26 @@ func drainReplyWakeOutboxWithHealth(ctx context.Context, store wakeOutboxStore, 
 		if err != nil {
 			return replyWakeOutboxHealth{}, fmt.Errorf("expire aged attempted wake outbox: %w", err)
 		}
+		// A PROVEN DELIVERY IS NOT AN UNKNOWN ONE (#1958). The sweep now resolves
+		// an aged row against destination evidence and returns the state it
+		// wrote, so only the rows it genuinely could not explain belong in this
+		// diagnostic. Counting every expired row here reported a false unknown
+		// delivery for each proven one AND drove both supervisors to log the
+		// drain unhealthy - the store-side fix stopped at the store, and this is
+		// the caller that still spoke for it.
 		if len(expired) > 0 {
+			mutated = true
+		}
+		unknown := 0
+		for _, entry := range expired {
+			if entry.State == db.WakeOutboxStateDeliveryUnknown {
+				unknown++
+			}
+		}
+		if unknown > 0 {
 			return replyWakeOutboxHealth{}, fmt.Errorf(
 				"wake outbox delivery unknown: expired %d aged attempted rows without retry",
-				len(expired),
+				unknown,
 			)
 		}
 	}

--- a/internal/cli/reply_wake_outbox_test.go
+++ b/internal/cli/reply_wake_outbox_test.go
@@ -1296,6 +1296,79 @@ func TestReplyWakeOutboxAgedAttemptedExpiresDeliveryUnknownWithoutDuplicateWake(
 	}
 }
 
+// TestReplyWakeOutboxProvenAgedDeliveryDoesNotReportUnknown is the review
+// finding on #2047, and it is the sibling seam ONE LAYER UP from the fix.
+//
+// #1958 item 3 taught the STORE to resolve an aged row against destination
+// evidence, and the store did. Its only production caller still treated every
+// nonempty expiry result as `wake outbox delivery unknown: expired N aged
+// attempted rows without retry`, which drove both supervisors to log the drain
+// unhealthy - so a delivery the store had just PROVEN still produced an
+// operator-facing unknown-delivery diagnostic. The fix stopped at the store and
+// this is the caller that spoke for it.
+//
+// The whole point is the DIFFERENCE from the test above: identical crash-residue
+// setup, plus an acknowledgment, and the health line must flip.
+func TestReplyWakeOutboxProvenAgedDeliveryDoesNotReportUnknown(t *testing.T) {
+	store, sink, wake, home := replyWakeTestHarness(t, []replyWakeTestRole{{"owner", "w1:p1"}})
+	ctx := context.Background()
+	directive, err := store.InsertWorkflowNote(ctx, db.WorkflowNote{
+		WorkflowID: "release/directives", Author: "coordinator",
+		Body: "[org:directive to=owner] do the thing", AddressedTarget: "owner",
+		// DIRECTIVE-CLASS on purpose: destination evidence exists only for a
+		// directive, and the store's guard correctly ignores it for a reply row.
+		// My first version of this fixture omitted this and the test failed for
+		// the RIGHT reason - a reply-class row must stay unknown - which is the
+		// guard doing its job rather than the fix failing.
+		AddressedWakeKind: db.WakeOutboxKindDirective,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	pending, err := store.ListWakeOutbox(ctx, db.WakeOutboxStatePending)
+	if err != nil || len(pending) != 1 {
+		t.Fatalf("pending = %+v, err=%v", pending, err)
+	}
+	// DESTINATION EVIDENCE: the seat acknowledged the directive, so its wake
+	// demonstrably landed however the row's own columns read.
+	if _, err := store.InsertWorkflowNote(ctx, db.WorkflowNote{
+		WorkflowID: "release/directives", Author: "owner",
+		Body: fmt.Sprintf("[org:directive-ack id=%d by=owner]", directive.ID),
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	attemptedAt := time.Date(2026, 7, 28, 12, 0, 0, 0, time.UTC)
+	claimed, err := store.ClaimWakeOutbox(ctx, pending[0].ID, nil, attemptedAt)
+	if err != nil || !claimed {
+		t.Fatalf("simulate pre-crash claim = %v, err=%v", claimed, err)
+	}
+
+	worker := defaultJobWorker(store, io.Discard, home)
+	installReplyWakeProductionSink(t, worker, sink.sink)
+	var stdout bytes.Buffer
+	if err := runEnabledRepoWorkerTicksTracked(
+		context.Background(), store, worker, 0, "", &stdout,
+		attemptedAt.Add(replyWakeAttemptedUnknownAfter), nil, nil,
+	); err != nil {
+		t.Fatalf("tick aborted: %v", err)
+	}
+	if strings.Contains(stdout.String(), "delivery unknown") {
+		t.Fatalf("a PROVEN delivery was reported as unknown: %q", stdout.String())
+	}
+	delivered, err := store.ListWakeOutbox(ctx, db.WakeOutboxStateDelivered)
+	if err != nil || len(delivered) != 1 || delivered[0].ID != pending[0].ID {
+		t.Fatalf("delivered rows = %+v, err=%v", delivered, err)
+	}
+	if wake.promptCalls != 0 {
+		t.Fatalf("a resolved row was re-emitted: calls=%d prompts=%v", wake.promptCalls, wake.prompts)
+	}
+	events, err := store.ListJobEvents(ctx, fmt.Sprintf("wake-outbox:%d", pending[0].ID))
+	if err != nil || len(events) != 1 || events[0].Kind != db.WakeOutboxDeliveredEventKind {
+		t.Fatalf("events = %+v, err=%v; want exactly one %q", events, err, db.WakeOutboxDeliveredEventKind)
+	}
+}
+
 func TestReplyWakeOutboxRuleDeletedMidDrainRefusesLaterBatch(t *testing.T) {
 	store, sink, wake, home := replyWakeTestHarness(t, []replyWakeTestRole{{"owner", "w1:p1"}})
 	ctx := context.Background()

--- a/internal/db/wake_outbox.go
+++ b/internal/db/wake_outbox.go
@@ -605,7 +605,7 @@ WHERE state = 'attempted' AND attempted_at IS NOT NULL AND attempted_at <= ?
 	}
 
 	seenSurvivor := map[string]int64{}
-	for _, entry := range entries {
+	for index, entry := range entries {
 		group := strings.ToLower(strings.TrimSpace(entry.TargetRole)) + "\x00" +
 			entry.CoalesceKey + "\x00" + entry.AttemptedAt
 		state, rowDetail := WakeOutboxStateDeliveryUnknown, detail
@@ -634,6 +634,16 @@ WHERE id = ? AND state = 'attempted' AND attempted_at <= ?`,
 		if affected != 1 {
 			return nil, fmt.Errorf("expire wake outbox row %d updated %d rows, want 1", entry.ID, affected)
 		}
+		// THE RETURN DESCRIBES WHAT THIS SWEEP DECIDED, not the row it read
+		// (#1958). The caller partitions on it to tell a PROVEN delivery from a
+		// genuinely unknown one, and returning the pre-update `attempted` state
+		// made every resolution indistinguishable from an unknown - which is how
+		// a proven delivery still produced an unknown-delivery diagnostic and
+		// drove the drain unhealthy.
+		entries[index].State = state
+		entries[index].LastError = rowDetail
+		entries[index].FinishedAt = stamp
+		entries[index].UpdatedAt = stamp
 		if collapsed {
 			// The audit event belongs to the obligation, not to every row it
 			// carried: N events for one undelivered wake is the same

--- a/internal/db/wake_outbox.go
+++ b/internal/db/wake_outbox.go
@@ -26,6 +26,11 @@ const (
 
 const (
 	WakeOutboxDeliveryUnknownEventKind = "wake_delivery_unknown"
+	// WakeOutboxDeliveredEventKind records an aged row whose delivery the store
+	// could PROVE from destination evidence rather than infer from its columns
+	// (#1958 item 3). It is a distinct kind because an operator reading the
+	// stream must be able to tell a resolved obligation from an unknown one.
+	WakeOutboxDeliveredEventKind = "wake_delivered"
 	// WakeOutboxDeliveryFailedEventKind records a wake that will NOT be retried
 	// again: either its cause is not transient or its attempt budget is spent
 	// (#1982). It exists so an undelivered obligation is attributable from the
@@ -414,6 +419,37 @@ func listWakeOutboxObligations(
 	return out, nil
 }
 
+// wakeOutboxDestinationEvidenceExists is the ONE definition of DESTINATION
+// EVIDENCE for a directive-class wake row: a note in the directive's own
+// workflow that acknowledges it or records its delivery. It is a fact about the
+// world - the wake reached the seat - so both readers of that fact share this
+// definition rather than keeping a copy each.
+//
+// #1958 item 3 is what a second copy cost. The obligation projection consulted
+// this evidence to pick a directive's phase, and ExpireAgedWakeOutbox - the
+// function immediately below it - wrote `delivery_unknown` without ever asking.
+// #1911 measured the consequence: directive 126123 was acknowledged about two
+// minutes after its row was created and 78 minutes before that row was flagged
+// as undelivered.
+//
+// It references wake_outbox.source_id, so it is valid in any statement whose
+// subject is wake_outbox, SELECT or UPDATE alike.
+const wakeOutboxDestinationEvidenceExists = `EXISTS (
+				SELECT 1
+				FROM workflow_notes d
+				JOIN workflow_notes r ON r.workflow_id = d.workflow_id
+				WHERE d.id = CAST(wake_outbox.source_id AS INTEGER)
+					AND (
+						substr(r.body, 1, length('[org:directive-ack id=' || wake_outbox.source_id || ' ')) = '[org:directive-ack id=' || wake_outbox.source_id || ' '
+						OR substr(r.body, 1, length('[org:directive-delivered id=' || wake_outbox.source_id || ' ')) = '[org:directive-delivered id=' || wake_outbox.source_id || ' '
+					)
+			)`
+
+// wakeOutboxDirectiveClass restricts a predicate to the rows destination
+// evidence can exist for. A reply-class row has no equivalent marker, so it
+// keeps the unknown outcome rather than being laundered by an absent check.
+const wakeOutboxDirectiveClass = `source_kind = 'workflow_note' AND coalesce_key LIKE 'directive:%'`
+
 func wakeOutboxObligationQuery(attemptedBefore time.Time) (string, []any) {
 	predicate, args := wakeOutboxObligationPredicate(attemptedBefore)
 	return `
@@ -432,16 +468,7 @@ SELECT id, source_kind, source_id, target_role, coalesce_key, state,
 						OR substr(r.body, 1, length('[org:directive-done id=' || wake_outbox.source_id || ' ')) = '[org:directive-done id=' || wake_outbox.source_id || ' '
 					)
 			) THEN 'terminal'
-			WHEN EXISTS (
-				SELECT 1
-				FROM workflow_notes d
-				JOIN workflow_notes r ON r.workflow_id = d.workflow_id
-				WHERE d.id = CAST(wake_outbox.source_id AS INTEGER)
-					AND (
-						substr(r.body, 1, length('[org:directive-ack id=' || wake_outbox.source_id || ' ')) = '[org:directive-ack id=' || wake_outbox.source_id || ' '
-						OR substr(r.body, 1, length('[org:directive-delivered id=' || wake_outbox.source_id || ' ')) = '[org:directive-delivered id=' || wake_outbox.source_id || ' '
-					)
-			) THEN 'completion'
+			WHEN ` + wakeOutboxDestinationEvidenceExists + ` THEN 'completion'
 			ELSE 'acknowledgment'
 		END,
 		CASE
@@ -537,6 +564,7 @@ ORDER BY attempted_at, id`,
 
 	stamp := at.UTC().Format(BlockedEpisodeTimeLayout)
 	const detail = "delivery outcome unknown after attempted wake aged out; not retried"
+	const deliveredByEvidenceDetail = "delivery proven by destination evidence after attempted wake aged out; the directive was acknowledged"
 	// A CLAIMED BATCH IS ONE WAKE, AND THIS SWEEP IS THE SIBLING SEAM THAT DID
 	// NOT KNOW IT. #1982 moved the coalescing collapse from claim time to
 	// outcome time, which left a whole batch `attempted` until its outcome; this
@@ -549,11 +577,41 @@ ORDER BY attempted_at, id`,
 	// and the rows it collapsed are superseded into it: the same accounting a
 	// delivered or failed batch already uses. Rows are ordered by attempted_at
 	// then id, so the first row of each claim group is its survivor.
+	// DESTINATION EVIDENCE BEFORE THE WRITE-OFF (#1958 item 3). A row whose
+	// directive was acknowledged demonstrably reached its seat, so calling it
+	// `delivery_unknown` records a negative that the store can disprove. One
+	// query for the whole aged set, inside this transaction and after the write
+	// lock is already held, so it costs no extra contention.
+	delivered := map[int64]struct{}{}
+	evidenceRows, err := tx.QueryContext(writeCtx, `
+SELECT id FROM wake_outbox
+WHERE state = 'attempted' AND attempted_at IS NOT NULL AND attempted_at <= ?
+	AND `+wakeOutboxDirectiveClass+`
+	AND `+wakeOutboxDestinationEvidenceExists,
+		attemptedBefore.UTC().Format(BlockedEpisodeTimeLayout))
+	if err != nil {
+		return nil, err
+	}
+	for evidenceRows.Next() {
+		var id int64
+		if err := evidenceRows.Scan(&id); err != nil {
+			_ = evidenceRows.Close()
+			return nil, err
+		}
+		delivered[id] = struct{}{}
+	}
+	if err := evidenceRows.Close(); err != nil {
+		return nil, err
+	}
+
 	seenSurvivor := map[string]int64{}
 	for _, entry := range entries {
 		group := strings.ToLower(strings.TrimSpace(entry.TargetRole)) + "\x00" +
 			entry.CoalesceKey + "\x00" + entry.AttemptedAt
 		state, rowDetail := WakeOutboxStateDeliveryUnknown, detail
+		if _, proven := delivered[entry.ID]; proven {
+			state, rowDetail = WakeOutboxStateDelivered, deliveredByEvidenceDetail
+		}
 		survivor, collapsed := seenSurvivor[group]
 		if collapsed {
 			state, rowDetail = WakeOutboxStateSuperseded, WakeOutboxCoalescedDetail(survivor)
@@ -582,14 +640,20 @@ WHERE id = ? AND state = 'attempted' AND attempted_at <= ?`,
 			// over-counting in the job-event stream.
 			continue
 		}
+		kind, policy := WakeOutboxDeliveryUnknownEventKind, "expire_without_retry"
+		if state == WakeOutboxStateDelivered {
+			// A resolved obligation is not an unknown one, and an event stream
+			// that records it as unknown reproduces the defect downstream.
+			kind, policy = WakeOutboxDeliveredEventKind, "resolved_by_destination_evidence"
+		}
 		message := fmt.Sprintf(
-			"source=%s:%s target_role=%s attempted_at=%s policy=expire_without_retry",
-			entry.SourceKind, entry.SourceID, entry.TargetRole, entry.AttemptedAt,
+			"source=%s:%s target_role=%s attempted_at=%s policy=%s",
+			entry.SourceKind, entry.SourceID, entry.TargetRole, entry.AttemptedAt, policy,
 		)
 		if _, err := tx.ExecContext(writeCtx,
 			`INSERT INTO job_events(job_id, kind, message) VALUES (?, ?, ?)`,
 			fmt.Sprintf("wake-outbox:%d", entry.ID),
-			WakeOutboxDeliveryUnknownEventKind,
+			kind,
 			message,
 		); err != nil {
 			return nil, err

--- a/internal/db/wake_outbox_aged_evidence_test.go
+++ b/internal/db/wake_outbox_aged_evidence_test.go
@@ -1,0 +1,268 @@
+package db
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+)
+
+// TestAgedSweepHonoursDestinationEvidence is #1958 acceptance item 3.
+//
+// THE DEFECT. ExpireAgedWakeOutbox writes `delivery_unknown` on any attempted
+// row that aged out, without ever asking whether the wake demonstrably LANDED.
+// #1911 measured the consequence directly: directive 126123's row sat
+// `attempted` while its acknowledgment `[org:directive-ack id=126123 ...]` had
+// been recorded about two minutes after the row was created and 78 minutes
+// before the row was flagged as undelivered. An instrument built on the row's
+// own columns then reports delivered work as an outstanding obligation, and the
+// older the row the more confident the false positive looks.
+//
+// THE SIBLING SEAM. The store ALREADY knows how to read that evidence:
+// wakeOutboxObligationQuery, the function immediately above the sweep, joins
+// workflow_notes to find `[org:directive-ack ...]` and
+// `[org:directive-delivered ...]` markers to pick a directive's phase. The
+// sweep never consults it. One function apart, and only one of them asks.
+func TestAgedSweepHonoursDestinationEvidence(t *testing.T) {
+	for _, test := range []struct {
+		name      string
+		evidence  string
+		wantState string
+	}{
+		{name: "acknowledged", evidence: "[org:directive-ack id=%d by=worker]", wantState: WakeOutboxStateDelivered},
+		{name: "delivered-marker", evidence: "[org:directive-delivered id=%d to=worker]", wantState: WakeOutboxStateDelivered},
+		{name: "no-evidence", evidence: "", wantState: WakeOutboxStateDeliveryUnknown},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			store := openWorkflowTestStore(t)
+			ctx := context.Background()
+
+			directive, err := store.InsertWorkflowNote(ctx, WorkflowNote{
+				WorkflowID: "release/directives", Author: "coordinator",
+				Body: "[org:directive to=worker] do the thing",
+			})
+			if err != nil {
+				t.Fatalf("seed directive: %v", err)
+			}
+			if test.evidence != "" {
+				if _, err := store.InsertWorkflowNote(ctx, WorkflowNote{
+					WorkflowID: "release/directives", Author: "worker",
+					Body: fmt.Sprintf(test.evidence, directive.ID),
+				}); err != nil {
+					t.Fatalf("seed evidence: %v", err)
+				}
+			}
+
+			attemptedAt := time.Date(2026, 7, 28, 12, 0, 0, 0, time.UTC)
+			stamp := attemptedAt.Format(BlockedEpisodeTimeLayout)
+			if _, err := store.db.ExecContext(ctx, `
+INSERT INTO wake_outbox(source_kind, source_id, target_role, coalesce_key, state,
+	attempt_count, created_at, updated_at, attempted_at)
+VALUES ('workflow_note', ?, 'worker', 'directive:worker', 'attempted', 1, ?, ?, ?)`,
+				fmt.Sprint(directive.ID), stamp, stamp, stamp); err != nil {
+				t.Fatalf("seed wake: %v", err)
+			}
+
+			if _, err := store.ExpireAgedWakeOutbox(ctx, attemptedAt.Add(time.Hour), attemptedAt.Add(2*time.Hour)); err != nil {
+				t.Fatalf("ExpireAgedWakeOutbox: %v", err)
+			}
+
+			rows, err := store.ListWakeOutbox(ctx, test.wantState)
+			if err != nil {
+				t.Fatalf("ListWakeOutbox: %v", err)
+			}
+			if len(rows) != 1 {
+				all, _ := store.ListWakeOutbox(ctx, "")
+				t.Fatalf("rows in %s = %d, want 1; every row = %+v", test.wantState, len(rows), all)
+			}
+			if test.wantState == WakeOutboxStateDelivered && rows[0].LastError == "" {
+				t.Fatalf("a row resolved by destination evidence records no reason: %+v", rows[0])
+			}
+
+			// THE EVENT STREAM MUST NOT CALL A PROVEN DELIVERY UNKNOWN. An
+			// operator reads the stream, not the row, and a resolved obligation
+			// recorded as `wake_delivery_unknown` reproduces this defect
+			// downstream of the fix.
+			events, err := store.ListJobEvents(ctx, fmt.Sprintf("wake-outbox:%d", rows[0].ID))
+			if err != nil {
+				t.Fatalf("ListJobEvents: %v", err)
+			}
+			wantKind := WakeOutboxDeliveryUnknownEventKind
+			if test.wantState == WakeOutboxStateDelivered {
+				wantKind = WakeOutboxDeliveredEventKind
+			}
+			var kinds []string
+			for _, event := range events {
+				kinds = append(kinds, event.Kind)
+			}
+			if len(events) != 1 || events[0].Kind != wantKind {
+				t.Fatalf("job events = %v, want exactly one %q", kinds, wantKind)
+			}
+		})
+	}
+}
+
+// TestAgedSweepDoesNotLaunderAReplyRowWithADirectiveAck pins the guard that
+// mutant-survived without it.
+//
+// The evidence subquery joins on `source_id` cast to a note id, and a REPLY
+// row's source is also a note. So without the directive-class restriction, a
+// reply wake whose source note happens to share a workflow with some
+// directive's acknowledgment would be marked delivered on evidence that is
+// about a different obligation entirely. A reply has no acknowledgment marker
+// of its own, so its unknown outcome is the honest one.
+func TestAgedSweepDoesNotLaunderAReplyRowWithADirectiveAck(t *testing.T) {
+	store := openWorkflowTestStore(t)
+	ctx := context.Background()
+
+	// One workflow holding BOTH a reply-class source note and a directive with
+	// its own acknowledgment - the shape that makes an unguarded join wrong.
+	source, err := store.InsertWorkflowNote(ctx, WorkflowNote{
+		WorkflowID: "release/mixed", Author: "worker", Body: "a plain reply-worthy note",
+	})
+	if err != nil {
+		t.Fatalf("seed source: %v", err)
+	}
+	if _, err := store.InsertWorkflowNote(ctx, WorkflowNote{
+		WorkflowID: "release/mixed", Author: "worker",
+		Body: fmt.Sprintf("[org:directive-ack id=%d by=worker]", source.ID),
+	}); err != nil {
+		t.Fatalf("seed ack: %v", err)
+	}
+
+	attemptedAt := time.Date(2026, 7, 28, 12, 0, 0, 0, time.UTC)
+	stamp := attemptedAt.Format(BlockedEpisodeTimeLayout)
+	if _, err := store.db.ExecContext(ctx, `
+INSERT INTO wake_outbox(source_kind, source_id, target_role, coalesce_key, state,
+	attempt_count, created_at, updated_at, attempted_at)
+VALUES ('workflow_note', ?, 'owner', 'reply:owner', 'attempted', 1, ?, ?, ?)`,
+		fmt.Sprint(source.ID), stamp, stamp, stamp); err != nil {
+		t.Fatalf("seed reply wake: %v", err)
+	}
+
+	if _, err := store.ExpireAgedWakeOutbox(ctx, attemptedAt.Add(time.Hour), attemptedAt.Add(2*time.Hour)); err != nil {
+		t.Fatalf("ExpireAgedWakeOutbox: %v", err)
+	}
+
+	unknown, err := store.ListWakeOutbox(ctx, WakeOutboxStateDeliveryUnknown)
+	if err != nil {
+		t.Fatalf("ListWakeOutbox: %v", err)
+	}
+	if len(unknown) != 1 {
+		delivered, _ := store.ListWakeOutbox(ctx, WakeOutboxStateDelivered)
+		t.Fatalf("reply row in delivery_unknown = %d, want 1; delivered = %+v", len(unknown), delivered)
+	}
+}
+
+// TestAgedSweepRequiresEvidenceForItsOwnDirective pins that the evidence is
+// keyed to THE ROW'S directive, not to the existence of any acknowledgment.
+//
+// This is the case the no-evidence subtest cannot reach: with no markers in the
+// store at all, a predicate that ignores the id still finds nothing and looks
+// correct. Put ANOTHER directive's acknowledgment in the same workflow and the
+// difference becomes observable - an unacknowledged directive must stay
+// unknown even while its neighbour is acknowledged.
+func TestAgedSweepRequiresEvidenceForItsOwnDirective(t *testing.T) {
+	store := openWorkflowTestStore(t)
+	ctx := context.Background()
+
+	unacked, err := store.InsertWorkflowNote(ctx, WorkflowNote{
+		WorkflowID: "release/directives", Author: "coordinator",
+		Body: "[org:directive to=worker] the one nobody answered",
+	})
+	if err != nil {
+		t.Fatalf("seed unacked directive: %v", err)
+	}
+	neighbour, err := store.InsertWorkflowNote(ctx, WorkflowNote{
+		WorkflowID: "release/directives", Author: "coordinator",
+		Body: "[org:directive to=worker] the one that was answered",
+	})
+	if err != nil {
+		t.Fatalf("seed neighbour directive: %v", err)
+	}
+	if _, err := store.InsertWorkflowNote(ctx, WorkflowNote{
+		WorkflowID: "release/directives", Author: "worker",
+		Body: fmt.Sprintf("[org:directive-ack id=%d by=worker]", neighbour.ID),
+	}); err != nil {
+		t.Fatalf("seed neighbour ack: %v", err)
+	}
+
+	attemptedAt := time.Date(2026, 7, 28, 12, 0, 0, 0, time.UTC)
+	stamp := attemptedAt.Format(BlockedEpisodeTimeLayout)
+	if _, err := store.db.ExecContext(ctx, `
+INSERT INTO wake_outbox(source_kind, source_id, target_role, coalesce_key, state,
+	attempt_count, created_at, updated_at, attempted_at)
+VALUES ('workflow_note', ?, 'worker', 'directive:worker', 'attempted', 1, ?, ?, ?)`,
+		fmt.Sprint(unacked.ID), stamp, stamp, stamp); err != nil {
+		t.Fatalf("seed wake: %v", err)
+	}
+
+	if _, err := store.ExpireAgedWakeOutbox(ctx, attemptedAt.Add(time.Hour), attemptedAt.Add(2*time.Hour)); err != nil {
+		t.Fatalf("ExpireAgedWakeOutbox: %v", err)
+	}
+
+	unknown, err := store.ListWakeOutbox(ctx, WakeOutboxStateDeliveryUnknown)
+	if err != nil {
+		t.Fatalf("ListWakeOutbox: %v", err)
+	}
+	if len(unknown) != 1 {
+		delivered, _ := store.ListWakeOutbox(ctx, WakeOutboxStateDelivered)
+		t.Fatalf("unacked row in delivery_unknown = %d, want 1: it was resolved by ANOTHER directive's acknowledgment; delivered = %+v",
+			len(unknown), delivered)
+	}
+}
+
+// TestAgedSweepRequiresEvidenceInTheDirectivesOwnWorkflow pins what the
+// `d.id = CAST(source_id)` condition actually buys, which is not what it looks
+// like it buys.
+//
+// The marker comparison already keys on `wake_outbox.source_id`, so an ack
+// naming a DIFFERENT directive cannot match regardless of that condition -
+// which is why a mutant replacing it with `1=1` survived the neighbour test.
+// What it really constrains is WHERE the acknowledgment lives: it must be in
+// the directive's own workflow. An ack naming this row's directive id from an
+// unrelated workflow is not evidence about this obligation, and this test is
+// the only thing that says so.
+func TestAgedSweepRequiresEvidenceInTheDirectivesOwnWorkflow(t *testing.T) {
+	store := openWorkflowTestStore(t)
+	ctx := context.Background()
+
+	directive, err := store.InsertWorkflowNote(ctx, WorkflowNote{
+		WorkflowID: "release/directives", Author: "coordinator",
+		Body: "[org:directive to=worker] do the thing",
+	})
+	if err != nil {
+		t.Fatalf("seed directive: %v", err)
+	}
+	// The ack names the right id and lives in the WRONG workflow.
+	if _, err := store.InsertWorkflowNote(ctx, WorkflowNote{
+		WorkflowID: "some/other-workflow", Author: "worker",
+		Body: fmt.Sprintf("[org:directive-ack id=%d by=worker]", directive.ID),
+	}); err != nil {
+		t.Fatalf("seed foreign ack: %v", err)
+	}
+
+	attemptedAt := time.Date(2026, 7, 28, 12, 0, 0, 0, time.UTC)
+	stamp := attemptedAt.Format(BlockedEpisodeTimeLayout)
+	if _, err := store.db.ExecContext(ctx, `
+INSERT INTO wake_outbox(source_kind, source_id, target_role, coalesce_key, state,
+	attempt_count, created_at, updated_at, attempted_at)
+VALUES ('workflow_note', ?, 'worker', 'directive:worker', 'attempted', 1, ?, ?, ?)`,
+		fmt.Sprint(directive.ID), stamp, stamp, stamp); err != nil {
+		t.Fatalf("seed wake: %v", err)
+	}
+
+	if _, err := store.ExpireAgedWakeOutbox(ctx, attemptedAt.Add(time.Hour), attemptedAt.Add(2*time.Hour)); err != nil {
+		t.Fatalf("ExpireAgedWakeOutbox: %v", err)
+	}
+
+	unknown, err := store.ListWakeOutbox(ctx, WakeOutboxStateDeliveryUnknown)
+	if err != nil {
+		t.Fatalf("ListWakeOutbox: %v", err)
+	}
+	if len(unknown) != 1 {
+		delivered, _ := store.ListWakeOutbox(ctx, WakeOutboxStateDelivered)
+		t.Fatalf("row in delivery_unknown = %d, want 1: an ack from a foreign workflow was accepted as evidence; delivered = %+v",
+			len(unknown), delivered)
+	}
+}

--- a/skills/gitmoot/references/CLI.md
+++ b/skills/gitmoot/references/CLI.md
@@ -2081,6 +2081,12 @@ and an `agent_blocked` pane are **transient**: the claimed rows return to
 bounded at three attempts. Any other cause, and an exhausted budget, end the
 rows terminally and record a `wake_delivery_failed` job event on
 `wake-outbox:<id>` naming the role, cause and attempts.
+An aged row whose delivery the store can PROVE is recorded `delivered` with a
+`wake_delivered` job event carrying `policy=resolved_by_destination_evidence`,
+rather than `delivery_unknown`. The proof is a note in the directive's own
+workflow acknowledging it (`[org:directive-ack id=<id> ...]`) or recording its
+delivery (`[org:directive-delivered id=<id> ...]`), naming that row's directive;
+a reply-class row has no equivalent marker and keeps the unknown outcome.
 `attention`, `guard`, `job-terminal`, `review-verdict`, `recycle-overdue`, and
 `pane_input_pending` wakes remain best-effort. With no rule rows this path is
 off. Task episodes due in one evaluator pass produce one oldest-first digest

--- a/website/docs/reference/cli.md
+++ b/website/docs/reference/cli.md
@@ -1802,6 +1802,12 @@ are re-delivered as one coalesced wake, bounded at three attempts. Anything
 else, and an exhausted budget, ends the rows terminally and records a
 `wake_delivery_failed` job event on `wake-outbox:<id>` naming the role, cause
 and attempts. `attention`, `guard`, `job-terminal`,
+An aged row whose delivery the store can PROVE is recorded `delivered` with a
+`wake_delivered` job event carrying `policy=resolved_by_destination_evidence`,
+rather than `delivery_unknown`. The proof is a note in the directive's own
+workflow acknowledging it (`[org:directive-ack id=<id> ...]`) or recording its
+delivery (`[org:directive-delivered id=<id> ...]`), naming that row's directive;
+a reply-class row has no equivalent marker and keeps the unknown outcome.
 `review-verdict`, `recycle-overdue`, and `pane_input_pending` wakes remain
 best-effort; zero rules leaves the feature off.
 

--- a/website/docs/reference/cli.md
+++ b/website/docs/reference/cli.md
@@ -1802,14 +1802,15 @@ are re-delivered as one coalesced wake, bounded at three attempts. Anything
 else, and an exhausted budget, ends the rows terminally and records a
 `wake_delivery_failed` job event on `wake-outbox:<id>` naming the role, cause
 and attempts. `attention`, `guard`, `job-terminal`,
+`review-verdict`, `recycle-overdue`, and `pane_input_pending` wakes remain
+best-effort; zero rules leaves the feature off.
+
 An aged row whose delivery the store can PROVE is recorded `delivered` with a
 `wake_delivered` job event carrying `policy=resolved_by_destination_evidence`,
 rather than `delivery_unknown`. The proof is a note in the directive's own
 workflow acknowledging it (`[org:directive-ack id=<id> ...]`) or recording its
 delivery (`[org:directive-delivered id=<id> ...]`), naming that row's directive;
 a reply-class row has no equivalent marker and keeps the unknown outcome.
-`review-verdict`, `recycle-overdue`, and `pane_input_pending` wakes remain
-best-effort; zero rules leaves the feature off.
 
 ```sh
 gitmoot orchestrate planner "Coordinate the dashboard wave." --repo owner/repo --workflow fable/dashboard-redesign

--- a/website/docs/reference/event-stream.md
+++ b/website/docs/reference/event-stream.md
@@ -253,6 +253,18 @@ unexplained non-delivery), the batch becomes terminal AND a
 `wake_delivery_failed` job event is recorded on `wake-outbox:<id>` naming the
 target role, the cause and the attempts spent, so an undelivered obligation is
 attributable from the store rather than only from a daemon log line.
+An aged-out row whose delivery the store can PROVE is recorded as `delivered`
+rather than `delivery_unknown`, with a `wake_delivered` job event on
+`wake-outbox:<id>` carrying `policy=resolved_by_destination_evidence`. The proof
+is DESTINATION EVIDENCE: a note in the directive's own workflow that
+acknowledges it (`[org:directive-ack id=<id> ...]`) or records its delivery
+(`[org:directive-delivered id=<id> ...]`). Without that check the sweep recorded
+a negative the store could disprove: a directive acknowledged two minutes after
+its row was created was still flagged undelivered 78 minutes later, and every
+instrument built on `state` and `attempt_count` then reported delivered work as
+an outstanding obligation. The evidence must name THAT row's directive and live
+in the directive's own workflow; a reply-class row has no equivalent marker, so
+it keeps the unknown outcome rather than being laundered by an absent check.
 A wake addressed to a role that CANNOT receive it, because no enabled rule
 exists for that role and kind, records a `wake_unroutable` job event on
 `wake-outbox:<id>` naming the role, the kind, the source and WHICH condition it


### PR DESCRIPTION
Closes #1958 acceptance item 3. Items 4 and 5 are drain and `internal/cli` surface and were placed with gm-staged by phobos.

**Opened as a DRAFT deliberately.** A fleet press freeze binds pressers but not an armed engine merge gate, which can merge on approval-plus-green with no holder acting (#1731 did). Nothing of mine sits in that shape while I do not hold the merge token.

## Reproduced before fixed

```
--- FAIL: TestAgedSweepHonoursDestinationEvidence/acknowledged
    rows in delivered = 0, want 1; every row = [{... CoalesceKey:directive:worker
    State:delivery_unknown LastError:delivery outcome unknown after attempted wake aged out; not retried}]
--- FAIL: TestAgedSweepHonoursDestinationEvidence/delivered-marker
```

The `no-evidence` subtest passed before the fix and still passes, so the change resolves what it can prove and nothing else.

## The defect, and #1911's measurement of its cost

`ExpireAgedWakeOutbox` wrote `delivery_unknown` on any attempted row that aged out, without ever asking whether the wake demonstrably landed. #1911 measured the consequence: directive `126123` was acknowledged about **two minutes** after its row was created and **78 minutes before** that row was flagged as undelivered. Two coordinators then built escalation triggers on `(state, attempt_count, age)` and both fired false, because the columns say nothing about arrival.

**The sibling seam:** `wakeOutboxObligationQuery`, the function IMMEDIATELY ABOVE the sweep, already joined `workflow_notes` to read `[org:directive-ack ...]` and `[org:directive-delivered ...]` markers to pick a directive's phase. The sweep never consulted it. One function apart, and only one of them asked.

## The fix

The evidence clause is now **single-sourced**, and that is justified rather than reflexive: it is genuinely **one fact** - the wake reached the seat - not two values that happen to be equal. (The opposite case from earlier tonight: `daemonShutdownDrainTimeout` and `DurableWriteBudgetFor` share units and answer different questions, so deriving one from the other was refused.)

The sweep asks once for the whole aged set, inside the same transaction and **after** the write lock is already held, so it adds no contention. A proven row records `delivered` with a detail naming why, and a distinct `wake_delivered` job event carrying `policy=resolved_by_destination_evidence` - an event stream that called a resolved obligation unknown would reproduce this defect downstream of its own fix.

## Mutants: four, all killed, and two found real gaps

| Mutant | First result | Now |
| --- | --- | --- |
| sweep stops consulting the evidence | killed | killed |
| directive-class guard dropped | **survived** | killed by `TestAgedSweepDoesNotLaunderAReplyRowWithADirectiveAck` |
| audit event keeps the `unknown` kind | **survived** | killed by the event-kind assertion |
| `d.id = CAST(source_id)` replaced with `1=1` | **survived twice** | killed by `TestAgedSweepRequiresEvidenceInTheDirectivesOwnWorkflow` |

The last one is worth reading, because it changed my understanding of the code rather than my tests. It survived a neighbour-directive fixture too, and the reason is that **`d.id = CAST(source_id)` does not do what it looks like it does**: the marker comparison already keys on `wake_outbox.source_id`, so an ack naming a different directive can never match with or without it. What that condition actually constrains is **which workflow** the acknowledgment must live in. An ack naming the right directive from an unrelated workflow is not evidence about this obligation, and nothing said so until that test existed.

Guards deliberately kept, each with a test:

- **directive class only.** A reply-class row has no acknowledgment marker of its own, so it keeps the unknown outcome rather than being laundered by an absent check. Without the guard, a reply wake whose source note shares a workflow with some directive's ack is marked delivered on evidence about a different obligation.
- **the row's own directive**, in **the directive's own workflow**.

## Verification

`go build ./...` exit 0, `go vet ./internal/db` exit 0, and the full wake filter (`WakeOutbox|Wake|Expire|Finish|Claim|Obligation|Directive|Coalesc|Aged`) green, plus the `internal/cli` drain consumers (`TestReplyWake|TestUnroutable|TestRoutable|TestStalled|TestDelivered|TestUndelivered`).

**Local full verification is pending a disk constraint; CI is the gate.** Free space is at the fleet dispatch guard and the owner has stopped granting `./...` windows, so no untargeted package run was performed here. That is a decision, not an omission.

**The live rate is not re-derivable now:** dispatch is paused fleet-wide, so the contention that produced #1911's aged-out rows is not running. Proven by construction and by fixtures instead.

Docs updated in both trees: `docs/events.md` and `website/docs/reference/event-stream.md`.
