### PR TITLE
ci: trigger the workflow on merge_group so a queue entry can pass

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,6 +59,7 @@ jobs:
       - name: Classify
         id: diff
         run: |
+          # A merge_group entry takes this branch DELIBERATELY (queue tests the merged result, so no lane may skip); no merge_group case is missing below.
           if [ "${{ github.event_name }}" != "pull_request" ]; then
             echo "code=true" >> "$GITHUB_OUTPUT"
             echo "push to main — full gate"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,7 @@ on:
   push:
     branches: [main]
   pull_request:
+  merge_group:
 
 permissions:
   contents: read


### PR DESCRIPTION
One line: `merge_group:` in `ci.yml`'s `on:` block. Authorised by phobos, who
disabled ruleset 22536038 when this was found.

## The defect

A merge queue entry fires **`merge_group`** on a `gh-readonly-queue/main/...`
ref, not `pull_request`. The on-block had only `push: branches:[main]` and
`pull_request:`, so a queued entry ran **no workflow at all**. The required
`build / vet / test` check never reports, and GitHub dequeues the entry on
timeout.

The failure mode is the dangerous shape: it presents as **the queue** being
broken rather than the workflow being untriggered, so the natural next move is to
debug or disable the queue, which is the one thing that cannot reveal the cause.

Measured before the change, from the governing artifacts rather than from the
announcement that the queue was live:

- `grep -rln merge_group .github/workflows/` - nothing, across both `ci.yml` and
  `release.yml`.
- `build / vet / test` is defined in exactly one place, `ci.yml:76`, so no other
  workflow could supply it.
- `gh api "repos/gitmoot/gitmoot/actions/runs?event=merge_group"` -
  `total_count 0`. Never fired on this repo, which is consistent with the trigger
  being absent rather than present-but-unused.

## Why this is one line and not a rework

**The `changes` job is deliberately untouched, and that is a decision rather than
an omission.** Its first branch is:

```
if [ "${{ github.event_name }}" != "pull_request" ]; then echo "code=true"
```

So a `merge_group` entry already classifies as `code=true` and runs **every**
lane. That is the correct behaviour here, not an accident: the queue tests the
**merged result**, and the merged tree is exactly the one that must not skip a
lane. Do not later add a `merge_group` case to that job thinking it was missed.

## The required-check choice is permanently correct, not provisional

Recorded here because it changes what the ruleset should require, and the
original reasoning aimed at the wrong hazard.

`code=false` happens **only** when the diff is exclusively `go.mod` and
`go.sum` - that is **dep-only**, not docs-only:

```
CHANGED=$(git diff --name-only "origin/${{ github.base_ref }}...HEAD")
if echo "$CHANGED" | grep -qvE '^(go\.mod|go\.sum)$'; then code=true; else code=false; fi
```

- A **docs-only** PR touches files outside those two, gets `code=true`, and runs
  all 27. Requiring every check would never have wedged it, so waiting to observe
  a docs-only PR through the queue would have told us nothing.
- A **dependency bump** touching only `go.mod`/`go.sum` skips `race-build` and
  `race` via `if: needs.changes.outputs.code == 'true'`. Requiring those would
  make such a PR **unmergeable forever**.
- `build-test` carries **no `if:`** at all and always runs.

So the single required check `build / vet / test` is the permanently correct
choice, and the set should not be widened to include the race lanes.

## Verification

`ci.yml` parses with `yaml.safe_load`; `on` keys are
`['merge_group', 'pull_request', 'push']`; `build-test` has no `if`; `race`
retains `needs.changes.outputs.code == 'true'`. No job definition changed - the
diff is a single added line.

The thing this PR **cannot** verify is the thing it exists for: that a real entry
merges through the queue. That needs the ruleset re-enabled after this lands, and
phobos holds that.

## Draft

Opened as a draft per the standing rule from gm-staged's finding: an armed engine
merge gate can merge an approved, green PR with no holder acting. Un-drafted only
when it is about to be pressed.

## What adding a trigger can BREAK, not only what it fixes

gm-transport asked for this before I had it, and then derived it independently
rather than taking my word. Both readings agree; each was made from the file
rather than from the other's message.

**1. No `pull_request`-context assumption is exposed.** Grepping every workflow
for `github.event.pull_request`, `github.event_name`, `github.head_ref` and
`github.base_ref` matches `ci.yml` **only**, at two lines, both inside the
classify job. Line 62 is the `event_name` test itself. Line 67 - the sole
`github.base_ref` use, and the one that WOULD fail, because `base_ref` is empty
outside a pull request - sits inside the branch reached only when
`event_name == "pull_request"`, so a `merge_group` event never executes it.
`release.yml` carries none of these keys. Blast radius is one file.

**2. Concurrency does not cross-cancel.** The group is `ci-${{ github.ref }}`
with `cancel-in-progress: true`. On a `merge_group` event `github.ref` is the
`gh-readonly-queue/main/...` ref, distinct from a PR's own ref, so a queue entry
cannot cancel a live PR run or be cancelled by one.

**3. The required check will actually report.** `build-test` has
`needs: changes`; `changes` succeeds with `code=true`; so `build / vet / test`
runs and reports on the entry, which is precisely the wedge this removes.

## A consequence to know before re-enabling (gm-transport)

Because `code=true` on every `merge_group` event, **a queue entry runs all 27
checks including the 15 race shards.** That is correct - the queue exists to test
the merged result - but each entry costs a full CI run, and with *one entry at a
time* the queue serialises at CI speed. Measured CI is **850-970s**, so the
throughput ceiling is roughly **four merges an hour** regardless of how many
seats are ready.

Still far better than the 27-minute rebase race it replaces, but it is a number
to have before anyone expects the queue to be free.
