### PR TITLE
fix(workflow): bind a delegated review to the head it reviews (#1730)

### DIFF
--- a/internal/cli/delegation_head_resolver_wiring_1730_test.go
+++ b/internal/cli/delegation_head_resolver_wiring_1730_test.go
@@ -1,0 +1,25 @@
+package cli
+
+import (
+	"context"
+	"testing"
+)
+
+// #1730 wiring guard. The engine resolves a delegated review's head by asserting
+// DelegationWorktrees to a RevParse-capable interface. That assertion is only
+// worth anything if the value production assigns satisfies it, and
+// daemon_workflow.go sets it to jobGitClient(checkout, runner).
+//
+// This is a COMPILE-TIME assertion in the package that does the wiring, so the
+// fix cannot become dead code through a change to jobGitClient's return type.
+// A runtime-only test in internal/workflow would keep passing with a fake.
+func TestJobGitClientSatisfiesTheDelegationHeadResolver(t *testing.T) {
+	var client any = jobGitClient("/tmp/does-not-need-to-exist", nil)
+	resolver, ok := client.(interface {
+		RevParse(ctx context.Context, rev string) (string, error)
+	})
+	if !ok {
+		t.Fatal("jobGitClient no longer satisfies the RevParse resolver the engine asserts for #1730; the delegated-review head fix would be dead in production")
+	}
+	_ = resolver
+}

--- a/internal/workflow/delegated_review_head_1730_test.go
+++ b/internal/workflow/delegated_review_head_1730_test.go
@@ -126,3 +126,93 @@ func TestDelegatedReviewOfAReviewParentKeepsTheInheritedHead(t *testing.T) {
 		t.Fatalf("a review parent's child resolved a branch tip it should not have: %v", resolver.calls)
 	}
 }
+
+// #2057 ROUND TWO, P1-B. On the NO-FINALIZER path the inherited head is the
+// pre-change commit, so an unresolvable branch must DROP it rather than attest a
+// verdict against a commit nobody reviewed. Round one removed this arm
+// wholesale; the justification only ever held for the finalizer path.
+func TestDelegatedReviewDropsAnUnresolvableHeadOnTheNoFinalizerPath(t *testing.T) {
+	ctx := context.Background()
+	resolver := &fakeHeadResolver{err: errors.New("git: unknown revision")}
+	engine, store := newDelegatedReviewFixture(t, resolver)
+
+	parent := db.Job{ID: "impl-nofin", Agent: "appkit-omp", Type: "implement", State: string(JobSucceeded)}
+	// No TaskID, so implementationNeedsFinalizer is false: nothing produced this
+	// head, and it is therefore the pre-change commit.
+	payload := JobPayload{Repo: "themartianapp/appkit", Branch: "adhoc-nofin", HeadSHA: staleImplementHead}
+	request := JobRequest{
+		ID: "impl-nofin/delegation/round2-review", Repo: payload.Repo, Branch: payload.Branch,
+		Action: "review", Agent: "reviewer", HeadSHA: payload.HeadSHA, DelegationID: "round2-review",
+	}
+	seedMergeGateFixtureAgent(t, store, "reviewer")
+	if err := engine.allocateAndEnqueueDelegationInner(ctx, parent, payload, Delegation{ID: "round2-review", Action: "review"}, request, taskRef{}); err != nil {
+		t.Fatalf("allocateAndEnqueueDelegationInner: %v", err)
+	}
+
+	child, err := store.GetJob(ctx, "impl-nofin/delegation/round2-review")
+	if err != nil {
+		t.Fatalf("child job not enqueued: %v", err)
+	}
+	childPayload, err := unmarshalPayload(child.Payload)
+	if err != nil {
+		t.Fatalf("unmarshalPayload: %v", err)
+	}
+	if childPayload.HeadSHA == staleImplementHead {
+		t.Fatal("an unresolvable branch on the no-finalizer path kept the pre-change head, so the row would attest a verdict at a commit nobody reviewed")
+	}
+	if childPayload.HeadSHA != "" {
+		t.Fatalf("child head = %q, want it dropped", childPayload.HeadSHA)
+	}
+	events, err := store.ListJobEvents(ctx, parent.ID)
+	if err != nil {
+		t.Fatalf("ListJobEvents: %v", err)
+	}
+	var found bool
+	for _, ev := range events {
+		if ev.Kind == "delegation_review_head_unbound" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatal("dropping the head was not recorded, so the loss is silent")
+	}
+}
+
+// And the finalizer path must NOT drop: there the inherited head is the head the
+// finalizer produced, so an unresolvable branch is not evidence it is stale.
+func TestDelegatedReviewKeepsTheFinalizedHeadWhenTheBranchWillNotResolve(t *testing.T) {
+	ctx := context.Background()
+	resolver := &fakeHeadResolver{err: errors.New("git: unknown revision")}
+	engine, store := newDelegatedReviewFixture(t, resolver)
+
+	if err := store.UpsertTask(ctx, db.Task{
+		ID: "task-fin", RepoFullName: "themartianapp/appkit", Title: "Fin",
+		State: string(TaskImplementing), Branch: "adhoc-fin", WorktreePath: "/tmp/gitmoot-task-fin",
+	}); err != nil {
+		t.Fatalf("UpsertTask: %v", err)
+	}
+	engine.ImplementationFinalizer = fakeImplementationFinalizer{}
+
+	parent := db.Job{ID: "impl-fin", Agent: "appkit-omp", Type: "implement", State: string(JobSucceeded)}
+	payload := JobPayload{Repo: "themartianapp/appkit", Branch: "adhoc-fin", HeadSHA: producedHead, TaskID: "task-fin"}
+	request := JobRequest{
+		ID: "impl-fin/delegation/round2-review", Repo: payload.Repo, Branch: payload.Branch,
+		Action: "review", Agent: "reviewer", HeadSHA: payload.HeadSHA, DelegationID: "round2-review",
+	}
+	seedMergeGateFixtureAgent(t, store, "reviewer")
+	if err := engine.allocateAndEnqueueDelegationInner(ctx, parent, payload, Delegation{ID: "round2-review", Action: "review"}, request, taskRef{}); err != nil {
+		t.Fatalf("allocateAndEnqueueDelegationInner: %v", err)
+	}
+
+	child, err := store.GetJob(ctx, "impl-fin/delegation/round2-review")
+	if err != nil {
+		t.Fatalf("child job not enqueued: %v", err)
+	}
+	childPayload, err := unmarshalPayload(child.Payload)
+	if err != nil {
+		t.Fatalf("unmarshalPayload: %v", err)
+	}
+	if childPayload.HeadSHA != producedHead {
+		t.Fatalf("child head = %q, want the finalizer's produced head %q kept", childPayload.HeadSHA, producedHead)
+	}
+}

--- a/internal/workflow/delegated_review_head_1730_test.go
+++ b/internal/workflow/delegated_review_head_1730_test.go
@@ -1,0 +1,179 @@
+package workflow
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/gitmoot/gitmoot/internal/db"
+)
+
+// #1730. A review delegated by an IMPLEMENT job recorded the parent's payload
+// head, which is the commit BEFORE the parent's change, so the row attested a
+// verdict at an ancestor of the tree the reviewer actually read.
+//
+// These tests drive Engine.allocateAndEnqueueDelegationInner, the production
+// path, with a ONE-CHILD delegation - the shape of the reproduced job. That
+// matters: readOnlyFanoutNeedsWorktree requires two or more read-only siblings
+// (worktree.go:941), so a lone review child never reaches the read-only
+// worktree branch, and a fix placed there would be unexercised by the very job
+// that motivated it.
+
+type fakeHeadResolver struct {
+	heads map[string]string
+	err   error
+	calls []string
+}
+
+func (f *fakeHeadResolver) AddWorktree(context.Context, string, string, string) error { return nil }
+
+func (f *fakeHeadResolver) RevParse(_ context.Context, rev string) (string, error) {
+	f.calls = append(f.calls, rev)
+	if f.err != nil {
+		return "", f.err
+	}
+	sha, ok := f.heads[rev]
+	if !ok {
+		return "", errors.New("unknown revision " + rev)
+	}
+	return sha, nil
+}
+
+const (
+	staleImplementHead = "0e2ce4f150ed8c8b816cc6b0715c8de0dd64f803"
+	producedHead       = "0c175d03796f5625a23d1c7c52464f55d7308d0e"
+)
+
+func newDelegatedReviewFixture(t *testing.T, resolver WorktreeManager) (Engine, *db.Store) {
+	t.Helper()
+	store := openEngineStore(t)
+	return Engine{Store: store, DelegationWorktrees: resolver}, store
+}
+
+// The reviewed head must be WRITTEN, not merely un-inherited: the row has to
+// name the commit the reviewer will read.
+func TestDelegatedReviewBindsToTheHeadTheImplementParentProduced(t *testing.T) {
+	ctx := context.Background()
+	resolver := &fakeHeadResolver{heads: map[string]string{"adhoc-be2e7f7f": producedHead}}
+	engine, store := newDelegatedReviewFixture(t, resolver)
+
+	parent := db.Job{ID: "impl-1730", Agent: "appkit-omp", Type: "implement", State: string(JobSucceeded)}
+	payload := JobPayload{
+		Repo: "themartianapp/appkit", Branch: "adhoc-be2e7f7f",
+		HeadSHA: staleImplementHead, TaskID: "task-1730",
+	}
+	request := JobRequest{
+		ID:   "impl-1730/delegation/round2-review",
+		Repo: payload.Repo, Branch: payload.Branch, Action: "review", Agent: "reviewer",
+		HeadSHA: payload.HeadSHA, DelegationID: "round2-review",
+	}
+	seedMergeGateFixtureAgent(t, store, "reviewer")
+	if err := engine.allocateAndEnqueueDelegationInner(ctx, parent, payload, Delegation{ID: "round2-review", Action: "review"}, request, taskRef{}); err != nil {
+		t.Fatalf("allocateAndEnqueueDelegationInner: %v", err)
+	}
+
+	child, err := store.GetJob(ctx, "impl-1730/delegation/round2-review")
+	if err != nil {
+		t.Fatalf("child job not enqueued: %v", err)
+	}
+	childPayload, err := unmarshalPayload(child.Payload)
+	if err != nil {
+		t.Fatalf("unmarshalPayload: %v", err)
+	}
+	if childPayload.HeadSHA == staleImplementHead {
+		t.Fatal("the child still records the implement parent's pre-change head; the row attests a verdict at an ancestor of the reviewed tree")
+	}
+	if childPayload.HeadSHA != producedHead {
+		t.Fatalf("child head = %q, want the branch tip %q that the parent produced", childPayload.HeadSHA, producedHead)
+	}
+	if len(resolver.calls) == 0 || resolver.calls[0] != "adhoc-be2e7f7f" {
+		t.Fatalf("the head was not resolved from the parent's branch: calls=%v", resolver.calls)
+	}
+}
+
+// A REVIEW parent must be untouched: its head IS the commit under review, and
+// unpinning it there would remove the exact-head guarantee the merge gate
+// depends on. Without this, the fix could be over-applied to every review
+// delegation.
+func TestDelegatedReviewOfAReviewParentKeepsTheInheritedHead(t *testing.T) {
+	ctx := context.Background()
+	resolver := &fakeHeadResolver{heads: map[string]string{"task-9": producedHead}}
+	engine, store := newDelegatedReviewFixture(t, resolver)
+
+	parent := db.Job{ID: "review-1730", Agent: "coord", Type: "review", State: string(JobSucceeded)}
+	payload := JobPayload{Repo: "gitmoot/gitmoot", Branch: "task-9", HeadSHA: staleImplementHead, TaskID: "task-9"}
+	request := JobRequest{
+		ID:   "review-1730/delegation/lens-a",
+		Repo: payload.Repo, Branch: payload.Branch, Action: "review", Agent: "lens",
+		HeadSHA: payload.HeadSHA, DelegationID: "lens-a",
+	}
+	seedMergeGateFixtureAgent(t, store, "lens")
+	if err := engine.allocateAndEnqueueDelegationInner(ctx, parent, payload, Delegation{ID: "lens-a", Action: "review"}, request, taskRef{}); err != nil {
+		t.Fatalf("allocateAndEnqueueDelegationInner: %v", err)
+	}
+	child, err := store.GetJob(ctx, "review-1730/delegation/lens-a")
+	if err != nil {
+		t.Fatalf("child job not enqueued: %v", err)
+	}
+	childPayload, err := unmarshalPayload(child.Payload)
+	if err != nil {
+		t.Fatalf("unmarshalPayload: %v", err)
+	}
+	if childPayload.HeadSHA != staleImplementHead {
+		t.Fatalf("a LENS child of a review parent lost its inherited exact head: got %q", childPayload.HeadSHA)
+	}
+	if len(resolver.calls) != 0 {
+		t.Fatalf("a review parent's child resolved a branch tip it should not have: %v", resolver.calls)
+	}
+}
+
+// When the branch cannot be resolved the stale head must be DROPPED rather than
+// recorded. An unbound verdict is worse than a correct one and better than a
+// wrongly-bound one, because a wrong head looks bound - and the event has to say
+// which happened, or the drop is indistinguishable from a job that never had a
+// head.
+func TestDelegatedReviewDropsAnUnresolvableHeadAndSaysSo(t *testing.T) {
+	ctx := context.Background()
+	resolver := &fakeHeadResolver{err: errors.New("git: unknown revision")}
+	engine, store := newDelegatedReviewFixture(t, resolver)
+
+	parent := db.Job{ID: "impl-1730b", Agent: "appkit-omp", Type: "implement", State: string(JobSucceeded)}
+	payload := JobPayload{Repo: "themartianapp/appkit", Branch: "gone-branch", HeadSHA: staleImplementHead, TaskID: "t"}
+	request := JobRequest{
+		ID:   "impl-1730b/delegation/round2-review",
+		Repo: payload.Repo, Branch: payload.Branch, Action: "review", Agent: "reviewer2",
+		HeadSHA: payload.HeadSHA, DelegationID: "round2-review",
+	}
+	seedMergeGateFixtureAgent(t, store, "reviewer2")
+	if err := engine.allocateAndEnqueueDelegationInner(ctx, parent, payload, Delegation{ID: "round2-review", Action: "review"}, request, taskRef{}); err != nil {
+		t.Fatalf("allocateAndEnqueueDelegationInner: %v", err)
+	}
+	child, err := store.GetJob(ctx, "impl-1730b/delegation/round2-review")
+	if err != nil {
+		t.Fatalf("child job not enqueued: %v", err)
+	}
+	childPayload, err := unmarshalPayload(child.Payload)
+	if err != nil {
+		t.Fatalf("unmarshalPayload: %v", err)
+	}
+	if strings.TrimSpace(childPayload.HeadSHA) != "" {
+		t.Fatalf("an unresolvable branch kept a head known to be stale: %q", childPayload.HeadSHA)
+	}
+	events, err := store.ListJobEvents(ctx, parent.ID)
+	if err != nil {
+		t.Fatalf("ListJobEvents: %v", err)
+	}
+	var found string
+	for _, event := range events {
+		if event.Kind == "delegation_review_head_unbound" {
+			found = event.Message
+		}
+	}
+	if found == "" {
+		t.Fatal("dropping the head recorded no event, so an unbound child is indistinguishable from one that never had a head")
+	}
+	if !strings.Contains(found, shortHead(staleImplementHead)) {
+		t.Fatalf("the event does not name the head that was dropped: %q", found)
+	}
+}

--- a/internal/workflow/delegated_review_head_1730_test.go
+++ b/internal/workflow/delegated_review_head_1730_test.go
@@ -3,7 +3,6 @@ package workflow
 import (
 	"context"
 	"errors"
-	"strings"
 	"testing"
 
 	"github.com/gitmoot/gitmoot/internal/db"
@@ -125,55 +124,5 @@ func TestDelegatedReviewOfAReviewParentKeepsTheInheritedHead(t *testing.T) {
 	}
 	if len(resolver.calls) != 0 {
 		t.Fatalf("a review parent's child resolved a branch tip it should not have: %v", resolver.calls)
-	}
-}
-
-// When the branch cannot be resolved the stale head must be DROPPED rather than
-// recorded. An unbound verdict is worse than a correct one and better than a
-// wrongly-bound one, because a wrong head looks bound - and the event has to say
-// which happened, or the drop is indistinguishable from a job that never had a
-// head.
-func TestDelegatedReviewDropsAnUnresolvableHeadAndSaysSo(t *testing.T) {
-	ctx := context.Background()
-	resolver := &fakeHeadResolver{err: errors.New("git: unknown revision")}
-	engine, store := newDelegatedReviewFixture(t, resolver)
-
-	parent := db.Job{ID: "impl-1730b", Agent: "appkit-omp", Type: "implement", State: string(JobSucceeded)}
-	payload := JobPayload{Repo: "themartianapp/appkit", Branch: "gone-branch", HeadSHA: staleImplementHead, TaskID: "t"}
-	request := JobRequest{
-		ID:   "impl-1730b/delegation/round2-review",
-		Repo: payload.Repo, Branch: payload.Branch, Action: "review", Agent: "reviewer2",
-		HeadSHA: payload.HeadSHA, DelegationID: "round2-review",
-	}
-	seedMergeGateFixtureAgent(t, store, "reviewer2")
-	if err := engine.allocateAndEnqueueDelegationInner(ctx, parent, payload, Delegation{ID: "round2-review", Action: "review"}, request, taskRef{}); err != nil {
-		t.Fatalf("allocateAndEnqueueDelegationInner: %v", err)
-	}
-	child, err := store.GetJob(ctx, "impl-1730b/delegation/round2-review")
-	if err != nil {
-		t.Fatalf("child job not enqueued: %v", err)
-	}
-	childPayload, err := unmarshalPayload(child.Payload)
-	if err != nil {
-		t.Fatalf("unmarshalPayload: %v", err)
-	}
-	if strings.TrimSpace(childPayload.HeadSHA) != "" {
-		t.Fatalf("an unresolvable branch kept a head known to be stale: %q", childPayload.HeadSHA)
-	}
-	events, err := store.ListJobEvents(ctx, parent.ID)
-	if err != nil {
-		t.Fatalf("ListJobEvents: %v", err)
-	}
-	var found string
-	for _, event := range events {
-		if event.Kind == "delegation_review_head_unbound" {
-			found = event.Message
-		}
-	}
-	if found == "" {
-		t.Fatal("dropping the head recorded no event, so an unbound child is indistinguishable from one that never had a head")
-	}
-	if !strings.Contains(found, shortHead(staleImplementHead)) {
-		t.Fatalf("the event does not name the head that was dropped: %q", found)
 	}
 }

--- a/internal/workflow/delegated_review_head_1730_test.go
+++ b/internal/workflow/delegated_review_head_1730_test.go
@@ -194,7 +194,12 @@ func TestDelegatedReviewKeepsTheFinalizedHeadWhenTheBranchWillNotResolve(t *test
 	engine.ImplementationFinalizer = fakeImplementationFinalizer{}
 
 	parent := db.Job{ID: "impl-fin", Agent: "appkit-omp", Type: "implement", State: string(JobSucceeded)}
-	payload := JobPayload{Repo: "themartianapp/appkit", Branch: "adhoc-fin", HeadSHA: producedHead, TaskID: "task-fin"}
+	// #2057 round three: "the finalizer produced this head" is now DURABLE STATE
+	// on the payload rather than something re-derived from a task lookup at read
+	// time. This fixture previously relied on that re-derivation, which is
+	// exactly the coupling the finding removed.
+	payload := JobPayload{Repo: "themartianapp/appkit", Branch: "adhoc-fin", HeadSHA: producedHead, TaskID: "task-fin",
+		ImplementationFinalized: true}
 	request := JobRequest{
 		ID: "impl-fin/delegation/round2-review", Repo: payload.Repo, Branch: payload.Branch,
 		Action: "review", Agent: "reviewer", HeadSHA: payload.HeadSHA, DelegationID: "round2-review",
@@ -214,5 +219,74 @@ func TestDelegatedReviewKeepsTheFinalizedHeadWhenTheBranchWillNotResolve(t *test
 	}
 	if childPayload.HeadSHA != producedHead {
 		t.Fatalf("child head = %q, want the finalizer's produced head %q kept", childPayload.HeadSHA, producedHead)
+	}
+}
+
+// #2057 round three, P1. AN UNCHANGED RESOLVE IS NOT A RESOLVE on the
+// no-finalizer path. RevParse succeeding and returning the SAME sha left both
+// arms silent - nonempty so not dropped, equal so not rebound - so the row kept
+// the pre-change commit this path documents. The earlier regression covered only
+// resolver FAILURE.
+func TestDelegatedReviewDropsAnUnchangedHeadOnTheNoFinalizerPath(t *testing.T) {
+	ctx := context.Background()
+	resolver := &fakeHeadResolver{heads: map[string]string{"adhoc-same": staleImplementHead}}
+	engine, store := newDelegatedReviewFixture(t, resolver)
+
+	parent := db.Job{ID: "impl-same", Agent: "appkit-omp", Type: "implement", State: string(JobSucceeded)}
+	payload := JobPayload{Repo: "themartianapp/appkit", Branch: "adhoc-same", HeadSHA: staleImplementHead}
+	request := JobRequest{
+		ID: "impl-same/delegation/round2-review", Repo: payload.Repo, Branch: payload.Branch,
+		Action: "review", Agent: "reviewer", HeadSHA: payload.HeadSHA, DelegationID: "round2-review",
+	}
+	seedMergeGateFixtureAgent(t, store, "reviewer")
+	if err := engine.allocateAndEnqueueDelegationInner(ctx, parent, payload, Delegation{ID: "round2-review", Action: "review"}, request, taskRef{}); err != nil {
+		t.Fatalf("allocateAndEnqueueDelegationInner: %v", err)
+	}
+
+	child, err := store.GetJob(ctx, "impl-same/delegation/round2-review")
+	if err != nil {
+		t.Fatalf("child job not enqueued: %v", err)
+	}
+	childPayload, err := unmarshalPayload(child.Payload)
+	if err != nil {
+		t.Fatalf("unmarshalPayload: %v", err)
+	}
+	if childPayload.HeadSHA == staleImplementHead {
+		t.Fatal("a resolve that returned the inherited sha left the pre-change head recorded as reviewed")
+	}
+	if childPayload.HeadSHA != "" {
+		t.Fatalf("child head = %q, want it dropped", childPayload.HeadSHA)
+	}
+}
+
+// The equality case must NOT drop when a finalizer produced the head: there the
+// branch tip and the produced head agreeing is the CORRECT outcome, not evidence
+// of staleness.
+func TestDelegatedReviewKeepsAnUnchangedHeadWhenAFinalizerProducedIt(t *testing.T) {
+	ctx := context.Background()
+	resolver := &fakeHeadResolver{heads: map[string]string{"adhoc-fin2": producedHead}}
+	engine, store := newDelegatedReviewFixture(t, resolver)
+
+	parent := db.Job{ID: "impl-fin2", Agent: "appkit-omp", Type: "implement", State: string(JobSucceeded)}
+	payload := JobPayload{Repo: "themartianapp/appkit", Branch: "adhoc-fin2", HeadSHA: producedHead,
+		TaskID: "task-fin2", ImplementationFinalized: true}
+	request := JobRequest{
+		ID: "impl-fin2/delegation/round2-review", Repo: payload.Repo, Branch: payload.Branch,
+		Action: "review", Agent: "reviewer", HeadSHA: payload.HeadSHA, DelegationID: "round2-review",
+	}
+	seedMergeGateFixtureAgent(t, store, "reviewer")
+	if err := engine.allocateAndEnqueueDelegationInner(ctx, parent, payload, Delegation{ID: "round2-review", Action: "review"}, request, taskRef{}); err != nil {
+		t.Fatalf("allocateAndEnqueueDelegationInner: %v", err)
+	}
+	child, err := store.GetJob(ctx, "impl-fin2/delegation/round2-review")
+	if err != nil {
+		t.Fatalf("child job not enqueued: %v", err)
+	}
+	childPayload, err := unmarshalPayload(child.Payload)
+	if err != nil {
+		t.Fatalf("unmarshalPayload: %v", err)
+	}
+	if childPayload.HeadSHA != producedHead {
+		t.Fatalf("child head = %q, want the produced head %q kept", childPayload.HeadSHA, producedHead)
 	}
 }

--- a/internal/workflow/delegation_finalizer_ordering_2057_test.go
+++ b/internal/workflow/delegation_finalizer_ordering_2057_test.go
@@ -348,6 +348,17 @@ func TestConcurrentAdvancesFinalizeExactlyOnce(t *testing.T) {
 	if got := counter.calls(); got != 1 {
 		t.Fatalf("FinalizeImplementation ran %d times across two concurrent advances, want exactly 1: it commits, pushes and opens a pull request", got)
 	}
+	// #2057 round five: THE LOSER NOW STOPS instead of proceeding. Its error is
+	// FinalizationInProgressError, which is retryable by the daemon; previously it
+	// carried on and dispatched delegations from the pre-finalization head.
+	var sawInProgress bool
+	for _, err := range errs {
+		if errors.As(err, &FinalizationInProgressError{}) {
+			sawInProgress = true
+		}
+	}
+	_ = sawInProgress
+
 	// A SEPARATE, PRE-EXISTING RACE SURFACES HERE AND IS NOT THIS TEST'S SUBJECT:
 	// once both advances are past the finalizer they both try to enqueue the same
 	// delegation child, and the loser fails on the jobs.id UNIQUE constraint. That
@@ -362,7 +373,8 @@ func TestConcurrentAdvancesFinalizeExactlyOnce(t *testing.T) {
 			continue
 		}
 		if strings.Contains(err.Error(), "UNIQUE constraint failed: jobs.id") ||
-			strings.Contains(err.Error(), "job id already exists") {
+			strings.Contains(err.Error(), "job id already exists") ||
+			strings.Contains(err.Error(), "finalization for") {
 			continue
 		}
 		t.Fatalf("advance %d returned an unexpected error: %v", slot, err)
@@ -452,4 +464,104 @@ func (f *flakyFinalizer) FinalizeImplementation(context.Context, db.Job, JobPayl
 		return JobPayload{}, errors.New("push implementation branch failed")
 	}
 	return f.payload, nil
+}
+
+// #2057 ROUND FIVE, P1. A LOST CLAIM MUST NOT BE READ AS COMPLETED WORK.
+//
+// The previous version set finalizedBeforeDelegations = true on a lost claim and
+// carried on, so the LOSER advanced the parent DAG and dispatched delegations
+// from the pre-finalization head and pull request while the winner was still
+// committing and pushing. My claim proved "someone started" and I read it as
+// "someone finished" - different facts with the same durable representation,
+// which is also why a crash after claiming was indistinguishable from success.
+//
+// Completion is now its own record, written AFTER the payload, so a loser that
+// sees it can trust the payload it reloads.
+func TestLostClaimWithoutCompletionStopsInsteadOfDispatchingStaleData(t *testing.T) {
+	ctx := context.Background()
+	engine, store := newOrderingFixture(t)
+	engine.ImplementationFinalizer = fakeImplementationFinalizer{err: errors.New("should not run: the claim is held")}
+
+	insertCompletedJob(t, store, db.Job{ID: "impl-lost", Agent: "lead", Type: "implement"}, orderingParentPayload())
+
+	// Another advance holds the claim and has NOT recorded completion.
+	claimed, err := store.ClaimJobEvent(ctx, db.JobEvent{
+		JobID:   "impl-lost",
+		Kind:    "implementation_finalize_claimed",
+		Message: "implementation finalization claimed for impl-lost (#2057)",
+	})
+	if err != nil || !claimed {
+		t.Fatalf("seed claim: claimed=%v err=%v", claimed, err)
+	}
+
+	advanceErr := engine.AdvanceJob(ctx, "impl-lost")
+	if advanceErr == nil {
+		t.Fatal("the claim loser advanced anyway, dispatching from data the winner is about to replace")
+	}
+	var inProgress FinalizationInProgressError
+	if !errors.As(advanceErr, &inProgress) {
+		t.Fatalf("loser must stop with a retryable in-progress error, got %v", advanceErr)
+	}
+
+	// Nothing was delegated from the stale payload.
+	if _, err := store.GetJob(ctx, "impl-lost/delegation/round2-review"); err == nil {
+		t.Fatal("a delegation was dispatched from the pre-finalization payload")
+	}
+}
+
+// AND ONCE COMPLETION IS RECORDED, a later advance proceeds and uses the
+// FINALIZED payload rather than its own stale copy.
+func TestLostClaimWithCompletionReloadsTheFinalizedPayload(t *testing.T) {
+	ctx := context.Background()
+	engine, store := newOrderingFixture(t)
+	engine.ImplementationFinalizer = fakeImplementationFinalizer{err: errors.New("should not run: already completed")}
+
+	stale := orderingParentPayload()
+	insertCompletedJob(t, store, db.Job{ID: "impl-done", Agent: "lead", Type: "implement"}, stale)
+
+	// The winner's outcome: claim taken, finalized payload persisted, completion
+	// recorded - in that order.
+	if _, err := store.ClaimJobEvent(ctx, db.JobEvent{
+		JobID: "impl-done", Kind: "implementation_finalize_claimed",
+		Message: "implementation finalization claimed for impl-done (#2057)",
+	}); err != nil {
+		t.Fatalf("seed claim: %v", err)
+	}
+	finalized := orderingParentPayload()
+	finalized.HeadSHA = orderingProducedHead
+	finalized.PullRequest = 4321
+	finalized.ImplementationFinalized = true
+	encoded, err := marshalPayload(finalized)
+	if err != nil {
+		t.Fatalf("marshalPayload: %v", err)
+	}
+	if err := store.UpdateJobPayload(ctx, "impl-done", encoded); err != nil {
+		t.Fatalf("UpdateJobPayload: %v", err)
+	}
+	if err := store.AddJobEventIfAbsent(ctx, db.JobEvent{
+		JobID: "impl-done", Kind: "implementation_finalize_completed",
+		Message: "implementation finalization completed for impl-done (#2057)",
+	}); err != nil {
+		t.Fatalf("seed completion: %v", err)
+	}
+
+	if err := engine.AdvanceJob(ctx, "impl-done"); err != nil {
+		t.Fatalf("an advance after recorded completion must proceed: %v", err)
+	}
+
+	// The delegated child carries the FINALIZED head and PR, not the stale ones.
+	child, err := store.GetJob(ctx, "impl-done/delegation/round2-review")
+	if err != nil {
+		t.Fatalf("delegation not enqueued: %v", err)
+	}
+	childPayload, err := unmarshalPayload(child.Payload)
+	if err != nil {
+		t.Fatalf("unmarshalPayload: %v", err)
+	}
+	if childPayload.HeadSHA != orderingProducedHead {
+		t.Fatalf("child head = %q, want the finalized %q: the loser used its own stale payload", childPayload.HeadSHA, orderingProducedHead)
+	}
+	if childPayload.PullRequest != 4321 {
+		t.Fatalf("child pull_request = %d, want 4321 from the finalized payload", childPayload.PullRequest)
+	}
 }

--- a/internal/workflow/delegation_finalizer_ordering_2057_test.go
+++ b/internal/workflow/delegation_finalizer_ordering_2057_test.go
@@ -1,0 +1,167 @@
+package workflow
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/gitmoot/gitmoot/internal/db"
+)
+
+// #2057, the accepted P1 on the #1730 fix.
+//
+// Cited against durable trees, not this checkout: in `origin/main` at 6b95d4cf
+// AND at the reviewed head fbde492a, `engine_run_budgets.go:698` dispatched
+// delegations and `:710` finalized the implementation - dispatch BEFORE
+// finalize. Until the finalizer runs, a task-backed implementation's work is not
+// committed, so the worktree HEAD is still the inherited pre-change commit and
+// there is nothing for a dispatch-time resolver to resolve.
+//
+// THE FIRST FIX COULD NOT HAVE CAUGHT THIS AND NEITHER COULD ITS TESTS. They
+// preloaded the fake resolver with the produced head before enqueue, which
+// supplies the postcondition of a step that has not run. Every value was right;
+// only their availability was wrong. Filed as a class in #2076.
+//
+// So these tests drive Engine.AdvanceJob - the production advancement path - and
+// deliberately install NO resolver. The finalizer's returned payload is then the
+// only possible source of the produced head, which is exactly the dependency
+// under test.
+
+const (
+	orderingInheritedHead = "1111111111111111111111111111111111111111"
+	orderingProducedHead  = "2222222222222222222222222222222222222222"
+)
+
+func newOrderingFixture(t *testing.T) (Engine, *db.Store) {
+	t.Helper()
+	ctx := context.Background()
+	store := openEngineStore(t)
+	seedAgent(t, store, "lead", []string{"implement"}, "gitmoot/gitmoot")
+	seedAgent(t, store, "reviewer", []string{"review"}, "gitmoot/gitmoot")
+	engine := testEngine(store)
+	if err := store.UpsertTask(ctx, db.Task{
+		ID:           "task-2057",
+		RepoFullName: "gitmoot/gitmoot",
+		GoalID:       "goal-2057",
+		Title:        "Ordering",
+		State:        string(TaskImplementing),
+		Branch:       "task-2057",
+		// A worktree path is what makes implementationNeedsFinalizer true, which
+		// is the whole population this defect lives in.
+		WorktreePath: "/tmp/gitmoot-task-2057",
+	}); err != nil {
+		t.Fatalf("UpsertTask: %v", err)
+	}
+	return engine, store
+}
+
+func orderingParentPayload() JobPayload {
+	return JobPayload{
+		Repo: "gitmoot/gitmoot", Branch: "task-2057",
+		GoalID: "goal-2057", TaskID: "task-2057", TaskTitle: "Ordering",
+		LeadAgent: "lead",
+		// The pre-change commit the parent was dispatched against.
+		HeadSHA: orderingInheritedHead,
+		Result: &AgentResult{
+			Decision: "implemented", Summary: "done",
+			Delegations: []Delegation{{
+				ID: "round2-review", Action: "review", Agent: "reviewer",
+			}},
+		},
+	}
+}
+
+// THE REGRESSION. A delegated review must inherit the head the FINALIZER
+// produced, which requires the finalizer to have run first. With the production
+// ordering reversed this records orderingInheritedHead - a commit that carries
+// none of the parent's work - and the row attests a verdict against an ancestor
+// of the tree the reviewer read.
+func TestDelegatedReviewInheritsTheFinalizedProducedHead(t *testing.T) {
+	ctx := context.Background()
+	engine, store := newOrderingFixture(t)
+
+	finalized := orderingParentPayload()
+	finalized.HeadSHA = orderingProducedHead
+	finalized.PullRequest = 2057
+	engine.ImplementationFinalizer = fakeImplementationFinalizer{payload: finalized}
+	// No DelegationWorktrees, so no resolver exists. If the child still carries
+	// the produced head, it can only have come from the finalized payload.
+	engine.DelegationWorktrees = nil
+
+	insertCompletedJob(t, store, db.Job{ID: "impl-2057", Agent: "lead", Type: "implement"}, orderingParentPayload())
+	if err := engine.AdvanceJob(ctx, "impl-2057"); err != nil {
+		t.Fatalf("AdvanceJob: %v", err)
+	}
+
+	child, err := store.GetJob(ctx, "impl-2057/delegation/round2-review")
+	if err != nil {
+		t.Fatalf("delegated review not enqueued: %v", err)
+	}
+	childPayload, err := unmarshalPayload(child.Payload)
+	if err != nil {
+		t.Fatalf("unmarshalPayload: %v", err)
+	}
+	if childPayload.HeadSHA == orderingInheritedHead {
+		t.Fatal("the delegated review inherited the parent's PRE-CHANGE head: delegations were dispatched before the implementation was finalized, so the verdict would name a commit carrying none of the work")
+	}
+	if childPayload.HeadSHA != orderingProducedHead {
+		t.Fatalf("child head = %q, want the finalizer's produced head %q", childPayload.HeadSHA, orderingProducedHead)
+	}
+	// The PR number is written by the same finalizer paths as the head. If the
+	// child sees the head but not the number, the dispatch read a half-updated
+	// payload rather than the finalized one.
+	if childPayload.PullRequest != 2057 {
+		t.Fatalf("child pull_request = %d, want 2057 from the finalized payload", childPayload.PullRequest)
+	}
+}
+
+// THE FINALIZER RUNS EXACTLY ONCE. It commits, pushes, and opens or adopts a
+// pull request, so a second call is not a harmless repeat - moving it earlier
+// must not leave the original call site running it again.
+func TestImplementationFinalizerRunsOncePerAdvance(t *testing.T) {
+	ctx := context.Background()
+	engine, store := newOrderingFixture(t)
+
+	finalized := orderingParentPayload()
+	finalized.HeadSHA = orderingProducedHead
+	counter := &countingFinalizer{payload: finalized}
+	engine.ImplementationFinalizer = counter
+
+	insertCompletedJob(t, store, db.Job{ID: "impl-2057b", Agent: "lead", Type: "implement"}, orderingParentPayload())
+	if err := engine.AdvanceJob(ctx, "impl-2057b"); err != nil {
+		t.Fatalf("AdvanceJob: %v", err)
+	}
+
+	if counter.calls != 1 {
+		t.Fatalf("FinalizeImplementation called %d times, want exactly 1: it commits, pushes and opens a PR", counter.calls)
+	}
+}
+
+// A FAILING FINALIZER MUST PREVENT THE DELEGATIONS, which is the ordering
+// consequence of the fix and the safer direction: the work whose review was
+// being delegated does not exist. Before the reorder the child was already
+// enqueued by the time the finalizer failed.
+func TestFailedFinalizerDispatchesNoDelegations(t *testing.T) {
+	ctx := context.Background()
+	engine, store := newOrderingFixture(t)
+	engine.ImplementationFinalizer = fakeImplementationFinalizer{err: errors.New("push implementation branch failed")}
+
+	insertCompletedJob(t, store, db.Job{ID: "impl-2057c", Agent: "lead", Type: "implement"}, orderingParentPayload())
+	if err := engine.AdvanceJob(ctx, "impl-2057c"); err == nil {
+		t.Fatal("AdvanceJob must surface the finalizer failure")
+	}
+
+	if _, err := store.GetJob(ctx, "impl-2057c/delegation/round2-review"); err == nil {
+		t.Fatal("a review was delegated for work the finalizer failed to commit or push")
+	}
+}
+
+type countingFinalizer struct {
+	payload JobPayload
+	calls   int
+}
+
+func (c *countingFinalizer) FinalizeImplementation(context.Context, db.Job, JobPayload) (JobPayload, error) {
+	c.calls++
+	return c.payload, nil
+}

--- a/internal/workflow/delegation_finalizer_ordering_2057_test.go
+++ b/internal/workflow/delegation_finalizer_ordering_2057_test.go
@@ -165,3 +165,41 @@ func (c *countingFinalizer) FinalizeImplementation(context.Context, db.Job, JobP
 	c.calls++
 	return c.payload, nil
 }
+
+// #2057 ROUND TWO, P1-A. An implement job that is ITSELF a delegation child
+// advances its parent's DAG, which can enqueue a ready dependent sibling or the
+// coordinator continuation. Finalizing after that left those jobs enqueued from
+// work that was never committed. Round one's failing-finalizer test used a
+// TOP-LEVEL job, so it could not reach this path - the finalizer must sit above
+// the parent advance, not merely above dispatchDelegations.
+func TestFailedFinalizerOnADelegationChildAdvancesNoParent(t *testing.T) {
+	ctx := context.Background()
+	engine, store := newOrderingFixture(t)
+	engine.ImplementationFinalizer = fakeImplementationFinalizer{err: errors.New("push implementation branch failed")}
+
+	parentPayload := orderingParentPayload()
+	insertCompletedJob(t, store, db.Job{ID: "coordinator-2057", Agent: "lead", Type: "implement"}, parentPayload)
+
+	// The child is an implement job WITH a parent, which is the shape round one
+	// could not express.
+	childPayload := orderingParentPayload()
+	childPayload.ParentJobID = "coordinator-2057"
+	insertCompletedJob(t, store, db.Job{ID: "child-2057", Agent: "lead", Type: "implement"}, childPayload)
+
+	before, err := store.ListJobs(ctx)
+	if err != nil {
+		t.Fatalf("ListJobs: %v", err)
+	}
+
+	if err := engine.AdvanceJob(ctx, "child-2057"); err == nil {
+		t.Fatal("AdvanceJob must surface the finalizer failure")
+	}
+
+	after, err := store.ListJobs(ctx)
+	if err != nil {
+		t.Fatalf("ListJobs: %v", err)
+	}
+	if len(after) != len(before) {
+		t.Fatalf("the failed finalizer still enqueued %d job(s) through the parent DAG: before=%d after=%d", len(after)-len(before), len(before), len(after))
+	}
+}

--- a/internal/workflow/delegation_finalizer_ordering_2057_test.go
+++ b/internal/workflow/delegation_finalizer_ordering_2057_test.go
@@ -203,3 +203,93 @@ func TestFailedFinalizerOnADelegationChildAdvancesNoParent(t *testing.T) {
 		t.Fatalf("the failed finalizer still enqueued %d job(s) through the parent DAG: before=%d after=%d", len(after)-len(before), len(before), len(after))
 	}
 }
+
+// #2057 ROUND THREE, P1. THE FINALIZER DECISION IS DURABLE, so a retry of
+// AdvanceJob after any later failure does not run it again. It commits, pushes
+// and opens or adopts a pull request; a second run is not a harmless repeat.
+func TestFinalizedImplementationIsNotFinalizedAgainOnRetry(t *testing.T) {
+	ctx := context.Background()
+	engine, store := newOrderingFixture(t)
+
+	finalized := orderingParentPayload()
+	finalized.HeadSHA = orderingProducedHead
+	counter := &countingFinalizer{payload: finalized}
+	engine.ImplementationFinalizer = counter
+
+	insertCompletedJob(t, store, db.Job{ID: "impl-retry", Agent: "lead", Type: "implement"}, orderingParentPayload())
+	if err := engine.AdvanceJob(ctx, "impl-retry"); err != nil {
+		t.Fatalf("first AdvanceJob: %v", err)
+	}
+	if counter.calls != 1 {
+		t.Fatalf("first advance called the finalizer %d times, want 1", counter.calls)
+	}
+
+	// The marker must have been PERSISTED, not merely held in the local variable.
+	row, err := store.GetJob(ctx, "impl-retry")
+	if err != nil {
+		t.Fatalf("GetJob: %v", err)
+	}
+	stored, err := unmarshalPayload(row.Payload)
+	if err != nil {
+		t.Fatalf("unmarshalPayload: %v", err)
+	}
+	if !stored.ImplementationFinalized {
+		t.Fatal("the finalized marker was not persisted, so a retry cannot know the work is already committed and pushed")
+	}
+
+	// Re-advance, as the daemon does after a later transient failure.
+	if err := engine.AdvanceJob(ctx, "impl-retry"); err != nil {
+		t.Fatalf("re-advance: %v", err)
+	}
+	if counter.calls != 1 {
+		t.Fatalf("the finalizer ran %d times across two advances: it commits, pushes and opens a PR, so the repeat is not harmless", counter.calls)
+	}
+}
+
+// FAIL CLOSED ON AN UNREADABLE TASK, AND ONLY THERE. implementationNeedsFinalizer
+// used to turn EVERY task lookup error into "no finalizer needed", so a transient
+// failure let the parent DAG and the delegations advance from work that was never
+// committed, and repeated failures ran the finalizer zero times.
+//
+// The two error cases are different facts and are asserted separately. A missing
+// row ANSWERS the question - this job is not task-backed - while a failed query
+// answers nothing. My first fix conflated them and three pre-existing tests
+// caught it, because it made every ad-hoc implement job attempt a finalizer.
+func TestUnreadableTaskDoesNotReadAsNeedingNoFinalizer(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("a query that fails answers nothing, so fail closed", func(t *testing.T) {
+		engine, store := newOrderingFixture(t)
+		engine.ImplementationFinalizer = fakeImplementationFinalizer{}
+		// A CLOSED store is the smallest real transient failure: GetTask returns an
+		// error that is not ErrNoRows. A nonexistent task id cannot express this -
+		// it is the missing-row case - which is why my first version of this test
+		// asserted the wrong thing and passed.
+		if err := store.Close(); err != nil {
+			t.Fatalf("close store: %v", err)
+		}
+		if !engine.implementationNeedsFinalizer(ctx, orderingParentPayload()) {
+			t.Fatal("an unreadable task read as needing no finalizer: the parent DAG and delegations would advance from uncommitted work")
+		}
+	})
+
+	t.Run("a missing task row answers the question, so stay false", func(t *testing.T) {
+		engine, _ := newOrderingFixture(t)
+		engine.ImplementationFinalizer = fakeImplementationFinalizer{}
+		payload := orderingParentPayload()
+		payload.TaskID = "task-that-does-not-exist"
+		if engine.implementationNeedsFinalizer(ctx, payload) {
+			t.Fatal("an absent task row was treated as a lookup failure, so every ad-hoc implement job would attempt a finalizer")
+		}
+	})
+
+	t.Run("no task at all is not task-backed", func(t *testing.T) {
+		engine, _ := newOrderingFixture(t)
+		engine.ImplementationFinalizer = fakeImplementationFinalizer{}
+		payload := orderingParentPayload()
+		payload.TaskID = ""
+		if engine.implementationNeedsFinalizer(ctx, payload) {
+			t.Fatal("a job with no TaskID was treated as task-backed")
+		}
+	})
+}

--- a/internal/workflow/delegation_finalizer_ordering_2057_test.go
+++ b/internal/workflow/delegation_finalizer_ordering_2057_test.go
@@ -849,8 +849,21 @@ func TestClaimMessageStaysStableAcrossABinaryChange(t *testing.T) {
 	_, store := newOrderingFixture(t)
 	insertCompletedJob(t, store, db.Job{ID: "impl-deploy", Agent: "lead", Type: "implement"}, orderingParentPayload())
 
-	// The OLD binary's claim: message with no owner in it, and no owner row.
-	seedFinalizeClaim(t, store, "impl-deploy", "")
+	// THE OLD BINARY'S MESSAGE IS A LITERAL, not a call to the current helper.
+	// Round eight's reviewer caught that: seeding both sides through
+	// implementationFinalizeClaimMessage made the test tautological, so changing
+	// the helper to a v2 string left it GREEN while the deploy contract it
+	// claims to protect was broken. This literal is the string the deployed
+	// b592f556, 9b88aca6 and b47bf3fc binaries all emit.
+	const deployed = "implementation finalization claimed for impl-deploy (#2057)"
+	if got := implementationFinalizeClaimMessage("impl-deploy"); got != deployed {
+		t.Fatalf("the claim message CHANGED: %q, want the deployed %q - a running finalization would no longer be excluded", got, deployed)
+	}
+	if claimed, err := store.ClaimJobEvent(ctx, db.JobEvent{
+		JobID: "impl-deploy", Kind: implementationFinalizeClaimedEvent, Message: deployed,
+	}); err != nil || !claimed {
+		t.Fatalf("seed the old binary's claim: claimed=%v err=%v", claimed, err)
+	}
 
 	// The NEW binary tries to claim the same finalization. It must LOSE.
 	claimed, err := store.ClaimJobEvent(ctx, db.JobEvent{
@@ -951,5 +964,146 @@ func TestConcurrentRecoveriesFinalizeAtMostOnce(t *testing.T) {
 	}
 	if recoveries > 1 {
 		t.Fatalf("recorded %d recoveries of one claim, want at most 1", recoveries)
+	}
+}
+
+// #2057 ROUND EIGHT, P1. RELEASING A CLAIM MUST TAKE ITS OWNER ROW WITH IT.
+//
+// Round seven released the claim on the payload-write arm and left the owner row
+// behind, so a LATER holder inherited a dead identity: the abandonment reader
+// found the prior boot's owner beside the new claim, called it abandoned, and
+// recovered a LIVE finalizer. The reviewer reproduced that.
+//
+// This drives the production helper both arms now use, and then asserts the
+// property that actually matters - that a release-then-reclaim cycle leaves
+// exactly ONE owner row, naming the CURRENT holder.
+func TestReleasingAClaimRemovesItsOwnerRow(t *testing.T) {
+	ctx := context.Background()
+	engine, store := newOrderingFixture(t)
+	insertCompletedJob(t, store, db.Job{ID: "impl-pair", Agent: "lead", Type: "implement"}, orderingParentPayload())
+
+	seedFinalizeClaim(t, store, "impl-pair", implementationFinalizeClaimOwnerMessage("impl-pair"))
+	if err := engine.releaseFinalizeClaim(ctx, "impl-pair"); err != nil {
+		t.Fatalf("releaseFinalizeClaim: %v", err)
+	}
+	claims, owners := finalizeClaimRowCounts(t, store, "impl-pair")
+	if claims != 0 || owners != 0 {
+		t.Fatalf("after release: claims=%d owners=%d, want 0 and 0 (a surviving owner row is the defect)", claims, owners)
+	}
+
+	// RECLAIM, which is the scenario that turned the leftover row into a live
+	// recovery: a new holder must not find a second, older owner beside its own.
+	seedFinalizeClaim(t, store, "impl-pair", implementationFinalizeClaimOwnerMessage("impl-pair"))
+	claims, owners = finalizeClaimRowCounts(t, store, "impl-pair")
+	if claims != 1 || owners != 1 {
+		t.Fatalf("after reclaim: claims=%d owners=%d, want exactly 1 and 1", claims, owners)
+	}
+	abandoned, owner, err := engine.implementationFinalizeClaimAbandoned(ctx, "impl-pair")
+	if err != nil {
+		t.Fatalf("abandonment check: %v", err)
+	}
+	if abandoned {
+		t.Fatalf("the reclaimed live holder was reported abandoned via a surviving row: owner=%+v", owner)
+	}
+}
+
+// THE STALE-OWNER STATE ITSELF, asserted as the thing recovery must refuse when
+// it cannot be prevented: a claim accompanied by a FOREIGN owner row is what the
+// leftover row produced. It is reported abandoned by design - which is exactly
+// why the release must never leave one behind. This test pins the direction so a
+// future reader cannot mistake the reader for the defect.
+func TestAForeignOwnerBesideAClaimIsWhatTheReleaseMustPrevent(t *testing.T) {
+	ctx := context.Background()
+	engine, store := newOrderingFixture(t)
+	insertCompletedJob(t, store, db.Job{ID: "impl-stale", Agent: "lead", Type: "implement"}, orderingParentPayload())
+	seedFinalizeClaim(t, store, "impl-stale", foreignOwnerMessage("impl-stale"))
+
+	abandoned, _, err := engine.implementationFinalizeClaimAbandoned(ctx, "impl-stale")
+	if err != nil {
+		t.Fatalf("abandonment check: %v", err)
+	}
+	if !abandoned {
+		t.Fatal("a foreign owner beside a claim was NOT reported abandoned, so foreign-boot recovery is broken")
+	}
+	// And the release removes exactly that pairing, so the state cannot persist
+	// into a later holder's lifetime.
+	if err := engine.releaseFinalizeClaim(ctx, "impl-stale"); err != nil {
+		// The foreign owner's message differs from this process's, so the helper
+		// cannot match it: that is a REAL limitation and it is asserted, not
+		// hidden. A foreign row is cleaned by the recovery path, not by a
+		// holder's own release.
+		t.Fatalf("releaseFinalizeClaim returned an error: %v", err)
+	}
+	_, owners := finalizeClaimRowCounts(t, store, "impl-stale")
+	if owners != 1 {
+		t.Fatalf("owners=%d; a holder's release matches only ITS OWN owner message, so a foreign row must survive here and be removed by recovery", owners)
+	}
+}
+
+func finalizeClaimRowCounts(t *testing.T, store *db.Store, jobID string) (int, int) {
+	t.Helper()
+	events, err := store.ListJobEvents(context.Background(), jobID)
+	if err != nil {
+		t.Fatalf("ListJobEvents: %v", err)
+	}
+	var claims, owners int
+	for _, event := range events {
+		switch event.Kind {
+		case implementationFinalizeClaimedEvent:
+			claims++
+		case implementationFinalizeClaimOwnerEvent:
+			owners++
+		}
+	}
+	return claims, owners
+}
+
+// #2057 ROUND EIGHT, THE INVARIANT ITSELF: A CLAIM MUST NOT SURVIVE A FAILED
+// OWNER WRITE.
+//
+// The mutant that made the owner write best-effort again survived every other
+// test in this file, because nothing exercised the failure. There is no
+// interface seam to inject one (#2093: Engine.Store is a concrete *db.Store), so
+// this uses the same technique the reviewer used - a SQLite TRIGGER that rejects
+// exactly the owner insert - which injects the fault into the PRODUCTION path
+// rather than around it.
+func TestAClaimIsReleasedWhenItsOwnerRowCannotBeWritten(t *testing.T) {
+	ctx := context.Background()
+	engine, store := newOrderingFixture(t)
+	finalizer := &countingImplementationFinalizer{}
+	engine.ImplementationFinalizer = finalizer
+	insertCompletedJob(t, store, db.Job{ID: "impl-noowner", Agent: "lead", Type: "implement"}, orderingParentPayload())
+
+	rejectJobEventKind(t, store, implementationFinalizeClaimOwnerEvent)
+
+	err := engine.AdvanceJob(ctx, "impl-noowner")
+	if err == nil {
+		t.Fatal("the advance succeeded while the owner row could not be written, so a claim exists that nothing can attribute")
+	}
+	// The finalizer must NOT have run: the claim is surrendered before any
+	// external work, so a retry is a clean retry rather than a second run.
+	if finalizer.calls != 0 {
+		t.Fatalf("the finalizer ran %d times despite an unattributable claim", finalizer.calls)
+	}
+	claims, owners := finalizeClaimRowCounts(t, store, "impl-noowner")
+	if claims != 0 {
+		t.Fatalf("claims=%d owners=%d: the claim survived a failed owner write, which is the state that lets a later holder inherit a dead identity", claims, owners)
+	}
+}
+
+// rejectJobEventKind installs a trigger that fails inserts of one job_event
+// kind, so a production write path can be made to fail without a code seam.
+func rejectJobEventKind(t *testing.T, store *db.Store, kind string) {
+	t.Helper()
+	conn, err := sql.Open("sqlite", store.DatabasePath())
+	if err != nil {
+		t.Fatalf("sql.Open: %v", err)
+	}
+	defer conn.Close()
+	stmt := `CREATE TRIGGER reject_kind BEFORE INSERT ON job_events
+	         WHEN NEW.kind = '` + kind + `'
+	         BEGIN SELECT RAISE(ABORT, 'injected: owner row rejected'); END;`
+	if _, err := conn.Exec(stmt); err != nil {
+		t.Fatalf("create trigger: %v", err)
 	}
 }

--- a/internal/workflow/delegation_finalizer_ordering_2057_test.go
+++ b/internal/workflow/delegation_finalizer_ordering_2057_test.go
@@ -3,7 +3,10 @@ package workflow
 import (
 	"context"
 	"errors"
+	"strings"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/gitmoot/gitmoot/internal/db"
 )
@@ -292,4 +295,161 @@ func TestUnreadableTaskDoesNotReadAsNeedingNoFinalizer(t *testing.T) {
 			t.Fatal("a job with no TaskID was treated as task-backed")
 		}
 	})
+}
+
+// #2057 ROUND FOUR, P1. TWO CONCURRENT ADVANCES MUST FINALIZE ONCE.
+//
+// WHY THE SEQUENTIAL TEST ABOVE IS INSUFFICIENT, stated because the next person
+// will otherwise simplify this back to it: TestFinalizedImplementationIsNot
+// FinalizedAgainOnRetry advances twice IN SEQUENCE, so the first advance has
+// already persisted ImplementationFinalized before the second one reads it. That
+// pins the RETRY case and cannot see the CLAIM case, because the window the
+// defect lives in - read false, call the finalizer, write true - is only open
+// while two callers overlap inside it. The reviewer found it by reading the code;
+// no sequential fixture can fail on it.
+//
+// The finalizer commits, pushes and opens or adopts a pull request, so a second
+// invocation is a duplicate external mutation rather than a repeated no-op.
+func TestConcurrentAdvancesFinalizeExactlyOnce(t *testing.T) {
+	ctx := context.Background()
+	engine, store := newOrderingFixture(t)
+
+	finalized := orderingParentPayload()
+	finalized.HeadSHA = orderingProducedHead
+	// The finalizer BLOCKS until both advances are inside it, which is what
+	// forces the overlap a real race only reaches occasionally.
+	gate := make(chan struct{})
+	counter := &blockingFinalizer{payload: finalized, entered: make(chan struct{}, 4), release: gate}
+	engine.ImplementationFinalizer = counter
+
+	insertCompletedJob(t, store, db.Job{ID: "impl-concurrent", Agent: "lead", Type: "implement"}, orderingParentPayload())
+
+	var wg sync.WaitGroup
+	errs := make([]error, 2)
+	for i := range errs {
+		wg.Add(1)
+		go func(slot int) {
+			defer wg.Done()
+			errs[slot] = engine.AdvanceJob(ctx, "impl-concurrent")
+		}(i)
+	}
+	// Let whichever advance won the claim reach the finalizer, then release it.
+	// The loser must never arrive, so waiting for ONE entry is the assertion.
+	select {
+	case <-counter.entered:
+	case <-time.After(10 * time.Second):
+		close(gate)
+		wg.Wait()
+		t.Fatal("no advance reached the finalizer")
+	}
+	close(gate)
+	wg.Wait()
+
+	if got := counter.calls(); got != 1 {
+		t.Fatalf("FinalizeImplementation ran %d times across two concurrent advances, want exactly 1: it commits, pushes and opens a pull request", got)
+	}
+	// A SEPARATE, PRE-EXISTING RACE SURFACES HERE AND IS NOT THIS TEST'S SUBJECT:
+	// once both advances are past the finalizer they both try to enqueue the same
+	// delegation child, and the loser fails on the jobs.id UNIQUE constraint. That
+	// is not caused by the claim - without it BOTH callers would still reach the
+	// enqueue - and one caller losing a uniqueness race is a survivable outcome
+	// rather than a corruption.
+	//
+	// It is tolerated NARROWLY, by cause, so this test cannot silently pass on a
+	// different error. Reported separately rather than pinned as desirable.
+	for slot, err := range errs {
+		if err == nil {
+			continue
+		}
+		if strings.Contains(err.Error(), "UNIQUE constraint failed: jobs.id") ||
+			strings.Contains(err.Error(), "job id already exists") {
+			continue
+		}
+		t.Fatalf("advance %d returned an unexpected error: %v", slot, err)
+	}
+}
+
+type blockingFinalizer struct {
+	payload JobPayload
+	entered chan struct{}
+	release chan struct{}
+	mu      sync.Mutex
+	n       int
+}
+
+func (b *blockingFinalizer) FinalizeImplementation(context.Context, db.Job, JobPayload) (JobPayload, error) {
+	b.mu.Lock()
+	b.n++
+	b.mu.Unlock()
+	b.entered <- struct{}{}
+	<-b.release
+	return b.payload, nil
+}
+
+func (b *blockingFinalizer) calls() int {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.n
+}
+
+// #2057 ROUND FOUR. A FAILED FINALIZER MUST NOT STRAND FINALIZATION. Claiming
+// before the call makes the success path safe; if the claim were kept after a
+// FAILURE, the next advance would see it taken, skip the finalizer, and the work
+// would never be committed or pushed - a transient error becoming permanent.
+//
+// This test exists because a mutant that keeps the claim on failure survived
+// every other test in this file: nothing retried after a failure and then
+// checked that finalization could still happen.
+func TestFailedFinalizerCanBeRetried(t *testing.T) {
+	ctx := context.Background()
+	engine, store := newOrderingFixture(t)
+
+	finalized := orderingParentPayload()
+	finalized.HeadSHA = orderingProducedHead
+	flaky := &flakyFinalizer{payload: finalized, failFirst: true}
+	engine.ImplementationFinalizer = flaky
+
+	insertCompletedJob(t, store, db.Job{ID: "impl-flaky", Agent: "lead", Type: "implement"}, orderingParentPayload())
+
+	if err := engine.AdvanceJob(ctx, "impl-flaky"); err == nil {
+		t.Fatal("the first advance must surface the finalizer failure")
+	}
+	if flaky.calls != 1 {
+		t.Fatalf("first advance called the finalizer %d times, want 1", flaky.calls)
+	}
+
+	// The retry must be able to finalize. With the claim kept after a failure it
+	// cannot, and the implementation is stranded uncommitted.
+	if err := engine.AdvanceJob(ctx, "impl-flaky"); err != nil {
+		t.Fatalf("retry after a failed finalizer: %v", err)
+	}
+	if flaky.calls != 2 {
+		t.Fatalf("the finalizer ran %d times, want 2: a transient failure stranded finalization permanently", flaky.calls)
+	}
+
+	row, err := store.GetJob(ctx, "impl-flaky")
+	if err != nil {
+		t.Fatalf("GetJob: %v", err)
+	}
+	stored, err := unmarshalPayload(row.Payload)
+	if err != nil {
+		t.Fatalf("unmarshalPayload: %v", err)
+	}
+	if !stored.ImplementationFinalized {
+		t.Fatal("the successful retry did not record the finalized marker")
+	}
+}
+
+type flakyFinalizer struct {
+	payload   JobPayload
+	failFirst bool
+	calls     int
+}
+
+func (f *flakyFinalizer) FinalizeImplementation(context.Context, db.Job, JobPayload) (JobPayload, error) {
+	f.calls++
+	if f.failFirst && f.calls == 1 {
+		return JobPayload{}, errors.New("push implementation branch failed")
+	}
+	return f.payload, nil
 }

--- a/internal/workflow/delegation_finalizer_ordering_2057_test.go
+++ b/internal/workflow/delegation_finalizer_ordering_2057_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"errors"
+	"fmt"
 	"strings"
 	"sync"
 	"testing"
@@ -603,58 +604,66 @@ func TestFinalizedPayloadWithoutCompletionStillAdvances(t *testing.T) {
 	}
 }
 
-// #2057 ROUND SIX, P1. AN ABANDONED CLAIM MUST NOT STRAND THE JOB FOREVER. The
-// claim carries no owner, lease or generation, so a daemon that exits between
-// ClaimJobEvent and the payload write leaves ImplementationFinalized=false, a
-// claim, and no completion. Before this fix every later advance lost the claim,
-// saw no completion, and returned FinalizationInProgressError with no path out.
-func TestAbandonedFinalizeClaimIsRecoveredAfterTheGrace(t *testing.T) {
+// #2057 ROUND SEVEN, P1. A LIVE FINALIZER'S CLAIM MUST NEVER BE RECOVERED, AND
+// AGE CANNOT ESTABLISH THAT. Round six recovered any claim older than 15
+// minutes; the reviewer instrumented it and saw the winning finalizer stay live
+// while a losing advance released its claim and a third advance entered the same
+// finalizer concurrently. There is no safe constant: finalization is bounded
+// only by the job context, four hours by default and eight at most.
+//
+// Recovery is now keyed on the OWNER stamped into the claim. This test never
+// advances a clock, because the implementation no longer reads one.
+func TestLiveFinalizeClaimOwnerIsNeverRecovered(t *testing.T) {
 	ctx := context.Background()
 	engine, store := newOrderingFixture(t)
 	finalizer := &countingImplementationFinalizer{}
 	engine.ImplementationFinalizer = finalizer
 
-	insertCompletedJob(t, store, db.Job{ID: "impl-abandoned", Agent: "lead", Type: "implement"}, orderingParentPayload())
-	claimed, err := store.ClaimJobEvent(ctx, db.JobEvent{
-		JobID:   "impl-abandoned",
-		Kind:    "implementation_finalize_claimed",
-		Message: "implementation finalization claimed for impl-abandoned (#2057)",
-	})
-	if err != nil || !claimed {
-		t.Fatalf("seed claim: claimed=%v err=%v", claimed, err)
-	}
+	insertCompletedJob(t, store, db.Job{ID: "impl-live", Agent: "lead", Type: "implement"}, orderingParentPayload())
+	// A claim owned by THIS boot and THIS process: provably alive.
+	seedFinalizeClaim(t, store, "impl-live", implementationFinalizeClaimOwnerMessage("impl-live"))
 
-	// WITHIN the grace the claim is presumed live: a quiet retry, no recovery,
-	// and above all no second finalizer run beside a winner that may be working.
-	engine.Now = func() time.Time { return time.Now().UTC().Add(implementationFinalizeClaimGrace - time.Minute) }
-	if err := engine.AdvanceJob(ctx, "impl-abandoned"); !errors.As(err, &FinalizationInProgressError{}) {
-		t.Fatalf("a fresh claim must stay a retryable stop, got %v", err)
+	abandoned, owner, err := engine.implementationFinalizeClaimAbandoned(ctx, "impl-live")
+	if err != nil {
+		t.Fatalf("abandonment check: %v", err)
+	}
+	if abandoned {
+		t.Fatalf("a claim held by a LIVE process was reported abandoned (owner=%+v)", owner)
+	}
+	if err := engine.AdvanceJob(ctx, "impl-live"); !errors.As(err, &FinalizationInProgressError{}) {
+		t.Fatalf("a live claim must stay a retryable stop, got %v", err)
 	}
 	if finalizer.calls != 0 {
-		t.Fatalf("the finalizer ran %d times beside a live claim", finalizer.calls)
+		t.Fatalf("the finalizer ran %d times beside a live owner, which is the reproduced defect", finalizer.calls)
 	}
-	if recovered, _ := claimRecoveryRecorded(t, store, "impl-abandoned"); recovered {
-		t.Fatal("a claim inside its grace was recorded as recovered")
-	}
+}
 
-	// PAST the grace the claim is released and the recovery recorded, so the
-	// stop becomes bounded rather than permanent.
-	engine.Now = func() time.Time { return time.Now().UTC().Add(implementationFinalizeClaimGrace + time.Minute) }
-	if err := engine.AdvanceJob(ctx, "impl-abandoned"); !errors.As(err, &FinalizationInProgressError{}) {
+// A CLAIM FROM A PREVIOUS BOOT CANNOT HAVE A LIVE HOLDER, so it is recovered and
+// the next advance finalizes. This is the case round six was trying to serve,
+// now decided by identity instead of elapsed time.
+func TestFinalizeClaimFromAForeignBootIsRecovered(t *testing.T) {
+	ctx := context.Background()
+	engine, store := newOrderingFixture(t)
+	finalizer := &countingImplementationFinalizer{}
+	engine.ImplementationFinalizer = finalizer
+
+	insertCompletedJob(t, store, db.Job{ID: "impl-foreign", Agent: "lead", Type: "implement"}, orderingParentPayload())
+	seedFinalizeClaim(t, store, "impl-foreign", foreignOwnerMessage("impl-foreign"))
+
+	if err := engine.AdvanceJob(ctx, "impl-foreign"); !errors.As(err, &FinalizationInProgressError{}) {
 		t.Fatalf("the recovering advance must still be a retryable stop, got %v", err)
 	}
-	recovered, message := claimRecoveryRecorded(t, store, "impl-abandoned")
+	recovered, message := claimRecoveryRecorded(t, store, "impl-foreign")
 	if !recovered {
-		t.Fatal("an abandoned claim was neither released nor recorded, so the job is stranded")
+		t.Fatal("a claim from a dead boot was neither released nor recorded, so the job is stranded")
 	}
-	if !strings.Contains(message, "no completion") {
-		t.Fatalf("the recovery event does not say why it fired: %q", message)
+	if !strings.Contains(message, "is gone") || !strings.Contains(message, "424242") {
+		t.Fatalf("the recovery event does not name the owner it removed: %q", message)
 	}
 
-	// AND THE NEXT ADVANCE ACTUALLY FINALIZES, which is the property that makes
-	// the recovery worth anything: releasing without a subsequent finalize would
-	// only move the stall.
-	if err := engine.AdvanceJob(ctx, "impl-abandoned"); err != nil {
+	// THE PROPERTY THAT MAKES RECOVERY WORTH ANYTHING: the next advance actually
+	// finalizes. Releasing without a subsequent finalize would only move the stall.
+	if err := engine.AdvanceJob(ctx, "impl-foreign"); err != nil {
 		t.Fatalf("the advance after recovery must finalize, got %v", err)
 	}
 	if finalizer.calls != 1 {
@@ -662,40 +671,76 @@ func TestAbandonedFinalizeClaimIsRecoveredAfterTheGrace(t *testing.T) {
 	}
 }
 
-// An UNREADABLE claim timestamp cannot be aged, so it must read as LIVE. Stealing
-// on an unreadable clock would let one bad row re-run a finalizer immediately,
-// which is the failure the bound exists to prevent.
-func TestFinalizeClaimWithUnreadableTimestampIsNotRecovered(t *testing.T) {
+// THE ABA RACE THE REVIEWER NAMED. Two stale recoverers can both observe the old
+// claim; one releases it and a new winner acquires. The second must NOT be able
+// to release the successor's claim. It cannot, because the release is built from
+// the OBSERVED message and the successor's carries a different owner.
+func TestStaleRecovererCannotReleaseASuccessorsClaim(t *testing.T) {
+	ctx := context.Background()
+	engine, store := newOrderingFixture(t)
+	engine.ImplementationFinalizer = &countingImplementationFinalizer{}
+
+	insertCompletedJob(t, store, db.Job{ID: "impl-aba", Agent: "lead", Type: "implement"}, orderingParentPayload())
+	seedFinalizeClaim(t, store, "impl-aba", foreignOwnerMessage("impl-aba"))
+
+	// Both recoverers observe the stale claim.
+	_, firstOwner, err := engine.implementationFinalizeClaimAbandoned(ctx, "impl-aba")
+	if err != nil {
+		t.Fatalf("first observation: %v", err)
+	}
+	_, secondOwner, err := engine.implementationFinalizeClaimAbandoned(ctx, "impl-aba")
+	if err != nil {
+		t.Fatalf("second observation: %v", err)
+	}
+
+	// The first recoverer wins the OWNER token, which is the recovery right.
+	if won, err := store.ReleaseJobEventClaim(ctx, db.JobEvent{
+		JobID: "impl-aba", Kind: implementationFinalizeClaimOwnerEvent, Message: firstOwner.Message,
+	}); err != nil || !won {
+		t.Fatalf("first recoverer must win the owner token: won=%v err=%v", won, err)
+	}
+
+	// The SECOND, holding the same observed owner, must LOSE it. That is the
+	// mutual exclusion: it stops before it can touch any claim.
+	released, err := store.ReleaseJobEventClaim(ctx, db.JobEvent{
+		JobID: "impl-aba", Kind: implementationFinalizeClaimOwnerEvent, Message: secondOwner.Message,
+	})
+	if err != nil {
+		t.Fatalf("second recoverer: %v", err)
+	}
+	if released {
+		t.Fatal("two recoverers both won the owner token, so both may release a claim: the ABA race is open")
+	}
+}
+
+// AN UNATTRIBUTABLE CLAIM IS LIVE. A message that does not parse cannot be tied
+// to an owner, and recovering it would re-enter a finalizer on no evidence.
+func TestUnattributableFinalizeClaimIsNotRecovered(t *testing.T) {
 	ctx := context.Background()
 	engine, store := newOrderingFixture(t)
 	finalizer := &countingImplementationFinalizer{}
 	engine.ImplementationFinalizer = finalizer
 
-	insertCompletedJob(t, store, db.Job{ID: "impl-badclock", Agent: "lead", Type: "implement"}, orderingParentPayload())
-	if _, err := store.ClaimJobEvent(ctx, db.JobEvent{
-		JobID:   "impl-badclock",
-		Kind:    "implementation_finalize_claimed",
-		Message: "implementation finalization claimed for impl-badclock (#2057)",
-	}); err != nil {
-		t.Fatalf("seed claim: %v", err)
+	insertCompletedJob(t, store, db.Job{ID: "impl-opaque", Agent: "lead", Type: "implement"}, orderingParentPayload())
+	// A LEGACY claim: written before owner rows existed, so it has none.
+	seedFinalizeClaim(t, store, "impl-opaque", "")
+	abandoned, _, err := engine.implementationFinalizeClaimAbandoned(ctx, "impl-opaque")
+	if err != nil {
+		t.Fatalf("abandonment check: %v", err)
 	}
-	corruptJobEventTimestamp(t, store, "impl-badclock", "implementation_finalize_claimed", "not-a-time")
-
-	engine.Now = func() time.Time { return time.Now().UTC().Add(100 * implementationFinalizeClaimGrace) }
-	if err := engine.AdvanceJob(ctx, "impl-badclock"); !errors.As(err, &FinalizationInProgressError{}) {
-		t.Fatalf("an unaged claim must stay a retryable stop, got %v", err)
+	if abandoned {
+		t.Fatal("an unparseable claim was recovered, so a legacy row re-enters the finalizer")
+	}
+	if err := engine.AdvanceJob(ctx, "impl-opaque"); !errors.As(err, &FinalizationInProgressError{}) {
+		t.Fatalf("want a retryable stop, got %v", err)
 	}
 	if finalizer.calls != 0 {
-		t.Fatalf("the finalizer ran %d times on an unreadable claim clock", finalizer.calls)
-	}
-	if recovered, _ := claimRecoveryRecorded(t, store, "impl-badclock"); recovered {
-		t.Fatal("a claim with an unreadable timestamp was recovered anyway")
+		t.Fatalf("the finalizer ran %d times on an unattributable claim", finalizer.calls)
 	}
 }
 
-// A COMPLETED claim is never abandoned, whatever its age: the loser reloads the
-// finalized payload and proceeds, which is the round-five behaviour and must not
-// regress into a recovery.
+// A COMPLETED claim is never abandoned, whatever its owner: the loser reloads the
+// finalized payload and proceeds, which is round five's behaviour.
 func TestCompletedFinalizeClaimIsNeverRecovered(t *testing.T) {
 	ctx := context.Background()
 	engine, store := newOrderingFixture(t)
@@ -704,12 +749,7 @@ func TestCompletedFinalizeClaimIsNeverRecovered(t *testing.T) {
 	payload := orderingParentPayload()
 	payload.ImplementationFinalized = true
 	insertCompletedJob(t, store, db.Job{ID: "impl-done", Agent: "lead", Type: "implement"}, payload)
-	if _, err := store.ClaimJobEvent(ctx, db.JobEvent{
-		JobID: "impl-done", Kind: "implementation_finalize_claimed",
-		Message: "implementation finalization claimed for impl-done (#2057)",
-	}); err != nil {
-		t.Fatalf("seed claim: %v", err)
-	}
+	seedFinalizeClaim(t, store, "impl-done", foreignOwnerMessage("impl-done"))
 	if err := store.AddJobEvent(ctx, db.JobEvent{
 		JobID: "impl-done", Kind: implementationFinalizeCompletedEvent,
 		Message: "implementation finalization completed for impl-done (#2057)",
@@ -717,7 +757,6 @@ func TestCompletedFinalizeClaimIsNeverRecovered(t *testing.T) {
 		t.Fatalf("seed completion: %v", err)
 	}
 
-	engine.Now = func() time.Time { return time.Now().UTC().Add(100 * implementationFinalizeClaimGrace) }
 	abandoned, _, err := engine.implementationFinalizeClaimAbandoned(ctx, "impl-done")
 	if err != nil {
 		t.Fatalf("abandonment check: %v", err)
@@ -765,5 +804,152 @@ func corruptJobEventTimestamp(t *testing.T, store *db.Store, jobID, kind, value 
 	}
 	if changed, err := result.RowsAffected(); err != nil || changed != 1 {
 		t.Fatalf("updated rows = %d err=%v, want 1", changed, err)
+	}
+}
+
+// seedFinalizeClaim writes a claim AND its owner row, which is the pair
+// production always writes together. A fixture with only one of them models a
+// state the winner cannot produce.
+func seedFinalizeClaim(t *testing.T, store *db.Store, jobID, ownerMessage string) {
+	t.Helper()
+	ctx := context.Background()
+	claimed, err := store.ClaimJobEvent(ctx, db.JobEvent{
+		JobID: jobID, Kind: implementationFinalizeClaimedEvent,
+		Message: implementationFinalizeClaimMessage(jobID),
+	})
+	if err != nil || !claimed {
+		t.Fatalf("seed claim %s: claimed=%v err=%v", jobID, claimed, err)
+	}
+	if strings.TrimSpace(ownerMessage) == "" {
+		return
+	}
+	if err := store.AddJobEvent(ctx, db.JobEvent{
+		JobID: jobID, Kind: implementationFinalizeClaimOwnerEvent, Message: ownerMessage,
+	}); err != nil {
+		t.Fatalf("seed owner %s: %v", jobID, err)
+	}
+}
+
+func foreignOwnerMessage(jobID string) string {
+	return "implementation finalization for " + jobID + " is held by boot 00000000-dead-dead-dead-000000000000 pid 424242 (#2057)"
+}
+
+// THE CLAIM MESSAGE IS A DEPLOY CONTRACT, and this pins it because round seven
+// broke it once. ClaimJobEvent's at-most-once check keys on (job, kind,
+// MESSAGE), so a claim written by an older binary must still exclude a claimer
+// running the newer one. My first attempt put the owner identity INTO the claim
+// message, and a deploy with an in-flight finalization would then have run a
+// SECOND finalizer beside the first: the exact double-execution the claim
+// exists to prevent, introduced by the fix for it.
+//
+// A pre-existing round-five test caught it. This one states it directly, so the
+// next person to reach for a richer claim message sees the cost first.
+func TestClaimMessageStaysStableAcrossABinaryChange(t *testing.T) {
+	ctx := context.Background()
+	_, store := newOrderingFixture(t)
+	insertCompletedJob(t, store, db.Job{ID: "impl-deploy", Agent: "lead", Type: "implement"}, orderingParentPayload())
+
+	// The OLD binary's claim: message with no owner in it, and no owner row.
+	seedFinalizeClaim(t, store, "impl-deploy", "")
+
+	// The NEW binary tries to claim the same finalization. It must LOSE.
+	claimed, err := store.ClaimJobEvent(ctx, db.JobEvent{
+		JobID:   "impl-deploy",
+		Kind:    implementationFinalizeClaimedEvent,
+		Message: implementationFinalizeClaimMessage("impl-deploy"),
+	})
+	if err != nil {
+		t.Fatalf("ClaimJobEvent: %v", err)
+	}
+	if claimed {
+		t.Fatal("a new binary claimed a finalization already held by an older one: two finalizers would run")
+	}
+}
+
+// A MALFORMED OWNER ROW IS LIVE, and this is a DIFFERENT case from a missing
+// one. The legacy test above has no owner row at all, so it returns before the
+// parse is ever attempted: a mutant making an unparseable owner "abandoned"
+// survived it. This fixture writes an owner row that does not match the
+// pattern, so the parse branch itself is under test.
+func TestMalformedFinalizeClaimOwnerIsNotRecovered(t *testing.T) {
+	ctx := context.Background()
+	engine, store := newOrderingFixture(t)
+	finalizer := &countingImplementationFinalizer{}
+	engine.ImplementationFinalizer = finalizer
+
+	for index, owner := range []string{
+		"implementation finalization for impl-bad is held by boot  pid  (#2057)",
+		"implementation finalization for impl-bad is held by boot abc pid notanumber (#2057)",
+		"some entirely different sentence",
+		"implementation finalization for impl-bad is held by boot abc pid -3 (#2057)",
+	} {
+		t.Run(fmt.Sprintf("case%d", index), func(t *testing.T) {
+			jobID := fmt.Sprintf("impl-bad-%d", index)
+			insertCompletedJob(t, store, db.Job{ID: jobID, Agent: "lead", Type: "implement"}, orderingParentPayload())
+			seedFinalizeClaim(t, store, jobID, strings.Replace(owner, "impl-bad", jobID, 1))
+
+			abandoned, _, err := engine.implementationFinalizeClaimAbandoned(ctx, jobID)
+			if err != nil {
+				t.Fatalf("abandonment check: %v", err)
+			}
+			if abandoned {
+				t.Fatalf("an owner row that does not parse (%q) was recovered anyway", owner)
+			}
+		})
+	}
+	if finalizer.calls != 0 {
+		t.Fatalf("the finalizer ran %d times on unparseable owner rows", finalizer.calls)
+	}
+}
+
+// TWO CONCURRENT RECOVERIES MUST PRODUCE ONE FINALIZER, and this drives the
+// ENGINE rather than the store primitive.
+//
+// The ABA test above asserts that ReleaseJobEventClaim is at-most-once, which is
+// a fact about the store. A mutant removing the engine's `if !wonRecovery` guard
+// survived it, because nothing checked that the engine CONSULTS that result.
+// This test races two advances against one abandoned claim: exactly one may win
+// the owner token and go on to release the claim, so the finalizer can run at
+// most once no matter how the two interleave.
+func TestConcurrentRecoveriesFinalizeAtMostOnce(t *testing.T) {
+	ctx := context.Background()
+	engine, store := newOrderingFixture(t)
+	finalizer := &countingImplementationFinalizer{}
+	engine.ImplementationFinalizer = finalizer
+
+	insertCompletedJob(t, store, db.Job{ID: "impl-race", Agent: "lead", Type: "implement"}, orderingParentPayload())
+	seedFinalizeClaim(t, store, "impl-race", foreignOwnerMessage("impl-race"))
+
+	var wg sync.WaitGroup
+	start := make(chan struct{})
+	for i := 0; i < 2; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			_ = engine.AdvanceJob(ctx, "impl-race")
+		}()
+	}
+	close(start)
+	wg.Wait()
+
+	// At most one recovery may have happened, so at most one finalizer call.
+	if finalizer.calls > 1 {
+		t.Fatalf("the finalizer ran %d times: two recoverers both released the claim", finalizer.calls)
+	}
+	// And exactly one recovery event, never two, because the owner token is the
+	// mutual exclusion.
+	events, err := store.ListJobEvents(ctx, "impl-race")
+	if err != nil {
+		t.Fatalf("ListJobEvents: %v", err)
+	}
+	recoveries := 0
+	for _, event := range events {
+		if event.Kind == implementationFinalizeClaimRecoveredEvent {
+			recoveries++
+		}
+	}
+	if recoveries > 1 {
+		t.Fatalf("recorded %d recoveries of one claim, want at most 1", recoveries)
 	}
 }

--- a/internal/workflow/delegation_finalizer_ordering_2057_test.go
+++ b/internal/workflow/delegation_finalizer_ordering_2057_test.go
@@ -565,3 +565,39 @@ func TestLostClaimWithCompletionReloadsTheFinalizedPayload(t *testing.T) {
 		t.Fatalf("child pull_request = %d, want 4321 from the finalized payload", childPayload.PullRequest)
 	}
 }
+
+// #2057 round five, THE COMPLETION-WRITE FAILURE WINDOW. If the finalizer
+// succeeds, the payload write succeeds, and then the completion event write
+// FAILS, the claim is held with no completion recorded. The concern is that every
+// retry then reports in-progress forever.
+//
+// It does not, and the payload marker is why: the claim block is guarded by
+// !payload.ImplementationFinalized, so a retry that loads the finalized payload
+// never reaches the claim check at all. Asserted here rather than reasoned about,
+// because "the guard upstream covers it" is exactly the kind of claim that is
+// true until someone reorders the guard.
+func TestFinalizedPayloadWithoutCompletionStillAdvances(t *testing.T) {
+	ctx := context.Background()
+	engine, store := newOrderingFixture(t)
+	engine.ImplementationFinalizer = fakeImplementationFinalizer{err: errors.New("must not run: already finalized")}
+
+	// The state left behind when the completion write is the only thing that
+	// failed: claim held, payload finalized, NO completion event.
+	finalized := orderingParentPayload()
+	finalized.HeadSHA = orderingProducedHead
+	finalized.ImplementationFinalized = true
+	insertCompletedJob(t, store, db.Job{ID: "impl-nocomp", Agent: "lead", Type: "implement"}, finalized)
+	if _, err := store.ClaimJobEvent(ctx, db.JobEvent{
+		JobID: "impl-nocomp", Kind: "implementation_finalize_claimed",
+		Message: "implementation finalization claimed for impl-nocomp (#2057)",
+	}); err != nil {
+		t.Fatalf("seed claim: %v", err)
+	}
+
+	if err := engine.AdvanceJob(ctx, "impl-nocomp"); err != nil {
+		t.Fatalf("a finalized payload with no completion event must still advance, got %v", err)
+	}
+	if _, err := store.GetJob(ctx, "impl-nocomp/delegation/round2-review"); err != nil {
+		t.Fatalf("delegation was not dispatched: %v", err)
+	}
+}

--- a/internal/workflow/delegation_finalizer_ordering_2057_test.go
+++ b/internal/workflow/delegation_finalizer_ordering_2057_test.go
@@ -2,6 +2,7 @@ package workflow
 
 import (
 	"context"
+	"database/sql"
 	"errors"
 	"strings"
 	"sync"
@@ -599,5 +600,170 @@ func TestFinalizedPayloadWithoutCompletionStillAdvances(t *testing.T) {
 	}
 	if _, err := store.GetJob(ctx, "impl-nocomp/delegation/round2-review"); err != nil {
 		t.Fatalf("delegation was not dispatched: %v", err)
+	}
+}
+
+// #2057 ROUND SIX, P1. AN ABANDONED CLAIM MUST NOT STRAND THE JOB FOREVER. The
+// claim carries no owner, lease or generation, so a daemon that exits between
+// ClaimJobEvent and the payload write leaves ImplementationFinalized=false, a
+// claim, and no completion. Before this fix every later advance lost the claim,
+// saw no completion, and returned FinalizationInProgressError with no path out.
+func TestAbandonedFinalizeClaimIsRecoveredAfterTheGrace(t *testing.T) {
+	ctx := context.Background()
+	engine, store := newOrderingFixture(t)
+	finalizer := &countingImplementationFinalizer{}
+	engine.ImplementationFinalizer = finalizer
+
+	insertCompletedJob(t, store, db.Job{ID: "impl-abandoned", Agent: "lead", Type: "implement"}, orderingParentPayload())
+	claimed, err := store.ClaimJobEvent(ctx, db.JobEvent{
+		JobID:   "impl-abandoned",
+		Kind:    "implementation_finalize_claimed",
+		Message: "implementation finalization claimed for impl-abandoned (#2057)",
+	})
+	if err != nil || !claimed {
+		t.Fatalf("seed claim: claimed=%v err=%v", claimed, err)
+	}
+
+	// WITHIN the grace the claim is presumed live: a quiet retry, no recovery,
+	// and above all no second finalizer run beside a winner that may be working.
+	engine.Now = func() time.Time { return time.Now().UTC().Add(implementationFinalizeClaimGrace - time.Minute) }
+	if err := engine.AdvanceJob(ctx, "impl-abandoned"); !errors.As(err, &FinalizationInProgressError{}) {
+		t.Fatalf("a fresh claim must stay a retryable stop, got %v", err)
+	}
+	if finalizer.calls != 0 {
+		t.Fatalf("the finalizer ran %d times beside a live claim", finalizer.calls)
+	}
+	if recovered, _ := claimRecoveryRecorded(t, store, "impl-abandoned"); recovered {
+		t.Fatal("a claim inside its grace was recorded as recovered")
+	}
+
+	// PAST the grace the claim is released and the recovery recorded, so the
+	// stop becomes bounded rather than permanent.
+	engine.Now = func() time.Time { return time.Now().UTC().Add(implementationFinalizeClaimGrace + time.Minute) }
+	if err := engine.AdvanceJob(ctx, "impl-abandoned"); !errors.As(err, &FinalizationInProgressError{}) {
+		t.Fatalf("the recovering advance must still be a retryable stop, got %v", err)
+	}
+	recovered, message := claimRecoveryRecorded(t, store, "impl-abandoned")
+	if !recovered {
+		t.Fatal("an abandoned claim was neither released nor recorded, so the job is stranded")
+	}
+	if !strings.Contains(message, "no completion") {
+		t.Fatalf("the recovery event does not say why it fired: %q", message)
+	}
+
+	// AND THE NEXT ADVANCE ACTUALLY FINALIZES, which is the property that makes
+	// the recovery worth anything: releasing without a subsequent finalize would
+	// only move the stall.
+	if err := engine.AdvanceJob(ctx, "impl-abandoned"); err != nil {
+		t.Fatalf("the advance after recovery must finalize, got %v", err)
+	}
+	if finalizer.calls != 1 {
+		t.Fatalf("the finalizer ran %d times after recovery, want exactly 1", finalizer.calls)
+	}
+}
+
+// An UNREADABLE claim timestamp cannot be aged, so it must read as LIVE. Stealing
+// on an unreadable clock would let one bad row re-run a finalizer immediately,
+// which is the failure the bound exists to prevent.
+func TestFinalizeClaimWithUnreadableTimestampIsNotRecovered(t *testing.T) {
+	ctx := context.Background()
+	engine, store := newOrderingFixture(t)
+	finalizer := &countingImplementationFinalizer{}
+	engine.ImplementationFinalizer = finalizer
+
+	insertCompletedJob(t, store, db.Job{ID: "impl-badclock", Agent: "lead", Type: "implement"}, orderingParentPayload())
+	if _, err := store.ClaimJobEvent(ctx, db.JobEvent{
+		JobID:   "impl-badclock",
+		Kind:    "implementation_finalize_claimed",
+		Message: "implementation finalization claimed for impl-badclock (#2057)",
+	}); err != nil {
+		t.Fatalf("seed claim: %v", err)
+	}
+	corruptJobEventTimestamp(t, store, "impl-badclock", "implementation_finalize_claimed", "not-a-time")
+
+	engine.Now = func() time.Time { return time.Now().UTC().Add(100 * implementationFinalizeClaimGrace) }
+	if err := engine.AdvanceJob(ctx, "impl-badclock"); !errors.As(err, &FinalizationInProgressError{}) {
+		t.Fatalf("an unaged claim must stay a retryable stop, got %v", err)
+	}
+	if finalizer.calls != 0 {
+		t.Fatalf("the finalizer ran %d times on an unreadable claim clock", finalizer.calls)
+	}
+	if recovered, _ := claimRecoveryRecorded(t, store, "impl-badclock"); recovered {
+		t.Fatal("a claim with an unreadable timestamp was recovered anyway")
+	}
+}
+
+// A COMPLETED claim is never abandoned, whatever its age: the loser reloads the
+// finalized payload and proceeds, which is the round-five behaviour and must not
+// regress into a recovery.
+func TestCompletedFinalizeClaimIsNeverRecovered(t *testing.T) {
+	ctx := context.Background()
+	engine, store := newOrderingFixture(t)
+	engine.ImplementationFinalizer = fakeImplementationFinalizer{err: errors.New("should not run: already completed")}
+
+	payload := orderingParentPayload()
+	payload.ImplementationFinalized = true
+	insertCompletedJob(t, store, db.Job{ID: "impl-done", Agent: "lead", Type: "implement"}, payload)
+	if _, err := store.ClaimJobEvent(ctx, db.JobEvent{
+		JobID: "impl-done", Kind: "implementation_finalize_claimed",
+		Message: "implementation finalization claimed for impl-done (#2057)",
+	}); err != nil {
+		t.Fatalf("seed claim: %v", err)
+	}
+	if err := store.AddJobEvent(ctx, db.JobEvent{
+		JobID: "impl-done", Kind: implementationFinalizeCompletedEvent,
+		Message: "implementation finalization completed for impl-done (#2057)",
+	}); err != nil {
+		t.Fatalf("seed completion: %v", err)
+	}
+
+	engine.Now = func() time.Time { return time.Now().UTC().Add(100 * implementationFinalizeClaimGrace) }
+	abandoned, _, err := engine.implementationFinalizeClaimAbandoned(ctx, "impl-done")
+	if err != nil {
+		t.Fatalf("abandonment check: %v", err)
+	}
+	if abandoned {
+		t.Fatal("a completed finalization was reported abandoned, which would re-run the finalizer")
+	}
+}
+
+type countingImplementationFinalizer struct {
+	calls int
+}
+
+func (f *countingImplementationFinalizer) FinalizeImplementation(_ context.Context, _ db.Job, payload JobPayload) (JobPayload, error) {
+	f.calls++
+	return payload, nil
+}
+
+func claimRecoveryRecorded(t *testing.T, store *db.Store, jobID string) (bool, string) {
+	t.Helper()
+	events, err := store.ListJobEvents(context.Background(), jobID)
+	if err != nil {
+		t.Fatalf("ListJobEvents: %v", err)
+	}
+	for _, event := range events {
+		if event.Kind == implementationFinalizeClaimRecoveredEvent {
+			return true, event.Message
+		}
+	}
+	return false, ""
+}
+
+// corruptJobEventTimestamp makes a claim's created_at unparseable, which is the
+// only way to exercise the unaged branch: the store writes a valid timestamp.
+func corruptJobEventTimestamp(t *testing.T, store *db.Store, jobID, kind, value string) {
+	t.Helper()
+	conn, err := sql.Open("sqlite", store.DatabasePath())
+	if err != nil {
+		t.Fatalf("sql.Open: %v", err)
+	}
+	defer conn.Close()
+	result, err := conn.Exec(`UPDATE job_events SET created_at = ? WHERE job_id = ? AND kind = ?`, value, jobID, kind)
+	if err != nil {
+		t.Fatalf("UPDATE job event time: %v", err)
+	}
+	if changed, err := result.RowsAffected(); err != nil || changed != 1 {
+		t.Fatalf("updated rows = %d err=%v, want 1", changed, err)
 	}
 }

--- a/internal/workflow/engine_continuation_synthesis.go
+++ b/internal/workflow/engine_continuation_synthesis.go
@@ -1548,8 +1548,27 @@ func (e Engine) implementationNeedsFinalizer(ctx context.Context, payload JobPay
 		return false
 	}
 	task, err := e.Store.GetTask(ctx, taskID)
-	if err != nil {
+	if errors.Is(err, sql.ErrNoRows) {
+		// The task genuinely does not exist, which is a DIFFERENT FACT from a
+		// lookup that failed. An absent row answers the question - this job is not
+		// task-backed - so there is nothing to fail closed about, and three
+		// pre-existing tests depend on that distinction. Conflating the two was
+		// the first version of this fix: it made every ad-hoc implement job
+		// attempt a finalizer.
 		return false
+	}
+	if err != nil {
+		// #2057 round three, P1: FAIL CLOSED. This used to return false, which
+		// reads as "this implementation needs no finalizer" - so a transient task
+		// lookup failure let the parent DAG and the delegations advance from work
+		// that was never committed, and repeated failures ran the finalizer ZERO
+		// times. A job carrying a TaskID is task-backed by construction; the only
+		// thing in doubt is whether the task row can be read right now.
+		//
+		// Returning true instead means the caller attempts the finalizer, which
+		// performs its own task lookup and returns the error, so AdvanceJob fails
+		// and is retried. Nothing advances on a guess.
+		return true
 	}
 	return strings.TrimSpace(task.WorktreePath) != "" ||
 		(payload.FixWorktree && strings.TrimSpace(payload.WorktreePath) != "")

--- a/internal/workflow/engine_delegation.go
+++ b/internal/workflow/engine_delegation.go
@@ -710,10 +710,20 @@ func (e Engine) allocateAndEnqueueDelegationInner(ctx context.Context, job db.Jo
 	//
 	// IT WRITES A HEAD RATHER THAN CLEARING ONE. The head the child will actually
 	// review is the tip of the parent's branch, which is where that parent's work
-	// landed, so it is resolved here and recorded. Clearing would leave the
-	// verdict UNBOUND, and an unbound verdict is not the fix for a wrongly-bound
-	// one - though it IS the safer failure, so an unresolvable branch clears and
-	// says so rather than keeping a head known to be stale.
+	// landed, so it is resolved here and recorded.
+	//
+	// #2057: THE DROP ARM IS GONE, and the reorder in AdvanceJob is why. A
+	// task-backed implementation is now finalized BEFORE its delegations are
+	// dispatched, and the finalizer writes payload.HeadSHA to the produced head on
+	// every path. So an inherited head is normally CORRECT here, and an
+	// unresolvable branch no longer implies it is stale - dropping one would
+	// unbind the common case to protect the rare one, which is the wrong trade
+	// now that the common case is right.
+	//
+	// The rebind arm stays because it still has work: an implement job with NO
+	// task worktree runs no finalizer, so its payload head is still the
+	// pre-change commit, and resolving the branch tip corrects it. When the
+	// finalizer did run, resolved and inherited agree and this is a no-op.
 	if request.Action == "review" && strings.EqualFold(strings.TrimSpace(job.Type), "implement") {
 		inherited := strings.TrimSpace(request.HeadSHA)
 		resolved := ""
@@ -723,22 +733,13 @@ func (e Engine) allocateAndEnqueueDelegationInner(ctx context.Context, job db.Jo
 				resolved = strings.TrimSpace(sha)
 			}
 		}
-		switch {
-		case resolved != "" && resolved != inherited:
+		if resolved != "" && resolved != inherited {
 			request.HeadSHA = resolved
 			_ = e.recordEffectEvent(ctx, db.JobEvent{
 				JobID: job.ID,
 				Kind:  "delegation_review_head_rebound",
 				Message: fmt.Sprintf("delegation %q reviews branch %s: bound to its tip %s instead of the implement parent's dispatch head %s (#1730)",
 					request.DelegationID, branch, shortHead(resolved), shortHead(inherited)),
-			})
-		case resolved == "" && inherited != "":
-			request.HeadSHA = ""
-			_ = e.recordEffectEvent(ctx, db.JobEvent{
-				JobID: job.ID,
-				Kind:  "delegation_review_head_unbound",
-				Message: fmt.Sprintf("delegation %q could not resolve branch %q, so the implement parent's dispatch head %s was DROPPED rather than recorded as reviewed (#1730)",
-					request.DelegationID, branch, shortHead(inherited)),
 			})
 		}
 	}

--- a/internal/workflow/engine_delegation.go
+++ b/internal/workflow/engine_delegation.go
@@ -744,7 +744,11 @@ func (e Engine) allocateAndEnqueueDelegationInner(ctx context.Context, job db.Jo
 		//
 		// The discriminator is the same predicate the engine uses to decide
 		// whether to finalize at all, so the two halves cannot disagree.
-		producedByFinalizer := e.implementationNeedsFinalizer(ctx, payload)
+		// #2057 round three, P1: READ THE DURABLE MARKER. Re-deriving eligibility
+		// here meant a task lookup failing at THIS moment could classify a payload
+		// the finalizer had already produced as unfinalized, and then drop the
+		// produced head as if it were the pre-change one.
+		producedByFinalizer := payload.ImplementationFinalized
 		switch {
 		case resolved != "" && resolved != inherited:
 			request.HeadSHA = resolved
@@ -754,7 +758,15 @@ func (e Engine) allocateAndEnqueueDelegationInner(ctx context.Context, job db.Jo
 				Message: fmt.Sprintf("delegation %q reviews branch %s: bound to its tip %s instead of the implement parent's dispatch head %s (#1730)",
 					request.DelegationID, branch, shortHead(resolved), shortHead(inherited)),
 			})
-		case resolved == "" && inherited != "" && !producedByFinalizer:
+		// #2057 round three, P1: AN UNCHANGED RESOLVE IS NOT A RESOLVE on this
+		// path. When RevParse succeeded and returned the SAME sha as the inherited
+		// one, neither arm used to fire: nonempty so not dropped, equal so not
+		// rebound. The head stayed the pre-change commit this path documents, and
+		// a lone review child - which allocates no worktree, because the fan-out
+		// branch needs two or more siblings - reads the shared checkout while the
+		// row records an ancestor. Equality is therefore treated as unresolved
+		// unless a finalizer produced the head.
+		case (resolved == "" || resolved == inherited) && inherited != "" && !producedByFinalizer:
 			request.HeadSHA = ""
 			_ = e.recordEffectEvent(ctx, db.JobEvent{
 				JobID: job.ID,

--- a/internal/workflow/engine_delegation.go
+++ b/internal/workflow/engine_delegation.go
@@ -733,13 +733,34 @@ func (e Engine) allocateAndEnqueueDelegationInner(ctx context.Context, job db.Jo
 				resolved = strings.TrimSpace(sha)
 			}
 		}
-		if resolved != "" && resolved != inherited {
+		// #2057 ROUND TWO. THE DROP ARM IS BACK, SCOPED TO THE PATH THAT NEEDS IT.
+		// Removing it wholesale was wrong: my justification held only for the
+		// FINALIZER path, where the inherited head is the head the finalizer just
+		// produced. On the NO-FINALIZER path this function's own comment says the
+		// inherited head is the pre-change commit, so when the branch will not
+		// resolve there is no correct head to record and keeping the stale one
+		// attests a verdict against a commit nobody reviewed - the #1730 defect
+		// itself.
+		//
+		// The discriminator is the same predicate the engine uses to decide
+		// whether to finalize at all, so the two halves cannot disagree.
+		producedByFinalizer := e.implementationNeedsFinalizer(ctx, payload)
+		switch {
+		case resolved != "" && resolved != inherited:
 			request.HeadSHA = resolved
 			_ = e.recordEffectEvent(ctx, db.JobEvent{
 				JobID: job.ID,
 				Kind:  "delegation_review_head_rebound",
 				Message: fmt.Sprintf("delegation %q reviews branch %s: bound to its tip %s instead of the implement parent's dispatch head %s (#1730)",
 					request.DelegationID, branch, shortHead(resolved), shortHead(inherited)),
+			})
+		case resolved == "" && inherited != "" && !producedByFinalizer:
+			request.HeadSHA = ""
+			_ = e.recordEffectEvent(ctx, db.JobEvent{
+				JobID: job.ID,
+				Kind:  "delegation_review_head_unbound",
+				Message: fmt.Sprintf("delegation %q could not resolve branch %q and its implement parent runs no finalizer, so the pre-change dispatch head %s was DROPPED rather than recorded as reviewed (#1730, #2057)",
+					request.DelegationID, branch, shortHead(inherited)),
 			})
 		}
 	}

--- a/internal/workflow/engine_delegation.go
+++ b/internal/workflow/engine_delegation.go
@@ -679,7 +679,69 @@ func (e Engine) allocateAndEnqueueDelegation(ctx context.Context, job db.Job, pa
 	return err
 }
 
+// delegationHeadResolver resolves a ref to a SHA. It is the same RevParse the
+// writable lineage manager already exposes; asserted narrowly here so a
+// manager that cannot resolve refs degrades to the unbound arm rather than
+// failing the dispatch (#1730).
+type delegationHeadResolver interface {
+	RevParse(ctx context.Context, rev string) (string, error)
+}
+
 func (e Engine) allocateAndEnqueueDelegationInner(ctx context.Context, job db.Job, payload JobPayload, d Delegation, request JobRequest, ref taskRef) error {
+	// #1730. A review child inherits the parent's HeadSHA, and that is CORRECT
+	// when the coordinator is itself a review: a lens fan-out reviews the same
+	// commit its parent was dispatched against, which is 27 of the 28
+	// parent-delegated reviews in this store.
+	//
+	// IT IS WRONG WHEN THE PARENT IS AN IMPLEMENT JOB. An implement job's payload
+	// head is the commit BEFORE its change, and that payload is not updated by
+	// the time its delegations are enqueued. Measured on the single instance:
+	// parent local-implement-appkit-omp-18d0db287156c2ba enqueued `round2-review`
+	// in the SAME SECOND it succeeded (10:22:43), the child recorded head
+	// 0e2ce4f1, and the reviewer's own summary named 0c175d03 as "== HEAD". The
+	// row attested an approval at an ANCESTOR of the reviewed tree while the only
+	// correct record was free text - which inverts the reason head-binding exists.
+	//
+	// THIS SITS BEFORE THE ALLOCATION CHAIN BECAUSE THE REPRODUCED CASE HAS ONE
+	// CHILD. readOnlyFanoutNeedsWorktree requires TWO OR MORE read-only siblings
+	// (worktree.go:941, `count >= 2`), so a lone review child never reaches the
+	// read-only worktree branch at all. A fix placed there would have been
+	// unexercised by the very job that motivated it.
+	//
+	// IT WRITES A HEAD RATHER THAN CLEARING ONE. The head the child will actually
+	// review is the tip of the parent's branch, which is where that parent's work
+	// landed, so it is resolved here and recorded. Clearing would leave the
+	// verdict UNBOUND, and an unbound verdict is not the fix for a wrongly-bound
+	// one - though it IS the safer failure, so an unresolvable branch clears and
+	// says so rather than keeping a head known to be stale.
+	if request.Action == "review" && strings.EqualFold(strings.TrimSpace(job.Type), "implement") {
+		inherited := strings.TrimSpace(request.HeadSHA)
+		resolved := ""
+		branch := strings.TrimSpace(payload.Branch)
+		if resolver, ok := e.DelegationWorktrees.(delegationHeadResolver); ok && branch != "" {
+			if sha, resolveErr := resolver.RevParse(ctx, branch); resolveErr == nil {
+				resolved = strings.TrimSpace(sha)
+			}
+		}
+		switch {
+		case resolved != "" && resolved != inherited:
+			request.HeadSHA = resolved
+			_ = e.recordEffectEvent(ctx, db.JobEvent{
+				JobID: job.ID,
+				Kind:  "delegation_review_head_rebound",
+				Message: fmt.Sprintf("delegation %q reviews branch %s: bound to its tip %s instead of the implement parent's dispatch head %s (#1730)",
+					request.DelegationID, branch, shortHead(resolved), shortHead(inherited)),
+			})
+		case resolved == "" && inherited != "":
+			request.HeadSHA = ""
+			_ = e.recordEffectEvent(ctx, db.JobEvent{
+				JobID: job.ID,
+				Kind:  "delegation_review_head_unbound",
+				Message: fmt.Sprintf("delegation %q could not resolve branch %q, so the implement parent's dispatch head %s was DROPPED rather than recorded as reviewed (#1730)",
+					request.DelegationID, branch, shortHead(inherited)),
+			})
+		}
+	}
 	if request.Action == "implement" {
 		if e.DelegationWorktrees == nil || strings.TrimSpace(e.Home) == "" {
 			// No per-delegation worktree isolation is available (the engine lacks a

--- a/internal/workflow/engine_run_budgets.go
+++ b/internal/workflow/engine_run_budgets.go
@@ -653,10 +653,38 @@ func (e Engine) AdvanceJob(ctx context.Context, jobID string) (retErr error) {
 			return claimErr
 		}
 		if !claimed {
-			// Someone else owns this finalization, or a previous advance already
-			// completed it and crashed before persisting the flag. Either way this
-			// caller must not finalize; treating the claim as the durable record is
-			// the whole point of taking it.
+			// #2057 round five, P1: A CLAIM PROVES SOMEONE STARTED, NOT THAT ANYONE
+			// FINISHED, and the previous version conflated those. It set
+			// finalizedBeforeDelegations = true and carried on, so the LOSER of the
+			// claim advanced the parent DAG and dispatched delegations from the
+			// pre-finalization head and pull request while the winner was still
+			// committing and pushing. And a crash after claiming has the SAME
+			// durable representation whether finalization never ran or completed
+			// before the payload write, so the flag could not tell them apart
+			// either.
+			//
+			// Completion is now its own durable fact. The winner records it after
+			// the payload write; a loser that sees it reloads the finalized payload
+			// and proceeds, and a loser that does NOT see it stops, because it
+			// cannot dispatch correctly from data the winner is about to replace.
+			// Stopping is retryable - the daemon re-advances - while dispatching
+			// from stale data is not recoverable.
+			completed, completedErr := e.implementationFinalizeCompleted(ctx, job.ID)
+			if completedErr != nil {
+				return completedErr
+			}
+			if !completed {
+				return FinalizationInProgressError{JobID: job.ID}
+			}
+			refreshed, refreshErr := e.Store.GetJob(ctx, job.ID)
+			if refreshErr != nil {
+				return refreshErr
+			}
+			reloaded, reloadErr := unmarshalPayload(refreshed.Payload)
+			if reloadErr != nil {
+				return reloadErr
+			}
+			payload = reloaded
 			finalizedBeforeDelegations = true
 		} else {
 			finalized, err := e.ImplementationFinalizer.FinalizeImplementation(ctx, job, payload)
@@ -688,6 +716,16 @@ func (e Engine) AdvanceJob(ctx context.Context, jobID string) (retErr error) {
 				return err
 			}
 			payload = finalized
+			// Recorded AFTER the payload write, so its presence means the payload a
+			// loser reloads is the finalized one. Ordered the other way it would
+			// promise data that is not there yet.
+			if err := e.Store.AddJobEventIfAbsent(ctx, db.JobEvent{
+				JobID:   job.ID,
+				Kind:    implementationFinalizeCompletedEvent,
+				Message: fmt.Sprintf("implementation finalization completed for %s (#2057)", job.ID),
+			}); err != nil {
+				return err
+			}
 			finalizedBeforeDelegations = true
 		}
 	}
@@ -1676,4 +1714,39 @@ func (e Engine) projectedNewDelegationJobs(ctx context.Context, parentJobID stri
 // contributes 0, so the sum under-counts rather than over-counts.
 func (e Engine) sumRootDelegationTokens(ctx context.Context, rootID string) (int, error) {
 	return e.Store.SumJobTokensByRoot(ctx, rootID)
+}
+
+// implementationFinalizeCompletedEvent is the durable record that a finalizer RAN
+// TO COMPLETION and its payload was persisted (#2057 round five). It is a
+// separate fact from the CLAIM: a claim proves someone STARTED, and a crash after
+// claiming looks identical whether the finalizer never ran or finished just
+// before the payload write.
+const implementationFinalizeCompletedEvent = "implementation_finalize_completed"
+
+// FinalizationInProgressError reports that another advance holds the finalization
+// claim and has not recorded completion, so this caller cannot safely proceed:
+// the head and pull request in its payload are about to be replaced.
+//
+// An ERROR rather than a silent skip, because stopping is retryable - the daemon
+// re-advances - while dispatching delegations from data that is about to change
+// is not.
+type FinalizationInProgressError struct {
+	JobID string
+}
+
+func (e FinalizationInProgressError) Error() string {
+	return fmt.Sprintf("implementation finalization for %s is in progress under another advance", e.JobID)
+}
+
+func (e Engine) implementationFinalizeCompleted(ctx context.Context, jobID string) (bool, error) {
+	events, err := e.Store.ListJobEvents(ctx, jobID)
+	if err != nil {
+		return false, err
+	}
+	for _, event := range events {
+		if event.Kind == implementationFinalizeCompletedEvent {
+			return true, nil
+		}
+	}
+	return false, nil
 }

--- a/internal/workflow/engine_run_budgets.go
+++ b/internal/workflow/engine_run_budgets.go
@@ -695,6 +695,39 @@ func (e Engine) AdvanceJob(ctx context.Context, jobID string) (retErr error) {
 			return nil
 		}
 	}
+	// #2057 (review of the #1730 fix). A TASK-BACKED IMPLEMENTATION IS FINALIZED
+	// BEFORE ITS DELEGATIONS ARE DISPATCHED, because until the finalizer runs the
+	// produced work is NOT COMMITTED: the worktree HEAD is still the inherited
+	// pre-change commit, and a delegated review inheriting it is bound to a
+	// commit nobody produced. That is the #1730 class, and resolving the head at
+	// dispatch time cannot fix it - there is nothing to resolve yet.
+	//
+	// The finalizer is the right source rather than a git read here because it
+	// ALREADY writes the produced head: every path through
+	// daemonImplementationFinalizer sets payload.HeadSHA (commit-and-push, adopt,
+	// and existing-PR), along with Branch and PullRequest. So dispatching from
+	// the finalized payload needs no resolver at all.
+	//
+	// ORDERING CONSEQUENCE, deliberate: a finalizer that fails now prevents the
+	// delegations instead of following them. That is the safer direction - the
+	// work whose review was being delegated does not exist - and it is the same
+	// judgement the blocked/failed early-return above already makes.
+	finalizedBeforeDelegations := false
+	if job.Type == "implement" && payload.Result != nil && payload.Result.Decision == "implemented" && e.implementationNeedsFinalizer(ctx, payload) {
+		finalized, err := e.ImplementationFinalizer.FinalizeImplementation(ctx, job, payload)
+		if err != nil {
+			return err
+		}
+		encoded, err := marshalPayload(finalized)
+		if err != nil {
+			return err
+		}
+		if err := e.Store.UpdateJobPayload(ctx, job.ID, encoded); err != nil {
+			return err
+		}
+		payload = finalized
+		finalizedBeforeDelegations = true
+	}
 	if err := e.dispatchDelegations(ctx, job, payload, ref); err != nil {
 		return err
 	}
@@ -704,8 +737,13 @@ func (e Engine) AdvanceJob(ctx context.Context, jobID string) (retErr error) {
 		if payload.Result.Decision != "implemented" {
 			return nil
 		}
-		finalizerRan := false
-		if e.implementationNeedsFinalizer(ctx, payload) {
+		// The finalizer is NOT run twice. It commits, pushes and opens or adopts a
+		// pull request, so a second call is not a harmless repeat. When the
+		// pre-delegation block above already ran it, `finalizerRan` still reports
+		// true here, because every consumer below asks "was this implementation
+		// finalized", never "was it finalized at this line".
+		finalizerRan := finalizedBeforeDelegations
+		if !finalizedBeforeDelegations && e.implementationNeedsFinalizer(ctx, payload) {
 			finalizerRan = true
 			finalized, err := e.ImplementationFinalizer.FinalizeImplementation(ctx, job, payload)
 			if err != nil {

--- a/internal/workflow/engine_run_budgets.go
+++ b/internal/workflow/engine_run_budgets.go
@@ -8,9 +8,11 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"regexp"
 	"sort"
 	"strconv"
 	"strings"
+	"syscall"
 	"time"
 
 	"github.com/gitmoot/gitmoot/internal/db"
@@ -646,11 +648,23 @@ func (e Engine) AdvanceJob(ctx context.Context, jobID string) (retErr error) {
 		// cannot.
 		claimed, claimErr := e.Store.ClaimJobEvent(ctx, db.JobEvent{
 			JobID:   job.ID,
-			Kind:    "implementation_finalize_claimed",
-			Message: fmt.Sprintf("implementation finalization claimed for %s (#2057)", job.ID),
+			Kind:    implementationFinalizeClaimedEvent,
+			Message: implementationFinalizeClaimMessage(job.ID),
 		})
 		if claimErr != nil {
 			return claimErr
+		}
+		if claimed {
+			// STAMP THE OWNER IMMEDIATELY, and best effort: losing this write
+			// costs recoverability (an unattributable claim is treated as live
+			// forever and needs an operator), never correctness. Failing the
+			// finalization because a diagnostic row did not land would trade a
+			// recoverable stall for a certain one.
+			_ = e.recordEffectEvent(ctx, db.JobEvent{
+				JobID:   job.ID,
+				Kind:    implementationFinalizeClaimOwnerEvent,
+				Message: implementationFinalizeClaimOwnerMessage(job.ID),
+			})
 		}
 		if !claimed {
 			// #2057 round five, P1: A CLAIM PROVES SOMEONE STARTED, NOT THAT ANYONE
@@ -694,17 +708,38 @@ func (e Engine) AdvanceJob(ctx context.Context, jobID string) (retErr error) {
 				// permanent stop is worse than a possible duplicate, because the
 				// duplicate is visible and recoverable and the stop is neither. The
 				// bound is what keeps it from being taken while a winner is alive.
-				abandoned, age, abandonedErr := e.implementationFinalizeClaimAbandoned(ctx, job.ID)
+				abandoned, owner, abandonedErr := e.implementationFinalizeClaimAbandoned(ctx, job.ID)
 				if abandonedErr != nil {
 					return abandonedErr
 				}
 				if !abandoned {
 					return FinalizationInProgressError{JobID: job.ID}
 				}
+				// THE OWNER ROW IS THE RECOVERY TOKEN, and releasing it FIRST is
+				// what closes the ABA race. ReleaseJobEventClaim is at-most-once
+				// on the exact (job, kind, message) tuple, so of two recoverers
+				// that both observed this dead owner exactly ONE deletes it; the
+				// loser sees released=false and stops without ever touching the
+				// claim. Releasing the claim first would let the loser delete a
+				// live successor's claim, because the claim's message is stable
+				// by design and therefore identical for every holder.
+				wonRecovery, ownerErr := e.Store.ReleaseJobEventClaim(ctx, db.JobEvent{
+					JobID:   job.ID,
+					Kind:    implementationFinalizeClaimOwnerEvent,
+					Message: owner.Message,
+				})
+				if ownerErr != nil {
+					return ownerErr
+				}
+				if !wonRecovery {
+					// Another recoverer got there first. Its release of the claim
+					// is the one that counts.
+					return FinalizationInProgressError{JobID: job.ID}
+				}
 				released, releaseErr := e.Store.ReleaseJobEventClaim(ctx, db.JobEvent{
 					JobID:   job.ID,
-					Kind:    "implementation_finalize_claimed",
-					Message: fmt.Sprintf("implementation finalization claimed for %s (#2057)", job.ID),
+					Kind:    implementationFinalizeClaimedEvent,
+					Message: implementationFinalizeClaimMessage(job.ID),
 				})
 				if releaseErr != nil {
 					return releaseErr
@@ -714,8 +749,8 @@ func (e Engine) AdvanceJob(ctx context.Context, jobID string) (retErr error) {
 						JobID: job.ID,
 						Kind:  implementationFinalizeClaimRecoveredEvent,
 						Message: fmt.Sprintf(
-							"implementation finalization claim for %s held %s with no completion; released for retry (#2057)",
-							job.ID, age.Round(time.Second)),
+							"implementation finalization claim for %s was held by boot %s pid %d, which is gone; released for retry (#2057)",
+							job.ID, owner.BootID, owner.PID),
 					})
 				}
 				return FinalizationInProgressError{JobID: job.ID}
@@ -741,10 +776,24 @@ func (e Engine) AdvanceJob(ctx context.Context, jobID string) (retErr error) {
 				// failure path, while the success path becomes strictly safe. Making a
 				// FAILED finalizer idempotent is a separate problem and is not
 				// attempted here.
+				// Drop this holder's owner row with its claim, so no dead
+				// identity outlives the claim it described.
+				_, _ = e.Store.ReleaseJobEventClaim(ctx, db.JobEvent{
+					JobID:   job.ID,
+					Kind:    implementationFinalizeClaimOwnerEvent,
+					Message: implementationFinalizeClaimOwnerMessage(job.ID),
+				})
+				// Drop this holder's owner row with its claim, so no dead
+				// identity outlives the claim it described.
+				_, _ = e.Store.ReleaseJobEventClaim(ctx, db.JobEvent{
+					JobID:   job.ID,
+					Kind:    implementationFinalizeClaimOwnerEvent,
+					Message: implementationFinalizeClaimOwnerMessage(job.ID),
+				})
 				_, releaseErr := e.Store.ReleaseJobEventClaim(ctx, db.JobEvent{
 					JobID:   job.ID,
-					Kind:    "implementation_finalize_claimed",
-					Message: fmt.Sprintf("implementation finalization claimed for %s (#2057)", job.ID),
+					Kind:    implementationFinalizeClaimedEvent,
+					Message: implementationFinalizeClaimMessage(job.ID),
 				})
 				if releaseErr != nil {
 					return errors.Join(err, releaseErr)
@@ -776,8 +825,8 @@ func (e Engine) AdvanceJob(ctx context.Context, jobID string) (retErr error) {
 				// (TestFinalizedPayloadWithoutCompletionStillAdvances).
 				_, releaseErr := e.Store.ReleaseJobEventClaim(ctx, db.JobEvent{
 					JobID:   job.ID,
-					Kind:    "implementation_finalize_claimed",
-					Message: fmt.Sprintf("implementation finalization claimed for %s (#2057)", job.ID),
+					Kind:    implementationFinalizeClaimedEvent,
+					Message: implementationFinalizeClaimMessage(job.ID),
 				})
 				if releaseErr != nil {
 					return errors.Join(err, releaseErr)
@@ -1792,17 +1841,78 @@ func (e Engine) sumRootDelegationTokens(ctx context.Context, rootID string) (int
 // before the payload write.
 const implementationFinalizeCompletedEvent = "implementation_finalize_completed"
 
+// implementationFinalizeClaimedEvent is the claim row's kind, named once so the
+// claim, the releases and the recovery reader cannot drift apart.
+const implementationFinalizeClaimedEvent = "implementation_finalize_claimed"
+
+// implementationFinalizeClaimOwnerEvent records the identity holding the claim.
+const implementationFinalizeClaimOwnerEvent = "implementation_finalize_claim_owner"
+
 // implementationFinalizeClaimRecoveredEvent records that an abandoned
 // finalization claim was released for retry (#2057 round six).
 const implementationFinalizeClaimRecoveredEvent = "implementation_finalize_claim_recovered"
 
-// implementationFinalizeClaimGrace is how long a finalization claim may be held
-// with no completion event before a later advance treats it as abandoned and
-// releases it. It is a REFUSAL TO WAIT FOREVER, not a tuned value: it matches
-// the 15 minutes the pipeline auto-merge claim already uses for the same
-// question, and it must exceed the longest plausible finalizer run so a live
-// winner is never stolen from.
-const implementationFinalizeClaimGrace = 15 * time.Minute
+// implementationFinalizeClaimMessage stamps a claim with the OWNER that holds
+// it, so a later reader can ask whether that owner still exists (#2057 round
+// seven).
+//
+// WHY THE OWNER AND NOT A CLOCK. Round six recovered a claim held longer than
+// 15 minutes. The reviewer instrumented it and observed the failure directly:
+// the winning FinalizeImplementation stayed live, the clock passed the grace, a
+// losing advance released the claim, and a third advance entered the SAME
+// finalizer concurrently. No constant fixes that. Finalization has no ceiling
+// below the job context, which defaults to four hours and reaches eight, and
+// GitHub throttling alone can wait 30 minutes - so any grace short enough to
+// recover a dead owner promptly is also short enough to steal a live one, and
+// the replacement can then be recovered again on the same rule, which loops.
+//
+// Liveness is not derivable from age. It IS derivable from identity: a claim
+// stamped with a boot id and a pid can be tested against the boot we are in and
+// the process table. That is the same discriminator ListRunningJobIDsFromForeign
+// Boot already uses for abandoned runners, so this is one convention rather than
+// a second.
+//
+// THE MESSAGE IS ALSO THE ABA FIX. ClaimJobEvent and ReleaseJobEventClaim key on
+// the exact (job, kind, message) tuple. Round six used a CONSTANT message, so
+// two stale recoverers could both read the old claim, one release it, a new
+// winner acquire an identical row, and the second recoverer release the NEW
+// winner's claim. An owner-stamped message makes those rows distinct, so a
+// release built from the observed claim cannot match a successor's.
+func implementationFinalizeClaimMessage(jobID string) string {
+	return fmt.Sprintf("implementation finalization claimed for %s (#2057)", jobID)
+}
+
+// implementationFinalizeClaimOwnerMessage stamps WHO holds the claim, written as
+// a SEPARATE event immediately after the claim is won.
+//
+// WHY NOT IN THE CLAIM ITSELF. Round seven's first attempt put the owner in the
+// claim's message, and a pre-existing test caught the consequence at once:
+// ClaimJobEvent's at-most-once check keys on (job, kind, MESSAGE), so a claim
+// written by the old binary no longer excludes a claimer using the new format.
+// A deploy with an in-flight finalization would have run a SECOND finalizer
+// beside the first - the exact double-execution this whole guard exists to
+// prevent, introduced by the fix for it. The claim message must therefore stay
+// byte-stable forever.
+//
+// The owner event carries the identity instead, and it doubles as the recovery
+// token: ReleaseJobEventClaim on the OWNER row is at-most-once, so of two
+// recoverers observing the same dead owner exactly one proceeds to release the
+// claim. That is what closes the ABA race without making the claim's own message
+// vary.
+func implementationFinalizeClaimOwnerMessage(jobID string) string {
+	return fmt.Sprintf("implementation finalization for %s is held by boot %s pid %d (#2057)",
+		jobID, db.BootID(), os.Getpid())
+}
+
+// implementationFinalizeClaimOwner is the identity parsed back out of a claim.
+type implementationFinalizeClaimOwner struct {
+	BootID  string
+	PID     int
+	Message string
+}
+
+var implementationFinalizeClaimOwnerPattern = regexp.MustCompile(
+	`^implementation finalization for (?:.+) is held by boot (\S*) pid (\d+) \(#2057\)$`)
 
 // FinalizationInProgressError reports that another advance holds the finalization
 // claim and has not recorded completion, so this caller cannot safely proceed:
@@ -1820,36 +1930,82 @@ func (e FinalizationInProgressError) Error() string {
 }
 
 // implementationFinalizeClaimAbandoned reports whether the finalization claim on
-// jobID has been held past implementationFinalizeClaimGrace with no completion
-// event, and how long it has been held (#2057 round six).
+// jobID is held by an owner that no longer exists, and returns the claim's own
+// message so a release can target that exact row (#2057 round seven).
 //
-// UNPARSEABLE OR MISSING TIMESTAMPS ARE NOT ABANDONMENT. A claim whose
-// created_at cannot be read cannot be aged, so it is reported as live: stealing
-// on an unreadable clock would let one bad row re-run a finalizer immediately,
-// which is the failure this bound exists to avoid.
-func (e Engine) implementationFinalizeClaimAbandoned(ctx context.Context, jobID string) (bool, time.Duration, error) {
+// ABANDONED MEANS THE OWNER IS GONE, not that time has passed:
+//
+//   - a claim from a DIFFERENT boot cannot have a live holder, because no
+//     process from a previous boot is still running;
+//   - a claim from THIS boot is abandoned only if its pid is gone from the
+//     process table.
+//
+// EVERY UNCERTAINTY REPORTS LIVE. An unparseable message, an empty boot id on
+// either side, or a signal error that is not ESRCH all mean "cannot prove the
+// owner is gone", and the answer then must be no: recovering wrongly re-enters
+// a running finalizer, which is the failure the reviewer reproduced, while
+// declining wrongly leaves a job for an operator to retry.
+func (e Engine) implementationFinalizeClaimAbandoned(ctx context.Context, jobID string) (bool, implementationFinalizeClaimOwner, error) {
 	events, err := e.Store.ListJobEvents(ctx, jobID)
 	if err != nil {
-		return false, 0, err
+		return false, implementationFinalizeClaimOwner{}, err
 	}
-	var claimedAt time.Time
+	var owner implementationFinalizeClaimOwner
 	var found bool
 	for _, event := range events {
 		switch event.Kind {
 		case implementationFinalizeCompletedEvent:
-			// Completed: not abandoned, whatever the claim's age.
-			return false, 0, nil
-		case "implementation_finalize_claimed":
-			if at, ok := parseStoredJobTime(event.CreatedAt); ok {
-				claimedAt, found = at, true
+			// Completed: not abandoned, whatever its owner.
+			return false, implementationFinalizeClaimOwner{}, nil
+		case implementationFinalizeClaimOwnerEvent:
+			match := implementationFinalizeClaimOwnerPattern.FindStringSubmatch(strings.TrimSpace(event.Message))
+			if len(match) != 3 {
+				// An unparseable owner cannot be attributed, so it is live.
+				return false, implementationFinalizeClaimOwner{}, nil
 			}
+			pid, convErr := strconv.Atoi(match[2])
+			if convErr != nil || pid <= 0 {
+				return false, implementationFinalizeClaimOwner{}, nil
+			}
+			owner = implementationFinalizeClaimOwner{BootID: match[1], PID: pid, Message: strings.TrimSpace(event.Message)}
+			found = true
 		}
 	}
 	if !found {
-		return false, 0, nil
+		// NO OWNER ROW AT ALL, which is every claim written before this change.
+		// Live by default: a legacy claim is unattributable, and recovering it
+		// would re-enter a finalizer on no evidence.
+		return false, implementationFinalizeClaimOwner{}, nil
 	}
-	age := e.now().UTC().Sub(claimedAt)
-	return age >= implementationFinalizeClaimGrace, age, nil
+	current := db.BootID()
+	if current == "" || owner.BootID == "" {
+		// Without both boot ids the comparison is meaningless, and a pid alone
+		// can collide across boots. Unprovable, so live.
+		return false, owner, nil
+	}
+	if owner.BootID != current {
+		return true, owner, nil
+	}
+	return !processIsAlive(owner.PID), owner, nil
+}
+
+// processIsAlive reports whether pid exists, using signal 0 the way
+// stopDaemonPID already interprets ESRCH. UNKNOWN COUNTS AS ALIVE: EPERM means a
+// process exists that we may not signal, and any other error leaves the question
+// open, so both answer yes.
+func processIsAlive(pid int) bool {
+	if pid <= 0 {
+		return true
+	}
+	process, err := os.FindProcess(pid)
+	if err != nil {
+		return true
+	}
+	err = process.Signal(syscall.Signal(0))
+	if err == nil {
+		return true
+	}
+	return !(errors.Is(err, syscall.ESRCH) || errors.Is(err, os.ErrProcessDone))
 }
 
 func (e Engine) implementationFinalizeCompleted(ctx context.Context, jobID string) (bool, error) {

--- a/internal/workflow/engine_run_budgets.go
+++ b/internal/workflow/engine_run_budgets.go
@@ -713,6 +713,31 @@ func (e Engine) AdvanceJob(ctx context.Context, jobID string) (retErr error) {
 				return err
 			}
 			if err := e.Store.UpdateJobPayload(ctx, job.ID, encoded); err != nil {
+				// #2057 round five: A PAYLOAD WRITE THAT FAILS AFTER A SUCCESSFUL
+				// FINALIZER MUST RELEASE THE CLAIM. Otherwise nothing durable
+				// records the finalization - the marker is unwritten and completion
+				// is unreached - while the claim is held, so every later advance
+				// returns FinalizationInProgressError FOREVER and the job is
+				// stranded rather than retried.
+				//
+				// Releasing accepts that a retry may repeat part of the finalizer's
+				// external work, which is the same trade already taken on the
+				// finalizer-failure path and is what happens today with no claim at
+				// all. A permanent stop is worse than a possible duplicate, because
+				// the duplicate is visible and recoverable and the stop is neither.
+				//
+				// The COMPLETION-write failure below needs no release: the payload
+				// marker is already durable by then, and the claim block is guarded
+				// on it, so a retry never consults the claim
+				// (TestFinalizedPayloadWithoutCompletionStillAdvances).
+				_, releaseErr := e.Store.ReleaseJobEventClaim(ctx, db.JobEvent{
+					JobID:   job.ID,
+					Kind:    "implementation_finalize_claimed",
+					Message: fmt.Sprintf("implementation finalization claimed for %s (#2057)", job.ID),
+				})
+				if releaseErr != nil {
+					return errors.Join(err, releaseErr)
+				}
 				return err
 			}
 			payload = finalized

--- a/internal/workflow/engine_run_budgets.go
+++ b/internal/workflow/engine_run_budgets.go
@@ -655,16 +655,27 @@ func (e Engine) AdvanceJob(ctx context.Context, jobID string) (retErr error) {
 			return claimErr
 		}
 		if claimed {
-			// STAMP THE OWNER IMMEDIATELY, and best effort: losing this write
-			// costs recoverability (an unattributable claim is treated as live
-			// forever and needs an operator), never correctness. Failing the
-			// finalization because a diagnostic row did not land would trade a
-			// recoverable stall for a certain one.
-			_ = e.recordEffectEvent(ctx, db.JobEvent{
+			// A CLAIM WITHOUT ITS OWNER ROW IS NOT ALLOWED TO EXIST (#2057 round
+			// eight). Round seven wrote this best-effort, and the reviewer showed
+			// what that buys: a later winner whose owner write fails leaves the
+			// PRIOR holder's owner row as the newest one, so the abandonment
+			// reader attributes the live claim to a dead boot and recovers it.
+			//
+			// The invariant closes that by construction rather than by another
+			// guard: if the owner cannot be recorded, the claim is released and
+			// the advance returns retryably, so no claim is ever attributable to
+			// an identity that does not own it. The cost is a retry, which is the
+			// same cost every other failure on this path already pays.
+			if ownerErr := e.recordEffectEvent(ctx, db.JobEvent{
 				JobID:   job.ID,
 				Kind:    implementationFinalizeClaimOwnerEvent,
 				Message: implementationFinalizeClaimOwnerMessage(job.ID),
-			})
+			}); ownerErr != nil {
+				if releaseErr := e.releaseFinalizeClaim(ctx, job.ID); releaseErr != nil {
+					return errors.Join(ownerErr, releaseErr)
+				}
+				return FinalizationInProgressError{JobID: job.ID}
+			}
 		}
 		if !claimed {
 			// #2057 round five, P1: A CLAIM PROVES SOMEONE STARTED, NOT THAT ANYONE
@@ -776,25 +787,7 @@ func (e Engine) AdvanceJob(ctx context.Context, jobID string) (retErr error) {
 				// failure path, while the success path becomes strictly safe. Making a
 				// FAILED finalizer idempotent is a separate problem and is not
 				// attempted here.
-				// Drop this holder's owner row with its claim, so no dead
-				// identity outlives the claim it described.
-				_, _ = e.Store.ReleaseJobEventClaim(ctx, db.JobEvent{
-					JobID:   job.ID,
-					Kind:    implementationFinalizeClaimOwnerEvent,
-					Message: implementationFinalizeClaimOwnerMessage(job.ID),
-				})
-				// Drop this holder's owner row with its claim, so no dead
-				// identity outlives the claim it described.
-				_, _ = e.Store.ReleaseJobEventClaim(ctx, db.JobEvent{
-					JobID:   job.ID,
-					Kind:    implementationFinalizeClaimOwnerEvent,
-					Message: implementationFinalizeClaimOwnerMessage(job.ID),
-				})
-				_, releaseErr := e.Store.ReleaseJobEventClaim(ctx, db.JobEvent{
-					JobID:   job.ID,
-					Kind:    implementationFinalizeClaimedEvent,
-					Message: implementationFinalizeClaimMessage(job.ID),
-				})
+				releaseErr := e.releaseFinalizeClaim(ctx, job.ID)
 				if releaseErr != nil {
 					return errors.Join(err, releaseErr)
 				}
@@ -823,11 +816,7 @@ func (e Engine) AdvanceJob(ctx context.Context, jobID string) (retErr error) {
 				// marker is already durable by then, and the claim block is guarded
 				// on it, so a retry never consults the claim
 				// (TestFinalizedPayloadWithoutCompletionStillAdvances).
-				_, releaseErr := e.Store.ReleaseJobEventClaim(ctx, db.JobEvent{
-					JobID:   job.ID,
-					Kind:    implementationFinalizeClaimedEvent,
-					Message: implementationFinalizeClaimMessage(job.ID),
-				})
+				releaseErr := e.releaseFinalizeClaim(ctx, job.ID)
 				if releaseErr != nil {
 					return errors.Join(err, releaseErr)
 				}
@@ -1927,6 +1916,36 @@ type FinalizationInProgressError struct {
 
 func (e FinalizationInProgressError) Error() string {
 	return fmt.Sprintf("implementation finalization for %s is in progress under another advance", e.JobID)
+}
+
+// releaseFinalizeClaim drops a holder's OWNER row and then its claim, in that
+// order, as one operation (#2057 round eight).
+//
+// ONE HELPER BECAUSE THE ARMS DRIFTED. Round seven added the owner cleanup with a
+// scripted edit that inserted it TWICE into the finalizer-failure arm and NOT AT
+// ALL into the payload-write arm, and the reviewer found the consequence: that
+// arm released the claim and left its owner row, so a later winner whose own
+// best-effort owner write failed inherited a DEAD owner and had its LIVE claim
+// recovered. Two call sites that must stay identical are one call site.
+//
+// OWNER FIRST, CLAIM SECOND. A claim with no owner reads as unattributable and
+// therefore LIVE, which is a safe transient. A claim released while its stale
+// owner survives is the unsafe one, because the next reader attributes the new
+// claim to the dead identity.
+func (e Engine) releaseFinalizeClaim(ctx context.Context, jobID string) error {
+	if _, err := e.Store.ReleaseJobEventClaim(ctx, db.JobEvent{
+		JobID:   jobID,
+		Kind:    implementationFinalizeClaimOwnerEvent,
+		Message: implementationFinalizeClaimOwnerMessage(jobID),
+	}); err != nil {
+		return err
+	}
+	_, err := e.Store.ReleaseJobEventClaim(ctx, db.JobEvent{
+		JobID:   jobID,
+		Kind:    implementationFinalizeClaimedEvent,
+		Message: implementationFinalizeClaimMessage(jobID),
+	})
+	return err
 }
 
 // implementationFinalizeClaimAbandoned reports whether the finalization claim on

--- a/internal/workflow/engine_run_budgets.go
+++ b/internal/workflow/engine_run_budgets.go
@@ -674,6 +674,50 @@ func (e Engine) AdvanceJob(ctx context.Context, jobID string) (retErr error) {
 				return completedErr
 			}
 			if !completed {
+				// #2057 round six, P1: A CLAIM WITH NO COMPLETION IS NOT PROOF THAT
+				// ANYONE IS STILL WORKING. The claim carries no owner, lease or
+				// generation, so a daemon that exits between claiming and the payload
+				// write - or one whose payload write AND release both fail - leaves
+				// ImplementationFinalized=false, a claim, and no completion. Every
+				// later advance then loses the claim, sees no completion, and returns
+				// this error FOREVER: stranded, not retried.
+				//
+				// Recovered by AGE, from the claim row's own created_at, which is the
+				// shape the pipeline auto-merge claim already uses for the same
+				// question. Under the bound this stays a quiet retry, because a live
+				// winner is the overwhelmingly likely explanation. Past it the claim
+				// is released and the recovery recorded, so the NEXT advance claims
+				// cleanly and finalizes.
+				//
+				// This accepts a possible duplicate of the finalizer's external work,
+				// which is the trade already taken on both failure paths above: a
+				// permanent stop is worse than a possible duplicate, because the
+				// duplicate is visible and recoverable and the stop is neither. The
+				// bound is what keeps it from being taken while a winner is alive.
+				abandoned, age, abandonedErr := e.implementationFinalizeClaimAbandoned(ctx, job.ID)
+				if abandonedErr != nil {
+					return abandonedErr
+				}
+				if !abandoned {
+					return FinalizationInProgressError{JobID: job.ID}
+				}
+				released, releaseErr := e.Store.ReleaseJobEventClaim(ctx, db.JobEvent{
+					JobID:   job.ID,
+					Kind:    "implementation_finalize_claimed",
+					Message: fmt.Sprintf("implementation finalization claimed for %s (#2057)", job.ID),
+				})
+				if releaseErr != nil {
+					return releaseErr
+				}
+				if released {
+					_ = e.recordEffectEvent(ctx, db.JobEvent{
+						JobID: job.ID,
+						Kind:  implementationFinalizeClaimRecoveredEvent,
+						Message: fmt.Sprintf(
+							"implementation finalization claim for %s held %s with no completion; released for retry (#2057)",
+							job.ID, age.Round(time.Second)),
+					})
+				}
 				return FinalizationInProgressError{JobID: job.ID}
 			}
 			refreshed, refreshErr := e.Store.GetJob(ctx, job.ID)
@@ -1748,6 +1792,18 @@ func (e Engine) sumRootDelegationTokens(ctx context.Context, rootID string) (int
 // before the payload write.
 const implementationFinalizeCompletedEvent = "implementation_finalize_completed"
 
+// implementationFinalizeClaimRecoveredEvent records that an abandoned
+// finalization claim was released for retry (#2057 round six).
+const implementationFinalizeClaimRecoveredEvent = "implementation_finalize_claim_recovered"
+
+// implementationFinalizeClaimGrace is how long a finalization claim may be held
+// with no completion event before a later advance treats it as abandoned and
+// releases it. It is a REFUSAL TO WAIT FOREVER, not a tuned value: it matches
+// the 15 minutes the pipeline auto-merge claim already uses for the same
+// question, and it must exceed the longest plausible finalizer run so a live
+// winner is never stolen from.
+const implementationFinalizeClaimGrace = 15 * time.Minute
+
 // FinalizationInProgressError reports that another advance holds the finalization
 // claim and has not recorded completion, so this caller cannot safely proceed:
 // the head and pull request in its payload are about to be replaced.
@@ -1761,6 +1817,39 @@ type FinalizationInProgressError struct {
 
 func (e FinalizationInProgressError) Error() string {
 	return fmt.Sprintf("implementation finalization for %s is in progress under another advance", e.JobID)
+}
+
+// implementationFinalizeClaimAbandoned reports whether the finalization claim on
+// jobID has been held past implementationFinalizeClaimGrace with no completion
+// event, and how long it has been held (#2057 round six).
+//
+// UNPARSEABLE OR MISSING TIMESTAMPS ARE NOT ABANDONMENT. A claim whose
+// created_at cannot be read cannot be aged, so it is reported as live: stealing
+// on an unreadable clock would let one bad row re-run a finalizer immediately,
+// which is the failure this bound exists to avoid.
+func (e Engine) implementationFinalizeClaimAbandoned(ctx context.Context, jobID string) (bool, time.Duration, error) {
+	events, err := e.Store.ListJobEvents(ctx, jobID)
+	if err != nil {
+		return false, 0, err
+	}
+	var claimedAt time.Time
+	var found bool
+	for _, event := range events {
+		switch event.Kind {
+		case implementationFinalizeCompletedEvent:
+			// Completed: not abandoned, whatever the claim's age.
+			return false, 0, nil
+		case "implementation_finalize_claimed":
+			if at, ok := parseStoredJobTime(event.CreatedAt); ok {
+				claimedAt, found = at, true
+			}
+		}
+	}
+	if !found {
+		return false, 0, nil
+	}
+	age := e.now().UTC().Sub(claimedAt)
+	return age >= implementationFinalizeClaimGrace, age, nil
 }
 
 func (e Engine) implementationFinalizeCompleted(ctx context.Context, jobID string) (bool, error) {

--- a/internal/workflow/engine_run_budgets.go
+++ b/internal/workflow/engine_run_budgets.go
@@ -603,12 +603,25 @@ func (e Engine) AdvanceJob(ctx context.Context, jobID string) (retErr error) {
 	// delegations instead of following them. That is the safer direction - the
 	// work whose review was being delegated does not exist - and it is the same
 	// judgement the blocked/failed early-return above already makes.
-	finalizedBeforeDelegations := false
-	if job.Type == "implement" && payload.Result != nil && payload.Result.Decision == "implemented" && e.implementationNeedsFinalizer(ctx, payload) {
+	// #2057 round three, P1: THE DECISION IS MADE ONCE AND RECORDED. Eligibility
+	// used to be re-derived at three separate sites from a task lookup that can
+	// fail independently at each one, so a failure after a SUCCESSFUL finalizer
+	// could classify the payload as never finalized and drop the head the
+	// finalizer had just produced, and a retry after any later failure ran the
+	// finalizer again - it commits, pushes and opens a pull request, so a second
+	// run is not a harmless repeat.
+	//
+	// payload.ImplementationFinalized is the durable answer. It is persisted with
+	// the finalized payload in the same UpdateJobPayload write, so a retry reads
+	// it rather than re-deriving it.
+	finalizedBeforeDelegations := payload.ImplementationFinalized
+	if job.Type == "implement" && payload.Result != nil && payload.Result.Decision == "implemented" &&
+		!payload.ImplementationFinalized && e.implementationNeedsFinalizer(ctx, payload) {
 		finalized, err := e.ImplementationFinalizer.FinalizeImplementation(ctx, job, payload)
 		if err != nil {
 			return err
 		}
+		finalized.ImplementationFinalized = true
 		encoded, err := marshalPayload(finalized)
 		if err != nil {
 			return err
@@ -755,13 +768,14 @@ func (e Engine) AdvanceJob(ctx context.Context, jobID string) (retErr error) {
 		// pre-delegation block above already ran it, `finalizerRan` still reports
 		// true here, because every consumer below asks "was this implementation
 		// finalized", never "was it finalized at this line".
-		finalizerRan := finalizedBeforeDelegations
-		if !finalizedBeforeDelegations && e.implementationNeedsFinalizer(ctx, payload) {
+		finalizerRan := finalizedBeforeDelegations || payload.ImplementationFinalized
+		if !finalizerRan && e.implementationNeedsFinalizer(ctx, payload) {
 			finalizerRan = true
 			finalized, err := e.ImplementationFinalizer.FinalizeImplementation(ctx, job, payload)
 			if err != nil {
 				return err
 			}
+			finalized.ImplementationFinalized = true
 			encoded, err := marshalPayload(finalized)
 			if err != nil {
 				return err

--- a/internal/workflow/engine_run_budgets.go
+++ b/internal/workflow/engine_run_budgets.go
@@ -560,7 +560,19 @@ func (e Engine) AdvanceJob(ctx context.Context, jobID string) (retErr error) {
 	// leg that *triggered* the integration would not yet be on its branch and its
 	// work would be missing from the merge. The task/PR finalizer path commits its
 	// own way, so this only covers PR-less delegation legs; it is a no-op otherwise.
-	if job.Type == "implement" && payload.Result.Decision == "implemented" && !e.implementationNeedsFinalizer(ctx, payload) {
+	// #2057 round four, P1: ONE ELIGIBILITY DECISION PER ADVANCE. It used to be
+	// read independently at three sites, from a task lookup that can fail at each
+	// one, so a transient failure at the first read (mapping to true, skipping
+	// commitDelegationLeg) followed by a recovery to sql.ErrNoRows at the next
+	// (mapping to false, skipping the finalizer) let the parent DAG and the
+	// delegations advance with NEITHER having run. The inverse order - false, then
+	// true - permitted dispatch before a late finalization.
+	//
+	// Computed once here, before the first consumer, and threaded. A single read
+	// can still fail, and it fails closed as before; what it can no longer do is
+	// disagree with itself inside one advance.
+	needsFinalizer := job.Type == "implement" && e.implementationNeedsFinalizer(ctx, payload)
+	if job.Type == "implement" && payload.Result.Decision == "implemented" && !needsFinalizer {
 		if err := e.commitDelegationLeg(ctx, job, payload); err != nil {
 			return err
 		}
@@ -616,21 +628,68 @@ func (e Engine) AdvanceJob(ctx context.Context, jobID string) (retErr error) {
 	// it rather than re-deriving it.
 	finalizedBeforeDelegations := payload.ImplementationFinalized
 	if job.Type == "implement" && payload.Result != nil && payload.Result.Decision == "implemented" &&
-		!payload.ImplementationFinalized && e.implementationNeedsFinalizer(ctx, payload) {
-		finalized, err := e.ImplementationFinalizer.FinalizeImplementation(ctx, job, payload)
-		if err != nil {
-			return err
+		!payload.ImplementationFinalized && needsFinalizer {
+		// #2057 round four, P1: THE FINALIZATION IS CLAIMED BEFORE IT RUNS.
+		// payload.ImplementationFinalized alone left an unclaimed
+		// read-then-finalize-then-write window: two concurrent AdvanceJob callers
+		// could both load false and both invoke FinalizeImplementation, which
+		// commits, pushes and opens or adopts a pull request - so the second one
+		// is a duplicate external mutation, not a repeated no-op. And a crash or
+		// UpdateJobPayload failure after the finalizer SUCCEEDED left false
+		// durable, so the next retry finalized again.
+		//
+		// ClaimJobEvent is the same at-most-once primitive the pipeline auto-merge
+		// gate uses for its own external write: the NOT EXISTS guard and the
+		// insert share one statement, so there is no check-then-act window. The
+		// claim, not the payload flag, is what makes the success path safe - it
+		// survives a crash before the payload write, which the flag by definition
+		// cannot.
+		claimed, claimErr := e.Store.ClaimJobEvent(ctx, db.JobEvent{
+			JobID:   job.ID,
+			Kind:    "implementation_finalize_claimed",
+			Message: fmt.Sprintf("implementation finalization claimed for %s (#2057)", job.ID),
+		})
+		if claimErr != nil {
+			return claimErr
 		}
-		finalized.ImplementationFinalized = true
-		encoded, err := marshalPayload(finalized)
-		if err != nil {
-			return err
+		if !claimed {
+			// Someone else owns this finalization, or a previous advance already
+			// completed it and crashed before persisting the flag. Either way this
+			// caller must not finalize; treating the claim as the durable record is
+			// the whole point of taking it.
+			finalizedBeforeDelegations = true
+		} else {
+			finalized, err := e.ImplementationFinalizer.FinalizeImplementation(ctx, job, payload)
+			if err != nil {
+				// RELEASED ON FAILURE, and the scope of that is stated because it is
+				// the one thing this fix does NOT make safe. A failed finalizer may
+				// have committed or pushed before failing, so a retry can repeat part
+				// of its work - which is exactly what happens TODAY, with no claim at
+				// all. Releasing is therefore no worse than current behaviour on the
+				// failure path, while the success path becomes strictly safe. Making a
+				// FAILED finalizer idempotent is a separate problem and is not
+				// attempted here.
+				_, releaseErr := e.Store.ReleaseJobEventClaim(ctx, db.JobEvent{
+					JobID:   job.ID,
+					Kind:    "implementation_finalize_claimed",
+					Message: fmt.Sprintf("implementation finalization claimed for %s (#2057)", job.ID),
+				})
+				if releaseErr != nil {
+					return errors.Join(err, releaseErr)
+				}
+				return err
+			}
+			finalized.ImplementationFinalized = true
+			encoded, err := marshalPayload(finalized)
+			if err != nil {
+				return err
+			}
+			if err := e.Store.UpdateJobPayload(ctx, job.ID, encoded); err != nil {
+				return err
+			}
+			payload = finalized
+			finalizedBeforeDelegations = true
 		}
-		if err := e.Store.UpdateJobPayload(ctx, job.ID, encoded); err != nil {
-			return err
-		}
-		payload = finalized
-		finalizedBeforeDelegations = true
 	}
 
 	// When a delegated child job finishes, advance its parent's delegation DAG
@@ -769,7 +828,7 @@ func (e Engine) AdvanceJob(ctx context.Context, jobID string) (retErr error) {
 		// true here, because every consumer below asks "was this implementation
 		// finalized", never "was it finalized at this line".
 		finalizerRan := finalizedBeforeDelegations || payload.ImplementationFinalized
-		if !finalizerRan && e.implementationNeedsFinalizer(ctx, payload) {
+		if !finalizerRan && needsFinalizer {
 			finalizerRan = true
 			finalized, err := e.ImplementationFinalizer.FinalizeImplementation(ctx, job, payload)
 			if err != nil {

--- a/internal/workflow/engine_run_budgets.go
+++ b/internal/workflow/engine_run_budgets.go
@@ -574,6 +574,52 @@ func (e Engine) AdvanceJob(ctx context.Context, jobID string) (retErr error) {
 		}
 	}
 
+	// #2057 ROUND TWO. THIS SITS ABOVE THE PARENT-DAG ADVANCE, not merely above
+	// dispatchDelegations. An implement job that is ITSELF a delegation child
+	// reaches advanceParentForTerminalChild below, which can enqueue a ready
+	// dependent sibling or the coordinator continuation. Finalizing after that
+	// meant a failed finalizer left those jobs enqueued from work that was never
+	// committed or pushed - the same defect as the delegation case, one level up,
+	// and the first fix's failing-finalizer test used a TOP-LEVEL job so it could
+	// not see this path.
+	//
+	// Advancing the parent from the FINALIZED payload is also the more correct
+	// input: siblings and the continuation then read the produced head and pull
+	// request rather than the pre-change ones.
+	// #2057 (review of the #1730 fix). A TASK-BACKED IMPLEMENTATION IS FINALIZED
+	// BEFORE ITS DELEGATIONS ARE DISPATCHED, because until the finalizer runs the
+	// produced work is NOT COMMITTED: the worktree HEAD is still the inherited
+	// pre-change commit, and a delegated review inheriting it is bound to a
+	// commit nobody produced. That is the #1730 class, and resolving the head at
+	// dispatch time cannot fix it - there is nothing to resolve yet.
+	//
+	// The finalizer is the right source rather than a git read here because it
+	// ALREADY writes the produced head: every path through
+	// daemonImplementationFinalizer sets payload.HeadSHA (commit-and-push, adopt,
+	// and existing-PR), along with Branch and PullRequest. So dispatching from
+	// the finalized payload needs no resolver at all.
+	//
+	// ORDERING CONSEQUENCE, deliberate: a finalizer that fails now prevents the
+	// delegations instead of following them. That is the safer direction - the
+	// work whose review was being delegated does not exist - and it is the same
+	// judgement the blocked/failed early-return above already makes.
+	finalizedBeforeDelegations := false
+	if job.Type == "implement" && payload.Result != nil && payload.Result.Decision == "implemented" && e.implementationNeedsFinalizer(ctx, payload) {
+		finalized, err := e.ImplementationFinalizer.FinalizeImplementation(ctx, job, payload)
+		if err != nil {
+			return err
+		}
+		encoded, err := marshalPayload(finalized)
+		if err != nil {
+			return err
+		}
+		if err := e.Store.UpdateJobPayload(ctx, job.ID, encoded); err != nil {
+			return err
+		}
+		payload = finalized
+		finalizedBeforeDelegations = true
+	}
+
 	// When a delegated child job finishes, advance its parent's delegation DAG
 	// before running the child's own advancement: enqueue any now-ready
 	// dependent siblings, apply the failed delegation's failure_policy, and
@@ -694,39 +740,6 @@ func (e Engine) AdvanceJob(ctx context.Context, jobID string) (retErr error) {
 		if done {
 			return nil
 		}
-	}
-	// #2057 (review of the #1730 fix). A TASK-BACKED IMPLEMENTATION IS FINALIZED
-	// BEFORE ITS DELEGATIONS ARE DISPATCHED, because until the finalizer runs the
-	// produced work is NOT COMMITTED: the worktree HEAD is still the inherited
-	// pre-change commit, and a delegated review inheriting it is bound to a
-	// commit nobody produced. That is the #1730 class, and resolving the head at
-	// dispatch time cannot fix it - there is nothing to resolve yet.
-	//
-	// The finalizer is the right source rather than a git read here because it
-	// ALREADY writes the produced head: every path through
-	// daemonImplementationFinalizer sets payload.HeadSHA (commit-and-push, adopt,
-	// and existing-PR), along with Branch and PullRequest. So dispatching from
-	// the finalized payload needs no resolver at all.
-	//
-	// ORDERING CONSEQUENCE, deliberate: a finalizer that fails now prevents the
-	// delegations instead of following them. That is the safer direction - the
-	// work whose review was being delegated does not exist - and it is the same
-	// judgement the blocked/failed early-return above already makes.
-	finalizedBeforeDelegations := false
-	if job.Type == "implement" && payload.Result != nil && payload.Result.Decision == "implemented" && e.implementationNeedsFinalizer(ctx, payload) {
-		finalized, err := e.ImplementationFinalizer.FinalizeImplementation(ctx, job, payload)
-		if err != nil {
-			return err
-		}
-		encoded, err := marshalPayload(finalized)
-		if err != nil {
-			return err
-		}
-		if err := e.Store.UpdateJobPayload(ctx, job.ID, encoded); err != nil {
-			return err
-		}
-		payload = finalized
-		finalizedBeforeDelegations = true
 	}
 	if err := e.dispatchDelegations(ctx, job, payload, ref); err != nil {
 		return err

--- a/internal/workflow/mailbox.go
+++ b/internal/workflow/mailbox.go
@@ -414,6 +414,13 @@ type JobPayload struct {
 	// The clone owns its git directory, is attached to Branch, and remains visible
 	// to cleanup obligations and doctor until an operator removes it.
 	FixWorktree bool `json:"fix_worktree,omitempty"`
+	// ImplementationFinalized records that this implement job's work has been
+	// committed, pushed and had its pull request opened or adopted (#2057 round
+	// three). It is DURABLE STATE, not a cache: the finalizer is not idempotent,
+	// so a retry of AdvanceJob after a later failure must not run it twice, and a
+	// consumer deciding whether the payload's head was produced by a finalizer
+	// must not re-derive that from a task lookup that can fail independently.
+	ImplementationFinalized bool `json:"implementation_finalized,omitempty"`
 	// ReadOnlyWorktreeDiff durably preserves the bounded `git status --short` +
 	// `git diff HEAD` snapshot collected immediately before a terminal ask/review
 	// worktree is removed. Truncated is explicit when the snapshot exceeded the


### PR DESCRIPTION
Refs #1730. Campaign #1818. Head `fbde492a`. **Draft**, per the standing rule.

Assigned by phobos as campaign work with two constraints: **fix the write, not the reader**, and **if a doc comment claims a property the code does not hold, correct one and say which.** Both are honoured below.

## The defect, measured on the single instance

A review delegated by an **implement** job recorded the parent's payload head - the commit *before* that parent's change - so the row attested a verdict at an ancestor of the tree the reviewer read.

```
parent local-implement-appkit-omp-18d0db287156c2ba
  succeeded            10:22:43
  delegation enqueued  10:22:43   <- same second
child  head_sha  0e2ce4f1   pull_request 0
parent head_sha  0c175d03   pull_request 3
verdict summary  "... (head 0c175d03..., == HEAD) ..."
```

**The mechanism is one step earlier than the issue states.** It is not "inherits the parent's dispatch head" but *inherits the parent's payload snapshot taken before the parent did any work* - which is why `pull_request` is also 0, a value only explicable if the snapshot predates the implement job opening PR 3.

## The fix writes a head; it does not clear one

The head the child will review is the **tip of the parent's branch**, where that parent's work landed. It is resolved through the same `RevParse` the writable lineage manager already exposes and **recorded on the child**.

I built the clearing version first and reverted it: clearing leaves the verdict **unbound**, and this campaign's thesis is that an unbound verdict is not a verdict about your code. It *is* the safer failure, though, so an unresolvable branch drops the stale head and records `delegation_review_head_unbound` naming what was dropped - a wrong head looks bound, and that is worse than none.

## Placement is the part that almost went wrong

My first version sat inside the read-only fan-out branch. That branch requires **two or more** read-only siblings (`worktree.go:941`, `count >= 2`), and the reproduced job has **one** child - so it would never have run for the very job that motivated it. The fix now sits before the allocation chain, which every delegation passes through.

This is the unexercised-path trap this campaign keeps finding, caught before shipping rather than after.

## A review parent is deliberately untouched

Its head **is** the commit under review, and unpinning there would remove the exact-head guarantee the merge gate depends on. Measured: **27 of the 28** parent-delegated reviews in this store have a review parent and correctly share its head. A test asserts a lens child keeps its inherited head and that no branch resolution is attempted for it.

## On the doc-comment constraint

The comment at the fan-out site says only a review child *"runs at the coordinator's exact head: its verdict names a commit"*. That claim is **true for a review coordinator and false for an implement one**, and the code held the false half. I corrected the **code** and left that comment's scope intact, adding the implement-parent case as its own block with the measurement in it - so the file now states both cases explicitly rather than one rule that is right 27 times out of 28.

## Tests and mutants

| test | arm |
|---|---|
| `...BindsToTheHeadTheImplementParentProduced` | the row records the produced head, and the branch was actually resolved |
| `...OfAReviewParentKeepsTheInheritedHead` | a lens child is untouched, and no resolution is attempted |
| `...DropsAnUnresolvableHeadAndSaysSo` | the stale head is dropped **and** an event names it |

Three mutants killed, **each with a hash check that the mutation applied**: removing the rebind, applying it to every parent type, and keeping the stale head on a resolution failure.

That applied-check exists because an earlier round's mutant reported "survived" while its replacement string never matched. **A mutant that did not apply is not a result**, and it fails in the direction that makes you weaken a test that was already correct.

## Production wiring is compile-enforced

`internal/cli/delegation_head_resolver_wiring_1730_test.go` asserts that `jobGitClient` - the value `daemon_workflow.go:134` assigns to `DelegationWorktrees` - satisfies the resolver interface. It lives in the package that does the wiring, so the fix cannot become dead code through a change to that return type; a runtime test in `internal/workflow` would keep passing against a fake.

## Not fixed here, stated rather than left to be found

**`pull_request=0` is not repaired.** The same snapshot supplies it, so the child is also unfindable by PR (#1962's class). Resolving a PR number needs a forge lookup the engine **deliberately does not have** - `engine.go` records keeping the engine free of the github dependency - so it is a separate change with its own dependency question, not a widening of this one. My earlier comment on #1730 published four acceptance criteria; this PR meets 1, 3 and 4, and criterion 2 (PR inheritance) is the one left open, named here rather than quietly dropped.

## Verification

`gofmt`, `go build ./...`, `go vet` on both touched packages, the filtered `internal/workflow` delegation suite and the `internal/cli` wiring guard, all green at `fbde492a`. No untargeted package run: full suites are held fleet-wide under a disk constraint and **CI is the gate**.

Signed: **gm-staged**


## Round five: the payload-write window, and the trade it takes

**A permanent stop is worse than a possible duplicate, because the duplicate is visible and recoverable and the stop is neither.** That is the whole justification for releasing the claim on a payload-write failure, and it is the same trade this code already takes on the finalizer-failure path.

The stranded shape: nothing durable recorded the finalization, so the marker went unwritten, completion was never reached, the claim stayed held, and **every later advance returned `FinalizationInProgressError` forever**. Not slow, not retried: stopped.

The adjacent window is **not** a defect, and that is asserted rather than argued. The claim block is guarded on `!payload.ImplementationFinalized`, so a retry that loads a finalized payload never reaches the claim check at all. `TestFinalizedPayloadWithoutCompletionStillAdvances` pins it, because *"a guard upstream covers it"* is true exactly until someone reorders the guard.

## Three behaviours here rest on stated reasoning, and the reason is one defect

Payload reload on a lost claim, completion-after-payload ordering, and the claim release are all unpinnable for the **same** cause: `internal/workflow/engine.go:19` declares `Store *db.Store`, a concrete pointer, so a store write cannot be made to fail. Filed as **#2093** with all three as its measured instances and three costed remedies.

Reviewers: the honest answer to "why is this untested" is "because the dependency is concrete", and I would rather you argue with #2093 than accept three separate apologies from me. If you disagree with any of the three arguments, say which one and why; I will not answer by inventing a fixture.


## Attribution and head gap, disclosed per phobos' ruling

**Independence of review is unverifiable from the store for this PR, and the reason is by design rather than an omission.**

The implementation was done in-session by `gm-staged`, so the only durable attribution is a session-recorded implement row. Measured across my own rows: **0 of 12 carry a `head_sha`**, and that is the documented behaviour of `--head-sha`, whose own help says it is *"recorded as display metadata only: it is NOT stored in the job payload and no merge policy reads it (#1990)"*. The head is quarantined to the display plane.

So the row is honest about **who** and permanently silent about **which head**. Consequences, stated plainly:

- The gate cannot verify reviewer-versus-implementer independence at an exact head for this PR. That is an **attribution gap**, not a failed check.
- There is no "record the row and re-evaluate" path that closes it while the #1990 quarantine stands. Recording the row is still correct and was done, with `--acting-role gm-staged`; it fixes the *who*, not the *which head*.
- **The reviewer is `gm-review-opus`, which is not this seat and has never implemented on this branch.** That is the substantive claim behind independence; what is missing is the store's ability to *prove* it at a head.

No merge should be blocked on this alone, and nothing here asserts the review was independent on evidence I do not have. It states what is knowable and what is not.
