### PR TITLE
fix(workflow): record an ask verdict the ledger cannot key (#1962)

### DIFF
--- a/internal/workflow/engine_run_budgets.go
+++ b/internal/workflow/engine_run_budgets.go
@@ -655,6 +655,33 @@ func (e Engine) AdvanceJob(ctx context.Context, jobID string) (retErr error) {
 			return err
 		}
 	}
+	// AN ASK THAT REVIEWED SOMETHING LOSES ITS FINDINGS SILENTLY (#1962). Both
+	// RecordReviewFindingsToLedger call sites above are inside `job.Type ==
+	// "review"`, so for an ask the writer is never CALLED - its own internal
+	// type guard is defence in depth and its recordLedgerSkip can never fire.
+	// The verdict is real and the loss leaves no trace anywhere.
+	//
+	// Measured on 2026-09-08: 15 succeeded gm-review-opus ask jobs, all 15
+	// carrying a decision and 11 carrying findings, produced ZERO ledger rows and
+	// ZERO events explaining it. Positive control on that zero: the same join
+	// over review-TYPE jobs the same day returns 28 jobs and 80 rows. Of the 15
+	// decisions, 6 were changes_requested, and one of those - PR #2029 at
+	// 8bdf8f54 - is an objection at that PR's CURRENT head, invisible to every
+	// PR-keyed surface.
+	//
+	// THIS RECORDS THE LOSS; IT DOES NOT CLOSE IT, and writing a row here would
+	// be worse than the gap. An observation with no pull request and no head
+	// cannot be keyed to anything a reader can query, and inventing a key is the
+	// #2054 class. So the honest outcome for an unbound verdict is a RECORDED
+	// skip rather than a silent one or a fabricated row.
+	//
+	// Making a BOUND ask write real observations is deliberately not attempted
+	// here: that path inherits #2059's field-name mismatch, where the wire reads
+	// id/title/state while reviewers emit uid/evidence/disposition, and it would
+	// convert these silent losses into empty OPEN findings. #2059 first.
+	if job.Type != "review" && reviewShapedResult(payload.Result) {
+		e.recordUnboundReviewVerdict(ctx, job, payload)
+	}
 	if payload.Result.Decision == "blocked" || payload.Result.Decision == "failed" {
 		return e.block(ctx, ref, payload.Result.Summary)
 	}

--- a/internal/workflow/findings_ledger_writer.go
+++ b/internal/workflow/findings_ledger_writer.go
@@ -720,9 +720,25 @@ func reviewShapedResult(result *AgentResult) bool {
 		return false
 	}
 	switch strings.ToLower(strings.TrimSpace(result.Decision)) {
-	case "approved", "changes_requested":
-		// FINDINGS ARE REQUIRED HERE TOO (#2061 CI, three race shards and the
-		// tagged e2e). "approved" alone was treated as a review verdict, so an
+	case "changes_requested":
+		// AN OBJECTION WITH NO FINDINGS ARRAY IS STILL AN OBJECTION (#2061 review,
+		// P2, found by EXECUTING the predicate rather than reading it).
+		//
+		// Requiring findings on every arm was right for "approved" and wrong here,
+		// and the asymmetry is not a special case: review_loop.go's
+		// namedReviewFindings already promotes a changes_requested SUMMARY to a
+		// finding when the array is empty. This mirrors that rule rather than
+		// inventing a second one - the same reason the "blocked" arm matches
+		// followUpReviewScopes.
+		//
+		// The two decisions differ in what silence MEANS. An approval carrying
+		// nothing has nothing to record. A changes_requested carrying a summary is
+		// a live objection, and losing it silently is precisely the class #1962
+		// exists to close.
+		return len(result.Findings) > 0 || strings.TrimSpace(result.Summary) != ""
+	case "approved":
+		// FINDINGS ARE REQUIRED FOR AN APPROVAL (#2061 CI, three race shards and
+		// the tagged e2e). "approved" alone was treated as a review verdict, so an
 		// ORDINARY ask that returns {"decision":"approved","findings":[]} - the
 		// shape the shipped result contract puts in front of every agent, and the
 		// literal payload of runtimeOverrideShellScript - emitted

--- a/internal/workflow/findings_ledger_writer.go
+++ b/internal/workflow/findings_ledger_writer.go
@@ -721,9 +721,24 @@ func reviewShapedResult(result *AgentResult) bool {
 	}
 	switch strings.ToLower(strings.TrimSpace(result.Decision)) {
 	case "approved", "changes_requested":
-		return true
+		// FINDINGS ARE REQUIRED HERE TOO (#2061 CI, three race shards and the
+		// tagged e2e). "approved" alone was treated as a review verdict, so an
+		// ORDINARY ask that returns {"decision":"approved","findings":[]} - the
+		// shape the shipped result contract puts in front of every agent, and the
+		// literal payload of runtimeOverrideShellScript - emitted
+		// review_verdict_unrecordable about work that was never a review.
+		// TestLocalExecutionBackendAllowsNonImplement caught it as an event kind
+		// absent from the main baseline.
+		//
+		// This is the same defect the reviewer's P3 named, surviving the fix I
+		// made for it: I required a review-SHAPED DECISION, and "approved" is one.
+		// The decision was never the discriminator. An ask that reviewed
+		// something SAYS WHAT IT FOUND; an ask that merely answers does not.
+		return len(result.Findings) > 0
 	case "":
 		// No decision at all: findings are the only signal that a review happened.
+		// Every arm now agrees on this, which is the point - findings are the
+		// discriminator and the decision only says which KIND of verdict it is.
 		return len(result.Findings) > 0
 	case "blocked", "failed":
 		// A REVIEWER THAT NAMED DEFECTS STILL REVIEWED (#2061 review, P2).

--- a/internal/workflow/findings_ledger_writer.go
+++ b/internal/workflow/findings_ledger_writer.go
@@ -725,6 +725,15 @@ func reviewShapedResult(result *AgentResult) bool {
 	case "":
 		// No decision at all: findings are the only signal that a review happened.
 		return len(result.Findings) > 0
+	case "blocked":
+		// A BLOCKED REVIEWER THAT NAMED DEFECTS STILL REVIEWED (#2061 review, P2).
+		// review_loop.go's followUpReviewScopes treats exactly this - decision
+		// "blocked" WITH findings - as a real verdict, and refuses it without
+		// them. Matching that predicate here rather than inventing a second one
+		// is the point: an ask dispatched as a review that blocks after finding
+		// defects would otherwise be lost silently, which is the class #1962
+		// exists to close.
+		return len(result.Findings) > 0
 	}
 	// A DECISION THAT IS NOT A REVIEW DECISION SETTLES IT, even with findings
 	// attached (#2061 review, P3). The first version returned true on findings
@@ -733,6 +742,13 @@ func reviewShapedResult(result *AgentResult) bool {
 	// that was never a review. The reviewer found that by reading the predicate
 	// rather than by running it, which is why no test caught it: every fixture I
 	// wrote used a review-shaped decision.
+	//
+	// "failed" IS DELIBERATELY NOT HERE, which is NARROWER THAN THE REVIEW ASKED
+	// FOR. They proposed blocked OR failed. review_loop.go names only "blocked",
+	// and every "failed" decision I can find is ENGINE-GENERATED rather than
+	// reviewer-authored - engine_run_budgets.go:104 constructs one. Admitting it
+	// would promote an engine-authored terminal state to a review verdict, which
+	// is the same manufacture the P3 above removed.
 	return false
 }
 

--- a/internal/workflow/findings_ledger_writer.go
+++ b/internal/workflow/findings_ledger_writer.go
@@ -706,6 +706,7 @@ func unstructuredLocatorText(locator string) string {
 	}
 	return locator
 }
+
 // reviewShapedResult reports whether a result is a review verdict regardless of
 // the job TYPE that produced it (#1962). An `agent ask` dispatched as "review
 // this PR at this head" returns exactly this shape - a review decision, usually

--- a/internal/workflow/findings_ledger_writer.go
+++ b/internal/workflow/findings_ledger_writer.go
@@ -706,3 +706,80 @@ func unstructuredLocatorText(locator string) string {
 	}
 	return locator
 }
+// reviewShapedResult reports whether a result is a review verdict regardless of
+// the job TYPE that produced it (#1962). An `agent ask` dispatched as "review
+// this PR at this head" returns exactly this shape - a review decision, usually
+// with findings - and the ledger writer never sees it because both of its call
+// sites are keyed on job.Type.
+//
+// It tests the RESULT rather than the prompt, because the prompt is not a
+// durable field and a classifier over prose is the thing #1534 forbids.
+func reviewShapedResult(result *AgentResult) bool {
+	if result == nil {
+		return false
+	}
+	if len(result.Findings) > 0 {
+		return true
+	}
+	switch strings.ToLower(strings.TrimSpace(result.Decision)) {
+	case "approved", "changes_requested":
+		return true
+	}
+	return false
+}
+
+// recordUnboundReviewVerdict makes an unrecordable review verdict FINDABLE
+// without inventing the binding it lacks (#1962).
+//
+// It writes no ledger observation on purpose. review_finding_observations is
+// keyed by repo + pull_request + head_sha; a row missing all three answers no
+// query anyone can write, and a synthesised key would be a record asserting a
+// binding nobody established. The gap stays open here - this only stops it being
+// invisible, which is the difference between a defect someone can find and one
+// that is indistinguishable from a review that reported nothing.
+//
+// Best effort by the same reasoning as the writer's summary event: a real
+// verdict must never be discarded over an audit row.
+func (e Engine) recordUnboundReviewVerdict(ctx context.Context, job db.Job, payload JobPayload) {
+	if e.Store == nil || payload.Result == nil {
+		return
+	}
+	missing := make([]string, 0, 3)
+	if payload.PullRequest <= 0 {
+		missing = append(missing, "pull_request")
+	}
+	if strings.TrimSpace(payload.HeadSHA) == "" {
+		missing = append(missing, "head_sha")
+	}
+	if strings.TrimSpace(payload.Repo) == "" {
+		missing = append(missing, "repo")
+	}
+	if len(missing) == 0 {
+		// Bound, and still not written, because this job's type keeps it away from
+		// the writer. Naming that separately matters: it is a different defect from
+		// an unbound dispatch and it is the case #2059 must land before anyone
+		// makes writable.
+		_ = e.Store.AddJobEvent(ctx, db.JobEvent{
+			JobID: job.ID,
+			Kind:  unboundReviewVerdictEventKind,
+			Message: fmt.Sprintf(
+				"%s job returned a review verdict (decision %q, %d finding(s)) bound to %s#%d at %s, but only job type \"review\" reaches the #1822 ledger writer, so nothing was recorded",
+				job.Type, strings.TrimSpace(payload.Result.Decision), len(payload.Result.Findings),
+				strings.TrimSpace(payload.Repo), payload.PullRequest, strings.TrimSpace(payload.HeadSHA)),
+		})
+		return
+	}
+	_ = e.Store.AddJobEvent(ctx, db.JobEvent{
+		JobID: job.ID,
+		Kind:  unboundReviewVerdictEventKind,
+		Message: fmt.Sprintf(
+			"%s job returned a review verdict (decision %q, %d finding(s)) with no %s, so it cannot be keyed to a pull request or head and no #1822 ledger row was written; re-dispatch with --pr and --head-sha to make it recordable",
+			job.Type, strings.TrimSpace(payload.Result.Decision), len(payload.Result.Findings),
+			strings.Join(missing, " and ")),
+	})
+}
+
+// unboundReviewVerdictEventKind marks a review verdict the ledger cannot key.
+// Its presence is what distinguishes a lost verdict from a review that genuinely
+// found nothing - before it, those two were the same absence.
+const unboundReviewVerdictEventKind = "review_verdict_unrecordable"

--- a/internal/workflow/findings_ledger_writer.go
+++ b/internal/workflow/findings_ledger_writer.go
@@ -725,8 +725,8 @@ func reviewShapedResult(result *AgentResult) bool {
 	case "":
 		// No decision at all: findings are the only signal that a review happened.
 		return len(result.Findings) > 0
-	case "blocked":
-		// A BLOCKED REVIEWER THAT NAMED DEFECTS STILL REVIEWED (#2061 review, P2).
+	case "blocked", "failed":
+		// A REVIEWER THAT NAMED DEFECTS STILL REVIEWED (#2061 review, P2).
 		// review_loop.go's followUpReviewScopes treats exactly this - decision
 		// "blocked" WITH findings - as a real verdict, and refuses it without
 		// them. Matching that predicate here rather than inventing a second one
@@ -743,12 +743,17 @@ func reviewShapedResult(result *AgentResult) bool {
 	// rather than by running it, which is why no test caught it: every fixture I
 	// wrote used a review-shaped decision.
 	//
-	// "failed" IS DELIBERATELY NOT HERE, which is NARROWER THAN THE REVIEW ASKED
-	// FOR. They proposed blocked OR failed. review_loop.go names only "blocked",
-	// and every "failed" decision I can find is ENGINE-GENERATED rather than
-	// reviewer-authored - engine_run_budgets.go:104 constructs one. Admitting it
-	// would promote an engine-authored terminal state to a review verdict, which
-	// is the same manufacture the P3 above removed.
+	// "failed" IS HERE BECAUSE THE REVIEWER OVERTURNED MY EXCLUSION WITH EVIDENCE
+	// I ASKED FOR. I had excluded it, arguing every "failed" I could find was
+	// engine-generated. They showed it is REVIEWER-AUTHORABLE and documented as
+	// such: ResultDecisions (result.go:38) is ONE closed set validated identically
+	// for every job type, and resultContractShape - the literal prompt text
+	// delivered to every agent, prompts/contract_generated.go:10 - offers "failed"
+	// alongside "blocked" with no reviewer exclusion. An agent told it may return
+	// "failed" will, and a reviewer that did so after naming defects reviewed.
+	//
+	// The findings requirement is what keeps this safe: an engine-generated
+	// "failed" carries no findings and is still not a verdict.
 	return false
 }
 

--- a/internal/workflow/findings_ledger_writer.go
+++ b/internal/workflow/findings_ledger_writer.go
@@ -719,13 +719,20 @@ func reviewShapedResult(result *AgentResult) bool {
 	if result == nil {
 		return false
 	}
-	if len(result.Findings) > 0 {
-		return true
-	}
 	switch strings.ToLower(strings.TrimSpace(result.Decision)) {
 	case "approved", "changes_requested":
 		return true
+	case "":
+		// No decision at all: findings are the only signal that a review happened.
+		return len(result.Findings) > 0
 	}
+	// A DECISION THAT IS NOT A REVIEW DECISION SETTLES IT, even with findings
+	// attached (#2061 review, P3). The first version returned true on findings
+	// ALONE, so an implement job that populated Findings - which the result shape
+	// permits - would have emitted a review_verdict_unrecordable event about work
+	// that was never a review. The reviewer found that by reading the predicate
+	// rather than by running it, which is why no test caught it: every fixture I
+	// wrote used a review-shaped decision.
 	return false
 }
 

--- a/internal/workflow/unrecordable_verdict_1962_test.go
+++ b/internal/workflow/unrecordable_verdict_1962_test.go
@@ -242,15 +242,24 @@ func TestBlockedWithoutFindingsIsNotAReviewVerdict(t *testing.T) {
 	}
 }
 
-// "failed" IS NOT A REVIEW VERDICT, and this pins the place I went NARROWER
-// than the review asked. engine_run_budgets.go constructs "failed" itself, so
-// admitting it would promote an engine-authored terminal state to a reviewer's
-// verdict - the manufacture the P3 arm removed.
-func TestFailedWithFindingsIsNotAReviewVerdict(t *testing.T) {
-	if reviewShapedResult(&AgentResult{
+// "failed" WITH FINDINGS IS A VERDICT, and this arm replaces the one that pinned
+// my exclusion. The reviewer overturned it with the evidence I asked for: the
+// result contract delivered to every agent offers "failed" with no reviewer
+// exclusion, so a reviewer-authored "failed" is expressible and documented.
+func TestFailedWithFindingsIsAReviewVerdict(t *testing.T) {
+	if !reviewShapedResult(&AgentResult{
 		Decision: "failed",
 		Findings: []json.RawMessage{json.RawMessage(`{"id":"F1","severity":"P1","title":"t"}`)},
 	}) {
-		t.Fatal("an engine-authored \"failed\" decision was treated as a review verdict")
+		t.Fatal("a failed reviewer that named defects was not treated as a review verdict")
+	}
+}
+
+// THE GUARD THAT KEEPS IT SAFE: an ENGINE-generated "failed" carries no
+// findings, so it is still not a verdict. Without this, admitting "failed"
+// would promote every engine terminal state to a review.
+func TestFailedWithoutFindingsIsNotAReviewVerdict(t *testing.T) {
+	if reviewShapedResult(&AgentResult{Decision: "failed", Summary: "worker crashed"}) {
+		t.Fatal("an engine-authored \"failed\" with no findings was treated as a review verdict")
 	}
 }

--- a/internal/workflow/unrecordable_verdict_1962_test.go
+++ b/internal/workflow/unrecordable_verdict_1962_test.go
@@ -217,3 +217,40 @@ func TestAdvanceJobRecordsAnUnrecordableAskVerdict(t *testing.T) {
 		t.Fatalf("ledger rows = %d, want 0; an unbound verdict must never be keyed", n)
 	}
 }
+
+// #2061 review, P2: A BLOCKED REVIEWER THAT NAMED DEFECTS STILL REVIEWED.
+//
+// review_loop.go's followUpReviewScopes treats decision "blocked" WITH findings
+// as a real verdict and refuses it without them. reviewShapedResult did not,
+// so an ask dispatched as a review that blocked after finding defects was lost
+// silently - the exact class #1962 closes. The reviewer found it by READING the
+// predicate; no fixture here used a non-success decision, in either direction.
+func TestBlockedWithFindingsIsAReviewVerdict(t *testing.T) {
+	if !reviewShapedResult(&AgentResult{
+		Decision: "blocked",
+		Findings: []json.RawMessage{json.RawMessage(`{"id":"F1","severity":"P1","title":"t"}`)},
+	}) {
+		t.Fatal("a blocked reviewer that named defects was not treated as a review verdict")
+	}
+}
+
+// THE OTHER DIRECTION, which is what makes the arm above non-vacuous: blocked
+// with NO findings is not a verdict, matching followUpReviewScopes exactly.
+func TestBlockedWithoutFindingsIsNotAReviewVerdict(t *testing.T) {
+	if reviewShapedResult(&AgentResult{Decision: "blocked"}) {
+		t.Fatal("a blocked job that named nothing was treated as a review verdict")
+	}
+}
+
+// "failed" IS NOT A REVIEW VERDICT, and this pins the place I went NARROWER
+// than the review asked. engine_run_budgets.go constructs "failed" itself, so
+// admitting it would promote an engine-authored terminal state to a reviewer's
+// verdict - the manufacture the P3 arm removed.
+func TestFailedWithFindingsIsNotAReviewVerdict(t *testing.T) {
+	if reviewShapedResult(&AgentResult{
+		Decision: "failed",
+		Findings: []json.RawMessage{json.RawMessage(`{"id":"F1","severity":"P1","title":"t"}`)},
+	}) {
+		t.Fatal("an engine-authored \"failed\" decision was treated as a review verdict")
+	}
+}

--- a/internal/workflow/unrecordable_verdict_1962_test.go
+++ b/internal/workflow/unrecordable_verdict_1962_test.go
@@ -144,6 +144,21 @@ func TestOrdinaryAskRecordsNoUnrecordableVerdict(t *testing.T) {
 	if reviewShapedResult(&AgentResult{Decision: "implemented", Summary: "did the thing"}) {
 		t.Fatal("an implement-shaped result was treated as a review verdict")
 	}
+	// #2061 review, P3: findings ALONE used to be sufficient, so an implement job
+	// that populated Findings - which the result shape permits - emitted an event
+	// about work that was never a review. Found by reading the predicate; every
+	// fixture here used a review-shaped decision, so no test could have caught it.
+	if reviewShapedResult(&AgentResult{
+		Decision: "implemented",
+		Findings: rawFindings(t, `{"uid":"#1-f1","severity":"P2","evidence":"a.go:1 - note"}`),
+	}) {
+		t.Fatal("an implement result carrying findings was treated as a review verdict")
+	}
+	// A verdict with findings and NO decision is still a review: findings are the
+	// only signal there is.
+	if !reviewShapedResult(&AgentResult{Findings: rawFindings(t, `{"severity":"P1"}`)}) {
+		t.Fatal("findings with no decision were not treated as a review verdict")
+	}
 	if reviewShapedResult(&AgentResult{Decision: "", Summary: "answered a question"}) {
 		t.Fatal("a plain ask answer was treated as a review verdict")
 	}

--- a/internal/workflow/unrecordable_verdict_1962_test.go
+++ b/internal/workflow/unrecordable_verdict_1962_test.go
@@ -165,8 +165,21 @@ func TestOrdinaryAskRecordsNoUnrecordableVerdict(t *testing.T) {
 	if reviewShapedResult(nil) {
 		t.Fatal("a nil result was treated as a review verdict")
 	}
-	if !reviewShapedResult(&AgentResult{Decision: "APPROVED "}) {
+	// Normalisation still matters, but it is tested WITH findings now: this arm
+	// used to assert that a bare "APPROVED " was a verdict, which encoded the very
+	// behaviour CI later refuted (#2061, three race shards plus the tagged e2e).
+	if !reviewShapedResult(&AgentResult{
+		Decision: "APPROVED ",
+		Findings: rawFindings(t, `{"uid":"#1-f1","severity":"P3","title":"t"}`),
+	}) {
 		t.Fatal("a review decision was missed on case and whitespace")
+	}
+	// AN ORDINARY ASK APPROVES NOTHING. This is the unit-level statement of what
+	// TestLocalExecutionBackendAllowsNonImplement measured end to end: the shipped
+	// result contract puts {"decision":"approved","findings":[]} in front of every
+	// agent, so that shape is the ORDINARY ask answer, not a review verdict.
+	if reviewShapedResult(&AgentResult{Decision: "approved", Summary: "ran on shell override"}) {
+		t.Fatal("an ordinary ask that approved nothing was treated as a review verdict")
 	}
 }
 

--- a/internal/workflow/unrecordable_verdict_1962_test.go
+++ b/internal/workflow/unrecordable_verdict_1962_test.go
@@ -276,3 +276,29 @@ func TestFailedWithoutFindingsIsNotAReviewVerdict(t *testing.T) {
 		t.Fatal("an engine-authored \"failed\" with no findings was treated as a review verdict")
 	}
 }
+
+// #2061 review, P2, found by EXECUTING the predicate: a changes_requested that
+// carries only a Summary is a live objection, and requiring findings on every
+// arm silently lost it. review_loop.go's namedReviewFindings already promotes
+// that summary to a finding; this mirrors the rule rather than inventing one.
+func TestChangesRequestedWithSummaryOnlyIsAReviewVerdict(t *testing.T) {
+	if !reviewShapedResult(&AgentResult{
+		Decision: "changes_requested",
+		Summary:  "the boundary check is inverted and the fix must precede merge",
+	}) {
+		t.Fatal("an objection carrying only a summary was not treated as a review verdict")
+	}
+}
+
+// THE ASYMMETRY IS THE POINT, so it is pinned. An approval carrying nothing has
+// nothing to record; an objection carrying a summary does. Without this arm a
+// later simplification would "tidy" the two decisions back into one rule and
+// reintroduce the e2e failure at #2061 (three race shards plus the tagged e2e).
+func TestApprovedWithSummaryOnlyIsNotAReviewVerdict(t *testing.T) {
+	if reviewShapedResult(&AgentResult{
+		Decision: "approved",
+		Summary:  "ran on shell override",
+	}) {
+		t.Fatal("an ordinary ask that approved with only a summary was treated as a review verdict")
+	}
+}

--- a/internal/workflow/unrecordable_verdict_1962_test.go
+++ b/internal/workflow/unrecordable_verdict_1962_test.go
@@ -302,3 +302,79 @@ func TestApprovedWithSummaryOnlyIsNotAReviewVerdict(t *testing.T) {
 		t.Fatal("an ordinary ask that approved with only a summary was treated as a review verdict")
 	}
 }
+
+// #2061 f3, filed OPEN by the verdict that approved this PR: the two arms above
+// call reviewShapedResult DIRECTLY, so they would pass against a branch where
+// the predicate is correct and the call site never reaches the summary-only
+// case. That is the same gap the comment on
+// TestAdvanceJobRecordsAnUnrecordableAskVerdict warns about for its own
+// predecessors, reappearing in the tests I added to close a predicate hole.
+//
+// This is the production-path arm for it: no findings array at all, only a
+// Summary, driven through AdvanceJob.
+func TestAdvanceJobRecordsASummaryOnlyObjection(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	seedAgent(t, store, "gm-review-opus", []string{"review"}, "gitmoot/gitmoot")
+	engine := testEngine(store)
+
+	insertCompletedJob(t, store, db.Job{ID: "ask-summary-only", Agent: "gm-review-opus", Type: "ask"}, JobPayload{
+		Repo: "gitmoot/gitmoot", TaskID: "task-ask-summary",
+		Result: &AgentResult{
+			Decision: "changes_requested", Severity: "P1",
+			Summary:  "the boundary check is inverted and must be fixed before merge",
+			Evidence: EvidenceExecuted,
+			TestsRun: []string{"go test ./internal/workflow/ -> ok"},
+		},
+	})
+
+	if err := engine.AdvanceJob(ctx, "ask-summary-only"); err != nil {
+		t.Fatalf("AdvanceJob returned error: %v", err)
+	}
+
+	events, err := store.ListJobEvents(ctx, "ask-summary-only")
+	if err != nil {
+		t.Fatalf("ListJobEvents: %v", err)
+	}
+	found := 0
+	for _, event := range events {
+		if event.Kind == "review_verdict_unrecordable" {
+			found++
+		}
+	}
+	if found != 1 {
+		t.Fatalf("review_verdict_unrecordable events = %d, want 1; an objection carrying only a "+
+			"summary must not vanish through the production path. events=%+v", found, events)
+	}
+}
+
+// THE ASYMMETRY, ALSO THROUGH THE PRODUCTION PATH. An ordinary ask that approves
+// with only a summary emits NOTHING. Without this arm, a later change could make
+// every summary-bearing ask a verdict and the arm above would still pass - which
+// is how the CI failure at #2061 happened in the first place.
+func TestAdvanceJobIgnoresASummaryOnlyApproval(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	seedAgent(t, store, "gm-review-opus", []string{"review"}, "gitmoot/gitmoot")
+	engine := testEngine(store)
+
+	insertCompletedJob(t, store, db.Job{ID: "ask-plain-approve", Agent: "gm-review-opus", Type: "ask"}, JobPayload{
+		Repo: "gitmoot/gitmoot", TaskID: "task-ask-approve",
+		Result: &AgentResult{Decision: "approved", Summary: "ran on shell override"},
+	})
+
+	if err := engine.AdvanceJob(ctx, "ask-plain-approve"); err != nil {
+		t.Fatalf("AdvanceJob returned error: %v", err)
+	}
+
+	events, err := store.ListJobEvents(ctx, "ask-plain-approve")
+	if err != nil {
+		t.Fatalf("ListJobEvents: %v", err)
+	}
+	for _, event := range events {
+		if event.Kind == "review_verdict_unrecordable" {
+			t.Fatalf("an ordinary ask that approved nothing emitted %q; this is the event whose "+
+				"spurious emission failed three race shards and the tagged e2e", event.Kind)
+		}
+	}
+}

--- a/internal/workflow/unrecordable_verdict_1962_test.go
+++ b/internal/workflow/unrecordable_verdict_1962_test.go
@@ -1,0 +1,204 @@
+package workflow
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/gitmoot/gitmoot/internal/db"
+)
+
+// #1962: an `agent ask` dispatched as "review this PR at this head" returns a
+// real review verdict, and the ledger writer never sees it - both call sites are
+// inside `job.Type == "review"`, so for an ask the writer is not CALLED and its
+// own recordLedgerSkip cannot fire. The verdict vanished with no row and no
+// event.
+//
+// Measured on 2026-09-08: 15 succeeded ask verdicts, 11 carrying findings, zero
+// ledger rows, zero explaining events. Positive control on that zero: the same
+// join over review-TYPE jobs the same day returns 28 jobs and 80 rows.
+//
+// The arms below are one property in three parts. The middle one is the reason
+// this change writes no rows: an unbound verdict must produce a RECORDED skip,
+// never a ledger row keyed to nothing.
+func unboundVerdictEvents(t *testing.T, store *db.Store, jobID string) []db.JobEvent {
+	t.Helper()
+	events, err := store.ListJobEvents(context.Background(), jobID)
+	if err != nil {
+		t.Fatalf("ListJobEvents(%s): %v", jobID, err)
+	}
+	var found []db.JobEvent
+	for _, event := range events {
+		if event.Kind == unboundReviewVerdictEventKind {
+			found = append(found, event)
+		}
+	}
+	return found
+}
+
+// ledgerRowCount counts observations the ledger holds for a repo/PR pair. The
+// unbound arms use the pair the verdict WOULD have claimed, so a fabricated key
+// would be caught rather than missed by looking somewhere it did not write.
+func ledgerRowCount(t *testing.T, store *db.Store, repo string, pullRequest int64) int {
+	t.Helper()
+	rows, err := store.ListReviewFindingObservations(context.Background(), repo, pullRequest)
+	if err != nil {
+		t.Fatalf("ListReviewFindingObservations(%s#%d): %v", repo, pullRequest, err)
+	}
+	return len(rows)
+}
+
+// rawFindings builds the wire form the engine actually carries.
+func rawFindings(t *testing.T, entries ...string) []json.RawMessage {
+	t.Helper()
+	out := make([]json.RawMessage, 0, len(entries))
+	for _, entry := range entries {
+		out = append(out, json.RawMessage(entry))
+	}
+	return out
+}
+
+// Arm 1: the loss becomes findable, and names what was missing.
+func TestUnboundAskVerdictRecordsTheLoss(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	engine := testEngine(store)
+
+	payload := JobPayload{
+		Result: &AgentResult{
+			Decision: "changes_requested",
+			Summary:  "objection at the current head",
+			Findings: rawFindings(t, `{"uid":"#2029-f1","severity":"P1","disposition":"open","evidence":"x.go:1 - why"}`),
+		},
+	}
+	job := db.Job{ID: "ask-unbound", Type: "ask", Agent: "gm-review-opus"}
+	engine.recordUnboundReviewVerdict(ctx, job, payload)
+
+	events := unboundVerdictEvents(t, store, "ask-unbound")
+	if len(events) != 1 {
+		t.Fatalf("review_verdict_unrecordable events = %d, want 1; a lost verdict must not be indistinguishable from a review that found nothing", len(events))
+	}
+	for _, want := range []string{"pull_request", "head_sha", "changes_requested", "--pr"} {
+		if !strings.Contains(events[0].Message, want) {
+			t.Fatalf("event message = %q, want it to name %q", events[0].Message, want)
+		}
+	}
+}
+
+// Arm 2. THE ARM THAT CONSTRAINS THE FIX. An unbound verdict must write NO
+// ledger row: review_finding_observations is keyed by repo + pull_request +
+// head_sha, so a row missing all three answers no query anyone can write, and a
+// synthesised key would assert a binding nobody established. Without this arm,
+// arm 1 is satisfied by a version that also fabricates rows - which is the
+// defect the issue exists to prevent, in the opposite direction.
+func TestUnboundAskVerdictWritesNoLedgerRow(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	engine := testEngine(store)
+
+	payload := JobPayload{
+		Result: &AgentResult{
+			Decision: "changes_requested",
+			Findings: rawFindings(t,
+				`{"uid":"#2029-f1","severity":"P1","evidence":"a.go:1 - why"}`,
+				`{"uid":"#2029-f2","severity":"P2","evidence":"b.go:2 - why"}`),
+		},
+	}
+	engine.recordUnboundReviewVerdict(ctx, db.Job{ID: "ask-norow", Type: "ask"}, payload)
+
+	if n := ledgerRowCount(t, store, "gitmoot/gitmoot", 2029); n != 0 {
+		t.Fatalf("ledger rows for an unbound verdict = %d, want 0; a row keyed to no PR and no head is worse than the gap", n)
+	}
+}
+
+// Arm 3: a BOUND verdict that still misses the writer is a different defect and
+// says so, rather than being reported as an unbound dispatch. This is the case
+// that must not be made writable until #2059's field-name mismatch is fixed.
+func TestBoundAskVerdictNamesTheTypeGateInstead(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	engine := testEngine(store)
+
+	payload := JobPayload{
+		Repo: "gitmoot/gitmoot", PullRequest: 2029, HeadSHA: "8bdf8f54",
+		Result: &AgentResult{Decision: "changes_requested"},
+	}
+	engine.recordUnboundReviewVerdict(ctx, db.Job{ID: "ask-bound", Type: "ask"}, payload)
+
+	events := unboundVerdictEvents(t, store, "ask-bound")
+	if len(events) != 1 {
+		t.Fatalf("events = %d, want 1", len(events))
+	}
+	if !strings.Contains(events[0].Message, "job type") || strings.Contains(events[0].Message, "--pr") {
+		t.Fatalf("message = %q, want the TYPE gate named and the re-dispatch remedy absent; a bound verdict does not need re-dispatching", events[0].Message)
+	}
+	if n := ledgerRowCount(t, store, "gitmoot/gitmoot", 2029); n != 0 {
+		t.Fatalf("ledger rows = %d, want 0 until #2059 lands", n)
+	}
+}
+
+// The control. Without it every arm above is satisfied by a version that fires
+// on everything, which would bury the real losses in noise from ordinary asks.
+func TestOrdinaryAskRecordsNoUnrecordableVerdict(t *testing.T) {
+	if reviewShapedResult(&AgentResult{Decision: "implemented", Summary: "did the thing"}) {
+		t.Fatal("an implement-shaped result was treated as a review verdict")
+	}
+	if reviewShapedResult(&AgentResult{Decision: "", Summary: "answered a question"}) {
+		t.Fatal("a plain ask answer was treated as a review verdict")
+	}
+	if reviewShapedResult(nil) {
+		t.Fatal("a nil result was treated as a review verdict")
+	}
+	if !reviewShapedResult(&AgentResult{Decision: "APPROVED "}) {
+		t.Fatal("a review decision was missed on case and whitespace")
+	}
+}
+
+// THE PRODUCTION-PATH ARM, and the only one that proves the call site is wired.
+// The three arms above call recordUnboundReviewVerdict directly, so they would
+// all pass against a branch where the helper exists and nothing ever invokes it -
+// which is precisely the defect being fixed, one level up: a writer that is
+// never called.
+//
+// This drives AdvanceJob with the measured shape: an `ask` job carrying a review
+// verdict and findings, dispatched with no PR and no head. It is also the base
+// control, because it compiles on main - it names no new symbol - and there it
+// records nothing at all.
+func TestAdvanceJobRecordsAnUnrecordableAskVerdict(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	seedAgent(t, store, "gm-review-opus", []string{"review"}, "gitmoot/gitmoot")
+	engine := testEngine(store)
+
+	insertCompletedJob(t, store, db.Job{ID: "ask-e2e", Agent: "gm-review-opus", Type: "ask"}, JobPayload{
+		Repo: "gitmoot/gitmoot", TaskID: "task-ask",
+		Result: &AgentResult{
+			Decision: "changes_requested", Severity: "P1", Summary: "objection at the current head",
+			Evidence: EvidenceExecuted,
+			TestsRun: []string{"go test ./internal/workflow/ -> ok"},
+			Findings: rawFindings(t, `{"uid":"#2029-f1","severity":"P1","disposition":"open","evidence":"internal/x.go:1 - why"}`),
+		},
+	})
+
+	if err := engine.AdvanceJob(ctx, "ask-e2e"); err != nil {
+		t.Fatalf("AdvanceJob returned error: %v", err)
+	}
+
+	events, err := store.ListJobEvents(ctx, "ask-e2e")
+	if err != nil {
+		t.Fatalf("ListJobEvents: %v", err)
+	}
+	found := 0
+	for _, event := range events {
+		if event.Kind == "review_verdict_unrecordable" {
+			found++
+		}
+	}
+	if found != 1 {
+		t.Fatalf("review_verdict_unrecordable events after AdvanceJob = %d, want 1; on main this is 0 and the verdict disappears with no row and no event. events=%+v", found, events)
+	}
+	if n := ledgerRowCount(t, store, "gitmoot/gitmoot", 0); n != 0 {
+		t.Fatalf("ledger rows = %d, want 0; an unbound verdict must never be keyed", n)
+	}
+}


### PR DESCRIPTION
Fixes the observability half of #1962. Scope decision posted to the issue before
building, at `issuecomment-5587730621`.

**Split note:** this PR was briefly a four-slice branch. Per phobos's instruction
it is now one slice, one PR, one head - #2063 is PR #2067, #2059 is PR #2069,
#2062 is PR #2070, and this carries only #1962. Order for review: #2063, #2059,
then this one.

## The defect, and it is not where the issue says

#1962 describes ask verdicts as unrecordable because `pull_request=0` and
`head_sha` is empty. True, but that is the second gate. The operative one is
that **`RecordReviewFindingsToLedger` is never called for an ask at all**: both
call sites (`engine_run_budgets.go:635`, `:654`) sit inside
`if job.Type == "review"`. Its internal `job.Type != "review"` guard is defence
in depth, and its `recordLedgerSkip` therefore cannot fire.

So the loss is silent **by construction**, which is why the population was 11
when #1962 was filed and 15 now with nobody noticing in between.

## Measured, with the control

Succeeded `gm-review-opus` ask jobs, 2026-09-08:

```
succeeded_asks  with_decision  with_findings  with_pr  with_head  ledger_rows
15              15             11             0        0          0
```

| decision | n |
|---|---|
| approved | 8 |
| changes_requested | **6** |
| skipped | 1 |

**Positive control**, because a zero is the shape this campaign keeps catching:
the same join over review-**type** jobs the same day returns **28 jobs, 80
rows**. The instrument reports non-zero when there is something to find.

**Five of the six objections are stale** (phobos mapped them: #2043 `fe4ca443`
closed; #2051 `1b478a15`, #2042 `b3ab398a`, #2026 `b24a8ef5` each superseded by a
later bound verdict). **One is live: #2029 at `8bdf8f54`, `changes_requested`,
still that PR's current head** - an objection at the current head of an open
draft, recorded nowhere a PR-keyed surface can see.

## What this does, and what it refuses to do

An ask-shaped job whose result carries a review decision or findings, with no
binding, now records `review_verdict_unrecordable` naming what was missing and
the remedy.

**It writes no ledger row, deliberately.** `review_finding_observations` is keyed
by repo + pull_request + head_sha; a row missing all three answers no query
anyone can write, and a synthesised key asserts a binding nobody established -
the #2054 class. An unbound verdict gets a **recorded** skip rather than a silent
one or a fabricated row.

A **bound** verdict that still misses the writer is named as the separate defect
it is, with a different message and no re-dispatch advice, because re-dispatching
would not fix it.

**Making a bound ask actually write is excluded on purpose.** That path inherits
#2059's field-name mismatch - the wire reads `id`/`title`/`state`, reviewers emit
`uid`/`evidence`/`disposition` - and would convert 15 silent losses into 15 empty
**open** findings. #2059 first. That is a constraint on future work, recorded in
the code.

## Tests

| arm | base | branch |
|---|---|---|
| `TestAdvanceJobRecordsAnUnrecordableAskVerdict` | **FAIL** | PASS |
| `TestUnboundAskVerdictRecordsTheLoss` | n/a | PASS |
| `TestUnboundAskVerdictWritesNoLedgerRow` | n/a | PASS |
| `TestBoundAskVerdictNamesTheTypeGateInstead` | n/a | PASS |
| `TestOrdinaryAskRecordsNoUnrecordableVerdict` | n/a | PASS |

**Only the first is a real reproduction, and I am saying so rather than
presenting five.** It drives `AdvanceJob` with the measured shape, names no new
symbol, and so compiles on `main` - where it fails with the defect verbatim: the
only event on the ask job is `succeeded`.

The other three call `recordUnboundReviewVerdict` directly. They cannot run on
base and, more importantly, **they would all pass against a branch where the
helper exists and nothing ever invokes it** - which is this very defect one level
up. That is why the production-path arm exists and why it is the control.

The last is a control on over-firing: an `implemented` result, a bare answer and
a nil result must not be treated as review verdicts, or the real losses drown in
noise from ordinary asks.

Neighbouring suites green:
`Ledger|Findings|AdvanceJob|Review|Merge|Gate|Ask` over `internal/workflow`, 60s.

Deploy notes: no config, no migration, no schema change. One new job-event kind.

## Draft

Per the standing rule from gm-staged's finding: an armed engine merge gate can
merge an approved green PR with no holder acting. Un-drafted only when it is
about to be pressed.


## Review status

The first review dispatched for this PR (`local-review-gm-review-opus-18d3643cdc1ef7c2-1`,
head `0be0a5e6`) was **cancelled as void**: I pushed #2063 onto the branch while
it ran, so it would have produced a verdict about a tree that no longer existed
and it was holding a runtime slot while other reviews queued. Phobos's
verdict-survival ruling (note 128972) covers **gate-authored** main-merges only
and says explicitly that a push I authored voids the verdict. This was mine.

Not re-dispatched: `gitmoot/gitmoot` dispatch is stalled repo-specifically and
phobos asked seats not to re-dispatch into it.

**Dispatching this review is itself constrained by the defect this PR describes.**
Until #2063 (PR #2067) lands, a seat implementing in session cannot name itself
as `--lead`, so every bound review carries a placeholder implementer and every
unbound alternative is `agent ask` - which is exactly the unrecordable shape
fixed here. That is the connection worth holding: **`ask` was the only door a
seat had**, which is why all nine reviews in the 2026-09-08 batch were unbound
asks with `pull_request=0`.
