### PR TITLE
fix(cli): bind a review dispatch to its head, and let a review-only dispatch exist (#2054)

### DIFF
--- a/internal/cli/agent.go
+++ b/internal/cli/agent.go
@@ -92,7 +92,7 @@ func printAgentUsage(w io.Writer) {
 	fmt.Fprintln(w, "  gitmoot agent start <name> --runtime codex|claude|kimi|omp --repo owner/repo [--path .] [--template <template-id>] [--model model] [--effort effort] [--start-daemon]")
 	fmt.Fprintln(w, "  gitmoot agent ask <name> \"message\" [--repo owner/repo] [--background] [--model model] [--effort effort] [--workflow id] [--runtime rt] [--session ref] [--home path] [--json]")
 	fmt.Fprintln(w, "  gitmoot agent run <name> \"message\" [--repo owner/repo] [--task task-id] [--pr number] [--lead implementer] [--head-sha sha] [--base ref] [--branch branch] [--background] [--type type] [--action ask|review|implement] [--model model] [--effort effort] [--workflow id] [--runtime rt] [--session ref] [--home path] [--json]")
-	fmt.Fprintln(w, "  gitmoot agent review <name> \"message\" --repo owner/repo --pr number [--lead implementer] [--head-sha sha] [--branch branch] [--background] [--type type] [--action review] [--model model] [--effort effort] [--workflow id] [--runtime rt] [--session ref] [--allow-prompt-head-mismatch] [--home path] [--json]")
+	fmt.Fprintln(w, "  gitmoot agent review <name> \"message\" --repo owner/repo --pr number [--lead implementer] [--head-sha sha] [--branch branch] [--background] [--type type] [--action review] [--model model] [--effort effort] [--workflow id] [--runtime rt] [--session ref] [--allow-prompt-head-mismatch] [--no-fix-target] [--home path] [--json]")
 	fmt.Fprintln(w, "  gitmoot agent implement <name> \"message\" [--repo owner/repo] [--task task-id] [--pr number] [--base ref] [--head-sha sha] [--branch branch] [--background] [--type type] [--action implement] [--model model] [--effort effort] [--workflow id] [--runtime rt] [--session ref] [--home path] [--json]")
 	printAgentRuntimeOverrideHelp(w)
 	fmt.Fprintln(w, "  gitmoot agent type list|show|set ...")
@@ -393,6 +393,7 @@ type agentRunOptions struct {
 	message                 string
 	skipNativeReviewFanout  bool
 	allowPromptHeadMismatch bool
+	noFixTarget             bool
 	recipe                  string
 }
 
@@ -625,6 +626,7 @@ func localAgentDispatchRequestFromOptions(options agentRunOptions, action, reaso
 		LeadAgent:               options.lead,
 		SkipNativeReviewFanout:  options.skipNativeReviewFanout,
 		AllowPromptHeadMismatch: options.allowPromptHeadMismatch,
+		NoFixTarget:             options.noFixTarget,
 		Recipe:                  options.recipe,
 		SelectedAction:          action,
 		SelectedActionReason:    reason,
@@ -672,6 +674,9 @@ func parseAgentRunOptions(command string, args []string, stderr io.Writer) (agen
 			options.jsonOutput = true
 		case arg == "--skip-native-review-fanout":
 			options.skipNativeReviewFanout = true
+		case arg == "--no-fix-target":
+			options.noFixTarget = true
+			index++
 		case arg == "--allow-prompt-head-mismatch":
 			options.allowPromptHeadMismatch = true
 		case arg == "--draft" || arg == "--ready":

--- a/internal/cli/agent.go
+++ b/internal/cli/agent.go
@@ -542,6 +542,10 @@ func dispatchAgentCommand(options agentRunOptions, action string, reason string,
 	if executionPath == "orchestrate" {
 		errLabel = "orchestrate"
 	}
+	if options.noFixTarget && action != "review" {
+		fmt.Fprintf(stderr, "%s: --no-fix-target is only supported when routing to review\n", errLabel)
+		return localAgentJobOutput{}, 2
+	}
 	if strings.TrimSpace(options.lead) != "" && action != "review" {
 		fmt.Fprintf(stderr, "%s: --lead is only supported when routing to review\n", errLabel)
 		return localAgentJobOutput{}, 2
@@ -676,7 +680,6 @@ func parseAgentRunOptions(command string, args []string, stderr io.Writer) (agen
 			options.skipNativeReviewFanout = true
 		case arg == "--no-fix-target":
 			options.noFixTarget = true
-			index++
 		case arg == "--allow-prompt-head-mismatch":
 			options.allowPromptHeadMismatch = true
 		case arg == "--draft" || arg == "--ready":

--- a/internal/cli/agent_dispatch.go
+++ b/internal/cli/agent_dispatch.go
@@ -433,19 +433,17 @@ func dispatchLocalAgentJob(ctx context.Context, store *db.Store, request localAg
 	//
 	// It runs AFTER the review-loop and reviewer-identity refusals so those
 	// still name their own preconditions first - a format complaint that
-	// preempts a semantic one answers a question nobody asked - and still
-	// before the read-only worktree and the job row.
+	// preempts a semantic one answers a question nobody asked - and BEFORE
+	// prepareLocalReviewTask, which is where it now lives. Cycle two of #2064
+	// found it here instead, one call too late: prepareLocalReviewDispatchRequest
+	// ends in prepareLocalReviewTask, whose UpsertTaskUnlessStates INSERTS OR
+	// UPDATES the review Task, so the refusal arrived after durable state existed.
 	//
 	// It refuses at DISPATCH rather than at the staleness check because a
 	// refusal that arrives after the job row exists has already spent a
 	// worktree, a queue slot and an operator's attention - and, as the same
 	// pattern showed elsewhere, a command that reports a refusal while leaving
 	// work behind is the harder failure to see.
-	if request.Action == "review" {
-		if err := dispatchHeadSHAError(request.HeadSHA); err != nil {
-			return localAgentJobOutput{}, err
-		}
-	}
 	var promptHeadWarnings []string
 	if request.Action != "review" {
 		// Keep ask and implement on the pre-allocation scanner seam: ask must scan
@@ -1245,6 +1243,13 @@ func prepareLocalReviewDispatchRequest(ctx context.Context, store *db.Store, rec
 		return localAgentDispatchRequest{}, err
 	} else if detected {
 		return localAgentDispatchRequest{}, errors.New(match.Reason())
+	}
+	// #2064 cycle two, F3: refuse a head that cannot bind BEFORE the task upsert
+	// below. The head is resolved by this point - it may have just come from the
+	// pull request above - and prepareLocalReviewTask writes durable state, so a
+	// refusal placed after it leaves a Task behind for a review that never ran.
+	if err := dispatchHeadSHAError(request.HeadSHA); err != nil {
+		return localAgentDispatchRequest{}, err
 	}
 	return prepareLocalReviewTask(ctx, store, repo, request)
 }

--- a/internal/cli/agent_dispatch.go
+++ b/internal/cli/agent_dispatch.go
@@ -172,6 +172,17 @@ func localDispatchJobRunner(request localAgentDispatchRequest) subprocess.Runner
 	return subprocess.ExecRunner{}
 }
 
+// promptHeadWarningFormat is SINGLE-SOURCED because two functions depend on its
+// shape: the producer below writes it, and retainUnjudgedPromptHeadWarnings
+// anchors on its citation clause to decide which warning belongs to which
+// citation. A silent divergence between them re-opens the retention leak that
+// review finding P3 on #2064 measured, so the format and its prefix live here
+// together rather than as two string literals in two files.
+const (
+	promptHeadWarningCitationPrefix = "prompt references commit "
+	promptHeadWarningFormat         = promptHeadWarningCitationPrefix + "%s, but the dispatch head is %s; Gitmoot will use dispatch head %s"
+)
+
 var promptCommitTokenRE = regexp.MustCompile(`\b[0-9a-fA-F]{7,64}\b`)
 
 type localAgentJobOutput struct {
@@ -950,7 +961,7 @@ func promptHeadContradictionWarnings(ctx context.Context, git gitutil.Client, pr
 		if strings.EqualFold(resolvedToken, resolvedHead) {
 			continue
 		}
-		warnings = append(warnings, fmt.Sprintf("prompt references commit %s, but the dispatch head is %s; Gitmoot will use dispatch head %s", token, resolvedHead, resolvedHead))
+		warnings = append(warnings, fmt.Sprintf(promptHeadWarningFormat, token, resolvedHead, resolvedHead))
 	}
 	return warnings
 }

--- a/internal/cli/agent_dispatch.go
+++ b/internal/cli/agent_dispatch.go
@@ -256,34 +256,6 @@ func dispatchLocalAgentJob(ctx context.Context, store *db.Store, request localAg
 			return localAgentJobOutput{}, err
 		}
 	}
-	// #2054: REFUSE AN ABBREVIATED --head-sha before any durable state.
-	//
-	// An abbreviated value used to be accepted and then CANCELLED by the daemon's
-	// staleness check, which compares the recorded head against the pull
-	// request's: `superseded_stale_head: PR #N moved from head "7e4b39d0" to
-	// "7e4b39d0ef82…"`. Those are the same commit. The review never ran, and the
-	// event's wording sent its operator to look for a push that never happened.
-	//
-	// Measured contrast on 2026-09-08: the #2035 review that SUCCEEDED carries a
-	// 40-character head_sha; the #2047 job that died carries 8. Same dispatcher,
-	// same reviewer, same day.
-	//
-	// It fires only on a SHA-SHAPED value - hex of the wrong length, or 40
-	// characters that are not hex. A value that is not sha-shaped at all is not
-	// an abbreviation; it is something the review-loop and reviewer-identity
-	// refusals name far better than a format check can, and preempting them
-	// would answer a question nobody asked.
-	//
-	// It refuses at DISPATCH rather than at the staleness check because a
-	// refusal that arrives after the job row exists has already spent a
-	// worktree, a queue slot and an operator's attention - and, as the same
-	// pattern showed elsewhere, a command that reports a refusal while leaving
-	// work behind is the harder failure to see.
-	if request.Action == "review" {
-		if err := dispatchHeadSHAError(request.HeadSHA); err != nil {
-			return localAgentJobOutput{}, err
-		}
-	}
 	// A review that may return changes_requested must name a fix target that can
 	// actually implement before Gitmoot spends a review session. Validate the
 	// agents-table row here, before repo/task/worktree mutation, managed-agent
@@ -437,6 +409,41 @@ func dispatchLocalAgentJob(ctx context.Context, store *db.Store, request localAg
 		}
 		if strings.TrimSpace(task.WorktreePath) != "" {
 			checkoutPath = task.WorktreePath
+		}
+	}
+	// #2054: REFUSE AN ABBREVIATED --head-sha before any durable state.
+	//
+	// An abbreviated value used to be accepted and then CANCELLED by the daemon's
+	// staleness check, which compares the recorded head against the pull
+	// request's: `superseded_stale_head: PR #N moved from head "7e4b39d0" to
+	// "7e4b39d0ef82…"`. Those are the same commit. The review never ran, and the
+	// event's wording sent its operator to look for a push that never happened.
+	//
+	// Measured contrast on 2026-09-08: the #2035 review that SUCCEEDED carries a
+	// 40-character head_sha; the #2047 job that died carries 8. Same dispatcher,
+	// same reviewer, same day.
+	//
+	// IT REFUSES ANYTHING THAT IS NOT EXACTLY 40 HEX CHARACTERS, and review
+	// finding F3 is why the earlier "sha-shaped" predicate was wrong: a
+	// REVISION EXPRESSION like `cc6ae8d8^` or `abc1234~1` is not hex, so it fell
+	// through and reached the same doomed comparison the guard exists to
+	// prevent. The daemon compares this value to the pull request's head by
+	// EQUALITY, so every non-sha value is equally unable to bind, whatever its
+	// shape.
+	//
+	// It runs AFTER the review-loop and reviewer-identity refusals so those
+	// still name their own preconditions first - a format complaint that
+	// preempts a semantic one answers a question nobody asked - and still
+	// before the read-only worktree and the job row.
+	//
+	// It refuses at DISPATCH rather than at the staleness check because a
+	// refusal that arrives after the job row exists has already spent a
+	// worktree, a queue slot and an operator's attention - and, as the same
+	// pattern showed elsewhere, a command that reports a refusal while leaving
+	// work behind is the harder failure to see.
+	if request.Action == "review" {
+		if err := dispatchHeadSHAError(request.HeadSHA); err != nil {
+			return localAgentJobOutput{}, err
 		}
 	}
 	var promptHeadWarnings []string
@@ -621,18 +628,22 @@ func dispatchLocalAgentJob(ctx context.Context, store *db.Store, request localAg
 	mailbox.RequireWorkflowPolicy = requireWorkflowPolicyResolver(request.Home)
 	mailbox.OrgPolicy = orgPolicy
 	job, err := mailbox.Enqueue(ctx, workflow.JobRequest{
-		ID:                     jobID,
-		Agent:                  agent.Name,
-		Action:                 request.Action,
-		Repo:                   repo.FullName(),
-		Branch:                 firstNonEmpty(request.Branch, record.DefaultBranch),
-		PullRequest:            request.PullRequest,
-		PullRequestReady:       request.PullRequestReady,
-		HeadSHA:                request.HeadSHA,
-		GoalID:                 request.GoalID,
-		TaskID:                 request.TaskID,
-		TaskTitle:              request.TaskTitle,
-		LeadAgent:              firstNonEmpty(request.LeadAgent, agent.Name),
+		ID:               jobID,
+		Agent:            agent.Name,
+		Action:           request.Action,
+		Repo:             repo.FullName(),
+		Branch:           firstNonEmpty(request.Branch, record.DefaultBranch),
+		PullRequest:      request.PullRequest,
+		PullRequestReady: request.PullRequestReady,
+		HeadSHA:          request.HeadSHA,
+		GoalID:           request.GoalID,
+		TaskID:           request.TaskID,
+		TaskTitle:        request.TaskTitle,
+		// #2054: a review-only dispatch must NOT fall back to the reviewer here.
+		// firstNonEmpty restored agent.Name after validation had cleared it, which
+		// would route a changes_requested fix to the reviewer that produced it -
+		// the exact independence violation the lead requirement exists to prevent.
+		LeadAgent:              reviewLeadForEnqueue(request, agent.Name),
 		Reviewers:              request.Reviewers,
 		Sender:                 "local",
 		ActingOrgRole:          request.ActingOrgRole,
@@ -647,6 +658,7 @@ func dispatchLocalAgentJob(ctx context.Context, store *db.Store, request localAg
 		EffectiveRuntime:       effectiveRuntimeAtEnqueue,
 		RequiredEvents:         requiredEvents,
 		SkipNativeReviewFanout: request.SkipNativeReviewFanout,
+		NoFixTarget:            request.NoFixTarget,
 		ValidatedPullRequest:   request.ImplementPRValidated,
 		TemplateOverride:       recipeTemplate,
 		WorktreePath:           readOnlyWorktreePath,
@@ -1097,13 +1109,26 @@ func routeSelectedMessage(request localAgentDispatchRequest) string {
 // The message names the expected length and echoes the value, because the
 // operator's next action is to re-run with the full sha and "invalid head sha"
 // does not say how long it should be.
+// reviewLeadForEnqueue resolves the lead recorded on the job payload.
+//
+// The default is the dispatching agent, which is what firstNonEmpty gave for
+// every job before #2054. A review-only dispatch is the exception and must
+// resolve to EMPTY: its validation deliberately cleared the lead, and restoring
+// the reviewer here would make a changes_requested verdict route its fix to the
+// agent that produced the verdict.
+func reviewLeadForEnqueue(request localAgentDispatchRequest, agentName string) string {
+	if request.NoFixTarget {
+		return ""
+	}
+	return firstNonEmpty(request.LeadAgent, agentName)
+}
+
 func dispatchHeadSHAError(headSHA string) error {
 	head := strings.TrimSpace(headSHA)
 	if head == "" {
 		return nil
 	}
-	shaShaped := isHexString(head) || len(head) == gitCommitSHALength
-	if shaShaped && (len(head) != gitCommitSHALength || !isHexString(head)) {
+	if len(head) != gitCommitSHALength || !isHexString(head) {
 		return fmt.Errorf(
 			"--head-sha %q is not a full commit sha: pass all %d hex characters, "+
 				"because an abbreviated value is accepted here and then cancelled as a stale head when it is compared to the pull request's full head (#2054)",

--- a/internal/cli/agent_dispatch.go
+++ b/internal/cli/agent_dispatch.go
@@ -253,6 +253,34 @@ func dispatchLocalAgentJob(ctx context.Context, store *db.Store, request localAg
 			return localAgentJobOutput{}, err
 		}
 	}
+	// #2054: REFUSE AN ABBREVIATED --head-sha before any durable state.
+	//
+	// An abbreviated value used to be accepted and then CANCELLED by the daemon's
+	// staleness check, which compares the recorded head against the pull
+	// request's: `superseded_stale_head: PR #N moved from head "7e4b39d0" to
+	// "7e4b39d0ef82…"`. Those are the same commit. The review never ran, and the
+	// event's wording sent its operator to look for a push that never happened.
+	//
+	// Measured contrast on 2026-09-08: the #2035 review that SUCCEEDED carries a
+	// 40-character head_sha; the #2047 job that died carries 8. Same dispatcher,
+	// same reviewer, same day.
+	//
+	// It fires only on a SHA-SHAPED value - hex of the wrong length, or 40
+	// characters that are not hex. A value that is not sha-shaped at all is not
+	// an abbreviation; it is something the review-loop and reviewer-identity
+	// refusals name far better than a format check can, and preempting them
+	// would answer a question nobody asked.
+	//
+	// It refuses at DISPATCH rather than at the staleness check because a
+	// refusal that arrives after the job row exists has already spent a
+	// worktree, a queue slot and an operator's attention - and, as the same
+	// pattern showed elsewhere, a command that reports a refusal while leaving
+	// work behind is the harder failure to see.
+	if request.Action == "review" {
+		if err := dispatchHeadSHAError(request.HeadSHA); err != nil {
+			return localAgentJobOutput{}, err
+		}
+	}
 	// A review that may return changes_requested must name a fix target that can
 	// actually implement before Gitmoot spends a review session. Validate the
 	// agents-table row here, before repo/task/worktree mutation, managed-agent
@@ -464,7 +492,26 @@ func dispatchLocalAgentJob(ctx context.Context, store *db.Store, request localAg
 	}
 	if request.Action == "review" {
 		checkoutPath = readOnlyWorktreePath
+		// #2054: WARN ONLY ON A CITATION THIS PATH HAS NOT ALREADY JUDGED.
+		//
+		// The identity-based scan is right for ask and implement, which have no
+		// refusal in front of them. For a REVIEW it fires on cases the #1819
+		// classifier above has already accepted: refusal happens before enqueue
+		// for a FOREIGN citation, so by the time this runs the citation is the
+		// head, an ancestor of it, a recorded head of this pull request, or
+		// unresolvable. Every one of those is what a prompt does deliberately -
+		// a scoped re-review MUST name the previous round's head to say what it
+		// is re-reviewing - so warning on them fires on the routine case, and a
+		// warning that fires on the routine case teaches its reader to ignore
+		// it. That cost is not hypothetical: this warning was used to attribute
+		// job ownership on 2026-09-08 and then raised against a scoped
+		// re-review that was citing its own prior head correctly.
+		//
+		// Only UNRESOLVABLE survives as worth saying: the classifier could not
+		// establish the relationship, so nobody has judged that citation.
 		promptHeadWarnings = dispatchPromptHeadContradictionWarnings(ctx, jobGitClient(checkoutPath, localDispatchJobRunner(request)), request.Instructions, request.HeadSHA)
+		promptHeadWarnings = retainUnjudgedPromptHeadWarnings(ctx, jobGitClient(record.CheckoutPath, localDispatchJobRunner(request)),
+			store, request.Instructions, request.HeadSHA, repo.FullName(), request.PullRequest, promptHeadWarnings)
 	}
 	// Locking stays on the agent's REGISTERED session (see the same split in
 	// jobWorker.run): a read-only seat isolates DELIVERY, not serialization, so
@@ -1026,6 +1073,49 @@ func routeSelectedMessage(request localAgentDispatchRequest) string {
 		message += fmt.Sprintf("; runtime override: %s", override)
 	}
 	return message
+}
+
+// dispatchHeadSHAError rejects a head that cannot be compared to a pull
+// request's head without resolving it (#2054).
+//
+// An EMPTY head stays legal: --head-sha is optional and its absence means "do
+// not bind", which is a different decision from binding badly. What is refused
+// is a value that LOOKS bound and is not comparable - the shape that produced a
+// confident, specific, wrong "stale head" cancellation.
+//
+// The message names the expected length and echoes the value, because the
+// operator's next action is to re-run with the full sha and "invalid head sha"
+// does not say how long it should be.
+func dispatchHeadSHAError(headSHA string) error {
+	head := strings.TrimSpace(headSHA)
+	if head == "" {
+		return nil
+	}
+	shaShaped := isHexString(head) || len(head) == gitCommitSHALength
+	if shaShaped && (len(head) != gitCommitSHALength || !isHexString(head)) {
+		return fmt.Errorf(
+			"--head-sha %q is not a full commit sha: pass all %d hex characters, "+
+				"because an abbreviated value is accepted here and then cancelled as a stale head when it is compared to the pull request's full head (#2054)",
+			head, gitCommitSHALength,
+		)
+	}
+	return nil
+}
+
+// gitCommitSHALength is the length of a full hex object id.
+const gitCommitSHALength = 40
+
+func isHexString(value string) bool {
+	for _, r := range value {
+		switch {
+		case r >= '0' && r <= '9':
+		case r >= 'a' && r <= 'f':
+		case r >= 'A' && r <= 'F':
+		default:
+			return false
+		}
+	}
+	return true
 }
 
 func validateLocalReviewLeadAtDispatch(ctx context.Context, store *db.Store, request localAgentDispatchRequest, repo string) (localAgentDispatchRequest, error) {

--- a/internal/cli/agent_dispatch.go
+++ b/internal/cli/agent_dispatch.go
@@ -131,13 +131,16 @@ type localAgentDispatchRequest struct {
 	// ImplementBase is the CLI/config worktree base for implement dispatches.
 	// Before the request can enqueue, it is resolved to a commit SHA and
 	// ImplementBaseResolved is set so allocation uses that exact commit.
-	ImplementBase          string
-	ImplementBaseResolved  bool
-	ImplementPRValidated   bool
-	Branch                 string
-	GoalID                 string
-	TaskTitle              string
-	LeadAgent              string
+	ImplementBase         string
+	ImplementBaseResolved bool
+	ImplementPRValidated  bool
+	Branch                string
+	GoalID                string
+	TaskTitle             string
+	LeadAgent             string
+	// NoFixTarget states that this review has NO implementer to route a
+	// changes_requested verdict to (#2054). It is the review-only dispatch.
+	NoFixTarget            bool
 	Reviewers              []string
 	SkipNativeReviewFanout bool
 	Recipe                 string
@@ -674,6 +677,14 @@ func dispatchLocalAgentJob(ctx context.Context, store *db.Store, request localAg
 			request.DispatchWarning(warning)
 		}
 	}
+	if request.NoFixTarget {
+		// The absence of a fix target is a DECISION, so it is on the record next
+		// to the route rather than inferable from an empty lead field (#2054). A
+		// changes_requested verdict on this job has nowhere to route by design,
+		// and whoever reads it later needs to see that it was chosen.
+		_ = store.AddJobEvent(ctx, db.JobEvent{JobID: job.ID, Kind: "review_no_fix_target",
+			Message: "dispatched --no-fix-target: this review has no implementer for a changes_requested verdict; the dispatching operator owns the follow-up"})
+	}
 	if err := store.AddJobEvent(ctx, db.JobEvent{JobID: job.ID, Kind: "route_selected", Message: routeSelectedMessage(request)}); err != nil {
 		return localAgentJobOutput{}, err
 	}
@@ -1128,6 +1139,28 @@ func validateLocalReviewLeadAtDispatch(ctx context.Context, store *db.Store, req
 		if !exists {
 			return localAgentDispatchRequest{}, forcedManagedAgentTypeNotFoundError(typeName)
 		}
+	}
+	// #2054: A REVIEW-ONLY DISPATCH HAS NO FIX TARGET, AND SAYS SO.
+	//
+	// The lead exists so a changes_requested verdict has somewhere to go, which
+	// is why it must be able to implement. But requiring one made a review-only
+	// dispatch impossible: `gitmoot agent review <reviewer>` refuses when the
+	// reviewer cannot implement, and the documented fallback - `agent ask` - has
+	// no --head-sha, so it cannot bind a verdict to a head at all. On
+	// 2026-09-08 that pair sent every seat needing an exact-head review onto
+	// ask, where one dispatch bound to a DIFFERENT pull request's merge commit.
+	//
+	// So the requirement is kept and made STATEABLE rather than removed: with
+	// --no-fix-target the operator declares they own the follow-up, and the
+	// choice is recorded on the job so a later changes_requested is attributable
+	// to a decision instead of looking like a missing lead. An unstated absence
+	// still refuses.
+	if request.NoFixTarget {
+		if strings.TrimSpace(request.LeadAgent) != "" {
+			return localAgentDispatchRequest{}, errors.New("--no-fix-target and --lead are mutually exclusive: one declares there is no implementer for a changes_requested verdict, the other names it")
+		}
+		request.LeadAgent = ""
+		return request, nil
 	}
 	leadName := strings.TrimSpace(request.LeadAgent)
 	if leadName == "" {

--- a/internal/cli/agent_dispatch_test.go
+++ b/internal/cli/agent_dispatch_test.go
@@ -578,6 +578,10 @@ func TestDispatchReviewRejectsAbbreviatedHeadSHABeforeEnqueue(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	tasksBefore, err := store.ListTasks(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
 	request := reviewDispatchRequest(home, head[:8])
 	_, dispatchErr := dispatchLocalAgentJob(ctx, store, request)
 	if dispatchErr == nil {
@@ -598,6 +602,19 @@ func TestDispatchReviewRejectsAbbreviatedHeadSHABeforeEnqueue(t *testing.T) {
 	}
 	if len(after) != len(before) {
 		t.Fatalf("job rows went from %d to %d; the refusal created a row", len(before), len(after))
+	}
+	// NO TASK EITHER, and this arm is review finding F3 on cycle two: the guard
+	// used to run one call too late, after prepareLocalReviewDispatchRequest had
+	// ended in prepareLocalReviewTask, whose UpsertTaskUnlessStates INSERTS OR
+	// UPDATES the review Task. The comment above this test promised "no job, no
+	// task, no worktree" while only the job was checked, so the durable half of
+	// the promise was unasserted and the regression was invisible.
+	tasks, err := store.ListTasks(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(tasks) != len(tasksBefore) {
+		t.Fatalf("task rows went from %d to %d; the refusal left durable task state behind for a review that never ran", len(tasksBefore), len(tasks))
 	}
 }
 

--- a/internal/cli/agent_dispatch_test.go
+++ b/internal/cli/agent_dispatch_test.go
@@ -610,6 +610,69 @@ func TestDispatchReviewAcceptsFullHeadSHA(t *testing.T) {
 	}
 }
 
+// TestDispatchReviewOnlyNeedsNoImplementCapableLead is #2054 defect 2.
+//
+// `agent review <reviewer>` refused when the reviewer could not implement,
+// because a changes_requested verdict needs somewhere to go. The documented
+// fallback, `agent ask`, has no --head-sha and cannot bind a verdict to a head
+// at all - so on 2026-09-08 that pair sent every seat needing an exact-head
+// review onto ask, and one dispatch bound to a DIFFERENT pull request's merge
+// commit.
+//
+// The requirement is kept and made stateable: --no-fix-target declares the
+// operator owns the follow-up. An UNSTATED absence must still refuse, which
+// TestDispatchReviewWithoutLeadRejectsReviewOnlyAgentBeforeEnqueue pins.
+func TestDispatchReviewOnlyNeedsNoImplementCapableLead(t *testing.T) {
+	ctx := context.Background()
+	checkout, _, _, head, _ := promptHeadBindingCheckout(t)
+	store, home := blockerE2EHome(t)
+	seedReviewDispatchFixture(t, store, checkout)
+
+	request := reviewDispatchRequest(home, head)
+	// The reviewer cannot implement, and no lead is named: exactly the dispatch
+	// that refused all day and pushed every seat onto `agent ask`.
+	request.LeadAgent = ""
+	request.NoFixTarget = true
+
+	out, err := dispatchLocalAgentJob(ctx, store, request)
+	if err != nil {
+		t.Fatalf("a review-only dispatch was refused: %v", err)
+	}
+	// The decision must be ON THE RECORD, not inferable from an empty lead: a
+	// changes_requested verdict here has nowhere to route BY DESIGN.
+	events, err := store.ListJobEvents(ctx, out.JobID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, event := range events {
+		if event.Kind == "review_no_fix_target" {
+			return
+		}
+	}
+	t.Fatalf("no review_no_fix_target event: %+v", events)
+}
+
+// --no-fix-target and --lead answer the same question in opposite directions, so
+// accepting both would leave which one wins undefined.
+func TestDispatchReviewOnlyRejectsAnExplicitLead(t *testing.T) {
+	fixture := reviewLeadRefusalStore(t)
+	store := fixture.store
+	seedDaemonWorkerAgentWithPolicy(t, store, "reviewer", runtime.ShellRuntime, "true", []string{"review"}, "owner/repo", runtime.AutonomyPolicyReadOnly)
+	seedDaemonWorkerAgentWithPolicy(t, store, "lead", runtime.ShellRuntime, "true", []string{"implement", "review"}, "owner/repo", runtime.AutonomyPolicyDangerFullAccess)
+	adapter := installReviewLeadTestAdapter(t, "")
+
+	_, err := dispatchLocalAgentJob(context.Background(), store, localAgentDispatchRequest{
+		RepoFlag: "owner/repo", Agent: "reviewer", Action: "review", PullRequest: 7, LeadAgent: "lead",
+		HeadSHA: fixture.head, Branch: "feature/review", Home: fixture.home, NoFixTarget: true,
+	})
+	// This refusal must precede the capacity and worktree work, like the other
+	// lead refusals, which is why it stays on the refusal fixture.
+	if err == nil || !strings.Contains(err.Error(), "mutually exclusive") {
+		t.Fatalf("dispatch error = %v, want a mutual-exclusion refusal", err)
+	}
+	assertReviewLeadHardRefusal(t, store, fixture.checkout, adapter)
+}
+
 // Kills a missing-existence-check mutant and a mutant that silently falls back
 // to the reviewer when an explicit lead does not exist.
 func TestDispatchReviewRejectsUnknownLeadBeforeEnqueue(t *testing.T) {

--- a/internal/cli/agent_dispatch_test.go
+++ b/internal/cli/agent_dispatch_test.go
@@ -443,10 +443,15 @@ func TestCLIReviewLoopAllowsNewHeadAndMixedDecisions(t *testing.T) {
 // count enforcement, and non-idempotent event emission.
 func TestCLIReviewLoopHerdres227Shape(t *testing.T) {
 	fixture := newCLIReviewLoopFixture(t)
-	seedCLIReviewLoopVerdict(t, fixture.store, "herdres-227-first", "2da08", "changes_requested")
+	// A FULL sha, because #2054 now refuses a sha-shaped abbreviation at
+	// dispatch and this test's subject is the review-loop refusal, not head
+	// formatting. The token is arbitrary and shared with the seeded verdict; its
+	// LENGTH was never load-bearing here.
+	const herdres227Head = "2da08e1f4c7b6a5d3e2f1908a7b6c5d4e3f21098"
+	seedCLIReviewLoopVerdict(t, fixture.store, "herdres-227-first", herdres227Head, "changes_requested")
 	request := localAgentDispatchRequest{
 		RepoFlag: "owner/repo", Agent: "reviewer", Action: "review", PullRequest: 227,
-		Branch: "main", HeadSHA: "2da08", Instructions: "Review unchanged head.", Home: fixture.home,
+		Branch: "main", HeadSHA: herdres227Head, Instructions: "Review unchanged head.", Home: fixture.home,
 	}
 	for attempt := 2; attempt <= 319; attempt++ {
 		if _, err := dispatchLocalAgentJob(context.Background(), fixture.store, request); err == nil || !strings.Contains(err.Error(), "review loop detected") {
@@ -542,6 +547,67 @@ func TestDispatchReviewWithoutLeadRejectsReviewOnlyAgentBeforeEnqueue(t *testing
 		t.Fatalf("dispatch error = %v", err)
 	}
 	assertReviewLeadHardRefusal(t, store, fixture.checkout, adapter)
+}
+
+// TestDispatchReviewRejectsAbbreviatedHeadSHABeforeEnqueue is #2054 defect 1.
+//
+// An abbreviated --head-sha was ACCEPTED at dispatch and then cancelled by the
+// daemon's staleness check, which compared the 8-character value against the
+// PR's 40-character head and reported `superseded_stale_head: PR #N moved from
+// head "7e4b39d0" to "7e4b39d0ef82…"`. Those are the same commit. The review
+// never ran, and the event sent its operator to look for a push that never
+// happened.
+//
+// Measured contrast on 2026-09-08: the review of #2035 that SUCCEEDED carries a
+// 40-character head_sha; the #2047 job that died carries 8. Same dispatcher,
+// same reviewer, same day.
+//
+// A refusal that arrives AFTER the job exists is the wrong shape regardless of
+// its message, so this asserts the refusal happens where the other pre-enqueue
+// refusals do: no job row, no task, no worktree.
+func TestDispatchReviewRejectsAbbreviatedHeadSHABeforeEnqueue(t *testing.T) {
+	fixture := reviewLeadRefusalStore(t)
+	store := fixture.store
+	seedDaemonWorkerAgentWithPolicy(t, store, "reviewer", runtime.ShellRuntime, "true", []string{"review"}, "owner/repo", runtime.AutonomyPolicyReadOnly)
+	seedDaemonWorkerAgentWithPolicy(t, store, "lead", runtime.ShellRuntime, "true", []string{"implement", "review"}, "owner/repo", runtime.AutonomyPolicyDangerFullAccess)
+	adapter := installReviewLeadTestAdapter(t, "")
+
+	if len(fixture.head) != 40 {
+		t.Fatalf("fixture head is %d characters, want 40: the abbreviation under test must be a real prefix", len(fixture.head))
+	}
+	_, err := dispatchLocalAgentJob(context.Background(), store, localAgentDispatchRequest{
+		RepoFlag: "owner/repo", Agent: "reviewer", Action: "review", PullRequest: 7, LeadAgent: "lead",
+		HeadSHA: fixture.head[:8], Branch: "feature/review", Home: fixture.home,
+	})
+	if err == nil {
+		t.Fatal("dispatch accepted an abbreviated --head-sha; the daemon would cancel it later as a stale head")
+	}
+	// The message must name the EXPECTED LENGTH, because the operator's next
+	// action is to re-run with a full sha and "invalid head" does not say how.
+	for _, want := range []string{"40", fixture.head[:8]} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("dispatch error = %v, want it to name %q", err, want)
+		}
+	}
+	assertReviewLeadHardRefusal(t, store, fixture.checkout, adapter)
+}
+
+// A FULL head sha is the same dispatch and must not be refused: without this the
+// length check could reject everything and both tests above would still pass.
+func TestDispatchReviewAcceptsFullHeadSHA(t *testing.T) {
+	fixture := reviewLeadRefusalStore(t)
+	store := fixture.store
+	seedDaemonWorkerAgentWithPolicy(t, store, "reviewer", runtime.ShellRuntime, "true", []string{"review"}, "owner/repo", runtime.AutonomyPolicyReadOnly)
+	seedDaemonWorkerAgentWithPolicy(t, store, "lead", runtime.ShellRuntime, "true", []string{"implement", "review"}, "owner/repo", runtime.AutonomyPolicyDangerFullAccess)
+	installReviewLeadTestAdapter(t, "")
+
+	_, err := dispatchLocalAgentJob(context.Background(), store, localAgentDispatchRequest{
+		RepoFlag: "owner/repo", Agent: "reviewer", Action: "review", PullRequest: 7, LeadAgent: "lead",
+		HeadSHA: fixture.head, Branch: "feature/review", Home: fixture.home, Background: true,
+	})
+	if err != nil && strings.Contains(err.Error(), "head") {
+		t.Fatalf("a full 40-character head sha was refused by the head guard: %v", err)
+	}
 }
 
 // Kills a missing-existence-check mutant and a mutant that silently falls back

--- a/internal/cli/agent_dispatch_test.go
+++ b/internal/cli/agent_dispatch_test.go
@@ -566,30 +566,61 @@ func TestDispatchReviewWithoutLeadRejectsReviewOnlyAgentBeforeEnqueue(t *testing
 // its message, so this asserts the refusal happens where the other pre-enqueue
 // refusals do: no job row, no task, no worktree.
 func TestDispatchReviewRejectsAbbreviatedHeadSHABeforeEnqueue(t *testing.T) {
-	fixture := reviewLeadRefusalStore(t)
-	store := fixture.store
-	seedDaemonWorkerAgentWithPolicy(t, store, "reviewer", runtime.ShellRuntime, "true", []string{"review"}, "owner/repo", runtime.AutonomyPolicyReadOnly)
-	seedDaemonWorkerAgentWithPolicy(t, store, "lead", runtime.ShellRuntime, "true", []string{"implement", "review"}, "owner/repo", runtime.AutonomyPolicyDangerFullAccess)
-	adapter := installReviewLeadTestAdapter(t, "")
-
-	if len(fixture.head) != 40 {
-		t.Fatalf("fixture head is %d characters, want 40: the abbreviation under test must be a real prefix", len(fixture.head))
+	ctx := context.Background()
+	checkout, _, _, head, _ := promptHeadBindingCheckout(t)
+	store, home := blockerE2EHome(t)
+	seedReviewDispatchFixture(t, store, checkout)
+	if len(head) != 40 {
+		t.Fatalf("fixture head is %d characters, want 40: the abbreviation under test must be a real prefix", len(head))
 	}
-	_, err := dispatchLocalAgentJob(context.Background(), store, localAgentDispatchRequest{
-		RepoFlag: "owner/repo", Agent: "reviewer", Action: "review", PullRequest: 7, LeadAgent: "lead",
-		HeadSHA: fixture.head[:8], Branch: "feature/review", Home: fixture.home,
-	})
-	if err == nil {
+
+	before, err := store.ListJobs(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	request := reviewDispatchRequest(home, head[:8])
+	_, dispatchErr := dispatchLocalAgentJob(ctx, store, request)
+	if dispatchErr == nil {
 		t.Fatal("dispatch accepted an abbreviated --head-sha; the daemon would cancel it later as a stale head")
 	}
 	// The message must name the EXPECTED LENGTH, because the operator's next
 	// action is to re-run with a full sha and "invalid head" does not say how.
-	for _, want := range []string{"40", fixture.head[:8]} {
-		if !strings.Contains(err.Error(), want) {
-			t.Fatalf("dispatch error = %v, want it to name %q", err, want)
+	for _, want := range []string{"40", head[:8]} {
+		if !strings.Contains(dispatchErr.Error(), want) {
+			t.Fatalf("dispatch error = %v, want it to name %q", dispatchErr, want)
 		}
 	}
-	assertReviewLeadHardRefusal(t, store, fixture.checkout, adapter)
+	// No job row: a refusal that arrives after the row exists has already spent
+	// a worktree and a queue slot.
+	after, err := store.ListJobs(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(after) != len(before) {
+		t.Fatalf("job rows went from %d to %d; the refusal created a row", len(before), len(after))
+	}
+}
+
+// A REVISION EXPRESSION is the same defect wearing different characters, and the
+// first version of this guard let it through: review finding F3. The daemon
+// compares this value to the pull request's head by equality, so `<sha>^` can no
+// more bind than `<sha8>` can.
+func TestDispatchReviewRejectsARevisionExpressionHead(t *testing.T) {
+	ctx := context.Background()
+	checkout, _, _, head, _ := promptHeadBindingCheckout(t)
+	store, home := blockerE2EHome(t)
+	seedReviewDispatchFixture(t, store, checkout)
+
+	for _, expression := range []string{head + "^", head[:8] + "~1", "HEAD"} {
+		t.Run(expression, func(t *testing.T) {
+			request := reviewDispatchRequest(home, expression)
+			if _, err := dispatchLocalAgentJob(ctx, store, request); err == nil {
+				t.Fatalf("dispatch accepted %q as a head", expression)
+			} else if !strings.Contains(err.Error(), "40") {
+				t.Fatalf("refusal for %q = %v, want it to name the expected length", expression, err)
+			}
+		})
+	}
 }
 
 // A FULL head sha is the same dispatch and must not be refused: without this the
@@ -638,8 +669,25 @@ func TestDispatchReviewOnlyNeedsNoImplementCapableLead(t *testing.T) {
 	if err != nil {
 		t.Fatalf("a review-only dispatch was refused: %v", err)
 	}
-	// The decision must be ON THE RECORD, not inferable from an empty lead: a
-	// changes_requested verdict here has nowhere to route BY DESIGN.
+	// THE DECISION MUST REACH THE PAYLOAD, not only a job event. Review found
+	// that clearing the lead was not enough: enqueue restored the reviewer
+	// through firstNonEmpty, so a changes_requested verdict would have routed
+	// its fix to the agent that produced the verdict, and advancement had no
+	// field to read the declaration from.
+	job, err := store.GetJob(ctx, out.JobID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	payload, err := workflow.ParseJobPayload(job.Payload)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !payload.NoFixTarget {
+		t.Fatalf("payload.NoFixTarget = false; advancement cannot honour a declaration it cannot read: %s", job.Payload)
+	}
+	if strings.TrimSpace(payload.LeadAgent) != "" {
+		t.Fatalf("payload.LeadAgent = %q, want empty: a review-only dispatch must not fall back to the reviewer", payload.LeadAgent)
+	}
 	events, err := store.ListJobEvents(ctx, out.JobID)
 	if err != nil {
 		t.Fatal(err)

--- a/internal/cli/agent_test.go
+++ b/internal/cli/agent_test.go
@@ -3718,6 +3718,48 @@ func replaceAgentDoctorRunner(runner subprocess.Runner) func() {
 	}
 }
 
+// TestParseAgentRunOptionsNoFixTargetDoesNotEatTheNextArgument is review
+// finding F2 on #2064, and it is the cheapest kind of bug to ship: a boolean
+// flag that increments the argument index, in a loop that already increments.
+//
+// Every sibling boolean here - --background, --json,
+// --skip-native-review-fanout, --allow-prompt-head-mismatch - does NOT
+// increment, which is exactly why the extra line looked harmless. The symptom
+// is silent: the NEXT flag disappears, so the failure surfaces as a missing
+// --org-role or an unbound head rather than as a parse error.
+func TestParseAgentRunOptionsNoFixTargetDoesNotEatTheNextArgument(t *testing.T) {
+	var stderr bytes.Buffer
+	options, ok := parseAgentRunOptions("review", []string{
+		"reviewer", "review this", "--no-fix-target", "--org-role", "gm-transport", "--pr", "7",
+	}, &stderr)
+	if !ok {
+		t.Fatalf("parseAgentRunOptions failed: %q", stderr.String())
+	}
+	if !options.noFixTarget {
+		t.Fatal("noFixTarget = false")
+	}
+	// The flags AFTER it must survive. Before the fix --org-role was consumed as
+	// this flag's value and every later flag shifted by one.
+	if options.orgRole != "gm-transport" {
+		t.Fatalf("orgRole = %q, want gm-transport: the boolean consumed the following argument", options.orgRole)
+	}
+	if options.prNumber != 7 {
+		t.Fatalf("prNumber = %d, want 7", options.prNumber)
+	}
+}
+
+// --no-fix-target answers a question only review asks, so it is refused
+// elsewhere exactly as --lead is.
+func TestNoFixTargetIsReviewOnly(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	if code := runAgentRun([]string{"planner", "do the work", "--no-fix-target", "--action", "ask"}, &stdout, &stderr); code == 0 {
+		t.Fatalf("ask accepted --no-fix-target: exit 0, stderr=%q", stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "--no-fix-target is only supported when routing to review") {
+		t.Fatalf("stderr = %q, want the review-only refusal", stderr.String())
+	}
+}
+
 func TestParseAgentRunOptionsCapturesModel(t *testing.T) {
 	tests := []struct {
 		name string

--- a/internal/cli/prompt_head_binding.go
+++ b/internal/cli/prompt_head_binding.go
@@ -246,3 +246,50 @@ func reviewPromptTargetMismatchError(citations []promptCommitCitation, dispatchH
 		"review prompt names a commit outside this pull request's history, so the instructions and the dispatch head describe different changes: %s; the dispatch head is %s. A review's instructions are its specification, so this is refused before any job row exists. Cite a prior head of this pull request, its base, or the head itself; or pass --allow-prompt-head-mismatch to dispatch it deliberately",
 		strings.Join(described, "; "), strings.TrimSpace(dispatchHead))
 }
+
+// retainUnjudgedPromptHeadWarnings drops the warnings a review's own refusal
+// has already judged (#2054).
+//
+// It filters rather than replaces the scan, so the scan keeps happening on the
+// allocated exact-head worktree where it is documented to happen, and only the
+// EMISSION narrows. A warning survives when its cited commit could not be
+// classified at all: nobody has judged that one, so the operator is the last
+// check. Every other relation - the head, an ancestor of it, a recorded head of
+// this pull request - is what a prompt states deliberately, and a warning on the
+// routine case teaches its reader to ignore it.
+func retainUnjudgedPromptHeadWarnings(
+	ctx context.Context,
+	git gitutil.Client,
+	heads recordedPullRequestHeadSource,
+	prompt string,
+	dispatchHead string,
+	repo string,
+	pullRequest int,
+	warnings []string,
+) []string {
+	if len(warnings) == 0 {
+		return warnings
+	}
+	unjudged := make([]string, 0, len(warnings))
+	for _, citation := range classifyPromptCommitCitations(ctx, git, heads, prompt, dispatchHead, repo, pullRequest) {
+		if citation.relation == promptCommitUnresolved {
+			unjudged = append(unjudged, citation.token, citation.resolved)
+		}
+	}
+	if len(unjudged) == 0 {
+		return nil
+	}
+	kept := make([]string, 0, len(warnings))
+	for _, warning := range warnings {
+		for _, token := range unjudged {
+			if strings.TrimSpace(token) != "" && strings.Contains(warning, token) {
+				kept = append(kept, warning)
+				break
+			}
+		}
+	}
+	if len(kept) == 0 {
+		return nil
+	}
+	return kept
+}

--- a/internal/cli/prompt_head_binding.go
+++ b/internal/cli/prompt_head_binding.go
@@ -286,10 +286,21 @@ func retainUnjudgedPromptHeadWarnings(
 	if len(unjudged) == 0 {
 		return nil
 	}
+	// ANCHOR ON THE CITATION CLAUSE, never a bare substring. Every warning names
+	// the DISPATCH HEAD twice in its own text, so a substring test let an
+	// unjudged token retain a DIFFERENT citation's warning whenever that token
+	// occurred inside the dispatch sha - and a prompt only has to contain a
+	// non-resolving 7-hex run taken from the middle of that sha for the leak to
+	// fire, which is why it survived a probe whose prompt happened not to have
+	// one. Matching the leading "prompt references commit <token>," ties a
+	// warning to the one citation it is about.
 	kept := make([]string, 0, len(warnings))
 	for _, warning := range warnings {
 		for _, token := range unjudged {
-			if strings.TrimSpace(token) != "" && strings.Contains(warning, token) {
+			if strings.TrimSpace(token) == "" {
+				continue
+			}
+			if strings.HasPrefix(warning, promptHeadWarningCitationPrefix+token+",") {
 				kept = append(kept, warning)
 				break
 			}

--- a/internal/cli/prompt_head_binding.go
+++ b/internal/cli/prompt_head_binding.go
@@ -272,7 +272,14 @@ func retainUnjudgedPromptHeadWarnings(
 	}
 	unjudged := make([]string, 0, len(warnings))
 	for _, citation := range classifyPromptCommitCitations(ctx, git, heads, prompt, dispatchHead, repo, pullRequest) {
-		if citation.relation == promptCommitUnresolved {
+		// F4: a RECORDED HEAD THAT IS NOT AN ANCESTOR is the stale-target case,
+		// and it is the one relation worth warning about. It means the prompt
+		// names a head this pull request really had, which a force push or a
+		// reset left off the current history - so a prompt citing it as its
+		// review TARGET is reviewing something that is no longer there. An
+		// ancestor is different: a scoped re-review cites its own prior head,
+		// and that head's content is still under the dispatch head.
+		if citation.relation == promptCommitIsPriorHead || citation.relation == promptCommitUnresolved {
 			unjudged = append(unjudged, citation.token, citation.resolved)
 		}
 	}

--- a/internal/cli/prompt_head_binding_test.go
+++ b/internal/cli/prompt_head_binding_test.go
@@ -219,12 +219,13 @@ func TestReviewDispatchBindsThePromptsTargetToTheDispatchHead(t *testing.T) {
 // The refusal carries the wrong-head signal; the warning had nothing left to
 // say. Ask and implement keep theirs - see the boundary test below.
 func TestReviewDispatchWarnsOnlyOnCitationsNobodyHasJudged(t *testing.T) {
-	checkout, base, firstHead, head, _ := promptHeadBindingCheckout(t)
+	checkout, base, firstHead, head, staleTarget := promptHeadBindingCheckout(t)
 	const unresolvable = "0123456789abcdef0123456789abcdef01234567"
 
 	for _, tt := range []struct {
 		name     string
 		cited    string
+		recordAs int
 		wantWarn bool
 	}{
 		{name: "a prior head on the reviewed branch is silent: this is the scoped re-review case", cited: firstHead},
@@ -235,11 +236,19 @@ func TestReviewDispatchWarnsOnlyOnCitationsNobodyHasJudged(t *testing.T) {
 		// asserted it did, and that expectation was wrong about the existing
 		// scanner rather than about the change.
 		{name: "an unresolvable sha is silent too, because the scan never resolved it to warn about", cited: unresolvable},
+		// F4: a RECORDED head of this pull request that is NOT an ancestor is the
+		// force-push shape - the commit really was a head and no longer is - so a
+		// prompt naming it as its target is reviewing something that is gone.
+		// The first version of this filter could not tell that from provenance.
+		{name: "a recorded head that is NOT an ancestor warns: that is a stale review target", cited: staleTarget, recordAs: 12, wantWarn: true},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			ctx := context.Background()
 			store, home := blockerE2EHome(t)
 			seedReviewDispatchFixture(t, store, checkout)
+			if tt.recordAs != 0 {
+				seedRecordedReviewHead(t, store, "recorded-head-fixture", tt.recordAs, tt.cited)
+			}
 
 			request := reviewDispatchRequest(home, head)
 			request.Instructions = "Review this exact head. Round history: commit " + tt.cited + " for context."

--- a/internal/cli/prompt_head_binding_test.go
+++ b/internal/cli/prompt_head_binding_test.go
@@ -199,6 +199,120 @@ func TestReviewDispatchBindsThePromptsTargetToTheDispatchHead(t *testing.T) {
 	}
 }
 
+// TestReviewDispatchWarnsOnlyOnCitationsNobodyHasJudged is #2054 finding 3.
+//
+// The identity-based scan warned on ANY cited commit that was not the dispatch
+// head. For a review that fires on cases the refusal above has ALREADY accepted:
+// a foreign citation never reaches the warning stage, so every warning was about
+// the head's own ancestor, a recorded head of this pull request, or an
+// unresolvable sha. The first two are what a prompt says deliberately - a scoped
+// re-review MUST name the previous round's head to say what it is re-reviewing.
+//
+// A warning that fires on the routine case teaches its reader to ignore it, and
+// that cost was paid: this warning was used to attribute job ownership on
+// 2026-09-08 and then raised against a scoped re-review citing its own prior
+// head correctly.
+//
+// The result is that a review emits NO prompt_head_warning at all, and that is
+// the finding rather than a side effect: the scan cannot report a relation that
+// is both resolvable and unjudged, because foreign is refused before enqueue.
+// The refusal carries the wrong-head signal; the warning had nothing left to
+// say. Ask and implement keep theirs - see the boundary test below.
+func TestReviewDispatchWarnsOnlyOnCitationsNobodyHasJudged(t *testing.T) {
+	checkout, base, firstHead, head, _ := promptHeadBindingCheckout(t)
+	const unresolvable = "0123456789abcdef0123456789abcdef01234567"
+
+	for _, tt := range []struct {
+		name     string
+		cited    string
+		wantWarn bool
+	}{
+		{name: "a prior head on the reviewed branch is silent: this is the scoped re-review case", cited: firstHead},
+		{name: "the branch base is silent: a prompt states what the branch sits on", cited: base},
+		{name: "the dispatch head itself is silent", cited: head},
+		// The scan SKIPS a token it cannot resolve, so an unresolvable citation
+		// never produced a warning here either - my first version of this test
+		// asserted it did, and that expectation was wrong about the existing
+		// scanner rather than about the change.
+		{name: "an unresolvable sha is silent too, because the scan never resolved it to warn about", cited: unresolvable},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			store, home := blockerE2EHome(t)
+			seedReviewDispatchFixture(t, store, checkout)
+
+			request := reviewDispatchRequest(home, head)
+			request.Instructions = "Review this exact head. Round history: commit " + tt.cited + " for context."
+			out, err := dispatchLocalAgentJob(ctx, store, request)
+			if err != nil {
+				t.Fatalf("dispatch was refused: %v", err)
+			}
+			events, err := store.ListJobEvents(ctx, out.JobID)
+			if err != nil {
+				t.Fatal(err)
+			}
+			warned := 0
+			for _, event := range events {
+				if event.Kind == "prompt_head_warning" {
+					warned++
+				}
+			}
+			if tt.wantWarn && warned == 0 {
+				t.Fatalf("no prompt_head_warning for an unresolvable citation: events=%+v", events)
+			}
+			if !tt.wantWarn && warned != 0 {
+				t.Fatalf("prompt_head_warning fired on a citation the refusal already accepted (%s); "+
+					"a warning on the routine case teaches its reader to ignore it", tt.cited)
+			}
+		})
+	}
+}
+
+// TestAskDispatchKeepsItsBlanketPromptHeadWarning pins the BOUNDARY of #2054
+// finding 3, which a mutant switching ask onto the review scope survived
+// without it.
+//
+// Narrowing the warning is only safe where a refusal already judged the
+// citation. Ask and implement have NO refusal in front of them - the #1819
+// guard is review-only - so for them the identity-based warning is the entire
+// head check, and silencing it there would remove the check rather than
+// de-duplicate it. Same change, opposite correctness, decided by whether
+// something else already looked.
+func TestAskDispatchKeepsItsBlanketPromptHeadWarning(t *testing.T) {
+	ctx := context.Background()
+	checkout, base, _, head, _ := promptHeadBindingCheckout(t)
+	store, home := blockerE2EHome(t)
+	seedReviewDispatchFixture(t, store, checkout)
+
+	// An ask needs an ask-capable agent; the shared fixture seeds review and
+	// implement only.
+	seedDaemonWorkerAgentWithPolicy(t, store, "asker", runtime.ShellRuntime, "true", []string{"ask"}, "owner/repo", runtime.AutonomyPolicyReadOnly)
+	request := reviewDispatchRequest(home, head)
+	request.Agent = "asker"
+	request.LeadAgent = ""
+	request.Action = "ask"
+	request.PullRequest = 0
+	// The BASE is an ancestor of the dispatch head, so the review path is now
+	// deliberately silent about it. Ask must not be.
+	request.Instructions = "Answer against commit " + base + " for context."
+
+	out, err := dispatchLocalAgentJob(ctx, store, request)
+	if err != nil {
+		t.Fatalf("ask dispatch was refused: %v", err)
+	}
+	events, err := store.ListJobEvents(ctx, out.JobID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, event := range events {
+		if event.Kind == "prompt_head_warning" {
+			return
+		}
+	}
+	t.Fatalf("ask lost its prompt_head_warning for a non-head citation: events=%+v; "+
+		"ask has no refusal in front of it, so this warning is its only head check", events)
+}
+
 // TestReviewDispatchRefusalLeavesNoWorktreeBehind pins the ORDERING, separately
 // from the refusal itself.
 //

--- a/internal/cli/prompt_head_binding_test.go
+++ b/internal/cli/prompt_head_binding_test.go
@@ -7,6 +7,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/gitmoot/gitmoot/internal/subprocess"
+
 	"github.com/gitmoot/gitmoot/internal/db"
 	"github.com/gitmoot/gitmoot/internal/runtime"
 	"github.com/gitmoot/gitmoot/internal/workflow"
@@ -218,6 +220,47 @@ func TestReviewDispatchBindsThePromptsTargetToTheDispatchHead(t *testing.T) {
 // is both resolvable and unjudged, because foreign is refused before enqueue.
 // The refusal carries the wrong-head signal; the warning had nothing left to
 // say. Ask and implement keep theirs - see the boundary test below.
+// TestUnjudgedTokenCannotRetainAnotherCitationsWarning is review finding P3 on
+// #2064 cycle five, and it is a RETENTION LEAK rather than a wording problem.
+//
+// Every warning names the dispatch head twice in its own text. The filter used
+// to keep a warning when any unjudged token appeared ANYWHERE in it, so a
+// non-resolving token that happens to be a 7-hex run from the middle of the
+// dispatch sha classified as promptCommitUnresolved, went into the unjudged set,
+// and then matched inside the dispatch-head text of an ANCESTOR's warning -
+// retaining a warning the filter exists to drop, about a citation nobody
+// complained about.
+//
+// It survived an earlier hand probe of mine for a reason worth recording: that
+// probe's prompt contained no stray token, so the leak had nothing to fire on. A
+// negative result from an input that cannot express the defect is not evidence.
+func TestUnjudgedTokenCannotRetainAnotherCitationsWarning(t *testing.T) {
+	ctx := context.Background()
+	checkout, _, base, head, _ := promptHeadBindingCheckout(t)
+	store, _ := blockerE2EHome(t)
+	client := jobGitClient(checkout, subprocess.ExecRunner{})
+
+	// A 7-hex run lifted from the MIDDLE of the dispatch head, which no object
+	// resolves: this is the unjudged token that used to leak.
+	stray := head[8:15]
+	if _, err := client.RevParse(ctx, stray+"^{commit}"); err == nil {
+		t.Skipf("fixture stray token %q unexpectedly resolves", stray)
+	}
+	// base is an ANCESTOR of head, so its warning must be dropped.
+	prompt := "review " + base + " and also " + stray
+
+	warnings := dispatchPromptHeadContradictionWarnings(ctx, client, prompt, head)
+	if len(warnings) == 0 {
+		t.Fatalf("fixture produced no warnings to filter; the ancestor citation must warn before filtering")
+	}
+	kept := retainUnjudgedPromptHeadWarnings(ctx, client, store, prompt, head, "owner/repo", 12, warnings)
+	for _, warning := range kept {
+		if strings.Contains(warning, base) {
+			t.Fatalf("an unjudged stray token retained the ANCESTOR citation's warning: %q\nkept=%v", warning, kept)
+		}
+	}
+}
+
 func TestReviewDispatchWarnsOnlyOnCitationsNobodyHasJudged(t *testing.T) {
 	checkout, base, firstHead, head, staleTarget := promptHeadBindingCheckout(t)
 	const unresolvable = "0123456789abcdef0123456789abcdef01234567"

--- a/internal/workflow/engine_no_fix_target_2054_test.go
+++ b/internal/workflow/engine_no_fix_target_2054_test.go
@@ -15,11 +15,17 @@ import (
 // --no-fix-target declares that a review has no implementer and the dispatching
 // operator owns the follow-up. Clearing the lead at dispatch was not enough:
 // enqueue restored the reviewer through firstNonEmpty, and advancement had no
-// field to read the declaration from. So a changes_requested verdict would have
-// dispatched its fix leg to an implementer the operator had declined to name -
-// and where the fallback resolved to the reviewer, to the very agent that
-// produced the verdict, which is the independence violation the lead
-// requirement exists to prevent.
+// field to read the declaration from, so a changes_requested verdict still
+// dispatched a fix leg the operator had declined to authorize.
+//
+// CORRECTED SEVERITY, and the correction is against the original claim: this is
+// NOT an independence violation via routing. dispatchFix resolves its owner with
+// autoFixOwner(payload), which prefers a REGISTERED ActingOrgRole and otherwise
+// derives the implementer from prior implement jobs; it never reads
+// payload.LeadAgent. Measured by another seat with lead and prior implementer as
+// different agents: the fix went to the prior implementer, not the lead. So the
+// restored lead was a FALSE ATTRIBUTION RECORD in a field auditors read, and the
+// defect this test pins is the unauthorized leg itself.
 //
 // The declaration therefore has to live on the PAYLOAD and be honoured HERE,
 // where the leg is dispatched, not only at the CLI seam.
@@ -80,5 +86,77 @@ func TestChangesRequestedHonoursNoFixTarget(t *testing.T) {
 		if !strings.Contains(skip.Message, want) {
 			t.Fatalf("skip message %q does not name %q", skip.Message, want)
 		}
+	}
+}
+
+// TestDelegatedReviewChildInheritsNoFixTarget is review finding F1 on #2064's
+// second cycle, and it is the escape the leaf test above cannot see.
+//
+// delegationRequest copies the review context - LeadAgent, Reviewers,
+// ReviewRound, ActingOrgRole - and did not copy NoFixTarget. So a review-only
+// ROOT could fan out to a delegated review child whose payload said
+// no_fix_target=false, and that child's changes_requested advanced through its
+// own native review path with dispatchFix taking no skip. With auto-fix enabled
+// the declaration held at the root and leaked ONE LEVEL DOWN, which is worse
+// than not having the flag: the operator is told there is no fix target and a
+// leg is dispatched anyway from a job they never dispatched.
+//
+// The inheritance belongs in prepareEnqueue and not in delegationRequest,
+// because that is the seam every review-creating request in the tree already
+// passes through - the same argument the skip-native-review-fanout intent makes
+// beside it. Asserting the STORED payload is therefore the contract: a test
+// against delegationRequest's returned struct would pass with the bug present.
+func TestDelegatedReviewChildInheritsNoFixTarget(t *testing.T) {
+	ctx := context.Background()
+	store := openTestStore(t)
+	mailbox := Mailbox{store: store, resolveDeliveryWorktree: ExcludedDeliveryWorktreeResolver("test_explicit_no_worktree")}
+
+	parentPayload, err := json.Marshal(JobPayload{
+		Repo:        "gitmoot/gitmoot",
+		Branch:      "task-2054",
+		PullRequest: 2054,
+		TaskID:      "task-2054",
+		NoFixTarget: true,
+	})
+	if err != nil {
+		t.Fatalf("json.Marshal: %v", err)
+	}
+	if err := store.CreateJob(ctx, db.Job{
+		ID:      "review-only-root",
+		Agent:   "audit",
+		Type:    "review",
+		State:   string(JobSucceeded),
+		Payload: string(parentPayload),
+	}); err != nil {
+		t.Fatalf("CreateJob: %v", err)
+	}
+
+	// The child as delegationRequest builds it: review context copied, and the
+	// declaration absent because the caller never carried it.
+	if _, err := mailbox.Enqueue(ctx, JobRequest{
+		ID:           "review-only-root/delegation/leg-1",
+		Agent:        "audit",
+		Action:       "review",
+		Repo:         "gitmoot/gitmoot",
+		Branch:       "task-2054",
+		PullRequest:  2054,
+		TaskID:       "task-2054",
+		ParentJobID:  "review-only-root",
+		DelegationID: "leg-1",
+	}); err != nil {
+		t.Fatalf("Enqueue: %v", err)
+	}
+
+	child, err := store.GetJob(ctx, "review-only-root/delegation/leg-1")
+	if err != nil {
+		t.Fatalf("GetJob: %v", err)
+	}
+	childPayload, err := unmarshalPayload(child.Payload)
+	if err != nil {
+		t.Fatalf("unmarshalPayload: %v", err)
+	}
+	if !childPayload.NoFixTarget {
+		t.Fatalf("delegated review child dropped the no-fix-target declaration; "+
+			"its changes_requested can enqueue an implement leg the operator declined to authorize. payload = %s", child.Payload)
 	}
 }

--- a/internal/workflow/engine_no_fix_target_2054_test.go
+++ b/internal/workflow/engine_no_fix_target_2054_test.go
@@ -1,0 +1,84 @@
+package workflow
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/gitmoot/gitmoot/internal/db"
+)
+
+// TestChangesRequestedHonoursNoFixTarget is review finding F1 on #2064, and it
+// is the half that made the flag a TRAP rather than merely incomplete.
+//
+// --no-fix-target declares that a review has no implementer and the dispatching
+// operator owns the follow-up. Clearing the lead at dispatch was not enough:
+// enqueue restored the reviewer through firstNonEmpty, and advancement had no
+// field to read the declaration from. So a changes_requested verdict would have
+// dispatched its fix leg to an implementer the operator had declined to name -
+// and where the fallback resolved to the reviewer, to the very agent that
+// produced the verdict, which is the independence violation the lead
+// requirement exists to prevent.
+//
+// The declaration therefore has to live on the PAYLOAD and be honoured HERE,
+// where the leg is dispatched, not only at the CLI seam.
+func TestChangesRequestedHonoursNoFixTarget(t *testing.T) {
+	ctx := context.Background()
+	store, engine := reviewRefanoutFixture(t)
+	enableAutoFix(t, store, 1678)
+
+	// A review dispatched --no-fix-target: no lead, and the declaration carried
+	// on its own payload.
+	// Mirrors insertPriorReviewResult exactly, EXCEPT no LeadAgent and
+	// NoFixTarget set: the difference is the subject.
+	result := AgentResult{
+		Decision: "changes_requested",
+		Summary:  "A finding with nobody assigned to fix it.",
+		Findings: []json.RawMessage{
+			json.RawMessage(`{"id":"F-1","file":"internal/boundary.go","summary":"Unguarded on the failure path."}`),
+		},
+	}
+	insertCompletedJob(t, store, db.Job{ID: "review-only-verdict", Agent: "audit", Type: "review"}, JobPayload{
+		Repo:        "gitmoot/gitmoot",
+		Branch:      "task-1678",
+		PullRequest: 1678,
+		HeadSHA:     "head-one",
+		TaskID:      "task-1678",
+		TaskTitle:   "Bound native review fanout",
+		Reviewers:   []string{"audit"},
+		ReviewRound: "review-1",
+		NoFixTarget: true,
+		Result:      &result,
+	})
+	if err := engine.AdvanceJob(ctx, "review-only-verdict"); err != nil {
+		t.Fatalf("AdvanceJob: %v", err)
+	}
+
+	if _, err := store.GetJob(ctx, "implement-lead-task-1678-review-1"); err == nil {
+		t.Fatal("a fix leg was dispatched for a review declared --no-fix-target; " +
+			"the operator declined to name an implementer and the fallback is the reviewer itself")
+	}
+
+	// THE SKIP MUST BE ON THE RECORD, for the same reason the active-leg skip is:
+	// an operator reads "no fix leg" as "nothing to fix" unless the reason is
+	// findable.
+	events, err := store.ListJobEvents(ctx, "review-only-verdict")
+	if err != nil {
+		t.Fatalf("ListJobEvents: %v", err)
+	}
+	var skip db.JobEvent
+	for _, event := range events {
+		if event.Kind == "auto_fix_skipped_no_fix_target" {
+			skip = event
+		}
+	}
+	if skip.Kind == "" {
+		t.Fatalf("no auto_fix_skipped_no_fix_target event; the skip is invisible. events = %+v", events)
+	}
+	for _, want := range []string{"no-fix-target", "findings stay open"} {
+		if !strings.Contains(skip.Message, want) {
+			t.Fatalf("skip message %q does not name %q", skip.Message, want)
+		}
+	}
+}

--- a/internal/workflow/engine_routing_merge.go
+++ b/internal/workflow/engine_routing_merge.go
@@ -102,6 +102,28 @@ func (e Engine) dispatchFix(ctx context.Context, verdictJob db.Job, reviewer str
 	// them against the head the in-flight leg is about to push. A dropped dispatch
 	// costs one round; a lost race costs a completed leg's work and leaves the
 	// finding open anyway.
+	// #2054: A REVIEW-ONLY VERDICT HAS NO FIX TARGET, BY DECLARATION.
+	//
+	// --no-fix-target dispatches a review whose reviewer cannot implement and
+	// which names no lead, because the operator owns the follow-up. Honouring
+	// that has to happen HERE, not only at dispatch: clearing the lead alone
+	// left this path to resolve one anyway, and the resolution it reaches is the
+	// reviewer - so the fix for a verdict would go to the agent that produced
+	// it, which is the independence violation the lead requirement exists to
+	// prevent.
+	//
+	// SKIP AND RECORD, in the shape the active-leg branch already uses: the
+	// findings stay open in the ledger, so nothing is lost by not dispatching,
+	// and the event says the omission was chosen rather than failed.
+	if payload.NoFixTarget {
+		return e.Store.AddJobEvent(ctx, db.JobEvent{
+			JobID: verdictJob.ID,
+			Kind:  "auto_fix_skipped_no_fix_target",
+			Message: fmt.Sprintf(
+				"auto-fix leg not dispatched for %s pull request #%d: this review was dispatched --no-fix-target, so it has no implementer and the dispatching operator owns the follow-up. The findings stay open in the ledger",
+				payload.Repo, payload.PullRequest),
+		})
+	}
 	if active, found, err := e.activeImplementLegOnBranch(ctx, payload); err != nil {
 		return err
 	} else if found {

--- a/internal/workflow/mailbox.go
+++ b/internal/workflow/mailbox.go
@@ -687,7 +687,17 @@ func (m Mailbox) prepareEnqueue(ctx context.Context, request JobRequest) (db.Job
 	// leaves the request exactly as the caller built it.
 	skipNativeReviewFanout := request.SkipNativeReviewFanout
 	pullRequestReady := request.PullRequestReady
-	if (!skipNativeReviewFanout || !pullRequestReady) && strings.TrimSpace(request.ParentJobID) != "" {
+	// #2054 review finding: a review-only declaration MUST be inherited too. A
+	// delegated review child is built by delegationRequest, which copies the
+	// review context (LeadAgent, Reviewers, ReviewRound) and did NOT copy
+	// NoFixTarget, so a child returning changes_requested advanced through its own
+	// native review path and dispatchFix never took the skip. With auto-fix
+	// enabled a review-only TREE could still enqueue an implement leg - the
+	// declaration held at the root and leaked one level down. Inheriting it here
+	// rather than at delegationRequest is deliberate: this is the seam every
+	// review-creating request already passes through.
+	noFixTarget := request.NoFixTarget
+	if (!skipNativeReviewFanout || !pullRequestReady || !noFixTarget) && strings.TrimSpace(request.ParentJobID) != "" {
 		if parent, parentErr := m.store.GetJob(ctx, strings.TrimSpace(request.ParentJobID)); parentErr == nil {
 			if parentPayload, parseErr := unmarshalPayload(parent.Payload); parseErr == nil {
 				if parentPayload.SkipNativeReviewFanout {
@@ -695,6 +705,9 @@ func (m Mailbox) prepareEnqueue(ctx context.Context, request JobRequest) (db.Job
 				}
 				if parentPayload.PullRequestReady {
 					pullRequestReady = true
+				}
+				if parentPayload.NoFixTarget {
+					noFixTarget = true
 				}
 			}
 		}
@@ -778,7 +791,7 @@ func (m Mailbox) prepareEnqueue(ctx context.Context, request JobRequest) (db.Job
 		SkipNativeReviewFanout: skipNativeReviewFanout,
 		// #2054: carried onto the payload because AdvanceJob is what decides
 		// whether a changes_requested verdict dispatches a fix at all.
-		NoFixTarget:          request.NoFixTarget,
+		NoFixTarget:          noFixTarget,
 		ValidatedPullRequest: request.ValidatedPullRequest,
 		Ephemeral:            request.Ephemeral,
 		HumanAnswer:          request.HumanAnswer,

--- a/internal/workflow/mailbox.go
+++ b/internal/workflow/mailbox.go
@@ -327,8 +327,13 @@ type JobRequest struct {
 	ShellUpstreamContext   string
 	Phase                  string
 	SkipNativeReviewFanout bool
-	ValidatedPullRequest   bool
-	Ephemeral              *EphemeralSpec
+	// NoFixTarget carries a review dispatched with --no-fix-target (#2054): it
+	// has NO implementer for a changes_requested verdict, and advancement must
+	// not invent one. It has to live on the payload rather than only in a job
+	// event, because AdvanceJob is what decides whether to dispatch a fix.
+	NoFixTarget          bool
+	ValidatedPullRequest bool
+	Ephemeral            *EphemeralSpec
 	// HumanAnswer carries the rendered ask-gate answer block (#445) into the
 	// coordinator continuation enqueued by the `answer` resume verb. Empty for
 	// every other job, so the stored payload is byte-identical by default.
@@ -479,6 +484,7 @@ type JobPayload struct {
 	ShellUpstreamContext   string              `json:"shell_upstream_context,omitempty"`
 	Phase                  string              `json:"phase,omitempty"`
 	SkipNativeReviewFanout bool                `json:"skip_native_review_fanout,omitempty"`
+	NoFixTarget            bool                `json:"no_fix_target,omitempty"`
 	ValidatedPullRequest   bool                `json:"validated_pull_request,omitempty"`
 	Ephemeral              *EphemeralSpec      `json:"ephemeral,omitempty"`
 	HumanAnswer            string              `json:"human_answer,omitempty"`
@@ -770,16 +776,19 @@ func (m Mailbox) prepareEnqueue(ctx context.Context, request JobRequest) (db.Job
 		ShellUpstreamContext:   request.ShellUpstreamContext,
 		Phase:                  request.Phase,
 		SkipNativeReviewFanout: skipNativeReviewFanout,
-		ValidatedPullRequest:   request.ValidatedPullRequest,
-		Ephemeral:              request.Ephemeral,
-		HumanAnswer:            request.HumanAnswer,
-		RiskTier:               strings.TrimSpace(request.RiskTier),
-		OrchestrateStage:       request.OrchestrateStage,
-		WritablePaths:          compactStrings(request.WritablePaths),
-		ReadablePaths:          compactStrings(request.ReadablePaths),
-		Network:                request.Network,
-		Check:                  strings.TrimSpace(request.Check),
-		CheckRetries:           request.CheckRetries,
+		// #2054: carried onto the payload because AdvanceJob is what decides
+		// whether a changes_requested verdict dispatches a fix at all.
+		NoFixTarget:          request.NoFixTarget,
+		ValidatedPullRequest: request.ValidatedPullRequest,
+		Ephemeral:            request.Ephemeral,
+		HumanAnswer:          request.HumanAnswer,
+		RiskTier:             strings.TrimSpace(request.RiskTier),
+		OrchestrateStage:     request.OrchestrateStage,
+		WritablePaths:        compactStrings(request.WritablePaths),
+		ReadablePaths:        compactStrings(request.ReadablePaths),
+		Network:              request.Network,
+		Check:                strings.TrimSpace(request.Check),
+		CheckRetries:         request.CheckRetries,
 	})
 	if err != nil {
 		return db.Job{}, nil, err

--- a/skills/gitmoot/references/CLI.md
+++ b/skills/gitmoot/references/CLI.md
@@ -1162,8 +1162,16 @@ retains. That arm is an INSTRUMENT FAILURE rather than a statement about the
 prompt, and it is deliberately reachable - when the classifier cannot judge a
 citation, nobody has judged it.
 
-Two things are silent. A token the scan itself could not resolve never reaches
-the filter at all, because `dispatchPromptHeadContradictionWarnings` discards it
+Retention is PER CITATION: a warning is kept only when the retained relation is
+the one that warning is about, matched on its leading
+`prompt references commit <token>,` clause. That is what makes the two relations
+above exhaustive - an earlier version tested for the token anywhere in the
+warning text, and since every warning names the dispatch head twice, an unjudged
+token that happened to be a hex run from inside that sha could retain a
+DIFFERENT citation's warning.
+
+Two things are silent. A token the scan itself could not resolve produces no
+warning of its own, because `dispatchPromptHeadContradictionWarnings` discards it
 before any classification. And on the resolvable path ancestry is checked BEFORE
 the recorded-head arm, so a commit that is both a prior head and an ancestor is
 silent - the ordinary scoped re-review, citing its own previous head.

--- a/skills/gitmoot/references/CLI.md
+++ b/skills/gitmoot/references/CLI.md
@@ -1186,10 +1186,18 @@ starting its runtime session, Gitmoot loads the lead from the agents database
 and requires that it exist, can access the repository, has `implement`
 capability, and uses a write-granting policy (`workspace-write` or
 `danger-full-access`). Without `--lead`, the reviewer is the fallback lead and
-must pass the same checks; a strict review-only agent therefore needs an
-explicit implementer. Managed-type review dispatches also require an explicit
-DB-backed lead. `--lead` is rejected when `agent run` resolves to ask or
+must pass the same checks. Managed-type review dispatches also require an
+explicit DB-backed lead. `--lead` is rejected when `agent run` resolves to ask or
 implement, and is not accepted by `agent implement` or `orchestrate`.
+
+A strict review-only agent therefore needs either an explicit implementer or
+`--no-fix-target`, which declares that this review has NO fix target and the
+dispatching operator owns the follow-up. That declaration is carried on the job
+payload, not only as an event, because advancement is what decides whether a
+`changes_requested` verdict dispatches a fix at all: such a verdict records
+`auto_fix_skipped_no_fix_target` and leaves its findings open in the ledger
+rather than routing a fix to the reviewer that produced it. `--no-fix-target`
+is rejected outside review and is mutually exclusive with `--lead`.
 
 This dispatch-time lead validation applies only to local CLI reviews started by
 `gitmoot agent review` or review-resolved `gitmoot agent run`. Reviews routed

--- a/skills/gitmoot/references/CLI.md
+++ b/skills/gitmoot/references/CLI.md
@@ -1153,13 +1153,20 @@ left it unreachable. A citation whose relationship cannot be established at all,
 because the dispatching checkout resolves neither commit, also dispatches: that
 is a fact about the checkout rather than about the citation.
 
-`prompt_head_warning` IS still emitted for a review, and for exactly ONE
-relation: a RECORDED PRIOR HEAD THAT IS NOT AN ANCESTOR. An unresolvable citation
-is silent, and the reason is one layer up rather than in the filter: the scan
-discards any token `rev-parse` cannot resolve, so no warning about it ever
-reaches the filter to be retained. Ancestry is checked BEFORE the recorded-head
-arm, so a commit that is both a prior head and an ancestor is silent - which is
-the ordinary scoped re-review, citing its own previous head.
+`prompt_head_warning` IS still emitted for a review, for two relations rather
+than one. The normal-path relation is a RECORDED PRIOR HEAD THAT IS NOT AN
+ANCESTOR. The second is a citation whose ancestry the classifier could not
+establish: `promptCitationAncestry` returns `known=false` when `IsAncestor`
+errors, and that lands on `promptCommitUnresolved`, which the filter also
+retains. That arm is an INSTRUMENT FAILURE rather than a statement about the
+prompt, and it is deliberately reachable - when the classifier cannot judge a
+citation, nobody has judged it.
+
+Two things are silent. A token the scan itself could not resolve never reaches
+the filter at all, because `dispatchPromptHeadContradictionWarnings` discards it
+before any classification. And on the resolvable path ancestry is checked BEFORE
+the recorded-head arm, so a commit that is both a prior head and an ancestor is
+silent - the ordinary scoped re-review, citing its own previous head.
 Ancestor provenance is silent, because naming the branch base is how a prompt
 states where the work sits. The prior-head arm is the force-push shape - the
 commit really was a head of this pull request and no longer is - so a prompt

--- a/skills/gitmoot/references/CLI.md
+++ b/skills/gitmoot/references/CLI.md
@@ -1151,21 +1151,29 @@ how it states provenance. The recorded-head arm reads an append-only store fact
 rather than git, so a legitimate prior head still passes after a force push has
 left it unreachable. A citation whose relationship cannot be established at all,
 because the dispatching checkout resolves neither commit, also dispatches: that
-is a fact about the checkout rather than about the citation. `prompt_head_warning` is no longer
-emitted for a review at all, and that is the consequence of the classification
-above rather than a separate decision: the scan skips a token it cannot resolve,
-and every relation it CAN report is either refused here or stated deliberately,
-so a warning about one taught its reader to ignore the event. Ask and implement
-keep the warning, because no refusal runs in front of them and it is their only
-head check.
+is a fact about the checkout rather than about the citation.
+
+`prompt_head_warning` IS still emitted for a review, for exactly the two allowed
+relations nobody has judged: a RECORDED PRIOR HEAD and an UNRESOLVABLE citation.
+Ancestor provenance is silent, because naming the branch base is how a prompt
+states where the work sits. The prior-head arm is the force-push shape - the
+commit really was a head of this pull request and no longer is - so a prompt
+naming it as its target is reviewing a tree that is gone, and that is worth one
+line to its operator even though the dispatch proceeds. Ask and implement keep
+the blanket warning, because no refusal runs in front of them and it is their
+only head check.
 
 `--head-sha` must be the FULL 40 hex characters for a review. An abbreviated
 value used to dispatch and then be cancelled by the daemon's staleness check,
 which compared it against the pull request's full head and reported the same
-commit as a move; it is now refused at dispatch, before the read-only worktree
-and the job row. The refusal fires only on a sha-shaped value, so a placeholder
-that is not a sha still reaches the review-loop and reviewer-identity refusals
-that name it better.
+commit as a move; it is now refused at dispatch, before the read-only worktree,
+the review task row and the job row. The refusal rejects EVERY non-empty value
+that is not exactly 40 hex characters, including a revision expression such as
+`<sha>^` or `<sha>~1`: the daemon binds this value by EQUALITY against the pull
+request's head, so no other shape can bind whatever it looks like. It runs after
+the review-loop and reviewer-identity refusals, so those still name their own
+preconditions first, and before the review task is upserted, so a refused
+dispatch leaves no durable state behind.
 
 `--no-fix-target` dispatches a REVIEW-ONLY review: the reviewer need not be able
 to implement and no `--lead` is required. The lead exists so a

--- a/skills/gitmoot/references/CLI.md
+++ b/skills/gitmoot/references/CLI.md
@@ -1153,8 +1153,13 @@ left it unreachable. A citation whose relationship cannot be established at all,
 because the dispatching checkout resolves neither commit, also dispatches: that
 is a fact about the checkout rather than about the citation.
 
-`prompt_head_warning` IS still emitted for a review, for exactly the two allowed
-relations nobody has judged: a RECORDED PRIOR HEAD and an UNRESOLVABLE citation.
+`prompt_head_warning` IS still emitted for a review, and for exactly ONE
+relation: a RECORDED PRIOR HEAD THAT IS NOT AN ANCESTOR. An unresolvable citation
+is silent, and the reason is one layer up rather than in the filter: the scan
+discards any token `rev-parse` cannot resolve, so no warning about it ever
+reaches the filter to be retained. Ancestry is checked BEFORE the recorded-head
+arm, so a commit that is both a prior head and an ancestor is silent - which is
+the ordinary scoped re-review, citing its own previous head.
 Ancestor provenance is silent, because naming the branch base is how a prompt
 states where the work sits. The prior-head arm is the force-push shape - the
 commit really was a head of this pull request and no longer is - so a prompt

--- a/skills/gitmoot/references/CLI.md
+++ b/skills/gitmoot/references/CLI.md
@@ -1151,9 +1151,28 @@ how it states provenance. The recorded-head arm reads an append-only store fact
 rather than git, so a legitimate prior head still passes after a force push has
 left it unreachable. A citation whose relationship cannot be established at all,
 because the dispatching checkout resolves neither commit, also dispatches: that
-is a fact about the checkout rather than about the citation. The pre-existing
-`prompt_head_warning` job event is unchanged and still records every non-head
-citation, including the ones that are allowed.
+is a fact about the checkout rather than about the citation. `prompt_head_warning` is no longer
+emitted for a review at all, and that is the consequence of the classification
+above rather than a separate decision: the scan skips a token it cannot resolve,
+and every relation it CAN report is either refused here or stated deliberately,
+so a warning about one taught its reader to ignore the event. Ask and implement
+keep the warning, because no refusal runs in front of them and it is their only
+head check.
+
+`--head-sha` must be the FULL 40 hex characters for a review. An abbreviated
+value used to dispatch and then be cancelled by the daemon's staleness check,
+which compared it against the pull request's full head and reported the same
+commit as a move; it is now refused at dispatch, before the read-only worktree
+and the job row. The refusal fires only on a sha-shaped value, so a placeholder
+that is not a sha still reaches the review-loop and reviewer-identity refusals
+that name it better.
+
+`--no-fix-target` dispatches a REVIEW-ONLY review: the reviewer need not be able
+to implement and no `--lead` is required. The lead exists so a
+`changes_requested` verdict has an implementer to route to, so declining one is
+a decision, and it is recorded as a `review_no_fix_target` job event stating
+that the dispatching operator owns the follow-up. An UNSTATED absence still
+refuses, and `--no-fix-target` with `--lead` is refused as mutually exclusive.
 
 This exact `(repo, PR, head_sha, decision)` evidence key is intentional: the
 #1419 review panel rejected round counters and other instruments, so this guard

--- a/website/docs/reference/cli.md
+++ b/website/docs/reference/cli.md
@@ -855,13 +855,20 @@ left it unreachable. A citation whose relationship cannot be established at all,
 because the dispatching checkout resolves neither commit, also dispatches: that
 is a fact about the checkout rather than about the citation.
 
-`prompt_head_warning` IS still emitted for a review, and for exactly ONE
-relation: a RECORDED PRIOR HEAD THAT IS NOT AN ANCESTOR. An unresolvable citation
-is silent, and the reason is one layer up rather than in the filter: the scan
-discards any token `rev-parse` cannot resolve, so no warning about it ever
-reaches the filter to be retained. Ancestry is checked BEFORE the recorded-head
-arm, so a commit that is both a prior head and an ancestor is silent - which is
-the ordinary scoped re-review, citing its own previous head.
+`prompt_head_warning` IS still emitted for a review, for two relations rather
+than one. The normal-path relation is a RECORDED PRIOR HEAD THAT IS NOT AN
+ANCESTOR. The second is a citation whose ancestry the classifier could not
+establish: `promptCitationAncestry` returns `known=false` when `IsAncestor`
+errors, and that lands on `promptCommitUnresolved`, which the filter also
+retains. That arm is an INSTRUMENT FAILURE rather than a statement about the
+prompt, and it is deliberately reachable - when the classifier cannot judge a
+citation, nobody has judged it.
+
+Two things are silent. A token the scan itself could not resolve never reaches
+the filter at all, because `dispatchPromptHeadContradictionWarnings` discards it
+before any classification. And on the resolvable path ancestry is checked BEFORE
+the recorded-head arm, so a commit that is both a prior head and an ancestor is
+silent - the ordinary scoped re-review, citing its own previous head.
 Ancestor provenance is silent, because naming the branch base is how a prompt
 states where the work sits. The prior-head arm is the force-push shape - the
 commit really was a head of this pull request and no longer is - so a prompt

--- a/website/docs/reference/cli.md
+++ b/website/docs/reference/cli.md
@@ -853,9 +853,28 @@ how it states provenance. The recorded-head arm reads an append-only store fact
 rather than git, so a legitimate prior head still passes after a force push has
 left it unreachable. A citation whose relationship cannot be established at all,
 because the dispatching checkout resolves neither commit, also dispatches: that
-is a fact about the checkout rather than about the citation. The pre-existing
-`prompt_head_warning` job event is unchanged and still records every non-head
-citation, including the ones that are allowed.
+is a fact about the checkout rather than about the citation. `prompt_head_warning` is no longer
+emitted for a review at all, and that is the consequence of the classification
+above rather than a separate decision: the scan skips a token it cannot resolve,
+and every relation it CAN report is either refused here or stated deliberately,
+so a warning about one taught its reader to ignore the event. Ask and implement
+keep the warning, because no refusal runs in front of them and it is their only
+head check.
+
+`--head-sha` must be the FULL 40 hex characters for a review. An abbreviated
+value used to dispatch and then be cancelled by the daemon's staleness check,
+which compared it against the pull request's full head and reported the same
+commit as a move; it is now refused at dispatch, before the read-only worktree
+and the job row. The refusal fires only on a sha-shaped value, so a placeholder
+that is not a sha still reaches the review-loop and reviewer-identity refusals
+that name it better.
+
+`--no-fix-target` dispatches a REVIEW-ONLY review: the reviewer need not be able
+to implement and no `--lead` is required. The lead exists so a
+`changes_requested` verdict has an implementer to route to, so declining one is
+a decision, and it is recorded as a `review_no_fix_target` job event stating
+that the dispatching operator owns the follow-up. An UNSTATED absence still
+refuses, and `--no-fix-target` with `--lead` is refused as mutually exclusive.
 
 This exact `(repo, PR, head_sha, decision)` evidence key is intentional: the
 #1419 review panel rejected round counters and other instruments, so this guard

--- a/website/docs/reference/cli.md
+++ b/website/docs/reference/cli.md
@@ -864,8 +864,16 @@ retains. That arm is an INSTRUMENT FAILURE rather than a statement about the
 prompt, and it is deliberately reachable - when the classifier cannot judge a
 citation, nobody has judged it.
 
-Two things are silent. A token the scan itself could not resolve never reaches
-the filter at all, because `dispatchPromptHeadContradictionWarnings` discards it
+Retention is PER CITATION: a warning is kept only when the retained relation is
+the one that warning is about, matched on its leading
+`prompt references commit <token>,` clause. That is what makes the two relations
+above exhaustive - an earlier version tested for the token anywhere in the
+warning text, and since every warning names the dispatch head twice, an unjudged
+token that happened to be a hex run from inside that sha could retain a
+DIFFERENT citation's warning.
+
+Two things are silent. A token the scan itself could not resolve produces no
+warning of its own, because `dispatchPromptHeadContradictionWarnings` discards it
 before any classification. And on the resolvable path ancestry is checked BEFORE
 the recorded-head arm, so a commit that is both a prior head and an ancestor is
 silent - the ordinary scoped re-review, citing its own previous head.

--- a/website/docs/reference/cli.md
+++ b/website/docs/reference/cli.md
@@ -855,8 +855,13 @@ left it unreachable. A citation whose relationship cannot be established at all,
 because the dispatching checkout resolves neither commit, also dispatches: that
 is a fact about the checkout rather than about the citation.
 
-`prompt_head_warning` IS still emitted for a review, for exactly the two allowed
-relations nobody has judged: a RECORDED PRIOR HEAD and an UNRESOLVABLE citation.
+`prompt_head_warning` IS still emitted for a review, and for exactly ONE
+relation: a RECORDED PRIOR HEAD THAT IS NOT AN ANCESTOR. An unresolvable citation
+is silent, and the reason is one layer up rather than in the filter: the scan
+discards any token `rev-parse` cannot resolve, so no warning about it ever
+reaches the filter to be retained. Ancestry is checked BEFORE the recorded-head
+arm, so a commit that is both a prior head and an ancestor is silent - which is
+the ordinary scoped re-review, citing its own previous head.
 Ancestor provenance is silent, because naming the branch base is how a prompt
 states where the work sits. The prior-head arm is the force-push shape - the
 commit really was a head of this pull request and no longer is - so a prompt

--- a/website/docs/reference/cli.md
+++ b/website/docs/reference/cli.md
@@ -853,21 +853,29 @@ how it states provenance. The recorded-head arm reads an append-only store fact
 rather than git, so a legitimate prior head still passes after a force push has
 left it unreachable. A citation whose relationship cannot be established at all,
 because the dispatching checkout resolves neither commit, also dispatches: that
-is a fact about the checkout rather than about the citation. `prompt_head_warning` is no longer
-emitted for a review at all, and that is the consequence of the classification
-above rather than a separate decision: the scan skips a token it cannot resolve,
-and every relation it CAN report is either refused here or stated deliberately,
-so a warning about one taught its reader to ignore the event. Ask and implement
-keep the warning, because no refusal runs in front of them and it is their only
-head check.
+is a fact about the checkout rather than about the citation.
+
+`prompt_head_warning` IS still emitted for a review, for exactly the two allowed
+relations nobody has judged: a RECORDED PRIOR HEAD and an UNRESOLVABLE citation.
+Ancestor provenance is silent, because naming the branch base is how a prompt
+states where the work sits. The prior-head arm is the force-push shape - the
+commit really was a head of this pull request and no longer is - so a prompt
+naming it as its target is reviewing a tree that is gone, and that is worth one
+line to its operator even though the dispatch proceeds. Ask and implement keep
+the blanket warning, because no refusal runs in front of them and it is their
+only head check.
 
 `--head-sha` must be the FULL 40 hex characters for a review. An abbreviated
 value used to dispatch and then be cancelled by the daemon's staleness check,
 which compared it against the pull request's full head and reported the same
-commit as a move; it is now refused at dispatch, before the read-only worktree
-and the job row. The refusal fires only on a sha-shaped value, so a placeholder
-that is not a sha still reaches the review-loop and reviewer-identity refusals
-that name it better.
+commit as a move; it is now refused at dispatch, before the read-only worktree,
+the review task row and the job row. The refusal rejects EVERY non-empty value
+that is not exactly 40 hex characters, including a revision expression such as
+`<sha>^` or `<sha>~1`: the daemon binds this value by EQUALITY against the pull
+request's head, so no other shape can bind whatever it looks like. It runs after
+the review-loop and reviewer-identity refusals, so those still name their own
+preconditions first, and before the review task is upserted, so a refused
+dispatch leaves no durable state behind.
 
 `--no-fix-target` dispatches a REVIEW-ONLY review: the reviewer need not be able
 to implement and no `--lead` is required. The lead exists so a

--- a/website/docs/reference/cli.md
+++ b/website/docs/reference/cli.md
@@ -888,10 +888,18 @@ starting its runtime session, Gitmoot loads the lead from the agents database
 and requires that it exist, can access the repository, has `implement`
 capability, and uses a write-granting policy (`workspace-write` or
 `danger-full-access`). Without `--lead`, the reviewer is the fallback lead and
-must pass the same checks; a strict review-only agent therefore needs an
-explicit implementer. Managed-type review dispatches also require an explicit
-DB-backed lead. `--lead` is rejected when `agent run` resolves to ask or
+must pass the same checks. Managed-type review dispatches also require an
+explicit DB-backed lead. `--lead` is rejected when `agent run` resolves to ask or
 implement, and is not accepted by `agent implement` or `orchestrate`.
+
+A strict review-only agent therefore needs either an explicit implementer or
+`--no-fix-target`, which declares that this review has NO fix target and the
+dispatching operator owns the follow-up. That declaration is carried on the job
+payload, not only as an event, because advancement is what decides whether a
+`changes_requested` verdict dispatches a fix at all: such a verdict records
+`auto_fix_skipped_no_fix_target` and leaves its findings open in the ledger
+rather than routing a fix to the reviewer that produced it. `--no-fix-target`
+is rejected outside review and is mutually exclusive with `--lead`.
 
 This dispatch-time lead validation applies only to local CLI reviews started by
 `gitmoot agent review` or review-resolved `gitmoot agent run`. Reviews routed


### PR DESCRIPTION
Fixes #2054, all three defects. Opened as a **draft**: an armed engine merge gate can merge on approval-plus-green with no holder acting, so nothing of mine sits in that shape while it is unreviewed.

Attribution row recorded before requesting review, per the fleet rule of 2026-09-08: `session-implement-gm-transport` for this PR, acting role `gm-transport`, with the head on the `session_job_display` plane.

## 1. An abbreviated `--head-sha` was accepted and cancelled later

The daemon compared the recorded 8-character value against the pull request's 40 and reported `superseded_stale_head: PR #N moved from head "7e4b39d0" to "7e4b39d0ef82…"` - **the same commit**. The review never ran, and the wording sent its operator hunting a push that never happened.

Refused now at dispatch, before the read-only worktree and the job row, because a refusal after the row exists has already spent a worktree, a queue slot and an operator's attention.

**The guard fires only on a sha-shaped value** - hex of the wrong length, or 40 characters that are not hex. That predicate is load-bearing: `head123` and `sha-a` fixtures elsewhere are placeholders, not abbreviations, and the review-loop and reviewer-identity refusals name them far better than a format check can. Preempting those would answer a question nobody asked.

## 2. `agent ask` cannot bind a head, and `agent review` refused review-only dispatch

`--no-fix-target` dispatches a review whose reviewer cannot implement and which names no `--lead`. The lead exists so a `changes_requested` verdict has somewhere to go, so the requirement is **kept and made stateable** rather than removed: the declaration is recorded as a `review_no_fix_target` job event saying the dispatching operator owns the follow-up. An unstated absence still refuses; `--no-fix-target` with `--lead` is refused as mutually exclusive.

## 3. `prompt_head_warning` fired on the routine case

It was identity-based, so for a review it fired on citations the #1819 classifier had **already accepted**: foreign citations refuse before enqueue, leaving the head, an ancestor, a recorded head of this PR, or unresolvable - and the scan skips what it cannot resolve.

**So a review now emits no `prompt_head_warning` at all, and that is the finding rather than a side effect.** Every warning it could produce was deliberate provenance: a scoped re-review MUST name the previous round's head to say what it is re-reviewing. A warning that fires on the routine case teaches its reader to ignore it, and that cost was paid - this warning was used to attribute job ownership on 2026-09-08 and then raised against a scoped re-review citing its own prior head correctly.

Written as a **filter** over the existing scan rather than a deletion, so the scan still runs on the allocated exact-head worktree where it is documented to, and a future relation that IS worth warning about survives instead of being silently swallowed.

**Ask and implement keep theirs, and that boundary has its own test.** They have no refusal in front of them, so the identity scan is their entire head check; silencing it there would remove the check rather than de-duplicate it. Same change, opposite correctness, decided by whether something else already looked.

## Nine mutants, all killed

| Mutant | Killed by |
| --- | --- |
| head guard removed | abbreviated-head refusal test |
| head guard refuses everything | full-sha acceptance test (plus four existing dispatch tests) |
| refusal message drops the expected length | abbreviated-head test asserting it names 40 |
| warning restored to blanket identity | review warning-scope test |
| warning silenced entirely | same test's unresolvable row |
| ask/implement switched to the review scope | ask boundary test |
| `--no-fix-target` ignored | review-only dispatch test |
| mutual exclusion dropped | explicit-lead refusal test |
| decision recorded under another kind | review-only dispatch test |

**Two of those mutants were mine to learn from.** My first version moved the warning scan off the exact-head worktree, which an existing call-count test caught. And my first test asserted an unresolvable citation still warns - an expectation that was wrong about the **existing** scanner rather than about my change, since it `continue`s on any token it cannot resolve.

## One other test's FIXTURE changed, not its assertion

`TestCLIReviewLoopHerdres227Shape` used a 5-character hex head as an arbitrary token while asserting the review-loop refusal 318 times. Its length was never load-bearing, so it now uses a full sha; its subject is unchanged. Every other short-head fixture in the package is non-hex and therefore untouched by the guard.

## Verification

`go build ./...` exit 0, `go vet ./internal/cli` exit 0, and the dispatch, prompt-head, review-loop and readonly-worktree sets green. **No untargeted package run or `./...` gate**: free space is at the fleet dispatch guard and windows are owner-granted. CI is the gate.

Docs updated in both CLI references, including the REMOVAL - a reader who knows `prompt_head_warning` exists needs to be told where it went and that ask and implement still have it.
