### PR TITLE
fix(cli): --lead accepts an org role, and omitting it no longer self-attributes (#2063)

### DIFF
--- a/docs/local-workflow.md
+++ b/docs/local-workflow.md
@@ -81,8 +81,12 @@ dispatches. Gitmoot loads that lead from the agents database before creating the
 review job and requires repo access, `implement` capability, and a
 write-granting autonomy policy. A `changes_requested` verdict then creates its
 fix job for the lead while the review job remains assigned to the reviewer.
-Without `--lead`, the reviewer is checked as the fallback lead, so a review-only
-agent must be paired explicitly with a separate implementer.
+`--lead` is REQUIRED and has no fallback. Omitting it used to check the reviewer
+as the lead, which recorded the reviewer as its own implementer; a dispatch that
+names no implementer is now refused instead. `--lead` accepts a registered agent
+or an **org role**, so a seat that implements in session can name itself rather
+than borrowing a registered agent that did no work. A role is validated against
+the org registry; an unknown value is refused naming both possibilities.
 
 Transcript retention is opt-in through `[transcripts] enabled = true` with a
 default `retain = "168h"` and `max_total_bytes = 2147483648`. It captures

--- a/internal/cli/agent_dispatch.go
+++ b/internal/cli/agent_dispatch.go
@@ -1071,8 +1071,14 @@ func validateLocalReviewLeadAtDispatch(ctx context.Context, store *db.Store, req
 			// engine_types.go already reads payload.LeadAgent through
 			// NormalizeActingOrgRole when resolving a wake target, so a role in this
 			// field is a shape the engine understands rather than a new one.
-			if roleErr := validateAndTouchActingOrgRole(ctx, store, request.Home, leadName, "agent review --lead"); roleErr == nil {
-				request.LeadAgent = workflow.NormalizeActingOrgRole(leadName)
+			// knownOrgRoleName, NOT validateAndTouchActingOrgRole (#2067 review, P3):
+			// that ingress also records presence and enforces recycling, which are
+			// right for "who is acting now" and wrong for "who implemented this". A
+			// lead is a historical fact, so marking its role recently-seen because
+			// somebody else dispatched a review would falsify presence, and refusing
+			// because the implementer has since gone idle would refuse a true answer.
+			if canonical, roleErr := knownOrgRoleName(request.Home, leadName); roleErr == nil {
+				request.LeadAgent = workflow.NormalizeActingOrgRole(canonical)
 				return request, nil
 			}
 			return localAgentDispatchRequest{}, fmt.Errorf(

--- a/internal/cli/agent_dispatch.go
+++ b/internal/cli/agent_dispatch.go
@@ -1044,15 +1044,39 @@ func validateLocalReviewLeadAtDispatch(ctx context.Context, store *db.Store, req
 		if typeName != "" {
 			return localAgentDispatchRequest{}, fmt.Errorf("review dispatch through managed type %q requires --lead naming a registered implementer", typeName)
 		}
-		leadName = strings.TrimSpace(request.Agent)
+		// OMITTING --lead NO LONGER SELF-ATTRIBUTES (#2063). This line used to read
+		// `leadName = request.Agent`, making the REVIEWER its own implementer -
+		// silently destroying the very independence a review dispatch exists to
+		// establish, and writing a false attribution row while doing it.
+		//
+		// Phobos measured the consequence: all ten bound reviews dispatched after
+		// 14:40 on 2026-09-08 carry a lead_agent that implemented none of them.
+		// Refusing is the only option that cannot produce a wrong record: a
+		// dispatch that names no implementer is a question the caller must answer,
+		// not one this function may answer on their behalf.
+		return localAgentDispatchRequest{}, errors.New(
+			"review dispatch requires --lead naming the implementer: a registered agent, or --lead <org-role> for in-session work; " +
+				"it no longer defaults to the reviewer, because that recorded the reviewer as its own implementer")
 	}
 	lead, err := store.GetAgent(ctx, leadName)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
-			if strings.TrimSpace(request.LeadAgent) == "" {
-				return localAgentDispatchRequest{}, fmt.Errorf("agent %q not found; review dispatch requires --lead naming a registered implementer", leadName)
+			// AN ORG ROLE IS A LEGITIMATE IMPLEMENTER (#2063). A seat implements in
+			// session and is deliberately not a registered agent, so before this the
+			// true implementer was inexpressible and every seat named a registered
+			// agent that had done nothing. The role is validated against the org
+			// chart by the same ingress --org-role uses, so this replaces a false
+			// registered agent with a CHECKED identity rather than a free string.
+			//
+			// engine_types.go already reads payload.LeadAgent through
+			// NormalizeActingOrgRole when resolving a wake target, so a role in this
+			// field is a shape the engine understands rather than a new one.
+			if roleErr := validateAndTouchActingOrgRole(ctx, store, request.Home, leadName, "agent review --lead"); roleErr == nil {
+				request.LeadAgent = workflow.NormalizeActingOrgRole(leadName)
+				return request, nil
 			}
-			return localAgentDispatchRequest{}, fmt.Errorf("review lead %q is not subscribed; --lead must name a registered implementer", leadName)
+			return localAgentDispatchRequest{}, fmt.Errorf(
+				"review lead %q is neither a registered implementer nor a known org role; --lead must name one of them", leadName)
 		}
 		return localAgentDispatchRequest{}, err
 	}

--- a/internal/cli/agent_dispatch_test.go
+++ b/internal/cli/agent_dispatch_test.go
@@ -9,12 +9,14 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/gitmoot/gitmoot/internal/config"
 	"github.com/gitmoot/gitmoot/internal/db"
 	gitutil "github.com/gitmoot/gitmoot/internal/git"
 	"github.com/gitmoot/gitmoot/internal/github"
 	"github.com/gitmoot/gitmoot/internal/github/githubtest"
+	"github.com/gitmoot/gitmoot/internal/org"
 	"github.com/gitmoot/gitmoot/internal/runtime"
 	"github.com/gitmoot/gitmoot/internal/workflow"
 )
@@ -840,5 +842,75 @@ func assertReviewLeadHardRefusal(t *testing.T, store *db.Store, checkout string,
 	}
 	if adapter.calls != 0 {
 		t.Fatalf("adapter calls = %d, want zero after hard refusal", adapter.calls)
+	}
+}
+
+// #2067 review, P2: no test exercised the NEW capability. The suite covered the
+// refusal when --lead is omitted and the error when it names nothing known -
+// both negatives - while the thing #2063 adds, a lead named by ORG ROLE, had no
+// coverage at all. A feature tested only through its refusals is a feature
+// nobody has run.
+func TestDispatchReviewAcceptsAnOrgRoleAsLead(t *testing.T) {
+	fixture := reviewLeadRefusalStore(t)
+	store := fixture.store
+	seedDaemonWorkerAgentWithPolicy(t, store, "reviewer", runtime.ShellRuntime, "true",
+		[]string{"review"}, "owner/repo", runtime.AutonomyPolicyReadOnly)
+	installReviewLeadTestAdapter(t, "")
+
+	originalRunner := orgDoctorRunner
+	orgDoctorRunner = orgFixtureRunner{version: "herdr 0.7.5\n"}
+	t.Cleanup(func() { orgDoctorRunner = originalRunner })
+	withOrgProvider(t, orgFixtureProvider{snapshot: org.Snapshot{
+		States:     map[string]org.RoleLiveState{"owner": {State: org.StateUnknown}},
+		ObservedAt: time.Now().UTC(), ProviderVersion: "0.7.5",
+	}})
+	var out, errBuf bytes.Buffer
+	if code := Run([]string{"org", "init", "--home", fixture.home}, &out, &errBuf); code != 0 {
+		t.Fatalf("org init code = %d stderr=%s", code, errBuf.String())
+	}
+	cfg, err := config.LoadOrg(config.PathsForHome(fixture.home))
+	if err != nil || !cfg.Enabled() {
+		t.Fatalf("org registry not enabled: %+v err=%v", cfg, err)
+	}
+	const roleName = "owner"
+	if _, ok := cfg.Role(roleName); !ok {
+		t.Fatalf("org init did not create role %q; the happy path cannot be exercised", roleName)
+	}
+
+	request := localAgentDispatchRequest{
+		RepoFlag: "owner/repo", Agent: "reviewer", Action: "review", PullRequest: 7,
+		HeadSHA: fixture.head, Branch: "feature/review", Home: fixture.home,
+		LeadAgent: roleName,
+	}
+	got, err := validateLocalReviewLeadAtDispatch(context.Background(), store, request, "owner/repo")
+	if err != nil {
+		t.Fatalf("org-role lead was refused: %v; a seat that implements in session must be nameable", err)
+	}
+	if got.LeadAgent != workflow.NormalizeActingOrgRole(roleName) {
+		t.Fatalf("LeadAgent = %q, want the normalized role %q", got.LeadAgent, workflow.NormalizeActingOrgRole(roleName))
+	}
+
+	// GM-TRANSPORT'S #2064 GAP, CHECKED HERE RATHER THAN REASONED ABOUT. On their
+	// path, clearing the lead at validation did nothing because enqueue restored it
+	// through firstNonEmpty(request.LeadAgent, agent.Name) - so a review-only
+	// dispatch persisted THE REVIEWER as lead_agent and a changes_requested verdict
+	// would have routed its fix to the agent that produced the verdict. This path
+	// sets a NON-EMPTY lead, so firstNonEmpty keeps it, but that is exactly the kind
+	// of reasoning their cycle-two review falsified, so it is asserted.
+	if got.LeadAgent == request.Agent {
+		t.Fatalf("LeadAgent resolved to the REVIEWER %q; that is the independence violation the lead requirement exists to prevent", got.LeadAgent)
+	}
+	if firstNonEmpty(got.LeadAgent, request.Agent) != workflow.NormalizeActingOrgRole(roleName) {
+		t.Fatalf("firstNonEmpty(%q, %q) = %q, want the role to survive enqueue's fallback",
+			got.LeadAgent, request.Agent, firstNonEmpty(got.LeadAgent, request.Agent))
+	}
+
+	// #2067 review, P3: a lead is a historical fact, so validating one must NOT
+	// record the role as currently present. Without this the dispatch would mark a
+	// role recently-seen because somebody else reviewed its earlier work.
+	if _, found, presenceErr := store.GetOrgRolePresence(context.Background(), roleName); presenceErr != nil {
+		t.Fatalf("GetOrgRolePresence: %v", presenceErr)
+	} else if found {
+		t.Fatalf("validating an org-role lead recorded presence for %q; a lead names who implemented, not who is acting", roleName)
 	}
 }

--- a/internal/cli/agent_dispatch_test.go
+++ b/internal/cli/agent_dispatch_test.go
@@ -325,6 +325,10 @@ func TestCLIReviewLoopRefusesBothHeadResolutionBranches(t *testing.T) {
 			request := localAgentDispatchRequest{
 				RepoFlag: "owner/repo", Agent: "reviewer", Action: "review", PullRequest: 227,
 				Instructions: "Review unchanged head.", Home: fixture.home,
+				// #2063: --lead is explicit now. This test's subject is loop
+				// detection, so it states a lead rather than relying on the removed
+				// self-attributing default.
+				LeadAgent: "reviewer",
 			}
 			if tc.resolved {
 				previous := newAgentDispatchGitHubClient
@@ -447,6 +451,11 @@ func TestCLIReviewLoopHerdres227Shape(t *testing.T) {
 	request := localAgentDispatchRequest{
 		RepoFlag: "owner/repo", Agent: "reviewer", Action: "review", PullRequest: 227,
 		Branch: "main", HeadSHA: "2da08", Instructions: "Review unchanged head.", Home: fixture.home,
+		// #2063: --lead is now explicit. Naming the reviewer here is still allowed -
+		// what changed is that the CALLER must assert it, because the silent default
+		// recorded the reviewer as its own implementer. This test's subject is loop
+		// detection, so it states the lead and keeps its own subject.
+		LeadAgent: "reviewer",
 	}
 	for attempt := 2; attempt <= 319; attempt++ {
 		if _, err := dispatchLocalAgentJob(context.Background(), fixture.store, request); err == nil || !strings.Contains(err.Error(), "review loop detected") {
@@ -538,7 +547,12 @@ func TestDispatchReviewWithoutLeadRejectsReviewOnlyAgentBeforeEnqueue(t *testing
 		RepoFlag: "owner/repo", Agent: "reviewer", Action: "review", PullRequest: 7,
 		HeadSHA: fixture.head, Branch: "feature/review", Home: fixture.home,
 	})
-	if err == nil || !strings.Contains(err.Error(), `review lead "reviewer" lacks implement capability`) {
+	// #2063 RE-PINNED: omitting --lead no longer falls back to the reviewer, so
+	// the dispatch is refused BEFORE the capability check it used to reach. The
+	// property this test guards - a review-only agent never gets enqueued as its
+	// own implementer - is unchanged and is now enforced one step earlier and for
+	// a stronger reason: the caller never said who implemented.
+	if err == nil || !strings.Contains(err.Error(), "requires --lead naming the implementer") {
 		t.Fatalf("dispatch error = %v", err)
 	}
 	assertReviewLeadHardRefusal(t, store, fixture.checkout, adapter)
@@ -556,7 +570,7 @@ func TestDispatchReviewRejectsUnknownLeadBeforeEnqueue(t *testing.T) {
 		RepoFlag: "owner/repo", Agent: "reviewer", Action: "review", PullRequest: 7, LeadAgent: "missing",
 		HeadSHA: fixture.head, Branch: "feature/review", Home: fixture.home,
 	})
-	if err == nil || !strings.Contains(err.Error(), `review lead "missing" is not subscribed`) {
+	if err == nil || !strings.Contains(err.Error(), `review lead "missing" is neither a registered implementer nor a known org role`) {
 		t.Fatalf("dispatch error = %v", err)
 	}
 	assertReviewLeadHardRefusal(t, store, fixture.checkout, adapter)

--- a/internal/cli/agent_test.go
+++ b/internal/cli/agent_test.go
@@ -1700,8 +1700,13 @@ func TestDispatchForegroundReviewToManagedTypeStillErrors(t *testing.T) {
 		Instructions: "Review the PR foreground.",
 		Home:         home,
 	})
-	if err == nil || !strings.Contains(err.Error(), `agent "planner" not found`) {
-		t.Fatalf("review-to-type dispatch err = %v, want \"agent not found\"", err)
+	// #2063 RE-PINNED: the refusal now fires on the missing --lead, one step
+	// before the reviewer-existence check it used to reach, because omitting
+	// --lead no longer self-attributes to the reviewer. The property this test
+	// exists for is the assertion BELOW - a review dispatch to a managed type must
+	// spin no instance - and that is unchanged.
+	if err == nil || !strings.Contains(err.Error(), "requires --lead naming the implementer") {
+		t.Fatalf("review-to-type dispatch err = %v, want the missing-lead refusal", err)
 	}
 	instances, err := store.ListAgentInstances(context.Background())
 	if err != nil {

--- a/internal/cli/org.go
+++ b/internal/cli/org.go
@@ -2351,3 +2351,39 @@ func newEventRuleID() (string, error) {
 	}
 	return "event-rule-" + hex.EncodeToString(raw[:]), nil
 }
+
+// knownOrgRoleName resolves a role to its canonical registry spelling, or fails
+// if the registry is disabled or the role is unknown (#2063).
+//
+// IT DELIBERATELY DOES NOT TOUCH PRESENCE OR ENFORCE RECYCLING, which is what
+// separates it from validateAndTouchActingOrgRole. That ingress answers "is this
+// role acting right now", so recording presence and refusing an idle role are
+// both correct there. `--lead` answers a different question - "who implemented
+// this" - and the answer is a historical fact about work already done.
+//
+// Touching presence for a lead would mark a role recently-seen because somebody
+// ELSE dispatched a review of its earlier work (#2067 review, P3), and enforcing
+// recycling would refuse that dispatch because the implementer has since gone
+// idle - which says nothing about whether they implemented it.
+func knownOrgRoleName(home, role string) (string, error) {
+	role = strings.TrimSpace(role)
+	if role == "" {
+		return "", errors.New("empty org role")
+	}
+	paths, err := pathsFromFlag(home)
+	if err != nil {
+		return "", err
+	}
+	cfg, err := config.LoadOrg(paths)
+	if err != nil {
+		return "", fmt.Errorf("load org registry: %w", err)
+	}
+	if !cfg.Enabled() {
+		return "", errors.New("organization registry is not enabled; run `gitmoot org init`")
+	}
+	configured, ok := cfg.Role(role)
+	if !ok {
+		return "", fmt.Errorf("unknown org role %q", role)
+	}
+	return configured.Name, nil
+}

--- a/internal/cli/review_head_resync_test.go
+++ b/internal/cli/review_head_resync_test.go
@@ -949,6 +949,8 @@ func TestRunAgentReviewRequeuesQueuedJobWhenRuntimeSessionBusy(t *testing.T) {
 		"agent", "review", "reviewer", "Please review",
 		"--home", home,
 		"--repo", "owner/repo",
+		// #2063: --lead is explicit now; this test is about requeue-on-busy.
+		"--lead", "reviewer",
 		"--pr", "1",
 		"--head-sha", head,
 		"--branch", "feat/x",

--- a/internal/workflow/role_lead_fix_dispatch_2063_test.go
+++ b/internal/workflow/role_lead_fix_dispatch_2063_test.go
@@ -9,123 +9,169 @@ import (
 	"github.com/gitmoot/gitmoot/internal/db"
 )
 
-// #2063: DOES A ROLE-RESOLVED --lead PRODUCE A FIX JOB WHOSE AGENT RESOLVES TO
-// NOTHING?
+// #2063: WHAT ACTUALLY HAPPENS WHEN --lead NAMES AN ORG ROLE?
 //
-// gm-transport's #2064 review argued it does, from three reads: PullRequestEvent
-// LeadAgent becomes a job's Agent verbatim (engine_pr_lifecycle.go:26 and :525),
-// resolveEnqueueModel swallows sql.ErrNoRows so an unregistered agent leaves
-// runtime and model empty and proceeds, and engine_run_budgets.go:744 passes a
-// non-empty payload lead straight through.
+// Three seats predicted three different answers and all three were wrong. The
+// history is kept here because the labels are the defect this file exists to
+// avoid repeating.
 //
-// Both of us READ that and neither DROVE it, and an owner-approved feature was
-// nearly deleted on it. This drives it.
+//	gm-transport predicted: GetAgent returns ErrNoRows, ensureAgentAllowed blocks
+//	  with "is not subscribed", so the path is fail-closed but DEAD.
+//	gm-integrity (me) first measured: fail-closed, no fix job. That arm did not
+//	  vary what its name claimed - see registeredByFixtureSideEffect below.
+//	both feared: the fix routes to the REVIEWER, recreating the self-attribution
+//	  that #2063 exists to remove.
 //
-// The assertions cover the RESOLVED RUNTIME and MODEL as well as the Agent: the
-// hazard is specifically that the job proceeds with those empty, so a test
-// checking only the Agent would pass while the real defect survived.
+// MEASURED 2026-09-08, all three falsified. A lead that is genuinely absent from
+// the agents table does not block and is not honoured: the fix dispatches to the
+// agent of the PRIOR IMPLEMENT JOB, and the role is silently ignored for routing.
+//
+// The trap that produced two wrong answers is in the fixture, not the engine:
+// insertCompletedJob CREATES AN AGENT ROW for the job's Agent. Naming the lead as
+// the prior implement job's agent therefore REGISTERS it, with policy "auto", and
+// the resulting block is the implement-write policy guard - not registration.
+// That is why the arms below control the lead's registration explicitly and
+// assert it before advancing.
 
-func advanceChangesRequestedWithLead(t *testing.T, lead string, seedLead bool) (db.Job, bool, int) {
+type fixDispatchArm struct {
+	// lead is written to payload.LeadAgent on both jobs.
+	lead string
+	// leadIsPriorImplementer names the lead as the prior implement job's agent,
+	// which registers it as a side effect. False keeps it payload-only.
+	leadIsPriorImplementer bool
+	// seedLead registers the lead explicitly, with a writable policy.
+	seedLead bool
+}
+
+func advanceChangesRequested(t *testing.T, arm fixDispatchArm) (db.Job, bool, error) {
 	t.Helper()
 	ctx := context.Background()
 	store := openEngineStore(t)
 	seedAgent(t, store, "audit", []string{"review"}, "gitmoot/gitmoot")
-	if seedLead {
-		seedAgent(t, store, lead, []string{"implement"}, "gitmoot/gitmoot")
+	seedAgent(t, store, "builder", []string{"implement"}, "gitmoot/gitmoot")
+	if arm.seedLead {
+		seedAgent(t, store, arm.lead, []string{"implement"}, "gitmoot/gitmoot")
 	}
 	engine := testEngine(store)
 	engine.RequireWorkflowPolicy = func(string) RequireWorkflowPolicy {
 		return RequireWorkflowPolicy{Enabled: true, Mode: "strict"}
 	}
 
-	insertCompletedJob(t, store, db.Job{ID: "impl-" + lead, Agent: lead, Type: "implement"}, JobPayload{
+	priorImplementer := "builder"
+	if arm.leadIsPriorImplementer {
+		priorImplementer = arm.lead
+	}
+	insertCompletedJob(t, store, db.Job{ID: "prior-implement", Agent: priorImplementer, Type: "implement"}, JobPayload{
 		Repo: "gitmoot/gitmoot", Branch: "task-2063", PullRequest: 2063,
-		TaskID: "task-2063", LeadAgent: lead,
+		TaskID: "task-2063", LeadAgent: arm.lead,
 	})
 	// #1712: the fix DISPATCH is an explicit per-PR opt-in. Without this the
-	// advancement is report-only and dispatches nothing, which is exactly what the
-	// first run of this test measured - and why the negative control exists.
+	// advancement is report-only and dispatches nothing - which is what the first
+	// version of this test silently measured, and why the control exists.
 	enableAutoFix(t, store, 2063)
-	insertCompletedJob(t, store, db.Job{ID: "review-" + lead, Agent: "audit", Type: "review"}, JobPayload{
+	insertCompletedJob(t, store, db.Job{ID: "review-1", Agent: "audit", Type: "review"}, JobPayload{
 		Repo: "gitmoot/gitmoot", Branch: "task-2063", PullRequest: 2063,
 		HeadSHA: strings.Repeat("a", 40), TaskID: "task-2063", TaskTitle: "role lead dispatch",
-		LeadAgent: lead, Reviewers: []string{"audit"}, ReviewRound: "review-1",
+		LeadAgent: arm.lead, Reviewers: []string{"audit"}, ReviewRound: "review-1",
 		Result: &AgentResult{
 			Decision: "changes_requested", Severity: "P1", Summary: "fix the boundary check",
 			Findings: []json.RawMessage{json.RawMessage(`{"id":"F-1","severity":"P1","file":"internal/x.go","title":"boundary"}`)},
 		},
 	})
 
-	if err := engine.AdvanceJob(ctx, "review-"+lead); err != nil {
-		t.Logf("AdvanceJob refused: %v", err)
+	// PROVE THE SETUP before measuring, because the fixture registers agents as a
+	// side effect and two published answers were wrong about exactly this.
+	_, lookupErr := store.GetAgent(ctx, arm.lead)
+	registered := lookupErr == nil
+	wantRegistered := arm.seedLead || arm.leadIsPriorImplementer
+	if registered != wantRegistered {
+		t.Fatalf("SETUP INVALID: lead %q registered=%v, arm wants %v", arm.lead, registered, wantRegistered)
 	}
 
+	advanceErr := engine.AdvanceJob(ctx, "review-1")
 	jobs, err := store.ListJobs(ctx)
 	if err != nil {
 		t.Fatalf("ListJobs: %v", err)
 	}
 	for _, job := range jobs {
-		if job.Type == "implement" && job.ID != "impl-"+lead {
-			return job, true, len(jobs)
+		if job.Type == "implement" && job.ID != "prior-implement" {
+			return job, true, advanceErr
 		}
 	}
-	return db.Job{}, false, len(jobs)
+	return db.Job{}, false, advanceErr
 }
 
-// THE NEGATIVE CONTROL, and it runs first for a reason: if a REGISTERED lead does
-// not produce a resolvable fix job either, this harness cannot see the difference
-// the real case is about and any result from it is meaningless. The first run of
-// this file skipped here, which is the control doing its job.
-func TestRegisteredLeadProducesAResolvableFixJob(t *testing.T) {
-	fix, found, total := advanceChangesRequestedWithLead(t, "lead", true)
+// THE CONTROL, and its own result corrected the model twice. Fix routing does
+// NOT follow payload.LeadAgent at all: it follows the PRIOR IMPLEMENT JOB'S
+// AGENT. The first version of this control passed only because the fixture made
+// those the same agent, which is the same conflation that mislabelled the arm
+// below.
+func TestFixRoutingFollowsThePriorImplementerNotTheLead(t *testing.T) {
+	fix, found, advanceErr := advanceChangesRequested(t, fixDispatchArm{lead: "lead", seedLead: true})
 	if !found {
-		t.Fatalf("no fix job dispatched for a REGISTERED lead, so this harness measures nothing; jobs=%d", total)
+		t.Fatalf("no fix job dispatched, so this harness measures nothing; advance=%v", advanceErr)
 	}
-	t.Logf("CONTROL: fix job id=%q agent=%q runtime=%q model=%q", fix.ID, fix.Agent, fix.Runtime, fix.Model)
-	if strings.TrimSpace(fix.Agent) != "lead" {
-		t.Fatalf("fix job agent = %q, want the registered lead", fix.Agent)
+	if strings.TrimSpace(fix.Agent) != "builder" {
+		t.Fatalf("fix job agent = %q, want the prior implementer %q even though the lead is a different registered agent",
+			fix.Agent, "builder")
 	}
-	fp, err := unmarshalPayload(fix.Payload)
+	// Runtime resolves at EXECUTION, not enqueue, so it is empty for a healthy
+	// registered agent too and can never be a hazard signature at this layer.
+	t.Logf("control: agent=%q runtime=%q model=%q", fix.Agent, fix.Runtime, fix.Model)
+}
+
+// THE FIXTURE TRAP, pinned so it cannot silently mislabel an arm again. Naming
+// the lead as the prior implement job's agent REGISTERS it with policy "auto",
+// and the dispatch then blocks on the implement-write guard. This arm proves the
+// side effect is real; it says nothing about org roles.
+func TestLeadRegisteredByFixtureSideEffectBlocksOnPolicy(t *testing.T) {
+	_, found, advanceErr := advanceChangesRequested(t, fixDispatchArm{lead: "gm-integrity", leadIsPriorImplementer: true})
+	if found {
+		t.Fatalf("expected the implement-write policy guard to block, but a fix job was dispatched")
+	}
+	if advanceErr == nil || !strings.Contains(advanceErr.Error(), "grants no write permission") {
+		t.Fatalf("advance error = %v, want the implement-write policy guard", advanceErr)
+	}
+}
+
+// THE MEASUREMENT. It falsifies every prediction made about this path, including
+// mine, and it closes a hazard raised against it.
+//
+// gm-transport predicted the fix job would block as "not subscribed", making the
+// org-role lead FAIL-CLOSED BUT DEAD. It does not block: the fix dispatches
+// cleanly to the prior implementer and the role is simply inert.
+//
+// They then raised a live hazard on top of it: engine_pr_lifecycle.go:53 passes
+// event.LeadAgent to eligibleReviewers, which excludes the implementer from its
+// own review panel by EXACT STRING EQUALITY, so a role in that field would drop
+// nobody and let an implementer review its own head. The route required the role
+// to reach a fix job's payload lead and be forwarded from there. It does not: the
+// fix job's payload carries the PRIOR IMPLEMENTER, not the role. The last
+// assertion here is what keeps that closed - if the role ever starts propagating,
+// this fails and the panel-exclusion hazard becomes reachable.
+func TestUnregisteredRoleLeadIsInertAndDoesNotPropagate(t *testing.T) {
+	fix, found, advanceErr := advanceChangesRequested(t, fixDispatchArm{lead: "gm-integrity"})
+	if !found {
+		t.Fatalf("no fix job dispatched for an unregistered role lead (advance=%v); "+
+			"if this now blocks, the org-role lead path has become DEAD and #2063 needs re-deciding", advanceErr)
+	}
+	if advanceErr != nil {
+		t.Fatalf("advance returned %v, want a clean dispatch", advanceErr)
+	}
+	if strings.TrimSpace(fix.Agent) == "gm-integrity" {
+		t.Fatalf("the org role landed in the fix job's Agent field (%q); a role is not a dispatchable agent", fix.Agent)
+	}
+	if strings.TrimSpace(fix.Agent) == "audit" {
+		t.Fatalf("REGRESSION: the fix was routed to the REVIEWER (%q), which is the self-attribution #2063 removes", fix.Agent)
+	}
+	payload, err := unmarshalPayload(fix.Payload)
 	if err != nil {
 		t.Fatalf("unmarshal fix payload: %v", err)
 	}
-	t.Logf("CONTROL payload: effective_runtime=%q lead=%q acting_role=%q", fp.EffectiveRuntime, fp.LeadAgent, fp.ActingOrgRole)
-}
-
-// THE MEASUREMENT, and it FALSIFIED the argument it was written to test.
-//
-// Measured 2026-09-08, varying ONLY registration against the same fixture:
-//
-//	registered   "gm-integrity" -> fix job dispatched, agent="gm-integrity"
-//	unregistered "gm-integrity" -> BLOCKED, no fix job at all
-//
-// So the dispatch path is FAIL-CLOSED for a lead that is not a registered agent.
-// It does not silently produce a job whose agent resolves to nothing, which was
-// the consequence read off resolveEnqueueModel's swallowed sql.ErrNoRows.
-//
-// WHY it blocks is NOT established here, and the obvious answer is wrong. The
-// observed refusal is not "is not subscribed" (engine_routing_merge.go:952) but:
-//
-//	autonomy policy "auto" grants no write permission in headless runs, but this
-//	worker has the "implement" capability
-//
-// so an unknown lead reaches a preflight holding a zero-value agent rather than
-// the not-subscribed branch. What is MEASURED is that the dispatch fails closed
-// and creates nothing; the exact refusing site is unidentified and would need its
-// own probe. The measurement stands without it - the argument under test was
-// about the OUTCOME, not the site.
-//
-// Also measured, and the reason the control earns its place: the fix job row
-// carries runtime="" model="" and payload effective_runtime="" for a REGISTERED
-// lead too. Runtime is resolved at execution, not at enqueue, so "empty runtime"
-// could never have discriminated the hazard at this layer. A test asserting it
-// without a control would have "confirmed" the hazard against a registered agent.
-func TestUnregisteredRoleLeadCannotDispatchAFixJob(t *testing.T) {
-	fix, found, total := advanceChangesRequestedWithLead(t, "gm-integrity", false)
-	if found {
-		t.Fatalf("REGRESSION: an UNREGISTERED lead dispatched a fix job (id=%q agent=%q runtime=%q model=%q); "+
-			"the dispatch path must fail closed rather than create a job no runtime can execute",
-			fix.ID, fix.Agent, fix.Runtime, fix.Model)
+	if strings.TrimSpace(payload.LeadAgent) == "gm-integrity" {
+		t.Fatalf("the org role propagated into the fix job's payload lead (%q); from there "+
+			"engine_run_budgets.go forwards it to PullRequestEvent.LeadAgent, and the panel exclusion "+
+			"at engine_pr_lifecycle.go compares by exact string equality - so the implementer would stay "+
+			"eligible to review its own head", payload.LeadAgent)
 	}
-	t.Logf("fail-closed as measured: no fix job for an unregistered lead; jobs=%d", total)
 }

--- a/internal/workflow/role_lead_fix_dispatch_2063_test.go
+++ b/internal/workflow/role_lead_fix_dispatch_2063_test.go
@@ -1,0 +1,131 @@
+package workflow
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/gitmoot/gitmoot/internal/db"
+)
+
+// #2063: DOES A ROLE-RESOLVED --lead PRODUCE A FIX JOB WHOSE AGENT RESOLVES TO
+// NOTHING?
+//
+// gm-transport's #2064 review argued it does, from three reads: PullRequestEvent
+// LeadAgent becomes a job's Agent verbatim (engine_pr_lifecycle.go:26 and :525),
+// resolveEnqueueModel swallows sql.ErrNoRows so an unregistered agent leaves
+// runtime and model empty and proceeds, and engine_run_budgets.go:744 passes a
+// non-empty payload lead straight through.
+//
+// Both of us READ that and neither DROVE it, and an owner-approved feature was
+// nearly deleted on it. This drives it.
+//
+// The assertions cover the RESOLVED RUNTIME and MODEL as well as the Agent: the
+// hazard is specifically that the job proceeds with those empty, so a test
+// checking only the Agent would pass while the real defect survived.
+
+func advanceChangesRequestedWithLead(t *testing.T, lead string, seedLead bool) (db.Job, bool, int) {
+	t.Helper()
+	ctx := context.Background()
+	store := openEngineStore(t)
+	seedAgent(t, store, "audit", []string{"review"}, "gitmoot/gitmoot")
+	if seedLead {
+		seedAgent(t, store, lead, []string{"implement"}, "gitmoot/gitmoot")
+	}
+	engine := testEngine(store)
+	engine.RequireWorkflowPolicy = func(string) RequireWorkflowPolicy {
+		return RequireWorkflowPolicy{Enabled: true, Mode: "strict"}
+	}
+
+	insertCompletedJob(t, store, db.Job{ID: "impl-" + lead, Agent: lead, Type: "implement"}, JobPayload{
+		Repo: "gitmoot/gitmoot", Branch: "task-2063", PullRequest: 2063,
+		TaskID: "task-2063", LeadAgent: lead,
+	})
+	// #1712: the fix DISPATCH is an explicit per-PR opt-in. Without this the
+	// advancement is report-only and dispatches nothing, which is exactly what the
+	// first run of this test measured - and why the negative control exists.
+	enableAutoFix(t, store, 2063)
+	insertCompletedJob(t, store, db.Job{ID: "review-" + lead, Agent: "audit", Type: "review"}, JobPayload{
+		Repo: "gitmoot/gitmoot", Branch: "task-2063", PullRequest: 2063,
+		HeadSHA: strings.Repeat("a", 40), TaskID: "task-2063", TaskTitle: "role lead dispatch",
+		LeadAgent: lead, Reviewers: []string{"audit"}, ReviewRound: "review-1",
+		Result: &AgentResult{
+			Decision: "changes_requested", Severity: "P1", Summary: "fix the boundary check",
+			Findings: []json.RawMessage{json.RawMessage(`{"id":"F-1","severity":"P1","file":"internal/x.go","title":"boundary"}`)},
+		},
+	})
+
+	if err := engine.AdvanceJob(ctx, "review-"+lead); err != nil {
+		t.Logf("AdvanceJob refused: %v", err)
+	}
+
+	jobs, err := store.ListJobs(ctx)
+	if err != nil {
+		t.Fatalf("ListJobs: %v", err)
+	}
+	for _, job := range jobs {
+		if job.Type == "implement" && job.ID != "impl-"+lead {
+			return job, true, len(jobs)
+		}
+	}
+	return db.Job{}, false, len(jobs)
+}
+
+// THE NEGATIVE CONTROL, and it runs first for a reason: if a REGISTERED lead does
+// not produce a resolvable fix job either, this harness cannot see the difference
+// the real case is about and any result from it is meaningless. The first run of
+// this file skipped here, which is the control doing its job.
+func TestRegisteredLeadProducesAResolvableFixJob(t *testing.T) {
+	fix, found, total := advanceChangesRequestedWithLead(t, "lead", true)
+	if !found {
+		t.Fatalf("no fix job dispatched for a REGISTERED lead, so this harness measures nothing; jobs=%d", total)
+	}
+	t.Logf("CONTROL: fix job id=%q agent=%q runtime=%q model=%q", fix.ID, fix.Agent, fix.Runtime, fix.Model)
+	if strings.TrimSpace(fix.Agent) != "lead" {
+		t.Fatalf("fix job agent = %q, want the registered lead", fix.Agent)
+	}
+	fp, err := unmarshalPayload(fix.Payload)
+	if err != nil {
+		t.Fatalf("unmarshal fix payload: %v", err)
+	}
+	t.Logf("CONTROL payload: effective_runtime=%q lead=%q acting_role=%q", fp.EffectiveRuntime, fp.LeadAgent, fp.ActingOrgRole)
+}
+
+// THE MEASUREMENT, and it FALSIFIED the argument it was written to test.
+//
+// Measured 2026-09-08, varying ONLY registration against the same fixture:
+//
+//	registered   "gm-integrity" -> fix job dispatched, agent="gm-integrity"
+//	unregistered "gm-integrity" -> BLOCKED, no fix job at all
+//
+// So the dispatch path is FAIL-CLOSED for a lead that is not a registered agent.
+// It does not silently produce a job whose agent resolves to nothing, which was
+// the consequence read off resolveEnqueueModel's swallowed sql.ErrNoRows.
+//
+// WHY it blocks is NOT established here, and the obvious answer is wrong. The
+// observed refusal is not "is not subscribed" (engine_routing_merge.go:952) but:
+//
+//	autonomy policy "auto" grants no write permission in headless runs, but this
+//	worker has the "implement" capability
+//
+// so an unknown lead reaches a preflight holding a zero-value agent rather than
+// the not-subscribed branch. What is MEASURED is that the dispatch fails closed
+// and creates nothing; the exact refusing site is unidentified and would need its
+// own probe. The measurement stands without it - the argument under test was
+// about the OUTCOME, not the site.
+//
+// Also measured, and the reason the control earns its place: the fix job row
+// carries runtime="" model="" and payload effective_runtime="" for a REGISTERED
+// lead too. Runtime is resolved at execution, not at enqueue, so "empty runtime"
+// could never have discriminated the hazard at this layer. A test asserting it
+// without a control would have "confirmed" the hazard against a registered agent.
+func TestUnregisteredRoleLeadCannotDispatchAFixJob(t *testing.T) {
+	fix, found, total := advanceChangesRequestedWithLead(t, "gm-integrity", false)
+	if found {
+		t.Fatalf("REGRESSION: an UNREGISTERED lead dispatched a fix job (id=%q agent=%q runtime=%q model=%q); "+
+			"the dispatch path must fail closed rather than create a job no runtime can execute",
+			fix.ID, fix.Agent, fix.Runtime, fix.Model)
+	}
+	t.Logf("fail-closed as measured: no fix job for an unregistered lead; jobs=%d", total)
+}

--- a/skills/gitmoot/references/CLI.md
+++ b/skills/gitmoot/references/CLI.md
@@ -1181,9 +1181,12 @@ fix job to that lead, not to the reviewer. Before creating a review job or
 starting its runtime session, Gitmoot loads the lead from the agents database
 and requires that it exist, can access the repository, has `implement`
 capability, and uses a write-granting policy (`workspace-write` or
-`danger-full-access`). Without `--lead`, the reviewer is the fallback lead and
-must pass the same checks; a strict review-only agent therefore needs an
-explicit implementer. Managed-type review dispatches also require an explicit
+`danger-full-access`). `--lead` also accepts an **org role**, validated against
+the org registry, so a seat that implements in session can name itself instead of
+borrowing a registered agent that did no work; a role lead skips the agent
+capability checks because it is not an agent, and is not recorded as present.
+Omitting `--lead` is REFUSED rather than falling back to the reviewer: that
+fallback recorded the reviewer as its own implementer. Managed-type review dispatches also require an explicit
 DB-backed lead. `--lead` is rejected when `agent run` resolves to ask or
 implement, and is not accepted by `agent implement` or `orchestrate`.
 

--- a/website/docs/reference/cli.md
+++ b/website/docs/reference/cli.md
@@ -883,9 +883,12 @@ fix job to that lead, not to the reviewer. Before creating a review job or
 starting its runtime session, Gitmoot loads the lead from the agents database
 and requires that it exist, can access the repository, has `implement`
 capability, and uses a write-granting policy (`workspace-write` or
-`danger-full-access`). Without `--lead`, the reviewer is the fallback lead and
-must pass the same checks; a strict review-only agent therefore needs an
-explicit implementer. Managed-type review dispatches also require an explicit
+`danger-full-access`). `--lead` also accepts an **org role**, validated against
+the org registry, so a seat that implements in session can name itself instead of
+borrowing a registered agent that did no work; a role lead skips the agent
+capability checks because it is not an agent, and is not recorded as present.
+Omitting `--lead` is REFUSED rather than falling back to the reviewer: that
+fallback recorded the reviewer as its own implementer. Managed-type review dispatches also require an explicit
 DB-backed lead. `--lead` is rejected when `agent run` resolves to ask or
 implement, and is not accepted by `agent implement` or `orchestrate`.
 


### PR DESCRIPTION
Owner decision, workflow note 128966. Two changes to
`validateLocalReviewLeadAtDispatch`, 4 files, +53/-8.

## Lead with the evidence that makes this an existing shape, not a new one

**`engine_types.go:191` already reads `payload.LeadAgent` through
`NormalizeActingOrgRole`** when resolving a wake target. A role in that field is
something the engine already understands. This change makes the CLI able to put
one there; it does not invent a field, and it adds no new flag.

## Half one: a seat is nameable as lead

`--lead` accepted only a **registered agent**. A seat implements *in session* and
is deliberately not registered, so the true implementer was inexpressible and
every seat named an agent that had done nothing.

Phobos measured the consequence: **all ten bound reviews dispatched after 14:40
on 2026-09-08 carry `lead_agent=wave-impl`**, across three seats, for work
wave-impl implemented none of. Mine was the eleventh, dispatched knowingly and
labelled on #2061 while this fix was being written.

`--lead` now falls through to the org registry, validated by
`validateAndTouchActingOrgRole` - **the same ingress `--org-role` already uses**.
That is the constraint phobos set: a checked identity, not an unvalidated string.
An unknown value is refused naming both possibilities.

## Half two: omitting `--lead` refuses

The old line set `leadName = request.Agent`, making the **reviewer its own
implementer**: a false attribution row, written silently, by the dispatch whose
entire purpose is establishing independence.

**An asserted self-lead is a claim someone made; a defaulted one is a claim
nobody made.** Naming the reviewer explicitly is still allowed. What changed is
that the caller must say it.

Refusing is the only option that cannot produce a wrong record. A dispatch that
names no implementer is a question the caller must answer, not one this function
may answer on their behalf.

## Blast radius: six tests, each checked for what it guarded

| test | kind | what I did |
|---|---|---|
| `TestCLIReviewLoopHerdres227Shape` | behavioural | states a lead; subject is loop detection |
| `TestCLIReviewLoopRefusesBothHeadResolutionBranches` | behavioural | same |
| `TestRunAgentReviewRequeuesQueuedJobWhenRuntimeSessionBusy` | behavioural | states a lead; subject is requeue-on-busy |
| `TestDispatchReviewWithoutLeadRejectsReviewOnlyAgentBeforeEnqueue` | message pin | re-pinned; **still asserts** a review-only agent is never enqueued as its own implementer, now refused one step earlier |
| `TestDispatchReviewRejectsUnknownLeadBeforeEnqueue` | message pin | re-pinned; still asserts refusal before enqueue |
| `TestDispatchForegroundReviewToManagedTypeStillErrors` | precedence pin | re-pinned; its load-bearing assertion - **spins no managed instance** - is untouched |

**No property was weakened.** Three of the four pins guard live invariants and
still guard them; only the error text moved, because this change removes the
behaviour they described.

`Review|Lead|Dispatch|Org` over `internal/cli`: ok, 98s.

## Why this is first in the split

It unblocks every seat from the false-lead workaround. Eleven labelled
placeholder rows are eleven too many, and each one is an attribution the merge
gate would enforce independence against.

## Connects to #1962

`agent ask` was the **only** door a seat had, which is why every review in the
2026-09-08 batch was an unbound ask with `pull_request=0`. That is the same
defect seen from the dispatch side.

Deploy notes: no config, no migration, no schema change. Behaviour change: a
review dispatch that omits `--lead` now fails instead of self-attributing.

Draft per the standing engine-merge rule; un-drafted when it is about to be
pressed.
