### PR TITLE
fix(workflow): gate the behind-merge exemption on conflict, not compare status (#2068)

### DIFF
--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -1884,7 +1884,12 @@ func (f *mergeGateRaceGitHub) CreateCommitStatus(_ context.Context, input github
 }
 
 func (f *mergeGateRaceGitHub) CompareCommits(context.Context, github.Repository, string, string) (github.CompareResult, error) {
-	return github.CompareResult{Status: "ahead"}, nil
+	// #2074 round four, P2: AHEAD CARRIES A POSITIVE ahead_by. GitHub's producer
+	// does not emit status=ahead with ahead_by=0 - the exact PR ancestry probe on
+	// this repo returned status=ahead, ahead_by=5, behind_by=0 - so the zero left
+	// this fake describing a tuple the API cannot produce. `identical` is the
+	// status that carries zero on both axes.
+	return github.CompareResult{Status: "ahead", AheadBy: 3}, nil
 }
 
 func (f *mergeGateRaceGitHub) MergePullRequest(_ context.Context, input github.MergePullRequestInput) (github.MergeResult, error) {

--- a/internal/daemon/merge_gate_transient_exit_test.go
+++ b/internal/daemon/merge_gate_transient_exit_test.go
@@ -101,14 +101,29 @@ func seedBlockedReviewTaskAttributed(t *testing.T, store *db.Store, repo github.
 			t.Fatalf("AddTaskEvent(merge_gate_blocked) returned error: %v", err)
 		}
 	}
+	// #2074: MERGEABILITY IS STATED, because the omission modelled a state
+	// production does not reach. GitHub's `mergeable` is null only while it is
+	// still COMPUTING, and it never merges a pull request whose mergeability it
+	// has not computed - so a fixture that omits the field and then expects a
+	// merge describes an unreachable scenario, not a scenario the gate should
+	// support. `pipeline_auto_merge.go:121` already treated nil as WAITING before
+	// this gate did, and two sibling fixtures in this same package state the
+	// field explicitly (`daemon_test.go:1827`,
+	// `external_merge_reconcile_test.go:251`). The omission here was an oversight.
+	//
+	// The nil case is not lost with it: TestTransientMergeGateDoesNotMerge
+	// WhenMergeabilityIsUnknown below pins nil to pending directly, so the behaviour
+	// this fixture used to exercise by accident is now asserted on purpose.
+	mergeable := true
 	return github.PullRequest{
-		Number:  1699,
-		Title:   "Review PR #1699",
-		State:   "open",
-		URL:     "https://github.com/gitmoot/gitmoot/pull/1699",
-		HeadRef: "task-1699",
-		BaseRef: "main",
-		HeadSHA: "3f3a1026",
+		Number:    1699,
+		Title:     "Review PR #1699",
+		State:     "open",
+		URL:       "https://github.com/gitmoot/gitmoot/pull/1699",
+		HeadRef:   "task-1699",
+		BaseRef:   "main",
+		HeadSHA:   "3f3a1026",
+		Mergeable: &mergeable,
 	}
 }
 
@@ -837,5 +852,92 @@ func TestMergeGateBlockClassSurvivesTheBlockingCallStack(t *testing.T) {
 	}
 	if gate.BlockClass != int(workflow.MergeBlockNone) {
 		t.Fatalf("pending row block class = %d, want MergeBlockNone", gate.BlockClass)
+	}
+}
+
+// #2074. UNKNOWN MERGEABILITY MUST NOT MERGE, ASSERTED IN THE PACKAGE THAT
+// DRIVES THE GATE.
+//
+// THIS MIRRORS THE TEST ABOVE EXACTLY AND CHANGES ONE FIELD: Mergeable is nil.
+// That is deliberate and it is the second version of this test. My first version
+// built its own shorter fixture and asserted only "not merged" - which is true
+// under the fix AND under the mutant that removes it, because the shorter setup
+// never reached a merge at all. It passed while pinning nothing, and the mutant
+// run is what exposed it.
+//
+// Mirroring the passing sequence makes the comparison exact: the test above
+// reaches ONE merge with mergeability stated, so reaching ZERO here can only be
+// the mergeability guard.
+func TestTransientMergeGateDoesNotMergeWhenMergeabilityIsUnknown(t *testing.T) {
+	ctx := context.Background()
+	store := testStore(t)
+	repo := github.Repository{Owner: "gitmoot", Name: "gitmoot"}
+	pull := seedBlockedReviewTask(t, store, repo, workflow.MergeBlockTransient, "local worktree is not clean")
+	// THE ONE DIFFERENCE from the passing case.
+	pull.Mergeable = nil
+	initialTask, err := store.GetTask(ctx, "review-pr-1699-3f3a1026")
+	if err != nil {
+		t.Fatal(err)
+	}
+	implementPayload, err := json.Marshal(workflow.JobPayload{
+		Repo: repo.FullName(), Branch: pull.HeadRef, PullRequest: int(pull.Number),
+		HeadSHA: pull.HeadSHA, TaskID: initialTask.ID,
+		Result: &workflow.AgentResult{Decision: "implemented", Summary: "implemented current head"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := store.CreateJob(ctx, db.Job{
+		ID: "implement-current-1699", Agent: "implementer", Type: "implement",
+		State: string(workflow.JobSucceeded), Payload: string(implementPayload),
+	}); err != nil {
+		t.Fatalf("CreateJob(implement-current-1699) returned error: %v", err)
+	}
+	client := &mergeGateRaceGitHub{
+		fakeGitHub: &fakeGitHub{
+			pulls:    []github.PullRequest{pull},
+			comments: map[int64][]github.IssueComment{pull.Number: {}},
+		},
+		checks: []github.PullRequestCheck{{Name: "ci", Bucket: "pass", State: "SUCCESS"}},
+		statuses: []github.CommitStatusInput{{
+			Repo: repo, SHA: pull.HeadSHA, State: "success", Context: "ci",
+		}},
+		statusSucceeded: []bool{true},
+	}
+	git := &delayedClearanceMergeGateGit{}
+	gate := &workflow.PolicyMergeGate{AutoMerge: true, Store: store, GitHub: client, Git: git}
+	engine := workflow.Engine{Store: store, MergeGate: gate}
+	now := time.Now().UTC().Add(time.Hour)
+	daemon := Daemon{
+		Repo: repo, Store: store, GitHub: client, Workflow: &engine,
+		Now: func() time.Time { return now },
+	}
+	poll := func(label string) {
+		t.Helper()
+		pollErr := daemon.PollOnce(ctx)
+		var blocked workflow.BlockedError
+		if pollErr != nil && !errors.As(pollErr, &blocked) {
+			t.Fatalf("%s: %v", label, pollErr)
+		}
+	}
+	for attempt := 1; attempt <= 3; attempt++ {
+		poll(fmt.Sprintf("release %d", attempt))
+		poll(fmt.Sprintf("dirty evaluation %d", attempt))
+		now = now.Add(transientMergeGateRetryInterval + time.Second)
+	}
+	git.clean = true
+	poll("release after real condition clearance")
+	poll("evaluate after real condition clearance")
+
+	task, err := store.GetTask(ctx, initialTask.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// THE DISCRIMINATOR. The mirrored test above reaches exactly one merge here.
+	if len(client.merges) != 0 {
+		t.Fatalf("merged with mergeability GitHub has not computed: merges=%+v task=%+v", client.merges, task)
+	}
+	if task.State == string(workflow.TaskMerged) {
+		t.Fatalf("task reached merged with unknown mergeability: %+v", task)
 	}
 }

--- a/internal/workflow/merge_gate.go
+++ b/internal/workflow/merge_gate.go
@@ -1953,12 +1953,31 @@ func (g PolicyMergeGate) ensureBranchFresh(ctx context.Context, repo github.Repo
 	}
 	status := strings.ToLower(strings.TrimSpace(compare.Status))
 	if compare.BehindBy > 0 || status == "behind" || status == "diverged" {
-		if status != "diverged" && g.baseAllowsBehindMerge(ctx, repo, base) {
-			// #1865: merely behind, and GitHub does not require an up-to-date
-			// head here. Requesting the update at this point would create a
-			// merge commit and supersede the head the verdict is bound to
-			// within seconds, buying a fresh paid review round. Merge the
+		if mergeableWithoutConflict(pr) && g.baseAllowsBehindMerge(ctx, repo, base) {
+			// #1865: the base has moved, and GitHub does not require an
+			// up-to-date head here. Requesting the update at this point would
+			// create a merge commit and supersede the head the verdict is bound
+			// to within seconds, buying a fresh paid review round. Merge the
 			// reviewed head instead.
+			//
+			// #2068: THE DISCRIMINATOR IS CONFLICT, NOT COMPARE STATUS. This
+			// read `status != "diverged"` and so could not fire for any pull
+			// request: GitHub reports "diverged" for any branch carrying its own
+			// commits, and "behind" requires ahead_by == 0, which is not a PR.
+			// Measured 2026-09-08 on this repo, five of five open PRs reported
+			// diverged (behind_by 2..9, ahead_by 1..5) and zero reported behind,
+			// so the exemption was unreachable and every base move re-entered
+			// the update path - the churn #1865 exists to prevent.
+			//
+			// "diverged" answers "do both refs have unique commits", which is
+			// true of every open PR the moment its base moves. It does NOT mean
+			// the merge conflicts: PR #2062 was diverged and CLEAN at the same
+			// time. GitHub answers conflict separately, in `mergeable`, which
+			// this gate already reads a few frames up.
+			//
+			// Unknown mergeability FAILS CLOSED to the update, matching
+			// baseAllowsBehindMerge: a merge GitHub has not finished computing
+			// and one it cannot compute are indistinguishable from here.
 			return MergeDecision{}, false, nil
 		}
 		_, err := g.GitHub.UpdatePullRequestBranch(ctx, github.UpdatePullRequestBranchInput{
@@ -1992,6 +2011,22 @@ func (g PolicyMergeGate) ensureBranchFresh(ctx context.Context, repo github.Repo
 		return decision, true, err
 	}
 	return MergeDecision{}, false, nil
+}
+
+// mergeableWithoutConflict reports whether GitHub has COMPUTED this pull
+// request's mergeability and says the merge does not conflict (#2068).
+//
+// This is the question the behind-merge exemption actually asks. `compare.status`
+// answers a different one - whether both refs carry unique commits - and is
+// "diverged" for every open pull request whose base has moved, conflicting or
+// not.
+//
+// A nil Mergeable is UNKNOWN, never "fine": GitHub computes mergeability
+// asynchronously, so a PR read moments after a base move legitimately returns
+// nil, and a token that cannot see it returns nil too. Both must keep the
+// mandatory branch update, which is the pre-#1865 behaviour.
+func mergeableWithoutConflict(pr github.PullRequest) bool {
+	return pr.Mergeable != nil && *pr.Mergeable
 }
 
 // baseAllowsBehindMerge reports whether a head that is merely BEHIND base may be

--- a/internal/workflow/merge_gate.go
+++ b/internal/workflow/merge_gate.go
@@ -393,7 +393,25 @@ func (g PolicyMergeGate) Evaluate(ctx context.Context, request MergeRequest) (Me
 	} else if handled {
 		return decision, nil
 	}
-	if pr.Mergeable != nil && !*pr.Mergeable {
+	// #2074 review, P1. THE GATE REQUIRES MERGEABILITY POSITIVELY, and nil is not
+	// a weak no - it is NOT YET KNOWN. The previous test refused only an explicit
+	// false, so a pull request whose comparison was already up to date - status
+	// "ahead" or "identical", where ensureBranchFresh returns unhandled and the
+	// new behind-branch guard never runs - reached
+	// executePullRequestMergeFenced with mergeability GitHub had not computed.
+	//
+	// The two cases are answered differently, mirroring PipelineAutoMerger
+	// (pipeline_auto_merge.go:121-129), which is the same decision made by the
+	// other merge path in this package:
+	//
+	//   nil   -> PENDING. GitHub computes mergeability asynchronously, so this is
+	//            normal moments after a base move and resolves on the next poll.
+	//            Blocking would turn an ordinary race into an operator ticket.
+	//   false -> BLOCK. A real conflict, transient because a push can fix it.
+	if pr.Mergeable == nil {
+		return g.pending(ctx, request, headSHA, "GitHub has not determined pull request mergeability yet; daemon will retry")
+	}
+	if !*pr.Mergeable {
 		return g.block(ctx, request, headSHA, "pull request is not mergeable; rebase or update the branch", MergeBlockTransient)
 	}
 	if required, reconciled, hold, err := ensureWorkloadModeReconciled(ctx, g.Store, g.GitHub, repo, int64(request.PullRequest), headSHA); err != nil {

--- a/internal/workflow/merge_gate_behind_merge_test.go
+++ b/internal/workflow/merge_gate_behind_merge_test.go
@@ -200,9 +200,22 @@ func TestMergeGateStillUpdatesWhenMergeabilityIsUnknown(t *testing.T) {
 // as before - the new guard must not reject valid input, and must not spend an
 // API call it does not need.
 func TestMergeGateMergesUpToDateBranchUnchanged(t *testing.T) {
-	for _, status := range []string{"identical", "ahead", ""} {
+	// #2074 round two, P2: the blank status is GONE from this ACCEPTANCE table.
+	// GitHub's compare status enum is diverged/ahead/behind/identical, so "" is
+	// not a production shape, and an acceptance test on an unreachable input can
+	// stay green through a real regression. The empty and unrecognised cases are
+	// still covered deliberately, as ROBUSTNESS, by
+	// TestMergeGateTreatsNumericBehindAsBehindWhateverTheStatusString below.
+	for _, status := range []string{"identical", "ahead"} {
 		t.Run("status="+status, func(t *testing.T) {
-			gh := behindMergeGateClient(github.CompareResult{Status: status})
+			// A real "ahead" response carries ahead_by > 0; "identical" carries
+			// zero on both axes, and passing AheadBy here would itself be a shape
+			// production cannot emit. So it is set per status rather than blanket.
+			compare := github.CompareResult{Status: status}
+			if status == "ahead" {
+				compare.AheadBy = 3
+			}
+			gh := behindMergeGateClient(compare)
 			gh.strictKnown = true
 			gh.strictBase = true // must be irrelevant when not behind
 
@@ -285,7 +298,7 @@ func TestMergeGateTreatsNumericBehindAsBehindWhateverTheStatusString(t *testing.
 func TestMergeGateWaitsWhenMergeabilityIsUnknownOnAnUpToDateHead(t *testing.T) {
 	for _, status := range []string{"ahead", "identical"} {
 		t.Run("status="+status, func(t *testing.T) {
-			gh := behindMergeGateClient(github.CompareResult{Status: status})
+			gh := behindMergeGateClient(github.CompareResult{Status: status, AheadBy: 2})
 			gh.pr.Mergeable = nil
 			gh.strictKnown = true
 			gh.strictBase = true
@@ -298,11 +311,27 @@ func TestMergeGateWaitsWhenMergeabilityIsUnknownOnAnUpToDateHead(t *testing.T) {
 			if len(gh.merges) != 0 {
 				t.Fatalf("the native merge was reached: %+v", gh.merges)
 			}
-			// PENDING, not blocked: GitHub computes this asynchronously and it
-			// resolves on the next poll. A block would make an ordinary race an
-			// operator ticket, which is the distinction PipelineAutoMerger makes.
 			if !strings.Contains(decision.Reason.Render(), "has not determined") {
 				t.Fatalf("decision must say mergeability is undetermined, got %q", decision.Reason.Render())
+			}
+			// PENDING, NOT BLOCKED, ASSERTED ON THE LIFECYCLE RATHER THAN THE PROSE
+			// (#2074 round two, P2). The reviewer changed the production nil arm to
+			// g.block with the IDENTICAL reason string and this test still passed,
+			// because it only checked that no merge happened and that the reason
+			// mentioned undetermined mergeability. Both are true of a block.
+			//
+			// The inversion matters: a blocked row publishes a FAILURE status and
+			// moves the task out of its automatic retry path, turning a race that
+			// resolves on the next poll into an operator ticket. So the three
+			// distinguishers are asserted directly.
+			if !decision.Ready {
+				t.Fatal("nil mergeability produced a BLOCK, not a pending: Ready is false, so the task leaves its automatic retry path")
+			}
+			if decision.BlockClass != 0 {
+				t.Fatalf("a pending decision must carry no block class, got %d", decision.BlockClass)
+			}
+			if !hasStatus(gh.statuses, GitmootMergeGateContext, "pending") {
+				t.Fatalf("the published commit status must be pending, got %+v", gh.statuses)
 			}
 		})
 	}
@@ -311,7 +340,7 @@ func TestMergeGateWaitsWhenMergeabilityIsUnknownOnAnUpToDateHead(t *testing.T) {
 // The explicit false case must stay a BLOCK, so the nil arm above cannot be
 // implemented by softening a real conflict into a wait.
 func TestMergeGateBlocksAnExplicitlyUnmergeableHead(t *testing.T) {
-	gh := behindMergeGateClient(github.CompareResult{Status: "ahead"})
+	gh := behindMergeGateClient(github.CompareResult{Status: "ahead", AheadBy: 2})
 	conflicting := false
 	gh.pr.Mergeable = &conflicting
 	gh.strictKnown = true
@@ -324,5 +353,14 @@ func TestMergeGateBlocksAnExplicitlyUnmergeableHead(t *testing.T) {
 	}
 	if !strings.Contains(decision.Reason.Render(), "not mergeable") {
 		t.Fatalf("decision must name the conflict, got %q", decision.Reason.Render())
+	}
+	// The opposite lifecycle from the nil case above. Without this the pair could
+	// both be satisfied by one behaviour, which is exactly how the nil test came
+	// to accept a block.
+	if decision.Ready {
+		t.Fatal("an explicit conflict must BLOCK, not wait: Ready is true, so it would keep retrying a merge GitHub has refused")
+	}
+	if !hasStatus(gh.statuses, GitmootMergeGateContext, "failure") {
+		t.Fatalf("a blocked decision must publish a failure status, got %+v", gh.statuses)
 	}
 }

--- a/internal/workflow/merge_gate_behind_merge_test.go
+++ b/internal/workflow/merge_gate_behind_merge_test.go
@@ -56,8 +56,27 @@ func evaluateBehindMergeGate(t *testing.T, gh *fakeMergeGateGitHub) MergeDecisio
 
 // Acceptance 1: the verdict's own head is what merges. No update is requested,
 // so nothing supersedes the reviewed head.
+//
+// #2074 review, P2. THE SHAPE HERE IS THE ONE PRODUCTION EMITS. This and the two
+// acceptance cases below previously constructed `Status: "behind"`, which GitHub
+// cannot report for an open pull request: `behind` requires `ahead_by == 0`, a
+// branch with no commits of its own. Measured with the gate's own call
+// (CompareCommits -> GET repos/{owner}/{repo}/compare/{base}...{head}) across
+// five open PRs on this repo: five `diverged` with `behind_by` 2..9 and
+// `ahead_by` 1..5, zero `behind`.
+//
+// The shape below is copied from one of those responses, #2057's head against
+// main: {"status":"diverged","ahead_by":1,"behind_by":4,"total_commits":1}.
+//
+// The first fix for this converted only the fixture in the test that changed
+// behaviour and argued these three could stay, on the grounds that the literal
+// `behind` arm of the `||` is still live code. The reviewer rejected that and was
+// right: these are PRODUCTION-PATH ACCEPTANCE tests, and the string arm is
+// covered deliberately and separately by the unknown-status robustness cases at
+// the end of this file. An acceptance test on an unreachable input can stay green
+// through a real regression.
 func TestMergeGateMergesBehindHeadWhenBaseAllowsIt(t *testing.T) {
-	gh := behindMergeGateClient(github.CompareResult{Status: "behind", BehindBy: 1})
+	gh := behindMergeGateClient(github.CompareResult{Status: "diverged", BehindBy: 4, AheadBy: 1})
 	gh.strictKnown = true
 	gh.strictBase = false
 
@@ -88,7 +107,7 @@ func TestMergeGateMergesBehindHeadWhenBaseAllowsIt(t *testing.T) {
 // Acceptance 1, other arm: where GitHub does require an up-to-date head, the
 // update is still the only way to merge, so the pre-#1865 path must survive.
 func TestMergeGateStillUpdatesWhenBaseRequiresUpToDateHead(t *testing.T) {
-	gh := behindMergeGateClient(github.CompareResult{Status: "behind", BehindBy: 1})
+	gh := behindMergeGateClient(github.CompareResult{Status: "diverged", BehindBy: 4, AheadBy: 1})
 	gh.strictKnown = true
 	gh.strictBase = true
 
@@ -121,7 +140,7 @@ func TestMergeGateFailsClosedWhenProtectionIsUndetermined(t *testing.T) {
 		}},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			gh := behindMergeGateClient(github.CompareResult{Status: "behind", BehindBy: 1})
+			gh := behindMergeGateClient(github.CompareResult{Status: "diverged", BehindBy: 4, AheadBy: 1})
 			tc.set(gh)
 
 			decision := evaluateBehindMergeGate(t, gh)
@@ -133,38 +152,6 @@ func TestMergeGateFailsClosedWhenProtectionIsUndetermined(t *testing.T) {
 				t.Fatalf("update inputs = %+v", gh.updates)
 			}
 		})
-	}
-}
-
-// #2068. THE SHAPE BELOW IS THE ONE PRODUCTION EMITS, AND THE FIXTURES ABOVE
-// ARE NOT.
-//
-// Every other case in this file constructs `Status: "behind"`. Measured against
-// the live API on 2026-09-08 with the gate's own call - CompareCommits, which
-// issues `GET repos/{owner}/{repo}/compare/{base}...{head}` (client.go
-// CompareCommits) - five of five open pull requests on this repository reported
-// `status=diverged` with `behind_by` 2..9 and `ahead_by` 1..5, and NONE reported
-// `behind`. That is structural, not incidental: `behind` requires `ahead_by ==
-// 0`, a branch with no commits of its own, which is not a pull request.
-//
-// The shape here is copied from one of those responses, #2057's head against
-// main: `{"status":"diverged","ahead_by":1,"behind_by":4,"total_commits":1}`.
-//
-// So the pre-#2068 guard (`status != "diverged"`) could not fire for a real PR,
-// and every base move re-entered the update path that #1865 exists to avoid,
-// while this file stayed green.
-func TestMergeGateMergesDivergedMergeableHeadWhenBaseAllowsIt(t *testing.T) {
-	gh := behindMergeGateClient(github.CompareResult{Status: "diverged", BehindBy: 4, AheadBy: 1})
-	gh.strictKnown = true
-	gh.strictBase = false
-
-	decision := evaluateBehindMergeGate(t, gh)
-
-	if !decision.Merged {
-		t.Fatalf("a diverged but mergeable head must merge without an update: %+v", decision)
-	}
-	if len(gh.updates) != 0 {
-		t.Fatalf("the reviewed head was superseded by an update: %+v", gh.updates)
 	}
 }
 
@@ -284,5 +271,58 @@ func TestMergeGateTreatsNumericBehindAsBehindWhateverTheStatusString(t *testing.
 				}
 			})
 		})
+	}
+}
+
+// #2074 review, P1. UNKNOWN MERGEABILITY MUST NOT REACH THE NATIVE MERGE, and
+// the hole was outside the behind branch entirely: for an already up-to-date
+// comparison ensureBranchFresh returns unhandled, so the behind-branch guard
+// never runs, and the old test `Mergeable != nil && !*Mergeable` was false for
+// nil. Evaluate then merged on mergeability GitHub had not computed.
+//
+// This drives Evaluate with the shape that exposes it - up to date AND nil -
+// which no fixture in this file previously produced.
+func TestMergeGateWaitsWhenMergeabilityIsUnknownOnAnUpToDateHead(t *testing.T) {
+	for _, status := range []string{"ahead", "identical"} {
+		t.Run("status="+status, func(t *testing.T) {
+			gh := behindMergeGateClient(github.CompareResult{Status: status})
+			gh.pr.Mergeable = nil
+			gh.strictKnown = true
+			gh.strictBase = true
+
+			decision := evaluateBehindMergeGate(t, gh)
+
+			if decision.Merged {
+				t.Fatalf("merged with mergeability GitHub has not determined: %+v", decision)
+			}
+			if len(gh.merges) != 0 {
+				t.Fatalf("the native merge was reached: %+v", gh.merges)
+			}
+			// PENDING, not blocked: GitHub computes this asynchronously and it
+			// resolves on the next poll. A block would make an ordinary race an
+			// operator ticket, which is the distinction PipelineAutoMerger makes.
+			if !strings.Contains(decision.Reason.Render(), "has not determined") {
+				t.Fatalf("decision must say mergeability is undetermined, got %q", decision.Reason.Render())
+			}
+		})
+	}
+}
+
+// The explicit false case must stay a BLOCK, so the nil arm above cannot be
+// implemented by softening a real conflict into a wait.
+func TestMergeGateBlocksAnExplicitlyUnmergeableHead(t *testing.T) {
+	gh := behindMergeGateClient(github.CompareResult{Status: "ahead"})
+	conflicting := false
+	gh.pr.Mergeable = &conflicting
+	gh.strictKnown = true
+	gh.strictBase = true
+
+	decision := evaluateBehindMergeGate(t, gh)
+
+	if decision.Merged || len(gh.merges) != 0 {
+		t.Fatalf("a conflicting head must not merge: %+v", decision)
+	}
+	if !strings.Contains(decision.Reason.Render(), "not mergeable") {
+		t.Fatalf("decision must name the conflict, got %q", decision.Reason.Render())
 	}
 }

--- a/internal/workflow/merge_gate_behind_merge_test.go
+++ b/internal/workflow/merge_gate_behind_merge_test.go
@@ -347,30 +347,23 @@ func TestMergeGateWaitsWhenMergeabilityIsUnknownOnAnUpToDateHead(t *testing.T) {
 	}
 }
 
-// The explicit false case must stay a BLOCK, so the nil arm above cannot be
-// implemented by softening a real conflict into a wait.
-func TestMergeGateBlocksAnExplicitlyUnmergeableHead(t *testing.T) {
-	gh := behindMergeGateClient(github.CompareResult{Status: "ahead", AheadBy: 2})
-	conflicting := false
-	gh.pr.Mergeable = &conflicting
-	gh.strictKnown = true
-	gh.strictBase = true
-
-	decision := evaluateBehindMergeGate(t, gh)
-
-	if decision.Merged || len(gh.merges) != 0 {
-		t.Fatalf("a conflicting head must not merge: %+v", decision)
-	}
-	if !strings.Contains(decision.Reason.Render(), "not mergeable") {
-		t.Fatalf("decision must name the conflict, got %q", decision.Reason.Render())
-	}
-	// The opposite lifecycle from the nil case above. Without this the pair could
-	// both be satisfied by one behaviour, which is exactly how the nil test came
-	// to accept a block.
-	if decision.Ready {
-		t.Fatal("an explicit conflict must BLOCK, not wait: Ready is true, so it would keep retrying a merge GitHub has refused")
-	}
-	if !hasStatus(gh.statuses, GitmootMergeGateContext, "failure") {
-		t.Fatalf("a blocked decision must publish a failure status, got %+v", gh.statuses)
-	}
-}
+// #2074 round four, P2: THE EXPLICIT-FALSE TEST AT AN UP-TO-DATE HEAD IS DELETED
+// BECAUSE THE STATE IT MODELLED CANNOT OCCUR.
+//
+// It constructed Status:"ahead" with Mergeable=false and called that a real
+// conflict. Those cannot describe one pull request: `ahead` means the base is an
+// ancestor of the head, so there is nothing to conflict WITH, and GitHub sets
+// mergeable=false for merge conflicts, which require divergence.
+//
+// Making the tuple coherent - diverged plus false - moves the case into
+// ensureBranchFresh, which handles it BEFORE the post-freshness mergeability
+// guard: that is TestMergeGateStillUpdatesDivergedConflictingBranch above, which
+// already covers the reachable conflict path.
+//
+// So the `!*pr.Mergeable` block after ensureBranchFresh is DEFENSIVE and is not
+// reachable through any compare status the API emits: conflicts arrive diverged
+// and are answered earlier. It stays, because a guard that costs one comparison
+// and refuses an impossible input is cheaper than proving the impossibility holds
+// forever - but it is defensive rather than test-defended, and pretending
+// otherwise required a fixture the API cannot produce. Same call as the surviving
+// eligibility mutant on #2057.

--- a/internal/workflow/merge_gate_behind_merge_test.go
+++ b/internal/workflow/merge_gate_behind_merge_test.go
@@ -298,7 +298,17 @@ func TestMergeGateTreatsNumericBehindAsBehindWhateverTheStatusString(t *testing.
 func TestMergeGateWaitsWhenMergeabilityIsUnknownOnAnUpToDateHead(t *testing.T) {
 	for _, status := range []string{"ahead", "identical"} {
 		t.Run("status="+status, func(t *testing.T) {
-			gh := behindMergeGateClient(github.CompareResult{Status: status, AheadBy: 2})
+			// #2074 round three, P2: AheadBy is set PER STATUS. "identical" reports
+			// ahead_by=0 and behind_by=0 - confirmed against an exact-commit
+			// comparison - so a blanket positive value here is a tuple the API
+			// cannot emit. The adjacent acceptance test already did this
+			// conditionally and I wrote the blanket version anyway, in the same
+			// file, one round later.
+			compare := github.CompareResult{Status: status}
+			if status == "ahead" {
+				compare.AheadBy = 2
+			}
+			gh := behindMergeGateClient(compare)
 			gh.pr.Mergeable = nil
 			gh.strictKnown = true
 			gh.strictBase = true

--- a/internal/workflow/merge_gate_behind_merge_test.go
+++ b/internal/workflow/merge_gate_behind_merge_test.go
@@ -136,23 +136,76 @@ func TestMergeGateFailsClosedWhenProtectionIsUndetermined(t *testing.T) {
 	}
 }
 
-// A diverged branch is not merely behind: merging it can conflict, so the
-// update stays mandatory there even when protection allows behind merges.
-func TestMergeGateStillUpdatesDivergedBranch(t *testing.T) {
-	gh := behindMergeGateClient(github.CompareResult{Status: "diverged", BehindBy: 1, AheadBy: 1})
+// #2068. THE SHAPE BELOW IS THE ONE PRODUCTION EMITS, AND THE FIXTURES ABOVE
+// ARE NOT.
+//
+// Every other case in this file constructs `Status: "behind"`. Measured against
+// the live API on 2026-09-08 with the gate's own call - CompareCommits, which
+// issues `GET repos/{owner}/{repo}/compare/{base}...{head}` (client.go
+// CompareCommits) - five of five open pull requests on this repository reported
+// `status=diverged` with `behind_by` 2..9 and `ahead_by` 1..5, and NONE reported
+// `behind`. That is structural, not incidental: `behind` requires `ahead_by ==
+// 0`, a branch with no commits of its own, which is not a pull request.
+//
+// The shape here is copied from one of those responses, #2057's head against
+// main: `{"status":"diverged","ahead_by":1,"behind_by":4,"total_commits":1}`.
+//
+// So the pre-#2068 guard (`status != "diverged"`) could not fire for a real PR,
+// and every base move re-entered the update path that #1865 exists to avoid,
+// while this file stayed green.
+func TestMergeGateMergesDivergedMergeableHeadWhenBaseAllowsIt(t *testing.T) {
+	gh := behindMergeGateClient(github.CompareResult{Status: "diverged", BehindBy: 4, AheadBy: 1})
+	gh.strictKnown = true
+	gh.strictBase = false
+
+	decision := evaluateBehindMergeGate(t, gh)
+
+	if !decision.Merged {
+		t.Fatalf("a diverged but mergeable head must merge without an update: %+v", decision)
+	}
+	if len(gh.updates) != 0 {
+		t.Fatalf("the reviewed head was superseded by an update: %+v", gh.updates)
+	}
+}
+
+// Conflict is the real reason to update, and it is reported by `mergeable`, not
+// by the compare status. A diverged head that GitHub says does not merge keeps
+// the mandatory update - the pre-#1865 behaviour - because merging the reviewed
+// head is not available.
+func TestMergeGateStillUpdatesDivergedConflictingBranch(t *testing.T) {
+	gh := behindMergeGateClient(github.CompareResult{Status: "diverged", BehindBy: 4, AheadBy: 1})
+	conflicting := false
+	gh.pr.Mergeable = &conflicting
 	gh.strictKnown = true
 	gh.strictBase = false
 
 	decision := evaluateBehindMergeGate(t, gh)
 
 	if decision.Merged {
-		t.Fatalf("diverged branch must not merge without an update: %+v", decision)
+		t.Fatalf("a conflicting head must not merge: %+v", decision)
 	}
 	if len(gh.updates) != 1 {
 		t.Fatalf("update inputs = %+v", gh.updates)
 	}
-	if gh.strictCalls != 0 {
-		t.Fatalf("diverged must not even consult protection: calls = %d", gh.strictCalls)
+}
+
+// UNKNOWN MERGEABILITY FAILS CLOSED. GitHub computes mergeability
+// asynchronously, so a PR read moments after a base move returns null, and a
+// token that cannot see it returns null too. Treating null as "fine" would merge
+// on the strength of a value GitHub has not produced.
+func TestMergeGateStillUpdatesWhenMergeabilityIsUnknown(t *testing.T) {
+	gh := behindMergeGateClient(github.CompareResult{Status: "diverged", BehindBy: 4, AheadBy: 1})
+	gh.pr.Mergeable = nil
+	gh.strictKnown = true
+	gh.strictBase = false
+
+	decision := evaluateBehindMergeGate(t, gh)
+
+	if decision.Merged {
+		t.Fatalf("unknown mergeability must not merge: %+v", decision)
+	}
+	if len(gh.updates) != 1 {
+		t.Fatalf("update inputs = %+v", gh.updates)
 	}
 }
 

--- a/internal/workflow/merge_gate_test.go
+++ b/internal/workflow/merge_gate_test.go
@@ -3055,7 +3055,7 @@ func TestPolicyMergeGateUpdatesStaleBranchAndStaysPending(t *testing.T) {
 	gh := &fakeMergeGateGitHub{
 		pr:      github.PullRequest{Number: 9, HeadRef: "task-9", BaseRef: "main", HeadSHA: "head123", Mergeable: &mergeable},
 		status:  github.CombinedStatus{State: "success"},
-		compare: github.CompareResult{Status: "behind", BehindBy: 1},
+		compare: github.CompareResult{Status: "diverged", BehindBy: 4, AheadBy: 1},
 	}
 	gate := PolicyMergeGate{AutoMerge: true, Store: store, GitHub: gh, Git: &fakeMergeGateGit{clean: true}}
 
@@ -3093,7 +3093,7 @@ func TestPolicyMergeGateBlocksStaleBranchUpdateConflict(t *testing.T) {
 	gh := &fakeMergeGateGitHub{
 		pr:        github.PullRequest{Number: 9, HeadRef: "task-9", BaseRef: "main", HeadSHA: "head123", Mergeable: &mergeable},
 		status:    github.CombinedStatus{State: "success"},
-		compare:   github.CompareResult{Status: "behind", BehindBy: 1},
+		compare:   github.CompareResult{Status: "diverged", BehindBy: 4, AheadBy: 1},
 		updateErr: github.UpdatePullRequestBranchError{Kind: github.UpdatePullRequestBranchErrorConflict, Detail: "conflict"},
 	}
 	gate := PolicyMergeGate{AutoMerge: true, Store: store, GitHub: gh, Git: &fakeMergeGateGit{clean: true}}
@@ -3132,7 +3132,7 @@ func TestPolicyMergeGateKeepsStaleHeadRacePending(t *testing.T) {
 	gh := &fakeMergeGateGitHub{
 		pr:        github.PullRequest{Number: 9, HeadRef: "task-9", BaseRef: "main", HeadSHA: "head123", Mergeable: &mergeable},
 		status:    github.CombinedStatus{State: "success"},
-		compare:   github.CompareResult{Status: "behind", BehindBy: 1},
+		compare:   github.CompareResult{Status: "diverged", BehindBy: 4, AheadBy: 1},
 		updateErr: github.UpdatePullRequestBranchError{Kind: github.UpdatePullRequestBranchErrorStaleHead, Detail: "stale head"},
 	}
 	gate := PolicyMergeGate{AutoMerge: true, Store: store, GitHub: gh, Git: &fakeMergeGateGit{clean: true}}


### PR DESCRIPTION
Fixes #2068. Refs #1865. Campaign #1818. Head `cf5b9c58`. **Draft.**

## The defect

#1865 added an exemption so the merge gate would stop requesting a branch update for a head whose base had merely moved. The update authors a merge commit that supersedes the head the verdict is bound to, so the next poll finds an unreviewed head and buys a fresh paid review round.

**The exemption could not fire for any pull request.** It read `status != "diverged"`, and GitHub reports `diverged` for any branch carrying its own commits. `behind` requires `ahead_by == 0` - a branch with no commits of its own, which is not a PR.

## Measured

Live API, using the gate's own call (`CompareCommits` -> `GET repos/{owner}/{repo}/compare/{base}...{head}`), 2026-09-08:

```
#2045 status=diverged  behind_by=9  ahead_by=2
#2051 status=diverged  behind_by=8  ahead_by=5
#2053 status=diverged  behind_by=4  ahead_by=1
#2057 status=diverged  behind_by=2  ahead_by=1
#2062 status=diverged  behind_by=2  ahead_by=1
```

**Five of five diverged. Zero behind.** Positive control that the field varies and the instrument can read the other values: the same call returned `status=ahead behind_by=0 ahead_by=3` for #2026 immediately after I rebased it.

So every base move re-entered the update path and re-advanced every open PR, which is the churn #1865 exists to prevent.

## Why the discriminator was wrong, not merely unlucky

`diverged` answers *"do both refs carry unique commits"*. That is true of every open PR the moment its base moves, and it says nothing about conflict: **#2062 was `diverged` and `CLEAN` at the same time.**

Conflict is reported by `mergeable`, which this gate already reads a few frames below the exemption. The fix uses that instead.

**Unknown mergeability fails closed to the update**, matching `baseAllowsBehindMerge`'s existing stance: GitHub computes mergeability asynchronously, so a `null` read moments after a base move and a token that cannot see it are indistinguishable from here. Treating `null` as fine would merge on a value GitHub has not produced.

## The fixture was as much the defect as the code

Every case in `merge_gate_behind_merge_test.go` constructed `Status: "behind"`. That is a state production never emits for a PR, so **the suite was green while the feature was dead** - and #1865's acceptance was satisfiable without ever observing a real compare response.

The replaced test is built from a real one. **Shape source, named as required:** `CompareCommits`, which issues `GET repos/{owner}/{repo}/compare/{base}...{head}` (`internal/github/client.go`), returning for #2057's head against `main`:

```json
{"status":"diverged","ahead_by":1,"behind_by":4,"total_commits":1}
```

### Sibling audit: a dead-guard class rarely has one member

Three more impossible fixtures, in a different file (`merge_gate_test.go`):

| test | before | after |
|---|---|---|
| `TestPolicyMergeGateUpdatesStaleBranchAndStaysPending` | `Status: "behind"` | real diverged shape |
| `TestPolicyMergeGateBlocksStaleBranchUpdateConflict` | `Status: "behind"` | real diverged shape |
| `TestPolicyMergeGateKeepsStaleHeadRacePending` | `Status: "behind"` | real diverged shape |

**All three pass unchanged on the real shape, and that is the finding:** their `"behind"` string was *inert*. They reach the update path through **undetermined protection** (`strictKnown` unset, so `baseAllowsBehindMerge` fails closed), never through the status. So they were not testing what their fixture claimed, and they are now production-shaped without any assertion change.

Deliberately left as `behind`: the parameterised `TestMergeGateTreatsNumericBehindAsBehindWhateverTheStatusString`, which exists to vary the status string on purpose, and the two `Status: "behind"` acceptance cases that cover the literal string arm of the `||`. That arm is still live code and worth pinning; the production-shaped coverage is now the diverged tests beside them.

## Tests

Three replace the one that encoded the wrong premise:

| case | expectation |
|---|---|
| diverged + mergeable + protection allows | merges the **reviewed head**, zero updates |
| diverged + **conflicting** | mandatory update stays |
| diverged + mergeability **unknown** | mandatory update stays |

## Mutants

Three, each gated on **applied** and **builds**:

| mutant | killed by |
|---|---|
| restore the dead `status != "diverged"` guard | the diverged+mergeable test |
| treat unknown mergeability as fine | the unknown test |
| drop the conflict check entirely | conflicting + unknown tests |

## Verification

`gofmt`, `go build ./...`, `go vet`, and the **full `internal/workflow` package** green in 140s - not a `-run` filter, since this changes a gate other suites drive.

## Not claimed

- **Not measured: the churn reduction in production.** That needs the fix deployed and a base move afterwards. What is measured is that the exemption was unreachable and is now reachable on the shape production emits.
- **Not a change to when an update is required.** Protection that requires an up-to-date head still gets one, and #1865 deliberately preserved that.
- **Not a claim that every gate-authored merge commit came from this path.** Other callers of the update do not exist in production (audited: one caller), but attribution of individual commits is a separate record.

Signed: **gm-staged**
