### PR TITLE
docs: -race is unreachable from a review seat, not from every seat

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,9 +50,18 @@ infrastructure rather than the documented boundary they are:
   includes the repo-wide gate and `./cmd/gitmoot`. A pure-Go package still builds
   and tests with default cgo, so a passing single-package run proves nothing about
   the gate.
-- **`-race` is unreachable in a seat**, because race requires cgo (`go: -race
-  requires cgo; enable cgo by setting CGO_ENABLED=1`). It is covered by CI's race
-  shards only, and its absence from a seat verdict is not a regression.
+- **`-race` is unreachable from a read-only review seat**, because race requires
+  cgo (`go: -race requires cgo; enable cgo by setting CGO_ENABLED=1`) and the
+  sandbox denies the C header above. Its absence from a review verdict is not a
+  regression. It is **not** unreachable from a full seat with its own clone:
+  measured on this host, `CGO_ENABLED=1 go test -race ./internal/db/` returns
+  `ok` from `/root/gm-transport`, so a seat that owns a checkout can run the
+  lane locally when CI cannot. Two limits on doing so. A race result is
+  timing-sensitive, so a clean local run is weaker evidence than a clean CI run
+  rather than equal to it, and it must never be reported as the lane passing.
+  And two concurrent `-race` workloads on one host perturb the scheduling each
+  is measuring, with a false clean on both the likely outcome, so the lane takes
+  one runner at a time: check for a live `-race` binary before starting one.
 
 When a seat's plain `go` returns 126, no usable toolchain was staged. The command
 is an engine-owned failure stub, never a fallthrough to the operator's `go`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -53,15 +53,34 @@ infrastructure rather than the documented boundary they are:
 - **`-race` is unreachable from a read-only review seat**, because race requires
   cgo (`go: -race requires cgo; enable cgo by setting CGO_ENABLED=1`) and the
   sandbox denies the C header above. Its absence from a review verdict is not a
-  regression. It is **not** unreachable from a full seat with its own clone:
-  measured on this host, `CGO_ENABLED=1 go test -race ./internal/db/` returns
-  `ok` from `/root/gm-transport`, so a seat that owns a checkout can run the
-  lane locally when CI cannot. Two limits on doing so. A race result is
+  regression, and the boundary is `ReadOnlySeat`, not the kind of clone you hold:
+  `readOnlyRuntimeSandboxGrants` stages the toolchain and applies Landlock for
+  jobs whose payload carries that marker, which includes native reviews,
+  ask/review delegation children, and pipeline worktrees, ephemeral workers
+  among them. A session that is **not** a `ReadOnlySeat`, is permitted to run
+  Bash by its autonomy policy, and has the C toolchain and headers available can
+  execute race-enabled tests: measured on this host,
+  `CGO_ENABLED=1 go test -race ./internal/db/` returns `ok`. Owning a checkout is
+  not the predicate and neither is being "a seat"; a restrictive autonomy policy
+  blocks Bash regardless.
+- **A local race run is a scoped PROBE, never the lane.** The lane is the
+  partitioned recipe below, and reproducing it takes `-tags e2e` (see the race
+  block): without the tag the compile silently drops 33 tagged `internal/cli`
+  files, 2 in `workflow` and 1 in `daemon`, and the shard plan derived from
+  `-test.list` shrinks to match with nothing failing. Measured on this host,
+  `internal/cli` lists **2236** tests with the tag and **2108** without it, so an
+  untagged run omits 128 and reports success. `internal/db` lists 402 either way,
+  which is the trap: probing that package proves a race binary can be built and
+  run and says nothing about the lane. A probe that omits the tag cannot answer
+  "does the lane pass". Report what you ran. A race result is also
   timing-sensitive, so a clean local run is weaker evidence than a clean CI run
-  rather than equal to it, and it must never be reported as the lane passing.
-  And two concurrent `-race` workloads on one host perturb the scheduling each
-  is measuring, with a false clean on both the likely outcome, so the lane takes
-  one runner at a time: check for a live `-race` binary before starting one.
+  rather than equal to it.
+- **Do not run two race workloads on this host at once.** This is a precaution,
+  not a measurement: detection depends on the interleavings a run actually
+  executes, and two competing full-repo race workloads change the scheduling
+  each observes. No experiment here establishes a direction for that effect, so
+  treat it as an unquantified risk to an assurance run rather than as a proven
+  false-clean mechanism. Check for a live `-race` binary before starting one.
 
 When a seat's plain `go` returns 126, no usable toolchain was staged. The command
 is an engine-owned failure stub, never a fallthrough to the operator's `go`.
@@ -93,7 +112,11 @@ go test -timeout 25m ./...
     shards="${spec##*:}"
     bundle="$race_dir/$package"
     mkdir -p "$bundle/partitions"
-    go test -c -race -o "$bundle/$package.test" "./internal/$package/"
+    # -tags e2e is REQUIRED, matching ci.yml: without it this compile silently
+    # drops the 33 tagged internal/cli files (plus 2 in workflow and 1 in
+    # daemon), and the shard plan derived from -test.list shrinks to match with
+    # nothing failing.
+    go test -c -race -tags e2e -o "$bundle/$package.test" "./internal/$package/"
     (
       cd "internal/$package"
       "$bundle/$package.test" -test.list '.*'

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,15 +54,15 @@ infrastructure rather than the documented boundary they are:
   cgo (`go: -race requires cgo; enable cgo by setting CGO_ENABLED=1`) and the
   sandbox denies the C header above. Its absence from a review verdict is not a
   regression, and the boundary is the `ReadOnlySeat` marker, not the kind of
-  clone you hold. Seven dispatch sites set it on `origin/main` - in
-  `internal/cli`: `daemon_checkout.go`, `daemon_scheduler.go`, `daemon_worker.go`,
-  `job_blocker_auth_probe.go`, `pipeline_enqueue.go`; in `internal/workflow`:
-  `engine_delegation.go`, `engine_pr_lifecycle.go` - so read the list from
-  `git grep -n 'ReadOnlySeat.*true' origin/main` rather than from a summary here.
-  Under that marker the daemon computes read-only sandbox grants through
-  `readOnlyRuntimeSandboxGrants`, which resolves the isolated tool cache and the
-  staged toolchain; the sandboxing itself is applied by the runtime layer and is
-  not this function's job. A session that is **not** a `ReadOnlySeat`, is
+  clone you hold. Do not trust an enumeration of the sites, including one written
+  here: get it from
+  `git grep -n 'ReadOnlySeat.*true' origin/main -- 'internal/*/*.go'`, and note
+  that the pattern matches two different things - the dispatch sites that SET the
+  marker on a request, payload or agent, and `applyReadOnlySeat`, which applies it
+  to a session. Under that marker the daemon computes read-only sandbox grants
+  through `readOnlyRuntimeSandboxGrants`, which resolves the isolated tool cache
+  and the staged toolchain; the sandboxing itself is applied by the runtime layer
+  and is not this function's job. A session that is **not** a `ReadOnlySeat`, is
   permitted to run Bash by its autonomy policy, and has the C toolchain and
   headers available can execute race-enabled tests: measured on this host,
   `CGO_ENABLED=1 go test -race ./internal/db/` returns `ok`. Owning a checkout is

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -53,13 +53,18 @@ infrastructure rather than the documented boundary they are:
 - **`-race` is unreachable from a read-only review seat**, because race requires
   cgo (`go: -race requires cgo; enable cgo by setting CGO_ENABLED=1`) and the
   sandbox denies the C header above. Its absence from a review verdict is not a
-  regression, and the boundary is `ReadOnlySeat`, not the kind of clone you hold:
-  `readOnlyRuntimeSandboxGrants` stages the toolchain and applies Landlock for
-  jobs whose payload carries that marker, which includes native reviews,
-  ask/review delegation children, and pipeline worktrees, ephemeral workers
-  among them. A session that is **not** a `ReadOnlySeat`, is permitted to run
-  Bash by its autonomy policy, and has the C toolchain and headers available can
-  execute race-enabled tests: measured on this host,
+  regression, and the boundary is the `ReadOnlySeat` marker, not the kind of
+  clone you hold. Seven dispatch sites set it on `origin/main` - in
+  `internal/cli`: `daemon_checkout.go`, `daemon_scheduler.go`, `daemon_worker.go`,
+  `job_blocker_auth_probe.go`, `pipeline_enqueue.go`; in `internal/workflow`:
+  `engine_delegation.go`, `engine_pr_lifecycle.go` - so read the list from
+  `git grep -n 'ReadOnlySeat.*true' origin/main` rather than from a summary here.
+  Under that marker the daemon computes read-only sandbox grants through
+  `readOnlyRuntimeSandboxGrants`, which resolves the isolated tool cache and the
+  staged toolchain; the sandboxing itself is applied by the runtime layer and is
+  not this function's job. A session that is **not** a `ReadOnlySeat`, is
+  permitted to run Bash by its autonomy policy, and has the C toolchain and
+  headers available can execute race-enabled tests: measured on this host,
   `CGO_ENABLED=1 go test -race ./internal/db/` returns `ok`. Owning a checkout is
   not the predicate and neither is being "a seat"; a restrictive autonomy policy
   blocks Bash regardless.
@@ -68,8 +73,10 @@ infrastructure rather than the documented boundary they are:
   block): without the tag the compile silently drops 33 tagged `internal/cli`
   files, 2 in `workflow` and 1 in `daemon`, and the shard plan derived from
   `-test.list` shrinks to match with nothing failing. Measured on this host,
-  `internal/cli` lists **2236** tests with the tag and **2108** without it, so an
-  untagged run omits 128 and reports success. `internal/db` lists 402 either way,
+  `internal/cli` LISTS **2236** tests with the tag and **2108** without it, so an
+  untagged binary carries 128 fewer tests to run. That is a count from
+  `-test.list` on both binaries; neither was executed to completion here, so the
+  claim is about what the shard plan can select, not about a passing run. `internal/db` lists 402 either way,
   which is the trap: probing that package proves a race binary can be built and
   run and says nothing about the lane. A probe that omits the tag cannot answer
   "does the lane pass". Report what you ran. A race result is also

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,19 +55,42 @@ infrastructure rather than the documented boundary they are:
   sandbox denies the C header above. Its absence from a review verdict is not a
   regression, and the boundary is the `ReadOnlySeat` marker, not the kind of
   clone you hold. Do not trust an enumeration of the sites, including one written
-  here: get it from
-  `git grep -n 'ReadOnlySeat.*true' origin/main -- 'internal/*/*.go'`, and note
-  that the pattern matches two different things - the dispatch sites that SET the
-  marker on a request, payload or agent, and `applyReadOnlySeat`, which applies it
-  to a session. Under that marker the daemon computes read-only sandbox grants
-  through `readOnlyRuntimeSandboxGrants`, which resolves the isolated tool cache
-  and the staged toolchain; the sandboxing itself is applied by the runtime layer
-  and is not this function's job. A session that is **not** a `ReadOnlySeat`, is
+  here:
+
+  ```sh
+  git grep -n 'ReadOnlySeat.*true' origin/main -- 'internal/*/*.go' ':!*_test.go'
+  ```
+
+  Nine hits on `7a63a37e`, and read them rather than counting them: the pattern
+  matches sites that SET the marker on a request, payload or agent, the
+  `applyReadOnlySeat` call that applies it to a session, and one COMMENT
+  (`internal/cli/daemon_worker.go:1642`) that names isolated shell pipeline stages
+  as carriers. Dropping `':!*_test.go'` returns 67, which is the fixtures talking.
+  Under the marker the daemon assembles the read-only grant environment in
+  `readOnlyRuntimeSandboxGrants` and enforcement is installed separately, by
+  `landlockRuntimeRunner` wrapping the job's runner in a
+  `subprocess.WrappingRunner` that carries the readable, writable and
+  read-only-workdir values. Read those two functions; a summary of what they grant
+  is exactly the kind of enumeration this bullet just told you not to trust. A session that is **not** a `ReadOnlySeat`, is
   permitted to run Bash by its autonomy policy, and has the C toolchain and
   headers available can execute race-enabled tests: measured on this host,
   `CGO_ENABLED=1 go test -race ./internal/db/` returns `ok`. Owning a checkout is
   not the predicate and neither is being "a seat"; a restrictive autonomy policy
   blocks Bash regardless.
+
+When a seat's plain `go` returns 126, no usable toolchain was staged. The command
+is an engine-owned failure stub, never a fallthrough to the operator's `go`.
+An absent `go` on the daemon `PATH` is silent; an unpinned source, copy failure,
+or unsafe path prints `gitmoot: read-only seat toolchain:` on daemon stderr,
+never in job events. `/opt`, `/usr/local`, `/nix/store`, `/snap`, and profile
+installations all take the same daemon-owned copy path; none retains a recursive
+host-root grant. See `docs/troubleshooting.md`, "`Permission denied`, exit 126,
+running Go".
+
+**Race runs on this host, for any session, not only a seat.** These two rules are
+general and a read-only review seat cannot act on either, which is why they sit
+outside the list above:
+
 - **A local race run is a scoped PROBE, never the lane.** The lane is the
   partitioned recipe below, and reproducing it takes `-tags e2e` (see the race
   block): without the tag the compile silently drops 33 tagged `internal/cli`
@@ -88,15 +111,6 @@ infrastructure rather than the documented boundary they are:
   each observes. No experiment here establishes a direction for that effect, so
   treat it as an unquantified risk to an assurance run rather than as a proven
   false-clean mechanism. Check for a live `-race` binary before starting one.
-
-When a seat's plain `go` returns 126, no usable toolchain was staged. The command
-is an engine-owned failure stub, never a fallthrough to the operator's `go`.
-An absent `go` on the daemon `PATH` is silent; an unpinned source, copy failure,
-or unsafe path prints `gitmoot: read-only seat toolchain:` on daemon stderr,
-never in job events. `/opt`, `/usr/local`, `/nix/store`, `/snap`, and profile
-installations all take the same daemon-owned copy path; none retains a recursive
-host-root grant. See `docs/troubleshooting.md`, "`Permission denied`, exit 126,
-running Go".
 
 Run from the repo root and make these pass before committing — they mirror the CI
 gate in `.github/workflows/ci.yml`:


### PR DESCRIPTION
## The sentence

`AGENTS.md` said, unqualified:

> **`-race` is unreachable in a seat**, because race requires cgo. It is covered by CI's race shards only, and its absence from a seat verdict is not a regression.

## The measurement

From this seat's own clone, `/root/gm-transport`:

```
CGO_ENABLED=1 go test -race -count=1 -run 'TestNothingMatchesThisName' ./internal/db/
ok  	github.com/gitmoot/gitmoot/internal/db	1.022s [no tests to run]
```

So the unreachability is a property of the **read-only review seat**, whose sandbox denies `/usr/include/stdc-predef.h` - which the bullet immediately above already states as the reason cgo fails there. The bullet is inside a block headed "Inside a read-only review seat", so its scope was correct in context and wrong in its own sentence. That is the part a reader carries away.

## Why the second clause is the one that mattered

"Covered by CI's race shards only" is what makes CI look like the sole runner of the lane. Today's GitHub artifact-service degradation meant the race lane gated nothing for eight merges, and a seat consulting this file would conclude there was no local alternative while holding a checkout that can run it. That is a rule causing the wrong operational decision, not a wording nit.

## Two limits recorded with the capability

An unqualified "seats can run race" would be the same defect pointing the other way, so both costs are in the text:

- a race result is **timing-sensitive**, so a clean local run is weaker evidence than a clean CI run rather than equal to it, and must never be reported as the lane passing;
- **two concurrent `-race` workloads on one host perturb the scheduling each is measuring**, with a false clean on both the likely outcome. Measured today: two seats claimed the same race obligation minutes apart. Mine was killed and the sharded run kept, and the surviving `-race` binary was confirmed by `cwd` rather than by the cancel's return. The lane takes one runner at a time, so check for a live `-race` binary before starting one.

## Provenance

Found independently by two seats within minutes, neither of whom inherited the sentence from the other. I measured it first and am proposing it; the concurrent-corruption half is the other seat's contribution and the sharded run is theirs.

Docs only, no code paths touched. A rule that reads as universal while describing one seat type is the same class as an instrument that reports truthfully about a question nobody asked.
