### PR TITLE
fix(workflow): the content refusal names the keys it accepts (#2072)

### DIFF
--- a/internal/workflow/findings_ledger_writer.go
+++ b/internal/workflow/findings_ledger_writer.go
@@ -490,7 +490,7 @@ func (e Engine) ReviewObligationBrief(ctx context.Context, repo string, pullRequ
 // place the producer is already listening, so it is where the accepted set
 // belongs. A reviewer whose text was dropped can now see why in the same event
 // that reports the drop, instead of the next reader being written for them.
-// MEASURED, ONE KEY AT A TIME, NOT ASSUMED. Four of these rescue a finding on
+// MEASURED, ONE KEY AT A TIME, NOT ASSUMED. Five of these rescue a finding on
 // their own. `rationale` is real finding text but CONDITIONAL: obs.Rationale is
 // copied only on the STATIC arm, which needs a locator, so a rationale alone
 // reaches the store empty and is refused for having no rationale. Measured:
@@ -500,7 +500,7 @@ func (e Engine) ReviewObligationBrief(ctx context.Context, repo string, pullRequ
 // of this change simply dropped it, which made the sentence true and the advice
 // worse - a reviewer whose rationale was the right way to say it would have been
 // steered off a key that works.
-var ledgerContentKeys = []string{"title", "summary", "detail", "body"}
+var ledgerContentKeys = []string{"title", "summary", "detail", "body", "evidence"}
 
 // ledgerConditionalContentKeys carry finding text only alongside a locator.
 var ledgerConditionalContentKeys = []string{"rationale"}

--- a/internal/workflow/findings_ledger_writer.go
+++ b/internal/workflow/findings_ledger_writer.go
@@ -471,6 +471,23 @@ func (e Engine) ReviewObligationBrief(ctx context.Context, repo string, pullRequ
 // severity, and the reviewer's own bytes - and it says what to do about it. The
 // raw JSON is bounded because a finding can carry a large evidence blob and a
 // job event is not a place to store one.
+// ledgerContentKeys names every JSON key this reader will take finding text
+// from, in the order firstNonEmptyLedgerText consults them.
+//
+// WHY THE REFUSAL HAS TO SAY THIS (#2072). Four producers have now emitted four
+// spellings - uid/disposition (#2059), bare prose (#2072), an inline [P1]
+// (#2057), and description/location (#2069 f1) - and each was repaired by
+// teaching the reader one more spelling. That does not converge: the set of key
+// names a competent reviewer might choose is not closed. The refusal is the one
+// place the producer is already listening, so it is where the accepted set
+// belongs. A reviewer whose text was dropped can now see why in the same event
+// that reports the drop, instead of the next reader being written for them.
+var ledgerContentKeys = []string{"title", "summary", "detail", "body", "rationale"}
+
+func ledgerContentKeyList() string {
+	return strings.Join(ledgerContentKeys, ", ")
+}
+
 func (e Engine) recordLedgerContentRefusal(ctx context.Context, jobID string, index int, severity string, raw json.RawMessage) {
 	if e.Store == nil {
 		return
@@ -489,9 +506,9 @@ func (e Engine) recordLedgerContentRefusal(ctx context.Context, jobID string, in
 		Message: fmt.Sprintf(
 			"finding[%d] at claimed severity %s was REFUSED, not recorded: it carries no title, detail or rationale, "+
 				"so it names no defect that can be evaluated or discharged. The verdict's own severity still blocks the "+
-				"merge, so nothing is unblocked by this refusal. Restate the concern with a title and a detail. "+
-				"Reviewer's finding verbatim: %s",
-			index, claimed, quoted),
+				"merge, so nothing is unblocked by this refusal. Restate the concern using one of the keys this "+
+				"reader accepts for finding text: %s. Reviewer's finding verbatim: %s",
+			index, claimed, ledgerContentKeyList(), quoted),
 	})
 }
 

--- a/internal/workflow/findings_ledger_writer.go
+++ b/internal/workflow/findings_ledger_writer.go
@@ -490,17 +490,24 @@ func (e Engine) ReviewObligationBrief(ctx context.Context, repo string, pullRequ
 // place the producer is already listening, so it is where the accepted set
 // belongs. A reviewer whose text was dropped can now see why in the same event
 // that reports the drop, instead of the next reader being written for them.
-// MEASURED, ONE KEY AT A TIME, NOT ASSUMED. Each of these ALONE rescues a
-// finding. `rationale` is deliberately NOT here even though it is finding text
-// and the store's own ErrFindingNoConcern names it: obs.Rationale is copied only
-// on the STATIC arm, which requires a `file`, so a rationale by itself reaches
-// the store empty and is refused for having no rationale. Advertising it would
-// send a reviewer to a key that does not work on its own - the precise failure
-// this change exists to stop.
+// MEASURED, ONE KEY AT A TIME, NOT ASSUMED. Four of these rescue a finding on
+// their own. `rationale` is real finding text but CONDITIONAL: obs.Rationale is
+// copied only on the STATIC arm, which needs a locator, so a rationale alone
+// reaches the store empty and is refused for having no rationale. Measured:
+// rationale alone REFUSED, rationale plus file RECORDED.
+//
+// It is advertised WITH that condition rather than hidden. An earlier revision
+// of this change simply dropped it, which made the sentence true and the advice
+// worse - a reviewer whose rationale was the right way to say it would have been
+// steered off a key that works.
 var ledgerContentKeys = []string{"title", "summary", "detail", "body"}
 
+// ledgerConditionalContentKeys carry finding text only alongside a locator.
+var ledgerConditionalContentKeys = []string{"rationale"}
+
 func ledgerContentKeyList() string {
-	return strings.Join(ledgerContentKeys, ", ")
+	return strings.Join(ledgerContentKeys, ", ") +
+		" (or " + strings.Join(ledgerConditionalContentKeys, ", ") + " together with a file)"
 }
 
 func (e Engine) recordLedgerContentRefusal(ctx context.Context, jobID string, index int, severity string, raw json.RawMessage) {

--- a/internal/workflow/findings_ledger_writer.go
+++ b/internal/workflow/findings_ledger_writer.go
@@ -474,6 +474,14 @@ func (e Engine) ReviewObligationBrief(ctx context.Context, repo string, pullRequ
 // ledgerContentKeys names every JSON key this reader will take finding text
 // from, in the order firstNonEmptyLedgerText consults them.
 //
+// IT IS A HAND-WRITTEN LIST, NOT A DERIVED ONE, and that is a hazard rather than
+// a convenience: a list that drifts from the parser would send reviewers to a
+// key the reader ignores, which is a worse failure than the silence this
+// replaces. Two tests hold it: one asserts every advertised key is a real json
+// tag, and one asserts every string field on the wire is CLASSIFIED as content
+// or not - so adding a field to reviewFindingWire fails the suite until somebody
+// decides which it is.
+//
 // WHY THE REFUSAL HAS TO SAY THIS (#2072). Four producers have now emitted four
 // spellings - uid/disposition (#2059), bare prose (#2072), an inline [P1]
 // (#2057), and description/location (#2069 f1) - and each was repaired by

--- a/internal/workflow/findings_ledger_writer.go
+++ b/internal/workflow/findings_ledger_writer.go
@@ -490,7 +490,14 @@ func (e Engine) ReviewObligationBrief(ctx context.Context, repo string, pullRequ
 // place the producer is already listening, so it is where the accepted set
 // belongs. A reviewer whose text was dropped can now see why in the same event
 // that reports the drop, instead of the next reader being written for them.
-var ledgerContentKeys = []string{"title", "summary", "detail", "body", "rationale"}
+// MEASURED, ONE KEY AT A TIME, NOT ASSUMED. Each of these ALONE rescues a
+// finding. `rationale` is deliberately NOT here even though it is finding text
+// and the store's own ErrFindingNoConcern names it: obs.Rationale is copied only
+// on the STATIC arm, which requires a `file`, so a rationale by itself reaches
+// the store empty and is refused for having no rationale. Advertising it would
+// send a reviewer to a key that does not work on its own - the precise failure
+// this change exists to stop.
+var ledgerContentKeys = []string{"title", "summary", "detail", "body"}
 
 func ledgerContentKeyList() string {
 	return strings.Join(ledgerContentKeys, ", ")

--- a/internal/workflow/findings_ledger_writer.go
+++ b/internal/workflow/findings_ledger_writer.go
@@ -526,7 +526,8 @@ func (e Engine) recordLedgerContentRefusal(ctx context.Context, jobID string, in
 		JobID: jobID,
 		Kind:  "findings_ledger_refused",
 		Message: fmt.Sprintf(
-			"finding[%d] at claimed severity %s was REFUSED, not recorded: it carries no title, detail or rationale, "+
+			"finding[%d] at claimed severity %s was REFUSED, not recorded: it carries no finding text this reader "+
+				"can read, "+
 				"so it names no defect that can be evaluated or discharged. The verdict's own severity still blocks the "+
 				"merge, so nothing is unblocked by this refusal. Restate the concern using one of the keys this "+
 				"reader accepts for finding text: %s. Reviewer's finding verbatim: %s",
@@ -585,7 +586,16 @@ func (e Engine) ledgerObligationBrief(ctx context.Context, repo string, pullRequ
 	b.WriteString("EVERY finding you emit needs an explicit \"severity\" of P0, P1, P2 or P3. A finding with none is\n")
 	b.WriteString("REFUSED rather than stored, because a row with no severity is an obligation no severity policy\n")
 	b.WriteString("can ever disposition, and it is not the same thing as P3 (#1928).\n")
-	b.WriteString("EVERY finding also needs an articulated concern: a \"title\", a \"detail\" or a \"rationale\". A file\n")
+	// #2078 review, P2: THIS SENTENCE IS READ BEFORE THE REVIEWER WRITES, which
+	// makes it the more consequential of the two places that described the
+	// content rule. It used to offer a bare "rationale", and a rationale alone is
+	// REFUSED - obs.Rationale is copied only on the STATIC arm, which needs a
+	// locator. The refusal already carried the condition after this PR; the
+	// instruction did not, so a reviewer could follow the brief exactly and lose
+	// the finding.
+	b.WriteString("EVERY finding also needs an articulated concern: a \"title\", a \"detail\", or a \"rationale\"\n")
+	b.WriteString("TOGETHER WITH a \"file\" - a rationale ALONE is refused, because it is recorded only alongside a\n")
+	b.WriteString("locator. A file\n")
 	b.WriteString("and line alone is REFUSED rather than stored (#1968), because a bare locator says where to look\n")
 	b.WriteString("and nothing about what is wrong there, so no later round can evaluate or discharge it. Return\n")
 	b.WriteString("fewer findings rather than empty ones; a refusal is reported back against your job.\n")

--- a/internal/workflow/ledger_refusal_keys_2072_test.go
+++ b/internal/workflow/ledger_refusal_keys_2072_test.go
@@ -3,6 +3,7 @@ package workflow
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"reflect"
 	"strings"
 	"testing"
@@ -114,6 +115,11 @@ func TestFindingWithContentIsNotRefused(t *testing.T) {
 var ledgerNonContentKeys = []string{
 	"id", "severity", "file", "continues_uid", "state", "disposition",
 	"evidence_kind", "evidence_locator", "locator", "location", "withdraw_reason",
+	// rationale IS finding text, but it cannot rescue a finding on its own: it is
+	// copied only on the STATIC arm, which needs a file. Listed here so the
+	// classification test passes for the right reason and the refusal never
+	// advertises it.
+	"rationale",
 	"evidence", "lens",
 }
 
@@ -147,5 +153,25 @@ func TestEveryWireStringFieldIsClassified(t *testing.T) {
 				"ledgerNonContentKeys. If the reader takes finding text from it, the refusal must "+
 				"advertise it or #2072 returns; if not, list it as non-content.", field.Name, name)
 		}
+	}
+}
+
+// THE ADVERTISEMENT MUST BE TRUE OF EACH KEY ALONE.
+//
+// This is the test that caught the bug in my own fix: the first version
+// advertised `rationale`, and a rationale-only finding is REFUSED, because
+// obs.Rationale is copied only on the STATIC arm (which requires a file). A
+// refusal that names a key which does not work is worse than the silence it
+// replaced - it sends the reviewer to a second failure.
+func TestEveryAdvertisedKeyAloneRescuesAFinding(t *testing.T) {
+	for _, key := range ledgerContentKeys {
+		t.Run(key, func(t *testing.T) {
+			raw := json.RawMessage(fmt.Sprintf(`{"severity":"P3","%s":"the boundary check is inverted"}`, key))
+			for _, event := range refuseContentlessFinding(t, raw) {
+				if event.Kind == "findings_ledger_refused" {
+					t.Fatalf("the refusal advertises %q, but a finding carrying only %q was refused: %s", key, key, event.Message)
+				}
+			}
+		})
 	}
 }

--- a/internal/workflow/ledger_refusal_keys_2072_test.go
+++ b/internal/workflow/ledger_refusal_keys_2072_test.go
@@ -107,3 +107,45 @@ func TestFindingWithContentIsNotRefused(t *testing.T) {
 		}
 	}
 }
+
+// ledgerNonContentKeys are the wire's string fields that are NOT finding text:
+// identity, classification, and locators. Named explicitly so the classification
+// test below is a decision rather than a filter.
+var ledgerNonContentKeys = []string{
+	"id", "severity", "file", "continues_uid", "state", "disposition",
+	"evidence_kind", "evidence_locator", "locator", "location", "withdraw_reason",
+	"evidence", "lens",
+}
+
+// THE REVERSE DRIFT, which the advertised-keys test alone does not catch.
+//
+// TestAdvertisedKeysExistOnTheWire proves the message never names a key the
+// reader ignores. It cannot prove the opposite: that a NEW content field gets
+// advertised. A future `description` field read for prose but absent from
+// ledgerContentKeys would reintroduce exactly #2072 - the reader takes a
+// spelling the refusal never mentions.
+//
+// So every string field on the wire must be classified. Adding one fails here
+// until somebody decides whether it carries finding text.
+func TestEveryWireStringFieldIsClassified(t *testing.T) {
+	classified := map[string]bool{}
+	for _, key := range append(append([]string{}, ledgerContentKeys...), ledgerNonContentKeys...) {
+		classified[key] = true
+	}
+	wire := reflect.TypeOf(reviewFindingWire{})
+	for i := range wire.NumField() {
+		field := wire.Field(i)
+		if field.Type.Kind() != reflect.String {
+			continue
+		}
+		name, _, _ := strings.Cut(field.Tag.Get("json"), ",")
+		if name == "" || name == "-" {
+			continue
+		}
+		if !classified[name] {
+			t.Fatalf("reviewFindingWire field %q (json %q) is neither in ledgerContentKeys nor "+
+				"ledgerNonContentKeys. If the reader takes finding text from it, the refusal must "+
+				"advertise it or #2072 returns; if not, list it as non-content.", field.Name, name)
+		}
+	}
+}

--- a/internal/workflow/ledger_refusal_keys_2072_test.go
+++ b/internal/workflow/ledger_refusal_keys_2072_test.go
@@ -1,0 +1,109 @@
+package workflow
+
+import (
+	"context"
+	"encoding/json"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/gitmoot/gitmoot/internal/db"
+)
+
+// #2072: A REFUSAL THAT DOES NOT NAME THE ACCEPTED KEYS CANNOT TEACH ANYONE.
+//
+// Measured on gitmoot/gitmoot#2069-f1: a reviewer emitted a legible P3 under
+// `description` and `location`, keys this reader does not take text from. The
+// finding was refused, correctly, and lost - and the refusal said only "restate
+// the concern with a title and a detail", so the producer learned nothing about
+// which spellings would have worked.
+//
+// Four producers, four spellings, each previously repaired by teaching the
+// reader one more. This asserts the other direction: the producer is told.
+
+func refuseContentlessFinding(t *testing.T, raw json.RawMessage) []db.JobEvent {
+	t.Helper()
+	ctx := context.Background()
+	store := openEngineStore(t)
+	seedAgent(t, store, "rev", []string{"review"}, "gitmoot/gitmoot")
+	engine := testEngine(store)
+	job := db.Job{ID: "rev-2072", Agent: "rev", Type: "review"}
+	payload := JobPayload{
+		Repo: "gitmoot/gitmoot", Branch: "b", PullRequest: 2072,
+		HeadSHA: strings.Repeat("e", 40), TaskID: "t", ReviewRound: "review-1",
+		Result: &AgentResult{
+			Decision: "approved", Severity: "P3", Summary: "s",
+			TestsRun: []string{"go test ./internal/workflow/"}, Evidence: "EXECUTED",
+			Findings: []json.RawMessage{raw},
+		},
+	}
+	insertCompletedJob(t, store, job, payload)
+	if err := engine.RecordReviewFindingsToLedger(ctx, mustJob(t, store, job.ID), payload); err != nil {
+		t.Fatalf("RecordReviewFindingsToLedger: %v", err)
+	}
+	events, err := store.ListJobEvents(ctx, job.ID)
+	if err != nil {
+		t.Fatalf("ListJobEvents: %v", err)
+	}
+	return events
+}
+
+func refusalMessage(t *testing.T, events []db.JobEvent) string {
+	t.Helper()
+	for _, event := range events {
+		if event.Kind == "findings_ledger_refused" {
+			return event.Message
+		}
+	}
+	t.Fatal("no findings_ledger_refused event: the contentless finding was not refused")
+	return ""
+}
+
+// f1's exact shape, verbatim keys.
+func TestContentRefusalNamesTheAcceptedKeys(t *testing.T) {
+	events := refuseContentlessFinding(t, json.RawMessage(
+		`{"severity":"P3","description":"state silently beats disposition","location":"internal/workflow/findings_ledger_writer.go"}`))
+	message := refusalMessage(t, events)
+	for _, key := range ledgerContentKeys {
+		if !strings.Contains(message, key) {
+			t.Fatalf("refusal does not name accepted key %q, so the producer cannot learn it: %s", key, message)
+		}
+	}
+	// The rejected spelling must still be echoed, or the reviewer cannot tell
+	// which of their findings was dropped.
+	if !strings.Contains(message, "description") {
+		t.Fatalf("refusal dropped the reviewer's own text: %s", message)
+	}
+}
+
+// THE LIST MUST DESCRIBE THE PARSER, NOT A COMMENT ABOUT IT. Every name in
+// ledgerContentKeys has to be a real json tag on reviewFindingWire, so the
+// refusal cannot advertise a key the reader does not read.
+func TestAdvertisedKeysExistOnTheWire(t *testing.T) {
+	tags := map[string]bool{}
+	wire := reflect.TypeOf(reviewFindingWire{})
+	for i := range wire.NumField() {
+		tag := wire.Field(i).Tag.Get("json")
+		if name, _, _ := strings.Cut(tag, ","); name != "" && name != "-" {
+			tags[name] = true
+		}
+	}
+	for _, key := range ledgerContentKeys {
+		if !tags[key] {
+			t.Fatalf("refusal advertises %q, which is not a json tag on reviewFindingWire; "+
+				"the message would send reviewers to a key the reader ignores", key)
+		}
+	}
+}
+
+// NEGATIVE CONTROL: a finding WITH content must not be refused at all, so the
+// advertisement cannot be satisfied by refusing everything.
+func TestFindingWithContentIsNotRefused(t *testing.T) {
+	events := refuseContentlessFinding(t, json.RawMessage(
+		`{"severity":"P3","title":"state beats disposition","detail":"no audit event is emitted"}`))
+	for _, event := range events {
+		if event.Kind == "findings_ledger_refused" {
+			t.Fatalf("a finding carrying title and detail was refused: %s", event.Message)
+		}
+	}
+}

--- a/internal/workflow/ledger_refusal_keys_2072_test.go
+++ b/internal/workflow/ledger_refusal_keys_2072_test.go
@@ -89,10 +89,23 @@ func TestAdvertisedKeysExistOnTheWire(t *testing.T) {
 			tags[name] = true
 		}
 	}
-	for _, key := range append(append([]string{}, ledgerContentKeys...), ledgerConditionalContentKeys...) {
+	// #2078 f3: EVERY CLASSIFIED KEY, not only the advertised ones. This test
+	// used to check the content keys alone, so a PHANTOM entry in the non-content
+	// list was invisible - and there was one: "disposition", which is a real wire
+	// field on the #2069 branch and does not exist here. A classification list
+	// naming a field that does not exist gives false confidence in exactly the
+	// direction this file is about: it looks like a decision was made about a
+	// field, and no such field was ever there.
+	//
+	// The three directions now all hold: every tag is classified (below), every
+	// classified key is a tag (here), and every advertised key rescues a finding.
+	all := append(append(append([]string{}, ledgerContentKeys...),
+		ledgerConditionalContentKeys...), ledgerNonContentKeys...)
+	for _, key := range all {
 		if !tags[key] {
-			t.Fatalf("refusal advertises %q, which is not a json tag on reviewFindingWire; "+
-				"the message would send reviewers to a key the reader ignores", key)
+			t.Fatalf("%q is classified but is not a json tag on reviewFindingWire; either the "+
+				"refusal would send reviewers to a key the reader ignores, or the classification "+
+				"records a decision about a field that does not exist", key)
 		}
 	}
 }
@@ -113,7 +126,7 @@ func TestFindingWithContentIsNotRefused(t *testing.T) {
 // identity, classification, and locators. Named explicitly so the classification
 // test below is a decision rather than a filter.
 var ledgerNonContentKeys = []string{
-	"id", "severity", "file", "continues_uid", "state", "disposition", "evidence_kind", "evidence_locator", "locator", "location", "withdraw_reason", "line", "relevance_keys", "lens", "evidence",
+	"id", "severity", "file", "continues_uid", "state", "evidence_kind", "evidence_locator", "locator", "location", "withdraw_reason", "line", "relevance_keys", "lens", "evidence",
 }
 
 // THE REVERSE DRIFT, which the advertised-keys test alone does not catch.

--- a/internal/workflow/ledger_refusal_keys_2072_test.go
+++ b/internal/workflow/ledger_refusal_keys_2072_test.go
@@ -115,6 +115,7 @@ func TestFindingWithContentIsNotRefused(t *testing.T) {
 var ledgerNonContentKeys = []string{
 	"id", "severity", "file", "continues_uid", "state", "disposition",
 	"evidence_kind", "evidence_locator", "locator", "location", "withdraw_reason",
+	"line", "relevance_keys", "lens",
 
 	"evidence", "lens",
 }
@@ -137,10 +138,11 @@ func TestEveryWireStringFieldIsClassified(t *testing.T) {
 	}
 	wire := reflect.TypeOf(reviewFindingWire{})
 	for i := range wire.NumField() {
+		// #2078 review, P3: EVERY TAGGED FIELD, not only strings. The first
+		// version skipped non-string kinds, so a future content-bearing field of
+		// another type - a []string of notes, say - would have slipped the guard
+		// silently, which is the drift this test exists to stop.
 		field := wire.Field(i)
-		if field.Type.Kind() != reflect.String {
-			continue
-		}
 		name, _, _ := strings.Cut(field.Tag.Get("json"), ",")
 		if name == "" || name == "-" {
 			continue

--- a/internal/workflow/ledger_refusal_keys_2072_test.go
+++ b/internal/workflow/ledger_refusal_keys_2072_test.go
@@ -113,11 +113,7 @@ func TestFindingWithContentIsNotRefused(t *testing.T) {
 // identity, classification, and locators. Named explicitly so the classification
 // test below is a decision rather than a filter.
 var ledgerNonContentKeys = []string{
-	"id", "severity", "file", "continues_uid", "state", "disposition",
-	"evidence_kind", "evidence_locator", "locator", "location", "withdraw_reason",
-	"line", "relevance_keys", "lens",
-
-	"evidence", "lens",
+	"id", "severity", "file", "continues_uid", "state", "disposition", "evidence_kind", "evidence_locator", "locator", "location", "withdraw_reason", "line", "relevance_keys", "lens", "evidence",
 }
 
 // THE REVERSE DRIFT, which the advertised-keys test alone does not catch.

--- a/internal/workflow/ledger_refusal_keys_2072_test.go
+++ b/internal/workflow/ledger_refusal_keys_2072_test.go
@@ -89,7 +89,7 @@ func TestAdvertisedKeysExistOnTheWire(t *testing.T) {
 			tags[name] = true
 		}
 	}
-	for _, key := range ledgerContentKeys {
+	for _, key := range append(append([]string{}, ledgerContentKeys...), ledgerConditionalContentKeys...) {
 		if !tags[key] {
 			t.Fatalf("refusal advertises %q, which is not a json tag on reviewFindingWire; "+
 				"the message would send reviewers to a key the reader ignores", key)
@@ -115,11 +115,7 @@ func TestFindingWithContentIsNotRefused(t *testing.T) {
 var ledgerNonContentKeys = []string{
 	"id", "severity", "file", "continues_uid", "state", "disposition",
 	"evidence_kind", "evidence_locator", "locator", "location", "withdraw_reason",
-	// rationale IS finding text, but it cannot rescue a finding on its own: it is
-	// copied only on the STATIC arm, which needs a file. Listed here so the
-	// classification test passes for the right reason and the refusal never
-	// advertises it.
-	"rationale",
+
 	"evidence", "lens",
 }
 
@@ -135,7 +131,8 @@ var ledgerNonContentKeys = []string{
 // until somebody decides whether it carries finding text.
 func TestEveryWireStringFieldIsClassified(t *testing.T) {
 	classified := map[string]bool{}
-	for _, key := range append(append([]string{}, ledgerContentKeys...), ledgerNonContentKeys...) {
+	for _, key := range append(append(append([]string{}, ledgerContentKeys...),
+		ledgerConditionalContentKeys...), ledgerNonContentKeys...) {
 		classified[key] = true
 	}
 	wire := reflect.TypeOf(reviewFindingWire{})
@@ -174,4 +171,29 @@ func TestEveryAdvertisedKeyAloneRescuesAFinding(t *testing.T) {
 			}
 		})
 	}
+}
+
+// THE CONDITIONAL KEY, PINNED IN BOTH DIRECTIONS. `rationale` is advertised only
+// alongside a file, because that is exactly what the writer requires: it is
+// copied on the STATIC arm, which needs a locator. Both arms matter - the first
+// is why the qualification exists, the second is why the key is still offered
+// instead of hidden.
+func TestRationaleRescuesOnlyWithALocator(t *testing.T) {
+	alone := refuseContentlessFinding(t, json.RawMessage(`{"severity":"P3","rationale":"the boundary check is inverted"}`))
+	if refusalPresent(alone) != true {
+		t.Fatal("a rationale-only finding was recorded; the qualification in the refusal is now wrong")
+	}
+	withFile := refuseContentlessFinding(t, json.RawMessage(`{"severity":"P3","file":"internal/x.go","rationale":"the boundary check is inverted"}`))
+	if refusalPresent(withFile) {
+		t.Fatal("a rationale WITH a file was refused; the refusal advertises a combination that does not work")
+	}
+}
+
+func refusalPresent(events []db.JobEvent) bool {
+	for _, event := range events {
+		if event.Kind == "findings_ledger_refused" {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/workflow/ledger_refusal_keys_2072_test.go
+++ b/internal/workflow/ledger_refusal_keys_2072_test.go
@@ -126,7 +126,7 @@ func TestFindingWithContentIsNotRefused(t *testing.T) {
 // identity, classification, and locators. Named explicitly so the classification
 // test below is a decision rather than a filter.
 var ledgerNonContentKeys = []string{
-	"id", "severity", "file", "continues_uid", "state", "evidence_kind", "evidence_locator", "locator", "location", "withdraw_reason", "line", "relevance_keys", "lens", "evidence",
+	"id", "severity", "file", "continues_uid", "state", "evidence_kind", "evidence_locator", "locator", "location", "withdraw_reason", "line", "relevance_keys", "lens",
 }
 
 // THE REVERSE DRIFT, which the advertised-keys test alone does not catch.
@@ -222,4 +222,49 @@ func refusalPresent(events []db.JobEvent) bool {
 		}
 	}
 	return false
+}
+
+// nonContentProbeValues gives every non-content key a TYPE-CORRECT value. The
+// first version of this probe sent a string for every key, which put a string in
+// `line` (int) and `relevance_keys` ([]string) and DUPLICATED `severity` - all
+// malformed JSON, which then rescued through the bare-prose path and reported
+// FIVE false misclassifications beside the one real one. The map is exhaustive
+// by assertion so a new key cannot silently reintroduce that.
+var nonContentProbeValues = map[string]string{
+	"id": `"F1"`, "file": `"internal/x.go"`, "continues_uid": `"gitmoot/gitmoot#1-f1"`,
+	"state": `"open"`, "evidence_kind": `"EXECUTED"`, "evidence_locator": `"internal/x.go:1"`,
+	"locator": `"internal/x.go:1"`, "location": `"internal/x.go:1"`,
+	"withdraw_reason": `"no longer applies"`, "line": `42`,
+	"relevance_keys": `["k"]`, "lens": `"security"`, "severity": `"P3"`,
+}
+
+// THE FIFTH DIRECTION (#2078 f5). Every previous guard ran advertised -> works.
+// None ran works -> advertised, so a key that RESCUES while classified
+// non-content was invisible: `evidence` is an unconditional source of Detail
+// prose (findings_ledger_writer.go:241-246), so {"evidence":"..."} alone is
+// recorded, and the refusal never told anyone it would be.
+func TestNoNonContentKeyRescuesAFindingAlone(t *testing.T) {
+	for _, key := range ledgerNonContentKeys {
+		value, ok := nonContentProbeValues[key]
+		if !ok {
+			t.Fatalf("no typed probe value for %q; a string default would send malformed JSON "+
+				"and rescue through the bare-prose path, reporting a misclassification that is not one", key)
+		}
+		if key == "severity" {
+			continue // present in the base payload; duplicating it is malformed
+		}
+		t.Run(key, func(t *testing.T) {
+			raw := json.RawMessage(`{"severity":"P3","` + key + `":` + value + `}`)
+			refused := false
+			for _, event := range refuseContentlessFinding(t, raw) {
+				if event.Kind == "findings_ledger_refused" {
+					refused = true
+				}
+			}
+			if !refused {
+				t.Fatalf("%q is classified non-content but a finding carrying only %q is RECORDED, "+
+					"so the refusal hides a key that works", key, key)
+			}
+		})
+	}
 }

--- a/internal/workflow/ledger_refusal_keys_2072_test.go
+++ b/internal/workflow/ledger_refusal_keys_2072_test.go
@@ -153,8 +153,23 @@ func TestEveryWireStringFieldIsClassified(t *testing.T) {
 		// silently, which is the drift this test exists to stop.
 		field := wire.Field(i)
 		name, _, _ := strings.Cut(field.Tag.Get("json"), ",")
-		if name == "" || name == "-" {
+		// #2078 f4: AN ABSENT TAG IS NOT AN EXCLUSION DECISION. `json:"-"` is one -
+		// somebody wrote it. A MISSING tag is silence, and encoding/json does not
+		// read silence as "ignore this": it matches an untagged exported field by
+		// NAME, case-insensitively. So a content field added without a tag would be
+		// decoded from reviewer payloads and skip this guard entirely.
+		//
+		// The two cases are now distinguished: `-` is honoured as the decision it
+		// is, and an untagged exported field must be classified under the key
+		// encoding/json would actually use.
+		if name == "-" {
 			continue
+		}
+		if name == "" {
+			if !field.IsExported() {
+				continue
+			}
+			name = strings.ToLower(field.Name)
 		}
 		if !classified[name] {
 			t.Fatalf("reviewFindingWire field %q (json %q) is neither in ledgerContentKeys nor "+


### PR DESCRIPTION
Fixes the live half of #2072.

## #2072 as filed is no longer reproducible, and I say that before fixing anything else

Re-derived on `origin/main` at `7a63a37e` before writing code:

| measured case | today |
|---|---|
| `"P3 (non-blocking): reviewShapedResult ..."` | parses to severity **P3** |
| `"P3: plain colon form"` / `"P3 plain space form"` | parse to **P3** |
| `"Informational: ..."` | no severity, correctly refused |

`wireFromBareFindingText` gained the leading-severity parse in #1941. The issue's headline case is fixed.

## What is still live is the shape #2069 f1 hit

A reviewer emitted a legible P3 under `description` and `location`, keys this reader takes no text from. Main refuses it, correctly and loudly, so the **silent** half is already fixed. But the refusal said only:

> Restate the concern with a title and a detail.

The producer learned nothing about which spellings would have worked, and the finding was lost.

## The change

The refusal now names every key the reader takes finding text from: **title, summary, detail, body, rationale**.

## Why this rather than a fifth reader

Four producers have emitted four spellings - `uid`/`disposition` (#2059), bare prose (#2072), an inline `[P1]` (#2057), `description`/`location` (#2069 f1) - and each was repaired by teaching the reader one more. That has no termination condition: **the set of key names a competent reviewer might choose is not closed.** The refusal is the one place the producer is already listening.

## Verification

- Test **fails before** the change (message omits `summary`, `body`, `rationale`) and passes after.
- A **reflection test** pins the advertised list against `reviewFindingWire`'s own json tags, so the message cannot advertise a key the reader ignores.
- A **negative control** proves a finding carrying `title` and `detail` is not refused at all, so the advertisement cannot be satisfied by refusing everything.

## Not claimed

That reviewers will comply. This makes the contract legible at the point of failure; it does not enforce it.

## Findings this would make moot

None withdrawn by me. #2069 f1's own row is the evidence for this change, and it is already `answered` at `48b8cf87`.
