### PR TITLE
feat(cli): findings can print the rows the obligation brief points at (#2077 f3)

### DIFF
--- a/internal/cli/findings.go
+++ b/internal/cli/findings.go
@@ -50,6 +50,19 @@ func runFindings(args []string, stdout, stderr io.Writer) int {
 	fs.SetOutput(stderr)
 	home := fs.String("home", "", "home directory to use instead of the current user's home")
 	jsonOutput := fs.Bool("json", false, "print the report as JSON")
+	// #2077 f3: THE BRIEF POINTS HERE AND THIS COULD NOT ANSWER.
+	//
+	// ledgerObligationBrief is byte-bounded, so once the budget is exhausted it
+	// omits mandatory UIDs and tells the reviewer to consult the findings ledger.
+	// This command was the ledger's only supported reader and it printed
+	// per-repository COUNTS - no rows, no UIDs - while a read-only review seat
+	// has no database access at all. The instruction was correct and the
+	// destination could not satisfy it.
+	//
+	// That is why the finding survived three rounds of bounding work: every fix
+	// was in the writer, and the missing half was here.
+	repo := fs.String("repo", "", "with --pr, list individual findings for this owner/repo instead of the per-repository summary")
+	pullRequest := fs.Int("pr", 0, "with --repo, the pull request whose findings to list")
 	if err := fs.Parse(args); err != nil {
 		if errors.Is(err, flag.ErrHelp) {
 			return 0
@@ -59,6 +72,19 @@ func runFindings(args []string, stdout, stderr io.Writer) int {
 	if fs.NArg() != 0 {
 		fmt.Fprintln(stderr, "findings does not accept positional arguments")
 		return 2
+	}
+	// BOTH OR NEITHER. A UID is unique only within a repository, and the store's
+	// reader is keyed on (repo, pull_request) - so a repo without a PR would have
+	// silently listed the pull_request=0 rows and reported "no findings" for a
+	// repository full of them. Measured: that is exactly what the first version
+	// of this command did. Refusing beats a listing that is empty for the wrong
+	// reason, which is the failure this whole finding is about.
+	if (strings.TrimSpace(*repo) == "") != (*pullRequest == 0) {
+		fmt.Fprintln(stderr, "findings: --repo and --pr must be given together; a finding UID is unique only within one repository's pull request")
+		return 2
+	}
+	if strings.TrimSpace(*repo) != "" {
+		return runFindingsRows(strings.TrimSpace(*repo), *pullRequest, *home, *jsonOutput, stdout, stderr)
 	}
 
 	reviewCfg := loadReviewConfig(*home)
@@ -107,5 +133,70 @@ func runFindings(args []string, stdout, stderr io.Writer) int {
 	fmt.Fprintln(stdout, "A repository with findings and ANSWERED 0 is recording obligations nothing consumes.")
 	fmt.Fprintln(stdout, "DECLARED undeclared means nobody has decided whether this repository consumes findings;")
 	fmt.Fprintln(stdout, "it behaves as consuming. advisory records and reports findings without holding the merge.")
+	return 0
+}
+
+// runFindingsRows lists individual ledger rows, which is what the obligation
+// brief tells a reviewer to consult (#2077 f3).
+//
+// It prints the UID first because that is the only thing a reviewer can act on:
+// continuing a prior finding requires citing its uid exactly, and typing its old
+// label mints a new finding instead. A budgeted brief omits UIDs; this is where
+// they are recoverable.
+func runFindingsRows(repo string, pullRequest int, home string, jsonOutput bool, stdout, stderr io.Writer) int {
+	var rows []db.ReviewFindingObservation
+	if err := withStoreAndPaths(home, func(_ config.Paths, store *db.Store) error {
+		var err error
+		rows, err = store.ListReviewFindingObservations(context.Background(), repo, int64(pullRequest))
+		return err
+	}); err != nil {
+		fmt.Fprintf(stderr, "findings: %v\n", err)
+		return 1
+	}
+
+	if jsonOutput {
+		encoded, err := json.MarshalIndent(rows, "", "  ")
+		if err != nil {
+			fmt.Fprintf(stderr, "findings: %v\n", err)
+			return 1
+		}
+		fmt.Fprintln(stdout, string(encoded))
+		return 0
+	}
+
+	if len(rows) == 0 {
+		// NAME BOTH REASONS. A reviewer sent here by a brief needs to know whether
+		// the ledger is empty or their filter missed, and those are different
+		// problems with different next steps.
+		if pullRequest > 0 {
+			fmt.Fprintf(stdout, "no findings recorded for %s#%d\n", repo, pullRequest)
+		} else {
+			fmt.Fprintf(stdout, "no findings recorded for %s\n", repo)
+		}
+		return 0
+	}
+
+	writer := tabwriter.NewWriter(stdout, 0, 0, 2, ' ', 0)
+	fmt.Fprintln(writer, "UID\tSEV\tSTATE\tPR\tHEAD\tTITLE")
+	for _, row := range rows {
+		head := row.HeadSHA
+		if len(head) > 8 {
+			head = head[:8]
+		}
+		title := strings.TrimSpace(row.Title)
+		if title == "" {
+			// A row with no title is the #2072 shape and the reviewer needs to see
+			// that it exists rather than a blank line they cannot cite.
+			title = "(no title recorded)"
+		}
+		fmt.Fprintf(writer, "%s\t%s\t%s\t%d\t%s\t%s\n",
+			row.FindingUID, row.Severity, row.State, row.PullRequest, head, title)
+	}
+	if err := writer.Flush(); err != nil {
+		fmt.Fprintf(stderr, "findings: %v\n", err)
+		return 1
+	}
+	fmt.Fprintln(stdout)
+	fmt.Fprintln(stdout, "Cite a UID verbatim as \"continues_uid\" to continue a finding; typing its label mints a new one.")
 	return 0
 }

--- a/internal/cli/findings.go
+++ b/internal/cli/findings.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/gitmoot/gitmoot/internal/config"
 	"github.com/gitmoot/gitmoot/internal/db"
+	"github.com/gitmoot/gitmoot/internal/workflow"
 )
 
 // findingsDeclaration renders a repository's #1969 findings-consumption
@@ -154,6 +155,12 @@ func runFindingsRows(repo string, pullRequest int, home string, jsonOutput bool,
 		return 1
 	}
 
+	// FOLD BEFORE EVERY OUTPUT PATH (#2086 review). The first fix put this after
+	// the JSON branch, so --json still returned the raw append-only log - the
+	// worse half, because JSON is what a dispatch path consumes and a human at
+	// least sees the duplicate UIDs.
+	rows = workflow.LatestObservationsInOrder(rows)
+
 	if jsonOutput {
 		encoded, err := json.MarshalIndent(rows, "", "  ")
 		if err != nil {
@@ -177,7 +184,6 @@ func runFindingsRows(repo string, pullRequest int, home string, jsonOutput bool,
 	//
 	// The fold rule is the engine's, not a new one: latestObservation in
 	// findings_ledger.go, including its QUOTED guard.
-	rows = foldLatestObservations(rows)
 
 	if len(rows) == 0 {
 		// NAME BOTH REASONS. A reviewer sent here by a brief needs to know whether
@@ -222,31 +228,4 @@ func runFindingsRows(repo string, pullRequest int, home string, jsonOutput bool,
 	fmt.Fprintln(stdout, "STATE is the last recorded observation. An answered finding can still be MANDATORY at a")
 	fmt.Fprintln(stdout, "later head if the files it names changed again, which only the merge gate can decide.")
 	return 0
-}
-
-// foldLatestObservations mirrors internal/workflow's latestObservation: the last
-// observation wins per finding UID, except that a QUOTED row never displaces one
-// that already carried EXECUTED or STATIC evidence.
-//
-// Kept identical on purpose. A listing that folded by a different rule than the
-// gate would disagree with it about which obligations are open, which relocates
-// the failure this command exists to remove instead of removing it.
-func foldLatestObservations(rows []db.ReviewFindingObservation) []db.ReviewFindingObservation {
-	latest := make(map[string]db.ReviewFindingObservation, len(rows))
-	order := make([]string, 0, len(rows))
-	for _, obs := range rows {
-		previous, seen := latest[obs.FindingUID]
-		if !seen {
-			order = append(order, obs.FindingUID)
-		}
-		if seen && obs.EvidenceKind == db.EvidenceQuoted && previous.EvidenceKind != db.EvidenceQuoted {
-			continue
-		}
-		latest[obs.FindingUID] = obs
-	}
-	folded := make([]db.ReviewFindingObservation, 0, len(order))
-	for _, uid := range order {
-		folded = append(folded, latest[uid])
-	}
-	return folded
 }

--- a/internal/cli/findings.go
+++ b/internal/cli/findings.go
@@ -155,10 +155,23 @@ func runFindingsRows(repo string, pullRequest int, home string, jsonOutput bool,
 		return 1
 	}
 
-	// FOLD BEFORE EVERY OUTPUT PATH (#2086 review). The first fix put this after
-	// the JSON branch, so --json still returned the raw append-only log - the
-	// worse half, because JSON is what a dispatch path consumes and a human at
-	// least sees the duplicate UIDs.
+	// FOLD BEFORE EVERY OUTPUT PATH (#2086 f1, and its comment lived twelve lines
+	// too low until #2086 f4).
+	//
+	// The store is APPEND-ONLY and its doc comment says so: it returns every
+	// observation and does not fold, so a caller folds. The first version printed
+	// the raw log, one line per observation, showing a finding as "open" at an old
+	// head beside its own "answered" row at a newer one - four lines for one
+	// finding on PR #2077. A reviewer sent here by a budgeted brief is asking
+	// WHICH OBLIGATIONS ARE OPEN, and a stale open row answers that wrongly using
+	// the ledger's own data.
+	//
+	// The second version folded AFTER the JSON branch, so --json still returned
+	// the raw log - the worse half, because JSON is what a dispatch path consumes
+	// and a human at least sees the duplicate UIDs and can wonder.
+	//
+	// The rule is the engine's, not a new one: workflow.LatestObservationsInOrder,
+	// including its QUOTED guard.
 	rows = workflow.LatestObservationsInOrder(rows)
 
 	if jsonOutput {
@@ -170,20 +183,6 @@ func runFindingsRows(repo string, pullRequest int, home string, jsonOutput bool,
 		fmt.Fprintln(stdout, string(encoded))
 		return 0
 	}
-
-	// FOLD TO LATEST PER FINDING (#2086 f1). The store is APPEND-ONLY and its own
-	// doc comment says so: it returns every observation and does not fold, so a
-	// caller folds. The first version printed the raw log, one line per
-	// observation, showing a finding as "open" at an old head beside its own
-	// "answered" row at a newer one - four lines for one finding on PR #2077.
-	//
-	// That is worse than the gap it was fixing. A reviewer sent here by a
-	// budgeted brief is asking WHICH OBLIGATIONS ARE OPEN, and a stale open row
-	// answers that wrongly using the ledger's own data. I read that exact output
-	// in my own smoke test and saw history rather than a defect.
-	//
-	// The fold rule is the engine's, not a new one: latestObservation in
-	// findings_ledger.go, including its QUOTED guard.
 
 	if len(rows) == 0 {
 		// NAME BOTH REASONS. A reviewer sent here by a brief needs to know whether

--- a/internal/cli/findings.go
+++ b/internal/cli/findings.go
@@ -164,6 +164,21 @@ func runFindingsRows(repo string, pullRequest int, home string, jsonOutput bool,
 		return 0
 	}
 
+	// FOLD TO LATEST PER FINDING (#2086 f1). The store is APPEND-ONLY and its own
+	// doc comment says so: it returns every observation and does not fold, so a
+	// caller folds. The first version printed the raw log, one line per
+	// observation, showing a finding as "open" at an old head beside its own
+	// "answered" row at a newer one - four lines for one finding on PR #2077.
+	//
+	// That is worse than the gap it was fixing. A reviewer sent here by a
+	// budgeted brief is asking WHICH OBLIGATIONS ARE OPEN, and a stale open row
+	// answers that wrongly using the ledger's own data. I read that exact output
+	// in my own smoke test and saw history rather than a defect.
+	//
+	// The fold rule is the engine's, not a new one: latestObservation in
+	// findings_ledger.go, including its QUOTED guard.
+	rows = foldLatestObservations(rows)
+
 	if len(rows) == 0 {
 		// NAME BOTH REASONS. A reviewer sent here by a brief needs to know whether
 		// the ledger is empty or their filter missed, and those are different
@@ -198,5 +213,40 @@ func runFindingsRows(repo string, pullRequest int, home string, jsonOutput bool,
 	}
 	fmt.Fprintln(stdout)
 	fmt.Fprintln(stdout, "Cite a UID verbatim as \"continues_uid\" to continue a finding; typing its label mints a new one.")
+	// #2086 f2: STATE IS NOT THE SAME QUESTION AS "DOES THIS STILL BLOCK".
+	// LedgerObligationsAtHead can treat an ANSWERED finding as still mandatory
+	// when the files its relevance keys name were touched again after the answer.
+	// No column over the raw ledger can show that - it is a function of the head
+	// under review, not of the row - so the limit is printed rather than left for
+	// a reader to discover by trusting STATE and being wrong.
+	fmt.Fprintln(stdout, "STATE is the last recorded observation. An answered finding can still be MANDATORY at a")
+	fmt.Fprintln(stdout, "later head if the files it names changed again, which only the merge gate can decide.")
 	return 0
+}
+
+// foldLatestObservations mirrors internal/workflow's latestObservation: the last
+// observation wins per finding UID, except that a QUOTED row never displaces one
+// that already carried EXECUTED or STATIC evidence.
+//
+// Kept identical on purpose. A listing that folded by a different rule than the
+// gate would disagree with it about which obligations are open, which relocates
+// the failure this command exists to remove instead of removing it.
+func foldLatestObservations(rows []db.ReviewFindingObservation) []db.ReviewFindingObservation {
+	latest := make(map[string]db.ReviewFindingObservation, len(rows))
+	order := make([]string, 0, len(rows))
+	for _, obs := range rows {
+		previous, seen := latest[obs.FindingUID]
+		if !seen {
+			order = append(order, obs.FindingUID)
+		}
+		if seen && obs.EvidenceKind == db.EvidenceQuoted && previous.EvidenceKind != db.EvidenceQuoted {
+			continue
+		}
+		latest[obs.FindingUID] = obs
+	}
+	folded := make([]db.ReviewFindingObservation, 0, len(order))
+	for _, uid := range order {
+		folded = append(folded, latest[uid])
+	}
+	return folded
 }

--- a/internal/cli/findings_rows_2077_test.go
+++ b/internal/cli/findings_rows_2077_test.go
@@ -1,0 +1,112 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/gitmoot/gitmoot/internal/db"
+)
+
+// #2077 f3: THE OBLIGATION BRIEF POINTS AT THIS COMMAND AND IT COULD NOT ANSWER.
+//
+// ledgerObligationBrief is byte-bounded. Once the budget is exhausted it omits
+// mandatory UIDs and tells the reviewer to consult the findings ledger - and
+// this command reported per-repository COUNTS only, no rows and no UIDs, while a
+// read-only review seat has no database access. The instruction was correct and
+// the destination could not satisfy it.
+//
+// The finding survived three rounds of bounding work on the writer, because the
+// missing half was never in the file being edited.
+
+func seedRowsFixture(t *testing.T) string {
+	t.Helper()
+	ctx := context.Background()
+	home := t.TempDir()
+	store := openCLIJobStore(t, home)
+
+	const head = "cccccccccccccccccccccccccccccccccccccccc"
+	record := func(repo string, pr int64, uid string, state db.FindingState, title string) {
+		t.Helper()
+		obs := db.ReviewFindingObservation{
+			FindingUID: uid, Repo: repo, PullRequest: pr, HeadSHA: head,
+			ObserverJob: "local-review-r1", State: state, Severity: "P1", RoundLabel: "r1",
+			Title: title, File: "internal/a.go",
+			EvidenceKind: db.EvidenceExecuted, ExecutedCommands: []string{"go test ./..."}, ExecutedCount: 1,
+		}
+		if _, err := store.RecordReviewFindingObservation(ctx, obs); err != nil {
+			t.Fatalf("RecordReviewFindingObservation(%s): %v", uid, err)
+		}
+	}
+	record("owner/repo", 7, "owner/repo#7-f1", db.FindingOpen, "the boundary check is inverted")
+	record("owner/repo", 7, "owner/repo#7-f2", db.FindingAnswered, "an earlier concern, since answered")
+	record("owner/other", 9, "owner/other#9-f1", db.FindingOpen, "a defect in another repository")
+	return home
+}
+
+// THE RETRIEVAL PATH. A reviewer sent here by a budgeted brief must be able to
+// recover the UID, because continuing a finding requires citing it verbatim -
+// typing its label mints a new one instead.
+func TestFindingsListsRowsAndUIDsForARepository(t *testing.T) {
+	home := seedRowsFixture(t)
+	var stdout, stderr bytes.Buffer
+	if code := Run([]string{"findings", "--home", home, "--repo", "owner/repo", "--pr", "7"}, &stdout, &stderr); code != 0 {
+		t.Fatalf("findings --repo exit = %d, stderr=%s", code, stderr.String())
+	}
+	out := stdout.String()
+	for _, want := range []string{"owner/repo#7-f1", "owner/repo#7-f2", "the boundary check is inverted"} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("listing omitted %q, so a reviewer cannot recover it:\n%s", want, out)
+		}
+	}
+	// Scoping is real, not decorative: another repository's obligations must not
+	// appear, or the listing cannot be trusted to be the set that blocks this PR.
+	if strings.Contains(out, "owner/other#9-f1") {
+		t.Fatalf("listing leaked another repository's finding:\n%s", out)
+	}
+}
+
+// --pr narrows to one pull request, which is what a brief on a specific PR sends
+// the reviewer to look up.
+func TestFindingsScopesRowsToOnePullRequest(t *testing.T) {
+	home := seedRowsFixture(t)
+	var stdout, stderr bytes.Buffer
+	if code := Run([]string{"findings", "--home", home, "--repo", "owner/repo", "--pr", "7"}, &stdout, &stderr); code != 0 {
+		t.Fatalf("findings --pr exit = %d, stderr=%s", code, stderr.String())
+	}
+	if out := stdout.String(); !strings.Contains(out, "owner/repo#7-f1") {
+		t.Fatalf("listing omitted the PR's own finding:\n%s", out)
+	}
+
+	var emptyOut, emptyErr bytes.Buffer
+	if code := Run([]string{"findings", "--home", home, "--repo", "owner/repo", "--pr", "999"}, &emptyOut, &emptyErr); code != 0 {
+		t.Fatalf("findings --pr 999 exit = %d, stderr=%s", code, emptyErr.String())
+	}
+	// AN EMPTY RESULT MUST SAY WHICH QUESTION IT ANSWERED. A reviewer who mistypes
+	// the PR number and sees a bare "no findings" will conclude the ledger is
+	// clear, which is the opposite of the truth.
+	if out := emptyOut.String(); !strings.Contains(out, "owner/repo#999") {
+		t.Fatalf("empty result did not name the repo and PR it searched:\n%s", out)
+	}
+}
+
+// EITHER FLAG ALONE IS REFUSED, and the --repo-alone arm is the one that matters:
+// the store's reader is keyed on (repo, pull_request), so a repo without a PR
+// listed the pull_request=0 rows and printed "no findings recorded" for a
+// repository full of them. An empty result for the wrong reason is precisely the
+// failure this finding is about, so it is refused rather than rendered.
+func TestFindingsRefusesEitherFlagAlone(t *testing.T) {
+	home := seedRowsFixture(t)
+	for _, args := range [][]string{
+		{"findings", "--home", home, "--pr", "7"},
+		{"findings", "--home", home, "--repo", "owner/repo"},
+	} {
+		var stdout, stderr bytes.Buffer
+		if code := Run(args, &stdout, &stderr); code == 0 {
+			t.Fatalf("%v exited 0; an unpaired flag cannot identify a finding set:\n%s", args, stdout.String())
+		} else if !strings.Contains(stderr.String(), "must be given together") {
+			t.Fatalf("%v refusal did not say what to supply: %s", args, stderr.String())
+		}
+	}
+}

--- a/internal/cli/findings_rows_2077_test.go
+++ b/internal/cli/findings_rows_2077_test.go
@@ -110,3 +110,75 @@ func TestFindingsRefusesEitherFlagAlone(t *testing.T) {
 		}
 	}
 }
+
+// #2086 f1: THE LISTING MUST SHOW CURRENT STATE, NOT THE APPEND-ONLY LOG.
+//
+// The store returns every observation and does not fold - its own doc comment
+// says a caller folds. The first version printed one line per observation, so a
+// finding appeared as "open" at an old head beside its own "answered" row at a
+// newer one. A reviewer sent here by a budgeted brief is asking WHICH
+// OBLIGATIONS ARE OPEN, and a stale open row answers that wrongly using the
+// ledger's own data - worse than the gap the command was added to close.
+func TestFindingsFoldsObservationsToCurrentState(t *testing.T) {
+	ctx := context.Background()
+	home := t.TempDir()
+	store := openCLIJobStore(t, home)
+
+	// A SECOND OBSERVATION OF ONE FINDING NEEDS ContinuesUID. Supplying the same
+	// FindingUID does NOT continue it - the store mints a fresh uid, which is how
+	// the first version of this fixture silently created two DIFFERENT findings
+	// and made the fold look broken when it was the fixture that was wrong.
+	record := func(head string, state db.FindingState, kind db.EvidenceKind, continues string) {
+		t.Helper()
+		obs := db.ReviewFindingObservation{
+			ContinuesUID: continues,
+			FindingUID:   "owner/repo#7-f1", Repo: "owner/repo", PullRequest: 7, HeadSHA: head,
+			ObserverJob: "local-review-" + head[:4], State: state, Severity: "P1",
+			Title: "the boundary check is inverted", File: "internal/a.go",
+			EvidenceKind: kind, ExecutedCommands: []string{"go test ./..."}, ExecutedCount: 1,
+		}
+		if kind != db.EvidenceExecuted {
+			obs.ExecutedCommands, obs.ExecutedCount = nil, 0
+			obs.Rationale = "checked by reading"
+		}
+		if _, err := store.RecordReviewFindingObservation(ctx, obs); err != nil {
+			t.Fatalf("RecordReviewFindingObservation(%s): %v", head, err)
+		}
+	}
+	record(strings.Repeat("a", 40), db.FindingOpen, db.EvidenceExecuted, "")
+	record(strings.Repeat("b", 40), db.FindingAnswered, db.EvidenceExecuted, "owner/repo#7-f1")
+
+	var stdout, stderr bytes.Buffer
+	if code := Run([]string{"findings", "--home", home, "--repo", "owner/repo", "--pr", "7"}, &stdout, &stderr); code != 0 {
+		t.Fatalf("findings exit = %d, stderr=%s", code, stderr.String())
+	}
+	out := stdout.String()
+	if n := strings.Count(out, "owner/repo#7-f1"); n != 1 {
+		t.Fatalf("finding appears %d times, want 1; the raw observation log is not current state:\n%s", n, out)
+	}
+	if !strings.Contains(out, "answered") {
+		t.Fatalf("listing shows a state other than the latest:\n%s", out)
+	}
+	// The stale OPEN row must be gone, not merely outnumbered: its presence is
+	// what would send a reviewer to re-answer a discharged obligation.
+	if strings.Contains(out, "open") {
+		t.Fatalf("a superseded open observation survived the fold:\n%s", out)
+	}
+}
+
+// THE QUOTED GUARD, which is why the fold reuses the engine's rule rather than
+// "last row wins": a later QUOTED observation must not displace one that carried
+// real executed evidence, or a listing would report an obligation as discharged
+// on the strength of a row that discharges nothing.
+func TestFindingsFoldKeepsExecutedEvidenceOverALaterQuotedRow(t *testing.T) {
+	folded := foldLatestObservations([]db.ReviewFindingObservation{
+		{FindingUID: "u1", State: db.FindingAnswered, EvidenceKind: db.EvidenceExecuted, Title: "executed"},
+		{FindingUID: "u1", State: db.FindingOpen, EvidenceKind: db.EvidenceQuoted, Title: "quoted"},
+	})
+	if len(folded) != 1 {
+		t.Fatalf("fold produced %d rows, want 1", len(folded))
+	}
+	if folded[0].EvidenceKind != db.EvidenceExecuted {
+		t.Fatalf("a later QUOTED row displaced EXECUTED evidence; the listing would disagree with the gate")
+	}
+}

--- a/internal/cli/findings_rows_2077_test.go
+++ b/internal/cli/findings_rows_2077_test.go
@@ -3,10 +3,13 @@ package cli
 import (
 	"bytes"
 	"context"
+	"encoding/json"
+	"strconv"
 	"strings"
 	"testing"
 
 	"github.com/gitmoot/gitmoot/internal/db"
+	"github.com/gitmoot/gitmoot/internal/workflow"
 )
 
 // #2077 f3: THE OBLIGATION BRIEF POINTS AT THIS COMMAND AND IT COULD NOT ANSWER.
@@ -171,7 +174,7 @@ func TestFindingsFoldsObservationsToCurrentState(t *testing.T) {
 // real executed evidence, or a listing would report an obligation as discharged
 // on the strength of a row that discharges nothing.
 func TestFindingsFoldKeepsExecutedEvidenceOverALaterQuotedRow(t *testing.T) {
-	folded := foldLatestObservations([]db.ReviewFindingObservation{
+	folded := workflow.LatestObservationsInOrder([]db.ReviewFindingObservation{
 		{FindingUID: "u1", State: db.FindingAnswered, EvidenceKind: db.EvidenceExecuted, Title: "executed"},
 		{FindingUID: "u1", State: db.FindingOpen, EvidenceKind: db.EvidenceQuoted, Title: "quoted"},
 	})
@@ -180,5 +183,44 @@ func TestFindingsFoldKeepsExecutedEvidenceOverALaterQuotedRow(t *testing.T) {
 	}
 	if folded[0].EvidenceKind != db.EvidenceExecuted {
 		t.Fatalf("a later QUOTED row displaced EXECUTED evidence; the listing would disagree with the gate")
+	}
+}
+
+// #2086 review: --json MUST fold too. The first fix folded after the JSON
+// branch, so the machine-readable output - the one a dispatch path consumes -
+// still returned the raw append-only log while the human table was correct.
+func TestFindingsJSONOutputIsAlsoFolded(t *testing.T) {
+	ctx := context.Background()
+	home := t.TempDir()
+	store := openCLIJobStore(t, home)
+	for i, spec := range []struct {
+		head      string
+		state     db.FindingState
+		continues string
+	}{{strings.Repeat("a", 40), db.FindingOpen, ""}, {strings.Repeat("b", 40), db.FindingAnswered, "owner/repo#7-f1"}} {
+		obs := db.ReviewFindingObservation{
+			ContinuesUID: spec.continues,
+			FindingUID:   "owner/repo#7-f1", Repo: "owner/repo", PullRequest: 7, HeadSHA: spec.head,
+			ObserverJob: "local-review-r" + strconv.Itoa(i), State: spec.state, Severity: "P1",
+			Title: "the boundary check is inverted", File: "internal/a.go",
+			EvidenceKind: db.EvidenceExecuted, ExecutedCommands: []string{"go test ./..."}, ExecutedCount: 1,
+		}
+		if _, err := store.RecordReviewFindingObservation(ctx, obs); err != nil {
+			t.Fatalf("RecordReviewFindingObservation: %v", err)
+		}
+	}
+	var stdout, stderr bytes.Buffer
+	if code := Run([]string{"findings", "--home", home, "--repo", "owner/repo", "--pr", "7", "--json"}, &stdout, &stderr); code != 0 {
+		t.Fatalf("findings --json exit = %d, stderr=%s", code, stderr.String())
+	}
+	var rows []db.ReviewFindingObservation
+	if err := json.Unmarshal(stdout.Bytes(), &rows); err != nil {
+		t.Fatalf("decode json: %v\n%s", err, stdout.String())
+	}
+	if len(rows) != 1 {
+		t.Fatalf("--json returned %d rows, want 1; the machine-readable path returned the raw log", len(rows))
+	}
+	if rows[0].State != db.FindingAnswered {
+		t.Fatalf("--json row state = %q, want the latest observation", rows[0].State)
 	}
 }

--- a/internal/workflow/findings_ledger.go
+++ b/internal/workflow/findings_ledger.go
@@ -129,6 +129,28 @@ func (s LedgerScope) degrade(format string, args ...any) {
 // the write path. A QUOTED row is still recorded and is still the fold for a
 // finding that has no other observation, which keeps a quoted-only mention
 // exactly as weak as it should be.
+// LatestObservationsInOrder folds an append-only observation list to the latest
+// row per finding UID, preserving first-appearance order.
+//
+// EXPORTED SO THERE IS ONE IMPLEMENTATION (#2086 review, P2). internal/cli had a
+// copy for the findings listing, and two copies of a fold rule is the drift
+// shape this campaign keeps finding: a listing that folded differently from the
+// gate would disagree with it about which obligations are open. A test that they
+// stay in sync would only detect that drift; sharing the function prevents it.
+func LatestObservationsInOrder(observations []db.ReviewFindingObservation) []db.ReviewFindingObservation {
+	latest := latestObservation(observations)
+	seen := make(map[string]bool, len(latest))
+	folded := make([]db.ReviewFindingObservation, 0, len(latest))
+	for _, obs := range observations {
+		if seen[obs.FindingUID] {
+			continue
+		}
+		seen[obs.FindingUID] = true
+		folded = append(folded, latest[obs.FindingUID])
+	}
+	return folded
+}
+
 func latestObservation(observations []db.ReviewFindingObservation) map[string]db.ReviewFindingObservation {
 	latest := map[string]db.ReviewFindingObservation{}
 	for _, obs := range observations {

--- a/internal/workflow/findings_ledger_order_2086_test.go
+++ b/internal/workflow/findings_ledger_order_2086_test.go
@@ -1,0 +1,60 @@
+package workflow
+
+import (
+	"testing"
+
+	"github.com/gitmoot/gitmoot/internal/db"
+)
+
+// #2086 f5: MULTI-UID OUTPUT ORDER WAS UNPINNED.
+//
+// The reviewer verified by reading that LatestObservationsInOrder never ranges
+// the `latest` map for output order - it uses the map only for keyed lookups and
+// emits in input-slice order, and ListReviewFindingObservations returns
+// ORDER BY rowid. So the behaviour was already correct and deterministic; what
+// was missing was a test that would notice if someone made it map-ordered.
+//
+// That is the whole risk this pins. Ranging a Go map is RANDOMISED per run, so a
+// refactor to `for uid := range latest` would pass every existing test - both
+// prior tests use a single UID, where order is unobservable - and produce a
+// listing whose row order changed on every invocation.
+func TestLatestObservationsInOrderKeepsFirstAppearanceOrderAcrossUIDs(t *testing.T) {
+	// Interleaved on purpose: if the fold emitted grouped-by-UID or map order,
+	// f2's later observation would not sit in f2's original position.
+	input := []db.ReviewFindingObservation{
+		{FindingUID: "u-f1", State: db.FindingOpen, EvidenceKind: db.EvidenceExecuted},
+		{FindingUID: "u-f2", State: db.FindingOpen, EvidenceKind: db.EvidenceExecuted},
+		{FindingUID: "u-f3", State: db.FindingOpen, EvidenceKind: db.EvidenceExecuted},
+		{FindingUID: "u-f2", State: db.FindingAnswered, EvidenceKind: db.EvidenceExecuted},
+		{FindingUID: "u-f4", State: db.FindingOpen, EvidenceKind: db.EvidenceExecuted},
+		{FindingUID: "u-f1", State: db.FindingAnswered, EvidenceKind: db.EvidenceExecuted},
+	}
+	want := []string{"u-f1", "u-f2", "u-f3", "u-f4"}
+
+	// Repeated because map-range order is randomised PER RANGE, not per process:
+	// a single pass could match by luck, and one lucky pass is exactly how an
+	// ordering regression survives a suite.
+	for attempt := range 32 {
+		folded := LatestObservationsInOrder(input)
+		if len(folded) != len(want) {
+			t.Fatalf("attempt %d: folded %d rows, want %d", attempt, len(folded), len(want))
+		}
+		for i, uid := range want {
+			if folded[i].FindingUID != uid {
+				t.Fatalf("attempt %d: row %d is %q, want %q; output order must follow first appearance "+
+					"in the input, not map iteration", attempt, i, folded[i].FindingUID, uid)
+			}
+		}
+	}
+
+	// Each UID must still carry its LATEST state, so the ordering guarantee is
+	// not bought by returning the first observation instead of the last.
+	folded := LatestObservationsInOrder(input)
+	if folded[0].State != db.FindingAnswered || folded[1].State != db.FindingAnswered {
+		t.Fatalf("first-appearance ORDER must not cost latest-observation STATE: got %q and %q",
+			folded[0].State, folded[1].State)
+	}
+	if folded[2].State != db.FindingOpen {
+		t.Fatalf("a single-observation finding changed state: %q", folded[2].State)
+	}
+}

--- a/skills/gitmoot/references/CLI.md
+++ b/skills/gitmoot/references/CLI.md
@@ -3272,6 +3272,16 @@ rendered: an earlier revision accepted `--repo` alone, silently listed the
 `pull_request = 0` rows, and printed `no findings recorded` for a repository full
 of them.
 
+Rows are folded to the **latest observation per finding**, using the engine's own
+rule (`latestObservation`), so the listing shows current state rather than the
+append-only log. A listing that folded differently from the gate would disagree
+with it about which obligations are open.
+
+`STATE` is the last recorded observation and is not the same question as "does this
+still block": an answered finding can still be mandatory at a later head if the
+files its relevance keys name changed again. Only the merge gate decides that, and
+the command says so in its own output.
+
 The row listing exists because the **obligation brief is byte-bounded**. Once its
 budget is exhausted the brief omits mandatory UIDs and tells the reviewer to
 consult the ledger, and until this command could print rows there was no supported

--- a/skills/gitmoot/references/CLI.md
+++ b/skills/gitmoot/references/CLI.md
@@ -3251,6 +3251,34 @@ such as a busy base-branch merge queue or a GitHub branch update in progress,
 are retried on the next daemon poll tick. The default poll interval is `30s`
 unless the daemon was started with a different `--poll`.
 
+## Findings Ledger
+
+`gitmoot findings` reports the #1822 findings ledger. Two shapes:
+
+```bash
+# Per-repository summary: who is recording obligations and who is answering them.
+gitmoot findings
+gitmoot findings --json
+
+# Individual rows for one pull request, with the UIDs a reviewer must cite.
+gitmoot findings --repo owner/repo --pr 12
+gitmoot findings --repo owner/repo --pr 12 --json
+```
+
+`--repo` and `--pr` are given **together or not at all**. The store keys findings
+on `(repo, pull_request)` and a finding UID is unique only within one repository's
+pull request, so an unpaired flag cannot identify a set. It is refused rather than
+rendered: an earlier revision accepted `--repo` alone, silently listed the
+`pull_request = 0` rows, and printed `no findings recorded` for a repository full
+of them.
+
+The row listing exists because the **obligation brief is byte-bounded**. Once its
+budget is exhausted the brief omits mandatory UIDs and tells the reviewer to
+consult the ledger, and until this command could print rows there was no supported
+way to do that: the summary reports counts, and a read-only review seat has no
+database access. Cite a UID verbatim as `continues_uid` to continue a finding -
+typing its label mints a new one instead.
+
 ## Result Checks
 
 After a daemon-run job's `gitmoot_result` is parsed, Gitmoot runs a set of

--- a/website/docs/reference/cli.md
+++ b/website/docs/reference/cli.md
@@ -2852,6 +2852,34 @@ system owns the merge decision, set `GITMOOT_DISABLE_NATIVE_MERGE_GATE=1`
 gate — fail-closed, it never merges gatelessly; the external gate makes the
 call.
 
+## Findings Ledger
+
+`gitmoot findings` reports the #1822 findings ledger. Two shapes:
+
+```bash
+# Per-repository summary: who is recording obligations and who is answering them.
+gitmoot findings
+gitmoot findings --json
+
+# Individual rows for one pull request, with the UIDs a reviewer must cite.
+gitmoot findings --repo owner/repo --pr 12
+gitmoot findings --repo owner/repo --pr 12 --json
+```
+
+`--repo` and `--pr` are given **together or not at all**. The store keys findings
+on `(repo, pull_request)` and a finding UID is unique only within one repository's
+pull request, so an unpaired flag cannot identify a set. It is refused rather than
+rendered: an earlier revision accepted `--repo` alone, silently listed the
+`pull_request = 0` rows, and printed `no findings recorded` for a repository full
+of them.
+
+The row listing exists because the **obligation brief is byte-bounded**. Once its
+budget is exhausted the brief omits mandatory UIDs and tells the reviewer to
+consult the ledger, and until this command could print rows there was no supported
+way to do that: the summary reports counts, and a read-only review seat has no
+database access. Cite a UID verbatim as `continues_uid` to continue a finding -
+typing its label mints a new one instead.
+
 ## Result Checks
 
 After a daemon-run job's `gitmoot_result` is parsed, Gitmoot runs a set of

--- a/website/docs/reference/cli.md
+++ b/website/docs/reference/cli.md
@@ -2873,6 +2873,16 @@ rendered: an earlier revision accepted `--repo` alone, silently listed the
 `pull_request = 0` rows, and printed `no findings recorded` for a repository full
 of them.
 
+Rows are folded to the **latest observation per finding**, using the engine's own
+rule (`latestObservation`), so the listing shows current state rather than the
+append-only log. A listing that folded differently from the gate would disagree
+with it about which obligations are open.
+
+`STATE` is the last recorded observation and is not the same question as "does this
+still block": an answered finding can still be mandatory at a later head if the
+files its relevance keys name changed again. Only the merge gate decides that, and
+the command says so in its own output.
+
 The row listing exists because the **obligation brief is byte-bounded**. Once its
 budget is exhausted the brief omits mandatory UIDs and tells the reviewer to
 consult the ledger, and until this command could print rows there was no supported


### PR DESCRIPTION
Fixes #2077's f3 (P1), which is gm-findings' finding on their PR. Coordinated with them before starting; they hold f5 and f6 and asked me to take this one as its own PR off main.

## Why a P1 survived three rounds

`ledgerObligationBrief` is byte-bounded. Once the budget is exhausted it omits mandatory UIDs and tells the reviewer to **consult the findings ledger** - and `gitmoot findings` reported per-repository **counts** only, no rows and no UIDs, while a read-only review seat has no database access.

The instruction was correct and the destination could not satisfy it.

Verified before writing code:

- `origin/main:internal/cli/findings.go` - **111 lines, one flag** (`--json`), no row or UID retrieval anywhere.
- `gh pr diff 2077 --name-only` - three files, **all** `internal/workflow`.

So the retrieval half was outside that PR by construction. Bounding the brief was necessary and could never be sufficient, which is exactly why three rounds of correct work did not move the finding.

## The change

```bash
gitmoot findings --repo owner/repo --pr 12
gitmoot findings --repo owner/repo --pr 12 --json
```

Lists UID, severity, state, PR, short head and title, and prints the sentence that makes a UID actionable: cite it verbatim as `continues_uid`, because typing its label mints a new finding instead.

**No `internal/db` change.** `ListReviewFindingObservations` already existed; only the CLI was missing.

## `--repo` and `--pr` are both-or-neither, and my own test is why

The store's reader is keyed on `(repo, pull_request)`. The first version accepted `--repo` alone, passed `pull_request = 0`, and printed:

```
no findings recorded for owner/repo
```

for a repository holding three. **An empty result for the wrong reason is precisely the failure this finding is about**, so the unpaired form is refused rather than rendered. `TestFindingsRefusesEitherFlagAlone` pins both arms.

## Verification

- Three tests: the retrieval path, PR scoping with a named-empty result, and the both-or-neither refusal.
- Full `internal/cli` package suite green (740s).
- **Against the live ledger**, on an isolated copy of the home - never `/root/.gitmoot`.

### The count in this section was stale, and how

An earlier revision said the listing showed **six** findings, three open. Re-run at `2026-09-09T04:30:14Z` against a fresh copy of the ledger it shows **eight**, three open (f3, f7, f8).

`#2077-f7` and `#2077-f8` were first observed at `2026-09-09T03:55:21Z`; this commit is `04:28:16Z`. **I did not timestamp the original run**, so I cannot prove from evidence whether it predates them - the ordering is plausible but unestablished, and stating it as fact would be the thing this PR exists to stop. The number is corrected and the reason for the gap is named rather than the digits quietly swapped.

The raw ledger for #2077 currently holds **20 rows across 8 distinct UIDs**, with f1 alone carrying four rows spanning `open` and `answered` - which is the unfolded shape f1 of #2086 reported.

### The instrument failure worth recording

The four-row output for `#2077-f1` appeared in this PR's own body **as evidence the feature worked**. I ran the measurement, published it, and read it as history; the reviewer read the same bytes as a defect.

Every other instrument failure in this campaign was an instrument that **lied** - a tail-piped `rc=0`, a mutant that never applied, a probe sending malformed JSON, a `gh pr edit` that discarded its body. This one **told the truth and its author interpreted it backwards**, which no read-back or anchor assertion would have caught.

## Docs

Both CLI reference surfaces had **no entry for this command at all**; added one to each.

## Findings this makes moot

None withdrawn by me. When this lands, gm-findings will answer f3's ledger row on #2077 citing this PR, so the obligation is discharged where it was raised.

## Not done here

The brief still says "consult the findings ledger" without naming the command. That text is in `findings_ledger.go`, which #2077 owns and is actively editing - so it is theirs to add in one line rather than mine to collide over.
