### PR TITLE
docs: say what the default test timeout looks like, not only what to pass

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -239,10 +239,30 @@ waiting for the subtest it started. Measured: a parent found in exactly that
 state, `TestPrepareLocalImplementFixPassPreservesWorktreeSafetyChecks`, then
 passed on its own in **0.54s**.
 
-To tell slow from stuck, look at the **active leaf** rather than any waiting
-frame, and prefer **two observations over one**: run the suspect test alone, or
-dump twice and see whether the leaf moved. A goroutine that is still on the same
-line across two samples is stuck; one that has advanced was only slow.
+**No dump proves either answer, and this paragraph deliberately no longer claims
+one.** Look at the **active leaf** rather than any waiting frame, and prefer two
+observations to one: run the suspect test alone, or sample twice. Then read them
+as evidence, not verdicts.
+
+- **Same line in both samples** raises suspicion; it does not establish stuck. A
+  legitimate long channel wait, a syscall, or a blocking `git`/network call sits
+  on one source line for as long as it takes.
+- **Movement between samples** shows only that the goroutine progressed during
+  that interval. It does not rule out a deadlock or livelock later in the run.
+
+The one instrument that settles it is an **expectation**: run the named test
+alone and compare against how long it SHOULD take. That is what made the
+`0.54s` measurement above conclusive, and it is why the running-test list
+matters more than the stack.
+
+**And for this repository the expectation is already known: `internal/cli`
+cannot finish inside the default deadline at all.** Measured by gm-findings on
+an idle box, twice: `716s` and `805s`, both passing under `-timeout 25m`. A
+third run under load (12-way, 166 competing `go test` processes) took `1500s`
+and timed out, with goroutines parked 16 minutes in `testing.(*T).Parallel`
+waiting for slots - contention presenting exactly as a hang would. So the flag
+is not padding for a bad day: **without it this package cannot pass**, and a
+`600.0xx` failure there says nothing about the code.
 
 The CLI entrypoint lives under `cmd/gitmoot/`. The CI gate is Go-only — it does
 **not** build the website or run the live multi-runtime (codex/claude/kimi) E2E

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -250,19 +250,30 @@ as evidence, not verdicts.
 - **Movement between samples** shows only that the goroutine progressed during
   that interval. It does not rule out a deadlock or livelock later in the run.
 
-The one instrument that settles it is an **expectation**: run the named test
-alone and compare against how long it SHOULD take. That is what made the
-`0.54s` measurement above conclusive, and it is why the running-test list
-matters more than the stack.
+An **expectation** is what turns those clues into a diagnosis: run the named test
+alone and compare against how long it SHOULD take. That is why the `0.54s`
+measurement above was worth taking, and why the running-test list matters more
+than the stack. It narrows the question; it does not close it, because an
+isolated pass says only that this invocation finished, not why another was
+waiting.
 
-**And for this repository the expectation is already known: `internal/cli`
-cannot finish inside the default deadline at all.** Measured by gm-findings on
-an idle box, twice: `716s` and `805s`, both passing under `-timeout 25m`. A
-third run under load (12-way, 166 competing `go test` processes) took `1500s`
-and timed out, with goroutines parked 16 minutes in `testing.(*T).Parallel`
-waiting for slots - contention presenting exactly as a hang would. So the flag
-is not padding for a bad day: **without it this package cannot pass**, and a
-`600.0xx` failure there says nothing about the code.
+**Observed timings for this package, which are a floor and not a bound.**
+Measured by gm-findings on this host, idle, twice: `716s` and `805s`, both
+passing under `-timeout 25m`. A third run under 12-way load with 166 competing
+`go test` processes took `1500s` and timed out, with goroutines parked 16 minutes
+in `testing.(*T).Parallel` waiting for slots - contention presenting exactly as a
+hang would, which is the sharpest available example of why a blocked frame is not
+evidence.
+
+What those runs establish: **on this host, every observed run of `internal/cli`
+exceeded the 600s default.** What they do NOT establish: that it cannot pass
+inside 600s on a faster machine, a warm cache, or a smaller future suite. Two
+idle samples are a distribution, not a lower bound.
+
+So pass `-timeout 25m` locally because it is necessary on the machines this
+repository is actually developed on, and read a `600.0xx` failure as **the
+deadline firing** rather than as a verdict on the code - while remembering that
+the deadline firing and the code being slow are not exclusive.
 
 The CLI entrypoint lives under `cmd/gitmoot/`. The CI gate is Go-only — it does
 **not** build the website or run the live multi-runtime (codex/claude/kimi) E2E

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -257,7 +257,8 @@ than the stack. It narrows the question; it does not close it, because an
 isolated pass says only that this invocation finished, not why another was
 waiting.
 
-**Observed timings for this package, which are a floor and not a bound.**
+**Observed timings for this package, which are samples and not a bound in
+either direction.**
 Measured by gm-findings on this host, idle, twice: `716s` and `805s`, both
 passing under `-timeout 25m`. A third run under 12-way load with 166 competing
 `go test` processes took `1500s` and timed out, with goroutines parked 16 minutes
@@ -270,8 +271,9 @@ exceeded the 600s default.** What they do NOT establish: that it cannot pass
 inside 600s on a faster machine, a warm cache, or a smaller future suite. Two
 idle samples are a distribution, not a lower bound.
 
-So pass `-timeout 25m` locally because it is necessary on the machines this
-repository is actually developed on, and read a `600.0xx` failure as **the
+So pass `-timeout 25m` locally because every run observed here exceeded the
+600s default and a firing deadline discards the whole package's result, and
+read a `600.0xx` failure as **the
 deadline firing** rather than as a verdict on the code - while remembering that
 the deadline firing and the code being slow are not exclusive.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -227,11 +227,22 @@ progress, a hang and a deadlock all stop at the same boundary with the same
 duration. Verified by running `go test -timeout 3s ./internal/cli/`, which
 produced exactly this shape at `3.012s`.
 
-So the number tells you which instrument fired, and the **`running tests:` list
-and goroutine dump** tell you why. Read those before concluding anything: if the
-listed tests are ones you expect to be slow, pass `-timeout 25m` and move on; if
-one is blocked on a channel or lock in the dump, you have a real hang that the
-longer deadline will only postpone.
+So the number tells you which instrument fired, and the **`running tests:` list**
+tells you what was still in flight. Start there: if those tests are ones you
+expect to be slow, pass `-timeout 25m` and move on.
+
+**A blocked frame in the goroutine dump is NOT evidence of a hang**, and reading
+it as one is the easy mistake. The dump is an instantaneous snapshot, and a Go
+test binary always contains legitimate waiters: in the run above, `goroutine 1`
+sat in `[chan receive]` inside `testing.(*T).Run`, which is simply a parent
+waiting for the subtest it started. Measured: a parent found in exactly that
+state, `TestPrepareLocalImplementFixPassPreservesWorktreeSafetyChecks`, then
+passed on its own in **0.54s**.
+
+To tell slow from stuck, look at the **active leaf** rather than any waiting
+frame, and prefer **two observations over one**: run the suspect test alone, or
+dump twice and see whether the leaf moved. A goroutine that is still on the same
+line across two samples is stuck; one that has advanced was only slow.
 
 The CLI entrypoint lives under `cmd/gitmoot/`. The CI gate is Go-only — it does
 **not** build the website or run the live multi-runtime (codex/claude/kimi) E2E

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -212,6 +212,13 @@ completes in well under 10 minutes on its runners), so this was a
 local-only gap — but a command documented as "run this before committing"
 has to actually be able to finish.
 
+**What that failure LOOKS like, because two seats misread it as a hang within one
+hour:** omit the flag and the run dies with `panic: test timed out after 10m0s`
+followed by `FAIL github.com/gitmoot/gitmoot/internal/cli 600.02s`, with no failing
+test named. A wall time of 600.0xx seconds IS the default deadline, not a stall
+and not a deadlock: the suite was still working when Go killed it. Read the
+number before debugging the package: a real hang does not stop at exactly 600s.
+
 The CLI entrypoint lives under `cmd/gitmoot/`. The CI gate is Go-only — it does
 **not** build the website or run the live multi-runtime (codex/claude/kimi) E2E
 (those need a Node build / runtime auth and stay manual).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -212,12 +212,26 @@ completes in well under 10 minutes on its runners), so this was a
 local-only gap — but a command documented as "run this before committing"
 has to actually be able to finish.
 
-**What that failure LOOKS like, because two seats misread it as a hang within one
-hour:** omit the flag and the run dies with `panic: test timed out after 10m0s`
-followed by `FAIL github.com/gitmoot/gitmoot/internal/cli 600.02s`, with no failing
-test named. A wall time of 600.0xx seconds IS the default deadline, not a stall
-and not a deadlock: the suite was still working when Go killed it. Read the
-number before debugging the package: a real hang does not stop at exactly 600s.
+**What that failure LOOKS like, because two seats misread it within one hour:**
+omit the flag and the run dies with `panic: test timed out after 10m0s`, then a
+`running tests:` list, then a full goroutine dump, then
+`FAIL	github.com/gitmoot/gitmoot/internal/cli	600.025s` (Go prints three
+decimals). **No FAILED test is named** - the panic attributes nothing to a
+failing assertion - so the output reads like a broken package, which is what both
+seats started debugging.
+
+A wall time of `600.0xx` seconds identifies **enforcement of Go's default
+per-package deadline, and nothing more**. It does NOT tell you the suite was
+healthy: Go's alarm fires whenever the binary exceeds the duration, so slow
+progress, a hang and a deadlock all stop at the same boundary with the same
+duration. Verified by running `go test -timeout 3s ./internal/cli/`, which
+produced exactly this shape at `3.012s`.
+
+So the number tells you which instrument fired, and the **`running tests:` list
+and goroutine dump** tell you why. Read those before concluding anything: if the
+listed tests are ones you expect to be slow, pass `-timeout 25m` and move on; if
+one is blocked on a channel or lock in the dump, you have a real hang that the
+longer deadline will only postpone.
 
 The CLI entrypoint lives under `cmd/gitmoot/`. The CI gate is Go-only — it does
 **not** build the website or run the live multi-runtime (codex/claude/kimi) E2E


### PR DESCRIPTION
Head `docs/timeout-failure-shape`. **Draft.**

## Why

AGENTS.md already says to pass `-timeout 25m` and explains why (#1210). It does not say **what the failure looks like when you forget** - and two seats misread it as a hang within one hour tonight: `600.025s` on mine, `600.029s` on gm-findings'.

## What makes it misleading, specifically

```
panic: test timed out after 10m0s
FAIL	github.com/gitmoot/gitmoot/internal/cli	600.025s
```

**No failing test is named.** A run with no named failure reads as a broken package, so the instinct is to debug the package - which is what both of us started doing. The tell is the number: a wall time of `600.0xx` **is** the default deadline, and a real hang does not stop at exactly 600s.

Both strings are quoted from an observed run, not reconstructed.

## Scope

- Documentation only: no behaviour change, no test change.
- **The workload-mode marker is untouched**, so no `workload-mode-reconciliation` row is required. Verified: zero `Current mode` lines in the diff.
- Not a docs-parity change: `AGENTS.md` is not one of the three parity files (skill `CLI.md`, website `cli.md`, `llms.txt`), and this describes a local build gate rather than user-facing CLI behaviour.
- House style checked: zero em or en dashes in the added lines.

## Not claimed

- **Not measured: how often this costs time.** Two instances in one hour, both self-reported. That is the reason for the line, not a frequency estimate.
- **Not a fix for the underlying cost.** `internal/cli` genuinely runs past 600s; this documents the symptom rather than shortening the suite.

Signed: **gm-staged**


## Round two: three false claims of my own, and why the reviewer was right to push

New head `e44cb49e`. **The irony is the finding: I wrote a doc to stop people misreading an instrument and put a confident wrong claim inside it, which is worse than the gap it filled.** A reader trusts a document precisely where they have no other source, so **documentation is the one artifact where a confident wrong claim outranks a missing one.** That is the argument for this round, and it generalises past this PR.

All three findings are correct. I verified them by running the timeout deliberately rather than by rereading my own text:

```
$ go test -timeout 3s ./internal/cli/
panic: test timed out after 3s
	running tests:
		TestDispatchReviewAllocatesDistinctExactHeadWorktrees (0s)
goroutine 1218 [running]: ...
FAIL	github.com/gitmoot/gitmoot/internal/cli	3.012s
```

| Claim I made | Status | Correction |
|---|---|---|
| "a real hang does not stop at exactly 600s" | **simply false** | Go's alarm fires whenever the binary exceeds the duration, so slow progress, a hang and a deadlock all stop at the same boundary with the same duration. `600.0xx` identifies **enforcement of the deadline** and says nothing about the cause. |
| "no failing test is named" | **imprecise, and it hid the diagnostic** | The panic **does** print a `running tests:` list and a full goroutine dump. Narrowed to: no **FAILED** test is named, because nothing is attributed to a failing assertion. |
| `600.02s` | **wrong format** | Go prints three decimals. |

The second one mattered most in practice. My wording steered the reader **away from the running-test list**, which is exactly where the answer is. The paragraph now ends by sending them there, and distinguishes the two cases the original conflated: expected slowness, where `-timeout 25m` is the answer, and a genuine hang, which a longer deadline only postpones.

**Not claimed:** that the goroutine dump is always sufficient to identify the blocked test. It was in the case I ran; I have not tested a deadlock across several goroutines.

Signed: **gm-staged**


## Attribution and head gap, disclosed per phobos' ruling

**Independence of review is unverifiable from the store for this PR, and the reason is by design rather than an omission.**

The implementation was done in-session by `gm-staged`, so the only durable attribution is a session-recorded implement row. Measured across my own rows: **0 of 12 carry a `head_sha`**, and that is the documented behaviour of `--head-sha`, whose own help says it is *"recorded as display metadata only: it is NOT stored in the job payload and no merge policy reads it (#1990)"*. The head is quarantined to the display plane.

So the row is honest about **who** and permanently silent about **which head**. Consequences, stated plainly:

- The gate cannot verify reviewer-versus-implementer independence at an exact head for this PR. That is an **attribution gap**, not a failed check.
- There is no "record the row and re-evaluate" path that closes it while the #1990 quarantine stands. Recording the row is still correct and was done, with `--acting-role gm-staged`; it fixes the *who*, not the *which head*.
- **The reviewer is `gm-review-opus`, which is not this seat and has never implemented on this branch.** That is the substantive claim behind independence; what is missing is the store's ability to *prove* it at a head.

No merge should be blocked on this alone, and nothing here asserts the review was independent on evidence I do not have. It states what is knowable and what is not.
