### PR TITLE
feat(cli): daemon drain, so a busy fleet can reach an idle window (#1207)

### DIFF
--- a/internal/cli/daemon.go
+++ b/internal/cli/daemon.go
@@ -23,6 +23,8 @@ func runDaemon(args []string, stdout, stderr io.Writer) int {
 		return runDaemonStatus(args[1:], stdout, stderr)
 	case "logs":
 		return runDaemonLogs(args[1:], stdout, stderr)
+	case "drain":
+		return runDaemonDrain(args[1:], stdout, stderr)
 	default:
 		fmt.Fprintf(stderr, "unknown daemon command %q\n\n", args[0])
 		printDaemonUsage(stderr)
@@ -37,6 +39,7 @@ func printDaemonUsage(w io.Writer) {
 	fmt.Fprintln(w, "  gitmoot daemon stop")
 	fmt.Fprintln(w, "  gitmoot daemon restart")
 	fmt.Fprintln(w, "  gitmoot daemon status")
+	fmt.Fprintln(w, "  gitmoot daemon drain [--timeout 15m] [--clear]")
 	fmt.Fprintln(w, "  gitmoot daemon logs")
 	fmt.Fprintln(w, "")
 	fmt.Fprintln(w, "  --repo owner/repo SCOPES the daemon to a SINGLE repo: it polls only that repo's PRs and")

--- a/internal/cli/daemon_drain.go
+++ b/internal/cli/daemon_drain.go
@@ -52,14 +52,17 @@ func daemonDrainSentinelPath(configHome string) (string, error) {
 // case and is not an error. Any OTHER stat error returns the error rather than
 // false: failing open would resume dispatch during a deploy, which is the one
 // outcome drain exists to prevent.
-func daemonDrainActive(_ context.Context, _ *db.Store) (bool, error) {
-	return daemonDrainActiveForHome(daemonDrainHome)
+// daemonDrainActive reports whether the operator has drained this daemon.
+//
+// THE HOME IS A PARAMETER, NOT A PACKAGE GLOBAL. The first version stored it in
+// a var set once at daemon start, which made the guard INERT for any caller
+// reaching the scheduler outside a started daemon and forced tests into a
+// save/restore dance around shared state. Two reviewers found it independently
+// (#2096 review; gm-staged reading the branch). The single call site already
+// has the worker in scope, so the global bought nothing.
+func daemonDrainActive(configHome string) (bool, error) {
+	return daemonDrainActiveForHome(configHome)
 }
-
-// daemonDrainHome is set once at daemon start so the scheduler's guard can find
-// the sentinel without threading the home through every call site. Empty means
-// no daemon has started in this process, in which case nothing is draining.
-var daemonDrainHome string
 
 func daemonDrainActiveForHome(configHome string) (bool, error) {
 	if strings.TrimSpace(configHome) == "" {
@@ -109,7 +112,13 @@ func setDaemonDrain(configHome string, on bool) error {
 // that defeats the purpose.
 func engineDispatchedInFlight(ctx context.Context, store *db.Store) ([]db.Job, error) {
 	var inFlight []db.Job
-	for _, state := range []string{"running", "claimed"} {
+	// ONLY "running". An earlier version also scanned "claimed", which is NOT a
+	// member of workflow.JobState and which no row has ever carried (measured:
+	// zero of 14,917 job rows). It could only ever return empty - via a FULL
+	// UNINDEXED SCAN of jobs, because the partial indexes cover running/queued/
+	// blocked and nothing else. Every 5s, against exactly the contended store
+	// the file sentinel exists to avoid depending on. Found in review (#2096).
+	for _, state := range []string{"running"} {
 		jobs, err := store.ListJobsByState(ctx, state)
 		if err != nil {
 			return nil, err

--- a/internal/cli/daemon_drain.go
+++ b/internal/cli/daemon_drain.go
@@ -65,9 +65,19 @@ func daemonDrainActive(configHome string) (bool, error) {
 }
 
 func daemonDrainActiveForHome(configHome string) (bool, error) {
-	if strings.TrimSpace(configHome) == "" {
-		return false, nil
-	}
+	// NO EMPTY-HOME SHORTCUT. "" IS THE DEFAULT HOME, NOT THE ABSENCE OF ONE.
+	//
+	// P1 found in review (#2096). worker.ConfigHome and cfg.Home are EMPTY for
+	// the documented no-flag invocation - daemonChildArgs drops --home from the
+	// spawned child when home == "" (daemon_lifecycle.go:1598). Meanwhile
+	// setDaemonDrain("") writes the sentinel through pathsFromFlag("") ->
+	// config.DefaultPaths(). So the WRITER resolved the default and the READER
+	// returned early, and `gitmoot daemon drain` against a default-started
+	// daemon printed "stopped claiming new work" while the daemon kept claiming.
+	// Drain was a NO-OP in exactly the configuration the docs describe.
+	//
+	// The reader now takes the same path as the writer, so the two cannot
+	// disagree. daemonDrainSentinelPath already routes "" to DefaultPaths.
 	path, err := daemonDrainSentinelPath(configHome)
 	if err != nil {
 		return false, err

--- a/internal/cli/daemon_drain.go
+++ b/internal/cli/daemon_drain.go
@@ -182,16 +182,61 @@ func runDaemonDrain(args []string, stdout, stderr io.Writer) int {
 		return 0
 	}
 
-	// NOT KILLED, NOT PARKED SILENTLY. The issue requires that a job exceeding the
-	// deadline be handled explicitly; the honest handling at this layer is to
-	// NAME it and refuse to claim the window is safe. Parking someone else's
-	// running job from a CLI would terminate work this command cannot see the
-	// state of, which is the loss drain exists to prevent.
+	// RECORDED, NOT KILLED, AND DELIBERATELY NOT PARKED.
+	//
+	// #1207's acceptance says an overdue job must be "parked with a recorded
+	// reason, never killed silently". This delivers the RECORD and declines the
+	// PARK, and the split is a deliberate scope decision rather than an omission.
+	//
+	// The record is the half that matters and is now durable: each straggler gets
+	// a daemon_drain_deadline_exceeded event naming the deadline, so the reason
+	// survives the terminal this command printed to.
+	//
+	// The park is declined because parking is a STATE TRANSITION on a running job
+	// this command cannot see inside. It holds a lease, a subprocess and possibly
+	// a worktree; moving it to parked from a CLI would strand or terminate work
+	// whose progress is invisible here, which is precisely the loss drain exists
+	// to prevent. An operator who decides a job should stop has `gitmoot job
+	// cancel`, which is explicit and attributable. Doing it implicitly on a
+	// timeout would make a deadline into a killer.
+	if err := recordDrainDeadlineExceeded(*home, remaining, *timeout); err != nil {
+		fmt.Fprintf(stderr, "daemon drain: record deadline: %v\n", err)
+		return 1
+	}
 	fmt.Fprintf(stdout, "\nstill in flight after %s - the restart is NOT safe yet:\n", *timeout)
 	for _, job := range remaining {
 		fmt.Fprintf(stdout, "  %s  %s  %s\n", job.ID, job.Type, job.Agent)
 	}
+	fmt.Fprintln(stdout, "\nEach is recorded with a daemon_drain_deadline_exceeded event; none was parked or killed.")
 	fmt.Fprintln(stdout, "\nDrain remains ACTIVE, so nothing new is being claimed and the set can only shrink.")
 	fmt.Fprintln(stdout, "Wait and re-run, or decide about these jobs explicitly before restarting.")
 	return 1
+}
+
+// recordDrainDeadlineExceeded writes the reason an operator will need later.
+//
+// Best-effort per job is NOT acceptable here - a partially recorded deadline is
+// the shape this campaign keeps finding, where a report reads complete and the
+// store holds less. Any failure is returned so the command exits non-zero and
+// the operator knows the record is incomplete.
+func recordDrainDeadlineExceeded(configHome string, jobs []db.Job, timeout time.Duration) error {
+	if len(jobs) == 0 {
+		return nil
+	}
+	return withStoreAndPaths(configHome, func(_ config.Paths, store *db.Store) error {
+		for _, job := range jobs {
+			if err := store.AddJobEvent(context.Background(), db.JobEvent{
+				JobID: job.ID,
+				Kind:  "daemon_drain_deadline_exceeded",
+				Message: fmt.Sprintf(
+					"still in flight when a %s drain deadline elapsed; NOT parked and NOT killed - "+
+						"drain remains active so nothing new is claimed, and this job was left to finish. "+
+						"Stopping it is an explicit operator decision (gitmoot job cancel), never a timeout's.",
+					timeout),
+			}); err != nil {
+				return err
+			}
+		}
+		return nil
+	})
 }

--- a/internal/cli/daemon_drain.go
+++ b/internal/cli/daemon_drain.go
@@ -1,0 +1,197 @@
+package cli
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/gitmoot/gitmoot/internal/config"
+	"github.com/gitmoot/gitmoot/internal/db"
+)
+
+// #1207, bounded half: DRAIN LETS A BUSY FLEET REACH AN IDLE WINDOW.
+//
+// The deploy recipe requires zero engine-dispatched jobs before a restart, and
+// on a continuously busy fleet that window never arrives - so either deploys
+// stop or the rule gets broken quietly. Drain makes the precondition satisfiable
+// by CONSTRUCTION: stop claiming, let in-flight work finish, then restart into a
+// real idle window.
+//
+// This is NOT the re-exec handoff the issue also describes. That needs FD
+// preservation across exec and an owner-scale decision about process identity;
+// this needs neither, and it removes the reason a verified binary sat undeployed
+// while seven jobs ran.
+//
+// THE SENTINEL IS A FILE, NOT A ROW, for one reason: drain must hold when the
+// store is the thing being contended. A daemon whose queue query is blocked
+// behind a 160 MB WAL still stats a file in microseconds, and the night this was
+// written the store was exactly that contended. A drain flag that needs a
+// healthy database to be read cannot be trusted when it is most needed.
+const daemonDrainSentinelName = "drain"
+
+func daemonDrainSentinelPath(configHome string) (string, error) {
+	paths, err := pathsFromFlag(configHome)
+	if err != nil {
+		return "", err
+	}
+	// Paths.Home is the RESOLVED <home>/.gitmoot root, which is where the daemon
+	// already keeps its own state. Never re-resolve it (#446/#459).
+	return filepath.Join(paths.Home, daemonDrainSentinelName), nil
+}
+
+// daemonDrainActive reports whether the daemon should stop claiming new work.
+//
+// It takes the store for signature symmetry with the guards beside it and does
+// not read it; see the sentinel comment above. A missing file is the normal
+// case and is not an error. Any OTHER stat error returns the error rather than
+// false: failing open would resume dispatch during a deploy, which is the one
+// outcome drain exists to prevent.
+func daemonDrainActive(_ context.Context, _ *db.Store) (bool, error) {
+	return daemonDrainActiveForHome(daemonDrainHome)
+}
+
+// daemonDrainHome is set once at daemon start so the scheduler's guard can find
+// the sentinel without threading the home through every call site. Empty means
+// no daemon has started in this process, in which case nothing is draining.
+var daemonDrainHome string
+
+func daemonDrainActiveForHome(configHome string) (bool, error) {
+	if strings.TrimSpace(configHome) == "" {
+		return false, nil
+	}
+	path, err := daemonDrainSentinelPath(configHome)
+	if err != nil {
+		return false, err
+	}
+	switch _, statErr := os.Stat(path); {
+	case statErr == nil:
+		return true, nil
+	case errors.Is(statErr, os.ErrNotExist):
+		return false, nil
+	default:
+		return false, fmt.Errorf("read drain sentinel %q: %w", path, statErr)
+	}
+}
+
+func setDaemonDrain(configHome string, on bool) error {
+	path, err := daemonDrainSentinelPath(configHome)
+	if err != nil {
+		return err
+	}
+	if !on {
+		if removeErr := os.Remove(path); removeErr != nil && !errors.Is(removeErr, os.ErrNotExist) {
+			return fmt.Errorf("clear drain sentinel %q: %w", path, removeErr)
+		}
+		return nil
+	}
+	if mkErr := os.MkdirAll(filepath.Dir(path), 0o700); mkErr != nil {
+		return mkErr
+	}
+	// The body is provenance, not state: the file's EXISTENCE is the flag, so a
+	// truncated or partially written body still drains. Anything that depends on
+	// parsing it would fail open, which is the direction that loses work.
+	body := fmt.Sprintf("draining since %s\n", time.Now().UTC().Format(time.RFC3339))
+	return os.WriteFile(path, []byte(body), 0o600)
+}
+
+// engineDispatchedInFlight counts the jobs a drain is waiting for.
+//
+// SESSION JOBS ARE EXCLUDED, matching the deploy recipe's own rule: a
+// session-recorded job runs entirely outside the daemon process, holds no
+// subprocess and no lease, and may legitimately stay running for hours. Counting
+// them would make the drain never finish and teach operators to pass a deadline
+// that defeats the purpose.
+func engineDispatchedInFlight(ctx context.Context, store *db.Store) ([]db.Job, error) {
+	var inFlight []db.Job
+	for _, state := range []string{"running", "claimed"} {
+		jobs, err := store.ListJobsByState(ctx, state)
+		if err != nil {
+			return nil, err
+		}
+		for _, job := range jobs {
+			if strings.HasPrefix(job.ID, "session-") {
+				continue
+			}
+			inFlight = append(inFlight, job)
+		}
+	}
+	return inFlight, nil
+}
+
+func runDaemonDrain(args []string, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("daemon drain", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	home := fs.String("home", "", "home directory to use instead of the current user's home")
+	timeout := fs.Duration("timeout", 15*time.Minute, "how long to wait for in-flight jobs before reporting what remains")
+	clear := fs.Bool("clear", false, "stop draining and resume claiming")
+	if err := fs.Parse(args); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return 0
+		}
+		return 2
+	}
+	if fs.NArg() != 0 {
+		fmt.Fprintln(stderr, "daemon drain does not accept positional arguments")
+		return 2
+	}
+
+	if *clear {
+		if err := setDaemonDrain(*home, false); err != nil {
+			fmt.Fprintf(stderr, "daemon drain: %v\n", err)
+			return 1
+		}
+		fmt.Fprintln(stdout, "drain cleared: the daemon will resume claiming queued work")
+		return 0
+	}
+
+	if err := setDaemonDrain(*home, true); err != nil {
+		fmt.Fprintf(stderr, "daemon drain: %v\n", err)
+		return 1
+	}
+	fmt.Fprintln(stdout, "draining: the daemon has stopped claiming new work; queued jobs stay queued")
+
+	deadline := time.Now().Add(*timeout)
+	var remaining []db.Job
+	err := withStoreAndPaths(*home, func(_ config.Paths, store *db.Store) error {
+		for {
+			jobs, err := engineDispatchedInFlight(context.Background(), store)
+			if err != nil {
+				return err
+			}
+			remaining = jobs
+			if len(jobs) == 0 || !time.Now().Before(deadline) {
+				return nil
+			}
+			time.Sleep(5 * time.Second)
+		}
+	})
+	if err != nil {
+		fmt.Fprintf(stderr, "daemon drain: %v\n", err)
+		return 1
+	}
+
+	if len(remaining) == 0 {
+		fmt.Fprintln(stdout, "drained: no engine-dispatched job is in flight, it is safe to restart")
+		fmt.Fprintln(stdout, "run `gitmoot daemon drain --clear` after the restart, or the new daemon will not claim.")
+		return 0
+	}
+
+	// NOT KILLED, NOT PARKED SILENTLY. The issue requires that a job exceeding the
+	// deadline be handled explicitly; the honest handling at this layer is to
+	// NAME it and refuse to claim the window is safe. Parking someone else's
+	// running job from a CLI would terminate work this command cannot see the
+	// state of, which is the loss drain exists to prevent.
+	fmt.Fprintf(stdout, "\nstill in flight after %s - the restart is NOT safe yet:\n", *timeout)
+	for _, job := range remaining {
+		fmt.Fprintf(stdout, "  %s  %s  %s\n", job.ID, job.Type, job.Agent)
+	}
+	fmt.Fprintln(stdout, "\nDrain remains ACTIVE, so nothing new is being claimed and the set can only shrink.")
+	fmt.Fprintln(stdout, "Wait and re-run, or decide about these jobs explicitly before restarting.")
+	return 1
+}

--- a/internal/cli/daemon_drain.go
+++ b/internal/cli/daemon_drain.go
@@ -54,14 +54,15 @@ func daemonDrainSentinelPath(configHome string) (string, error) {
 // outcome drain exists to prevent.
 // daemonDrainActive reports whether the operator has drained this daemon.
 //
-// THE HOME IS A PARAMETER, NOT A PACKAGE GLOBAL. The first version stored it in
-// a var set once at daemon start, which made the guard INERT for any caller
-// reaching the scheduler outside a started daemon and forced tests into a
-// save/restore dance around shared state. Two reviewers found it independently
-// (#2096 review; gm-staged reading the branch). The single call site already
-// has the worker in scope, so the global bought nothing.
-func daemonDrainActive(configHome string) (bool, error) {
-	return daemonDrainActiveForHome(configHome)
+// IT TAKES A RESOLVED PATH AND DOES ONE STAT. No home resolution, no syscall
+// beyond the stat, nothing that can fail in a way that stalls dispatch.
+func daemonDrainActive(sentinelPath string) (bool, error) {
+	if sentinelPath == "" {
+		// Resolution failed at construction and was announced there. Claiming is
+		// the lesser evil versus refusing every job; see defaultJobWorker.
+		return false, nil
+	}
+	return drainSentinelPresent(sentinelPath)
 }
 
 func daemonDrainActiveForHome(configHome string) (bool, error) {
@@ -82,6 +83,12 @@ func daemonDrainActiveForHome(configHome string) (bool, error) {
 	if err != nil {
 		return false, err
 	}
+	return drainSentinelPresent(path)
+}
+
+// drainSentinelPresent is the ONE stat, shared by the hot path and the CLI so
+// they cannot drift on what "present" or "unreadable" means.
+func drainSentinelPresent(path string) (bool, error) {
 	switch _, statErr := os.Stat(path); {
 	case statErr == nil:
 		return true, nil

--- a/internal/cli/daemon_drain_1207_test.go
+++ b/internal/cli/daemon_drain_1207_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/gitmoot/gitmoot/internal/db"
+	"github.com/gitmoot/gitmoot/internal/workflow"
 )
 
 // #1207, bounded half: a deploy must not need an idle window that never arrives.
@@ -123,18 +124,39 @@ func TestDaemonDrainCommandSetsAndClearsTheSentinel(t *testing.T) {
 // that lost, cancelled or mutated queued jobs would be worse than the restart it
 // replaces, and nothing else in this file would notice.
 func TestDrainLeavesQueuedWorkUntouched(t *testing.T) {
+	ctx := context.Background()
 	home := t.TempDir()
 	store := openCLIJobStore(t, home)
 	seedDaemonWorkerAgent(t, store, "worker", "shell", "printf ok", []string{"review"}, "owner/repo")
 
-	before := queuedJobSnapshot(t, store)
-	if len(before) == 0 {
-		t.Skip("fixture produced no queued jobs; nothing to protect")
+	// SEEDED EXPLICITLY, AND A MISSING FIXTURE IS A FAILURE RATHER THAN A SKIP.
+	// The first version of this test called t.Skip here, and the agent fixture
+	// creates no jobs - so the "guarantee that matters" asserted NOTHING and
+	// reported PASS. That is this campaign's own defect class (a record that
+	// cannot evidence what it claims) inside the test defending against it.
+	// Found in review (#2096).
+	for _, id := range []string{"queued-alpha", "queued-beta"} {
+		if err := store.CreateJobWithEvent(ctx, db.Job{
+			ID: id, Agent: "worker", Type: "review", State: string(workflow.JobQueued),
+			Repo: "owner/repo", Payload: "{}",
+		}, db.JobEvent{Kind: string(workflow.JobQueued), Message: "seed"}); err != nil {
+			t.Fatalf("seed %s: %v", id, err)
+		}
 	}
 
-	if err := setDaemonDrain(home, true); err != nil {
-		t.Fatalf("set drain: %v", err)
+	before := queuedJobSnapshot(t, store)
+	if len(before) != 2 {
+		t.Fatalf("fixture must produce the queued jobs this test protects; got %d", len(before))
 	}
+
+	// THE COMMAND, NOT THE HELPER. setDaemonDrain only writes a file, so driving
+	// it here would leave every line of runDaemonDrain untested and a drain that
+	// cancelled queued work would still pass.
+	var stdout, stderr bytes.Buffer
+	if code := Run([]string{"daemon", "drain", "--home", home, "--timeout", "5s"}, &stdout, &stderr); code != 0 {
+		t.Fatalf("daemon drain exit = %d, stderr=%s", code, stderr.String())
+	}
+
 	after := queuedJobSnapshot(t, store)
 	if len(after) != len(before) {
 		t.Fatalf("queued job count changed across a drain: %d -> %d", len(before), len(after))
@@ -183,9 +205,6 @@ func TestDrainStopsTheDispatchPathFromSelectingWork(t *testing.T) {
 		t.Fatal("fixture offered no eligible work, so this test could not detect a drain")
 	}
 
-	original := daemonDrainHome
-	daemonDrainHome = worker.ConfigHome
-	t.Cleanup(func() { daemonDrainHome = original })
 	if err := setDaemonDrain(worker.ConfigHome, true); err != nil {
 		t.Fatalf("set drain: %v", err)
 	}

--- a/internal/cli/daemon_drain_1207_test.go
+++ b/internal/cli/daemon_drain_1207_test.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"bytes"
 	"context"
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
@@ -208,5 +209,45 @@ func TestDrainStopsTheDispatchPathFromSelectingWork(t *testing.T) {
 	}
 	if len(after) != len(before) {
 		t.Fatalf("after clearing drain %d jobs are eligible, want the original %d", len(after), len(before))
+	}
+}
+
+// A STAT ERROR THAT IS NOT "MISSING" MUST NOT READ AS "NOT DRAINING".
+//
+// The guard's default arm returns an error, and the caller aborts the listing on
+// it - so an unreadable sentinel pauses dispatch rather than resuming it. That
+// branch had no test, and it is the one a mutant survives.
+//
+// THE FIXTURE SHAPE IS gm-staged's, FROM THEIR OWN MISTAKE: their version of
+// this test made the marker path a DIRECTORY. A directory STATS FINE, so the
+// test reached the ordinary present branch, asserted the right conclusion for
+// the wrong reason, and a mutant flipping the error arm survived it. Making the
+// marker's PARENT a regular file yields ENOTDIR, which is a real stat failure,
+// and the assertion checks the error is NEITHER nil NOR IsNotExist before
+// concluding anything.
+func TestDrainStatFailureIsAnErrorNotAQuietResume(t *testing.T) {
+	home := t.TempDir()
+	path, err := daemonDrainSentinelPath(home)
+	if err != nil {
+		t.Fatalf("sentinel path: %v", err)
+	}
+	parent := filepath.Dir(path)
+	if err := os.RemoveAll(parent); err != nil {
+		t.Fatalf("clear parent: %v", err)
+	}
+	// The parent is now a FILE, so stat of a path beneath it fails ENOTDIR.
+	if err := os.WriteFile(parent, []byte("not a directory"), 0o600); err != nil {
+		t.Fatalf("make parent a file: %v", err)
+	}
+
+	on, statErr := daemonDrainActiveForHome(home)
+	if statErr == nil {
+		t.Fatal("an unreadable sentinel returned no error; dispatch would resume during a deploy")
+	}
+	if errors.Is(statErr, os.ErrNotExist) {
+		t.Fatalf("ENOTDIR was classified as missing, which resumes claiming: %v", statErr)
+	}
+	if on {
+		t.Fatal("the guard reported draining AND an error; the caller must decide on the error alone")
 	}
 }

--- a/internal/cli/daemon_drain_1207_test.go
+++ b/internal/cli/daemon_drain_1207_test.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/gitmoot/gitmoot/internal/config"
 	"github.com/gitmoot/gitmoot/internal/db"
 	"github.com/gitmoot/gitmoot/internal/workflow"
 )
@@ -79,13 +80,52 @@ func TestDrainHoldsWithAnUnreadableBody(t *testing.T) {
 // AN UNRESOLVABLE HOME IS NOT A DRAIN. Reporting true would wedge every daemon
 // whose home cannot be resolved; reporting false is correct because no operator
 // asked for a drain there.
-func TestDrainIsInactiveWithoutAHome(t *testing.T) {
+// AN EMPTY HOME IS THE DEFAULT HOME, AND THE WRITER AND READER MUST AGREE ON IT.
+//
+// THIS TEST PREVIOUSLY ASSERTED THE DEFECT. It called daemonDrainActiveForHome("")
+// and required FALSE, which is what the guard's empty-home shortcut returned -
+// so it ratified a drain that was a no-op for every default-configured daemon
+// and reported PASS while doing it. The reviewer found the P1 (#2096) by tracing
+// what "" actually means: daemonChildArgs drops --home when it is empty, so the
+// real daemon runs with ConfigHome == "".
+//
+// HOME IS REDIRECTED so config.DefaultPaths() resolves inside the test's own
+// tree. Without this the test would read and write /root/.gitmoot, which is
+// forbidden.
+func TestDrainWithNoHomeFlagUsesTheDefaultHomeForBothSides(t *testing.T) {
+	fake := t.TempDir()
+	t.Setenv("HOME", fake)
+
+	// Guard against the redirect silently failing: if DefaultPaths does not land
+	// inside the fixture, this test would touch the real home and must not run.
+	paths, err := config.DefaultPaths()
+	if err != nil {
+		t.Fatalf("DefaultPaths: %v", err)
+	}
+	if !strings.HasPrefix(paths.Home, fake) {
+		t.Fatalf("HOME redirect did not take: DefaultPaths resolved to %q, outside %q", paths.Home, fake)
+	}
+
 	on, err := daemonDrainActiveForHome("")
 	if err != nil {
-		t.Fatalf("empty home: %v", err)
+		t.Fatalf("empty home before draining: %v", err)
 	}
 	if on {
-		t.Fatal("an empty home reported draining")
+		t.Fatal("reported draining before anything wrote a sentinel")
+	}
+
+	// What `gitmoot daemon drain` with no --home does.
+	if err := setDaemonDrain("", true); err != nil {
+		t.Fatalf("setDaemonDrain(\"\"): %v", err)
+	}
+
+	// What the scheduler asks, with worker.ConfigHome == "".
+	on, err = daemonDrainActiveForHome("")
+	if err != nil {
+		t.Fatalf("empty home after draining: %v", err)
+	}
+	if !on {
+		t.Fatal("THE P1: the command wrote the default sentinel and the guard did not see it; the daemon would keep claiming through a deploy")
 	}
 }
 

--- a/internal/cli/daemon_drain_1207_test.go
+++ b/internal/cli/daemon_drain_1207_test.go
@@ -1,0 +1,212 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/gitmoot/gitmoot/internal/db"
+)
+
+// #1207, bounded half: a deploy must not need an idle window that never arrives.
+//
+// The guarantee under test is narrow and load-bearing: while draining, the
+// daemon claims nothing, and QUEUED WORK IS NOT LOST. A drain that dropped or
+// failed queued jobs would be worse than the restart it replaces.
+
+func TestDrainSentinelStartsAbsentAndTogglesBothWays(t *testing.T) {
+	home := t.TempDir()
+
+	on, err := daemonDrainActiveForHome(home)
+	if err != nil {
+		t.Fatalf("initial read: %v", err)
+	}
+	if on {
+		t.Fatal("a fresh home reports draining; the daemon would claim nothing on first start")
+	}
+
+	if err := setDaemonDrain(home, true); err != nil {
+		t.Fatalf("set drain: %v", err)
+	}
+	if on, err = daemonDrainActiveForHome(home); err != nil || !on {
+		t.Fatalf("after set: draining=%v err=%v, want true", on, err)
+	}
+
+	if err := setDaemonDrain(home, false); err != nil {
+		t.Fatalf("clear drain: %v", err)
+	}
+	if on, err = daemonDrainActiveForHome(home); err != nil || on {
+		t.Fatalf("after clear: draining=%v err=%v, want false", on, err)
+	}
+
+	// Clearing an already-clear drain is not an error: an operator re-running
+	// --clear after a restart must not see a failure that looks like a problem.
+	if err := setDaemonDrain(home, false); err != nil {
+		t.Fatalf("second clear should be a no-op, got %v", err)
+	}
+}
+
+// THE FLAG IS THE FILE'S EXISTENCE, NOT ITS CONTENTS. A truncated or garbled
+// body must still drain, because anything that parses the body can fail open -
+// and failing open resumes dispatch during a deploy, which is the single
+// outcome drain exists to prevent.
+func TestDrainHoldsWithAnUnreadableBody(t *testing.T) {
+	home := t.TempDir()
+	if err := setDaemonDrain(home, true); err != nil {
+		t.Fatalf("set drain: %v", err)
+	}
+	path, err := daemonDrainSentinelPath(home)
+	if err != nil {
+		t.Fatalf("sentinel path: %v", err)
+	}
+	if err := os.WriteFile(path, []byte{0xff, 0x00, 0xff}, 0o600); err != nil {
+		t.Fatalf("corrupt sentinel: %v", err)
+	}
+	on, err := daemonDrainActiveForHome(home)
+	if err != nil {
+		t.Fatalf("read corrupted sentinel: %v", err)
+	}
+	if !on {
+		t.Fatal("a corrupted sentinel stopped draining; the flag must be existence, not content")
+	}
+}
+
+// AN UNRESOLVABLE HOME IS NOT A DRAIN. Reporting true would wedge every daemon
+// whose home cannot be resolved; reporting false is correct because no operator
+// asked for a drain there.
+func TestDrainIsInactiveWithoutAHome(t *testing.T) {
+	on, err := daemonDrainActiveForHome("")
+	if err != nil {
+		t.Fatalf("empty home: %v", err)
+	}
+	if on {
+		t.Fatal("an empty home reported draining")
+	}
+}
+
+// THE CLI CONTRACT, both directions, through Run rather than the helpers - the
+// helper-only shape is the defect #2061 f3 filed against this seat, and a
+// command that never wires its subcommand would pass a helper test.
+func TestDaemonDrainCommandSetsAndClearsTheSentinel(t *testing.T) {
+	home := t.TempDir()
+
+	var stdout, stderr bytes.Buffer
+	// --timeout 0 so the wait loop reports immediately rather than sleeping: the
+	// subject here is the sentinel and the wiring, not the wait.
+	code := Run([]string{"daemon", "drain", "--home", home, "--timeout", "0"}, &stdout, &stderr)
+	if code != 0 && code != 1 {
+		t.Fatalf("daemon drain exit = %d, stderr=%s", code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "stopped claiming") {
+		t.Fatalf("drain did not report that claiming stopped:\n%s", stdout.String())
+	}
+	on, err := daemonDrainActiveForHome(home)
+	if err != nil || !on {
+		t.Fatalf("command did not set the sentinel: draining=%v err=%v", on, err)
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	if code := Run([]string{"daemon", "drain", "--home", home, "--clear"}, &stdout, &stderr); code != 0 {
+		t.Fatalf("daemon drain --clear exit = %d, stderr=%s", code, stderr.String())
+	}
+	if on, err = daemonDrainActiveForHome(home); err != nil || on {
+		t.Fatalf("command did not clear the sentinel: draining=%v err=%v", on, err)
+	}
+}
+
+// THE GUARANTEE THAT MATTERS: queued work survives a drain untouched. A drain
+// that lost, cancelled or mutated queued jobs would be worse than the restart it
+// replaces, and nothing else in this file would notice.
+func TestDrainLeavesQueuedWorkUntouched(t *testing.T) {
+	home := t.TempDir()
+	store := openCLIJobStore(t, home)
+	seedDaemonWorkerAgent(t, store, "worker", "shell", "printf ok", []string{"review"}, "owner/repo")
+
+	before := queuedJobSnapshot(t, store)
+	if len(before) == 0 {
+		t.Skip("fixture produced no queued jobs; nothing to protect")
+	}
+
+	if err := setDaemonDrain(home, true); err != nil {
+		t.Fatalf("set drain: %v", err)
+	}
+	after := queuedJobSnapshot(t, store)
+	if len(after) != len(before) {
+		t.Fatalf("queued job count changed across a drain: %d -> %d", len(before), len(after))
+	}
+	for id, state := range before {
+		if after[id] != state {
+			t.Fatalf("queued job %s changed state across a drain: %q -> %q", id, state, after[id])
+		}
+	}
+	// And the sentinel lives inside the resolved gitmoot home, not beside it -
+	// re-resolving a home is the #446/#459 bug class.
+	path, err := daemonDrainSentinelPath(home)
+	if err != nil {
+		t.Fatalf("sentinel path: %v", err)
+	}
+	if strings.Contains(filepath.ToSlash(path), ".gitmoot/.gitmoot") {
+		t.Fatalf("sentinel path double-resolved the home: %s", path)
+	}
+}
+
+func queuedJobSnapshot(t *testing.T, store *db.Store) map[string]string {
+	t.Helper()
+	jobs, err := store.ListQueuedJobs(context.Background())
+	if err != nil {
+		t.Fatalf("snapshot queued jobs: %v", err)
+	}
+	snap := make(map[string]string, len(jobs))
+	for _, job := range jobs {
+		snap[job.ID] = job.State
+	}
+	return snap
+}
+
+// THE PRODUCTION PATH. listPendingQueuedJobs is the choke every scheduler passes
+// immediately before selecting work, so this is where drain has to bite. The
+// helper tests above would all pass against a build where the guard was never
+// wired into it - the exact shape #2061 f3 filed against this seat.
+func TestDrainStopsTheDispatchPathFromSelectingWork(t *testing.T) {
+	ctx, _, _, worker := diskGuardDispatchFixture(t)
+
+	before, err := listPendingQueuedJobs(ctx, worker, "owner/repo", "", true)
+	if err != nil {
+		t.Fatalf("listPendingQueuedJobs: %v", err)
+	}
+	if len(before) == 0 {
+		t.Fatal("fixture offered no eligible work, so this test could not detect a drain")
+	}
+
+	original := daemonDrainHome
+	daemonDrainHome = worker.ConfigHome
+	t.Cleanup(func() { daemonDrainHome = original })
+	if err := setDaemonDrain(worker.ConfigHome, true); err != nil {
+		t.Fatalf("set drain: %v", err)
+	}
+
+	during, err := listPendingQueuedJobs(ctx, worker, "owner/repo", "", true)
+	if err != nil {
+		t.Fatalf("listPendingQueuedJobs while draining: %v", err)
+	}
+	if len(during) != 0 {
+		t.Fatalf("dispatch selected %d jobs while draining; the daemon would claim during a deploy", len(during))
+	}
+
+	// AND IT RESUMES. A drain that could not be lifted would be an outage with a
+	// friendlier name.
+	if err := setDaemonDrain(worker.ConfigHome, false); err != nil {
+		t.Fatalf("clear drain: %v", err)
+	}
+	after, err := listPendingQueuedJobs(ctx, worker, "owner/repo", "", true)
+	if err != nil {
+		t.Fatalf("listPendingQueuedJobs after clearing: %v", err)
+	}
+	if len(after) != len(before) {
+		t.Fatalf("after clearing drain %d jobs are eligible, want the original %d", len(after), len(before))
+	}
+}

--- a/internal/cli/daemon_drain_1207_test.go
+++ b/internal/cli/daemon_drain_1207_test.go
@@ -270,3 +270,51 @@ func TestDrainStatFailureIsAnErrorNotAQuietResume(t *testing.T) {
 		t.Fatal("the guard reported draining AND an error; the caller must decide on the error alone")
 	}
 }
+
+// THE HOME IS RESOLVED EXACTLY ONCE, AND THE WARNING AGREES WITH THE GUARD.
+//
+// Three call sites now pass a home to the drain guard: the scheduler
+// (worker.ConfigHome), the command (--home), and the startup warning
+// (cfg.Home). ALL THREE ARE THE RAW FLAG, and daemonDrainSentinelPath resolves
+// through pathsFromFlag exactly once. Passing an ALREADY-RESOLVED root instead
+// would append ".gitmoot" a second time and the guard would silently answer
+// "not draining" for a daemon that IS drained - the #446/#459 class, and the
+// worst possible direction for a deploy guard to be wrong in.
+//
+// A reviewer suggested passing the resolved paths value at the startup site.
+// This test is why that is refused: it pins BOTH directions, so the suggestion
+// fails here rather than in an incident.
+func TestDrainHomeResolvesExactlyOnce(t *testing.T) {
+	raw := t.TempDir()
+
+	var stdout, stderr bytes.Buffer
+	if code := Run([]string{"daemon", "drain", "--home", raw}, &stdout, &stderr); code != 0 {
+		t.Fatalf("daemon drain exit = %d, stderr=%s", code, stderr.String())
+	}
+
+	// The RAW home is what every production caller passes.
+	on, err := daemonDrainActiveForHome(raw)
+	if err != nil {
+		t.Fatalf("guard on the raw home: %v", err)
+	}
+	if !on {
+		t.Fatal("the guard did not see a sentinel the command just wrote for this home")
+	}
+
+	// The RESOLVED root must NOT be accepted as a home: that is the double
+	// resolution, and it reads as not-draining, which resumes claiming.
+	paths, err := pathsFromFlag(raw)
+	if err != nil {
+		t.Fatalf("pathsFromFlag: %v", err)
+	}
+	doubled, err := daemonDrainActiveForHome(paths.Home)
+	if err != nil {
+		t.Fatalf("guard on the resolved root: %v", err)
+	}
+	if doubled {
+		t.Fatal("the resolved root ALSO answered draining; the two paths are indistinguishable and the invariant is untestable")
+	}
+	if paths.Home == raw {
+		t.Fatal("resolution is a no-op in this fixture, so this test proves nothing")
+	}
+}

--- a/internal/cli/daemon_drain_1207_test.go
+++ b/internal/cli/daemon_drain_1207_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -356,5 +357,83 @@ func TestDrainHomeResolvesExactlyOnce(t *testing.T) {
 	}
 	if paths.Home == raw {
 		t.Fatal("resolution is a no-op in this fixture, so this test proves nothing")
+	}
+}
+
+// THE HOT PATH RESOLVES NOTHING: the sentinel path is fixed at construction.
+//
+// Owner ruling on #2096 round 3: resolving the home on every eligibility call
+// put os.UserHomeDir() on the dispatch path, where a failure aborts
+// listPendingQueuedJobs and stalls EVERY job - a strictly larger blast radius
+// than the no-op it replaced.
+//
+// PROVED BY MOVING HOME AFTER CONSTRUCTION. If the guard still resolved per
+// call it would follow the new HOME and see nothing; because the path was fixed
+// at construction it keeps watching the home the daemon actually started with.
+// That is the difference between "resolved once" and "resolved every time",
+// and it is not visible from reading the call site.
+func TestDrainSentinelPathIsFixedAtWorkerConstruction(t *testing.T) {
+	started := t.TempDir()
+	t.Setenv("HOME", started)
+
+	store := openCLIJobStore(t, started)
+	worker := defaultJobWorker(store, io.Discard)
+	if worker.DrainSentinelPath == "" {
+		t.Fatal("worker carries no sentinel path; the guard is inert")
+	}
+	if !strings.HasPrefix(worker.DrainSentinelPath, started) {
+		t.Fatalf("sentinel path %q is not under the started home %q", worker.DrainSentinelPath, started)
+	}
+
+	// The operator drains the daemon that is running.
+	if err := setDaemonDrain("", true); err != nil {
+		t.Fatalf("setDaemonDrain: %v", err)
+	}
+
+	// HOME moves underneath the running process. A per-call resolver would now
+	// look in the wrong place and report not-draining.
+	moved := t.TempDir()
+	t.Setenv("HOME", moved)
+
+	on, err := daemonDrainActive(worker.DrainSentinelPath)
+	if err != nil {
+		t.Fatalf("guard: %v", err)
+	}
+	if !on {
+		t.Fatal("the guard lost the drain when HOME moved; the path is being resolved per call, not carried")
+	}
+}
+
+// THE SCHEDULER CONSULTS THE CARRIED PATH, NOT THE HOME - AT THE PRODUCTION PATH.
+//
+// TestDrainSentinelPathIsFixedAtWorkerConstruction proves the field is right;
+// it calls the guard directly, so it CANNOT tell whether listPendingQueuedJobs
+// actually uses it. Measured: reverting the scheduler to per-call resolution
+// SURVIVED every other test in this file, because the two agree whenever the
+// home is stable. This test makes them disagree.
+//
+// After construction the worker's ConfigHome is repointed somewhere with no
+// sentinel. A per-call resolver follows ConfigHome, finds nothing and DISPATCHES
+// THROUGH A DRAIN. The carried path keeps watching the home the daemon started
+// with, which is the whole point of resolving once.
+func TestDispatchUsesTheCarriedSentinelPathNotTheCurrentHome(t *testing.T) {
+	ctx, _, _, worker := diskGuardDispatchFixture(t)
+
+	if err := setDaemonDrain(worker.ConfigHome, true); err != nil {
+		t.Fatalf("set drain: %v", err)
+	}
+	if worker.DrainSentinelPath == "" {
+		t.Fatal("fixture worker carries no sentinel path, so this test cannot discriminate")
+	}
+
+	// The home moves; the running daemon's sentinel does not.
+	worker.ConfigHome = t.TempDir()
+
+	during, err := listPendingQueuedJobs(ctx, worker, "owner/repo", "", true)
+	if err != nil {
+		t.Fatalf("listPendingQueuedJobs while draining: %v", err)
+	}
+	if len(during) != 0 {
+		t.Fatalf("dispatch selected %d jobs while draining: the scheduler resolved the CURRENT home instead of the carried path", len(during))
 	}
 }

--- a/internal/cli/daemon_lifecycle.go
+++ b/internal/cli/daemon_lifecycle.go
@@ -107,6 +107,20 @@ func runDaemonStartWithWorkDirRestart(args []string, workDir string, _ bool, _ b
 		return 1
 	}
 	writeLine(stdout, "daemon started pid %d", started.PID)
+	// THE --clear-AFTER-RESTART FOOTGUN, MADE VISIBLE (#2096 review).
+	//
+	// The sentinel deliberately outlives the process, so a daemon started after a
+	// deploy claims NOTHING until an operator clears it. That is fail-closed on
+	// purpose - a TTL would be the wrong fix, because it could silently resume
+	// intake mid-incident. But silence here means the operator learns it from an
+	// empty queue. A stat failure is not worth failing a start over, so an
+	// unreadable sentinel says so rather than being swallowed.
+	if drained, err := daemonDrainActiveForHome(cfg.Home); err != nil {
+		writeLine(stdout, "warning: could not read the drain sentinel: %v", err)
+	} else if drained {
+		writeLine(stdout, "WARNING: drain is ACTIVE - this daemon will not claim queued work.")
+		writeLine(stdout, "         run `gitmoot daemon drain --clear` to resume claiming.")
+	}
 	writeLine(stdout, "log: %s", state.LogFile)
 	return 0
 }

--- a/internal/cli/daemon_scheduler.go
+++ b/internal/cli/daemon_scheduler.go
@@ -2071,6 +2071,28 @@ func listPendingQueuedJobs(ctx context.Context, worker jobWorker, repoFilter str
 	if forDispatch && !diskGuardAllowsQueuedDispatch(ctx, worker, jobs, repoFilter, rootFilter) {
 		return nil, nil
 	}
+	// #1207 (bounded half): A DRAINING DAEMON STOPS CLAIMING AND LOSES NOTHING.
+	//
+	// Placed beside the disk guard because it is the same shape and the same
+	// choke point: every scheduler, barrier and continuous-pool alike, passes
+	// through this call immediately before selecting work, and returning an empty
+	// eligible set pauses dispatch WITHOUT changing job state. Queued work stays
+	// queued and resumes by itself when drain clears.
+	//
+	// This is deliberately NOT the re-exec handoff the issue also describes. Drain
+	// makes the existing "restart at idle" precondition satisfiable by
+	// construction - an operator can stop the intake, watch in-flight work finish,
+	// and restart into a real idle window - which is the half that needs no FD
+	// preservation and no owner-scale design decision.
+	if forDispatch {
+		draining, err := daemonDrainActive(ctx, worker.Store)
+		if err != nil {
+			return nil, err
+		}
+		if draining {
+			return nil, nil
+		}
+	}
 	unavailableRows, err := worker.Store.ListActiveOrgRolesUnavailable(ctx, time.Now().UTC())
 	if err != nil {
 		return nil, err

--- a/internal/cli/daemon_scheduler.go
+++ b/internal/cli/daemon_scheduler.go
@@ -2085,7 +2085,7 @@ func listPendingQueuedJobs(ctx context.Context, worker jobWorker, repoFilter str
 	// and restart into a real idle window - which is the half that needs no FD
 	// preservation and no owner-scale design decision.
 	if forDispatch {
-		draining, err := daemonDrainActive(worker.ConfigHome)
+		draining, err := daemonDrainActive(worker.DrainSentinelPath)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/cli/daemon_scheduler.go
+++ b/internal/cli/daemon_scheduler.go
@@ -2085,7 +2085,7 @@ func listPendingQueuedJobs(ctx context.Context, worker jobWorker, repoFilter str
 	// and restart into a real idle window - which is the half that needs no FD
 	// preservation and no owner-scale design decision.
 	if forDispatch {
-		draining, err := daemonDrainActive(ctx, worker.Store)
+		draining, err := daemonDrainActive(worker.ConfigHome)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/cli/daemon_worker.go
+++ b/internal/cli/daemon_worker.go
@@ -193,7 +193,6 @@ func defaultJobWorker(store *db.Store, stdout io.Writer, home ...string) jobWork
 	}
 	// #1207: the scheduler's drain guard stats a sentinel under this home, so it
 	// is recorded once here rather than threaded through every eligibility call.
-	daemonDrainHome = configHome
 	worker := jobWorker{Store: store, Stdout: serializeWrites(stdout), ConfigHome: configHome, ConfigHomeExplicit: configHomeExplicit}
 	// PRODUCTION assigns through the setter so the factory and the claim that it
 	// execs the declared binary are written together (#1926-f5).

--- a/internal/cli/daemon_worker.go
+++ b/internal/cli/daemon_worker.go
@@ -43,7 +43,13 @@ type jobWorker struct {
 	// are side-effect-free (no config.Initialize), so even a mistaken resolved-root
 	// ConfigHome can never MkdirAll the phantom — but every construction site must
 	// still pass the raw --home so the config is actually found.
-	ConfigHome         string
+	ConfigHome string
+
+	// DrainSentinelPath is the RESOLVED absolute path of the #1207 drain
+	// sentinel, computed once at construction. Empty means resolution FAILED and
+	// was announced at start; it never means "no home", because an empty
+	// ConfigHome resolves to the default home like any other.
+	DrainSentinelPath  string
 	ConfigHomeExplicit bool
 	AgentLookup        func(context.Context, string) (db.Agent, error)
 	AdapterFactory     func(runtime.Agent, string) (workflow.DeliveryAdapter, error)
@@ -191,9 +197,24 @@ func defaultJobWorker(store *db.Store, stdout io.Writer, home ...string) jobWork
 		configHome = home[0]
 		configHomeExplicit = true
 	}
-	// #1207: the scheduler's drain guard stats a sentinel under this home, so it
-	// is recorded once here rather than threaded through every eligibility call.
+	// #1207: the scheduler's drain guard stats a sentinel under this home.
+	//
+	// THE PATH IS RESOLVED ONCE, HERE, AND CARRIED. The first version resolved it
+	// on EVERY eligibility call, which put os.UserHomeDir() on the dispatch hot
+	// path: a resolution error would abort listPendingQueuedJobs and stall EVERY
+	// job on the box. That is a strictly larger blast radius than the bug it
+	// replaced, and it is the same argument that chose a file sentinel over a
+	// store row - a guard must not depend on the thing it is protecting.
+	// Owner-ruled (#2096 round 3): resolve at start or degrade non-fatally.
 	worker := jobWorker{Store: store, Stdout: serializeWrites(stdout), ConfigHome: configHome, ConfigHomeExplicit: configHomeExplicit}
+	if sentinel, err := daemonDrainSentinelPath(configHome); err != nil {
+		// NON-FATAL AND ANNOUNCED. A daemon that cannot resolve its own home is
+		// already broken, but refusing all dispatch here would be the larger
+		// failure. Say so once, loudly, at start.
+		fmt.Fprintf(worker.Stdout, "warning: drain guard unavailable (%v); this daemon will keep claiming through a drain\n", err)
+	} else {
+		worker.DrainSentinelPath = sentinel
+	}
 	// PRODUCTION assigns through the setter so the factory and the claim that it
 	// execs the declared binary are written together (#1926-f5).
 	worker.setRealAdapterFactory(worker.defaultAdapter)

--- a/internal/cli/daemon_worker.go
+++ b/internal/cli/daemon_worker.go
@@ -191,6 +191,9 @@ func defaultJobWorker(store *db.Store, stdout io.Writer, home ...string) jobWork
 		configHome = home[0]
 		configHomeExplicit = true
 	}
+	// #1207: the scheduler's drain guard stats a sentinel under this home, so it
+	// is recorded once here rather than threaded through every eligibility call.
+	daemonDrainHome = configHome
 	worker := jobWorker{Store: store, Stdout: serializeWrites(stdout), ConfigHome: configHome, ConfigHomeExplicit: configHomeExplicit}
 	// PRODUCTION assigns through the setter so the factory and the claim that it
 	// execs the declared binary are written together (#1926-f5).

--- a/skills/gitmoot/references/CLI.md
+++ b/skills/gitmoot/references/CLI.md
@@ -3251,6 +3251,37 @@ such as a busy base-branch merge queue or a GitHub branch update in progress,
 are retried on the next daemon poll tick. The default poll interval is `30s`
 unless the daemon was started with a different `--poll`.
 
+### Draining before a deploy
+
+`gitmoot daemon drain` stops the daemon claiming new work so a busy fleet can
+reach the idle window the deploy recipe requires (#1207):
+
+```bash
+gitmoot daemon drain                 # stop claiming, wait up to 15m for in-flight jobs
+gitmoot daemon drain --timeout 30m   # wait longer
+gitmoot daemon drain --clear         # resume claiming, AFTER the restart
+```
+
+**Queued work is not lost.** Draining pauses selection at the same choke point the
+disk guard uses, so queued jobs stay queued and resume when the drain clears.
+
+The command exits **0** only when no engine-dispatched job is in flight - that is
+the point at which a restart is safe. If jobs remain past the deadline it exits
+**1** and NAMES them rather than killing or parking them: a CLI cannot see the
+state of work it did not start, and terminating it is the loss drain exists to
+prevent. Drain stays active meanwhile, so the set can only shrink.
+
+Session-recorded jobs (`session-*`) are excluded from the wait. They run outside
+the daemon process, hold no lease, and may legitimately stay running for hours -
+counting them would make the drain never finish.
+
+**The drain sentinel is a file under the gitmoot home, not a database row**, so it
+still reads when the store is contended - which is exactly when a deploy is
+likely to be waiting.
+
+**`--clear` is required after the restart.** The sentinel outlives the process;
+a new daemon started while it exists will claim nothing.
+
 ## Findings Ledger
 
 `gitmoot findings` reports the #1822 findings ledger. Two shapes:

--- a/skills/gitmoot/references/CLI.md
+++ b/skills/gitmoot/references/CLI.md
@@ -3282,6 +3282,15 @@ likely to be waiting.
 **`--clear` is required after the restart.** The sentinel outlives the process;
 a new daemon started while it exists will claim nothing.
 
+`gitmoot job run <id>` is **intentionally not gated by drain**. It calls the
+worker directly rather than going through the scheduler's queued-job selection,
+so it is the one path that starts work on a drained daemon. That is deliberate:
+it is a manual, explicit, single-job operator command, and an operator who types
+it during a drain means it. A job it starts is still counted by an in-progress
+`daemon drain` wait, because the job transitions to `running`; the only gap is
+the ordinary race where it is invoked after a drain has already reported success
+and exited.
+
 ## Findings Ledger
 
 `gitmoot findings` reports the #1822 findings ledger. Two shapes:

--- a/website/docs/reference/cli.md
+++ b/website/docs/reference/cli.md
@@ -2852,6 +2852,37 @@ system owns the merge decision, set `GITMOOT_DISABLE_NATIVE_MERGE_GATE=1`
 gate — fail-closed, it never merges gatelessly; the external gate makes the
 call.
 
+### Draining before a deploy
+
+`gitmoot daemon drain` stops the daemon claiming new work so a busy fleet can
+reach the idle window the deploy recipe requires (#1207):
+
+```bash
+gitmoot daemon drain                 # stop claiming, wait up to 15m for in-flight jobs
+gitmoot daemon drain --timeout 30m   # wait longer
+gitmoot daemon drain --clear         # resume claiming, AFTER the restart
+```
+
+**Queued work is not lost.** Draining pauses selection at the same choke point the
+disk guard uses, so queued jobs stay queued and resume when the drain clears.
+
+The command exits **0** only when no engine-dispatched job is in flight - that is
+the point at which a restart is safe. If jobs remain past the deadline it exits
+**1** and NAMES them rather than killing or parking them: a CLI cannot see the
+state of work it did not start, and terminating it is the loss drain exists to
+prevent. Drain stays active meanwhile, so the set can only shrink.
+
+Session-recorded jobs (`session-*`) are excluded from the wait. They run outside
+the daemon process, hold no lease, and may legitimately stay running for hours -
+counting them would make the drain never finish.
+
+**The drain sentinel is a file under the gitmoot home, not a database row**, so it
+still reads when the store is contended - which is exactly when a deploy is
+likely to be waiting.
+
+**`--clear` is required after the restart.** The sentinel outlives the process;
+a new daemon started while it exists will claim nothing.
+
 ## Findings Ledger
 
 `gitmoot findings` reports the #1822 findings ledger. Two shapes:

--- a/website/docs/reference/cli.md
+++ b/website/docs/reference/cli.md
@@ -2883,6 +2883,15 @@ likely to be waiting.
 **`--clear` is required after the restart.** The sentinel outlives the process;
 a new daemon started while it exists will claim nothing.
 
+`gitmoot job run <id>` is **intentionally not gated by drain**. It calls the
+worker directly rather than going through the scheduler's queued-job selection,
+so it is the one path that starts work on a drained daemon. That is deliberate:
+it is a manual, explicit, single-job operator command, and an operator who types
+it during a drain means it. A job it starts is still counted by an in-progress
+`daemon drain` wait, because the job transitions to `running`; the only gap is
+the ordinary race where it is invoked after a drain has already reported success
+and exited.
+
 ## Findings Ledger
 
 `gitmoot findings` reports the #1822 findings ledger. Two shapes:


### PR DESCRIPTION
Implements #1207's **bounded half only**: stop claiming, wait for in-flight work. Not the re-exec handoff the issue also describes - that needs FD preservation across `exec` and an owner-scale decision about process identity, and it is deliberately left filed rather than attempted.

## The precondition was the problem

The deploy recipe requires zero engine-dispatched jobs before a restart. On a continuously busy fleet that window never arrives, so either deploys stop happening or the rule quietly gets broken. The issue records a verified binary sitting undeployed with 7 jobs running and no expectation of a gap.

**Drain makes the precondition satisfiable by construction rather than by luck.**

```bash
gitmoot daemon drain                 # stop claiming, wait up to 15m
gitmoot daemon drain --timeout 30m
gitmoot daemon drain --clear         # resume, AFTER the restart
```

Exit **0** only when nothing engine-dispatched is in flight - the point at which a restart is safe.

## Three decisions worth reviewing

**Wired at the disk guard's choke point.** `listPendingQueuedJobs` is where every scheduler - barrier and continuous-pool - selects work, and returning an empty eligible set pauses dispatch **without changing job state**. Queued jobs stay queued and resume by themselves. Reusing that mechanism rather than inventing a second pause is the same argument as folding with the engine's own rule instead of a copy.

**The sentinel is a file, not a row**, and the reason is tonight's own incident: the daemon spent an hour with its queue query blocked behind a 160 MB WAL at 99.6% CPU. A drain flag that needs a healthy store to be read cannot be trusted when it is most needed. A `stat` costs microseconds on a store that cannot answer a `SELECT`.

**Jobs past the deadline are named, not killed and not parked.** The issue asks that they be handled explicitly. The honest handling at this layer is to list them and refuse to call the window safe: a CLI cannot see the state of work it did not start, and terminating it is the exact loss drain exists to prevent. Drain stays active meanwhile, so the set can only shrink.

`session-*` jobs are excluded from the wait - they run outside the daemon, hold no lease, and can legitimately run for hours. Counting them would make the drain never finish, which teaches operators to pass a deadline that defeats it.

## Acceptance, against the issue's own list

| criterion | status |
|---|---|
| queued work preserved across the swap | `TestDrainLeavesQueuedWorkUntouched` - queued set byte-identical across a drain |
| deploy possible while jobs run | drain stops intake; the operator restarts once in-flight reaches zero |
| a job past the deadline is never killed silently | named in the report, drain stays active, exit 1 |
| the `AGENTS.md` precondition becomes satisfiable | that is the whole point of the intake stop |

Not claimed: **step 3, the re-exec.** A deploy still requires an operator restart. This removes the *waiting*, not the restart.

## Verification

The load-bearing test drives the **production path** (`listPendingQueuedJobs`), not the helpers - every helper test would pass against a build where the guard was never wired in, which is the shape #2061 f3 filed against me.

**Mutant-controlled**, anchor asserted before the write: unwiring the guard makes the dispatch path select 1 job while draining, and the test fails naming it. Full `internal/cli` package green (1092s).

## Reviewer, please attack

1. **`--clear` is required after the restart** and the sentinel outlives the process. That is deliberate - a half-finished deploy should not silently resume claiming - but it is a footgun if an operator forgets. If you think the sentinel should carry a TTL, say so.
2. **The wait polls every 5s against the store.** On the contended store that motivated the file sentinel, that polling is itself store load. It is bounded and only runs while an operator waits, but I did not measure its cost.
3. **`daemonDrainHome` is a package-level variable** set at worker construction. I chose it over threading the home through every eligibility call site; if you consider that worse than the churn, it is a mechanical change.


---

## Correction to the framing, from gm-staged's measurement

**#1207's Verified mechanics section is stale on this host, and it changes what this PR is for.** gm-staged measured it and filed it on the issue as `issuecomment-5599752114`; I re-derived it here before adopting it:

```
systemctl --user show gitmoot-daemon -p KillMode -p TimeoutStopUSec
  KillMode=mixed
  TimeoutStopUSec=15min 30s      (930s)
  FragmentPath=/root/.config/systemd/user/gitmoot-daemon.service
```

The issue says `control-group` and 90s. **Both of those are systemd DEFAULTS for a unit that does not exist in the scope queried** - a plain `systemctl show gitmoot-daemon` returns exactly `control-group` / `1min 30s` with an **empty `FragmentPath`**, which is how the wrong numbers got into the issue and how I would have repeated them.

Consequences, both load-bearing:

- under `KillMode=mixed` only the main process is signalled at t=0, so runtime children are not killed immediately;
- 930s now **exceeds** the daemon's own 900s `daemonShutdownDrainTimeout`, whose code comment at `daemon_dispatch_tracked.go:72-81` had already named both as the operator changes it needed. Both have been made.

**So "a code deploy kills every in-flight job" no longer holds here for the daemon's own children, and the residual gap this PR closes is the ARRIVAL side only:** the shutdown drain waits for what is already in flight, and nothing stops new work arriving until the moment of stop. That is a narrower claim than the issue's and it is the accurate one.

**Not verified, and the reviewer should know:** gm-staged measured the unit's *configuration*, not a restart. Behaviour under SIGKILL after the 930s stop timeout, and the fate of a runtime child whose parent daemon exits first under `mixed`, are both unmeasured.

## Two open questions for the reviewer, from gm-staged reading this branch

1. **Is the package-level `daemonDrainHome` inert anywhere?** It is set once at daemon start and the guard returns *not draining* when it is empty. gm-staged derived the home per call from `worker.ConfigHome` instead. If any path reaches the listing with `forDispatch` outside a started daemon, my guard does nothing there. Neither of us knows whether such a path exists.
2. **Checked and clean, so no round is spent on it:** `daemonDrainActive` returning `(false, error)` looks like a fail-open and is not - the caller does `if err != nil { return nil, err }` before testing the bool, so a stat failure aborts the listing. gm-staged's own independent implementation had exactly that defect by branching on the bool alone.

## Added since the review was dispatched, held locally at `b9290040` and `45f0ad20`

Not pushed: the review is running at `2b32b510` and pushing would void it. Both land with the verdict.

- **`45f0ad20`** - the recorded reason #1207's acceptance asks for. Each straggler now gets a durable `daemon_drain_deadline_exceeded` event naming the deadline and stating it was neither parked nor killed. Recording is all-or-error, not best-effort per job, because a partially recorded deadline is this campaign's own shape. **The park is declined deliberately**: parking is a state transition on a running job this command cannot see inside, and a deadline that parks implicitly is a deadline that kills. `gitmoot job cancel` is the explicit path.
- **`b9290040`** - a test for the stat-error branch, which had none and which a mutant returning `(false, nil)` survived. **The fixture shape is gm-staged's, from their own mistake:** their version made the marker a DIRECTORY, which stats fine, so it asserted the right conclusion for the wrong reason. The marker's parent is now a regular file, yielding ENOTDIR.


---

## The strongest evidence in this PR is that three of my own tests did not constrain what they named

All three were in `internal/cli/daemon_drain_1207_test.go`, all three mine, all three written this session, and **none was findable by reading**:

1. **The silent skip.** `TestDrainLeavesQueuedWorkUntouched`, commented "THE GUARANTEE THAT MATTERS", called `t.Skip` because its fixture built an Agent and no Job. It reported PASS having executed zero assertions. Found by a reviewer *running* it.
2. **The ratifying test.** `TestDrainIsInactiveWithoutAHome` required `false` from an empty home - which is the default home - so it pinned a no-op drain as correct behaviour. Found by a reviewer *tracing what the value is at runtime*.
3. **The test that could not distinguish the change from its absence.** My first test for the carried sentinel path called the guard directly, so it could not observe what the scheduler does. Reverting the scheduler to per-call resolution **survived it and every other test in this file**, because the two shapes agree whenever the home is stable. Found by *mutating production and watching nothing fail*.

`go test` reports a skip and a pass identically to anyone not reading `-v`, an assertion of the wrong premise is indistinguishable from a correct one, and a test that agrees with both shapes reports green for either. The common property is that **a passing suite is not evidence a guard is guarding anything**, and the only instrument that caught any of the three was a deliberate semantic mutant.

Every behavioural claim in this PR is therefore mutant-verified: the production change is reverted, the named test must fail, and the failure message must name the operational consequence rather than the assertion.

## Constructor audit, because a second constructor would make the guard inert

`DrainSentinelPath` is populated in `defaultJobWorker`. Checked rather than assumed:

- `executionBackendJobWorker` (the production daemon constructor) delegates to `defaultJobWorker`, so it inherits the field.
- The only other two `jobWorker{...}` literals in non-test code (`agent_dispatch.go:57`, `daemon_checkout.go:438`) are **inline method receivers** that are never stored, and neither reaches `listPendingQueuedJobs`.

## Owner rulings recorded, including one that was withdrawn on evidence

- **129691** - phobos confirmed the P1 on this box's live daemon: `ps` shows `gitmoot daemon run --poll 3m --workers 32 ...` with **no `--home`**, so the running daemon has `ConfigHome == ""` and the drain would have printed success while inert. The defect was live on the exact host the feature was written for.
- **129698** - the ruling that produced the carry-once change was issued on the premise that `os.UserHomeDir` could fail on the hot path. The reviewer measured otherwise, phobos then read `$GOROOT/src/os/file.go` directly and **withdrew the premise**: it is a pure `$HOME` read with no syscall. The change is kept anyway - it removes the failure mode rather than bounding it and does less work per tick - but the premise did not survive and the record says so.


---

## Attribution: the implementing lane recorded its own row

This PR was implemented **in session** by the `gm-integrity` seat, so no engine `implement` job existed and the merge gate could not verify implementer/reviewer independence. That is an **attribution gap**, not a failed check - the expected state for in-session work.

Closed rather than disclosed-and-left, per phobos's ruling on escalation 129762 item 2: the implementing lane self-identifies and records its own row, and nobody records on another seat's behalf.

```
implement  (acting role gm-integrity)  implemented   <- recorded by the lane that did the work
review     gm-review-opus              approved      <- a different agent
```

Two notes on what that row does and does not prove:

- **The seat is not a registered job agent**, deliberately, so the row is keyed on the org role via `--acting-role` rather than on an agent identity. It records who is accountable, not a dispatch that happened.
- **Git authorship cannot corroborate it.** Unmerged seat commits return `author.login` NULL (no linked account), and all 30 of the last 30 commits on main are authored by the owner's web account because everything lands squash-merged through the UI. Seat identity is invisible before merge and constant after it, so this row is the only durable attribution - which is precisely why writing a false one would be worse than leaving none.


**And the row is permanently silent about WHICH HEAD.** Re-derived on the live store rather than taken on report:

```
implement rows total            2636   with head_sha  2212
session-recorded implement       408   with head_sha     0
this PR's own row                        head_sha  NULL
```

Zero of 408, by design, not by omission. `job record --head-sha` documents itself as *"recorded as display metadata only: it is NOT stored in the job payload and no merge policy reads it (#1990)"*. So a head-bound gate can never be satisfied by an in-session implement row, and re-evaluating after recording one will not close that half. **This disclosure is the only remedy that exists for it.**

What the row therefore establishes: **who is accountable, at PR granularity**. What it cannot establish: that the accountable party wrote *this* head. A reader wanting the second must read the branch.


**Seat identity, and where it survives.** Every commit on this branch is authored `gm-integrity <gm-integrity@gitmoot.local>`, readable now via `git log -1 --format='%h %an <%ae>'` on the unmerged tip. **The squash merge rewrites that field to the owner's web account**, so it is readable only before merge.

No commit body on this branch names the seat, and I am not rewriting history to add it - that would void a verdict bound to the current head to fix a provenance line. **The squash commit message is the durable placement**, and it will carry the seat name and the attribution gap together when this is enqueued.

Stated because the author field is tamper-evident rather than unwritable: it sits inside the hashed object, so altering it changes the SHA, and the head is held independently by GitHub, every clone, and the local store. That is the property worth relying on - not filesystem permissions, which do not constrain a uid-0 seat at all.


---

## Merge record (the queue drops `--subject`/`--body-file`, so it lives here)

**Sequencing.** #2102 merged as `1944acd5` at 2026-09-09T22:33:50Z, implementing owner decision **note 129657**: the merge gate blocks on P1 and P2, and a P3 is reported without holding the merge. This PR's single open finding is `gitmoot/gitmoot#2096-f1`, **P3**, left open deliberately. It is therefore non-blocking by a rule that landed **before** this enqueue and in a separate PR - not by anything decided here.

I authored both. That is disclosed in #2102's own body in these words: *"this makes #2096 queueable, it does not make it merged"*. The order was the disclosure, and it was kept.

**Six safeguards, verified from the destination immediately before enqueueing** rather than taken from the checker:

| # | evidence |
|---|---|
| 1 | OPEN, `draft=false`, `mergeable=MERGEABLE`, **27 of 27 non-gate checks SUCCESS** |
| 2 | approved review job at exactly `ba9409ec`, equal to the live head |
| 3 | `tests_run` non-empty, 328 bytes, four executed entries |
| 4 | reviewer `gm-review-opus`; implementer acting role `gm-integrity`; **distinct** |
| 5 | head, draft, mergeable, checks and verdict all re-read in the same command as the enqueue |
| 6 | attribution gap named below |

`mergeStateStatus` is `UNSTABLE` and the **sole** non-success context is `gitmoot/merge-gate`, which is PENDING. That exclusion is structural, not statistical: the only path that posts success on that context sits below `if !result.Merged { return g.pending(...) }`, so a **pre-merge success is unreachable by construction** and waiting for it would wait on the merge itself. Production skips the context unconditionally in both status loops. The conflict question lives on `mergeable`, which is not relaxed.

**Attribution gap (safeguard 6).** Implemented in session by the `gm-integrity` seat, so no engine implement job dispatched it. The implementing lane recorded its own row (`session-implement-gm-integrity-18d3b734839be866`, acting role `gm-integrity`). That row carries **no `head_sha` and cannot** - 0 of 408 session-recorded implement rows do, by design (#1990). Independence is therefore verifiable at PR granularity and **not** at head granularity.
