### PR TITLE
test(cli): give the prompt-head fixture the two clients production passes

### DIFF
--- a/internal/cli/prompt_head_binding_test.go
+++ b/internal/cli/prompt_head_binding_test.go
@@ -2,11 +2,13 @@ package cli
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 
+	gitutil "github.com/gitmoot/gitmoot/internal/git"
 	"github.com/gitmoot/gitmoot/internal/subprocess"
 
 	"github.com/gitmoot/gitmoot/internal/db"
@@ -236,94 +238,92 @@ func TestReviewDispatchBindsThePromptsTargetToTheDispatchHead(t *testing.T) {
 // negative result from an input that cannot express the defect is not evidence.
 func TestUnjudgedTokenCannotRetainAnotherCitationsWarning(t *testing.T) {
 	ctx := context.Background()
-	scanCheckout, _, ancestor, head, foreign := promptHeadBindingCheckout(t)
+	canonical, _, ancestor, head, foreign := promptHeadBindingCheckout(t)
 	store, _ := blockerE2EHome(t)
 
-	// TWO CLIENTS, BECAUSE PRODUCTION PASSES TWO. agent_dispatch.go hands the
-	// SCAN a client rooted at the allocated exact-head worktree and the FILTER a
-	// client rooted at record.CheckoutPath - the canonical checkout. An earlier
-	// version of this test passed ONE client to both, so it could not detect any
-	// defect arising from their divergence, INCLUDING the divergence I had
-	// already flagged as a hazard before writing it.
+	// TWO CLIENTS, BUILT THE WAY PRODUCTION BUILDS THEM. agent_dispatch.go hands
+	// the SCAN a client rooted at the ALLOCATED exact-head worktree and the FILTER
+	// a client rooted at record.CheckoutPath - the canonical checkout - and the
+	// allocation is a `git worktree add --detach` FROM that canonical checkout.
+	// An earlier version of this test passed ONE client to both and so could not
+	// detect any defect arising from their divergence.
+	//
+	// A LATER VERSION OVERCORRECTED, and review caught it: it built the filter's
+	// client as an INDEPENDENT repository so the sibling commit was unresolvable
+	// there, and then made that unresolvability load-bearing. Production cannot
+	// be in that state. A linked worktree shares the canonical object database
+	// and refs, so if the scan resolves an object the filter resolves it too.
+	// A fixture that models an impossible state teaches a false model of
+	// production, so the split is gone and the shared store is asserted below.
+	scanCheckout := linkedWorktreeAtHead(t, canonical, head)
 	scan := jobGitClient(scanCheckout, subprocess.ExecRunner{})
-	filterCheckout := canonicalCheckoutMissingSiblingBranch(t, scanCheckout)
-	filter := jobGitClient(filterCheckout, subprocess.ExecRunner{})
+	filter := jobGitClient(canonical, subprocess.ExecRunner{})
 
-	// THE DIVERGENCE HAS TO BE LOAD-BEARING AND NOT VACUOUS. If the filter's
-	// checkout cannot resolve the DISPATCH HEAD, classifyPromptCommitCitations
-	// returns nil on its head guard, the filter returns nil, and every assertion
-	// below passes for the wrong reason. So the canonical clone carries the
-	// review branch - head and its ancestors resolve there - and lacks only the
-	// SIBLING branch, which is the one citation the two clients disagree about.
-	if _, err := filter.RevParse(ctx, head+"^{commit}"); err != nil {
-		t.Fatalf("filter checkout cannot resolve the dispatch head, so the filter would refuse for the wrong reason: %v", err)
-	}
-	if _, err := filter.RevParse(ctx, foreign+"^{commit}"); err == nil {
-		t.Fatalf("filter checkout resolves the sibling commit %s, so the two clients do not diverge and this test is back to one seam", foreign)
-	}
-	if _, err := scan.RevParse(ctx, foreign+"^{commit}"); err != nil {
-		t.Fatalf("scan checkout cannot resolve the sibling commit %s, so no warning about it is produced: %v", foreign, err)
+	// The shared store is the production property, so it is a POSITIVE CONTROL
+	// rather than an assumption: both clients resolve the head and the sibling.
+	for name, client := range map[string]gitutil.Client{"scan": scan, "filter": filter} {
+		for _, ref := range []string{head, foreign, ancestor} {
+			if _, err := client.RevParse(ctx, ref+"^{commit}"); err != nil {
+				t.Fatalf("%s client cannot resolve %s, so the two clients do not share one object store as production's pair does: %v", name, ref, err)
+			}
+		}
 	}
 
-	// THE STRAY TOKEN MUST STAY, and its absence is a defect I introduced while
-	// widening this fixture: a 7-hex run lifted from the MIDDLE of the dispatch
-	// head is the ONLY input that expresses the leak, because the leak fired
-	// when an unjudged token occurred inside the dispatch-head text that every
-	// warning carries. Replacing it with the sibling sha removed the defect from
-	// the input and both mutants survived - a negative result from an input that
-	// cannot express the defect, committed while fixing exactly that error.
+	// THE STRAY TOKEN IS THE ONLY INPUT THAT EXPRESSES THE LEAK: a 7-hex run
+	// lifted from the MIDDLE of the dispatch head, which nothing resolves. The
+	// leak fired when an unjudged token occurred inside the dispatch-head text
+	// that every warning carries. Replacing it with the sibling sha removed the
+	// defect from the input and both mutants survived - a negative result from an
+	// input that cannot express the defect.
 	stray := head[8:15]
+	// FAIL, NEVER SKIP. This used to t.Skipf, which silently withdraws the whole
+	// regression the one time the fixture stops expressing the defect - a skip is
+	// indistinguishable from coverage in every report anyone reads.
 	if _, err := scan.RevParse(ctx, stray+"^{commit}"); err == nil {
-		t.Skipf("fixture stray token %q unexpectedly resolves", stray)
+		t.Fatalf("fixture stray token %q resolves, so it cannot be unjudged and this test cannot express the leak", stray)
 	}
 
-	// The prompt cites an ANCESTOR of the dispatch head, whose warning the
-	// filter must drop; the SIBLING commit, which the filter's checkout cannot
-	// resolve and therefore cannot judge; and the STRAY run, which nothing
-	// resolves in either checkout.
 	prompt := "review " + ancestor + " and also " + foreign + " and " + stray
+	// The stray's PRESENCE IN THE PROMPT is the precondition, and deleting it
+	// from the prompt used to pass while making the leak mutant survive.
+	if !strings.Contains(prompt, stray) {
+		t.Fatalf("prompt %q lost the stray token %q, so nothing lands in the unjudged set", prompt, stray)
+	}
 
 	warnings := dispatchPromptHeadContradictionWarnings(ctx, scan, prompt, head)
 	if len(warnings) < 2 {
-		t.Fatalf("scan produced %d warnings, want both citations warned before filtering: %v", len(warnings), warnings)
+		t.Fatalf("scan produced %d warnings, want both resolvable citations warned before filtering: %v", len(warnings), warnings)
 	}
-	kept := retainUnjudgedPromptHeadWarnings(ctx, filter, store, prompt, head, "owner/repo", 12, warnings)
 
-	// The unjudged set must be NON-EMPTY, or the leak has nothing to fire on and
-	// a clean result proves nothing - the same vacuity that let an earlier hand
-	// probe of mine return KEPT=0 against a prompt with no stray token.
-	var keptForeign bool
-	for _, warning := range kept {
-		if strings.Contains(warning, foreign) {
-			keptForeign = true
-		}
-		if strings.Contains(warning, ancestor) {
-			t.Fatalf("an unjudged citation retained the ANCESTOR citation's warning: %q\nkept=%v", warning, kept)
-		}
+	kept := retainUnjudgedPromptHeadWarnings(ctx, filter, store, prompt, head, "owner/repo", 12, warnings)
+	// NOTHING MAY BE KEPT. The ancestor is judged, the sibling resolves and is no
+	// recorded head, and the stray has no warning of its own - so no warning here
+	// is about an unjudged citation. The leak retained them anyway, because the
+	// stray occurs inside the dispatch-head text every warning repeats.
+	if len(kept) != 0 {
+		t.Fatalf("an unjudged token retained %d warning(s) that are not about it: %v", len(kept), kept)
 	}
-	if !keptForeign {
-		t.Fatalf("the unresolvable sibling citation was not retained, so nothing was unjudged and the drop above is vacuous: kept=%v", kept)
+
+	// POSITIVE CONTROL FOR THAT EMPTY RESULT, because retainUnjudged returns nil
+	// when the unjudged set is EMPTY and that nil is indistinguishable from the
+	// decision above. The same call keeps a warning that really is about the
+	// stray, which proves the stray reached the unjudged set.
+	control := retainUnjudgedPromptHeadWarnings(ctx, filter, store, prompt, head, "owner/repo", 12,
+		[]string{fmt.Sprintf(promptHeadWarningFormat, stray, head, head)})
+	if len(control) != 1 {
+		t.Fatalf("control kept %d warnings, want the stray's own warning retained; the empty result above would then be vacuous: %v", len(control), control)
 	}
 }
 
-// canonicalCheckoutMissingSiblingBranch clones the review branch ALONE, so the
-// clone resolves the dispatch head and its ancestors but not the sibling
-// pull request's commit. That asymmetry is what production has and what a
-// single-client fixture cannot represent.
-func canonicalCheckoutMissingSiblingBranch(t *testing.T, source string) string {
+// linkedWorktreeAtHead mirrors how production allocates the scan client's
+// checkout: `git worktree add --detach` from the canonical checkout, so the two
+// clients share one object database and one set of refs. Verified on this host:
+// a detached linked worktree and its canonical checkout report the same
+// --git-common-dir and both resolve every object the other can.
+func linkedWorktreeAtHead(t *testing.T, canonical string, head string) string {
 	t.Helper()
-	dir := filepath.Join(t.TempDir(), "canonical")
-	if err := os.MkdirAll(dir, 0o755); err != nil {
-		t.Fatalf("create canonical checkout dir: %v", err)
-	}
-	// FETCH ONE REF RATHER THAN CLONE. A local clone copies the whole object
-	// store even with --single-branch --no-hardlinks, so the sibling commit
-	// remains resolvable and the two clients do not actually diverge - the
-	// guard in the caller caught exactly that. A fetch transfers only what is
-	// reachable from the named ref.
-	runGit(t, dir, "init", "--quiet")
-	runGit(t, dir, "fetch", "--quiet", "--no-tags", source, "refs/heads/feature/review:refs/heads/feature/review")
-	runGit(t, dir, "checkout", "--quiet", "feature/review")
+	dir := filepath.Join(t.TempDir(), "readonly-seat")
+	runGit(t, canonical, "worktree", "add", "--detach", dir, head)
 	return dir
 }
 

--- a/internal/cli/prompt_head_binding_test.go
+++ b/internal/cli/prompt_head_binding_test.go
@@ -236,29 +236,95 @@ func TestReviewDispatchBindsThePromptsTargetToTheDispatchHead(t *testing.T) {
 // negative result from an input that cannot express the defect is not evidence.
 func TestUnjudgedTokenCannotRetainAnotherCitationsWarning(t *testing.T) {
 	ctx := context.Background()
-	checkout, _, base, head, _ := promptHeadBindingCheckout(t)
+	scanCheckout, _, ancestor, head, foreign := promptHeadBindingCheckout(t)
 	store, _ := blockerE2EHome(t)
-	client := jobGitClient(checkout, subprocess.ExecRunner{})
 
-	// A 7-hex run lifted from the MIDDLE of the dispatch head, which no object
-	// resolves: this is the unjudged token that used to leak.
+	// TWO CLIENTS, BECAUSE PRODUCTION PASSES TWO. agent_dispatch.go hands the
+	// SCAN a client rooted at the allocated exact-head worktree and the FILTER a
+	// client rooted at record.CheckoutPath - the canonical checkout. An earlier
+	// version of this test passed ONE client to both, so it could not detect any
+	// defect arising from their divergence, INCLUDING the divergence I had
+	// already flagged as a hazard before writing it.
+	scan := jobGitClient(scanCheckout, subprocess.ExecRunner{})
+	filterCheckout := canonicalCheckoutMissingSiblingBranch(t, scanCheckout)
+	filter := jobGitClient(filterCheckout, subprocess.ExecRunner{})
+
+	// THE DIVERGENCE HAS TO BE LOAD-BEARING AND NOT VACUOUS. If the filter's
+	// checkout cannot resolve the DISPATCH HEAD, classifyPromptCommitCitations
+	// returns nil on its head guard, the filter returns nil, and every assertion
+	// below passes for the wrong reason. So the canonical clone carries the
+	// review branch - head and its ancestors resolve there - and lacks only the
+	// SIBLING branch, which is the one citation the two clients disagree about.
+	if _, err := filter.RevParse(ctx, head+"^{commit}"); err != nil {
+		t.Fatalf("filter checkout cannot resolve the dispatch head, so the filter would refuse for the wrong reason: %v", err)
+	}
+	if _, err := filter.RevParse(ctx, foreign+"^{commit}"); err == nil {
+		t.Fatalf("filter checkout resolves the sibling commit %s, so the two clients do not diverge and this test is back to one seam", foreign)
+	}
+	if _, err := scan.RevParse(ctx, foreign+"^{commit}"); err != nil {
+		t.Fatalf("scan checkout cannot resolve the sibling commit %s, so no warning about it is produced: %v", foreign, err)
+	}
+
+	// THE STRAY TOKEN MUST STAY, and its absence is a defect I introduced while
+	// widening this fixture: a 7-hex run lifted from the MIDDLE of the dispatch
+	// head is the ONLY input that expresses the leak, because the leak fired
+	// when an unjudged token occurred inside the dispatch-head text that every
+	// warning carries. Replacing it with the sibling sha removed the defect from
+	// the input and both mutants survived - a negative result from an input that
+	// cannot express the defect, committed while fixing exactly that error.
 	stray := head[8:15]
-	if _, err := client.RevParse(ctx, stray+"^{commit}"); err == nil {
+	if _, err := scan.RevParse(ctx, stray+"^{commit}"); err == nil {
 		t.Skipf("fixture stray token %q unexpectedly resolves", stray)
 	}
-	// base is an ANCESTOR of head, so its warning must be dropped.
-	prompt := "review " + base + " and also " + stray
 
-	warnings := dispatchPromptHeadContradictionWarnings(ctx, client, prompt, head)
-	if len(warnings) == 0 {
-		t.Fatalf("fixture produced no warnings to filter; the ancestor citation must warn before filtering")
+	// The prompt cites an ANCESTOR of the dispatch head, whose warning the
+	// filter must drop; the SIBLING commit, which the filter's checkout cannot
+	// resolve and therefore cannot judge; and the STRAY run, which nothing
+	// resolves in either checkout.
+	prompt := "review " + ancestor + " and also " + foreign + " and " + stray
+
+	warnings := dispatchPromptHeadContradictionWarnings(ctx, scan, prompt, head)
+	if len(warnings) < 2 {
+		t.Fatalf("scan produced %d warnings, want both citations warned before filtering: %v", len(warnings), warnings)
 	}
-	kept := retainUnjudgedPromptHeadWarnings(ctx, client, store, prompt, head, "owner/repo", 12, warnings)
+	kept := retainUnjudgedPromptHeadWarnings(ctx, filter, store, prompt, head, "owner/repo", 12, warnings)
+
+	// The unjudged set must be NON-EMPTY, or the leak has nothing to fire on and
+	// a clean result proves nothing - the same vacuity that let an earlier hand
+	// probe of mine return KEPT=0 against a prompt with no stray token.
+	var keptForeign bool
 	for _, warning := range kept {
-		if strings.Contains(warning, base) {
-			t.Fatalf("an unjudged stray token retained the ANCESTOR citation's warning: %q\nkept=%v", warning, kept)
+		if strings.Contains(warning, foreign) {
+			keptForeign = true
+		}
+		if strings.Contains(warning, ancestor) {
+			t.Fatalf("an unjudged citation retained the ANCESTOR citation's warning: %q\nkept=%v", warning, kept)
 		}
 	}
+	if !keptForeign {
+		t.Fatalf("the unresolvable sibling citation was not retained, so nothing was unjudged and the drop above is vacuous: kept=%v", kept)
+	}
+}
+
+// canonicalCheckoutMissingSiblingBranch clones the review branch ALONE, so the
+// clone resolves the dispatch head and its ancestors but not the sibling
+// pull request's commit. That asymmetry is what production has and what a
+// single-client fixture cannot represent.
+func canonicalCheckoutMissingSiblingBranch(t *testing.T, source string) string {
+	t.Helper()
+	dir := filepath.Join(t.TempDir(), "canonical")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("create canonical checkout dir: %v", err)
+	}
+	// FETCH ONE REF RATHER THAN CLONE. A local clone copies the whole object
+	// store even with --single-branch --no-hardlinks, so the sibling commit
+	// remains resolvable and the two clients do not actually diverge - the
+	// guard in the caller caught exactly that. A fetch transfers only what is
+	// reachable from the named ref.
+	runGit(t, dir, "init", "--quiet")
+	runGit(t, dir, "fetch", "--quiet", "--no-tags", source, "refs/heads/feature/review:refs/heads/feature/review")
+	runGit(t, dir, "checkout", "--quiet", "feature/review")
+	return dir
 }
 
 func TestReviewDispatchWarnsOnlyOnCitationsNobodyHasJudged(t *testing.T) {


### PR DESCRIPTION
## The defect

`agent_dispatch.go:531-532` hands the **scan** a client rooted at the allocated exact-head worktree and the **filter** a client rooted at `record.CheckoutPath`, the canonical checkout:

```go
promptHeadWarnings = dispatchPromptHeadContradictionWarnings(ctx, jobGitClient(checkoutPath, ...), ...)
promptHeadWarnings = retainUnjudgedPromptHeadWarnings(ctx, jobGitClient(record.CheckoutPath, ...), ...)
```

`TestUnjudgedTokenCannotRetainAnotherCitationsWarning` passed **one** client to both. It exercised a seam production never takes, so it could not detect any defect arising from their divergence.

**Worse than writing to the signature:** I had already flagged that exact asymmetry as a hazard - "two git clients on one decision" - while trying to explain warnings I could not account for, and then wrote an instrument blind to it. A fixture that collapses two production inputs into one cannot detect any defect arising from their divergence, including the one it was written after suspecting.

## What changed

The fixture now mirrors production. The canonical checkout is built by fetching **one ref** rather than cloning: a local clone copies the whole object store even with `--single-branch --no-hardlinks`, so the sibling commit stayed resolvable and the two clients did not actually diverge.

Three guards now fail loudly rather than passing quietly:

- the filter **must** resolve the dispatch head - without this, `classifyPromptCommitCitations` returns nil on its head guard and every assertion below passes for the wrong reason;
- the filter must **not** resolve the sibling commit - otherwise there is no divergence and the test is back to one seam;
- the scan **must** resolve it - otherwise no warning about it is produced at all.

The first guard is what caught the failed clone attempt, before I trusted the result.

## Two mutants survived my first rewrite, and that is the part worth reading

Widening the seam, I replaced the stray token with the sibling sha. **The stray token was the only input that expresses the leak** - it fired when an unjudged token occurred inside the dispatch-head text that every warning carries, and a sibling sha does not occur there. So the rewrite removed the defect from the input and the substring mutant passed clean: a negative result from an input that cannot express the defect, committed while fixing that same error one layer up.

The prompt now cites all three - ancestor, sibling, and the 7-hex run from the middle of the dispatch head - and the substring mutant fails again with the ancestor's warning visibly retained in the failure message.

## Verification

`go build ./...` exit 0, `go vet ./internal/cli` exit 0, `internal/cli` green (128.7s). Mutant A (restore `strings.Contains`) fails as required. Mutant B (disable the ancestor arm) passes and is **not** claimed as covered here: with the ancestor arm gone the citation classifies as foreign and is dropped anyway, so this test's contract cannot see it - that property belongs to `TestReviewDispatchWarnsOnlyOnCitationsNobodyHasJudged`.

**Unchallenged and unchanged:** the anchored-prefix fix is correct and the leak test still discriminates the leak. This widens what the test can see; it does not repair what the test proved.

## Scope

One fixture change, nothing else. The **production** question this exposes - whether `record.CheckoutPath` can fail to resolve a commit the worktree resolves on a real dispatch - is deliberately **not** in this PR: it is a claim about production that this fix would make visible rather than repair, and it is being measured separately.
## Measured: the divergence this fixture models cannot occur for this pair

Recorded here because the PR must not imply it tests a real production hazard.

A live review read-only seat on this host:

```
/root/.gitmoot/worktrees/gitmoot--gitmoot/delegations/local-review-gm-review-opus-18d2cf985433e27d/readonly-seat
  .git        -> gitdir: /root/gitmoot-checkouts/gitmoot/.git/worktrees/readonly-seat6
  common-dir  -> /root/gitmoot-checkouts/gitmoot/.git
```

The scan's `checkoutPath` is a **`git worktree` of** `record.CheckoutPath`, so the two clients share **one object store** - the worktree's `git-common-dir` *is* the canonical repository's `.git`. `RevParse` of an explicit sha is an object-store lookup, so **any commit the scan can resolve, the filter can resolve.** The direction I hypothesised - canonical lacking a commit the worktree has - is impossible by construction here, not merely unobserved.

The code says the same thing from the other side. `engine_delegation.go` handles a cold checkout that lacks the PR commit by **fetching into that checkout** before allocating, recording `delegation_worktree_pr_ref_fetched`, and names `maybeAllocateDispatchReadOnlyWorktree` and `prepareNativeReviewWorktreeForRunner` as carrying the same retry. The remedy runs on the canonical repo, so the worktree cannot end up ahead of it.

**So this fixture's specific scenario - a canonical checkout missing a cited commit - is unrepresentative of this call pair.** What the change still buys, and all it claims:

- the fixture passes **two clients where production passes two**, so the collapsed seam is gone and a future divergence at this call site is observable rather than invisible;
- it kills the substring mutant, which the single-client version also did and which remains the defect under test;
- its guards make a vacuous pass impossible, which the single-client version did not check.

What it does **not** buy: evidence about a live defect. There is none at this pair, and the hazard I named earlier when I could not explain some warnings is answered - not by finding it, but by finding it cannot exist. I would rather have that written down than leave a plausible hazard standing unexamined.

I have not measured the other two named allocation sites, only read that they carry the same fetch retry. A divergence there would need its own probe.


---

## Merge note

Enqueued by `gm-transport` under `merge_rule: self`, verified at enqueue time from two durable sources rather than from a message: `gitmoot org brief --role gm-transport` reports `merge_rule: self` and `gitmoot org chart` reports `merge=self`. Owner standing-delegation row 107983's six safeguards, each checked immediately before enqueue:

1. **Open, mergeable, clean, all checks succeeded.** `state: open`, `draft: false`, `mergeable: true`, `mergeable_state: clean`, 27 of 27 success, 0 failing, 0 pending.
2. **Approved at the current head.** Job `local-review-gm-review-opus-18d3c9ff1d602367-1`, `decision: approved`, `head_sha 8b6e99f90b35a9c914b84fbc62b9583c11d4accb`, which is this PR's head.
3. **Non-empty `tests_run`.** Seven entries, including an independent `git worktree add --detach` reproduction of the shared `--git-common-dir` claim and the reviewer's own mutation of the anchored match.
4. **Reviewer is neither implementer nor lead.** Reviewer `gm-review-opus`; implementer and lead are not that agent.
5. **Immediate pre-enqueue re-read.** The state in 1 and 2 was re-read in the same command sequence as this enqueue, not carried from an earlier turn.
6. **Attribution gap, named rather than skipped.** This PR was implemented in-session, so there is no engine implementation job for it and its recorded attribution carries `at_head=UNRECORD`. That is the in-session shape, not a missing recording step, and it is stated here rather than left for a reader to hunt.

### The base is stale and the queue is the instrument for it

This PR's base is `85131c51`; `main` has since moved twice, through `1944acd5` to `fd54b3cf`. So the 27/27 above describes `merge(head, 85131c51)`, a tree that no longer exists. The head axis is clean - the approval names the current head - and the base axis is the queue's job: it re-tests the real merge against whatever `main` is when this reaches the front.

Deliberately **not** rebased to chase the base. `main`'s measured median gap between commits tonight is about 31 minutes against a local check that takes roughly 900 seconds, so rebasing to restore a current green is a loop that does not terminate. If the queue rejects this for conflicts, that is the queue working, not a surprise.
