### PR TITLE
fix(cli): refuse a review whose seat cannot run go (#1817)

### DIFF
--- a/internal/cli/daemon_worker.go
+++ b/internal/cli/daemon_worker.go
@@ -860,6 +860,30 @@ func (w jobWorker) run(ctx context.Context, job db.Job) error {
 		_ = w.postJobResultComment(ctx, job.ID, agent, checkout, refusal)
 		return nil
 	}
+	// #1817: THE SAME QUESTION FOR THE TOOL A REVIEW ACTUALLY RUNS. Measured
+	// instance: local-review-gm-review-opus-18d3b8e6790b3231-1 reviewed
+	// gitmoot/gitmoot#2066 at its exact head, returned APPROVED, and its whole
+	// tests_run read "go test ./internal/workflow (attempted): could not run
+	// ... `go` is a stub that exits 126". The seat's own runtime staged fine,
+	// so the sibling arm above stayed silent, no event named the failure, and
+	// the verdict satisfied an exact-head review gate having executed nothing.
+	//
+	// SCOPED TO REVIEW, not to every seat, because the un-evented staging miss
+	// is a deliberate choice with a named cost: an event here would make a
+	// job's event sequence depend on host disk state. That reason holds for
+	// ask, implement and produce; it does not hold for the one action whose
+	// contract IS to execute the repository's gate.
+	if job.Type == "review" && seatSetup.toolchainUnavailable != "" && w.adapterIsDeclaredReal() {
+		refusal := error(&seatToolchainCapabilityError{agentName: agent.Name, cause: seatSetup.toolchainUnavailable})
+		if eventErr := w.Store.AddJobEvent(ctx, db.JobEvent{JobID: job.ID, Kind: seatToolchainUnavailableEvent, Message: refusal.Error()}); eventErr != nil {
+			writeLine(w.Stdout, "job %s %s event failed: %v", job.ID, seatToolchainUnavailableEvent, eventErr)
+		}
+		if finishErr := w.finishQueuedJob(ctx, job, workflow.JobBlocked, refusal); finishErr != nil {
+			return finishErr
+		}
+		_ = w.postJobResultComment(ctx, job.ID, agent, checkout, refusal)
+		return nil
+	}
 	var readOnlyState *readOnlyRuntimeAdapter
 	readOnlyStateCleaned := false
 	if stateAdapter, ok := adapter.(readOnlyRuntimeAdapter); ok {
@@ -1479,6 +1503,12 @@ type readOnlySandboxGrants struct {
 	// anything, and it would refuse every claude seat in CI, where no runtime
 	// CLI is installed at all.
 	runtimeUnavailable string
+	// toolchainUnavailable names why the seat's staged Go toolchain is absent,
+	// or "" when it staged normally. Same reporting rule as the field above and
+	// the same reason: seat setup does not know whether this job's contract
+	// requires executing anything, and the staging miss is an operator-visible
+	// fact about the host rather than a defect in the job.
+	toolchainUnavailable string
 }
 
 type readOnlyRuntimeAdapter struct {
@@ -1536,7 +1566,7 @@ func wrapReadOnlySandboxAdapter(home string, agent runtime.Agent, checkout strin
 	if err != nil {
 		return nil, readOnlySeatSetup{}, err
 	}
-	setup := readOnlySeatSetup{dropped: grants.dropped, runtimeUnavailable: grants.runtimeUnavailable}
+	setup := readOnlySeatSetup{dropped: grants.dropped, runtimeUnavailable: grants.runtimeUnavailable, toolchainUnavailable: grants.toolchainUnavailable}
 	wrap := func(runner subprocess.Runner) subprocess.Runner {
 		baseEnv := readOnlyRuntimeBaseEnv(agent.Runtime, os.Environ(), filepath.Join(grants.cacheRoot, "gh"))
 		curated := graftRuntimeBaseRunner(runner, subprocess.CuratedGroupRunner{
@@ -1927,6 +1957,19 @@ func readOnlyRuntimeSandboxGrants(home string, agent runtime.Agent, checkout str
 	}
 	if diagnostic != "" {
 		fmt.Fprintf(os.Stderr, "gitmoot: read-only seat toolchain: %s\n", diagnostic)
+	}
+	// #1817: WHETHER THE SEAT CAN RUN `go` AT ALL, recorded beside the sibling
+	// runtime answer. The diagnostic above cannot carry this: the `go` absent
+	// arm passes "" (toolchain_seat.go:39), so a host with no Go on the daemon
+	// PATH publishes the exit-126 shim and reports nothing. The ROOT is the
+	// fact - stageSeatToolchain returns the published-unavailable root in every
+	// failure arm - so key on it and use the diagnostic only to sharpen the
+	// cause when one exists.
+	if staged != "" && filepath.Base(staged) == "go"+toolchain.UnavailableRuntimeSuffix {
+		grants.toolchainUnavailable = strings.TrimSpace(diagnostic)
+		if grants.toolchainUnavailable == "" {
+			grants.toolchainUnavailable = "no Go installation resolved on the daemon PATH, so the seat's `go` is the engine's exit-126 unavailable command"
+		}
 	}
 	if staged != "" {
 		if err := validateStagedToolchainPlacement(staged, grants.writes); err != nil {

--- a/internal/cli/seat_runtime_capability.go
+++ b/internal/cli/seat_runtime_capability.go
@@ -16,6 +16,9 @@ type readOnlySeatSetup struct {
 	// runtimeUnavailable is why the seat's own runtime resolves to the
 	// engine's exit-126 unavailable command, or "" when it staged normally.
 	runtimeUnavailable string
+	// toolchainUnavailable is why the seat's `go` resolves to the engine's
+	// exit-126 unavailable command, or "" when the toolchain staged normally.
+	toolchainUnavailable string
 }
 
 // seatRuntimeUnavailableEvent records that a job was refused because the
@@ -49,5 +52,36 @@ func (e *seatRuntimeCapabilityError) Error() string {
 	return fmt.Sprintf(
 		"read-only seat capability preflight blocked agent %q: runtime %q is published unavailable to seats, so every command this job dispatches would exit 126 without running (%s); remedy: restore the daemon-staged %s artifact, or dispatch this job to an agent whose runtime stages",
 		e.agentName, e.runtimeName, cause, e.runtimeName,
+	)
+}
+
+// seatToolchainUnavailableEvent records that a REVIEW job was refused because
+// the seat cannot run `go`. Scoped to review for the reason the staging miss
+// was left un-evented in the first place (daemon_worker.go): a job's event
+// sequence must not depend on the host's toolchain and disk state, and
+// TestExecBackendLocalDefaultDaemonE2E pins an exact baseline for an `ask`
+// job. A review is the one action whose contract is to execute the
+// repository's gate, so for review - and only review - the absence is a fact
+// about the job's outcome rather than about the host.
+const seatToolchainUnavailableEvent = "seat_toolchain_unavailable"
+
+// seatToolchainCapabilityError is the #1817 capability refusal for a review
+// seat whose Go toolchain is published unavailable. BLOCKED rather than
+// FAILED, for the same reason as its runtime sibling: nothing was wrong with
+// the job, the capability it needs is absent, and `failed` reads as "this
+// reviewer tried" and invites the identical re-dispatch.
+type seatToolchainCapabilityError struct {
+	agentName string
+	cause     string
+}
+
+func (e *seatToolchainCapabilityError) Error() string {
+	cause := strings.TrimSpace(e.cause)
+	if cause == "" {
+		cause = "no daemon-staged Go toolchain exists"
+	}
+	return fmt.Sprintf(
+		"read-only seat capability preflight blocked review agent %q: the seat's Go toolchain is published unavailable, so `go build`, `go vet` and `go test` would each exit 126 without running (%s); a verdict from this seat could not have executed the repository's gate; remedy: restore the daemon-staged Go artifact, or dispatch this review to a host whose toolchain stages",
+		e.agentName, cause,
 	)
 }

--- a/internal/cli/seat_runtime_capability_test.go
+++ b/internal/cli/seat_runtime_capability_test.go
@@ -282,3 +282,121 @@ func TestSeatRuntimeUnavailableIgnoresAnUnrelatedPublishedRoot(t *testing.T) {
 		t.Errorf("cause %q borrowed another runtime's diagnostic or lost the runtime name", cause)
 	}
 }
+
+// unstageableGoFixture is a `go` whose PATH entry is not inside a bin/ or
+// sbin/ installation, which stageSeatToolchain classifies as unavailable
+// (toolchain_seat.go:51). Deterministic on a host with or without a real Go
+// installed, and unlike the ELOOP that produced the live instance it needs no
+// pre-published launcher.
+const unstageableGoFixture = "#!/bin/sh\nexit 0\n"
+
+// seedUnavailableToolchainReviewSeat is the measured #1817 shape that the
+// runtime arm cannot see: the seat's OWN runtime stages fine, so
+// runtimeUnavailable stays empty, while `go` resolves to the engine's exit-126
+// command. That is the live instance, job
+// local-review-gm-review-opus-18d3b8e6790b3231-1: gitmoot/gitmoot#2066
+// reviewed at its exact head, decision APPROVED, whole tests_run reading
+// "could not run ... `go` is a stub that exits 126".
+func seedUnavailableToolchainReviewSeat(t *testing.T, jobID string, action string) (*db.Store, string, string) {
+	t.Helper()
+	hostBin := t.TempDir()
+	// The POSITIVE CONTROL rides inside the fixture: claude stages, so a
+	// failure here can only come from the toolchain predicate.
+	writeRuntimeFixture(t, hostBin, "claude", stageableRuntimeFixture)
+	writeRuntimeFixture(t, hostBin, "go", unstageableGoFixture)
+	prependRuntimeFixturePath(t, hostBin)
+
+	store, home := blockerE2EHome(t)
+	checkout := readonlyWorktreeGitCheckout(t, "owner/repo")
+	seedDaemonWorkerRepo(t, store, "owner/repo", checkout)
+	sourceDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(sourceDir, ".credentials.json"),
+		[]byte(`{"claudeAiOauth":{"accessToken":"fixture-token"}}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	seedDaemonWorkerAgentWithPolicy(t, store, "gm-review-opus", runtime.ClaudeRuntime,
+		"550e8400-e29b-41d4-a716-446655440000", []string{"review", "ask"}, "owner/repo", runtime.AutonomyPolicyReadOnly)
+	enqueueDaemonWorkerJob(t, store, workflow.JobRequest{
+		ID: jobID, Agent: "gm-review-opus", Action: action, Repo: "owner/repo",
+		WorktreePath: checkout, ReadOnlySeat: true, RuntimeConfigDir: sourceDir,
+	})
+	return store, home, checkout
+}
+
+func runUnavailableToolchainSeatJob(t *testing.T, store *db.Store, home string, checkout string, jobID string) []db.JobEvent {
+	t.Helper()
+	ctx := context.Background()
+	// NO AdapterFactory override: the production factory is the caller that
+	// would actually exec `go` inside the seat.
+	worker := defaultJobWorker(store, io.Discard, home)
+	worker.CheckoutValidator = func(context.Context, db.Job, workflow.JobPayload, runtime.Agent) (string, error) {
+		return checkout, nil
+	}
+	job, err := store.GetJob(ctx, jobID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := worker.run(ctx, job); err != nil {
+		t.Fatal(err)
+	}
+	events, err := store.ListJobEvents(ctx, jobID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return events
+}
+
+// TestSeatToolchainUnavailableEndsAReviewBlockedNotVerdicted is the arm that
+// fails before the fix: the job ran to a verdict with nothing executed, and no
+// event named the missing capability.
+func TestSeatToolchainUnavailableEndsAReviewBlockedNotVerdicted(t *testing.T) {
+	ctx := context.Background()
+	store, home, checkout := seedUnavailableToolchainReviewSeat(t, "seat-toolchain-unavailable", "review")
+	events := runUnavailableToolchainSeatJob(t, store, home, checkout, "seat-toolchain-unavailable")
+
+	settled, err := store.GetJob(ctx, "seat-toolchain-unavailable")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if settled.State != string(workflow.JobBlocked) {
+		t.Fatalf("job state = %q, want %q: a reviewer that cannot run `go` must come back blocked with the failing check named, never with a verdict a consumer reads as review evidence", settled.State, workflow.JobBlocked)
+	}
+	var refusal string
+	for _, event := range events {
+		if event.Kind == seatToolchainUnavailableEvent {
+			refusal = event.Message
+		}
+		// The sibling arm must stay silent, or this test would pass on the
+		// wrong predicate: the fixture's claude stages successfully.
+		if event.Kind == seatRuntimeUnavailableEvent {
+			t.Fatalf("%q fired on a seat whose own runtime staged: %s", seatRuntimeUnavailableEvent, event.Message)
+		}
+	}
+	if refusal == "" {
+		t.Fatalf("no %q event: the failing check is not readable from the job's own event stream. events=%+v", seatToolchainUnavailableEvent, events)
+	}
+	// The AGENT is who a coordinator re-dispatches away from, and the CAUSE is
+	// what an operator repairs.
+	for _, want := range []string{"gm-review-opus", "bin/ or sbin/"} {
+		if !strings.Contains(refusal, want) {
+			t.Errorf("%q event %q does not name %q", seatToolchainUnavailableEvent, refusal, want)
+		}
+	}
+}
+
+// TestSeatToolchainUnavailableDoesNotRefuseANonReviewSeat is the
+// over-rejection control, and it defends a DOCUMENTED choice rather than a
+// preference: the staging miss is deliberately un-evented because a job's
+// event sequence must not depend on host disk state, and
+// TestExecBackendLocalDefaultDaemonE2E pins an exact baseline for an `ask`
+// job. Only review's contract requires executing the repository's gate.
+func TestSeatToolchainUnavailableDoesNotRefuseANonReviewSeat(t *testing.T) {
+	store, home, checkout := seedUnavailableToolchainReviewSeat(t, "seat-toolchain-ask", "ask")
+	events := runUnavailableToolchainSeatJob(t, store, home, checkout, "seat-toolchain-ask")
+
+	for _, event := range events {
+		if event.Kind == seatToolchainUnavailableEvent {
+			t.Fatalf("%q fired on an %q job: the un-evented staging miss is deliberate for every action whose contract does not require running the gate. message=%s", seatToolchainUnavailableEvent, "ask", event.Message)
+		}
+	}
+}


### PR DESCRIPTION
Refs #1817.

## The defect

A review seat whose Go toolchain is published unavailable is dispatched anyway, runs to a verdict, and returns `approved` at the exact head with nothing executed. Nothing in the job's event stream names the missing capability.

Measured instance, my own PR, tonight:

```
job       local-review-gm-review-opus-18d3b8e6790b3231-1
pr        gitmoot/gitmoot#2066 at exact head fd32dffe
state     succeeded
decision  approved
tests_run ["go test ./internal/workflow (attempted): could not run - this readonly-seat
           worktree has no functional Go toolchain; `go` is a stub that exits 126 with
           'gitmoot: runtime unavailable: no daemon-staged artifact exists'.
           No tests executed; review is static (diff read + code trace) only."]
```

The job's 19 events contain `route_selected`, `readonly_worktree_allocated`, `effective_runtime`, `running`, `succeeded` and no capability event of any kind.

The existing #1817 preflight is not at fault and is not changed: it asks whether the seat's OWN runtime staged. Here it staged. `claude-ba7128fd22b1bc20` is a real published root on this host, so `runtimeUnavailable` was correctly empty while `go` was the shim.

Reproduced artifact:

```
/root/.gitmoot/runtimes/go-unavailable-v1/.bin/go   102 bytes, mode -r-x------
  #!/bin/sh
  printf '%s\n' 'gitmoot: runtime unavailable: no daemon-staged artifact exists' >&2
  exit 126
```

## Why the toolchain arm cannot reuse either existing signal

`stageSeatToolchain` returns `(staged, env, diagnostic, err)`, and neither of the first three answers the capability question:

- `diagnostic` is `""` in the `go` absent arm (`toolchain_seat.go:39`), so a host with no Go on the daemon PATH publishes the exit-126 shim and reports nothing. Measured: zero `read-only seat toolchain` lines in three days of this daemon's journal.
- `staged` is non-empty in every failure arm too, because `unavailableSeatToolchain` returns the published-unavailable ROOT.

So the predicate keys on the root's identity, `filepath.Base(staged) == "go" + toolchain.UnavailableRuntimeSuffix`, and uses the diagnostic only to sharpen the cause when one exists.

## The change

1. `readOnlySandboxGrants.toolchainUnavailable`, set beside the existing `runtimeUnavailable`, reported rather than refused for the same reason: seat setup does not know whether the caller will exec anything.
2. `readOnlySeatSetup.toolchainUnavailable` carries it to the worker.
3. The worker refuses `job.Type == "review"` with `seat_toolchain_unavailable` and `blocked`, gated on `adapterIsDeclaredReal()` exactly as its sibling is.

**Scoped to review deliberately.** The un-evented staging miss is a documented choice with a named cost: a job's event sequence must not depend on the host's toolchain and disk state, and `TestExecBackendLocalDefaultDaemonE2E` pins an exact baseline. I verified that test's job type is `ask` (`execbackend_e2e_test.go:949`), so a review-scoped event cannot perturb it. Review is the one action whose contract is to execute the repository's gate.

**BLOCKED not FAILED**, matching the sibling arm and #1823's principle. Measured pre-fix state of the new test: `failed`, which reads as "this reviewer tried" and invites the identical re-dispatch.

## Tests

Both arms live beside the runtime arms in `internal/cli/seat_runtime_capability_test.go` and drive the production worker with no `AdapterFactory` override.

| test | before | after |
|---|---|---|
| `TestSeatToolchainUnavailableEndsAReviewBlockedNotVerdicted` | FAIL, `job state = "failed", want "blocked"` | PASS |
| `TestSeatToolchainUnavailableDoesNotRefuseANonReviewSeat` | PASS | PASS |

The fixture carries its own positive control: `claude` is written with the stageable fixture so it stages successfully, and the review arm fails the test if `seat_runtime_unavailable` fires. Without that, a predicate keyed on the wrong fact would pass.

`go build ./...`, `go vet ./internal/cli/ ./internal/toolchain/`, and `go test ./internal/cli/` all pass. Race is CI's, not runnable in a seat.

## Not claimed

I have not established why staging failed on this host. `go1.26.4` is on the daemon PATH, a real staged toolchain exists at `/root/.gitmoot/toolchains/go1.26.4-d9cf614354030113`, the `go-unavailable-v1` root is dated Sep 7, and the journal carries zero toolchain diagnostics. That is a host question; this PR makes the consequence refuse and be readable rather than silent.

I have not measured how often this class occurs across the store. The evidence here is one job, dispatched and measured by me.
