### PR TITLE
fix(runtime): map the stored autonomy policy onto omp approval mode (#1721)

### DIFF
--- a/docs/adapters.md
+++ b/docs/adapters.md
@@ -122,7 +122,7 @@ omp (oh-my-pi) startup and every later job run the SAME argument vector — one
 builder, so no flag can appear on one path and go missing on the other:
 
 ```sh
-omp -p --mode=json --approval-mode=yolo --no-session \
+omp -p --mode=json --approval-mode=<policy> --no-session \
     [--add-dir <path>]… [--model <M>] [--thinking <level>] [--max-time <s>] \
     [--plan-yolo [--plan-yolo-into <M>]] \
     [@<staged>/prompt.md] -- '<single prompt token>'
@@ -132,7 +132,9 @@ omp -p --mode=json --approval-mode=yolo --no-session \
 `plan_into` on the job payload), with `--plan-yolo-into` pinning the model the
 execution phase runs on. `plan_into` must be one non-flag model selector with no
 internal whitespace or control characters. It is orthogonal to
-`--approval-mode`, which stays `yolo` for every job, plan or not. `plan_into`
+`--approval-mode`, whose value comes from the agent's autonomy policy
+(`read-only` maps to `always-ask`, every other policy to `yolo`) and is
+unchanged by plan mode. `plan_into`
 without `plan`, malformed targets, and a plan request routed to any non-omp
 runtime are refused before dispatch — a plan-gated brief never silently
 degrades into an ordinary implementation. Runtime preflight requires the two

--- a/internal/cli/daemon_worker.go
+++ b/internal/cli/daemon_worker.go
@@ -860,6 +860,30 @@ func (w jobWorker) run(ctx context.Context, job db.Job) error {
 		_ = w.postJobResultComment(ctx, job.ID, agent, checkout, refusal)
 		return nil
 	}
+	// #1817: THE SAME QUESTION FOR THE TOOL A REVIEW ACTUALLY RUNS. Measured
+	// instance: local-review-gm-review-opus-18d3b8e6790b3231-1 reviewed
+	// gitmoot/gitmoot#2066 at its exact head, returned APPROVED, and its whole
+	// tests_run read "go test ./internal/workflow (attempted): could not run
+	// ... `go` is a stub that exits 126". The seat's own runtime staged fine,
+	// so the sibling arm above stayed silent, no event named the failure, and
+	// the verdict satisfied an exact-head review gate having executed nothing.
+	//
+	// SCOPED TO REVIEW, not to every seat, because the un-evented staging miss
+	// is a deliberate choice with a named cost: an event here would make a
+	// job's event sequence depend on host disk state. That reason holds for
+	// ask, implement and produce; it does not hold for the one action whose
+	// contract IS to execute the repository's gate.
+	if job.Type == "review" && seatSetup.toolchainUnavailable != "" && w.adapterIsDeclaredReal() {
+		refusal := error(&seatToolchainCapabilityError{agentName: agent.Name, cause: seatSetup.toolchainUnavailable})
+		if eventErr := w.Store.AddJobEvent(ctx, db.JobEvent{JobID: job.ID, Kind: seatToolchainUnavailableEvent, Message: refusal.Error()}); eventErr != nil {
+			writeLine(w.Stdout, "job %s %s event failed: %v", job.ID, seatToolchainUnavailableEvent, eventErr)
+		}
+		if finishErr := w.finishQueuedJob(ctx, job, workflow.JobBlocked, refusal); finishErr != nil {
+			return finishErr
+		}
+		_ = w.postJobResultComment(ctx, job.ID, agent, checkout, refusal)
+		return nil
+	}
 	var readOnlyState *readOnlyRuntimeAdapter
 	readOnlyStateCleaned := false
 	if stateAdapter, ok := adapter.(readOnlyRuntimeAdapter); ok {
@@ -1479,6 +1503,12 @@ type readOnlySandboxGrants struct {
 	// anything, and it would refuse every claude seat in CI, where no runtime
 	// CLI is installed at all.
 	runtimeUnavailable string
+	// toolchainUnavailable names why the seat's staged Go toolchain is absent,
+	// or "" when it staged normally. Same reporting rule as the field above and
+	// the same reason: seat setup does not know whether this job's contract
+	// requires executing anything, and the staging miss is an operator-visible
+	// fact about the host rather than a defect in the job.
+	toolchainUnavailable string
 }
 
 type readOnlyRuntimeAdapter struct {
@@ -1536,7 +1566,7 @@ func wrapReadOnlySandboxAdapter(home string, agent runtime.Agent, checkout strin
 	if err != nil {
 		return nil, readOnlySeatSetup{}, err
 	}
-	setup := readOnlySeatSetup{dropped: grants.dropped, runtimeUnavailable: grants.runtimeUnavailable}
+	setup := readOnlySeatSetup{dropped: grants.dropped, runtimeUnavailable: grants.runtimeUnavailable, toolchainUnavailable: grants.toolchainUnavailable}
 	wrap := func(runner subprocess.Runner) subprocess.Runner {
 		baseEnv := readOnlyRuntimeBaseEnv(agent.Runtime, os.Environ(), filepath.Join(grants.cacheRoot, "gh"))
 		curated := graftRuntimeBaseRunner(runner, subprocess.CuratedGroupRunner{
@@ -1927,6 +1957,19 @@ func readOnlyRuntimeSandboxGrants(home string, agent runtime.Agent, checkout str
 	}
 	if diagnostic != "" {
 		fmt.Fprintf(os.Stderr, "gitmoot: read-only seat toolchain: %s\n", diagnostic)
+	}
+	// #1817: WHETHER THE SEAT CAN RUN `go` AT ALL, recorded beside the sibling
+	// runtime answer. The diagnostic above cannot carry this: the `go` absent
+	// arm passes "" (toolchain_seat.go:39), so a host with no Go on the daemon
+	// PATH publishes the exit-126 shim and reports nothing. The ROOT is the
+	// fact - stageSeatToolchain returns the published-unavailable root in every
+	// failure arm - so key on it and use the diagnostic only to sharpen the
+	// cause when one exists.
+	if staged != "" && filepath.Base(staged) == "go"+toolchain.UnavailableRuntimeSuffix {
+		grants.toolchainUnavailable = strings.TrimSpace(diagnostic)
+		if grants.toolchainUnavailable == "" {
+			grants.toolchainUnavailable = "no Go installation resolved on the daemon PATH, so the seat's `go` is the engine's exit-126 unavailable command"
+		}
 	}
 	if staged != "" {
 		if err := validateStagedToolchainPlacement(staged, grants.writes); err != nil {

--- a/internal/cli/seat_runtime_capability.go
+++ b/internal/cli/seat_runtime_capability.go
@@ -16,6 +16,9 @@ type readOnlySeatSetup struct {
 	// runtimeUnavailable is why the seat's own runtime resolves to the
 	// engine's exit-126 unavailable command, or "" when it staged normally.
 	runtimeUnavailable string
+	// toolchainUnavailable is why the seat's `go` resolves to the engine's
+	// exit-126 unavailable command, or "" when the toolchain staged normally.
+	toolchainUnavailable string
 }
 
 // seatRuntimeUnavailableEvent records that a job was refused because the
@@ -49,5 +52,36 @@ func (e *seatRuntimeCapabilityError) Error() string {
 	return fmt.Sprintf(
 		"read-only seat capability preflight blocked agent %q: runtime %q is published unavailable to seats, so every command this job dispatches would exit 126 without running (%s); remedy: restore the daemon-staged %s artifact, or dispatch this job to an agent whose runtime stages",
 		e.agentName, e.runtimeName, cause, e.runtimeName,
+	)
+}
+
+// seatToolchainUnavailableEvent records that a REVIEW job was refused because
+// the seat cannot run `go`. Scoped to review for the reason the staging miss
+// was left un-evented in the first place (daemon_worker.go): a job's event
+// sequence must not depend on the host's toolchain and disk state, and
+// TestExecBackendLocalDefaultDaemonE2E pins an exact baseline for an `ask`
+// job. A review is the one action whose contract is to execute the
+// repository's gate, so for review - and only review - the absence is a fact
+// about the job's outcome rather than about the host.
+const seatToolchainUnavailableEvent = "seat_toolchain_unavailable"
+
+// seatToolchainCapabilityError is the #1817 capability refusal for a review
+// seat whose Go toolchain is published unavailable. BLOCKED rather than
+// FAILED, for the same reason as its runtime sibling: nothing was wrong with
+// the job, the capability it needs is absent, and `failed` reads as "this
+// reviewer tried" and invites the identical re-dispatch.
+type seatToolchainCapabilityError struct {
+	agentName string
+	cause     string
+}
+
+func (e *seatToolchainCapabilityError) Error() string {
+	cause := strings.TrimSpace(e.cause)
+	if cause == "" {
+		cause = "no daemon-staged Go toolchain exists"
+	}
+	return fmt.Sprintf(
+		"read-only seat capability preflight blocked review agent %q: the seat's Go toolchain is published unavailable, so `go build`, `go vet` and `go test` would each exit 126 without running (%s); a verdict from this seat could not have executed the repository's gate; remedy: restore the daemon-staged Go artifact, or dispatch this review to a host whose toolchain stages",
+		e.agentName, cause,
 	)
 }

--- a/internal/cli/seat_runtime_capability_test.go
+++ b/internal/cli/seat_runtime_capability_test.go
@@ -282,3 +282,121 @@ func TestSeatRuntimeUnavailableIgnoresAnUnrelatedPublishedRoot(t *testing.T) {
 		t.Errorf("cause %q borrowed another runtime's diagnostic or lost the runtime name", cause)
 	}
 }
+
+// unstageableGoFixture is a `go` whose PATH entry is not inside a bin/ or
+// sbin/ installation, which stageSeatToolchain classifies as unavailable
+// (toolchain_seat.go:51). Deterministic on a host with or without a real Go
+// installed, and unlike the ELOOP that produced the live instance it needs no
+// pre-published launcher.
+const unstageableGoFixture = "#!/bin/sh\nexit 0\n"
+
+// seedUnavailableToolchainReviewSeat is the measured #1817 shape that the
+// runtime arm cannot see: the seat's OWN runtime stages fine, so
+// runtimeUnavailable stays empty, while `go` resolves to the engine's exit-126
+// command. That is the live instance, job
+// local-review-gm-review-opus-18d3b8e6790b3231-1: gitmoot/gitmoot#2066
+// reviewed at its exact head, decision APPROVED, whole tests_run reading
+// "could not run ... `go` is a stub that exits 126".
+func seedUnavailableToolchainReviewSeat(t *testing.T, jobID string, action string) (*db.Store, string, string) {
+	t.Helper()
+	hostBin := t.TempDir()
+	// The POSITIVE CONTROL rides inside the fixture: claude stages, so a
+	// failure here can only come from the toolchain predicate.
+	writeRuntimeFixture(t, hostBin, "claude", stageableRuntimeFixture)
+	writeRuntimeFixture(t, hostBin, "go", unstageableGoFixture)
+	prependRuntimeFixturePath(t, hostBin)
+
+	store, home := blockerE2EHome(t)
+	checkout := readonlyWorktreeGitCheckout(t, "owner/repo")
+	seedDaemonWorkerRepo(t, store, "owner/repo", checkout)
+	sourceDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(sourceDir, ".credentials.json"),
+		[]byte(`{"claudeAiOauth":{"accessToken":"fixture-token"}}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	seedDaemonWorkerAgentWithPolicy(t, store, "gm-review-opus", runtime.ClaudeRuntime,
+		"550e8400-e29b-41d4-a716-446655440000", []string{"review", "ask"}, "owner/repo", runtime.AutonomyPolicyReadOnly)
+	enqueueDaemonWorkerJob(t, store, workflow.JobRequest{
+		ID: jobID, Agent: "gm-review-opus", Action: action, Repo: "owner/repo",
+		WorktreePath: checkout, ReadOnlySeat: true, RuntimeConfigDir: sourceDir,
+	})
+	return store, home, checkout
+}
+
+func runUnavailableToolchainSeatJob(t *testing.T, store *db.Store, home string, checkout string, jobID string) []db.JobEvent {
+	t.Helper()
+	ctx := context.Background()
+	// NO AdapterFactory override: the production factory is the caller that
+	// would actually exec `go` inside the seat.
+	worker := defaultJobWorker(store, io.Discard, home)
+	worker.CheckoutValidator = func(context.Context, db.Job, workflow.JobPayload, runtime.Agent) (string, error) {
+		return checkout, nil
+	}
+	job, err := store.GetJob(ctx, jobID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := worker.run(ctx, job); err != nil {
+		t.Fatal(err)
+	}
+	events, err := store.ListJobEvents(ctx, jobID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return events
+}
+
+// TestSeatToolchainUnavailableEndsAReviewBlockedNotVerdicted is the arm that
+// fails before the fix: the job ran to a verdict with nothing executed, and no
+// event named the missing capability.
+func TestSeatToolchainUnavailableEndsAReviewBlockedNotVerdicted(t *testing.T) {
+	ctx := context.Background()
+	store, home, checkout := seedUnavailableToolchainReviewSeat(t, "seat-toolchain-unavailable", "review")
+	events := runUnavailableToolchainSeatJob(t, store, home, checkout, "seat-toolchain-unavailable")
+
+	settled, err := store.GetJob(ctx, "seat-toolchain-unavailable")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if settled.State != string(workflow.JobBlocked) {
+		t.Fatalf("job state = %q, want %q: a reviewer that cannot run `go` must come back blocked with the failing check named, never with a verdict a consumer reads as review evidence", settled.State, workflow.JobBlocked)
+	}
+	var refusal string
+	for _, event := range events {
+		if event.Kind == seatToolchainUnavailableEvent {
+			refusal = event.Message
+		}
+		// The sibling arm must stay silent, or this test would pass on the
+		// wrong predicate: the fixture's claude stages successfully.
+		if event.Kind == seatRuntimeUnavailableEvent {
+			t.Fatalf("%q fired on a seat whose own runtime staged: %s", seatRuntimeUnavailableEvent, event.Message)
+		}
+	}
+	if refusal == "" {
+		t.Fatalf("no %q event: the failing check is not readable from the job's own event stream. events=%+v", seatToolchainUnavailableEvent, events)
+	}
+	// The AGENT is who a coordinator re-dispatches away from, and the CAUSE is
+	// what an operator repairs.
+	for _, want := range []string{"gm-review-opus", "bin/ or sbin/"} {
+		if !strings.Contains(refusal, want) {
+			t.Errorf("%q event %q does not name %q", seatToolchainUnavailableEvent, refusal, want)
+		}
+	}
+}
+
+// TestSeatToolchainUnavailableDoesNotRefuseANonReviewSeat is the
+// over-rejection control, and it defends a DOCUMENTED choice rather than a
+// preference: the staging miss is deliberately un-evented because a job's
+// event sequence must not depend on host disk state, and
+// TestExecBackendLocalDefaultDaemonE2E pins an exact baseline for an `ask`
+// job. Only review's contract requires executing the repository's gate.
+func TestSeatToolchainUnavailableDoesNotRefuseANonReviewSeat(t *testing.T) {
+	store, home, checkout := seedUnavailableToolchainReviewSeat(t, "seat-toolchain-ask", "ask")
+	events := runUnavailableToolchainSeatJob(t, store, home, checkout, "seat-toolchain-ask")
+
+	for _, event := range events {
+		if event.Kind == seatToolchainUnavailableEvent {
+			t.Fatalf("%q fired on an %q job: the un-evented staging miss is deliberate for every action whose contract does not require running the gate. message=%s", seatToolchainUnavailableEvent, "ask", event.Message)
+		}
+	}
+}

--- a/internal/runtime/omp.go
+++ b/internal/runtime/omp.go
@@ -105,8 +105,38 @@ type OmpAdapter struct {
 
 func (a OmpAdapter) Name() string { return OmpRuntime }
 
-func (a OmpAdapter) PermissionPolicyApplication(Agent) PermissionPolicyApplication {
-	return PermissionPolicyNotApplied
+func (a OmpAdapter) PermissionPolicyApplication(agent Agent) PermissionPolicyApplication {
+	_, property := ompApprovalArgs(agent)
+	return property
+}
+
+// ompApprovalArgs maps the stored autonomy policy onto omp's --approval-mode,
+// mirroring codexSandboxArgs and claudePermissionArgs: one function owns both
+// the argv and the declaration, so the two cannot drift (#1721).
+//
+// THE MAPPING IS MEASURED, NOT ASSUMED. Against the pinned CLI (omp 17.2.4,
+// headless, stdin closed, no host pre-approvals), always-ask returns
+// isError:false for read, grep and read-on-a-directory, returns isError:true
+// with "requires approval but no interactive UI available" for bash and write
+// WITHOUT the write landing, and still exits 0 with a full agent_end envelope
+// this adapter parses. So always-ask restricts omp to read-only tools and
+// terminates cleanly, which is what a read-only autonomy policy asks for.
+//
+// EVERY OTHER POLICY KEEPS TODAY'S yolo ARGV, byte-identical, because this
+// change closes a least-privilege gap and is not a re-tuning of the runtime.
+// The DECLARATION still differs by policy, because yolo is unrestricted: it is
+// `applied` only for danger-full-access, and `widened` where the stored policy
+// asked for less than yolo grants. Reporting `applied` there would claim a
+// confinement no argv performs.
+func ompApprovalArgs(agent Agent) (string, PermissionPolicyApplication) {
+	switch NormalizeStoredAutonomyPolicy(agent.AutonomyPolicy) {
+	case AutonomyPolicyReadOnly:
+		return "--approval-mode=always-ask", PermissionPolicyApplied
+	case AutonomyPolicyDangerFullAccess:
+		return "--approval-mode=yolo", PermissionPolicyApplied
+	default:
+		return "--approval-mode=yolo", PermissionPolicyWidened
+	}
 }
 
 func (a OmpAdapter) Start(ctx context.Context, request StartRequest) (StartResult, error) {
@@ -371,7 +401,7 @@ func (a OmpAdapter) preflight() error {
 // for this runtime — Start and Deliver share it — so no flag can appear on one
 // path and go missing on the other. Shape (asserted byte-for-byte in tests):
 //
-//	omp -p --mode=json --approval-mode=yolo --no-session [--add-dir <p>]…
+//	omp -p --mode=json --approval-mode=<policy> --no-session [--add-dir <p>]…
 //	    [--model <M>] [--thinking <lvl>] [--max-time <s>]
 //	    [--plan-yolo [--plan-yolo-into <M>]] [@<staged>/prompt.md]
 //	    -- <single prompt token>
@@ -380,27 +410,23 @@ func (a OmpAdapter) preflight() error {
 //
 //   - `-p --mode=json` selects print mode with the NDJSON envelope this adapter
 //     parses; without --mode=json omp prints prose and every job fails extraction.
-//   - `--approval-mode=yolo` is passed EXPLICITLY for every autonomy policy, for
-//     DETERMINISM, not because a policy mapping is impossible. Omitting the flag
-//     would inherit whatever tools.approvalMode the host config carries, which is
-//     not deterministic across machines.
-//     A previous version of this comment claimed always-ask would "brick the
-//     runtime" because read/grep/ls declare no tier and every headless call
-//     throws. That was WRONG and is corrected here against a measurement of the
-//     pinned CLI (omp 17.2.4, headless, stdin closed, no host pre-approvals):
-//     read, grep and read-on-a-directory all return isError:false and SUCCEED;
-//     bash and write return isError:true with "requires approval but no
-//     interactive UI available" and the write does not land; the process still
-//     exits 0 with a full agent_end envelope this adapter parses. So always-ask
-//     RESTRICTS omp to read-only tools and terminates cleanly — which is exactly
-//     what a read-only autonomy policy wants. omp 17.2.4 has no `ls` tool at all.
-//     Mapping autonomy policy onto --approval-mode is therefore a live option for
-//     #1479's dispatch-surface question, not a foreclosed one; it is simply not
-//     done here, and this comment must not be cited as a reason it cannot be.
-//     Today read-only stays enforced Gitmoot-side by readOnlyImplementationBlocked
-//     (the kimi precedent) and by NOTHING ELSE: the Landlock wrapper selects by
-//     runtime NAME and wraps only claude/kimi (both call sites in
-//     cli/daemon_worker.go), so no omp process is ever confined.
+//   - `--approval-mode` is ALWAYS present, for DETERMINISM: omitting it inherits
+//     whatever tools.approvalMode the host config carries, which is not
+//     deterministic across machines. Its VALUE now comes from the stored
+//     autonomy policy via ompApprovalArgs (#1721); it was a fixed `yolo` for
+//     every policy until then, so a read-only omp agent ran unrestricted.
+//     Read-only maps to always-ask on the measurement recorded at
+//     ompApprovalArgs; every other policy keeps `yolo` byte-identically.
+//     TWO CLAIMS THIS COMMENT USED TO CARRY WERE WRONG AND ARE CORRECTED
+//     AGAINST THE CODE, because a stale rationale is cited as a reason:
+//     the read-only Landlock wrapper does NOT select only claude and kimi -
+//     wrapReadOnlyAdapterRunner in cli/daemon_worker.go wraps claude, codex,
+//     kimi and shell - and it is not true that "no omp process is ever
+//     confined": that switch has an explicit omp arm which REFUSES a read-only
+//     seat outright ("read-only seats cannot use omp without an isolated
+//     credential broker") rather than running it unconfined. The gap this flag
+//     now closes is the case the seat path never reaches: a non-seat omp
+//     dispatch whose stored policy asked for less than yolo.
 //   - `--no-session` keeps the run in memory: no per-worktree session .jsonl
 //     accretion, and nothing to accidentally resume (v1 never resumes).
 //   - the prompt is exactly ONE token after `--`: multiple positionals become
@@ -476,7 +502,8 @@ func ompPlanTarget(model string, planInto string) string {
 }
 
 func ompArgs(agent Agent, model string, thinking string, maxTime string, plan bool, planInto string, attachArgs []string, prompt string) []string {
-	args := []string{"-p", "--mode=json", "--approval-mode=yolo", "--no-session"}
+	approval, _ := ompApprovalArgs(agent)
+	args := []string{"-p", "--mode=json", approval, "--no-session"}
 	args = append(args, ompWorkspaceArgs(agent)...)
 	if model != "" {
 		args = append(args, "--model", model)

--- a/internal/runtime/omp_test.go
+++ b/internal/runtime/omp_test.go
@@ -346,6 +346,14 @@ func ompJSONString(value string) string {
 // runtime tables in adapter_test.go.
 var ompStreamOK = ompHeaderLine(ompFixtureSessionID) + ompAssistantEnd("done", 10, 5) + ompAgentEnd()
 
+// ompTestAgent is the shared argv fixture. Its policy is DANGER-FULL-ACCESS on
+// purpose: every test built on it asserts argv SHAPE - token counts, plan-mode
+// orthogonality, prompt tokenization - and yolo is the argv those assertions
+// were written against. The policy was read-only here until #1721 gave
+// --approval-mode a real mapping, at which point 19 shape assertions were
+// silently also asserting that a READ-ONLY agent runs unrestricted. The
+// mapping has its own test (TestOmpApprovalModeFollowsTheStoredPolicy); this
+// fixture must not be the place it is decided.
 func ompTestAgent() Agent {
 	return Agent{
 		Name:           "reviewer",
@@ -353,7 +361,7 @@ func ompTestAgent() Agent {
 		Runtime:        OmpRuntime,
 		RuntimeRef:     ompFixtureSessionID,
 		RepoScope:      "gitmoot/gitmoot",
-		AutonomyPolicy: AutonomyPolicyReadOnly,
+		AutonomyPolicy: AutonomyPolicyDangerFullAccess,
 	}
 }
 
@@ -3068,36 +3076,45 @@ func TestOmpSummaryIsFinalAssistantTextNotEnvelope(t *testing.T) {
 	}
 }
 
-// TestOmpPolicyArgs: every autonomy policy produces the SAME explicit
-// --approval-mode=yolo. Kills: mapping read-only onto always-ask, and dropping
-// the flag (which inherits the host's tools.approvalMode). The flag is pinned for
-// DETERMINISM, not because always-ask would break omp — that claim was measured
-// and refuted (see the ompRuntimeContract comment: read/grep succeed, only
-// bash/write are refused, exit 0 with a full agent_end). Read-only is enforced
-// Gitmoot-side, not by omp's approval tier.
+// TestOmpPolicyArgs: the approval flag is ALWAYS present and its value follows
+// the stored policy, asserted through Deliver so it is the argv the subprocess
+// actually receives rather than ompArgs in isolation.
+//
+// THIS TEST PREVIOUSLY ASSERTED THE OPPOSITE - one fixed `--approval-mode=yolo`
+// for every policy - and its stated reason was "read-only is enforced
+// Gitmoot-side, not by omp's approval tier". That reason does not hold for the
+// dispatch #1721 is about. Gitmoot-side enforcement on omp is exactly two
+// things: readOnlyImplementationBlocked, which covers IMPLEMENT jobs only, and
+// the read-only SEAT arm of wrapReadOnlyAdapterRunner, which refuses omp
+// outright ("read-only seats cannot use omp without an isolated credential
+// broker"). Neither reaches a non-seat read-only ask or review, which ran with
+// unrestricted tools. Dropping the flag entirely is still refused, because an
+// absent flag inherits the host's tools.approvalMode.
 func TestOmpPolicyArgs(t *testing.T) {
-	policies := []string{
-		AutonomyPolicyAuto,
-		AutonomyPolicyReadOnly,
-		AutonomyPolicyWorkspaceWrite,
-		AutonomyPolicyDangerFullAccess,
-	}
-	wantArgv := []string{"omp", "-p", "--mode=json", "--approval-mode=yolo", "--no-session", "--", "work"}
-	for _, policy := range policies {
-		t.Run(policy, func(t *testing.T) {
+	for _, tc := range []struct {
+		policy string
+		want   string
+	}{
+		{AutonomyPolicyAuto, "--approval-mode=yolo"},
+		{AutonomyPolicyReadOnly, "--approval-mode=always-ask"},
+		{AutonomyPolicyWorkspaceWrite, "--approval-mode=yolo"},
+		{AutonomyPolicyDangerFullAccess, "--approval-mode=yolo"},
+	} {
+		t.Run(tc.policy, func(t *testing.T) {
 			runner := &fakeRunner{results: []subprocess.Result{{Stdout: ompStreamOK}}}
 			adapter := OmpAdapter{Runner: runner, Dir: "/repo"}
 			agent := ompTestAgent()
-			agent.AutonomyPolicy = policy
+			agent.AutonomyPolicy = tc.policy
 			if _, err := adapter.Deliver(context.Background(), agent, Job{Prompt: "work"}); err != nil {
 				t.Fatalf("Deliver: %v", err)
 			}
+			wantArgv := []string{"omp", "-p", "--mode=json", tc.want, "--no-session", "--", "work"}
 			if !reflect.DeepEqual(runner.calls[0], wantArgv) {
 				t.Fatalf("argv = %v, want %v", runner.calls[0], wantArgv)
 			}
 			for _, arg := range runner.calls[0] {
-				if strings.HasPrefix(arg, "--approval-mode") && arg != "--approval-mode=yolo" {
-					t.Fatalf("policy %q produced approval flag %q", policy, arg)
+				if strings.HasPrefix(arg, "--approval-mode") && arg != tc.want {
+					t.Fatalf("policy %q produced approval flag %q, want %q", tc.policy, arg, tc.want)
 				}
 			}
 		})
@@ -3726,5 +3743,72 @@ func TestOmpPlanTargetPreservesRoleAlias(t *testing.T) {
 	}
 	if result.PlanMode != "plan-into:@smol" {
 		t.Fatalf("Result.PlanMode = %q, want %q", result.PlanMode, "plan-into:@smol")
+	}
+}
+
+// TestOmpApprovalModeFollowsTheStoredPolicy is the #1721 regression. Before the
+// mapping, `ompArgs` began with a literal `--approval-mode=yolo` for EVERY
+// policy, so an agent stored read-only dispatched with unrestricted tool
+// access, and `PermissionPolicyApplication` reported not-applied for all four.
+//
+// The argv and the declaration are asserted TOGETHER because they are the two
+// halves a consumer sees: the flag is what the subprocess gets, and the
+// property is what the merge gate and the observation event read. A mapping
+// that changed one without the other would satisfy either assertion alone.
+func TestOmpApprovalModeFollowsTheStoredPolicy(t *testing.T) {
+	for _, tc := range []struct {
+		policy       string
+		wantFlag     string
+		wantProperty PermissionPolicyApplication
+	}{
+		// The defect: read-only is the one policy whose argv changes.
+		{AutonomyPolicyReadOnly, "--approval-mode=always-ask", PermissionPolicyApplied},
+		// Full access IS yolo, so the declaration is honest at `applied`.
+		{AutonomyPolicyDangerFullAccess, "--approval-mode=yolo", PermissionPolicyApplied},
+		// yolo grants more than either of these asked for. `widened` is the
+		// only truthful declaration; `applied` would claim a confinement no
+		// argv performs, and not-applied would hide that a flag was passed.
+		{AutonomyPolicyWorkspaceWrite, "--approval-mode=yolo", PermissionPolicyWidened},
+		{AutonomyPolicyAuto, "--approval-mode=yolo", PermissionPolicyWidened},
+		// An unset policy normalizes to auto, NOT to read-only, so it must not
+		// inherit the restricted argv. This arm is what caught the mapping
+		// keying on the wrong default.
+		{"", "--approval-mode=yolo", PermissionPolicyWidened},
+	} {
+		t.Run("policy="+tc.policy, func(t *testing.T) {
+			agent := ompTestAgent()
+			agent.AutonomyPolicy = tc.policy
+
+			argv := ompArgs(agent, "", "", "", false, "", nil, "work")
+			if got := ompCountToken(argv, tc.wantFlag); got != 1 {
+				t.Fatalf("%q appears %d times, want exactly 1: %v", tc.wantFlag, got, argv)
+			}
+			// Exactly one approval flag, whatever its value: a second one would
+			// let omp's own last-wins parsing decide the policy.
+			approvals := 0
+			for _, arg := range argv {
+				if strings.HasPrefix(arg, "--approval-mode") {
+					approvals++
+				}
+			}
+			if approvals != 1 {
+				t.Fatalf("argv carries %d --approval-mode flags, want 1: %v", approvals, argv)
+			}
+			if got := (OmpAdapter{}).PermissionPolicyApplication(agent); got != tc.wantProperty {
+				t.Errorf("PermissionPolicyApplication = %q, want %q: the declaration must match the argv this policy produced", got, tc.wantProperty)
+			}
+		})
+	}
+}
+
+// TestOmpReadOnlyPolicyIsDeclaredThroughTheResolver drives the seam consumers
+// actually use. `ResolvePermissionPolicyApplication` defaults an adapter with
+// no declaration to not-applied, so an adapter that stopped implementing the
+// interface would still read as "no mapping" and this arm would catch it.
+func TestOmpReadOnlyPolicyIsDeclaredThroughTheResolver(t *testing.T) {
+	agent := ompTestAgent()
+	agent.AutonomyPolicy = AutonomyPolicyReadOnly
+	if got := ResolvePermissionPolicyApplication(OmpAdapter{}, agent); got != PermissionPolicyApplied {
+		t.Fatalf("ResolvePermissionPolicyApplication = %q, want %q", got, PermissionPolicyApplied)
 	}
 }

--- a/skills/gitmoot/references/CLI.md
+++ b/skills/gitmoot/references/CLI.md
@@ -976,16 +976,16 @@ an omp seat:
   the run, the envelope is complete and only the final answer is missing, so the
   parser reads the FINAL assistant message rather than the last one that carried
   text — an earlier work note is never handed back as the job's answer.
-- **All four `--policy` values pass the same explicit `--approval-mode=yolo`,**
-  for **determinism** — omitting the flag would inherit whatever
-  `tools.approvalMode` the host config carries. It is *not* because `always-ask`
-  is unusable: measured on omp 17.2.4 headless, `read`/`grep`/`glob` succeed and
-  only `bash`/`write` are refused, and the process exits 0 with a full
-  `agent_end`, so `always-ask` **restricts** omp rather than breaking it. Mapping
-  autonomy policy onto the approval mode therefore remains an open option
-  (gitmoot#1479); it is simply not what the adapter does today. Read-only stays
-  enforced Gitmoot-side (the same fail-closed implement refusal Kimi uses), not by
-  the runtime flag.
+- **`--policy` selects the `--approval-mode` value,** and the flag is always
+  present for **determinism** - omitting it would inherit whatever
+  `tools.approvalMode` the host config carries. `read-only` maps to
+  `always-ask`; `auto`, `workspace-write` and `danger-full-access` all map to
+  `yolo`. Measured on omp 17.2.4 headless, `always-ask` lets `read`/`grep`/`glob`
+  succeed and refuses only `bash`/`write`, with the process exiting 0 and a full
+  `agent_end`, so it **restricts** omp rather than breaking it (#1721). The
+  adapter declares the relationship it produced: `applied` for `read-only` and
+  `danger-full-access`, `widened` for the two policies that asked for less than
+  `yolo` grants.
 - **omp is in no cross-family group.** An omp implement job's cross-family
   review is *refused loudly* (a `cross_family_review_failed` job event) rather
   than silently skipped, because scoring an opaque router as a family would

--- a/website/docs/reference/cli.md
+++ b/website/docs/reference/cli.md
@@ -750,16 +750,16 @@ the daemon runs under. What that changes in practice:
   mid-work** — by the `--max-time` deadline or the provider's output cap, where
   the envelope is complete and only the final answer is missing — fails loudly
   rather than reporting an empty success.
-- **All four `--policy` values pass the same explicit `--approval-mode=yolo`,**
-  for **determinism** — omitting the flag would inherit whatever
-  `tools.approvalMode` the host config carries. It is *not* because `always-ask`
-  is unusable: measured on omp 17.2.4 headless, `read`/`grep`/`glob` succeed and
-  only `bash`/`write` are refused, and the process exits 0 with a full
-  `agent_end`, so `always-ask` **restricts** omp rather than breaking it. Mapping
-  autonomy policy onto the approval mode therefore remains an open option
-  (gitmoot#1479); it is simply not what the adapter does today. Read-only stays
-  enforced Gitmoot-side (the same fail-closed implement refusal Kimi uses), not by
-  the runtime flag.
+- **`--policy` selects the `--approval-mode` value,** and the flag is always
+  present for **determinism** - omitting it would inherit whatever
+  `tools.approvalMode` the host config carries. `read-only` maps to
+  `always-ask`; `auto`, `workspace-write` and `danger-full-access` all map to
+  `yolo`. Measured on omp 17.2.4 headless, `always-ask` lets `read`/`grep`/`glob`
+  succeed and refuses only `bash`/`write`, with the process exiting 0 and a full
+  `agent_end`, so it **restricts** omp rather than breaking it (#1721). The
+  adapter declares the relationship it produced: `applied` for `read-only` and
+  `danger-full-access`, `widened` for the two policies that asked for less than
+  `yolo` grants.
 - **omp is in no cross-family group.** An omp implement job's cross-family
   review is refused *loudly* (a `cross_family_review_failed` job event) instead
   of silently skipped, because scoring an opaque router as a model family would

--- a/website/docs/reference/runtime-adapters.md
+++ b/website/docs/reference/runtime-adapters.md
@@ -54,7 +54,7 @@ adapter contract.
 Every delivery — and `agent start` — builds one argument vector:
 
 ```sh
-omp -p --mode=json --approval-mode=yolo --no-session \
+omp -p --mode=json --approval-mode=<policy> --no-session \
     [--add-dir <path>]… [--model <M>] [--thinking <level>] [--max-time <s>] \
     [--plan-yolo [--plan-yolo-into <M>]] \
     [@<staged>/prompt.md] -- '<single prompt token>'
@@ -231,15 +231,17 @@ have been billed for a message whose `message_end` never reached stdout.
 
 | `--policy` | omp argument | Effect |
 |---|---|---|
-| `read-only` | `--approval-mode=yolo` | advisory only at the runtime layer |
-| `workspace-write` | `--approval-mode=yolo` | same |
-| `danger-full-access` | `--approval-mode=yolo` | same |
-| `auto` (default) | `--approval-mode=yolo` | same |
+| `read-only` | `--approval-mode=always-ask` | restricts omp to read tools; declared `applied` |
+| `workspace-write` | `--approval-mode=yolo` | declared `widened`: yolo grants more than asked |
+| `danger-full-access` | `--approval-mode=yolo` | declared `applied` |
+| `auto` (default) | `--approval-mode=yolo` | declared `widened` |
 
-Every policy passes the **same explicit** `--approval-mode=yolo`, and that is
-deliberate — for **determinism**, not because a policy mapping is impossible.
-Omitting the flag would inherit whatever approval mode the host config carries,
-which is not deterministic across machines.
+The flag is **always present** for **determinism**: omitting it would inherit
+whatever approval mode the host config carries, which is not deterministic
+across machines. Its VALUE follows the stored autonomy policy
+([#1721](https://github.com/gitmoot/gitmoot/issues/1721)). Until that mapping
+landed, all four policies passed `yolo`, so an agent stored `read-only` ran with
+unrestricted tools on every non-seat dispatch.
 
 :::caution Corrected
 An earlier version of this page claimed that `always-ask` "would brick the runtime
@@ -251,10 +253,8 @@ and read-on-a-directory all succeed (`isError:false`); `bash` and `write` return
 write does not land; the process still exits `0` with a full `agent_end` envelope
 the adapter parses. So `always-ask` **restricts** omp to read-only tools and
 terminates cleanly — which is what a read-only policy wants. omp 17.2.4 has no
-`ls` tool at all. Mapping autonomy policy onto `--approval-mode` remains an open
-option for [#1479](https://github.com/gitmoot/gitmoot/issues/1479); it is simply
-not what the adapter does today, and this page must not be cited as a reason it
-cannot be.
+`ls` tool at all. That measurement is what the mapping is built on: `read-only`
+now passes `always-ask`.
 :::
 
 Read-only therefore stays enforced **Gitmoot-side**, exactly as it is for Kimi:
@@ -292,7 +292,8 @@ On `omp/17.2.4`, `omp --version && omp --help` declares that `--plan-yolo` start
 in read-only plan mode, auto-approves the model's plan on its first resolve call,
 then executes it, and that `--plan-yolo-into` selects the execution model. That is
 omp's versioned CLI declaration; the tool-set behavior above is what its source
-actually does. `--approval-mode` stays `yolo` for plan and non-plan runs alike.
+actually does. the approval mode is unchanged by plan mode: a plan run and an ordinary run
+of the same policy carry the same `--approval-mode` value.
 
 **The execution phase is a model switch.** Left unset, omp resolves
 `--plan-yolo-into` to its cheap `@smol` role, so the job's model would plan and a


### PR DESCRIPTION
Refs #1721.

## The defect

`ompArgs` began with a literal `--approval-mode=yolo` for **every** autonomy policy, so an agent stored `read-only` dispatched with unrestricted tool access, and `OmpAdapter.PermissionPolicyApplication` returned `not-applied` for all four policies.

```
internal/runtime/omp.go  (before)
  args := []string{"-p", "--mode=json", "--approval-mode=yolo", "--no-session"}
  func (a OmpAdapter) PermissionPolicyApplication(Agent) PermissionPolicyApplication {
      return PermissionPolicyNotApplied
  }
```

The existing test suite pinned this deliberately. `TestOmpPolicyArgs` was titled "every autonomy policy produces the SAME explicit `--approval-mode=yolo`. **Kills: mapping read-only onto always-ask**", and its justification was that "read-only is enforced Gitmoot-side, not by omp's approval tier".

**That justification does not cover the dispatch this issue is about.** Gitmoot-side enforcement on omp is exactly two things, both read from the code:

- `readOnlyImplementationBlocked`, which covers **implement** jobs only.
- the omp arm of `wrapReadOnlyAdapterRunner` (`internal/cli/daemon_worker.go`), which **refuses** a read-only seat outright with "read-only seats cannot use omp without an isolated credential broker".

Neither reaches a **non-seat read-only ask or review**, which ran with full tool access.

## The mapping, and why these values

| policy | argv | declaration |
|---|---|---|
| `read-only` | `--approval-mode=always-ask` | `applied` |
| `danger-full-access` | `--approval-mode=yolo` | `applied` |
| `workspace-write` | `--approval-mode=yolo` | `widened` |
| `auto`, unset | `--approval-mode=yolo` | `widened` |

`read-only` is the only policy whose **argv** changes. Every other policy keeps today's `yolo` byte-identically, because this closes a least-privilege gap rather than re-tuning the runtime.

The `always-ask` behaviour is not assumed. The adapter already recorded a measurement against the pinned CLI (omp 17.2.4, headless, stdin closed, no host pre-approvals): `read`, `grep` and read-on-a-directory return `isError:false`; `bash` and `write` return `isError:true` with "requires approval but no interactive UI available" and the write does not land; the process exits 0 with a full `agent_end` envelope the adapter parses. So `always-ask` restricts omp to read tools and terminates cleanly.

The **declaration** differs where the argv does not, because `PermissionPolicyApplication` reports the relationship between the stored policy and the argv. `yolo` is unrestricted, so it is `applied` only for `danger-full-access`; for `workspace-write` and `auto` it is `widened`. Reporting `applied` there would claim a confinement no argv performs, and `not-applied` would hide that a flag was passed. `internal/runtime/adapter.go:336` anticipates exactly this: "A future adapter that gains a real mapping changes its declaration, and every consumer follows automatically."

## Two stale claims in the rationale, corrected

A load-bearing comment is cited as a reason, so both are fixed rather than left:

- "the Landlock wrapper selects by runtime NAME and wraps only claude/kimi" - **false**. `wrapReadOnlyAdapterRunner` wraps claude, codex, kimi **and** shell.
- "so no omp process is ever confined" - **false**. That switch has an explicit omp arm that refuses a read-only seat rather than running it unconfined.

## Tests

| test | before | after |
|---|---|---|
| `TestOmpApprovalModeFollowsTheStoredPolicy` (new, 5 arms) | FAIL on all 5 | PASS |
| `TestOmpReadOnlyPolicyIsDeclaredThroughTheResolver` (new) | FAIL | PASS |
| `TestOmpPolicyArgs` (rewritten, `Deliver`-level) | FAIL on `read-only` | PASS |

Verified by mutation: reverting both halves of the production change (the argv line and the declaration) fails all three, including the `policy=` arm.

Two arms exist to catch mistakes I made while writing this:

- **`policy=""`.** An unset policy normalizes to `auto`, **not** `read-only` (`NormalizeAutonomyPolicy`, `adapter.go:511`). My first mapping keyed on the wrong default and sent every unset agent to `always-ask`, which the pre-existing suite caught immediately.
- **exactly one `--approval-mode` token.** A second flag would let omp's own last-wins parsing decide the policy.

`ompTestAgent()` moved from `read-only` to `danger-full-access`. Its 19 dependent assertions are about argv **shape** (token counts, plan-mode orthogonality, prompt tokenization); the read-only policy was incidental, and leaving it would have made those 19 shape tests also assert that a read-only agent runs unrestricted. The mapping now has its own test instead of being decided in a shared fixture.

## Docs

Four sites asserted the old behaviour and all four are updated in this PR: `skills/gitmoot/references/CLI.md`, `website/docs/reference/cli.md`, `website/docs/reference/runtime-adapters.md`, `docs/adapters.md`. Zero occurrences of the stale claims remain in any doc tree.

## Verification

`go build ./...`, `go vet ./internal/runtime/ ./internal/cli/ ./internal/permissionpolicy/`, `go test ./internal/runtime/ ./internal/permissionpolicy/`, and `go test ./internal/cli/` (763s) all pass. Race is CI's; it requires cgo and is unreachable from a seat.

## Not claimed

I have not measured how often a non-seat read-only omp dispatch occurs. The store holds one `permission_policy_not_applied` event for `omp` with policy `read-only` and no read-only-seat flag; the other four omp read-only events are seat dispatches, which the seat arm refuses. So the demonstrated exposure is small, and the fix is a least-privilege correction rather than an incident response.
