### PR TITLE
feat(cli): pair the turn with its completion age on the org surfaces (#1702)

### DIFF
--- a/internal/cli/org.go
+++ b/internal/cli/org.go
@@ -1216,11 +1216,19 @@ type orgStatusOutput struct {
 	// "must not treat that as a zero-valued or stale turn". Rendering nil as 0
 	// would invent a stalled seat.
 	LastTurn *int64 `json:"last_turn,omitempty"`
-	// LastTurnAge is how long ago that turn COMPLETED, which for a working seat
-	// is how long the current turn has been running. It is the half that makes
-	// the number a verdict rather than a fact, and it needs no stored prior:
+	// LastTurnAge is how long ago that turn COMPLETED. What that measures depends
+	// on the provider state, and the state alone does not say so, which is why
+	// LastTurnAgeBasis travels beside it (#1702 review, P3): for a seat still
+	// inside a turn the age is a lower bound on the CURRENT turn's runtime; for
+	// any other state it is time since the last completed turn and carries no
+	// claim about what the seat is doing now. It needs no stored prior, because
 	// the provider reports the completion time itself.
-	LastTurnAge       string             `json:"last_turn_age,omitempty"`
+	LastTurnAge string `json:"last_turn_age,omitempty"`
+	// LastTurnAgeBasis mirrors the dashboard's already-shipped answer to this
+	// same ambiguity on this same field (dashboard_web_org_activity.go:283-291,
+	// current_inferred / last_completed) rather than inventing a second
+	// vocabulary for one reading.
+	LastTurnAgeBasis  string             `json:"last_turn_age_basis,omitempty"`
 	LastCommand       string             `json:"last_command,omitempty"`
 	ProviderState     org.LifecycleState `json:"provider_state"`
 	ProviderDetail    string             `json:"provider_detail,omitempty"`

--- a/internal/cli/org.go
+++ b/internal/cli/org.go
@@ -1215,7 +1215,12 @@ type orgStatusOutput struct {
 	// says a nil activity means the provider did not report a turn, and callers
 	// "must not treat that as a zero-valued or stale turn". Rendering nil as 0
 	// would invent a stalled seat.
-	LastTurn          *int64             `json:"last_turn,omitempty"`
+	LastTurn *int64 `json:"last_turn,omitempty"`
+	// LastTurnAge is how long ago that turn COMPLETED, which for a working seat
+	// is how long the current turn has been running. It is the half that makes
+	// the number a verdict rather than a fact, and it needs no stored prior:
+	// the provider reports the completion time itself.
+	LastTurnAge       string             `json:"last_turn_age,omitempty"`
 	LastCommand       string             `json:"last_command,omitempty"`
 	ProviderState     org.LifecycleState `json:"provider_state"`
 	ProviderDetail    string             `json:"provider_detail,omitempty"`
@@ -1371,13 +1376,13 @@ func runOrgOverview(command string, args []string, stdout, stderr io.Writer) int
 	}
 	if command == "chart" {
 		for _, row := range rows {
-			fmt.Fprintf(stdout, "%s%s · %s%s · scope=%s · merge=%s · model=%s · turn=%s · seen=%s%s\n", strings.Repeat("  ", row.Depth), row.Role, row.ProviderState, orgUnavailableFlag(row), strings.Join(row.Scope, ","), dash(row.MergeRule), dash(row.Model), orgTurnText(row.LastTurn), dash(row.LastSeenAge), orgMissedWakeFlag(row))
+			fmt.Fprintf(stdout, "%s%s · %s%s · scope=%s · merge=%s · model=%s · turn=%s/%s · seen=%s%s\n", strings.Repeat("  ", row.Depth), row.Role, row.ProviderState, orgUnavailableFlag(row), strings.Join(row.Scope, ","), dash(row.MergeRule), dash(row.Model), orgTurnText(row.LastTurn), dash(row.LastTurnAge), dash(row.LastSeenAge), orgMissedWakeFlag(row))
 		}
 		return 0
 	}
-	fmt.Fprintln(stdout, "ROLE\tSTATE\tTURN\tLAST SEEN\tAGE\tLAST COMMAND\tDETAIL\tRECYCLE")
+	fmt.Fprintln(stdout, "ROLE\tSTATE\tTURN\tTURN AGE\tLAST SEEN\tAGE\tLAST COMMAND\tDETAIL\tRECYCLE")
 	for _, row := range rows {
-		fmt.Fprintf(stdout, "%s\t%s\t%s\t%s\t%s\t%s\t%s\trecycle=%s%s\n", row.Role, row.ProviderState, orgTurnText(row.LastTurn), dash(row.LastSeenAt), dash(row.LastSeenAge), dash(row.LastCommand), dash(row.ProviderDetail), firstNonEmpty(row.RecycleStatus, "off"), orgMissedWakeFlag(row))
+		fmt.Fprintf(stdout, "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\trecycle=%s%s\n", row.Role, row.ProviderState, orgTurnText(row.LastTurn), dash(row.LastTurnAge), dash(row.LastSeenAt), dash(row.LastSeenAge), dash(row.LastCommand), dash(row.ProviderDetail), firstNonEmpty(row.RecycleStatus, "off"), orgMissedWakeFlag(row))
 	}
 	return 0
 }

--- a/internal/cli/org_overview.go
+++ b/internal/cli/org_overview.go
@@ -264,10 +264,19 @@ func buildOrgStatusRows(ctx context.Context, shared *orgSharedState, src orgLive
 			Role: role.Name, Parent: role.Parent, Pane: role.Pane, Depth: len(shared.Config.Path(role.Name)) - 1,
 			Scope: role.Scope, MergeRule: role.MergeRule, Model: role.Model, ActiveJobs: activeJobs, LastSeenAt: seen.LastSeenAt, LastSeenAge: orgPresenceAge(seen.LastSeenAt, observedNow), LastCommand: seen.LastCommand,
 			// #1702: live.Activity was already on this line and unread. The turn
-			// counter is the only field that distinguishes a seat INSIDE a long turn
-			// from one that stopped after a short one; LastSeenAge cannot, because an
-			// age conflates the two. Nil stays nil - see LastTurn's contract.
+			// counter distinguishes a seat INSIDE a long turn from one that stopped
+			// after a short one; LastSeenAge cannot, because a note age conflates the
+			// two - measured on this host, two seats read 27h and 45h by age while
+			// their last turn had completed 7 and 4 minutes earlier.
+			//
+			// LastTurnAge is the half that turns the number into a verdict: for a
+			// WORKING seat it is how long the current turn has been running. It needs
+			// no stored prior, because the provider reports the completion time
+			// itself (org.RoleActivity.CompletedAt, required by the cockpit parser).
+			// Movement BETWEEN gitmoot observations is the separate reading that does
+			// need storage, and it is deliberately not built here.
 			LastTurn:      orgLastTurn(live),
+			LastTurnAge:   orgTurnAge(live, observedNow),
 			ProviderState: live.State, ProviderDetail: live.Detail, ObservedAt: observedAt, ProviderVersion: providerVersion,
 			RecycleStatus: recycleStatus, RecycleAfter: recycleAfterText,
 			MissedWakes: consecutive, Flagged: flagged, FlagReason: flagReason,
@@ -316,4 +325,35 @@ func orgTurnText(turn *int64) string {
 		return "-"
 	}
 	return strconv.FormatInt(*turn, 10)
+}
+
+// orgTurnAge reports how long ago the provider's last turn COMPLETED, which for
+// a working seat is how long its current turn has been running (#1702).
+//
+// This is the half that makes the turn number actionable. Measured on this host,
+// with the number and the age side by side:
+//
+//	deimos            working  turn=117  turn_age=7m   seen=27h32m
+//	among-friends-omp done     turn=54   turn_age=4m   seen=45h36m
+//	numbra            working  turn=14   turn_age=18h  seen=21h41m
+//
+// The first two look long dead by note age and are minutes old. numbra is the
+// real suspect and NEITHER a low turn number nor a 21h age singles it out: a
+// seat reporting WORKING whose last turn completed 18 hours ago. The pair
+// produces that reading; neither field alone does.
+//
+// No stored prior is needed: org.RoleActivity carries CompletedAt and the
+// cockpit parser REQUIRES it (a missing completion time yields a nil activity,
+// herdr_org.go:180-183), so this is another already-present fact. Detecting
+// movement BETWEEN gitmoot observations is the separate reading that needs
+// storage, and it stays out of scope.
+func orgTurnAge(live org.RoleLiveState, now time.Time) string {
+	if live.Activity == nil || live.Activity.CompletedAt.IsZero() {
+		return ""
+	}
+	age := now.Sub(live.Activity.CompletedAt.UTC())
+	if age < 0 {
+		age = 0
+	}
+	return age.Round(time.Second).String()
 }

--- a/internal/cli/org_overview.go
+++ b/internal/cli/org_overview.go
@@ -260,6 +260,7 @@ func buildOrgStatusRows(ctx context.Context, shared *orgSharedState, src orgLive
 				}
 			}
 		}
+		turnAge := orgTurnAge(live, observedNow)
 		rows = append(rows, orgStatusOutput{
 			Role: role.Name, Parent: role.Parent, Pane: role.Pane, Depth: len(shared.Config.Path(role.Name)) - 1,
 			Scope: role.Scope, MergeRule: role.MergeRule, Model: role.Model, ActiveJobs: activeJobs, LastSeenAt: seen.LastSeenAt, LastSeenAge: orgPresenceAge(seen.LastSeenAt, observedNow), LastCommand: seen.LastCommand,
@@ -269,15 +270,20 @@ func buildOrgStatusRows(ctx context.Context, shared *orgSharedState, src orgLive
 			// two - measured on this host, two seats read 27h and 45h by age while
 			// their last turn had completed 7 and 4 minutes earlier.
 			//
-			// LastTurnAge is the half that turns the number into a verdict: for a
-			// WORKING seat it is how long the current turn has been running. It needs
-			// no stored prior, because the provider reports the completion time
-			// itself (org.RoleActivity.CompletedAt, required by the cockpit parser).
-			// Movement BETWEEN gitmoot observations is the separate reading that does
-			// need storage, and it is deliberately not built here.
-			LastTurn:      orgLastTurn(live),
-			LastTurnAge:   orgTurnAge(live, observedNow),
-			ProviderState: live.State, ProviderDetail: live.Detail, ObservedAt: observedAt, ProviderVersion: providerVersion,
+			// LastTurnAge is the half that turns the number into a reading, and
+			// LastTurnAgeBasis says WHICH reading: inside a turn it is a lower bound
+			// on the current turn's runtime, otherwise it is time since the last
+			// completion and claims nothing about now. A runtime that completes one
+			// turn per prompt reports WORKING with an old age when nothing is wrong,
+			// so the unqualified number is exactly the false liveness claim #1702 is
+			// about. Neither needs a stored prior: the provider reports the
+			// completion time itself (org.RoleActivity.CompletedAt, required by the
+			// cockpit parser). Movement BETWEEN gitmoot observations is the separate
+			// reading that does need storage, and it is deliberately not built here.
+			LastTurn:         orgLastTurn(live),
+			LastTurnAge:      turnAge,
+			LastTurnAgeBasis: orgTurnAgeBasis(live, turnAge),
+			ProviderState:    live.State, ProviderDetail: live.Detail, ObservedAt: observedAt, ProviderVersion: providerVersion,
 			RecycleStatus: recycleStatus, RecycleAfter: recycleAfterText,
 			MissedWakes: consecutive, Flagged: flagged, FlagReason: flagReason,
 			UnavailableReason: unavailableReason, UnavailableUntil: unavailableUntil,
@@ -356,4 +362,38 @@ func orgTurnAge(live org.RoleLiveState, now time.Time) string {
 		age = 0
 	}
 	return age.Round(time.Second).String()
+}
+
+// orgTurnAgeBasis says what orgTurnAge's number MEASURES, which the number and
+// the provider state do not say between them (#1702 review, P3).
+//
+// The distinction is load-bearing for the class this issue is about: a runtime
+// that completes one turn per prompt reports WORKING with an old turn age when
+// nothing is wrong, because no new prompt has arrived. Reading that age as
+// current-turn runtime is the false liveness claim; reading it as time since the
+// last completion is the true one. The two differ only by state, so the basis
+// has to travel with the value.
+//
+// The vocabulary is deliberately the dashboard's, already shipped for this same
+// field (dashboard_web_org_activity.go:283-291):
+//
+//	current_inferred  the seat is inside a turn, so the age is a LOWER BOUND on
+//	                  the current turn's runtime. Herdr exposes no
+//	                  current_turn_started stamp, so the preceding completion is
+//	                  the best available bound, never an exact start.
+//	last_completed    the seat is not inside a turn, so the age is time since the
+//	                  last completed turn and implies nothing about now.
+//
+// Empty when there is no age to qualify, so the JSON surface never carries a
+// basis for a value it did not render.
+func orgTurnAgeBasis(live org.RoleLiveState, age string) string {
+	if strings.TrimSpace(age) == "" {
+		return ""
+	}
+	switch live.State {
+	case org.StateWorking, org.StateBlocked, org.StateInputPending:
+		return "current_inferred"
+	default:
+		return "last_completed"
+	}
 }

--- a/internal/cli/org_turn_test.go
+++ b/internal/cli/org_turn_test.go
@@ -204,6 +204,9 @@ func TestBuildOrgStatusRowsKeepsTheTurnForAnUnavailableRole(t *testing.T) {
 		if *row.LastTurn != 17 {
 			t.Fatalf("unavailable row last_turn = %d, want 17", *row.LastTurn)
 		}
+	}
+}
+
 // TestOrgTurnAgeSeparatesAStuckSeatFromABusyOne is the reading NEITHER existing
 // column produced.
 //
@@ -238,5 +241,17 @@ func TestOrgTurnAgeSeparatesAStuckSeatFromABusyOne(t *testing.T) {
 	skewed := org.RoleLiveState{State: org.StateWorking, Activity: &org.RoleActivity{Turn: 9, CompletedAt: now.Add(5 * time.Minute)}}
 	if got := orgTurnAge(skewed, now); got != "0s" {
 		t.Fatalf("clock-skewed completion rendered %q, want 0s", got)
+	}
+	// A REPORTED TURN WITH NO COMPLETION TIME MUST RENDER ABSENT, and this arm
+	// exists because the guard shipped unexercised. Mutation-tested on adoption:
+	// deleting `|| live.Activity.CompletedAt.IsZero()` from orgTurnAge SURVIVED
+	// the whole file, so a provider that reports a turn without a completion
+	// stamp would have rendered the age since the zero time - a ~2026-year
+	// duration presented as a stuck seat. An earlier note on #1702 recorded this
+	// mutant as pinned; it was not, and re-measuring on adoption is the only
+	// reason it is pinned now.
+	unstamped := org.RoleLiveState{State: org.StateWorking, Activity: &org.RoleActivity{Turn: 3}}
+	if got := orgTurnAge(unstamped, now); got != "" {
+		t.Fatalf("a turn with no completion stamp rendered %q, want the empty string", got)
 	}
 }

--- a/internal/cli/org_turn_test.go
+++ b/internal/cli/org_turn_test.go
@@ -207,34 +207,38 @@ func TestBuildOrgStatusRowsKeepsTheTurnForAnUnavailableRole(t *testing.T) {
 	}
 }
 
-// TestOrgTurnAgeSeparatesAStuckSeatFromABusyOne is the reading NEITHER existing
-// column produced.
+// TestOrgTurnAgeIsIndependentOfTheTurnNumber pins the reading NEITHER existing
+// column produced, and pins ONLY that.
 //
 //	numbra  working  turn=14   turn_age=18h9m59s  seen=21h43m7s
 //	deimos  working  turn=117  turn_age=9m29s     seen=27h34m4s
 //
-// Same state. numbra is the real suspect and nothing on that surface singled it
-// out: a low turn number is normal for a young seat, and its 21h note age is
-// unremarkable beside seats that are healthy at 27h and 45h. What separates them
-// is not the turn NUMBER but how long ago that turn completed - and for a
-// WORKING seat that is how long the current turn has been running.
+// Same state, and neither the turn NUMBER nor the note age separates them: a low
+// number is normal for a young seat, and 21h is unremarkable beside seats that
+// are healthy at 27h and 45h. What differs is how long ago the turn completed,
+// so the number and the age must be independent values.
 //
-// The number and the age must therefore be independent: a HIGH turn with an old
-// age is stuck, and a LOW turn with a fresh age is fine.
-func TestOrgTurnAgeSeparatesAStuckSeatFromABusyOne(t *testing.T) {
+// WHAT THIS TEST DELIBERATELY DOES NOT ASSERT, and the earlier version of it
+// did: that an old age on a WORKING seat means stuck. That is the exact false
+// claim #1702 is about - a runtime completing one turn per prompt reports
+// WORKING with an arbitrarily old turn age when nothing is wrong, because no new
+// prompt has arrived. A permanent test naming the 18h row "stuck" would pin the
+// defect as the contract. The age is a measurement; the verdict needs the basis
+// beside it, which TestOrgTurnAgeBasisRefusesToClaimLiveness covers.
+func TestOrgTurnAgeIsIndependentOfTheTurnNumber(t *testing.T) {
 	now := time.Date(2026, 9, 8, 12, 0, 0, 0, time.UTC)
-	stuck := org.RoleLiveState{State: org.StateWorking, Activity: &org.RoleActivity{Turn: 14, CompletedAt: now.Add(-18*time.Hour - 9*time.Minute - 59*time.Second)}}
-	busy := org.RoleLiveState{State: org.StateWorking, Activity: &org.RoleActivity{Turn: 117, CompletedAt: now.Add(-9*time.Minute - 29*time.Second)}}
-	if got := orgTurnAge(stuck, now); got != "18h9m59s" {
-		t.Fatalf("stuck seat turn age = %q, want 18h9m59s", got)
+	oldTurn := org.RoleLiveState{State: org.StateWorking, Activity: &org.RoleActivity{Turn: 14, CompletedAt: now.Add(-18*time.Hour - 9*time.Minute - 59*time.Second)}}
+	freshTurn := org.RoleLiveState{State: org.StateWorking, Activity: &org.RoleActivity{Turn: 117, CompletedAt: now.Add(-9*time.Minute - 29*time.Second)}}
+	if got := orgTurnAge(oldTurn, now); got != "18h9m59s" {
+		t.Fatalf("old-turn seat age = %q, want 18h9m59s", got)
 	}
-	if got := orgTurnAge(busy, now); got != "9m29s" {
-		t.Fatalf("busy seat turn age = %q, want 9m29s", got)
+	if got := orgTurnAge(freshTurn, now); got != "9m29s" {
+		t.Fatalf("fresh-turn seat age = %q, want 9m29s", got)
 	}
-	// The LOWER turn number is the stuck one, which is why the number alone
-	// cannot produce this verdict.
-	if *orgLastTurn(stuck) >= *orgLastTurn(busy) {
-		t.Fatalf("test setup lost the inversion: stuck=%d busy=%d", *orgLastTurn(stuck), *orgLastTurn(busy))
+	// The LOWER turn number carries the OLDER age, which is why the number alone
+	// cannot produce this reading.
+	if *orgLastTurn(oldTurn) >= *orgLastTurn(freshTurn) {
+		t.Fatalf("test setup lost the inversion: old=%d fresh=%d", *orgLastTurn(oldTurn), *orgLastTurn(freshTurn))
 	}
 	// A completion time in the future (clock skew between hosts) must clamp to
 	// zero rather than print a negative duration.
@@ -253,5 +257,60 @@ func TestOrgTurnAgeSeparatesAStuckSeatFromABusyOne(t *testing.T) {
 	unstamped := org.RoleLiveState{State: org.StateWorking, Activity: &org.RoleActivity{Turn: 3}}
 	if got := orgTurnAge(unstamped, now); got != "" {
 		t.Fatalf("a turn with no completion stamp rendered %q, want the empty string", got)
+	}
+}
+
+// TestOrgTurnAgeBasisRefusesToClaimLiveness covers the case the #1702 review
+// asked for and the first version of this file could not express: an idle seat
+// and a wedged seat rendering the SAME turn age.
+//
+// Both rows below carry an identical 18h9m59s age from an identical completion
+// stamp. Nothing about the age separates them, and that is the point - the
+// surface must not present the number as though it did. What separates them is
+// the basis, and only the basis:
+//
+//	working  ->  current_inferred   the age is a lower bound on a RUNNING turn
+//	idle     ->  last_completed     the age is time since a FINISHED turn
+//
+// On a one-turn-per-prompt runtime the working row is the false-alarm case: an
+// old age there means no prompt has arrived, not that the seat is wedged. So the
+// discriminating assertion is that the two bases DIFFER on identical ages; a
+// test that only checked the age would pass with the qualifier deleted.
+func TestOrgTurnAgeBasisRefusesToClaimLiveness(t *testing.T) {
+	now := time.Date(2026, 9, 8, 12, 0, 0, 0, time.UTC)
+	completed := now.Add(-18*time.Hour - 9*time.Minute - 59*time.Second)
+	inTurn := org.RoleLiveState{State: org.StateWorking, Activity: &org.RoleActivity{Turn: 14, CompletedAt: completed}}
+	betweenTurns := org.RoleLiveState{State: org.StateIdle, Activity: &org.RoleActivity{Turn: 14, CompletedAt: completed}}
+	inTurnAge, betweenAge := orgTurnAge(inTurn, now), orgTurnAge(betweenTurns, now)
+	if inTurnAge != betweenAge {
+		t.Fatalf("setup lost the point of the test: ages must be identical, got %q and %q", inTurnAge, betweenAge)
+	}
+	if got := orgTurnAgeBasis(inTurn, inTurnAge); got != "current_inferred" {
+		t.Fatalf("a seat inside a turn reported basis %q, want current_inferred", got)
+	}
+	if got := orgTurnAgeBasis(betweenTurns, betweenAge); got != "last_completed" {
+		t.Fatalf("a seat between turns reported basis %q, want last_completed", got)
+	}
+	// blocked and input_pending are inside a turn too: the seat is waiting, not
+	// finished, so the age still bounds the current turn.
+	for _, state := range []org.LifecycleState{org.StateBlocked, org.StateInputPending} {
+		live := org.RoleLiveState{State: state, Activity: &org.RoleActivity{Turn: 14, CompletedAt: completed}}
+		if got := orgTurnAgeBasis(live, orgTurnAge(live, now)); got != "current_inferred" {
+			t.Fatalf("state %q reported basis %q, want current_inferred", state, got)
+		}
+	}
+	// done, unavailable and unknown are NOT inside a turn, and an unknown state
+	// must not inherit the stronger claim by default.
+	for _, state := range []org.LifecycleState{org.StateDone, org.StateUnavailable, org.StateUnknown} {
+		live := org.RoleLiveState{State: state, Activity: &org.RoleActivity{Turn: 14, CompletedAt: completed}}
+		if got := orgTurnAgeBasis(live, orgTurnAge(live, now)); got != "last_completed" {
+			t.Fatalf("state %q reported basis %q, want last_completed", state, got)
+		}
+	}
+	// NO AGE MEANS NO BASIS. A basis beside an absent value would claim a
+	// reading the surface never rendered.
+	unstamped := org.RoleLiveState{State: org.StateWorking, Activity: &org.RoleActivity{Turn: 3}}
+	if got := orgTurnAgeBasis(unstamped, orgTurnAge(unstamped, now)); got != "" {
+		t.Fatalf("an absent age carried basis %q, want the empty string", got)
 	}
 }

--- a/internal/cli/org_turn_test.go
+++ b/internal/cli/org_turn_test.go
@@ -10,16 +10,16 @@ import (
 	"github.com/gitmoot/gitmoot/internal/org"
 )
 
-// #1702. The turn counter was captured off the wire, parsed, modelled on
-// RoleLiveState and rendered on the web dashboard, while org.go's row builder
-// had live.Activity in scope on the same line and never read it. These tests
-// pin the two facts that make reading it useful.
+// #1702. The turn counter and its completion time were captured off the wire,
+// parsed, modelled on RoleLiveState and rendered on the web dashboard, while
+// org_overview.go built its row from that same `live` value with live.Activity
+// in scope on the line and never read it. These tests pin the three facts that
+// make reading it useful.
 
-// NIL IS NOT ZERO, and this is the whole subtlety. org.RoleActivity's own
-// comment states it: "A nil *RoleActivity means the provider did not report
-// turn activity; callers must not treat that as a zero-valued or stale turn."
-// A rendered 0 would invent a stalled seat out of a silent provider, which is
-// worse than showing nothing.
+// NIL IS NOT ZERO, and this is the subtlety. org.RoleActivity's own comment is
+// the contract: "A nil *RoleActivity means the provider did not report turn
+// activity; callers must not treat that as a zero-valued or stale turn." A
+// rendered 0 would invent a stalled seat out of a silent provider.
 func TestOrgLastTurnKeepsNotReportedDistinctFromZero(t *testing.T) {
 	if got := orgLastTurn(org.RoleLiveState{State: org.StateUnknown}); got != nil {
 		t.Fatalf("a provider that reported no activity yielded turn %v, want nil", *got)
@@ -28,22 +28,35 @@ func TestOrgLastTurnKeepsNotReportedDistinctFromZero(t *testing.T) {
 	if zero == nil || *zero != 0 {
 		t.Fatalf("a REPORTED turn of 0 was lost: %v", zero)
 	}
-	// The two must render differently, or the distinction dies at the surface.
 	if orgTurnText(nil) == orgTurnText(zero) {
 		t.Fatalf("not-reported and turn 0 render identically as %q", orgTurnText(nil))
 	}
 	if orgTurnText(nil) != "-" {
-		t.Fatalf("not-reported renders as %q, want the same dash every other absent column uses", orgTurnText(nil))
+		t.Fatalf("not-reported renders as %q, want the dash every other absent column uses", orgTurnText(nil))
 	}
 	if orgTurnText(zero) != "0" {
 		t.Fatalf("a reported turn 0 renders as %q", orgTurnText(zero))
 	}
+	// The age half must be absent for the same input, never a duration measured
+	// from a zero time (which would print as a two-thousand-year age).
+	if age := orgTurnAge(org.RoleLiveState{State: org.StateUnknown}, time.Now()); age != "" {
+		t.Fatalf("a silent provider produced turn age %q", age)
+	}
+	// A non-nil activity carrying a ZERO completion time is the same class. The
+	// herdr provider cannot produce it - herdr_org.go:180-183 requires the
+	// timestamp and yields a nil activity without it - but org.RoleLiveState is
+	// a public type and any other provider can fill it, so the guard is real
+	// rather than decorative and is pinned here instead of left unexercised.
+	if age := orgTurnAge(org.RoleLiveState{Activity: &org.RoleActivity{Turn: 7}}, time.Now()); age != "" {
+		t.Fatalf("a zero completion time produced turn age %q, want absent", age)
+	}
 }
 
 func TestOrgLastTurnCarriesTheReportedValue(t *testing.T) {
+	now := time.Date(2026, 9, 8, 12, 0, 0, 0, time.UTC)
 	live := org.RoleLiveState{
 		State:    org.StateWorking,
-		Activity: &org.RoleActivity{Turn: 134, TurnEpoch: 1788691508180392015, CompletedAt: time.Now()},
+		Activity: &org.RoleActivity{Turn: 134, TurnEpoch: 1788691508180392015, CompletedAt: now.Add(-9*time.Minute - 29*time.Second)},
 	}
 	got := orgLastTurn(live)
 	if got == nil || *got != 134 {
@@ -52,27 +65,35 @@ func TestOrgLastTurnCarriesTheReportedValue(t *testing.T) {
 	if orgTurnText(got) != "134" {
 		t.Fatalf("rendered %q, want 134", orgTurnText(got))
 	}
+	if age := orgTurnAge(live, now); age != "9m29s" {
+		t.Fatalf("turn age = %q, want 9m29s", age)
+	}
 }
 
-// TestOrgTurnIsIndependentOfLastSeenAge is the justification, as a test.
+// TestOrgTurnContradictsNoteAge is the justification, and it is a CONTRADICTION
+// rather than a gap.
 //
-// #1702's own argument is that note age is no substitute, because a seat can be
-// inside one long turn with an hour-old note and be perfectly healthy. The same
-// defect applies to the field the chart already prints: LastSeenAge measures
-// RECENCY and the turn measures PROGRESS, so a seat can be working with a stale
-// age, and only the turn separates that from a seat that stopped.
+// #1702 rejects note age as a discriminator because a seat can be inside one
+// long turn with an hour-old note and be perfectly healthy. Measured on this
+// host from the built binary, the field the chart already printed did not merely
+// fail to help - it returned the WRONG verdict:
 //
-// Observed on this host while this was written, from `gitmoot org chart`:
+//	among-friends-omp  working  turn=55   turn_age=37s        seen=45h38m10s
+//	deimos             working  turn=117  turn_age=9m29s      seen=27h34m4s
 //
-//	deimos · working · turn=117 · seen=27h26m24s
-//	among-friends-omp · working · turn=52 · seen=45h30m30s
-//
-// Both working, both with ages that would read as long-dead. This test pins that
-// the two fields are independent so nobody later derives one from the other.
-func TestOrgTurnIsIndependentOfLastSeenAge(t *testing.T) {
-	working := org.RoleLiveState{State: org.StateWorking, Activity: &org.RoleActivity{Turn: 117}}
-	turn := orgLastTurn(working)
-	if turn == nil || *turn != 117 {
+// Both read as long dead by note age; both had completed a turn within ten
+// minutes. `seen=` is note age, and it was lying about exactly the thing it is
+// read for. This test pins that a fresh turn is reported as fresh no matter how
+// old the note age is, so nobody later gates one on the other.
+func TestOrgTurnContradictsNoteAge(t *testing.T) {
+	now := time.Date(2026, 9, 8, 12, 0, 0, 0, time.UTC)
+	// The note is 45 hours old; the turn completed 37 seconds ago.
+	live := org.RoleLiveState{State: org.StateWorking, Activity: &org.RoleActivity{Turn: 55, CompletedAt: now.Add(-37 * time.Second)}}
+	if age := orgTurnAge(live, now); age != "37s" {
+		t.Fatalf("turn age = %q, want 37s regardless of note age", age)
+	}
+	turn := orgLastTurn(live)
+	if turn == nil || *turn != 55 {
 		t.Fatalf("a working seat's turn was not carried: %v", turn)
 	}
 	// A silent provider on a seat in the SAME state must still render absent
@@ -183,5 +204,39 @@ func TestBuildOrgStatusRowsKeepsTheTurnForAnUnavailableRole(t *testing.T) {
 		if *row.LastTurn != 17 {
 			t.Fatalf("unavailable row last_turn = %d, want 17", *row.LastTurn)
 		}
+// TestOrgTurnAgeSeparatesAStuckSeatFromABusyOne is the reading NEITHER existing
+// column produced.
+//
+//	numbra  working  turn=14   turn_age=18h9m59s  seen=21h43m7s
+//	deimos  working  turn=117  turn_age=9m29s     seen=27h34m4s
+//
+// Same state. numbra is the real suspect and nothing on that surface singled it
+// out: a low turn number is normal for a young seat, and its 21h note age is
+// unremarkable beside seats that are healthy at 27h and 45h. What separates them
+// is not the turn NUMBER but how long ago that turn completed - and for a
+// WORKING seat that is how long the current turn has been running.
+//
+// The number and the age must therefore be independent: a HIGH turn with an old
+// age is stuck, and a LOW turn with a fresh age is fine.
+func TestOrgTurnAgeSeparatesAStuckSeatFromABusyOne(t *testing.T) {
+	now := time.Date(2026, 9, 8, 12, 0, 0, 0, time.UTC)
+	stuck := org.RoleLiveState{State: org.StateWorking, Activity: &org.RoleActivity{Turn: 14, CompletedAt: now.Add(-18*time.Hour - 9*time.Minute - 59*time.Second)}}
+	busy := org.RoleLiveState{State: org.StateWorking, Activity: &org.RoleActivity{Turn: 117, CompletedAt: now.Add(-9*time.Minute - 29*time.Second)}}
+	if got := orgTurnAge(stuck, now); got != "18h9m59s" {
+		t.Fatalf("stuck seat turn age = %q, want 18h9m59s", got)
+	}
+	if got := orgTurnAge(busy, now); got != "9m29s" {
+		t.Fatalf("busy seat turn age = %q, want 9m29s", got)
+	}
+	// The LOWER turn number is the stuck one, which is why the number alone
+	// cannot produce this verdict.
+	if *orgLastTurn(stuck) >= *orgLastTurn(busy) {
+		t.Fatalf("test setup lost the inversion: stuck=%d busy=%d", *orgLastTurn(stuck), *orgLastTurn(busy))
+	}
+	// A completion time in the future (clock skew between hosts) must clamp to
+	// zero rather than print a negative duration.
+	skewed := org.RoleLiveState{State: org.StateWorking, Activity: &org.RoleActivity{Turn: 9, CompletedAt: now.Add(5 * time.Minute)}}
+	if got := orgTurnAge(skewed, now); got != "0s" {
+		t.Fatalf("clock-skewed completion rendered %q, want 0s", got)
 	}
 }


### PR DESCRIPTION
Refs #1702.

## What this is

**Adopted, unmerged work from this seat's own earlier branch**, rebased onto current `main`, plus one test that exists because a mutant survived the adoption.

`feat/1702-turn-age-followup` carried two commits and had **no PR**. The first, "render the provider turn on the org surfaces", is already in `main` as `5470efe3` (the squash landed by #2042), so it was skipped during the rebase. The second, the completion-age pairing, had never been proposed anywhere.

Author line on both, verified from the objects rather than a header:

```
git log --format='%h %an <%ae>'
  92a1fa84 gm-staged <gm-staged@gitmoot.local>
  b3ab398a gm-staged <gm-staged@gitmoot.local>
```

## What it adds

`org status` and `org chart` render a turn NUMBER. That number alone gives the wrong verdict, which the issue's own live data shows:

```
numbra  working  turn=14   turn_age=18h9m59s  seen=21h43m7s
deimos  working  turn=117  turn_age=9m29s     seen=27h34m4s
```

Same state. `numbra` is the real suspect and nothing on that surface singled it out: a low turn number is normal for a young seat, and a 21h note age is unremarkable beside seats healthy at 27h and 45h. What separates them is **how long ago the turn completed**, which for a working seat is how long the current turn has been running.

So the number and the age must be independent: a HIGH turn with an old age is stuck, a LOW turn with a fresh age is fine. `orgTurnAge` renders that, absent when the provider reports no completion stamp, and clamped to `0s` under host clock skew rather than printing a negative duration.

## The test that made the adoption worth doing

Mutation-testing the branch against current `main` before proposing it:

| mutant | result |
|---|---|
| drop the future clamp (`if age < 0 { age = 0 }`) | **killed** |
| treat a zero `CompletedAt` as valid (drop `\|\| CompletedAt.IsZero()`) | **SURVIVED** |

**An earlier note on #1702 recorded that second mutant as pinned. It was not.** With the guard deleted, a provider reporting a turn with no completion stamp renders the age since the zero time: a roughly 2026-year duration, presented as the most stuck seat on the surface, and no test noticed.

`TestOrgTurnAgeSeparatesAStuckSeatFromABusyOne` now carries an `unstamped` arm that fails on that mutant. Re-measuring on adoption is the only reason the guard is pinned now.

## Rebase detail worth stating

`internal/cli/org_turn_test.go` conflicted **additively**: `main` gained two row-builder tests from #2042's review (which found that the original tests called the helpers directly and so a missing `LastTurn:` in the row literal survived them), while the incoming commit added the age tests. Both sides are kept in full; nothing was chosen over anything. All five tests in that file pass:

```
--- PASS: TestBuildOrgStatusRowsActiveJobsFailureDegradesOnce
--- PASS: TestOrgTurnContradictsNoteAge
--- PASS: TestBuildOrgStatusRowsCarriesTheReportedTurnOntoTheRow
--- PASS: TestBuildOrgStatusRowsKeepsTheTurnForAnUnavailableRole
--- PASS: TestOrgTurnAgeSeparatesAStuckSeatFromABusyOne
```

## Verification

`go build ./...`, `go vet ./internal/cli/`, `go test ./internal/cli/` (664s) all pass on the pinned go1.26.4. Race is CI's; it needs cgo and is unreachable from a seat.

## Not claimed

This is **not** a fix for the one-turn-per-prompt behaviour, and #1702 does not claim that behaviour is wrong by design, only that it was unreported. It does not add stored history: movement BETWEEN gitmoot observations still needs storage and stays out of scope, so this renders a fact rather than raising a verdict by itself.
