### PR TITLE
fix(workflow): an explicitly cancelled review is not a crashed reviewer (#1799)

### DIFF
--- a/internal/workflow/cancelled_not_crashed_1799_test.go
+++ b/internal/workflow/cancelled_not_crashed_1799_test.go
@@ -1,0 +1,99 @@
+package workflow
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/gitmoot/gitmoot/internal/db"
+)
+
+// #1799, directive 108042. The gate labelled an explicitly cancelled review job
+// a "crashed reviewer at evaluated head" and escalated for a requeue or merge
+// bridge. A cancellation is neither a crash nor reviewer evidence, and the wrong
+// label sends an operator to the wrong remedy.
+//
+// Measured in this store before the fix: 534 cancelled review jobs would have
+// been reported as crashed reviewers, 346 of them carrying the discriminator in
+// their own events - "cancel requested from queued" 196, "from running" 92,
+// "from blocked" 59. Both instances the directive names reproduce:
+// local-review-g7-review-18d189d4598f1a86 (cancel requested from queued) and
+// local-review-gm-review-opus-18d18c6aa78d3aec (cancel requested from running,
+// then cancel_settled).
+
+func seed1799Review(t *testing.T, store *db.Store, id, agent string, state JobState, payload JobPayload) {
+	t.Helper()
+	seedMergeGateFixtureAgent(t, store, agent)
+	encoded, err := marshalPayload(payload)
+	if err != nil {
+		t.Fatalf("marshalPayload: %v", err)
+	}
+	job := db.Job{ID: id, Agent: agent, Type: "review", State: string(state), Payload: encoded}
+	if err := store.CreateJobWithEvent(context.Background(), job, db.JobEvent{Kind: string(state), Message: "seeded"}); err != nil {
+		t.Fatalf("CreateJobWithEvent: %v", err)
+	}
+}
+
+// A CANCELLED slot must be diagnosed as cancelled, and must still refuse.
+// Both halves matter: the label is the defect, and the refusal is the behaviour
+// that must not change - a cancellation is not a verdict either.
+func TestGateCallsACancelledReviewSlotCancelledNotCrashed(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	head := strings.Repeat("7", 40)
+	payload := JobPayload{
+		Repo: "mobile/app", Branch: "task-1799", PullRequest: 1799, HeadSHA: head,
+		TaskID: "task-1799", ReviewRound: "review-1",
+	}
+	implPayload := payload
+	implPayload.ReviewRound = ""
+	implPayload.Result = &AgentResult{Decision: "implemented", Summary: "implemented"}
+	seedMergeGateFixtureAgent(t, store, "implementer-1799")
+	insertCompletedJob(t, store, db.Job{ID: "implement-1799", Agent: "implementer-1799", Type: "implement"}, implPayload)
+	seed1799Review(t, store, "review-1799-cancelled", "g6-review-sol", JobCancelled, payload)
+
+	err := (PolicyMergeGate{Store: store}).ensureFinalReviewCaptured(ctx, MergeRequest{
+		Repo: "mobile/app", PullRequest: 1799, TaskID: "task-1799", Reviewer: "g6-review-sol",
+	}, head)
+	if err == nil {
+		t.Fatal("a cancelled review slot at the evaluated head did not refuse; a cancellation is not a verdict")
+	}
+	if strings.Contains(err.Error(), "crashed reviewer") {
+		t.Fatalf("an explicitly cancelled slot is still reported as a crashed reviewer: %v", err)
+	}
+	for _, want := range []string{"cancelled", "not crashed"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("refusal does not name the cancellation (%q): %v", want, err)
+		}
+	}
+}
+
+// The other arm: a genuinely FAILED reviewer must still be reported as crashed.
+// Without this the fix could be over-applied into calling every terminal
+// non-success a cancellation, which loses the distinction in the other
+// direction.
+func TestGateStillCallsAFailedReviewSlotCrashed(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	head := strings.Repeat("8", 40)
+	payload := JobPayload{
+		Repo: "mobile/app", Branch: "task-1800", PullRequest: 1800, HeadSHA: head,
+		TaskID: "task-1800", ReviewRound: "review-1",
+	}
+	implPayload := payload
+	implPayload.ReviewRound = ""
+	implPayload.Result = &AgentResult{Decision: "implemented", Summary: "implemented"}
+	seedMergeGateFixtureAgent(t, store, "implementer-1800")
+	insertCompletedJob(t, store, db.Job{ID: "implement-1800", Agent: "implementer-1800", Type: "implement"}, implPayload)
+	seed1799Review(t, store, "review-1800-failed", "g6-review-sol", JobFailed, payload)
+
+	err := (PolicyMergeGate{Store: store}).ensureFinalReviewCaptured(ctx, MergeRequest{
+		Repo: "mobile/app", PullRequest: 1800, TaskID: "task-1800", Reviewer: "g6-review-sol",
+	}, head)
+	if err == nil {
+		t.Fatal("a failed review slot did not refuse")
+	}
+	if !strings.Contains(err.Error(), "crashed reviewer") {
+		t.Fatalf("a FAILED reviewer is no longer reported as crashed, so the distinction was lost in the other direction: %v", err)
+	}
+}

--- a/internal/workflow/merge_gate.go
+++ b/internal/workflow/merge_gate.go
@@ -1021,7 +1021,25 @@ func (g PolicyMergeGate) ensureFinalReviewCaptured(ctx context.Context, request 
 		switch JobState(review.job.State) {
 		case JobQueued, JobRunning:
 			return mergePending{reason: fmt.Sprintf("waiting for reviewer %s at evaluated head (job %s is %s)", effectiveReviewerIdentityName(review.job, review.payload), review.job.ID, review.job.State)}
-		case JobFailed, JobCancelled:
+		case JobCancelled:
+			// #1799. An EXPLICIT CANCELLATION IS NOT A CRASH, and calling it one sends
+			// an operator to the wrong remedy. Measured in this store: 534 cancelled
+			// review jobs would have been reported as crashed reviewers, 346 of them
+			// carrying the discriminator in their own events - "cancel requested from
+			// queued" 196, "from running" 92, "from blocked" 59.
+			//
+			// Directive 108042 recorded two in one hour: a duplicate cancelled on
+			// purpose, and one cancelled after sixteen minutes with the intent
+			// pre-declared in a workflow note. Both were escalated as crashed
+			// reviewers asking for a requeue or merge bridge; neither reviewer crashed.
+			//
+			// STILL FAIL-CLOSED, and deliberately: a cancelled slot at the evaluated
+			// head is not a verdict, so it still refuses. Only the DIAGNOSIS changes,
+			// because "retry the crashed job" and "this slot was cancelled on purpose,
+			// so decide whether it should be re-dispatched at all" are different
+			// operator actions.
+			return fmt.Errorf("cancelled review slot for reviewer %s at evaluated head (job %s was cancelled, not crashed); a cancellation is not a verdict, so decide whether this slot should be re-dispatched at that head or superseded by a new head. Reassigning the review to a different agent cannot clear this reviewer's slot", effectiveReviewerIdentityName(review.job, review.payload), review.job.ID)
+		case JobFailed:
 			return fmt.Errorf("crashed reviewer %s at evaluated head (job %s is %s); retry or settle that same job, or push a new head. Reassigning the review to a different agent cannot clear this reviewer's slot", effectiveReviewerIdentityName(review.job, review.payload), review.job.ID, review.job.State)
 		}
 	}
@@ -1517,6 +1535,10 @@ func ensureDelegatedReviewEvidence(parent db.Job, children []db.Job, declared []
 	var blocking []string
 	var active []string
 	var crashed []string
+	// #1799: cancelled children are reported separately from crashed ones. A
+	// reader deciding whether to retry, re-dispatch or leave a slot alone needs
+	// the distinction; folding them together sent operators to the wrong remedy.
+	var cancelled []string
 	var abstaining []string
 	var parked []string
 	var unrecognized []string
@@ -1563,7 +1585,12 @@ func ensureDelegatedReviewEvidence(parent db.Job, children []db.Job, declared []
 			default:
 				unrecognized = append(unrecognized, fmt.Sprintf("%s (unrecognized decision %q)", childID, decision))
 			}
-		case JobFailed, JobCancelled:
+		case JobCancelled:
+			// #1799: a cancelled lens child is not a crashed one. Same bucket-mixing
+			// as the slot classification above, in the fan-out summary a reader uses
+			// to decide what to do next.
+			cancelled = append(cancelled, fmt.Sprintf("%s (%s)", childID, child.State))
+		case JobFailed:
 			crashed = append(crashed, fmt.Sprintf("%s (%s)", childID, child.State))
 		case JobBlocked:
 			parked = append(parked, fmt.Sprintf("%s (%s)", childID, child.State))
@@ -1574,6 +1601,7 @@ func ensureDelegatedReviewEvidence(parent db.Job, children []db.Job, declared []
 	sort.Strings(blocking)
 	sort.Strings(active)
 	sort.Strings(crashed)
+	sort.Strings(cancelled)
 	sort.Strings(abstaining)
 	sort.Strings(parked)
 	sort.Strings(unrecognized)
@@ -1589,6 +1617,9 @@ func ensureDelegatedReviewEvidence(parent db.Job, children []db.Job, declared []
 	}
 	if len(crashed) > 0 {
 		details = append(details, "crashed children: "+strings.Join(crashed, ", "))
+	}
+	if len(cancelled) > 0 {
+		details = append(details, "cancelled children: "+strings.Join(cancelled, ", "))
 	}
 	if len(abstaining) > 0 {
 		details = append(details, "abstaining children: "+strings.Join(abstaining, ", "))
@@ -1623,6 +1654,19 @@ func ensureDelegatedReviewEvidence(parent db.Job, children []db.Job, declared []
 	if len(crashed) > 0 {
 		return fmt.Errorf(
 			"delegated review parent %s has crashed delegation children (%s); rerun or repair the delegated review",
+			parent.ID,
+			reasonDetails,
+		)
+	}
+	// #1799: BEHAVIOUR-PRESERVING BY CONSTRUCTION. Before this change a cancelled
+	// child sat in `crashed`, so a fan-out of only-cancelled children refused
+	// here. Splitting the bucket without this arm would have let that case fall
+	// through to `abstaining` - or past every arm - and stop refusing, which is a
+	// gate weakening dressed as a message fix. It still refuses; only the
+	// diagnosis and the remedy differ.
+	if len(cancelled) > 0 {
+		return fmt.Errorf(
+			"delegated review parent %s has CANCELLED delegation children (%s); a cancellation is not a verdict and not a crash, so decide whether those slots should be re-dispatched rather than repaired",
 			parent.ID,
 			reasonDetails,
 		)

--- a/internal/workflow/merge_gate_test.go
+++ b/internal/workflow/merge_gate_test.go
@@ -2121,7 +2121,10 @@ func TestPolicyMergeGateUndecidedRoundOrderNeverHidesUnfinishedReviewer(t *testi
 		{name: "queued", state: JobQueued, wantReason: "waiting for reviewer audit", wantPending: true},
 		{name: "running", state: JobRunning, wantReason: "waiting for reviewer audit", wantPending: true},
 		{name: "failed", state: JobFailed, wantReason: "crashed reviewer audit"},
-		{name: "cancelled", state: JobCancelled, wantReason: "crashed reviewer audit"},
+		// #1799: a cancellation is diagnosed as a cancellation. The `failed` row
+		// above still expects "crashed reviewer", which is what keeps this table
+		// asserting the DISTINCTION rather than one label for both states.
+		{name: "cancelled", state: JobCancelled, wantReason: "cancelled review slot for reviewer audit"},
 	} {
 		for _, order := range []struct {
 			name       string
@@ -3770,9 +3773,15 @@ func TestPolicyMergeGateParksCancelledReviewerAtEvaluatedHead(t *testing.T) {
 	if !decision.LeaveOpen || !decision.Reason.IsGateMiss() || decision.Merged {
 		t.Fatalf("decision = %+v, want cancelled reviewer parked", decision)
 	}
-	if !strings.Contains(decision.Reason.Render(), "crashed reviewer reviewer-b") ||
+	// #1799: this assertion pinned the DEFECT - it required a cancelled job to be
+	// reported as a crashed reviewer. The park itself is the behaviour worth
+	// keeping and is unchanged above; only the diagnosis is corrected here.
+	if !strings.Contains(decision.Reason.Render(), "cancelled review slot for reviewer reviewer-b") ||
 		!strings.Contains(decision.Reason.Render(), "review-cancelled") {
-		t.Fatalf("decision reason = %q, want crashed reviewer and cancelled job", decision.Reason)
+		t.Fatalf("decision reason = %q, want a cancelled slot naming the cancelled job", decision.Reason)
+	}
+	if strings.Contains(decision.Reason.Render(), "crashed reviewer") {
+		t.Fatalf("a cancelled reviewer is still called crashed: %q", decision.Reason)
 	}
 	if len(gh.merges) != 0 {
 		t.Fatalf("merge calls = %+v, want none", gh.merges)
@@ -4053,8 +4062,10 @@ func TestPolicyMergeGateCLIReviewResolvesOnlySettledNonVerdictEngineRound(t *tes
 			cliRecorded: "2026-07-31 12:02:00", wantReason: "crashed reviewer audit",
 		},
 		{
+			// #1799: still BLOCKING, which is the property this row exists for; the
+			// diagnosis is now a cancellation rather than a crash.
 			name: "cancelled row keeps blocking", state: JobCancelled,
-			cliRecorded: "2026-07-31 12:02:00", wantReason: "crashed reviewer audit",
+			cliRecorded: "2026-07-31 12:02:00", wantReason: "cancelled review slot for reviewer audit",
 		},
 		{
 			name: "queued row keeps waiting", state: JobQueued,
@@ -4632,10 +4643,13 @@ func TestPolicyMergeGateWinningDelegationOutcomeNamesSubordinateObligations(t *t
 func TestPolicyMergeGateDelegatedReviewEvidenceEnumeration(t *testing.T) {
 	type outcome string
 	const (
-		satisfies        outcome = "SAT"
-		waits            outcome = "WAIT"
-		blocks           outcome = "BLOCK"
-		parksCrashed     outcome = "PARK_C"
+		satisfies    outcome = "SAT"
+		waits        outcome = "WAIT"
+		blocks       outcome = "BLOCK"
+		parksCrashed outcome = "PARK_C"
+		// #1799: a cancelled child parks in its OWN class. Folding it into PARK_C
+		// is the mislabel this matrix would otherwise keep asserting.
+		parksCancelled   outcome = "PARK_X"
 		parksAbstaining  outcome = "PARK_A"
 		parksUnknown     outcome = "PARK_U"
 		parksCouldNotRun outcome = "PARK_STATE_BLOCKED_COULD_NOT_RUN"
@@ -4692,7 +4706,7 @@ func TestPolicyMergeGateDelegatedReviewEvidenceEnumeration(t *testing.T) {
 		{id: "H11_NIL_RESULT", children: []childFixture{{label: "nil-result", state: JobSucceeded, nilResult: true}}, want: parksUnknown},
 		{id: "H12_MALFORMED_PAYLOAD", children: []childFixture{{label: "malformed-payload", state: JobSucceeded, malformed: true}}, want: parksUnknown},
 		{id: "H13_STATE_FAILED_CRASHED", children: []childFixture{crashed("state-failed-crashed")}, want: parksCrashed},
-		{id: "H14_STATE_CANCELLED_CRASHED", children: []childFixture{child("state-cancelled-crashed", JobCancelled, "")}, want: parksCrashed},
+		{id: "H14_STATE_CANCELLED", children: []childFixture{child("state-cancelled", JobCancelled, "")}, want: parksCancelled},
 		{id: "H15_STATE_BLOCKED_COULD_NOT_RUN", children: []childFixture{couldNotRun("state-blocked-could-not-run")}, want: parksCouldNotRun},
 		{id: "H16_UNRECOGNIZED_STATE", children: []childFixture{child("unrecognized-state", JobState("paused"), "")}, want: parksUnknown},
 
@@ -4824,6 +4838,11 @@ func TestPolicyMergeGateDelegatedReviewEvidenceEnumeration(t *testing.T) {
 						if decision.Merged || !decision.LeaveOpen || !decision.Reason.IsGateMiss() ||
 							!strings.Contains(decision.Reason.Render(), "crashed delegation children") {
 							t.Fatalf("decision = %+v, want PARK-C", decision)
+						}
+					case parksCancelled:
+						if decision.Merged || !decision.LeaveOpen || !decision.Reason.IsGateMiss() ||
+							!strings.Contains(decision.Reason.Render(), "CANCELLED delegation children") {
+							t.Fatalf("decision = %+v, want PARK-X", decision)
 						}
 					case parksAbstaining:
 						if decision.Merged || !decision.LeaveOpen || !decision.Reason.IsGateMiss() ||
@@ -6862,7 +6881,10 @@ func TestPolicyMergeGateAtHeadStateGuardAdmitsNothingUnsucceeded(t *testing.T) {
 		{JobQueued, "waiting for reviewer", "crashed-reviewer switch, pending arm"},
 		{JobRunning, "waiting for reviewer", "crashed-reviewer switch, pending arm"},
 		{JobFailed, "crashed reviewer", "crashed-reviewer switch, error arm"},
-		{JobCancelled, "crashed reviewer", "crashed-reviewer switch, error arm"},
+		// #1799: the mechanism is now its OWN arm, which is the point of this table -
+		// it attributes each state's refusal to a named mechanism, and cancelled and
+		// failed no longer share one.
+		{JobCancelled, "cancelled review slot", "cancelled-slot switch, error arm"},
 		{JobBlocked, "has unusable job state", "unusable-state guard in the slot scan, NOT the switch"},
 	} {
 		t.Run(string(tt.state), func(t *testing.T) {


### PR DESCRIPTION
Refs #1799.

## Status of the prior attempt, stated first

PR **#2062** carried this change on `fix/1799-cancelled-is-not-crashed`, reached an **approved** verdict at head `2c253891`, and was **closed on 2026-09-08T23:32 with no closing comment giving a reason**. The branch is not an ancestor of `main`. I could not find a stated defect, so this is a re-proposal on current `main` rather than a rewrite, with the prior verdict's weakness disclosed below.

Both commits, verified from the objects rather than from PR metadata:

```
git log --format='%h %an <%ae>'
  2c253891 gm-staged <gm-staged@gitmoot.local>
```

**The prior verdict was `evidence=static_only` with `tests_run=4`.** By the standard this campaign is built on (#1817), a static-only approval is not evidence that the tests ran, so I re-verified everything below myself rather than citing it.

## The defect still exists in main

```
origin/main:internal/workflow/merge_gate.go:1024    case JobFailed, JobCancelled:
origin/main:internal/workflow/merge_gate.go:1566    case JobFailed, JobCancelled:
```

Both sites fold an explicit cancellation into the crashed-reviewer arm, so a cancelled review slot is reported as `crashed reviewer ... retry or settle that same job`. That sends an operator to the wrong remedy: retrying a crash and deciding whether a deliberately cancelled slot should be re-dispatched at all are different actions.

## Re-measured, and my numbers differ from the branch's

| measurement | branch, 2026-09-08 | mine, 2026-09-09 |
|---|---|---|
| cancelled review jobs | 534 | **548** |
| carrying a cancel discriminator in their own events | 346 | **358** |
| cancel requested from queued | 196 | **204** |
| from running | 92 | **96** |
| from blocked | 59 | **59** |

Same shape, one day of drift. I am reporting mine and naming the difference as elapsed time rather than as a correction. Six of the newest are review jobs I cancelled myself tonight, including one on PR #2051 that I cancelled to move a dispatch's provenance into the PR comment.

## The change

`JobCancelled` gets its own arm at both sites. It **still refuses**: a cancelled slot at the evaluated head is not a verdict. Only the diagnosis and the suggested remedy change.

The delegated-evidence site adds a `cancelled` bucket beside `crashed`, with an explicit refusal arm. Its own comment names the hazard: splitting the bucket without that arm would let a fan-out of only-cancelled children fall through to `abstaining` and stop refusing, which would be a gate weakening dressed as a message fix.

## Mutation record

| mutant | result | killed by |
|---|---|---|
| fold `JobCancelled` back into the `JobFailed` arm (gate site) | **killed** | `TestGateCallsACancelledReviewSlotCancelledNotCrashed` |
| delete the cancelled-refusal arm at the delegated site | **killed** | `TestPolicyMergeGateDelegatedReviewEvidenceEnumeration` |

I ran the second mutant specifically because the first site had a dedicated test and the second did not appear in the new test file at all. It turned out to be pinned by an existing enumeration test the branch updated. That check is here because the identical shape was **not** covered on the branch I adopted an hour ago for #1702, where a mutant a note claimed was pinned survived the whole file.

## Verification

`go build ./...`, `go vet ./internal/workflow/`, `go test ./internal/workflow/` (99.6s) all pass on the pinned go1.26.4. Race is CI's; it needs cgo and is unreachable from a seat.

## Not claimed

I have not established why #2062 was closed. If it was closed for a reason not recorded on the PR, that reason still applies and this should be closed too. I have also not measured how many of the 548 cancellations were escalated as crashes; the issue cites two from directive 108042, and I did not re-derive that pair.
