### PR TITLE
feat(cli): record which clause declined a queued job, with the value it tested

### DIFF
--- a/internal/cli/daemon_scheduler.go
+++ b/internal/cli/daemon_scheduler.go
@@ -379,8 +379,10 @@ var (
 // immediately instead of being suppressed by the old one. That is the whole
 // diagnostic value: the transition is the interesting event.
 //
-// Volume is bounded by construction: at most one row per (job, reason) per TTL,
-// so a job stalled 46 minutes on one clause writes 4 rows, not 2760.
+// Volume is bounded by construction: at most one row per (job, CLAUSE) per TTL,
+// so a job stalled 46 minutes on one clause writes 4 rows, not 2760 - and the
+// bound holds even though the recorded operands change between passes, because
+// the key is the clause and only the message carries the values.
 const (
 	dispatchDeclineEpisodeTTL = 15 * time.Minute
 	dispatchDeclineEpisodeMax = 512
@@ -420,11 +422,17 @@ func markDispatchDeclineEpisode(key string) {
 // episode. detail MUST carry the value the clause tested, not just its name: a
 // reason without its operand is another thing to investigate, which is the defect
 // this instrumentation exists to remove.
-func recordDispatchDecline(ctx context.Context, store *db.Store, job db.Job, detail string) {
-	if store == nil || strings.TrimSpace(detail) == "" {
+func recordDispatchDecline(ctx context.Context, store *db.Store, job db.Job, clause string, detail string) {
+	if store == nil || strings.TrimSpace(clause) == "" || strings.TrimSpace(detail) == "" {
 		return
 	}
-	key := job.ID + "\x00" + detail
+	// KEY ON THE CLAUSE, NOT ON THE DETAIL. The detail carries operands that move
+	// between passes - selected= changes with how many jobs were admitted earlier
+	// in the same pass, active= changes as instances come and go - so keying on it
+	// opens a NEW episode per distinct value and emits a row per operand change.
+	// That is the #598 flood wearing a dedup key, and it would have silently
+	// broken the bound this whole design exists to hold.
+	key := job.ID + "\x00" + clause
 	if dispatchDeclineEpisodeOpen(key) {
 		return
 	}
@@ -2863,7 +2871,7 @@ func selectRunnableQueuedJobsSeeded(ctx context.Context, store *db.Store, pendin
 		// no slots every queued job is declined and nothing recorded why. A repo
 		// whose scheduler resolves to zero looks identical to an idle one.
 		for _, job := range pending {
-			recordDispatchDecline(ctx, store, job, fmt.Sprintf("no dispatch slots: limit=%d", limit))
+			recordDispatchDecline(ctx, store, job, "slots", fmt.Sprintf("no dispatch slots: limit=%d", limit))
 		}
 		return nil, pending
 	}
@@ -2877,12 +2885,12 @@ func selectRunnableQueuedJobsSeeded(ctx context.Context, store *db.Store, pendin
 	queued := make([]db.Job, 0, min(limit, len(pending)))
 	remaining := make([]db.Job, 0, len(pending))
 	for _, job := range pending {
-		admitted, detail := selector.selects(ctx, store, job, len(queued))
+		admitted, clause, detail := selector.selects(ctx, store, job, len(queued))
 		if admitted {
 			queued = append(queued, job)
 			continue
 		}
-		recordDispatchDecline(ctx, store, job, detail)
+		recordDispatchDecline(ctx, store, job, clause, detail)
 		remaining = append(remaining, job)
 	}
 	return queued, remaining
@@ -2948,27 +2956,27 @@ func memoizedRuntimeResourceKey(ctx context.Context, store *db.Store, job db.Job
 // the product: "declined: limit" is nearly worthless, "selected=32 limit=32"
 // answers the question in one line. Admission behaviour is unchanged - every
 // return value is the same bool as before.
-func (s queuedJobResourceSelector) selects(ctx context.Context, store *db.Store, job db.Job, selected int) (bool, string) {
+func (s queuedJobResourceSelector) selects(ctx context.Context, store *db.Store, job db.Job, selected int) (admitted bool, clause string, detail string) {
 	if selected >= s.limit {
-		return false, fmt.Sprintf("dispatch limit reached: selected=%d limit=%d", selected, s.limit)
+		return false, "limit", fmt.Sprintf("dispatch limit reached: selected=%d limit=%d", selected, s.limit)
 	}
 	checkoutKey := queuedJobCheckoutKey(ctx, store, job)
 	runtimeKey := queuedJobRuntimeResourceKey(ctx, store, job)
 	if s.checkouts[checkoutKey] {
-		return false, fmt.Sprintf("checkout already taken this pass: checkout=%s", checkoutKey)
+		return false, "checkout", fmt.Sprintf("checkout already taken this pass: checkout=%s", checkoutKey)
 	}
 	runtimeAlreadySelected := runtimeKey != "" && s.runtimes[runtimeKey]
 	runtimeAlreadyLocked := runtimeKey != "" && !runtimeAlreadySelected && runtimeResourceLocked(ctx, store, runtimeKey)
 	if runtimeAlreadySelected || runtimeAlreadyLocked {
 		if ok, tempDetail := s.canUseTempWorker(ctx, store, job); !ok && runtimeAlreadySelected {
-			return false, fmt.Sprintf("runtime already taken this pass and no temp session: runtime=%s; %s", runtimeKey, tempDetail)
+			return false, "runtime", fmt.Sprintf("runtime already taken this pass and no temp session: runtime=%s; %s", runtimeKey, tempDetail)
 		}
 	}
 	s.checkouts[checkoutKey] = true
 	if runtimeKey != "" {
 		s.runtimes[runtimeKey] = true
 	}
-	return true, ""
+	return true, "", ""
 }
 
 func runtimeResourceLocked(ctx context.Context, store *db.Store, runtimeKey string) bool {

--- a/internal/cli/daemon_scheduler.go
+++ b/internal/cli/daemon_scheduler.go
@@ -370,6 +370,70 @@ var (
 	runtimeLockWaitEpisodes = map[string]time.Time{}
 )
 
+// dispatchDeclineEpisodes dedups the dispatch_declined job_event exactly as
+// runtimeLockWaitEpisodes dedups runtime_lock_wait, and for the same measured
+// reason: selects runs EVERY SECOND, PER REPO, PER QUEUED JOB, so one row per
+// decline would reproduce #598's flood (76k rows, 56% of job_events) on a
+// different clause. The key is jobID + reason, so a job whose decline REASON
+// CHANGES - limit today, contended runtime tomorrow - records the new reason
+// immediately instead of being suppressed by the old one. That is the whole
+// diagnostic value: the transition is the interesting event.
+//
+// Volume is bounded by construction: at most one row per (job, reason) per TTL,
+// so a job stalled 46 minutes on one clause writes 4 rows, not 2760.
+const (
+	dispatchDeclineEpisodeTTL = 15 * time.Minute
+	dispatchDeclineEpisodeMax = 512
+)
+
+var (
+	dispatchDeclineMu       sync.Mutex
+	dispatchDeclineEpisodes = map[string]time.Time{}
+)
+
+// dispatchDeclineEpisodeOpen is READ-ONLY, like runtimeLockWaitEpisodeOpen: a
+// failed event write leaves the episode closed so the next pass re-attempts it.
+func dispatchDeclineEpisodeOpen(key string) bool {
+	dispatchDeclineMu.Lock()
+	defer dispatchDeclineMu.Unlock()
+	emitted, ok := dispatchDeclineEpisodes[key]
+	if !ok {
+		return false
+	}
+	return time.Since(emitted) < dispatchDeclineEpisodeTTL
+}
+
+func markDispatchDeclineEpisode(key string) {
+	dispatchDeclineMu.Lock()
+	defer dispatchDeclineMu.Unlock()
+	dispatchDeclineEpisodes[key] = time.Now()
+	if len(dispatchDeclineEpisodes) > dispatchDeclineEpisodeMax {
+		for k, at := range dispatchDeclineEpisodes {
+			if time.Since(at) >= dispatchDeclineEpisodeTTL {
+				delete(dispatchDeclineEpisodes, k)
+			}
+		}
+	}
+}
+
+// recordDispatchDecline writes ONE dispatch_declined event per (job, reason) per
+// episode. detail MUST carry the value the clause tested, not just its name: a
+// reason without its operand is another thing to investigate, which is the defect
+// this instrumentation exists to remove.
+func recordDispatchDecline(ctx context.Context, store *db.Store, job db.Job, detail string) {
+	if store == nil || strings.TrimSpace(detail) == "" {
+		return
+	}
+	key := job.ID + "\x00" + detail
+	if dispatchDeclineEpisodeOpen(key) {
+		return
+	}
+	if err := store.AddJobEvent(ctx, db.JobEvent{JobID: job.ID, Kind: "dispatch_declined", Message: detail}); err != nil {
+		return
+	}
+	markDispatchDeclineEpisode(key)
+}
+
 // runtimeLockWaitEpisodeOpen reports whether jobID currently has an open, already-
 // emitted wait episode: an entry exists AND its event was emitted within the last
 // runtimeLockWaitEpisodeTTL. It is READ-ONLY — it never mutates the map — so a
@@ -2795,6 +2859,12 @@ func selectRunnableQueuedJobsWithPolicy(ctx context.Context, store *db.Store, pe
 // held by a running job is not selected. The seed maps are copied, never mutated.
 func selectRunnableQueuedJobsSeeded(ctx context.Context, store *db.Store, pending []db.Job, limit int, policy config.ParallelSessionPolicy, seedCheckouts map[string]bool, seedRuntimes map[string]bool) ([]db.Job, []db.Job) {
 	if limit <= 0 {
+		// A FOURTH DECLINE POINT, outside selects and not in the issue's list: with
+		// no slots every queued job is declined and nothing recorded why. A repo
+		// whose scheduler resolves to zero looks identical to an idle one.
+		for _, job := range pending {
+			recordDispatchDecline(ctx, store, job, fmt.Sprintf("no dispatch slots: limit=%d", limit))
+		}
 		return nil, pending
 	}
 	selector := queuedJobResourceSelector{
@@ -2807,10 +2877,12 @@ func selectRunnableQueuedJobsSeeded(ctx context.Context, store *db.Store, pendin
 	queued := make([]db.Job, 0, min(limit, len(pending)))
 	remaining := make([]db.Job, 0, len(pending))
 	for _, job := range pending {
-		if selector.selects(ctx, store, job, len(queued)) {
+		admitted, detail := selector.selects(ctx, store, job, len(queued))
+		if admitted {
 			queued = append(queued, job)
 			continue
 		}
+		recordDispatchDecline(ctx, store, job, detail)
 		remaining = append(remaining, job)
 	}
 	return queued, remaining
@@ -2871,27 +2943,32 @@ func memoizedRuntimeResourceKey(ctx context.Context, store *db.Store, job db.Job
 	return key
 }
 
-func (s queuedJobResourceSelector) selects(ctx context.Context, store *db.Store, job db.Job, selected int) bool {
+// selects reports whether the job is admitted, and when it is NOT, returns the
+// clause that declined it WITH THE VALUE THAT CLAUSE TESTED (#2117). The detail is
+// the product: "declined: limit" is nearly worthless, "selected=32 limit=32"
+// answers the question in one line. Admission behaviour is unchanged - every
+// return value is the same bool as before.
+func (s queuedJobResourceSelector) selects(ctx context.Context, store *db.Store, job db.Job, selected int) (bool, string) {
 	if selected >= s.limit {
-		return false
+		return false, fmt.Sprintf("dispatch limit reached: selected=%d limit=%d", selected, s.limit)
 	}
 	checkoutKey := queuedJobCheckoutKey(ctx, store, job)
 	runtimeKey := queuedJobRuntimeResourceKey(ctx, store, job)
 	if s.checkouts[checkoutKey] {
-		return false
+		return false, fmt.Sprintf("checkout already taken this pass: checkout=%s", checkoutKey)
 	}
 	runtimeAlreadySelected := runtimeKey != "" && s.runtimes[runtimeKey]
 	runtimeAlreadyLocked := runtimeKey != "" && !runtimeAlreadySelected && runtimeResourceLocked(ctx, store, runtimeKey)
 	if runtimeAlreadySelected || runtimeAlreadyLocked {
-		if !s.canUseTempWorker(ctx, store, job) && runtimeAlreadySelected {
-			return false
+		if ok, tempDetail := s.canUseTempWorker(ctx, store, job); !ok && runtimeAlreadySelected {
+			return false, fmt.Sprintf("runtime already taken this pass and no temp session: runtime=%s; %s", runtimeKey, tempDetail)
 		}
 	}
 	s.checkouts[checkoutKey] = true
 	if runtimeKey != "" {
 		s.runtimes[runtimeKey] = true
 	}
-	return true
+	return true, ""
 }
 
 func runtimeResourceLocked(ctx context.Context, store *db.Store, runtimeKey string) bool {
@@ -2902,33 +2979,36 @@ func runtimeResourceLocked(ctx context.Context, store *db.Store, runtimeKey stri
 	return err == nil
 }
 
-func (s queuedJobResourceSelector) canUseTempWorker(ctx context.Context, store *db.Store, job db.Job) bool {
+// canUseTempWorker reports eligibility and, when refused, WHY - including the
+// temp-session numerator it tested (#2117). Behaviour is unchanged: every refusal
+// returns false exactly where it did before.
+func (s queuedJobResourceSelector) canUseTempWorker(ctx context.Context, store *db.Store, job db.Job) (bool, string) {
 	if store == nil {
-		return false
+		return false, "temp session unavailable: no store"
 	}
 	payload, err := daemonJobPayload(job)
 	if err != nil {
-		return false
+		return false, fmt.Sprintf("temp session unavailable: unreadable payload: %v", err)
 	}
 	dbAgent, err := store.GetAgent(ctx, job.Agent)
 	if err != nil {
-		return false
+		return false, fmt.Sprintf("temp session unavailable: agent %q not readable: %v", job.Agent, err)
 	}
 	agent := runtimeAgent(dbAgent)
 	typ := tempWorkerAgentType(agent.Name)
 	count, err := store.CountActiveAgentInstances(ctx, typ, agent.AutonomyPolicy, time.Now().UTC())
 	if err != nil {
-		return false
+		return false, fmt.Sprintf("temp session unavailable: count active instances for %q: %v", typ, err)
 	}
 	if count+s.tempReservations[typ] >= s.policy.MaxTempSessionsPerAgent {
-		return false
+		return false, fmt.Sprintf("temp sessions exhausted: type=%s active=%d reserved=%d cap=%d", typ, count, s.tempReservations[typ], s.policy.MaxTempSessionsPerAgent)
 	}
 	eligible := tempWorkerEligible(ctx, store, job, payload, agent, s.policy, time.Now().UTC())
 	if !eligible.Eligible {
-		return false
+		return false, fmt.Sprintf("temp session ineligible: type=%s reason=%s", typ, eligible.Reason)
 	}
 	s.tempReservations[typ]++
-	return true
+	return true, ""
 }
 
 func queuedJobMatchesRepo(job db.Job, repoFilter string) bool {

--- a/internal/cli/daemon_scheduler.go
+++ b/internal/cli/daemon_scheduler.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"sort"
@@ -437,6 +438,16 @@ func recordDispatchDecline(ctx context.Context, store *db.Store, job db.Job, cla
 		return
 	}
 	if err := store.AddJobEvent(ctx, db.JobEvent{JobID: job.ID, Kind: "dispatch_declined", Message: detail}); err != nil {
+		// A VISIBILITY FEATURE MUST NOT FAIL INVISIBLY. Retry-next-tick is the
+		// intended design - the episode stays closed, so the next pass re-attempts -
+		// but a SUSTAINED write failure would then retry forever per declining job
+		// with no operator-visible signal at all, which is the exact blindness this
+		// change exists to remove. Logged per failed attempt rather than deduped:
+		// suppressing the log would recreate the invisibility, and a store that
+		// cannot accept a job event is a fleet-level fault where this volume is the
+		// least of the problems. Matches event_rule_sink.go's precedent for a
+		// best-effort store write in a path with no stdout.
+		slog.Warn("dispatch decline event write failed", "job_id", job.ID, "clause", clause, "error", err)
 		return
 	}
 	markDispatchDeclineEpisode(key)

--- a/internal/cli/daemon_scheduler_test.go
+++ b/internal/cli/daemon_scheduler_test.go
@@ -5739,3 +5739,129 @@ func assertCursorCacheWiredForBothKinds(t *testing.T, drive func(context.Context
 		t.Fatalf("cursor reads = %d, want at least one per gated query per tick", got)
 	}
 }
+
+// TestDispatchDeclineRecordsTheValueTheClauseTested is #2117. A job left queued
+// by the selector produced NO artifact of any kind: selects returned a bare false
+// and the caller dropped the job into `remaining` with no event and no log line.
+// Six independent candidate mechanisms were eliminated against a live stall
+// without ever being able to read which clause had declined the job, because
+// nothing recorded it.
+//
+// The contract is not that a message exists. It is that the OPERAND the clause
+// tested is recoverable: "declined on the limit" is another thing to investigate,
+// "selected=2 limit=2" answers the question. So this asserts the operand's
+// presence - the contended runtime key, and the cap arithmetic - and never the
+// phrasing around it.
+func TestDispatchDeclineRecordsTheValueTheClauseTested(t *testing.T) {
+	ctx := context.Background()
+	store := daemonWorkerStore(t)
+	// Episode dedup is package-level, so fixture ids MUST be unique per test or a
+	// sibling test's open episode suppresses this one's event and the assertion
+	// sees zero - indistinguishable from the feature being broken.
+	uniq := t.Name()
+	// Two agents on ONE runtime session: the second job is declined for the
+	// runtime clause, which is the clause tonight's stall implicated.
+	seedDaemonWorkerAgent(t, store, "lead-a-"+uniq, runtime.CodexRuntime, "session-1", []string{"implement"}, "owner/repo")
+	seedDaemonWorkerAgent(t, store, "lead-b-"+uniq, runtime.CodexRuntime, "session-1", []string{"implement"}, "owner/repo")
+	for _, id := range []string{"task-a-" + uniq, "task-b-" + uniq} {
+		if err := store.UpsertTask(ctx, db.Task{ID: id, RepoFullName: "owner/repo", State: string(workflow.TaskImplementing), Branch: id, WorktreePath: "/tmp/gitmoot/" + id}); err != nil {
+			t.Fatalf("UpsertTask %s: %v", id, err)
+		}
+	}
+	enqueueDaemonWorkerJob(t, store, workflow.JobRequest{ID: "job-a-" + uniq, Agent: "lead-a-" + uniq, Action: "implement", Repo: "owner/repo", Branch: "task-a-" + uniq, TaskID: "task-a-" + uniq})
+	enqueueDaemonWorkerJob(t, store, workflow.JobRequest{ID: "job-b-" + uniq, Agent: "lead-b-" + uniq, Action: "implement", Repo: "owner/repo", Branch: "task-b-" + uniq, TaskID: "task-b-" + uniq})
+	jobs, err := store.ListQueuedJobs(ctx)
+	if err != nil {
+		t.Fatalf("ListQueuedJobs: %v", err)
+	}
+
+	selected, remaining := selectRunnableQueuedJobsWithPolicy(ctx, store, jobs, 2, config.ParallelSessionPolicy{SameSession: config.ParallelSessionQueue})
+	if len(selected) != 1 || len(remaining) != 1 {
+		t.Fatalf("selected=%d remaining=%d, want one admitted and one declined on the shared runtime", len(selected), len(remaining))
+	}
+
+	declined := remaining[0].ID
+	events, err := store.ListJobEvents(ctx, declined)
+	if err != nil {
+		t.Fatalf("ListJobEvents(%s): %v", declined, err)
+	}
+	var messages []string
+	for _, event := range events {
+		if event.Kind == "dispatch_declined" {
+			messages = append(messages, event.Message)
+		}
+	}
+	if len(messages) != 1 {
+		t.Fatalf("dispatch_declined events for the declined job = %d, want exactly one; events=%+v", len(messages), events)
+	}
+	// The runtime key is the operand of the clause that declined it. Without the
+	// key an operator cannot tell WHICH session was contended, which is the whole
+	// question a stall poses.
+	runtimeKey := queuedJobRuntimeResourceKey(ctx, store, remaining[0])
+	if runtimeKey == "" {
+		t.Fatal("fixture produced no runtime key, so the runtime clause cannot be the one under test")
+	}
+	if !strings.Contains(messages[0], runtimeKey) {
+		t.Fatalf("decline detail %q does not carry the contended runtime key %q", messages[0], runtimeKey)
+	}
+	// The temp-session arithmetic is the second operand: a reader must be able to
+	// see the cap it was compared against, which is what #2116 could not be
+	// measured against after the fact.
+	if !strings.Contains(messages[0], "cap=") && !strings.Contains(messages[0], "reason=") {
+		t.Fatalf("decline detail %q carries no temp-session operand: neither the cap it tested nor the ineligibility reason", messages[0])
+	}
+}
+
+// TestDispatchDeclineDedupsPerReasonRatherThanPerPass pins the volume bound. The
+// selector runs every second, per repo, per queued job, so one row per decline
+// reproduces #598's flood - 76k rows, 56% of job_events - on a different clause.
+// A guard nobody can leave on is worse than none.
+// The job ids here MUST differ from the test above: the episode map is
+// package-level and persists across tests in one process, so reusing an id
+// inherits that test's OPEN episode and this test silently observes zero
+// events - which is what it looks like when the feature is broken.
+func TestDispatchDeclineDedupsPerReasonRatherThanPerPass(t *testing.T) {
+	ctx := context.Background()
+	store := daemonWorkerStore(t)
+	// Episode dedup is package-level, so fixture ids MUST be unique per test or a
+	// sibling test's open episode suppresses this one's event and the assertion
+	// sees zero - indistinguishable from the feature being broken.
+	uniq := t.Name()
+	seedDaemonWorkerAgent(t, store, "lead-c-"+uniq, runtime.CodexRuntime, "session-1", []string{"implement"}, "owner/repo")
+	seedDaemonWorkerAgent(t, store, "lead-d-"+uniq, runtime.CodexRuntime, "session-1", []string{"implement"}, "owner/repo")
+	for _, id := range []string{"task-c-" + uniq, "task-d-" + uniq} {
+		if err := store.UpsertTask(ctx, db.Task{ID: id, RepoFullName: "owner/repo", State: string(workflow.TaskImplementing), Branch: id, WorktreePath: "/tmp/gitmoot/" + id}); err != nil {
+			t.Fatalf("UpsertTask %s: %v", id, err)
+		}
+	}
+	enqueueDaemonWorkerJob(t, store, workflow.JobRequest{ID: "job-c-" + uniq, Agent: "lead-c-" + uniq, Action: "implement", Repo: "owner/repo", Branch: "task-c-" + uniq, TaskID: "task-c-" + uniq})
+	enqueueDaemonWorkerJob(t, store, workflow.JobRequest{ID: "job-d-" + uniq, Agent: "lead-d-" + uniq, Action: "implement", Repo: "owner/repo", Branch: "task-d-" + uniq, TaskID: "task-d-" + uniq})
+	jobs, err := store.ListQueuedJobs(ctx)
+	if err != nil {
+		t.Fatalf("ListQueuedJobs: %v", err)
+	}
+
+	// Three passes, as three consecutive dispatcher ticks would.
+	var declined string
+	for pass := 0; pass < 3; pass++ {
+		_, remaining := selectRunnableQueuedJobsWithPolicy(ctx, store, jobs, 2, config.ParallelSessionPolicy{SameSession: config.ParallelSessionQueue})
+		if len(remaining) != 1 {
+			t.Fatalf("pass %d remaining=%d, want one", pass, len(remaining))
+		}
+		declined = remaining[0].ID
+	}
+
+	events, err := store.ListJobEvents(ctx, declined)
+	if err != nil {
+		t.Fatalf("ListJobEvents: %v", err)
+	}
+	count := 0
+	for _, event := range events {
+		if event.Kind == "dispatch_declined" {
+			count++
+		}
+	}
+	if count != 1 {
+		t.Fatalf("dispatch_declined events after three identical passes = %d, want exactly 1; a row per pass is the #598 flood", count)
+	}
+}

--- a/internal/cli/daemon_scheduler_test.go
+++ b/internal/cli/daemon_scheduler_test.go
@@ -5961,3 +5961,83 @@ func TestDispatchDeclineDedupsOnTheClauseNotTheOperand(t *testing.T) {
 		}
 	}
 }
+
+// TestDispatchDeclineClauseLabelsMatchTheirBranch closes the gap #2118's reviewer
+// found by injecting the mutant that proves it: MISLABELLING a branch's clause
+// string - the limit branch returning "checkout", say - compiles, leaves admission
+// and the message text untouched, and SURVIVED all three of the other tests. It is
+// not a live bug today; production's labels are distinct and correct. It is a
+// latent one, and the failure mode is specific: the clause is the DEDUP KEY, so two
+// branches sharing a label collide into one episode and the second reason is
+// silently suppressed for the whole TTL.
+//
+// So this asserts the correspondence directly rather than through the event: each
+// branch must return ITS OWN label alongside the detail that names its operand.
+func TestDispatchDeclineClauseLabelsMatchTheirBranch(t *testing.T) {
+	ctx := context.Background()
+	store := daemonWorkerStore(t)
+	uniq := t.Name()
+	seedDaemonWorkerAgent(t, store, "lead-"+uniq, runtime.CodexRuntime, "session-1", []string{"implement"}, "owner/repo")
+	task := "task-" + uniq
+	if err := store.UpsertTask(ctx, db.Task{ID: task, RepoFullName: "owner/repo", State: string(workflow.TaskImplementing), Branch: task, WorktreePath: "/tmp/gitmoot/" + task}); err != nil {
+		t.Fatalf("UpsertTask: %v", err)
+	}
+	enqueueDaemonWorkerJob(t, store, workflow.JobRequest{ID: "job-" + uniq, Agent: "lead-" + uniq, Action: "implement", Repo: "owner/repo", Branch: task, TaskID: task})
+	jobs, err := store.ListQueuedJobs(ctx)
+	if err != nil {
+		t.Fatalf("ListQueuedJobs: %v", err)
+	}
+	job := jobs[0]
+
+	checkoutKey := queuedJobCheckoutKey(ctx, store, job)
+	runtimeKey := queuedJobRuntimeResourceKey(ctx, store, job)
+
+	for _, tt := range []struct {
+		name       string
+		selector   queuedJobResourceSelector
+		selected   int
+		wantClause string
+		wantInMsg  string
+	}{
+		{
+			// The limit branch, reached by having already admitted its whole budget.
+			name:       "limit",
+			selector:   queuedJobResourceSelector{limit: 1, checkouts: map[string]bool{}, runtimes: map[string]bool{}, tempReservations: map[string]int{}},
+			selected:   1,
+			wantClause: "limit",
+			wantInMsg:  "selected=1 limit=1",
+		},
+		{
+			// The checkout branch, reached by pre-seeding this job's own key.
+			name:       "checkout",
+			selector:   queuedJobResourceSelector{limit: 8, checkouts: map[string]bool{checkoutKey: true}, runtimes: map[string]bool{}, tempReservations: map[string]int{}},
+			wantClause: "checkout",
+			wantInMsg:  checkoutKey,
+		},
+		{
+			// The runtime branch, reached by pre-seeding the runtime key with a
+			// serializing policy so no temp session can rescue it.
+			name:       "runtime",
+			selector:   queuedJobResourceSelector{limit: 8, policy: config.ParallelSessionPolicy{SameSession: config.ParallelSessionQueue}, checkouts: map[string]bool{}, runtimes: map[string]bool{runtimeKey: true}, tempReservations: map[string]int{}},
+			wantClause: "runtime",
+			wantInMsg:  runtimeKey,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			admitted, clause, detail := tt.selector.selects(ctx, store, job, tt.selected)
+			if admitted {
+				t.Fatalf("%s branch admitted the job, so this row tests nothing", tt.name)
+			}
+			// THE LABEL IS THE DEDUP KEY. A branch returning another branch's label
+			// collides two reasons into one episode and suppresses the second.
+			if clause != tt.wantClause {
+				t.Fatalf("%s branch returned clause %q, want %q; a mislabelled clause collides two decline reasons under one dedup key", tt.name, clause, tt.wantClause)
+			}
+			// And the operand must still be the one THIS branch tested, so a label
+			// swap cannot be repaired by a matching message swap.
+			if !strings.Contains(detail, tt.wantInMsg) {
+				t.Fatalf("%s branch detail %q does not carry %q", tt.name, detail, tt.wantInMsg)
+			}
+		})
+	}
+}

--- a/internal/cli/daemon_scheduler_test.go
+++ b/internal/cli/daemon_scheduler_test.go
@@ -5865,3 +5865,99 @@ func TestDispatchDeclineDedupsPerReasonRatherThanPerPass(t *testing.T) {
 		t.Fatalf("dispatch_declined events after three identical passes = %d, want exactly 1; a row per pass is the #598 flood", count)
 	}
 }
+
+// TestDispatchDeclineDedupsOnTheClauseNotTheOperand pins the volume contract
+// against the defect that the first #2117 implementation actually had: the
+// episode key included the FORMATTED DETAIL, and the detail carries operands
+// that move between passes - selected= changes with how many jobs were admitted
+// earlier in the same pass. So every distinct operand value opened a NEW episode
+// and wrote another row, which is #598's flood wearing a dedup key. The comments
+// claimed per-clause dedup while the code keyed per-detail, and nothing failed.
+//
+// Two passes at DIFFERENT limits make the same job decline on the same clause
+// with two different operands. The contract is one row, and the operands must
+// still be present in it.
+func TestDispatchDeclineDedupsOnTheClauseNotTheOperand(t *testing.T) {
+	ctx := context.Background()
+	store := daemonWorkerStore(t)
+	uniq := t.Name()
+	// Distinct sessions so the runtime clause never fires: this test is about the
+	// limit clause, and a runtime decline would mask it.
+	for index, session := range []string{"session-1", "session-2", "session-3"} {
+		agent := fmt.Sprintf("lead-%d-%s", index, uniq)
+		task := fmt.Sprintf("task-%d-%s", index, uniq)
+		seedDaemonWorkerAgent(t, store, agent, runtime.CodexRuntime, session, []string{"implement"}, "owner/repo")
+		if err := store.UpsertTask(ctx, db.Task{ID: task, RepoFullName: "owner/repo", State: string(workflow.TaskImplementing), Branch: task, WorktreePath: "/tmp/gitmoot/" + task}); err != nil {
+			t.Fatalf("UpsertTask %s: %v", task, err)
+		}
+		enqueueDaemonWorkerJob(t, store, workflow.JobRequest{ID: fmt.Sprintf("job-%d-%s", index, uniq), Agent: agent, Action: "implement", Repo: "owner/repo", Branch: task, TaskID: task})
+	}
+	jobs, err := store.ListQueuedJobs(ctx)
+	if err != nil {
+		t.Fatalf("ListQueuedJobs: %v", err)
+	}
+	if len(jobs) != 3 {
+		t.Fatalf("queued jobs = %d, want three", len(jobs))
+	}
+	policy := config.ParallelSessionPolicy{SameSession: config.ParallelSessionQueue}
+	last := jobs[2].ID
+
+	// Two ticks at different limits. ADMISSION OUTPUT IS ASSERTED TOO: this change
+	// must not alter which jobs run, only what is recorded about the ones that did not.
+	for _, pass := range []struct {
+		limit      int
+		wantQueued int
+	}{{limit: 2, wantQueued: 2}, {limit: 1, wantQueued: 1}} {
+		queued, remaining := selectRunnableQueuedJobsWithPolicy(ctx, store, jobs, pass.limit, policy)
+		if len(queued) != pass.wantQueued || len(queued)+len(remaining) != len(jobs) {
+			t.Fatalf("limit=%d admitted %d (remaining %d), want %d admitted and every job accounted for", pass.limit, len(queued), len(remaining), pass.wantQueued)
+		}
+		if remaining[len(remaining)-1].ID != last {
+			t.Fatalf("limit=%d last remaining=%s, want %s declined in both passes", pass.limit, remaining[len(remaining)-1].ID, last)
+		}
+	}
+
+	events, err := store.ListJobEvents(ctx, last)
+	if err != nil {
+		t.Fatalf("ListJobEvents: %v", err)
+	}
+	var limitRows []string
+	for _, event := range events {
+		if event.Kind == "dispatch_declined" && strings.Contains(event.Message, "limit") {
+			limitRows = append(limitRows, event.Message)
+		}
+	}
+	// Two passes, two different operand values, ONE row. Keying on the detail
+	// yields two here, which is the bug this test exists for.
+	if len(limitRows) != 1 {
+		t.Fatalf("limit-clause declines for %s = %d %v, want exactly one across two passes at different limits", last, len(limitRows), limitRows)
+	}
+	// And the surviving row still answers the question in one line.
+	if !strings.Contains(limitRows[0], "selected=") || !strings.Contains(limitRows[0], "limit=") {
+		t.Fatalf("decline detail %q lost its operands; a clause name without the value it tested is another thing to investigate", limitRows[0])
+	}
+
+	// The limit<=0 caller path declines EVERY pending job, so it is the highest
+	// volume branch of the four and needs the same bound.
+	for pass := 0; pass < 2; pass++ {
+		queued, remaining := selectRunnableQueuedJobsWithPolicy(ctx, store, jobs, 0, policy)
+		if len(queued) != 0 || len(remaining) != len(jobs) {
+			t.Fatalf("limit=0 pass %d admitted %d and left %d, want zero admitted and every job pending", pass, len(queued), len(remaining))
+		}
+	}
+	for _, job := range jobs {
+		slotRows := 0
+		rows, err := store.ListJobEvents(ctx, job.ID)
+		if err != nil {
+			t.Fatalf("ListJobEvents %s: %v", job.ID, err)
+		}
+		for _, event := range rows {
+			if event.Kind == "dispatch_declined" && strings.Contains(event.Message, "no dispatch slots") {
+				slotRows++
+			}
+		}
+		if slotRows != 1 {
+			t.Fatalf("no-slots declines for %s = %d, want exactly one across two passes", job.ID, slotRows)
+		}
+	}
+}


### PR DESCRIPTION

## What this changes

A job the selector declines currently produces **no artifact of any kind**. `selects` returned a bare `false` and the caller dropped the job into `remaining` with no event, no log line and no counter. Six candidate mechanisms were eliminated against a live stall without ever being able to read which clause declined the job.

This adds a `dispatch_declined` job event carrying the clause **and the value that clause tested**. A reason without its operand is another thing to investigate: `declined on the limit` needs a second query, `selected=32 limit=32` answers the question in one line.

## Four decline points, and the fourth is not in the issue's list

| Clause | Recorded operand |
| --- | --- |
| `limit <= 0`, **outside `selects` entirely** | `no dispatch slots: limit=%d` |
| `selected >= s.limit` | `selected=%d limit=%d` |
| `s.checkouts[checkoutKey]` | the contended `checkout=` key |
| runtime taken and no temp session | the `runtime=` key **plus** `active=`, `reserved=`, `cap=`, or the ineligibility `reason=` |

The fourth is the one worth flagging: `selectRunnableQueuedJobsSeeded` returns `nil, pending` when `limit <= 0`, so **a repo whose scheduler resolves to zero slots declines every queued job and is indistinguishable from an idle repo.** I read the branches rather than trusting the enumeration, as instructed.

## Volume: solved by precedent, not invention

`selects` runs every second, per repo, per queued job. A row per decline reproduces **#598's flood - 76k rows, 56% of the whole `job_events` table** - on a different clause, and a guard nobody can leave on is worse than none.

So this mirrors `runtimeLockWaitEpisodes`: an episode map keyed **job plus clause**, a 15-minute TTL for liveness, the same bounded prune, and the mark written **only after** a successful `AddJobEvent` so a failed write retries instead of being suppressed.

Keying on the clause as well as the job is deliberate: a job whose decline clause **changes** records the new one immediately, because the transition is the interesting event. Bound: **one row per (job, clause) per TTL**, so a job stalled 46 minutes on one clause writes 4 rows, not 2760.

### The first push of this PR got that wrong, and it is worth reading

`6a75b55b` keyed the episode on `job.ID` + **the formatted detail**, and the detail carries operands that move between passes. `selected=` changes with how many jobs were admitted earlier in the same pass. So **every distinct operand value opened a new episode and wrote another row**: #598's flood wearing a dedup key. The comments promised per-clause dedup while the code keyed per-detail, and **both tests passed**, because each re-declined with an identical detail.

Fixed in `1d754dc8`. The test that would have caught it is now in the PR: two ticks at *different* limits make one job decline on one clause with two different operands. Restoring the old key prints the flood in the failure:

```
limit-clause declines = 2 [dispatch limit reached: selected=2 limit=2
                           dispatch limit reached: selected=1 limit=1]
```

## These rows are not readable through the CLI today, and that is deliberate layering

`dispatch_declined` lands in `job_events`, and **nothing in the CLI exposes `job_events`**. Measured: `gitmoot job show <id> --json` returns `ID, Agent, Type, State, Payload, Model, Runtime, ...` and **no events key at all**; `gitmoot job list --state queued --json` returns bare rows. So a lane reading either surface sees `state=queued` and nothing else, even after this change records exactly why that job was declined.

That gap is **not specific to this event kind** - it is true of every kind - and it is a reader-side defect one layer up, filed as #1591 (the refusal "writes a `job_events` row and touches nothing else", so the row carries no reason) and #1899 (the same refusal "is invisible in `gitmoot job list --json`"). This PR is deliberately **not** coupled to them: coupling a decision record to a CLI surface redesign would block the observability behind the redesign, and the redesign should be justified by every producer rather than by this one.

Until #1591 lands, the rows are queryable from the store, which is what every job-level question on this host already does. That is a sufficient answer, not a good one.

**If #1591's remedy lands as a reason field on the job row, `dispatch_declined` is its natural producer** and the two want designing together rather than each adding a surface. Recorded here so a future reader does not discover the gap by querying the CLI and finding nothing.

## Admission behaviour is unchanged

Every return value in `selects` and `canUseTempWorker` is the same bool it was; both simply also return a detail string. No job's outcome differs. I did not touch the `CountActiveAgentInstances` cap or the policy-load fallback inversion - those are gitmoot#2116 and separate products.

## Verification

- `go build ./...` exit 0, `go vet ./internal/cli` exit 0, no generated drift.
- Three tests, failing before and passing after; one covers the limit clause, its operands, and the `limit<=0` path.
- **Four mutants, all compiling and semantic.** Dropping the recorder call kills the first two tests. Returning the clause name *without* its operand fails with `does not carry the contended runtime key "runtime:codex:session-1"`. Restoring the operand-keyed dedup prints the two-row flood above. Dropping the recorder at the `limit<=0` path gives `no-slots declines = 0`.
- The first mutant attempt **did not compile** (removing the operands left `tempDetail` unused), so it was invalid by this fleet's standard and was redone rather than reported.

### Test isolation is part of the contract

The episode map is package-level, so a fixed fixture id inherits a sibling test's **open** episode and the assertion observes zero events - indistinguishable from the feature being broken. **That happened:** the tests passed alone and failed in the wider set. Fixture ids are now scoped to `t.Name()`, with a comment saying why so nobody tidies them back.

## The acceptance criterion I could NOT meet

The issue asks for a demonstration on the live stall. **I cannot run it.** The instrumentation only produces events from the running daemon, which requires this to merge and deploy; and `recordDispatchDecline` writes to the store, so I cannot exercise it against the live store from a seat. **So the instrumentation is unexercised against a real stall, and I am reporting that rather than assuming coverage.** What would demonstrate it: after deployment, the next time a `gitmoot/gitmoot` review waits while other repos dispatch, `ListJobEvents` on the waiting job should name the clause and its operand. If it does not fire, that is a result about the four branches being wrong, and it is recoverable in one query.

## This does not fix the latency

**The cause of the 20-to-60 minute waits remains unknown.** This makes the next stall diagnosable in one tick instead of six eliminations. Eliminated so far, four with positive controls: the runtime session lock blocking selection, silent session-lock starvation, checkout-key serialization, a per-repo concurrency override, the host-global admission budget, and a pre-dispatch step erroring and skipping dispatch. The hourly-period lead and the temp-session cap were both mine and both died on measurement.

**Merge note:** enqueue through the merge queue once approved. Merge authority stays with the coordinator and the owner; `merge_rule` for this seat is none.





---

## Attribution: who implemented this, and why the gate cannot establish it

There is **no engine implementation job** for this PR, because it was implemented in-session. That is the expected state for in-session work, not a failed independence check and not a missing recording step - so a merge gate reading for an implementer finds nothing and cannot establish who wrote it.

Recorded as the durable attribution: `session-implement-gm-transport-18d3cb8e0790c3e5`, `acting_org_role: gm-transport`, `decision: implemented`, `pull_request: 2118`. Recorded by the lane that did the work; deliberately no row for any other seat and none for the reviewer, because a false WHO on an already headless WHAT is worse than an absent row - the absent one is at least honest about not knowing.

**The row is honest about WHO and permanently silent about WHICH HEAD.** Per #1990, a caller-asserted `--head-sha` is quarantined to the display plane: the CLI echoes `head_sha_plane: "display"` and the stored payload has no `head_sha` key at all. Verified on this row - its payload keys are `acting_org_role, branch, constraints, dispatched_by, instructions, pull_request, repo, result, sender, task_id, task_title`. Verified across the population: **484 session rows, zero with a top-level `head_sha` key.**

So re-evaluating the gate will not clear this and is not being attempted. Recording is worth doing because it is the only durable attribution that exists, and it does not flip a head-bound check while the quarantine stands. The merge requirement remains one substantive independent review, which this PR has; an unverifiable attribution does not retroactively disqualify a review nobody has evidence against.

One measurement note for anyone who re-derives the population figure: `payload LIKE '%head_sha%'` returns **12** rows and is the wrong instrument - all 12 merely *mention* the string in nested text, and none carries the key. This row is one of the 12, because its own summary says it carries no `head_sha`. Match on the parsed key, not the substring.


---

## Merge note

Enqueued by `gm-transport` under `merge_rule: self`, verified at enqueue time from two durable sources rather than from a message: `gitmoot org brief --role gm-transport` reports `merge_rule: self`, `gitmoot org chart` reports `merge=self`. Owner standing-delegation row 107983's six safeguards, each re-read immediately before this enqueue:

1. **Open, mergeable, clean, every check succeeded.** `state: open`, `draft: false`, `mergeable: true`, `mergeable_state: clean`, 27 of 27 success, 0 failing, 0 pending, at head `c164b8d3`.
2. **Approved at the current head.** Job `local-review-gm-review-opus-18d3cb7f0acef592-1`, `decision: approved`, `head_sha c164b8d3`. The earlier approval at `1d754dc8` was voided when I pushed the two review fixes; this is the re-review of that delta.
3. **Non-empty `tests_run`**, and both prior findings carry `state: answered` with substantive detail rather than a disposition. The reviewer independently verified both of my claims: the `slog` precedent at `event_rule_sink.go:150-214`, and the plumbing cost, by confirming `selectRunnableQueuedJobsSeeded` has no `io.Writer` today while the `blocked_ttl` sweep already holds `stdout`.
4. **Reviewer is neither implementer nor lead.** Reviewer `gm-review-opus`; the implementing lane is `gm-transport`.
5. **Immediate pre-enqueue re-read**, in the same command sequence as this enqueue.
6. **Attribution gap named**, in full above under "Attribution".

Two P3s were raised and **answered by fixing them**, not by dispositioning them. Under workflow note 129657 they would not have held the merge in any case - P1 and P2 hold, P3 does not - but the obligation wanted an answer and a fix is the stronger one.

### The base is stale and the queue is the instrument for it

Base `1944acd5`; `main` has moved to `39678913`. So the 27/27 above describes `merge(head, 1944acd5)`, not the landing tree. Head axis clean, base axis the queue's job: it re-tests the real merge at the front. Not rebased to chase - `main`'s measured median gap between commits tonight is about 31 minutes against a local check of roughly 900 seconds, which is a loop that does not terminate. #2105 was enqueued on the same reasoning tonight and merged.
