### PR TITLE
test(e2b): exercise the four client guards that survived mutation (#1650)

### DIFF
--- a/internal/execbackend/e2b/client_test.go
+++ b/internal/execbackend/e2b/client_test.go
@@ -922,3 +922,108 @@ type roundTripFunc func(*http.Request) (*http.Response, error)
 func (fn roundTripFunc) RoundTrip(request *http.Request) (*http.Response, error) {
 	return fn(request)
 }
+
+// The four tests below exercise guards that #1650 measured as INERT: each guard
+// is correct code that no test reached, so deleting it left the suite green.
+// Each test is written against the mutant that survived, not against the guard's
+// text, so it fails if the guard is removed and passes only when it fires.
+
+// TestNewClientRejectsUnusableBaseURL covers the #1650 M10 mutant: deleting the
+// scheme/host/query/fragment check left the suite green.
+//
+// The four rejected shapes are the four disjuncts of that check, one each, so a
+// partial weakening is caught rather than only wholesale deletion. The accepted
+// case is the control: without it a guard that rejected EVERYTHING would pass.
+func TestNewClientRejectsUnusableBaseURL(t *testing.T) {
+	t.Parallel()
+
+	for _, base := range []string{
+		"ftp://example.invalid",        // scheme
+		"https://",                     // host
+		"https://example.invalid?a=b",  // query
+		"https://example.invalid#frag", // fragment
+	} {
+		if _, err := NewClient(testAPIKey, Options{BaseURL: base}); err == nil {
+			t.Errorf("NewClient(BaseURL=%q) succeeded, want rejection", base)
+		}
+	}
+	if _, err := NewClient(testAPIKey, Options{BaseURL: "https://example.invalid/api/"}); err != nil {
+		t.Errorf("NewClient with a usable base URL failed: %v", err)
+	}
+}
+
+// TestNewClientRejectsNegativeRequestTimeout covers the #1650 M11 mutant.
+//
+// Zero is NOT an error - it selects DefaultRequestTimeout - so the negative case
+// is the only one that reaches the guard, and asserting zero succeeds keeps a
+// future "timeout <= 0" from passing this test while breaking the default.
+func TestNewClientRejectsNegativeRequestTimeout(t *testing.T) {
+	t.Parallel()
+
+	if _, err := NewClient(testAPIKey, Options{RequestTimeout: -time.Second}); err == nil {
+		t.Error("NewClient(RequestTimeout=-1s) succeeded, want rejection")
+	}
+	if _, err := NewClient(testAPIKey, Options{RequestTimeout: 0}); err != nil {
+		t.Errorf("NewClient(RequestTimeout=0) failed, want the default: %v", err)
+	}
+}
+
+// TestCreateRejectsMalformedCreateResponse covers the #1650 M8 mutant: a 201
+// whose body omits sandboxID. Deleting the guard left the suite green because
+// every existing Create test returns a well-formed body.
+//
+// A 201 is the point: the transport succeeded and the status is success, so
+// nothing but this guard stands between a malformed body and a Sandbox with an
+// empty ID flowing on to callers.
+func TestCreateRejectsMalformedCreateResponse(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		_, _ = w.Write([]byte(`{"templateID":"template-a","clientID":"c1"}`))
+	}))
+	defer server.Close()
+
+	client, err := NewClient(testAPIKey, Options{BaseURL: server.URL})
+	if err != nil {
+		t.Fatalf("NewClient returned error: %v", err)
+	}
+	sandbox, _, err := client.Create(context.Background(), "template-a", time.Minute, CreateOptions{})
+	if err == nil {
+		t.Fatalf("Create accepted a 201 with no sandboxID, returning %+v", sandbox)
+	}
+	if !strings.Contains(err.Error(), "missing sandboxID") {
+		t.Errorf("Create error = %v, want it to name the missing sandboxID", err)
+	}
+}
+
+// TestResponseTotalRunningRejectsDuplicateHeaders covers the #1650 M9 mutant,
+// the cardinality arm of the X-Total-Running check.
+//
+// Duplicate headers are the untested arm: with two values the pre-mutation code
+// refuses, while the mutant silently reads the FIRST and discards the second -
+// so a provider sending two different counts would be believed. The single-value
+// and absent cases are controls that keep this from passing a guard that refuses
+// everything.
+func TestResponseTotalRunningRejectsDuplicateHeaders(t *testing.T) {
+	t.Parallel()
+
+	duplicated := http.Header{}
+	duplicated.Add("X-Total-Running", "3")
+	duplicated.Add("X-Total-Running", "9")
+	if _, _, err := responseTotalRunning(duplicated); err == nil {
+		t.Error("responseTotalRunning accepted duplicate X-Total-Running headers")
+	}
+
+	single := http.Header{}
+	single.Add("X-Total-Running", "3")
+	total, ok, err := responseTotalRunning(single)
+	if err != nil || !ok || total != 3 {
+		t.Errorf("responseTotalRunning(single) = (%d, %v, %v), want (3, true, nil)", total, ok, err)
+	}
+
+	if total, ok, err := responseTotalRunning(http.Header{}); err != nil || ok || total != 0 {
+		t.Errorf("responseTotalRunning(absent) = (%d, %v, %v), want (0, false, nil)", total, ok, err)
+	}
+}


### PR DESCRIPTION
Closes #1650.

## What was measured, before writing anything

All four guards named in #1650 are correct code that no test reached. Each mutant compiles, changes production behaviour, and starts from a passing baseline:

```
baseline  ok  github.com/gitmoot/gitmoot/internal/execbackend/e2b  0.235s

M8  accept a 201 with no sandboxID      SURVIVED (guard is inert)
M9  accept duplicate X-Total-Running    SURVIVED (guard is inert)
M10 accept any base URL                 SURVIVED (guard is inert)
M11 accept a negative timeout           SURVIVED (guard is inert)
```

## After this change, the identical mutants

```
M8  KILLED by TestCreateRejectsMalformedCreateResponse
M9  KILLED by TestResponseTotalRunningRejectsDuplicateHeaders
M10 KILLED by TestNewClientRejectsUnusableBaseURL
M11 KILLED by TestNewClientRejectsNegativeRequestTimeout
```

Same four mutants, same script, tree restored clean after each run.

## Why the corpus was the defect, not the assertions

The issue's framing is that each guard is semantically dead. Reading the corpus line before the assertion, in every case the guard was unreachable from the tests that existed rather than wrongly written:

- **M8** every existing `Create` test returns a well-formed body, so no test produced a 201 the guard could reject.
- **M9** every existing header test sets `X-Total-Running` exactly once, so the cardinality arm had no input. The value arm was covered; the count arm was not.
- **M10** and **M11** every existing client is built with `Options{}` or a `BaseURL` from `httptest`, so neither validator ever saw a bad argument.

That is a population gap, not a logic gap, which is why deleting the code left the suite green.

## Test design

Each test is written **against the mutant that survived**, not against the guard's text, so it fails when the guard is deleted rather than when its wording changes.

- **M10** rejects the four disjuncts one at a time - scheme, host, query, fragment - so a *partial* weakening is caught rather than only wholesale deletion.
- **M11** asserts that a zero timeout **succeeds**, because zero selects `DefaultRequestTimeout`. Without that arm a future `timeout <= 0` would pass the test while breaking the default.
- **M9** and **M10** both carry a positive control (a valid single header, a usable base URL) so a guard that refused *everything* could not pass.
- **M9** is tested at the function rather than through a server, because `responseTotalRunning` is where the cardinality decision lives and a server round-trip would add a second failure mode to a single-purpose assertion.

## Scope

Tests only. **No production code changed** - the four guards were already correct, which is why the issue records them as inert rather than broken.

## Not claimed

The eight mutants that #1650 reports as already killed were not re-run; this PR addresses the four survivors only. The `Gone`/`autoPause` safety case that PR #1636's round 10 was about is untouched.


---

## Merge note: the six safeguards, with 4 and 6 answered by hand

Checked immediately before enqueueing.

1. **OPEN, MERGEABLE, CLEAN, every check succeeded.** 27 non-gate contexts, 0 not successful. `mergeState=UNSTABLE` is `gitmoot/merge-gate=PENDING`, which is excluded structurally: the only path posting success on that context sits below `if !result.Merged { return g.pending(...) }` (`merge_gate.go:443`), so a pre-merge success is unreachable by construction, and production skips it unconditionally in both loops (`:2333`, `:2360`). `mergeable=MERGEABLE` is not relaxed.
2. **A review job succeeded with `decision=approved` at this exact head** `bf0163c3` - job `local-review-gm-review-opus-18d3dd40896a7806-1`.
3. **Non-empty `tests_run`**: 13 executed entries, 1620 bytes, including a **pre-PR baseline** run of the parent commit's test file - the reviewer established green before as well as after.
4. **The reviewer is neither the implementer nor the lead.** Reviewer `gm-review-opus`; implementer `gm-findings` (this seat); lead recorded on the review payload as `gm-omp-impl`. Three distinct identities. I did not dispatch this review - it was already present at my head when I went to request one, and the loop guard refused my duplicate dispatch, which is how I found it.
5. **Head and checks re-read immediately before enqueueing**, not from an earlier observation.
6. **Attribution gap, named rather than skipped.** `implement rows=0`. This PR was implemented in-session, so no implement job exists and no row is head-bound. Per #1990 the caller-asserted head is display-only and is not stored in the job payload, so an in-session implementation is honest about *who* and permanently silent about *which head*. That is a disclosure, not a check that passed.

Enqueued through the merge queue rather than merged directly.
