### PR TITLE
feat(cli): reconcile off-box instances on a cadence, not once per process (#1539)

### DIFF
--- a/internal/cli/daemon_scheduler.go
+++ b/internal/cli/daemon_scheduler.go
@@ -1670,6 +1670,17 @@ func runDaemonWorkerTickTracked(ctx context.Context, store *db.Store, worker job
 	if err := sweepBlockedTaskWakeEvents(ctx, store, workflowHome, repoFilter, cand.config.blockedRoleWakeAfter(workflowHome), stdout, now); err != nil {
 		writeLine(stdout, "blocked_since task sweep failed: %v", err)
 	}
+	// Periodic off-box reconciliation (#1539). Before this, reconciliation ran
+	// ONCE PER PROCESS at backend construction, so an instance orphaned while a
+	// long-lived daemon kept running was not reconciled until the next restart -
+	// an unbounded window with only the provider-side TTL underneath it. Failure
+	// is LOGGED AND SWALLOWED like the sweeps above, and the pass carries its own
+	// advance-on-success back-off so a failing provider is polled less rather
+	// than every tick. The construction-time reap stays FAIL-CLOSED on purpose;
+	// the reason is recorded in execbackend_reconcile.go.
+	if err := reconcileExecBackendInventory(ctx, worker, stdout, now); err != nil {
+		writeLine(stdout, "execution backend reconciliation failed: %v", err)
+	}
 	// Checkout-mutating maintenance (advancement/merge retries, delegation
 	// worktree reclaims) is gated on the ACTUAL mutation hazard — each
 	// candidate is skipped while an in-flight job holds the checkout key the

--- a/internal/cli/execbackend_lifecycle.go
+++ b/internal/cli/execbackend_lifecycle.go
@@ -49,6 +49,15 @@ func (w jobWorker) defaultExecutionBackend(backend execbackend.Backend, cfg conf
 		// Reap once per resolved root in this process. A restarted daemon has a
 		// fresh map and therefore reconciles the prior process's instances before
 		// provisioning its first new job.
+		//
+		// THIS PATH IS FAIL-CLOSED ON PURPOSE and must stay that way: a reap
+		// failure below aborts backend construction, and therefore the dispatch
+		// that triggered it. Double-running a job against a live instance the
+		// previous process left behind is unrecoverable; refusing one dispatch is
+		// not. The PERIODIC pass in execbackend_reconcile.go has the OPPOSITE
+		// polarity - log-and-continue - because there the risk is a provider
+		// outage becoming a gitmoot outage, and the restart invariant is already
+		// held here (#1539). Do not align one with the other.
 		rootKey := string(backend) + "|" + root
 		if _, loaded := reapedExecutionBackendRoots.LoadOrStore(rootKey, struct{}{}); !loaded {
 			var reaper execbackend.Reaper = local

--- a/internal/cli/execbackend_reconcile.go
+++ b/internal/cli/execbackend_reconcile.go
@@ -89,6 +89,24 @@ func reconcileExecBackendInventory(ctx context.Context, worker jobWorker, stdout
 	if err != nil {
 		return fmt.Errorf("resolve execution backend for reconciliation: %w", err)
 	}
+	// THE CADENCE KEY IS THE BACKEND, AND THAT IS DELIBERATE ON TWO AXES.
+	//
+	// Across REPOS: runDaemonWorkerTickTracked runs per repo, so several ticks
+	// share one cadence entry - which is correct rather than starvation, because
+	// reconciliation is provider-global by construction.
+	// ListRecoverableExecBackendAttempts filters on `provider = ?` ALONE and the
+	// execbackend_attempts table has NO repo column, so one pass already covers
+	// every repo's attempts. Keying per repo would multiply identical provider
+	// inventory reads by the repo count for no added coverage.
+	//
+	// Across PROVIDER TARGETS: the construction guard keys finer -
+	// `backend|root` for local and `backend|baseURL|sha256(apiKey)` for remote -
+	// because it also runs from non-daemon callers. Within one daemon those
+	// dimensions are PROCESS CONSTANTS: RemoteExecConfig is loaded per home
+	// (config.LoadRemoteExecConfig(paths)) and a daemon has one home, so its
+	// local root and its E2B base URL and key cannot vary between ticks. If a
+	// daemon ever serves multiple homes or accounts, this key must gain those
+	// dimensions or one target will suppress another's pass.
 	key := string(backend)
 	if !execBackendReconcileState.due(key, now) {
 		return nil

--- a/internal/cli/execbackend_reconcile.go
+++ b/internal/cli/execbackend_reconcile.go
@@ -1,0 +1,121 @@
+package cli
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"sync"
+	"time"
+
+	"github.com/gitmoot/gitmoot/internal/execbackend"
+)
+
+// execBackendReconcileBaseInterval is the steady-state cadence for the periodic
+// off-box reconciliation pass (#1539). It is deliberately far slower than the
+// worker tick: a provider inventory read is a paid, rate-limited network call,
+// and the pass exists to bound how long an orphan can hold state, not to detect
+// one promptly. The provider-side hard TTL set at creation remains the primary
+// fail-safe and is unaffected by this cadence.
+const execBackendReconcileBaseInterval = 5 * time.Minute
+
+// TWO POLARITIES IN ONE SUBSYSTEM, ON PURPOSE. Do not "fix" one to match the
+// other; #1539 asks for both.
+//
+//   - AT BACKEND CONSTRUCTION (execbackend_lifecycle.go) a reap failure is
+//     FAIL-CLOSED: it aborts construction and the dispatch that triggered it, so
+//     a restarted daemon cannot provision before reconciling the previous
+//     process's instances. Double-running a job against a live remote instance is
+//     unrecoverable; refusing one dispatch is not.
+//   - ON THE WORKER TICK (this file) a failure is LOG-AND-CONTINUE, matching
+//     every other maintenance step in runDaemonWorkerTickTracked. A transient
+//     provider read must not stop the daemon's other sweeps or its dispatch.
+//     #1539: "back-off cadence (advance-on-success), log-and-continue (never
+//     abort the tick)".
+//
+// The asymmetry is the point: one path guards against double-execution at the
+// only moment it can happen, the other guards against a provider outage becoming
+// a gitmoot outage.
+type execBackendReconcileCadence struct {
+	mu     sync.Mutex
+	nextAt map[string]time.Time
+	streak map[string]int
+}
+
+var execBackendReconcileState = &execBackendReconcileCadence{
+	nextAt: map[string]time.Time{},
+	streak: map[string]int{},
+}
+
+// due reports whether key's next attempt is owed at now. An unseen key is due
+// immediately, so a freshly started daemon reconciles on its first tick rather
+// than waiting out a full interval.
+func (c *execBackendReconcileCadence) due(key string, now time.Time) bool {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	next, seen := c.nextAt[key]
+	return !seen || !now.Before(next)
+}
+
+// succeeded resets the back-off: ADVANCE ON SUCCESS. A provider that recovers
+// returns to the steady cadence immediately instead of serving out a penalty it
+// no longer deserves.
+func (c *execBackendReconcileCadence) succeeded(key string, now time.Time) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.streak[key] = 0
+	c.nextAt[key] = now.Add(execBackendReconcileBaseInterval)
+}
+
+// failed lengthens the interval for key using the daemon's existing streak
+// back-off, so a persistently failing provider is polled less rather than every
+// tick. It returns the interval actually applied for logging.
+func (c *execBackendReconcileCadence) failed(key string, now time.Time) time.Duration {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.streak[key]++
+	interval := repoBackoffInterval(execBackendReconcileBaseInterval, c.streak[key])
+	c.nextAt[key] = now.Add(interval)
+	return interval
+}
+
+// reconcileExecBackendInventory runs one periodic bidirectional reconciliation
+// pass when the configured backend exposes a provider inventory.
+//
+// It returns an error only so the caller can log it in the tick's existing
+// idiom; the caller MUST NOT abort on it. A backend with no inventory (the local
+// backend) is a no-op, not a failure: there is nothing off-box to reconcile.
+func reconcileExecBackendInventory(ctx context.Context, worker jobWorker, stdout io.Writer, now time.Time) error {
+	backend, cfg, err := daemonJobExecBackendFor(worker, "", false)
+	if err != nil {
+		return fmt.Errorf("resolve execution backend for reconciliation: %w", err)
+	}
+	key := string(backend)
+	if !execBackendReconcileState.due(key, now) {
+		return nil
+	}
+	if worker.ExecutionBackendFactory == nil {
+		return nil
+	}
+	built, err := worker.ExecutionBackendFactory(backend, cfg)
+	if err != nil {
+		interval := execBackendReconcileState.failed(key, now)
+		return fmt.Errorf("build execution backend %q for reconciliation (next attempt in %s): %w", backend, interval, err)
+	}
+	reaper, ok := built.(execbackend.InventoryReaper)
+	if !ok {
+		// No provider inventory to read. Record success so a local-only daemon
+		// does not re-resolve the backend on every single tick.
+		execBackendReconcileState.succeeded(key, now)
+		return nil
+	}
+	report, err := reaper.ReapInventory(ctx)
+	if err != nil {
+		interval := execBackendReconcileState.failed(key, now)
+		return fmt.Errorf("reconcile execution backend %q inventory (next attempt in %s): %w", backend, interval, err)
+	}
+	execBackendReconcileState.succeeded(key, now)
+	if len(report.Destroyed) > 0 {
+		writeLine(stdout, "execution backend reconciliation: destroyed %d orphaned instance(s) on %s", len(report.Destroyed), backend)
+	}
+	return nil
+}

--- a/internal/cli/execbackend_reconcile_test.go
+++ b/internal/cli/execbackend_reconcile_test.go
@@ -1,0 +1,78 @@
+package cli
+
+import (
+	"testing"
+	"time"
+)
+
+// TestExecBackendReconcileCadenceAdvancesOnSuccess pins the cadence contract
+// #1539 asks for. Before this change reconciliation ran ONCE PER PROCESS at
+// backend construction, so there was no cadence to get wrong; the failure this
+// guards is a provider outage turning into a per-tick hot loop, or a recovered
+// provider serving out a penalty it no longer deserves.
+func TestExecBackendReconcileCadenceAdvancesOnSuccess(t *testing.T) {
+	cadence := &execBackendReconcileCadence{nextAt: map[string]time.Time{}, streak: map[string]int{}}
+	now := time.Date(2026, 9, 10, 5, 0, 0, 0, time.UTC)
+	const key = "remote"
+
+	// An unseen backend is due immediately: a freshly started daemon must
+	// reconcile on its first tick rather than waiting out a full interval.
+	if !cadence.due(key, now) {
+		t.Fatal("an unseen backend is not due; a restarted daemon would wait a full interval before reconciling")
+	}
+
+	cadence.succeeded(key, now)
+	if cadence.due(key, now.Add(execBackendReconcileBaseInterval-time.Second)) {
+		t.Fatal("backend is due before the base interval elapsed; the pass would run on consecutive ticks")
+	}
+	if !cadence.due(key, now.Add(execBackendReconcileBaseInterval)) {
+		t.Fatal("backend is not due at the base interval; the cadence would never fire again")
+	}
+
+	// A failure must push the next attempt strictly FURTHER OUT than the steady
+	// cadence, or a persistently failing provider is polled every tick.
+	failedAt := now.Add(execBackendReconcileBaseInterval)
+	first := cadence.failed(key, failedAt)
+	if first <= execBackendReconcileBaseInterval {
+		t.Fatalf("first failure interval %s is not longer than the base %s; a failing provider would be polled at the steady rate", first, execBackendReconcileBaseInterval)
+	}
+	second := cadence.failed(key, failedAt)
+	if second < first {
+		t.Fatalf("second failure interval %s is shorter than the first %s; the back-off is not monotonic", second, first)
+	}
+
+	// ADVANCE ON SUCCESS: one success clears the whole penalty rather than
+	// decaying it, so a provider that recovers returns to the steady cadence.
+	cadence.succeeded(key, failedAt)
+	if cadence.due(key, failedAt.Add(execBackendReconcileBaseInterval-time.Second)) {
+		t.Fatal("due before the base interval after recovery")
+	}
+	if !cadence.due(key, failedAt.Add(execBackendReconcileBaseInterval)) {
+		t.Fatalf("after a success the next attempt is still backed off past the base interval %s; the provider is serving a penalty it no longer deserves", execBackendReconcileBaseInterval)
+	}
+
+	// THE STREAK ITSELF MUST BE ZEROED, not decayed, and that is only observable
+	// on the NEXT failure: succeeded() sets nextAt unconditionally, so asserting
+	// on due() alone cannot tell a reset from a decrement. A mutant replacing the
+	// reset with `streak--` survived until this assertion existed.
+	afterRecovery := cadence.failed(key, failedAt)
+	if afterRecovery != first {
+		t.Fatalf("first failure after a success backs off %s, want the fresh-failure interval %s; the success decayed the streak instead of clearing it, so a flapping provider ratchets", afterRecovery, first)
+	}
+}
+
+// TestExecBackendReconcileCadenceIsPerBackend keeps one failing backend from
+// suppressing another's reconciliation - the cadence is keyed, and a shared
+// timer would silently couple them.
+func TestExecBackendReconcileCadenceIsPerBackend(t *testing.T) {
+	cadence := &execBackendReconcileCadence{nextAt: map[string]time.Time{}, streak: map[string]int{}}
+	now := time.Date(2026, 9, 10, 5, 0, 0, 0, time.UTC)
+
+	cadence.failed("remote", now)
+	if !cadence.due("local", now) {
+		t.Fatal("a failure on one backend made another backend not due; the cadence is not keyed per backend")
+	}
+	if cadence.due("remote", now) {
+		t.Fatal("the failing backend is still due immediately; its back-off was not recorded")
+	}
+}


### PR DESCRIPTION
Addresses gitmoot#1539 (P3b, epic gitmoot#1529). **Must land before any cloud provider**, per that issue's first line.

## What was actually missing

Seven of #1539's eight scope bullets are already implemented - they landed via #1576/#1577 and the wiring that followed, and the issue's own thread still says the durable half is "unwired", which is out of date. I verified each at the deciding code and posted that assessment on the issue rather than rebuilding what exists.

Two bullets remained:

**G1 - reconciliation ran ONCE PER PROCESS.** `execbackend_lifecycle.go` guards the reap with `reapedExecutionBackendRoots.LoadOrStore` at **backend construction** ("Reap once per resolved root in this process"), and nothing in `daemon_scheduler.go` scheduled it. That satisfies "a daemon restart reconciles" and leaves "back-off cadence (advance-on-success)" unmet: an instance orphaned while a long-lived daemon keeps running was not reconciled until the next process start - an unbounded window with only the provider-side TTL beneath it.

**G2 - a reap failure aborted backend construction**, the opposite of the issue's "log-and-continue (never abort the tick)". A transient provider read failed the dispatch that triggered it.

## The change

One periodic pass in `runDaemonWorkerTickTracked`, in the tick's existing idiom - log and continue, like the `blocked_ttl` and `blocked_since` sweeps immediately above it. Back-off reuses the daemon's existing `repoBackoffInterval` streak helper rather than adding a second cadence primitive, and is **keyed per backend** so one failing provider cannot suppress another's reconciliation.

**No new table, no new state, no new store query.** `orphaned` and `ListRecoverableExecBackendAttempts` already suffice, and `reconcileInventory` already performs both reconciliation directions.

A backend that does not implement `execbackend.InventoryReaper` records **success**, so a local-only daemon neither errors every tick nor re-resolves its backend every tick.

## The asymmetry, and why it is defended at both sites

| Path | Polarity | Reason |
|---|---|---|
| backend construction | **fail-closed** | double-running a job against an instance the previous process left live is unrecoverable; refusing one dispatch is not |
| worker tick | **log-and-continue** | a provider outage must not become a gitmoot outage, and the restart invariant is already held at construction |

Same subsystem, opposite polarities, both correct. A comment at **each** site states the reason and says not to align one with the other. Written down deliberately: a deliberate value with no recorded why becomes a preference somebody deletes.

## Verification

`go build ./...` 0, `go vet ./internal/cli` 0, targeted tests green.

Three arms, three **compiling semantic** mutants from a passing baseline: unseen-key-not-due (a restarted daemon would wait a full interval) dies; a shared, unkeyed timer dies; and -

**Mutant A survived the first version, and the test was the defect.** Replacing the advance-on-success reset with `streak--` passed, because `succeeded()` sets `nextAt` unconditionally - so asserting on `due()` cannot distinguish a reset from a decay. The difference is only observable on the **next** failure. The added assertion pins it and now fails with `backs off 20m0s, want the fresh-failure interval 10m0s`, i.e. a flapping provider's cadence would creep upward forever.

## Coordination and scope

- `execbackend_ledger.go` is split by function under jarvis coordination receipt 130281: `gm-integrity` owns `Provision`, cost accounting and migrations; I own `teardown`, `Reap`, `reconcileInventory`. **This PR touches none of that file** - the change is in `daemon_scheduler.go` plus a new `execbackend_reconcile.go`.
- `gm-integrity` merges first on the shared file; I rebase behind them. Their #1540 dependency on this cadence is **operational, not textual** - the merges are not coupled.
- **Not done deliberately:** `ListExecBackendAttemptsWithoutSandboxID` is dead code (recorded as #2127). It lives in `internal/db/store_execbackend_attempts.go`, gm-integrity's exclusive region, and I told them I would not touch it. The boundary says stop and say so rather than make a small edit there.

## Not claimed

**This does not make #1540's cost cap operable by itself, and it is not a cloud-readiness claim.** It closes two of #1539's bullets; the campaign gate on P5 (#1542) remains both this and #1540. I also have not exercised this against a real provider - there is no cloud account in play - so the pass is verified against the cadence contract and the tick's error policy, not against E2B inventory behaviour.

**Merge note:** merge authority for this seat is `merge_rule: self`, exercised only under the six safeguards and only after one substantive independent review at the exact head; I do not self-review.


---

## Merge note

Enqueued by `gm-transport` under `merge_rule: self`, read at enqueue time from the durable surfaces rather than from a briefing prompt: `gitmoot org brief --role gm-transport` reports `merge_rule: self` and `gitmoot org chart` reports `merge=self`. (Two sibling seats acted on a prose-restated `none` tonight; #2133 has the cause. Rendering it from config is the reason this note names the command.)

Owner standing-delegation row 107983's six safeguards, each re-read immediately before this enqueue:

1. **Open, mergeable, clean, every check succeeded.** `state: open`, `draft: false`, `mergeable: true`, `mergeable_state: clean`; 27 of 27 success, **0 failing, 0 cancelled, 0 pending** at head `b001addc8b21ea5749987166bf3476e5d876e5f2`.
2. **Approved at that exact head.** Job `local-review-gm-review-opus-18d3de97f9c1bf6f-1`, `decision: approved`, `head_sha b001addc…`, `evidence: executed`.
3. **`tests_run` is non-empty and names commands with results** - 8 entries, 1946 bytes, **zero empty**. Checked as fields, not as prose: entries 1-3 are `go build`, `go vet` and the targeted test with outcomes; entry 4 is an **independent mutation-testing reproduction** in an isolated scratch module, killing the `streak--` mutant plus a guarded decrement and a halving decay; entry 7 traces the schema and query behind my cadence-key premise; entry 8 honestly records that two full-package runs did not finish in sandbox time, so full-suite health rests on CI's 27/27 rather than the reviewer's local run.
4. **Reviewer is neither implementer nor lead.** Reviewer `gm-review-opus`; `lead_agent: gm-omp-impl`; implementing lane `gm-transport`.
5. **Immediate pre-enqueue re-read**, in this command sequence. `mergeable_state` first returned `unknown` while GitHub recomputed after main moved; I waited for it to settle rather than enqueueing on an unknown.
6. **Attribution gap, named.** In-session implementation, so no engine implement job exists. Durable attribution is `session-implement-gm-transport-18d3e07a2298dd2a`, `acting_org_role: gm-transport`, `decision: implemented` - recorded with `--acting-role` because `gm-transport` is not a registered agent. No row names the coordinator and none names the reviewer.

### The head this note refers to, stated because the row cannot carry it

**`b001addc8b21ea5749987166bf3476e5d876e5f2`.** Per #2130, `--head-sha` on `job record` is display metadata only and is not persisted - 428 of 428 rows empty. I verified it on my own row with three instruments: the payload has no `head_sha` key, `gitmoot job show` shows none, and `--json` shows none at top level either. So the head lives in this sentence, not in the attribution row.

### Base has drifted, and the queue is the instrument

The PR's base is `ac88e058`; main is now `85ca41b6`. The reviewer flagged the first drift (`e7058719`, gitmoot#2126, test-only, zero file overlap) as **informational and non-blocking**, and GitHub reports `mergeable: true` / `clean`. So the 27/27 above describes `merge(head, ac88e058)` rather than today's landing tree, and the merge queue re-tests the real merge at the front. Not rebased to chase it: main moved twice during this enqueue alone.

### The reviewer's two findings, both non-blocking, neither deferred silently

- **Informational:** the base drift above.
- **Low severity:** `execBackendReconcileState` is a package-level singleton shared across the `internal/cli` test binary. The reviewer verified by grep that no current test combines a real `ExecutionBackendFactory` with a call through `runDaemonWorkerTickTracked`, so there is **no live cross-test pollution today** - the risk is a future test. I am not fixing it in this PR: the two cadence tests already construct their own `execBackendReconcileCadence` rather than touching the singleton, so the pollution surface is a test that does not exist yet. Recorded here so the next author of such a test sees it.
