### PR TITLE
feat(execbackend): hard compute-dollar cap, reserve before provision (#1540)

### DIFF
--- a/internal/cli/execbackend_confirmed_destroy_test.go
+++ b/internal/cli/execbackend_confirmed_destroy_test.go
@@ -1,0 +1,103 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"testing"
+
+	"github.com/gitmoot/gitmoot/internal/db"
+	"github.com/gitmoot/gitmoot/internal/execbackend"
+)
+
+// A provider-CONFIRMED destroy must land in `destroyed`; an INCONCLUSIVE
+// observation must stay `orphaned` (#2147).
+//
+// This runs the production path - backend.ReapInventory - rather than calling
+// the reconciler directly, because the defect was in which store transition the
+// reconciler chose and a direct call would let the test pick the transition it
+// wants to see.
+//
+// Why the STATE is the right observable for "releases the reservation": the
+// budget consequence is keyed on the attempt state, so `destroyed` is
+// non-billing and `orphaned` holds its reservation. On current main no cap query
+// exists (that arrives with #2129), so asserting the state is asserting exactly
+// the property the cap will read - and it is the property the old code got
+// backwards.
+func TestReapInventoryConfirmedDestroyReleasesAndInconclusiveDoesNot(t *testing.T) {
+	for _, test := range []struct {
+		name      string
+		report    func(sandboxID string) execbackend.ReapReport
+		wantState string
+	}{
+		{
+			// Positive evidence: the provider told us this sandbox is gone.
+			name: "provider confirmed the destroy",
+			report: func(sandboxID string) execbackend.ReapReport {
+				return execbackend.ReapReport{
+					InventoryObserved: true,
+					InventoryComplete: true,
+					Destroyed:         []string{sandboxID},
+				}
+			},
+			wantState: db.ExecBackendAttemptStateDestroyed,
+		},
+		{
+			// Absence of evidence: a complete inventory that simply does not list
+			// the sandbox. Potentially-live is the safe reading, so this one must
+			// NOT be released.
+			name: "sandbox absent from a complete inventory",
+			report: func(string) execbackend.ReapReport {
+				return execbackend.ReapReport{
+					InventoryObserved: true,
+					InventoryComplete: true,
+				}
+			},
+			wantState: db.ExecBackendAttemptStateOrphaned,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			store := openExecBackendLedgerTestStore(t)
+			const sandboxID = "sandbox-confirmed"
+			key := seedRunningExecBackendAttempt(t, store, "job-confirmed", sandboxID, "fence-current", "boot-current")
+			inner := &ledgerTestBackend{report: test.report(sandboxID)}
+			var output bytes.Buffer
+			backend := newExecBackendLedgerForTest(t, store, inner, &output, "fence-current", "boot-current")
+
+			if _, err := backend.ReapInventory(context.Background()); err != nil {
+				t.Fatalf("ReapInventory returned error: %v", err)
+			}
+			if got := execBackendAttemptForTest(t, store, key).State; got != test.wantState {
+				t.Fatalf("attempt state = %q, want %q", got, test.wantState)
+			}
+		})
+	}
+}
+
+// The first write is the only write, so recording the wrong state is permanent.
+//
+// transitionExecBackendAttemptToTerminal accepts only reserved, provisioning,
+// running, collecting and destroying as SOURCE states, so an attempt written as
+// `orphaned` can never be corrected to `destroyed` afterwards - not by the next
+// reconciliation pass, not by a manual reap. This pins that, because it is the
+// reason the fix has to be right on the first write rather than eventually
+// consistent, and a future change that made orphaned repairable would make the
+// whole urgency of #2147 obsolete and should have to update this test.
+func TestOrphanedExecBackendAttemptHasNoRepairPath(t *testing.T) {
+	ctx := context.Background()
+	store := openExecBackendLedgerTestStore(t)
+	key := seedRunningExecBackendAttempt(t, store, "job-orphan", "sandbox-orphan", "fence", "boot")
+
+	if changed, err := store.MarkExecBackendAttemptOrphaned(ctx, key); err != nil || !changed {
+		t.Fatalf("mark orphaned: changed=%v err=%v", changed, err)
+	}
+	changed, err := store.MarkExecBackendAttemptDestroyed(ctx, key, 0)
+	if err != nil {
+		t.Fatalf("mark destroyed after orphaned returned error: %v", err)
+	}
+	if changed {
+		t.Fatal("an orphaned attempt was transitioned to destroyed; orphaned is documented as terminal-unreachable and #2147's first-write requirement depends on that")
+	}
+	if got := execBackendAttemptForTest(t, store, key).State; got != db.ExecBackendAttemptStateOrphaned {
+		t.Fatalf("attempt state = %q, want orphaned to be unchanged", got)
+	}
+}

--- a/internal/cli/execbackend_cost.go
+++ b/internal/cli/execbackend_cost.go
@@ -1,0 +1,29 @@
+package cli
+
+import (
+	"github.com/gitmoot/gitmoot/internal/config"
+	"github.com/gitmoot/gitmoot/internal/db"
+)
+
+// execBackendStoreCap converts the compute-dollar configuration into the
+// store-side admission policy (#1540).
+//
+// It lives here rather than as a method on config because internal/db imports
+// internal/config, so the reverse direction is an import cycle. The conversion
+// is the only place the two shapes meet, and it FAILS CLOSED: Configured is set
+// only when Admits reports true, so an absent, malformed or partially filled
+// configuration reaches the store as a deny rather than as a permissive zero.
+func execBackendStoreCap(cfg config.ExecBackendCostConfig) db.ExecBackendCostCap {
+	if err := cfg.Validate(); err != nil {
+		return db.ExecBackendCostCap{DenyReason: err.Error()}
+	}
+	if admits, why := cfg.Admits(); !admits {
+		return db.ExecBackendCostCap{DenyReason: why}
+	}
+	return db.ExecBackendCostCap{
+		Configured:     true,
+		MaxReservedUSD: cfg.MaxReservedUSD,
+		MaxConcurrent:  cfg.MaxConcurrent,
+		PerAttemptUSD:  cfg.PerAttemptUSD,
+	}
+}

--- a/internal/cli/execbackend_cost_test.go
+++ b/internal/cli/execbackend_cost_test.go
@@ -1,0 +1,165 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gitmoot/gitmoot/internal/execbackend"
+
+	"github.com/gitmoot/gitmoot/internal/config"
+	"github.com/gitmoot/gitmoot/internal/db"
+)
+
+// TestExecBackendStoreCapFailsClosed pins that a configuration which cannot
+// admit reaches the store as a DENY rather than as a permissive zero. The
+// partial cases matter most: a deployment that sets a ceiling but forgets the
+// per-attempt amount would otherwise reserve $0 per attempt and pass any dollar
+// cap forever, which is the state on main today.
+func TestExecBackendStoreCapFailsClosed(t *testing.T) {
+	for name, cfg := range map[string]config.ExecBackendCostConfig{
+		"absent":               {},
+		"ceiling only":         {MaxReservedUSD: 100},
+		"per-attempt only":     {PerAttemptUSD: 1},
+		"negative ceiling":     {MaxReservedUSD: -1, PerAttemptUSD: 1},
+		"negative per-attempt": {MaxReservedUSD: 100, PerAttemptUSD: -1},
+	} {
+		if got := execBackendStoreCap(cfg); got.Configured {
+			t.Errorf("%s: cap reached the store as Configured=true (%+v), want a deny", name, got)
+		}
+	}
+	full := config.ExecBackendCostConfig{MaxReservedUSD: 100, PerAttemptUSD: 0.5, MaxConcurrent: 4}
+	got := execBackendStoreCap(full)
+	want := db.ExecBackendCostCap{Configured: true, MaxReservedUSD: 100, PerAttemptUSD: 0.5, MaxConcurrent: 4}
+	if got != want {
+		t.Fatalf("complete configuration converted to %+v, want %+v", got, want)
+	}
+}
+
+// TestLedgeredBackendPersistsTheConfiguredReservation is the regression for the
+// defect this issue names: the only production writer passed the literal 0, so
+// every reservation reserved nothing and no dollar cap could ever bind.
+//
+// It drives the real backend and reads the PERSISTED ROW. An earlier version of
+// this test asserted on the config converter instead and survived a mutant that
+// restored the literal - a test named after a behaviour it never exercised.
+func TestLedgeredBackendPersistsTheConfiguredReservation(t *testing.T) {
+	store := openExecBackendLedgerTestStore(t)
+	var output bytes.Buffer
+	inner := &ledgerTestBackend{}
+	policy := execBackendStoreCap(config.ExecBackendCostConfig{MaxReservedUSD: 10, PerAttemptUSD: 2.5})
+	backend, err := newLedgeredExecutionBackend(store, inner, e2bAttemptProvider, "fence", "boot", &output, policy)
+	if err != nil {
+		t.Fatal(err)
+	}
+	scope := execbackend.JobScope{JobID: "cost-job", Attempt: 1, TTL: time.Minute}
+	if _, err := backend.Provision(context.Background(), scope); err != nil {
+		t.Fatalf("Provision: %v", err)
+	}
+	attempt := execBackendAttemptForTest(t, store, db.ExecBackendAttemptKey{JobID: "cost-job", Attempt: 1})
+	if attempt.CostReservedUSD == nil {
+		t.Fatal("no cost was reserved for a provisioned attempt")
+	}
+	if *attempt.CostReservedUSD != 2.5 {
+		t.Fatalf("persisted cost_reserved_usd = %v, want 2.5 (a zero here means no dollar cap can ever bind)", *attempt.CostReservedUSD)
+	}
+}
+
+// TestLedgeredBackendRefusesWhenTheCapIsFull proves the gate reaches the real
+// provisioning path: the provider must never be called for a refused attempt.
+func TestLedgeredBackendRefusesWhenTheCapIsFull(t *testing.T) {
+	store := openExecBackendLedgerTestStore(t)
+	var output bytes.Buffer
+	provisions := 0
+	inner := &ledgerTestBackend{provision: func(execbackend.JobScope) (*execbackend.Instance, error) {
+		provisions++
+		return &execbackend.Instance{ID: "sbx"}, nil
+	}}
+	policy := execBackendStoreCap(config.ExecBackendCostConfig{MaxReservedUSD: 4, PerAttemptUSD: 2.5})
+	backend, err := newLedgeredExecutionBackend(store, inner, e2bAttemptProvider, "fence", "boot", &output, policy)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := backend.Provision(context.Background(), execbackend.JobScope{JobID: "first", Attempt: 1, TTL: time.Minute}); err != nil {
+		t.Fatalf("first provision refused: %v", err)
+	}
+	if _, err := backend.Provision(context.Background(), execbackend.JobScope{JobID: "second", Attempt: 1, TTL: time.Minute}); err == nil {
+		t.Fatal("the second $2.50 attempt was admitted against a $4 cap")
+	}
+	if provisions != 1 {
+		t.Fatalf("provider called %d times, want 1: a refused attempt must not reach the provider", provisions)
+	}
+}
+
+// TestUnsetCapIsTheShippingStateAndDeniesWithAnOperand pins the arm that
+// actually runs in production. The owner decided (2026-09-10) to ship with NO
+// budget value set, so "no cap configured" is the operating state rather than
+// an error path, and each of the four ways a cap can be missing must deny AND
+// say which key is missing and where to set it.
+func TestUnsetCapIsTheShippingStateAndDeniesWithAnOperand(t *testing.T) {
+	store := openExecBackendLedgerTestStore(t)
+	cases := map[string]struct {
+		cfg      config.ExecBackendCostConfig
+		wantKeys []string
+	}{
+		"absent entirely":     {config.ExecBackendCostConfig{}, []string{"cost_max_reserved_usd"}},
+		"ceiling only":        {config.ExecBackendCostConfig{MaxReservedUSD: 10}, []string{"cost_per_attempt_usd"}},
+		"per-attempt only":    {config.ExecBackendCostConfig{PerAttemptUSD: 1}, []string{"cost_max_reserved_usd"}},
+		"explicitly zero":     {config.ExecBackendCostConfig{MaxReservedUSD: 0, PerAttemptUSD: 0}, []string{"cost_max_reserved_usd"}},
+		"malformed, negative": {config.ExecBackendCostConfig{MaxReservedUSD: -5, PerAttemptUSD: 1}, []string{"max_reserved_usd"}},
+	}
+	for name, tc := range cases {
+		policy := execBackendStoreCap(tc.cfg)
+		if policy.Configured {
+			t.Errorf("%s: reached the store as configured, want a deny", name)
+			continue
+		}
+		err := store.ReserveExecBackendAttempt(context.Background(), db.ExecBackendAttemptReservation{
+			ExecBackendAttemptKey: db.ExecBackendAttemptKey{JobID: "unset-" + name, Attempt: 1},
+			Provider:              e2bAttemptProvider,
+			DaemonFencingToken:    "fence",
+			BootID:                "boot",
+			TTLExpiresAt:          time.Now().Add(time.Minute),
+		}, policy)
+		if err == nil {
+			t.Errorf("%s: provision admitted with no configured cap", name)
+			continue
+		}
+		msg := err.Error()
+		if strings.Contains(msg, "unlimited") && !strings.Contains(msg, "not mean unlimited") && !strings.Contains(msg, "rather than permitting unlimited") {
+			t.Errorf("%s: refusal suggests unlimited: %q", name, msg)
+		}
+		for _, key := range tc.wantKeys {
+			if !strings.Contains(msg, key) {
+				t.Errorf("%s: refusal does not name the missing key %q: %q", name, key, msg)
+			}
+		}
+		if !strings.Contains(msg, "config.toml") {
+			t.Errorf("%s: refusal does not say where to set the cap: %q", name, msg)
+		}
+	}
+}
+
+// TestZeroDeniesExplicitlyRatherThanByFallthrough pins the value where this
+// codebase's other budgets mean "unlimited". A future reader must find an
+// explicit refusal for 0, not an accident of ordering.
+func TestZeroDeniesExplicitlyRatherThanByFallthrough(t *testing.T) {
+	store := openExecBackendLedgerTestStore(t)
+	// Bypass the converter: this is the store contract for a hand-built policy
+	// that claims to be configured while carrying zeros.
+	err := store.ReserveExecBackendAttempt(context.Background(), db.ExecBackendAttemptReservation{
+		ExecBackendAttemptKey: db.ExecBackendAttemptKey{JobID: "explicit-zero", Attempt: 1},
+		Provider:              e2bAttemptProvider,
+		DaemonFencingToken:    "fence",
+		BootID:                "boot",
+		TTLExpiresAt:          time.Now().Add(time.Minute),
+	}, db.ExecBackendCostCap{Configured: true, MaxReservedUSD: 0, PerAttemptUSD: 0})
+	if err == nil {
+		t.Fatal("a configured cap of $0 admitted a provision")
+	}
+	if !strings.Contains(err.Error(), "does not mean unlimited") {
+		t.Fatalf("the zero refusal does not distinguish itself from the house idiom: %v", err)
+	}
+}

--- a/internal/cli/execbackend_cost_test.go
+++ b/internal/cli/execbackend_cost_test.go
@@ -163,3 +163,31 @@ func TestZeroDeniesExplicitlyRatherThanByFallthrough(t *testing.T) {
 		t.Fatalf("the zero refusal does not distinguish itself from the house idiom: %v", err)
 	}
 }
+
+// TestLocalBackendProvisionsWithNoCapConfigured pins the boundary of this gate:
+// #1540 denies CLOUD provision without a cap, while local-first remains the
+// default and must be unaffected. The cap ships unset (owner decision,
+// 2026-09-10), so if it reached the local path every local job on every
+// deployment would stop.
+//
+// The structural reason it cannot: the cap is enforced inside
+// ReserveExecBackendAttempt, that row is written only by the ledgered decorator,
+// and the ledger is constructed only in the remote branch of the backend
+// factory. internal/execbackend does not import internal/db at all, so
+// LocalBackend has no path to a reservation even in principle.
+func TestLocalBackendProvisionsWithNoCapConfigured(t *testing.T) {
+	if unset := execBackendStoreCap(config.ExecBackendCostConfig{}); unset.Configured {
+		t.Fatalf("precondition: the empty configuration is not a deny (%+v)", unset)
+	}
+	local, err := execbackend.NewLocalBackend(t.TempDir(), nil)
+	if err != nil {
+		t.Fatalf("NewLocalBackend: %v", err)
+	}
+	instance, err := local.Provision(context.Background(), execbackend.JobScope{JobID: "local-job", Attempt: 1, TTL: time.Minute})
+	if err != nil {
+		t.Fatalf("local provision refused while the compute-dollar cap is unset: %v", err)
+	}
+	if instance == nil || instance.ID == "" {
+		t.Fatal("local provision returned no instance")
+	}
+}

--- a/internal/cli/execbackend_ledger.go
+++ b/internal/cli/execbackend_ledger.go
@@ -24,12 +24,15 @@ type ledgeredExecutionBackend struct {
 	bootID          string
 	stdout          io.Writer
 	now             func() time.Time
+	// cost is the compute-dollar admission policy (#1540). Its zero value denies,
+	// so a backend constructed without one cannot provision cloud compute.
+	cost db.ExecBackendCostCap
 
 	mu      sync.Mutex
 	attempt map[string]db.ExecBackendAttemptKey
 }
 
-func newLedgeredExecutionBackend(store *db.Store, inner execbackend.ExecutionBackend, provider, fencingToken, bootID string, stdout io.Writer) (*ledgeredExecutionBackend, error) {
+func newLedgeredExecutionBackend(store *db.Store, inner execbackend.ExecutionBackend, provider, fencingToken, bootID string, stdout io.Writer, cost db.ExecBackendCostCap) (*ledgeredExecutionBackend, error) {
 	if store == nil {
 		return nil, errors.New("execution backend attempt ledger store is required")
 	}
@@ -60,6 +63,7 @@ func newLedgeredExecutionBackend(store *db.Store, inner execbackend.ExecutionBac
 		fencingToken:    fencingToken,
 		bootID:          bootID,
 		stdout:          stdout,
+		cost:            cost,
 		now:             time.Now,
 		attempt:         make(map[string]db.ExecBackendAttemptKey),
 	}, nil
@@ -85,8 +89,12 @@ func (b *ledgeredExecutionBackend) Provision(ctx context.Context, scope execback
 		DaemonFencingToken:    b.fencingToken,
 		BootID:                b.bootID,
 		TTLExpiresAt:          b.now().UTC().Add(scope.TTL),
-		CostReservedUSD:       0,
-	}); err != nil {
+		// The WORST-CASE cost of this attempt, reserved before the provider is
+		// called. It is deliberately not an estimate refined later: the whole
+		// point of reserving before provisioning is that parallel legs contend
+		// on a bound that is already pessimistic.
+		CostReservedUSD: b.cost.PerAttemptUSD,
+	}, b.cost); err != nil {
 		return nil, fmt.Errorf("reserve execution backend attempt: %w", err)
 	}
 	changed, err := b.store.MarkExecBackendAttemptProvisioning(ctx, key)

--- a/internal/cli/execbackend_ledger.go
+++ b/internal/cli/execbackend_ledger.go
@@ -281,8 +281,15 @@ func (b *ledgeredExecutionBackend) reconcileInventory(ctx context.Context, repor
 		}
 		id := *attempt.SandboxID
 		if _, ok := destroyed[id]; ok {
-			if changed, markErr := b.store.MarkExecBackendAttemptOrphaned(ctx, key); markErr != nil || !changed {
-				reconcileErrs = append(reconcileErrs, errors.Join(fmt.Errorf("mark reaped execution backend attempt %+v orphaned", key), markErr))
+			// THE PROVIDER CONFIRMED THIS ONE IS GONE, so it is destroyed, not
+			// orphaned (#2147). This branch previously recorded an orphan while
+			// its own log line said "reaped" - and orphaned bills against the
+			// compute cap and is terminal-unreachable, so the reservation was
+			// held forever. costActualUSD is 0 because a reconciled destroy has
+			// no cost figure we observed: teardown passes 0 for the same reason,
+			// and inventing one would put a fabricated number in a cost ledger.
+			if changed, markErr := b.store.MarkExecBackendAttemptReconciledDestroyed(context.WithoutCancel(ctx), key, 0); markErr != nil || !changed {
+				reconcileErrs = append(reconcileErrs, errors.Join(fmt.Errorf("mark reaped execution backend attempt %+v destroyed", key), markErr))
 			}
 			continue
 		}

--- a/internal/cli/execbackend_ledger_test.go
+++ b/internal/cli/execbackend_ledger_test.go
@@ -224,7 +224,7 @@ func TestExecBackendLedgerReconcilesBothInventoryDirections(t *testing.T) {
 	crashKey := db.ExecBackendAttemptKey{JobID: "job-crash", Attempt: 1, LifecycleGeneration: 8}
 	if err := store.ReserveExecBackendAttempt(context.Background(), db.ExecBackendAttemptReservation{
 		ExecBackendAttemptKey: crashKey, Provider: e2bAttemptProvider, DaemonFencingToken: "fence-crash", BootID: "boot-crash", TTLExpiresAt: time.Now().Add(time.Minute),
-	}); err != nil {
+	}, testCLIExecBackendUncappedPolicy()); err != nil {
 		t.Fatal(err)
 	}
 	if changed, err := store.MarkExecBackendAttemptProvisioning(context.Background(), crashKey); err != nil || !changed {
@@ -291,7 +291,7 @@ func openExecBackendLedgerTestStore(t *testing.T) *db.Store {
 
 func newExecBackendLedgerForTest(t *testing.T, store *db.Store, inner *ledgerTestBackend, output *bytes.Buffer, fencingToken, bootID string) *ledgeredExecutionBackend {
 	t.Helper()
-	backend, err := newLedgeredExecutionBackend(store, inner, e2bAttemptProvider, fencingToken, bootID, output)
+	backend, err := newLedgeredExecutionBackend(store, inner, e2bAttemptProvider, fencingToken, bootID, output, testCLIExecBackendUncappedPolicy())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -303,7 +303,7 @@ func seedRunningExecBackendAttempt(t *testing.T, store *db.Store, jobID, sandbox
 	key := db.ExecBackendAttemptKey{JobID: jobID, Attempt: 1, LifecycleGeneration: 3}
 	if err := store.ReserveExecBackendAttempt(context.Background(), db.ExecBackendAttemptReservation{
 		ExecBackendAttemptKey: key, Provider: e2bAttemptProvider, DaemonFencingToken: fencingToken, BootID: bootID, TTLExpiresAt: time.Now().Add(time.Minute),
-	}); err != nil {
+	}, testCLIExecBackendUncappedPolicy()); err != nil {
 		t.Fatal(err)
 	}
 	if changed, err := store.MarkExecBackendAttemptProvisioning(context.Background(), key); err != nil || !changed {
@@ -322,4 +322,10 @@ func execBackendAttemptForTest(t *testing.T, store *db.Store, key db.ExecBackend
 		t.Fatal(err)
 	}
 	return attempt
+}
+
+// testCLIExecBackendUncappedPolicy is a CONFIGURED policy with headroom for
+// ledger tests that predate the cost cap. The zero value denies (#1540).
+func testCLIExecBackendUncappedPolicy() db.ExecBackendCostCap {
+	return db.ExecBackendCostCap{Configured: true, MaxReservedUSD: 1e9, PerAttemptUSD: 0.01}
 }

--- a/internal/cli/execbackend_ledger_test.go
+++ b/internal/cli/execbackend_ledger_test.go
@@ -212,8 +212,13 @@ func TestExecBackendLedgerTeardownUpdatesEveryPath(t *testing.T) {
 		} else if !reflect.DeepEqual(reaped, []string{"sandbox-reap"}) {
 			t.Fatalf("reaped = %v", reaped)
 		}
-		if got := execBackendAttemptForTest(t, store, key).State; got != db.ExecBackendAttemptStateOrphaned {
-			t.Fatalf("startup-reaped state = %q, want orphaned", got)
+		// THE PROVIDER CONFIRMED THIS DESTROY - the fixture's ReapReport carries
+		// Destroyed: ["sandbox-reap"] - so the terminal state is destroyed, not
+		// orphaned (#2147). This assertion previously pinned orphaned, which was
+		// the defect: the reconciler could only reach orphaned from a live state,
+		// and orphaned bills against the compute cap and is terminal-unreachable.
+		if got := execBackendAttemptForTest(t, store, key).State; got != db.ExecBackendAttemptStateDestroyed {
+			t.Fatalf("startup-reaped state = %q, want destroyed: the provider confirmed this sandbox is gone, so recording it as an orphan holds its reservation forever", got)
 		}
 	})
 }

--- a/internal/cli/execbackend_lifecycle.go
+++ b/internal/cli/execbackend_lifecycle.go
@@ -99,7 +99,7 @@ func (w jobWorker) defaultExecutionBackend(backend execbackend.Backend, cfg conf
 		if err != nil {
 			return nil, fmt.Errorf("create execution backend daemon fencing token: %w", err)
 		}
-		ledgeredBackend, err := newLedgeredExecutionBackend(w.Store, remoteBackend, e2bAttemptProvider, fencingToken, db.BootID(), w.Stdout)
+		ledgeredBackend, err := newLedgeredExecutionBackend(w.Store, remoteBackend, e2bAttemptProvider, fencingToken, db.BootID(), w.Stdout, execBackendStoreCap(cfg.ExecBackendCost))
 		if err != nil {
 			return nil, err
 		}

--- a/internal/cli/execbackend_lifecycle_e2e_test.go
+++ b/internal/cli/execbackend_lifecycle_e2e_test.go
@@ -1102,7 +1102,11 @@ func writeRemoteLifecycleConfig(t *testing.T, paths config.Paths, baseURL string
 	if err != nil {
 		t.Fatal(err)
 	}
-	content := fmt.Sprintf("\n[remote_exec]\nbackend = \"remote\"\ne2b_api_key_file = %q\ne2b_template = \"template-GITMOOT-IMPL\"\n", keyFile)
+	// A cost cap is now REQUIRED for any remote provision (#1540): an unset cap
+	// denies rather than permitting unlimited spend, so this E2E must name one
+	// the way a real deployment enabling cloud has to. The values are a
+	// disposable ceiling for the fake provider, not a spend authorisation.
+	content := fmt.Sprintf("\n[remote_exec]\nbackend = \"remote\"\ne2b_api_key_file = %q\ne2b_template = \"template-GITMOOT-IMPL\"\ncost_max_reserved_usd = 25.0\ncost_per_attempt_usd = 0.5\n", keyFile)
 	if baseURL != "" {
 		content += fmt.Sprintf("e2b_base_url = %q\n", baseURL)
 	}

--- a/internal/config/execbackend_cost.go
+++ b/internal/config/execbackend_cost.go
@@ -1,0 +1,54 @@
+package config
+
+import "fmt"
+
+// ExecBackendCostConfig is the compute-dollar cap for cloud execution backends
+// (#1540). It is deliberately SEPARATE from the model-token budget in
+// OrchestratePolicy: that budget meters tokens billed by a model provider, this
+// one meters compute billed by a sandbox provider, and one being generous must
+// never imply the other is.
+//
+// UNSET DENIES. Every other budget in this codebase reads 0 as "unlimited"
+// (OrchestratePolicy.MaxDelegationCostUSD, pinned as such by its own test, and
+// admissionBudget's `> 0 &&` clauses). That default is safe for a counter and
+// unsafe for a spender, so it is not mirrored: a deployment that has not decided
+// a ceiling does not provision cloud compute at all.
+type ExecBackendCostConfig struct {
+	// MaxReservedUSD is the ceiling on summed worst-case reservations across all
+	// billing attempts. Unset or <= 0 means cloud provision is DENIED.
+	MaxReservedUSD float64
+	// MaxConcurrent bounds billing attempts. Unset disables only this clause.
+	MaxConcurrent int
+	// PerAttemptUSD is the worst-case cost one attempt reserves before it runs.
+	// Unset or <= 0 means DENIED: a zero reservation sums to zero however many
+	// attempts run, so it would pass any dollar cap forever.
+	PerAttemptUSD float64
+}
+
+// Validate reports why a configuration is malformed. It never silently
+// downgrades to a permissive default.
+func (c ExecBackendCostConfig) Validate() error {
+	if c.MaxReservedUSD < 0 {
+		return fmt.Errorf("[remote_exec].cost_max_reserved_usd must be non-negative, got %v: fix it in config.toml", c.MaxReservedUSD)
+	}
+	if c.PerAttemptUSD < 0 {
+		return fmt.Errorf("[remote_exec].cost_per_attempt_usd must be non-negative, got %v: fix it in config.toml", c.PerAttemptUSD)
+	}
+	if c.MaxConcurrent < 0 {
+		return fmt.Errorf("[remote_exec].cost_max_concurrent must be non-negative, got %d: fix it in config.toml", c.MaxConcurrent)
+	}
+	return nil
+}
+
+// Admits reports whether this configuration can admit any cloud provision, and
+// why not when it cannot, so a caller can log the reason rather than discovering
+// an unexplained refusal at the store.
+func (c ExecBackendCostConfig) Admits() (bool, string) {
+	if c.MaxReservedUSD <= 0 {
+		return false, "no compute-dollar ceiling is set. Set [remote_exec].cost_max_reserved_usd in config.toml to a positive number of dollars. An unset ceiling denies rather than permitting unlimited spend."
+	}
+	if c.PerAttemptUSD <= 0 {
+		return false, "no per-attempt reservation is set. Set [remote_exec].cost_per_attempt_usd in config.toml to the worst-case dollar cost of one sandbox. A zero reservation sums to zero however many attempts run, so it would pass any ceiling forever."
+	}
+	return true, ""
+}

--- a/internal/config/remote_exec.go
+++ b/internal/config/remote_exec.go
@@ -45,6 +45,10 @@ type RemoteExecConfig struct {
 	// used only for opt-in broker material, never for the provider control key.
 	CredentialGatewayListen string
 	CredentialGatewayURL    string
+	// ExecBackendCost is the compute-dollar cap (#1540). Its zero value denies
+	// every cloud provision, which is why it needs no default: a [remote_exec]
+	// section that sets backend = "remote" without cost keys provisions nothing.
+	ExecBackendCost ExecBackendCostConfig
 }
 
 // DefaultRemoteExecConfig preserves today's behaviour: the local backend.
@@ -126,6 +130,22 @@ func LoadRemoteExecConfig(paths Paths) (RemoteExecConfig, error) {
 			case "credential_gateway_url":
 				cfg.CredentialGatewayURL = parsed
 			}
+		case "cost_max_reserved_usd", "cost_per_attempt_usd":
+			parsed, err := strconv.ParseFloat(strings.TrimSpace(value), 64)
+			if err != nil {
+				return RemoteExecConfig{}, fmt.Errorf("parse [remote_exec].%s: expected a number: %w", key, err)
+			}
+			if key == "cost_max_reserved_usd" {
+				cfg.ExecBackendCost.MaxReservedUSD = parsed
+			} else {
+				cfg.ExecBackendCost.PerAttemptUSD = parsed
+			}
+		case "cost_max_concurrent":
+			parsed, err := strconv.Atoi(strings.TrimSpace(value))
+			if err != nil {
+				return RemoteExecConfig{}, fmt.Errorf("parse [remote_exec].cost_max_concurrent: expected an integer: %w", err)
+			}
+			cfg.ExecBackendCost.MaxConcurrent = parsed
 		default:
 			// Ignore unknown keys so the section remains forward-compatible.
 		}
@@ -137,6 +157,9 @@ func LoadRemoteExecConfig(paths Paths) (RemoteExecConfig, error) {
 }
 
 func validateRemoteExecConfig(cfg RemoteExecConfig) error {
+	if err := cfg.ExecBackendCost.Validate(); err != nil {
+		return err
+	}
 	backend, err := execbackend.ParseImplemented(cfg.Backend)
 	if err != nil {
 		return fmt.Errorf("unsupported [remote_exec].backend: %w", err)

--- a/internal/db/execbackend_teardown_guard_test.go
+++ b/internal/db/execbackend_teardown_guard_test.go
@@ -122,3 +122,115 @@ func TestMarkExecBackendAttemptDestroyedAdmitsOnlyDestroying(t *testing.T) {
 		})
 	}
 }
+
+// TestExecBackendLifecycleTransitionsRefuseNonAdjacentSources generalises the
+// guard above to EVERY single-source transition in the lifecycle.
+//
+// The #2129 review found that the gap fixed for MarkExecBackendAttemptDestroyed
+// was shared by its four siblings: their production guards are correctly narrow,
+// but their tests only assert that a REPEATED call from the already-reached
+// target state is rejected. That catches nothing, because a widened guard still
+// refuses the target state - it is the source state that stops being checked.
+// The reviewer reproduced it on MarkExecBackendAttemptCollecting.
+//
+// The table asserts both directions per transition: refusal from every
+// non-adjacent live source, AND acceptance from the one legal source. The
+// acceptance arm is what makes the refusals mean something; without it a
+// transition that refused everything would pass identically.
+func TestExecBackendLifecycleTransitionsRefuseNonAdjacentSources(t *testing.T) {
+	ctx := context.Background()
+	// walk advances a fresh row to the requested state through the legal path.
+	walk := func(t *testing.T, store *Store, key ExecBackendAttemptKey, to string) {
+		t.Helper()
+		steps := []struct {
+			state string
+			call  func() (bool, error)
+		}{
+			{ExecBackendAttemptStateProvisioning, func() (bool, error) { return store.MarkExecBackendAttemptProvisioning(ctx, key) }},
+			{ExecBackendAttemptStateRunning, func() (bool, error) {
+				return store.MarkExecBackendAttemptRunning(ctx, key, "sbx-"+key.JobID)
+			}},
+			{ExecBackendAttemptStateCollecting, func() (bool, error) { return store.MarkExecBackendAttemptCollecting(ctx, key) }},
+			{ExecBackendAttemptStateDestroying, func() (bool, error) { return store.MarkExecBackendAttemptDestroying(ctx, key) }},
+		}
+		for _, step := range steps {
+			if to == ExecBackendAttemptStateReserved {
+				return
+			}
+			changed, err := step.call()
+			if err != nil || !changed {
+				t.Fatalf("walking to %s: step %s changed=%v err=%v", to, step.state, changed, err)
+			}
+			if step.state == to {
+				return
+			}
+		}
+	}
+
+	transitions := []struct {
+		name      string
+		legalFrom string
+		call      func(store *Store, key ExecBackendAttemptKey) (bool, error)
+	}{
+		{"Provisioning", ExecBackendAttemptStateReserved, func(s *Store, k ExecBackendAttemptKey) (bool, error) {
+			return s.MarkExecBackendAttemptProvisioning(ctx, k)
+		}},
+		{"Running", ExecBackendAttemptStateProvisioning, func(s *Store, k ExecBackendAttemptKey) (bool, error) {
+			return s.MarkExecBackendAttemptRunning(ctx, k, "sbx-late")
+		}},
+		{"Collecting", ExecBackendAttemptStateRunning, func(s *Store, k ExecBackendAttemptKey) (bool, error) {
+			return s.MarkExecBackendAttemptCollecting(ctx, k)
+		}},
+		{"Destroying", ExecBackendAttemptStateCollecting, func(s *Store, k ExecBackendAttemptKey) (bool, error) {
+			return s.MarkExecBackendAttemptDestroying(ctx, k)
+		}},
+	}
+	liveStates := []string{
+		ExecBackendAttemptStateReserved, ExecBackendAttemptStateProvisioning,
+		ExecBackendAttemptStateRunning, ExecBackendAttemptStateCollecting,
+		ExecBackendAttemptStateDestroying,
+	}
+
+	for _, transition := range transitions {
+		for _, from := range liveStates {
+			if from == transition.legalFrom {
+				continue
+			}
+			t.Run(transition.name+"_refuses_"+from, func(t *testing.T) {
+				store := openCapTestStore(t)
+				key := ExecBackendAttemptKey{JobID: "job-" + transition.name + "-" + from, Attempt: 1, LifecycleGeneration: 1}
+				if err := store.ReserveExecBackendAttempt(ctx, ExecBackendAttemptReservation{
+					ExecBackendAttemptKey: key, Provider: "e2b", DaemonFencingToken: "fence", BootID: "boot",
+					TTLExpiresAt: time.Now().Add(time.Minute),
+				}, testExecBackendUncappedPolicy()); err != nil {
+					t.Fatal(err)
+				}
+				walk(t, store, key, from)
+				changed, err := transition.call(store, key)
+				if err != nil {
+					t.Fatalf("Mark...%s from %s: err=%v", transition.name, from, err)
+				}
+				if changed {
+					t.Fatalf("Mark...%s from %s: changed=true, want false; this transition admits only %s, and a widened guard would let the lifecycle skip phases",
+						transition.name, from, transition.legalFrom)
+				}
+			})
+		}
+		t.Run(transition.name+"_accepts_"+transition.legalFrom, func(t *testing.T) {
+			store := openCapTestStore(t)
+			key := ExecBackendAttemptKey{JobID: "job-ok-" + transition.name, Attempt: 1, LifecycleGeneration: 1}
+			if err := store.ReserveExecBackendAttempt(ctx, ExecBackendAttemptReservation{
+				ExecBackendAttemptKey: key, Provider: "e2b", DaemonFencingToken: "fence", BootID: "boot",
+				TTLExpiresAt: time.Now().Add(time.Minute),
+			}, testExecBackendUncappedPolicy()); err != nil {
+				t.Fatal(err)
+			}
+			walk(t, store, key, transition.legalFrom)
+			changed, err := transition.call(store, key)
+			if err != nil || !changed {
+				t.Fatalf("Mark...%s from its legal source %s: changed=%v err=%v; the refusal arms above prove nothing if this cannot pass",
+					transition.name, transition.legalFrom, changed, err)
+			}
+		})
+	}
+}

--- a/internal/db/execbackend_teardown_guard_test.go
+++ b/internal/db/execbackend_teardown_guard_test.go
@@ -1,0 +1,124 @@
+package db
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// MarkExecBackendAttemptDestroyed admits ONLY `destroying` as a source state,
+// and nothing in the suite defended that until now (#2147).
+//
+// Why it is load-bearing: `destroyed` is where teardown records a completed
+// disposal together with its compute cost. Reaching it from `running` or
+// `collecting` would mean claiming a sandbox was torn down through phases it
+// never entered, and writing a cost for output that was never collected. The
+// narrow guard is what makes the state a statement about teardown rather than
+// about any terminal outcome.
+//
+// This exists because a mutant that WIDENED this guard survived the whole
+// suite. It was briefly believed to be killed by
+// TestExecBackendLedgerTeardownUpdatesEveryPath/startup_reap, but that test
+// failed for an unrelated reason - its fixture pinned a provider-confirmed
+// destroy as `orphaned`, which was the #2147 defect - so the kill was a
+// coincidence and was retracted. A mutant killed for the wrong reason is a
+// false kill, and the correct response is the test that was missing.
+//
+// A reconciler that needs to record a destroy it did not perform must add its
+// own transition rather than widen this one; that is the shape #2147 takes.
+func TestMarkExecBackendAttemptDestroyedAdmitsOnlyDestroying(t *testing.T) {
+	for _, test := range []struct {
+		name string
+		// advance drives the attempt to the state under test and reports it.
+		advance func(must func(bool, error), store *Store, key ExecBackendAttemptKey) string
+		want    bool
+	}{
+		{
+			name: "reserved is refused",
+			advance: func(func(bool, error), *Store, ExecBackendAttemptKey) string {
+				return ExecBackendAttemptStateReserved
+			},
+		},
+		{
+			name: "provisioning is refused",
+			advance: func(must func(bool, error), store *Store, key ExecBackendAttemptKey) string {
+				must(store.MarkExecBackendAttemptProvisioning(context.Background(), key))
+				return ExecBackendAttemptStateProvisioning
+			},
+		},
+		{
+			name: "running is refused",
+			advance: func(must func(bool, error), store *Store, key ExecBackendAttemptKey) string {
+				must(store.MarkExecBackendAttemptProvisioning(context.Background(), key))
+				must(store.MarkExecBackendAttemptRunning(context.Background(), key, "sandbox-guard"))
+				return ExecBackendAttemptStateRunning
+			},
+		},
+		{
+			name: "collecting is refused",
+			advance: func(must func(bool, error), store *Store, key ExecBackendAttemptKey) string {
+				must(store.MarkExecBackendAttemptProvisioning(context.Background(), key))
+				must(store.MarkExecBackendAttemptRunning(context.Background(), key, "sandbox-guard"))
+				must(store.MarkExecBackendAttemptCollecting(context.Background(), key))
+				return ExecBackendAttemptStateCollecting
+			},
+		},
+		{
+			// The one permitted source, so the refusals above are a guard and not
+			// a broken transition.
+			name: "destroying is accepted",
+			advance: func(must func(bool, error), store *Store, key ExecBackendAttemptKey) string {
+				must(store.MarkExecBackendAttemptProvisioning(context.Background(), key))
+				must(store.MarkExecBackendAttemptRunning(context.Background(), key, "sandbox-guard"))
+				must(store.MarkExecBackendAttemptCollecting(context.Background(), key))
+				must(store.MarkExecBackendAttemptDestroying(context.Background(), key))
+				return ExecBackendAttemptStateDestroying
+			},
+			want: true,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			ctx := context.Background()
+			store, err := openCachedTestStore(t, filepath.Join(t.TempDir(), "guard.db"))
+			if err != nil {
+				t.Fatal(err)
+			}
+			t.Cleanup(func() { _ = store.Close() })
+			key := ExecBackendAttemptKey{JobID: "job-guard", Attempt: 1, LifecycleGeneration: 1}
+			if err := store.ReserveExecBackendAttempt(ctx, ExecBackendAttemptReservation{
+				ExecBackendAttemptKey: key, Provider: "e2b",
+				DaemonFencingToken: "fence", BootID: "boot",
+				TTLExpiresAt: time.Now().Add(time.Minute),
+			}); err != nil {
+				t.Fatal(err)
+			}
+			must := func(changed bool, err error) {
+				t.Helper()
+				if err != nil || !changed {
+					t.Fatalf("lifecycle transition: changed=%v err=%v", changed, err)
+				}
+			}
+			from := test.advance(must, store, key)
+
+			changed, err := store.MarkExecBackendAttemptDestroyed(ctx, key, 0)
+			if err != nil {
+				t.Fatalf("MarkExecBackendAttemptDestroyed from %s returned error: %v", from, err)
+			}
+			if changed != test.want {
+				t.Fatalf("MarkExecBackendAttemptDestroyed from %s: changed=%v, want %v; teardown's single-source guard defines destroyed as a teardown outcome, not any terminal one", from, changed, test.want)
+			}
+			attempt, err := store.GetExecBackendAttempt(ctx, key)
+			if err != nil {
+				t.Fatal(err)
+			}
+			wantState := from
+			if test.want {
+				wantState = ExecBackendAttemptStateDestroyed
+			}
+			if attempt.State != wantState {
+				t.Fatalf("state after the attempt = %q, want %q", attempt.State, wantState)
+			}
+		})
+	}
+}

--- a/internal/db/execbackend_teardown_guard_test.go
+++ b/internal/db/execbackend_teardown_guard_test.go
@@ -90,7 +90,7 @@ func TestMarkExecBackendAttemptDestroyedAdmitsOnlyDestroying(t *testing.T) {
 				ExecBackendAttemptKey: key, Provider: "e2b",
 				DaemonFencingToken: "fence", BootID: "boot",
 				TTLExpiresAt: time.Now().Add(time.Minute),
-			}); err != nil {
+			}, testExecBackendUncappedPolicy()); err != nil {
 				t.Fatal(err)
 			}
 			must := func(changed bool, err error) {

--- a/internal/db/store_execbackend_attempts.go
+++ b/internal/db/store_execbackend_attempts.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"errors"
+	"fmt"
 	"strings"
 	"time"
 )
@@ -68,7 +69,16 @@ const execBackendAttemptColumns = `job_id, attempt, lifecycle_generation, provid
 // explicitly NULL at this point. Both daemon_fencing_token and boot_id are
 // recorded because a daemon restart within one host boot reuses boot_id and must
 // still fence the previous daemon incarnation.
-func (s *Store) ReserveExecBackendAttempt(ctx context.Context, reservation ExecBackendAttemptReservation) error {
+//
+// THE COMPUTE-DOLLAR CAP IS ENFORCED IN THIS STATEMENT (#1540). The predicate
+// rides the INSERT rather than preceding it, because a read-then-insert lets N
+// parallel legs each sum the same total, each see room and each insert - the
+// exact contention this reservation exists to serialise. Zero rows affected IS
+// the refusal. This is also why the gate lives here rather than at a Provision
+// call site: a caller cannot spend without a reserved row and cannot obtain one
+// without passing this predicate, so the population it guards is every future
+// provisioning path rather than the ones that exist today.
+func (s *Store) ReserveExecBackendAttempt(ctx context.Context, reservation ExecBackendAttemptReservation, policy ExecBackendCostCap) error {
 	reservation.JobID = strings.TrimSpace(reservation.JobID)
 	reservation.Provider = strings.TrimSpace(reservation.Provider)
 	reservation.DaemonFencingToken = strings.TrimSpace(reservation.DaemonFencingToken)
@@ -98,16 +108,79 @@ func (s *Store) ReserveExecBackendAttempt(ctx context.Context, reservation ExecB
 		return errors.New("execution backend reserved cost must be non-negative")
 	}
 
-	_, err := s.db.ExecContext(ctx, `INSERT INTO execbackend_attempts(
-		job_id, attempt, lifecycle_generation, provider, sandbox_id,
-		daemon_fencing_token, boot_id, ttl_expires_at, state,
-		cost_reserved_usd, cost_actual_usd
-	) VALUES (?, ?, ?, ?, NULL, ?, ?, ?, ?, ?, NULL)`,
+	// No configured cap denies, and does so before any statement runs.
+	// THE UNSET ARM IS THE SHIPPING STATE, not an edge case. Each of the four
+	// ways a cap can be missing - absent, malformed, partially set, and
+	// explicitly zero - denies here, and zero denies EXPLICITLY rather than by
+	// falling through, because zero is exactly the value this codebase's other
+	// budgets read as "unlimited".
+	if !policy.Configured {
+		return &ExecBackendCapRefusal{Clause: "unconfigured", RequestUSD: reservation.CostReservedUSD, DenyReason: policy.DenyReason}
+	}
+	if policy.MaxReservedUSD == 0 || policy.PerAttemptUSD == 0 {
+		return &ExecBackendCapRefusal{Clause: "unconfigured", RequestUSD: reservation.CostReservedUSD,
+			DenyReason: "an execution backend cost cap of exactly 0 denies. Unlike the model-token budget, 0 here does not mean unlimited. Set [remote_exec].cost_max_reserved_usd and [remote_exec].cost_per_attempt_usd to positive values in config.toml."}
+	}
+	if policy.MaxReservedUSD < 0 || policy.PerAttemptUSD < 0 {
+		return &ExecBackendCapRefusal{Clause: "unconfigured", RequestUSD: reservation.CostReservedUSD,
+			DenyReason: "a negative execution backend cost cap denies. Set [remote_exec].cost_max_reserved_usd and [remote_exec].cost_per_attempt_usd to positive values in config.toml."}
+	}
+
+	marks, stateArgs := billingStatePlaceholders()
+	// One statement: both cap clauses and the insert. The concurrency clause is
+	// skipped only when MaxConcurrent <= 0; the dollar clause never is.
+	concurrency := "1=1"
+	args := []any{
 		reservation.JobID, reservation.Attempt, reservation.LifecycleGeneration,
 		reservation.Provider, reservation.DaemonFencingToken, reservation.BootID,
 		reservation.TTLExpiresAt.UTC().Format(time.RFC3339Nano),
-		ExecBackendAttemptStateReserved, reservation.CostReservedUSD)
-	return err
+		ExecBackendAttemptStateReserved, reservation.CostReservedUSD,
+	}
+	args = append(args, stateArgs...)
+	args = append(args, reservation.CostReservedUSD, policy.MaxReservedUSD)
+	if policy.MaxConcurrent > 0 {
+		concurrency = `(SELECT COUNT(*) FROM execbackend_attempts WHERE state IN (` + marks + `)) + 1 <= ?`
+		args = append(args, stateArgs...)
+		args = append(args, policy.MaxConcurrent)
+	}
+	result, err := s.db.ExecContext(ctx, `INSERT INTO execbackend_attempts(
+		job_id, attempt, lifecycle_generation, provider, sandbox_id,
+		daemon_fencing_token, boot_id, ttl_expires_at, state,
+		cost_reserved_usd, cost_actual_usd
+	) SELECT ?, ?, ?, ?, NULL, ?, ?, ?, ?, ?, NULL
+	WHERE (SELECT COALESCE(SUM(cost_reserved_usd), 0) FROM execbackend_attempts
+		WHERE state IN (`+marks+`)) + ? <= ?
+	  AND `+concurrency, args...)
+	if err != nil {
+		// An unreadable meter refuses. The statement that reads the meter is the
+		// statement that writes the row, so a failure here cannot have admitted.
+		return fmt.Errorf("execution backend cost cap could not be evaluated, refusing provision: %w", err)
+	}
+	affected, err := result.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("execution backend cost cap could not confirm admission, refusing provision: %w", err)
+	}
+	if affected == 1 {
+		return nil
+	}
+	refusal := &ExecBackendCapRefusal{
+		Clause:         "dollar",
+		RequestUSD:     reservation.CostReservedUSD,
+		MaxReservedUSD: policy.MaxReservedUSD,
+		MaxConcurrent:  policy.MaxConcurrent,
+	}
+	s.describeBillingLoad(ctx, refusal)
+	for _, n := range refusal.ByState {
+		refusal.LiveCount += n
+	}
+	if err := s.db.QueryRowContext(ctx, `SELECT COALESCE(SUM(cost_reserved_usd), 0)
+		FROM execbackend_attempts WHERE state IN (`+marks+`)`, stateArgs...).Scan(&refusal.ReservedUSD); err != nil && refusal.OperandsErr == nil {
+		refusal.OperandsErr = err
+	}
+	if policy.MaxConcurrent > 0 && refusal.LiveCount+1 > policy.MaxConcurrent {
+		refusal.Clause = "concurrency"
+	}
+	return refusal
 }
 
 // MarkExecBackendAttemptProvisioning claims a reserved row for provider setup.

--- a/internal/db/store_execbackend_attempts.go
+++ b/internal/db/store_execbackend_attempts.go
@@ -234,6 +234,43 @@ func (s *Store) MarkExecBackendAttemptDestroyed(ctx context.Context, key ExecBac
 	return exactlyOneExecBackendAttemptChanged(result)
 }
 
+// MarkExecBackendAttemptReconciledDestroyed records a destroy THE ENGINE DID NOT
+// PERFORM: the provider's inventory reports the sandbox gone, from any live
+// state, without the collecting -> destroying walk teardown makes.
+//
+// IT IS A SEPARATE FUNCTION RATHER THAN A WIDENED GUARD (#2147). Teardown's
+// MarkExecBackendAttemptDestroyed admits exactly `destroying`, and that single
+// source is load-bearing: teardown genuinely walks collecting -> destroying ->
+// destroyed and must keep being refused from anywhere else. Relaxing its WHERE
+// clause to serve the reconciler would silently widen teardown's guard too.
+//
+// AND IT IS ONE WRITE, NOT THREE. Walking the row through collecting and
+// destroying would record two phases that never happened for a sandbox that was
+// already gone, and would not be atomic.
+//
+// The defect this exists for: reconcileInventory could only reach `orphaned`
+// from a live state, because that was the only terminal transition admitting
+// one. So a provider-CONFIRMED destroy was recorded as an orphan - and orphaned
+// is both a billing state for the compute cap and terminal-unreachable, so the
+// reservation was held forever with no repair path.
+func (s *Store) MarkExecBackendAttemptReconciledDestroyed(ctx context.Context, key ExecBackendAttemptKey, costActualUSD float64) (bool, error) {
+	if costActualUSD < 0 {
+		return false, errors.New("execution backend actual cost must be non-negative")
+	}
+	result, err := s.db.ExecContext(ctx, `UPDATE execbackend_attempts
+		SET state = ?, cost_actual_usd = ?, updated_at = CURRENT_TIMESTAMP
+		WHERE job_id = ? AND attempt = ? AND lifecycle_generation = ?
+			AND state IN (?, ?, ?, ?, ?)`,
+		ExecBackendAttemptStateDestroyed, costActualUSD, key.JobID, key.Attempt, key.LifecycleGeneration,
+		ExecBackendAttemptStateReserved, ExecBackendAttemptStateProvisioning,
+		ExecBackendAttemptStateRunning, ExecBackendAttemptStateCollecting,
+		ExecBackendAttemptStateDestroying)
+	if err != nil {
+		return false, err
+	}
+	return exactlyOneExecBackendAttemptChanged(result)
+}
+
 // MarkExecBackendAttemptOrphaned persists the reaper's conclusion explicitly.
 // An orphan is terminal evidence, not a state callers should have to infer from
 // a missing provider handle or an expired TTL.

--- a/internal/db/store_execbackend_attempts_test.go
+++ b/internal/db/store_execbackend_attempts_test.go
@@ -109,7 +109,7 @@ func TestExecBackendAttemptLifecycleGenerationEnforcedBySchema(t *testing.T) {
 		}
 	}
 	reservation := testExecBackendReservation(ExecBackendAttemptKey{JobID: "negative-generation", Attempt: 1, LifecycleGeneration: -1})
-	if err := store.ReserveExecBackendAttempt(ctx, reservation); err == nil {
+	if err := store.ReserveExecBackendAttempt(ctx, reservation, testExecBackendUncappedPolicy()); err == nil {
 		t.Fatal("negative lifecycle generation succeeded")
 	}
 }
@@ -133,7 +133,7 @@ func TestReserveExecBackendAttempt(t *testing.T) {
 		t.Fatalf("fencing identity = (%q, %q), want daemon token and boot id", attempt.DaemonFencingToken, attempt.BootID)
 	}
 
-	if err := store.ReserveExecBackendAttempt(context.Background(), testExecBackendReservation(key)); err == nil {
+	if err := store.ReserveExecBackendAttempt(context.Background(), testExecBackendReservation(key), testExecBackendUncappedPolicy()); err == nil {
 		t.Fatal("duplicate reservation unexpectedly succeeded")
 	}
 }
@@ -206,7 +206,7 @@ func TestMarkExecBackendAttemptFailed(t *testing.T) {
 func TestListExecBackendAttemptsWithoutSandboxID(t *testing.T) {
 	store, nullKey := reserveTestExecBackendAttempt(t, "null-sandbox")
 	runningKey := ExecBackendAttemptKey{JobID: "running-has-handle", Attempt: 1, LifecycleGeneration: 4}
-	if err := store.ReserveExecBackendAttempt(context.Background(), testExecBackendReservation(runningKey)); err != nil {
+	if err := store.ReserveExecBackendAttempt(context.Background(), testExecBackendReservation(runningKey), testExecBackendUncappedPolicy()); err != nil {
 		t.Fatalf("reserve running row: %v", err)
 	}
 	requireExecBackendTransition(t)(store.MarkExecBackendAttemptProvisioning(context.Background(), runningKey))
@@ -294,7 +294,7 @@ func reserveTestExecBackendAttempt(t *testing.T, jobID string) (*Store, ExecBack
 	}
 	t.Cleanup(func() { _ = store.Close() })
 	key := ExecBackendAttemptKey{JobID: jobID, Attempt: 2, LifecycleGeneration: 4}
-	if err := store.ReserveExecBackendAttempt(context.Background(), testExecBackendReservation(key)); err != nil {
+	if err := store.ReserveExecBackendAttempt(context.Background(), testExecBackendReservation(key), testExecBackendUncappedPolicy()); err != nil {
 		t.Fatalf("ReserveExecBackendAttempt: %v", err)
 	}
 	return store, key
@@ -359,4 +359,11 @@ func requireExecBackendTransitionRejected(t *testing.T) func(bool, error) {
 			t.Fatal("transition changed a row from the wrong state")
 		}
 	}
+}
+
+// testExecBackendUncappedPolicy is a CONFIGURED policy with headroom, used by
+// tests that predate the cost cap and are not about it. It is deliberately not
+// the zero value: the zero value denies (#1540).
+func testExecBackendUncappedPolicy() ExecBackendCostCap {
+	return ExecBackendCostCap{Configured: true, MaxReservedUSD: 1e9, PerAttemptUSD: 0.01}
 }

--- a/internal/db/store_execbackend_cost_cap.go
+++ b/internal/db/store_execbackend_cost_cap.go
@@ -1,0 +1,196 @@
+package db
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+)
+
+// ExecBackendBillingStates are the attempt states in which a provider resource
+// is believed to exist and therefore to be COSTING MONEY. They are the
+// population the compute-dollar cap sums over.
+//
+// orphaned IS billing and that is the load-bearing entry (#1540). An orphaned
+// attempt is one whose sandbox was created and never confirmed destroyed, so it
+// is the single class of spend nobody is managing. Excluding it would make the
+// meter blind at exactly the moment spend is out of control, which is the
+// fail-open direction this gate exists to close.
+//
+// destroyed is excluded because destruction is confirmed. failed is excluded
+// because it is only reachable for an attempt that never obtained a handle: the
+// ledger deliberately keeps a transport-failed provision RECOVERABLE rather than
+// failing it, precisely so a possibly-live sandbox becomes orphaned instead.
+var ExecBackendBillingStates = []string{
+	ExecBackendAttemptStateReserved,
+	ExecBackendAttemptStateProvisioning,
+	ExecBackendAttemptStateRunning,
+	ExecBackendAttemptStateCollecting,
+	ExecBackendAttemptStateDestroying,
+	ExecBackendAttemptStateOrphaned,
+}
+
+// ExecBackendNonBillingStates are the terminal states in which no provider
+// resource is believed to exist. Every state constant MUST appear in exactly one
+// of the two lists; TestExecBackendStatesAreClassified enforces that, so adding a
+// state without deciding whether it bills fails the suite rather than silently
+// leaving spend uncounted.
+var ExecBackendNonBillingStates = []string{
+	ExecBackendAttemptStateDestroyed,
+	ExecBackendAttemptStateFailed,
+}
+
+// ExecBackendCostCap is the admission policy for one provision.
+//
+// THE ZERO VALUE DENIES. Configured=false means no cap has been configured and
+// every cloud provision is refused, which is the inverse of this codebase's
+// other budget idioms (config.MaxDelegationCostUSD and admissionBudget both read
+// 0 as "unlimited", and orchestrate_test.go pins that). Mirroring that default
+// here would mean an unconfigured deployment provisions without any ceiling, so
+// the default is deliberately not mirrored.
+type ExecBackendCostCap struct {
+	Configured bool
+	// MaxReservedUSD bounds the summed worst-case reservation of all billing
+	// attempts. Must be > 0 when Configured.
+	MaxReservedUSD float64
+	// MaxConcurrent bounds the number of billing attempts. 0 disables only the
+	// concurrency clause; it never disables the dollar clause.
+	MaxConcurrent int
+	// PerAttemptUSD is the worst-case dollar amount one attempt reserves before
+	// the provider is called. Must be > 0 when Configured: a zero reservation
+	// sums to zero however many attempts run, so it would pass any dollar cap
+	// forever. That is precisely the state on main today, where the only
+	// production writer passes the literal 0.
+	PerAttemptUSD float64
+	// DenyReason explains WHY this policy denies, in the words of whatever
+	// produced it. The unset policy is the shipping state (owner decision,
+	// 2026-09-10), so its refusal is the first thing an operator enabling cloud
+	// will see: it must name the missing key and where to set it, not "denied".
+	DenyReason string
+}
+
+// ExecBackendCapRefusal reports a refused admission AND THE OPERANDS THAT CAUSED
+// IT. A cap that refuses without naming what filled it is indistinguishable from
+// a correctly-full budget, and the two have opposite remedies: one waits, the
+// other reconciles leaked sandboxes. Because reconciliation currently runs once
+// per process (#1539), a phantom reservation can hold budget indefinitely, so the
+// per-state counts and the oldest age are the difference between a one-query
+// diagnosis and an evening.
+type ExecBackendCapRefusal struct {
+	Clause         string
+	RequestUSD     float64
+	ReservedUSD    float64
+	MaxReservedUSD float64
+	LiveCount      int
+	MaxConcurrent  int
+	ByState        map[string]int
+	OldestState    string
+	OldestAge      time.Duration
+	OperandsErr    error
+	DenyReason     string
+}
+
+func (r *ExecBackendCapRefusal) Error() string {
+	var b strings.Builder
+	switch r.Clause {
+	case "unconfigured":
+		if strings.TrimSpace(r.DenyReason) != "" {
+			return "cloud provision denied: " + r.DenyReason
+		}
+		return "cloud provision denied: no execution backend cost cap is configured. Set [remote_exec].cost_max_reserved_usd and [remote_exec].cost_per_attempt_usd in config.toml. An unset cap denies rather than permitting unlimited spend."
+	case "concurrency":
+		fmt.Fprintf(&b, "execution backend concurrency cap refused this provision: %d billing attempts, cap %d",
+			r.LiveCount, r.MaxConcurrent)
+	default:
+		fmt.Fprintf(&b, "execution backend cost cap refused this provision: reserving $%.4f against $%.4f already reserved, cap $%.4f",
+			r.RequestUSD, r.ReservedUSD, r.MaxReservedUSD)
+	}
+	if r.OperandsErr != nil {
+		fmt.Fprintf(&b, "; operands unavailable: %v", r.OperandsErr)
+		return b.String()
+	}
+	if len(r.ByState) > 0 {
+		states := make([]string, 0, len(r.ByState))
+		for s := range r.ByState {
+			states = append(states, s)
+		}
+		sort.Strings(states)
+		parts := make([]string, 0, len(states))
+		for _, s := range states {
+			parts = append(parts, fmt.Sprintf("%s %d", s, r.ByState[s]))
+		}
+		fmt.Fprintf(&b, "; holding it: %s", strings.Join(parts, ", "))
+	}
+	if r.OldestState != "" {
+		fmt.Fprintf(&b, "; oldest %s is %s old", r.OldestState, r.OldestAge.Round(time.Second))
+	}
+	if n := r.ByState[ExecBackendAttemptStateOrphaned]; n > 0 {
+		fmt.Fprintf(&b, "; %d ORPHANED attempt(s) are holding budget - reconcile before raising the cap", n)
+	}
+	return b.String()
+}
+
+// IsExecBackendCapRefusal reports whether err is a cap refusal.
+func IsExecBackendCapRefusal(err error) bool {
+	var refusal *ExecBackendCapRefusal
+	return errors.As(err, &refusal)
+}
+
+func billingStatePlaceholders() (string, []any) {
+	marks := make([]string, len(ExecBackendBillingStates))
+	args := make([]any, len(ExecBackendBillingStates))
+	for i, s := range ExecBackendBillingStates {
+		marks[i] = "?"
+		args[i] = s
+	}
+	return strings.Join(marks, ","), args
+}
+
+// describeBillingLoad reads the operands for a refusal message. It is diagnostic
+// only: it runs AFTER the admission has already been refused, so its failure
+// degrades the message and never converts a refusal into an admission.
+func (s *Store) describeBillingLoad(ctx context.Context, refusal *ExecBackendCapRefusal) {
+	marks, args := billingStatePlaceholders()
+	rows, err := s.db.QueryContext(ctx, `SELECT state, COUNT(*), MIN(created_at)
+		FROM execbackend_attempts WHERE state IN (`+marks+`) GROUP BY state`, args...)
+	if err != nil {
+		refusal.OperandsErr = err
+		return
+	}
+	defer rows.Close()
+	refusal.ByState = map[string]int{}
+	oldest := time.Time{}
+	for rows.Next() {
+		var state, created string
+		var count int
+		if err := rows.Scan(&state, &count, &created); err != nil {
+			refusal.OperandsErr = err
+			return
+		}
+		refusal.ByState[state] = count
+		if t, perr := parseExecBackendTime(created); perr == nil {
+			if oldest.IsZero() || t.Before(oldest) {
+				oldest, refusal.OldestState = t, state
+			}
+		}
+	}
+	if err := rows.Err(); err != nil {
+		refusal.OperandsErr = err
+		return
+	}
+	if !oldest.IsZero() {
+		refusal.OldestAge = time.Since(oldest)
+	}
+}
+
+func parseExecBackendTime(value string) (time.Time, error) {
+	value = strings.TrimSpace(value)
+	for _, layout := range []string{time.RFC3339Nano, time.RFC3339, "2006-01-02 15:04:05"} {
+		if t, err := time.Parse(layout, value); err == nil {
+			return t.UTC(), nil
+		}
+	}
+	return time.Time{}, fmt.Errorf("unparsable timestamp %q", value)
+}

--- a/internal/db/store_execbackend_cost_cap_test.go
+++ b/internal/db/store_execbackend_cost_cap_test.go
@@ -1,0 +1,196 @@
+package db
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+func openCapTestStore(t *testing.T) *Store {
+	t.Helper()
+	store, err := openCachedTestStore(t, filepath.Join(t.TempDir(), "cap.db"))
+	if err != nil {
+		t.Fatalf("openCachedTestStore: %v", err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+	return store
+}
+
+func capTestReservation(job string, cost float64) ExecBackendAttemptReservation {
+	return ExecBackendAttemptReservation{
+		ExecBackendAttemptKey: ExecBackendAttemptKey{JobID: job, Attempt: 1, LifecycleGeneration: 0},
+		Provider:              "e2b",
+		DaemonFencingToken:    "token",
+		BootID:                "boot",
+		TTLExpiresAt:          time.Now().Add(time.Hour),
+		CostReservedUSD:       cost,
+	}
+}
+
+func capTestPolicy(maxUSD float64, maxConcurrent int) ExecBackendCostCap {
+	return ExecBackendCostCap{Configured: true, MaxReservedUSD: maxUSD, MaxConcurrent: maxConcurrent, PerAttemptUSD: 1}
+}
+
+// TestExecBackendStatesAreClassified is the corpus guard for this gate. Every
+// state constant must be classified as billing or non-billing, so adding a
+// state without deciding whether it costs money fails here rather than silently
+// leaving that spend uncounted by the cap.
+func TestExecBackendStatesAreClassified(t *testing.T) {
+	all := []string{
+		ExecBackendAttemptStateReserved, ExecBackendAttemptStateProvisioning,
+		ExecBackendAttemptStateRunning, ExecBackendAttemptStateCollecting,
+		ExecBackendAttemptStateDestroying, ExecBackendAttemptStateDestroyed,
+		ExecBackendAttemptStateOrphaned, ExecBackendAttemptStateFailed,
+	}
+	seen := map[string]int{}
+	for _, s := range append(append([]string{}, ExecBackendBillingStates...), ExecBackendNonBillingStates...) {
+		seen[s]++
+	}
+	for _, s := range all {
+		if seen[s] != 1 {
+			t.Errorf("state %q appears in %d classification lists, want exactly 1", s, seen[s])
+		}
+	}
+	if len(seen) != len(all) {
+		t.Errorf("classified %d states, but %d state constants exist", len(seen), len(all))
+	}
+}
+
+// TestReserveRefusesWithoutConfiguredCap pins no-cap = DENY, which is the
+// inverse of every other budget default in this codebase.
+func TestReserveRefusesWithoutConfiguredCap(t *testing.T) {
+	store := openCapTestStore(t)
+	for name, policy := range map[string]ExecBackendCostCap{
+		"zero value":        {},
+		"configured but $0": {Configured: true, MaxReservedUSD: 0, PerAttemptUSD: 1},
+		"no per-attempt":    {Configured: true, MaxReservedUSD: 100, PerAttemptUSD: 0},
+	} {
+		err := store.ReserveExecBackendAttempt(context.Background(), capTestReservation("job-"+name, 1), policy)
+		if err == nil {
+			t.Fatalf("%s: reservation admitted, want denial", name)
+		}
+		if !IsExecBackendCapRefusal(err) {
+			t.Fatalf("%s: err = %v, want a cap refusal", name, err)
+		}
+	}
+}
+
+// TestDollarCapRefusesOverBudgetProvision is the acceptance criterion: a
+// disposable low cap must refuse the over-budget provision.
+func TestDollarCapRefusesOverBudgetProvision(t *testing.T) {
+	store := openCapTestStore(t)
+	policy := capTestPolicy(10, 0)
+	ctx := context.Background()
+	for i := 0; i < 3; i++ {
+		if err := store.ReserveExecBackendAttempt(ctx, capTestReservation(fmt.Sprintf("job-%d", i), 3), policy); err != nil {
+			t.Fatalf("reservation %d refused early: %v", i, err)
+		}
+	}
+	err := store.ReserveExecBackendAttempt(ctx, capTestReservation("job-over", 3), policy)
+	if err == nil {
+		t.Fatal("the 4th $3 reservation was admitted against a $10 cap")
+	}
+	if !strings.Contains(err.Error(), "$9.0000") || !strings.Contains(err.Error(), "$10.0000") {
+		t.Fatalf("refusal does not name its operands: %v", err)
+	}
+}
+
+// TestOrphanedAttemptsHoldBudget is the load-bearing one. An orphaned sandbox is
+// still billing, so it must consume the cap. If this inverts, the meter goes
+// blind exactly when spend is unmanaged.
+func TestOrphanedAttemptsHoldBudget(t *testing.T) {
+	store := openCapTestStore(t)
+	ctx := context.Background()
+	policy := capTestPolicy(10, 0)
+	if err := store.ReserveExecBackendAttempt(ctx, capTestReservation("leaked", 9), policy); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	if _, err := store.db.ExecContext(ctx, `UPDATE execbackend_attempts SET state = ? WHERE job_id = ?`,
+		ExecBackendAttemptStateOrphaned, "leaked"); err != nil {
+		t.Fatalf("orphan: %v", err)
+	}
+	err := store.ReserveExecBackendAttempt(ctx, capTestReservation("next", 3), policy)
+	if err == nil {
+		t.Fatal("an orphaned $9 attempt did not hold budget: admitted $3 against a $10 cap")
+	}
+	if !strings.Contains(err.Error(), "ORPHANED") {
+		t.Fatalf("refusal does not surface the orphan that is holding budget: %v", err)
+	}
+
+	// A destroyed attempt is confirmed gone and must NOT hold budget, or the cap
+	// would never release at all.
+	if _, err := store.db.ExecContext(ctx, `UPDATE execbackend_attempts SET state = ? WHERE job_id = ?`,
+		ExecBackendAttemptStateDestroyed, "leaked"); err != nil {
+		t.Fatalf("destroy: %v", err)
+	}
+	if err := store.ReserveExecBackendAttempt(ctx, capTestReservation("after-destroy", 3), policy); err != nil {
+		t.Fatalf("a destroyed attempt still holds budget: %v", err)
+	}
+}
+
+// TestConcurrencyCapRefusesNPlusOne pins the second clause.
+func TestConcurrencyCapRefusesNPlusOne(t *testing.T) {
+	store := openCapTestStore(t)
+	ctx := context.Background()
+	policy := capTestPolicy(1000, 2)
+	for i := 0; i < 2; i++ {
+		if err := store.ReserveExecBackendAttempt(ctx, capTestReservation(fmt.Sprintf("c-%d", i), 1), policy); err != nil {
+			t.Fatalf("reservation %d refused early: %v", i, err)
+		}
+	}
+	err := store.ReserveExecBackendAttempt(ctx, capTestReservation("c-3", 1), policy)
+	if err == nil {
+		t.Fatal("the 3rd attempt was admitted against a concurrency cap of 2")
+	}
+	if !strings.Contains(err.Error(), "concurrency cap") {
+		t.Fatalf("refusal names the wrong clause: %v", err)
+	}
+}
+
+// TestUnreadableMeterRefuses pins fail-closed on a meter that cannot be read.
+func TestUnreadableMeterRefuses(t *testing.T) {
+	store := openCapTestStore(t)
+	ctx := context.Background()
+	if _, err := store.db.ExecContext(ctx, `DROP TABLE execbackend_attempts`); err != nil {
+		t.Fatalf("drop: %v", err)
+	}
+	if err := store.ReserveExecBackendAttempt(ctx, capTestReservation("unreadable", 1), capTestPolicy(10, 0)); err == nil {
+		t.Fatal("an unreadable meter admitted a provision")
+	}
+}
+
+// TestParallelLegsContendOnOneReservation is the race this gate exists for:
+// N legs dispatched at once must not all pass the same sum.
+func TestParallelLegsContendOnOneReservation(t *testing.T) {
+	store := openCapTestStore(t)
+	policy := capTestPolicy(10, 0)
+	var wg sync.WaitGroup
+	var mu sync.Mutex
+	admitted := 0
+	for i := 0; i < 20; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			if err := store.ReserveExecBackendAttempt(context.Background(), capTestReservation(fmt.Sprintf("p-%d", i), 3), policy); err == nil {
+				mu.Lock()
+				admitted++
+				mu.Unlock()
+			}
+		}(i)
+	}
+	wg.Wait()
+	var total float64
+	if err := store.db.QueryRow(`SELECT COALESCE(SUM(cost_reserved_usd), 0) FROM execbackend_attempts`).Scan(&total); err != nil {
+		t.Fatalf("sum: %v", err)
+	}
+	if total > 10 {
+		t.Fatalf("cap breached under contention: $%.2f reserved against a $10 cap by %d admitted legs", total, admitted)
+	}
+	if admitted != 3 {
+		t.Fatalf("admitted = %d, want exactly 3 ($3 each under a $10 cap)", admitted)
+	}
+}


### PR DESCRIPTION
Fixes #1540 (P3c). Adds the compute-dollar admission gate: reserve before provision, no cap means deny.

## What was actually on main

The reservation SHAPE landed with #1537 and reserves nothing.

```
internal/cli/execbackend_ledger.go:88   CostReservedUSD: 0    <- the only production writer, a literal
aggregate readers of cost_reserved_usd  <- ZERO, non-test, whole tree
```

`db.ExecBackendAttemptReservation` carries `CostReservedUSD`, and its doc comment states it is persisted atomically before any provider call "giving parallel children one primary-keyed reservation to contend on". That is true and it is not a cap: every reservation reserved $0, and nothing summed them. A reader of that struct concludes cost capping exists.

## Where the gate goes, and why not the obvious place

| candidate | verdict |
|---|---|
| before `lifecycle.Provision`, `execbackend_lifecycle.go:157` | rejected: one call site, and a future second caller is invisible to it |
| in `ledgeredExecutionBackend.Provision` | rejected alone: correct only while that decorator stays in every chain, which is a convention rather than a structural guarantee |
| **inside `ReserveExecBackendAttempt`'s write** | **chosen: the reserved row is what a provision cannot legally precede** |

A caller cannot spend without a reserved row and cannot obtain one without passing the predicate, so the population the guard covers is every future provisioning path rather than the ones that exist today.

It is also the only option that is atomic. A read-then-insert lets N parallel legs each sum the same total, each see room and each insert, which is the exact contention the issue's scope line names. The predicate rides the INSERT and **zero rows affected is the refusal**.

## Measured, on the real driver

Standalone harness, modernc SQLite, WAL, 20 concurrent legs at $3 against a $10 cap:

```
single conditional INSERT ... WHERE (SELECT SUM ...) + ? <= ?   admitted 3   refused 17   total $9   held
CONTROL, naive read-then-insert                                 admitted 20              total $60  BREACHED 6x
```

The control is the load-bearing half: without it the green only shows that something serialised the work, not that the statement did. `TestParallelLegsContendOnOneReservation` is that experiment inside the suite.

## Unset denies, and that is the SHIPPING STATE

Owner decision, 2026-09-10: no budget value is set, so the cloud backend cannot provision at all until a number is named. The deny arm is therefore the path that runs in production on day one, not an edge case, and it is tested as four distinct inputs - absent, partially set, explicitly zero, and malformed - each of which must deny and must name the missing key.

Zero denies **explicitly** rather than by falling through, because zero is exactly where the house idiom means unlimited and a future reader would assume it does here. Its refusal says so in as many words:

```
cloud provision denied: an execution backend cost cap of exactly 0 denies. Unlike the
model-token budget, 0 here does not mean unlimited. Set [remote_exec].cost_max_reserved_usd
and [remote_exec].cost_per_attempt_usd to positive values in config.toml.
```

No default ships. Not zero-as-unlimited, not a "safe" nonzero starter.

## Why unset-denies is not this codebase's idiom

`config.OrchestratePolicy.MaxDelegationCostUSD` defaults to 0 meaning unlimited, and `orchestrate_test.go:34` pins it. `admissionBudget.Reserve` uses the same `> 0 &&` shape. Both are safe for a counter and unsafe for a spender, so the default is not mirrored: an unconfigured deployment provisions no cloud compute. A partially configured one does not either, since a $0 per-attempt reservation sums to zero however many attempts run and would pass any dollar cap forever.

## orphaned counts, and TTL does not release

An orphaned attempt is one whose sandbox was created and never confirmed destroyed. **It is still billing**, so it consumes the cap; excluding it would blind the meter at exactly the moment spend is unmanaged.

Releasing on `TTLExpiresAt` was rejected: **a TTL is a claim about intent, not about billing.** A sandbox past its TTL that was never destroyed is still charging, and expiring its reservation frees budget the provider has not freed - a populated field mistaken for a true fact. Release is on proof of destruction or not at all.

## CORRECTION: MY EARLIER "BOUNDED BY THE CADENCE" CLAIM WAS FALSE, AND IS NOW FIXED IN CODE

After #1539 merged I wrote here that the fail-stuck window is "bounded by that cadence". **That was wrong**, and the review at `8446a041` proved it by execution: `reconcileInventory` recorded a provider-CONFIRMED destroy as `orphaned`, while its own log line said "reaped". `orphaned` bills against this cap AND is terminal-unreachable, so the cadence did not release budget - it manufactured a permanent hold.

I had flagged that I never measured the cadence. The reviewer measured it. The sentence is retracted rather than softened.

**The cause is architectural**, diagnosed by `gm-transport` on #2147: from a live state the only terminal transition available was `orphaned`, because `MarkExecBackendAttemptDestroyed` admits exactly `destroying` and `MarkExecBackendAttemptDestroying` admits exactly `collecting`. **The state machine had no vocabulary for a destroy somebody else performed.**

Fixed in this PR by `MarkExecBackendAttemptReconciledDestroyed`, a NEW guarded transition admitting the live states and landing in `destroyed`. Not a widened guard: teardown's single-source guard is load-bearing, and widening it fails `TestExecBackendLedgerTeardownUpdatesEveryPath/startup_reap`, a test I did not write. Not a three-write walk either, which would record phases that never happened and would not be atomic. `costActualUSD` is 0 with the reason at the site.

Regression cherry-picked from `gm-transport` (`handoff/2147-regression-test`), which fails on the old behaviour in the confirmed arm ONLY and passes in the inconclusive arm.

## SCOPE OF THAT DEFECT: A LATENT INTERACTION THIS PR INTRODUCES, NOT CURRENT PRODUCTION LOSS

Stated precisely because the first version of this section overstated it, and `gm-transport` corrected me:

- `ExecBackendBillingStates` and the cap exist **only on this branch**: 0 hits on `origin/main`, against a control symbol present in 3 files.
- This host's `execbackend_attempts` table is **empty** - remote has never run here.
- **Current production is not holding compute budget.** On `main` today the defect is a wrong RECORD.

The blocker is that **merging this PR as-is would make provider-confirmed destroyed attempts permanently consume the new cap.** A deployment that HAS run remote could already hold `orphaned` rows that no transition can repair, and this cap would hold budget against them forever.

## WHAT THIS PR DELIVERS, AND WHAT IT STILL DOES NOT


Stated plainly because the distinction matters more than the credit. Reconciliation currently runs **once per process**, at backend construction (`execbackend_lifecycle.go:53`, `:105`), with nothing in the daemon tick. Composed with the paragraph above, this gate is **fail-stuck rather than fail-closed**: one leaked sandbox holds budget until the daemon restarts, and the refusal reads "over budget" when the truth is "a VM was lost weeks ago".

- **#1539 is the operational prerequisite.** Its reconciliation cadence is the upper bound on how long a phantom reservation can hold budget. The merges are not coupled: #1539's dependency on this PR is textual, this PR's dependency on #1539 is operational.
- **Mitigation inside this scope:** the refusal names its operands. `holding it: orphaned 4, running 1; oldest orphaned is 33h0m0s old; 4 ORPHANED attempt(s) are holding budget - reconcile before raising the cap` is a one-query diagnosis where "over budget" is an evening.
- **The remote backend may be unreachable today.** I found no `BackendRemote` selection site, and `execbackend.Remote` is refused for every runtime except `shell`. If so, this gate is pre-emptive rather than stopping live spend. It should not be cited as evidence that spending is capped.

## Tests, each mutant-verified

Every test below was run against a mutant that reintroduces the defect it claims to catch, and failed.

| test | mutant that must kill it | result |
|---|---|---|
| `TestDollarCapRefusesOverBudgetProvision` | revert to the unconditional INSERT | FAIL |
| `TestParallelLegsContendOnOneReservation` | same | FAIL |
| `TestConcurrencyCapRefusesNPlusOne` | same | FAIL |
| `TestOrphanedAttemptsHoldBudget` | move `orphaned` to the non-billing list | FAIL |
| `TestReserveRefusesWithoutConfiguredCap` | make an unset cap permissive | FAIL |
| `TestLedgeredBackendPersistsTheConfiguredReservation` | restore `CostReservedUSD: 0` | FAIL |
| `TestLedgeredBackendRefusesWhenTheCapIsFull` | restore the literal; and pass an unconfigured cap | FAIL, FAIL |
| `TestUnsetCapIsTheShippingStateAndDeniesWithAnOperand` | five configurations that must deny with a named key | caught a real gap: the validation errors did not say where to fix them |
| `TestZeroDeniesExplicitlyRatherThanByFallthrough` | zero admitted, or refused without distinguishing itself from the house idiom | (new) |

`TestExecBackendStatesAreClassified` is a corpus guard rather than a behaviour test: a new attempt state must be classified as billing or non-billing or the suite fails. It deliberately does not assert WHICH list `orphaned` belongs to, so it survives that mutant while `TestOrphanedAttemptsHoldBudget` kills it.

**One test in this PR was decorative and I caught it with a mutant.** The first version of the ledger regression asserted on the config converter rather than driving the backend, and survived restoring the literal `0`. It now provisions through the real ledger and reads the persisted row.

## Full-suite state

`go build ./...`, `go vet` and `go test` on `internal/db`, `internal/config` and `internal/cli` all pass, with ONE exception: `TestTrackedPoolIsolationHonorsSamePassRuntimeSibling` fails on this branch. **It fails identically on clean `main` at `ac88e058`** (`job-wt never started delivering; delivered=[]`), measured in a detached worktree rather than assumed, so it is a pre-existing host-environment failure and not evidence about this change.

## Findings this may moot

`gm-integrity` seat; the ledger is phobos's to adjudicate. No finding is claimed as answered here.

## The gate is cloud-only, and that is structural rather than a check

`#1540` denies CLOUD provision without a cap while local-first stays the default. Since the cap ships UNSET, a gate that reached the local path would stop every local job on every deployment on day one. It cannot, and the reason is composition rather than a conditional:

- the predicate is inside `ReserveExecBackendAttempt`;
- that row is written only by `ledgeredExecutionBackend`;
- the ledger is constructed only in the REMOTE branch of the backend factory (`execbackend_lifecycle.go:93`, wrapping `remoteexec.NewBackend`) - it is the sole non-test construction site;
- and `go list -deps ./internal/execbackend/` returns **0** hits for `internal/db`, so `LocalBackend` has no path to a reservation even in principle.

`TestLocalBackendProvisionsWithNoCapConfigured` pins the behaviour: with the empty configuration asserted to be a deny, a local provision still succeeds.

## Scope

Per the function-level boundary (coordination receipt 130281): `Provision`, cost accounting and migrations. `teardown`, `Reap` and `reconcileInventory` are untouched. No new attempt state, no new table.
