### PR TITLE
fix(runtime): map omp workspace-write to --approval-mode=write, not yolo (#1721)

### DIFF
--- a/internal/runtime/omp.go
+++ b/internal/runtime/omp.go
@@ -114,24 +114,42 @@ func (a OmpAdapter) PermissionPolicyApplication(agent Agent) PermissionPolicyApp
 // mirroring codexSandboxArgs and claudePermissionArgs: one function owns both
 // the argv and the declaration, so the two cannot drift (#1721).
 //
-// THE MAPPING IS MEASURED, NOT ASSUMED. Against the pinned CLI (omp 17.2.4,
-// headless, stdin closed, no host pre-approvals), always-ask returns
-// isError:false for read, grep and read-on-a-directory, returns isError:true
-// with "requires approval but no interactive UI available" for bash and write
-// WITHOUT the write landing, and still exits 0 with a full agent_end envelope
-// this adapter parses. So always-ask restricts omp to read-only tools and
-// terminates cleanly, which is what a read-only autonomy policy asks for.
+// THE MAPPING IS MEASURED, NOT ASSUMED. Against the installed CLI (omp 18.1.15,
+// headless, stdin closed, no host pre-approvals), with the decider being the
+// FILESYSTEM rather than the transcript:
 //
-// EVERY OTHER POLICY KEEPS TODAY'S yolo ARGV, byte-identical, because this
-// change closes a least-privilege gap and is not a re-tuning of the runtime.
-// The DECLARATION still differs by policy, because yolo is unrestricted: it is
-// `applied` only for danger-full-access, and `widened` where the stored policy
-// asked for less than yolo grants. Reporting `applied` there would claim a
-// confinement no argv performs.
+//	mode         in-dir write (tool)  shell command  write outside cwd
+//	always-ask   refused              -              -
+//	write        landed               REFUSED        REFUSED
+//	yolo         landed               landed         landed
+//	(no flag)    -                    landed         landed
+//
+// always-ask returns isError:true with "requires approval but no interactive UI
+// available" for bash and write WITHOUT the write landing, and still exits 0
+// with a full agent_end envelope this adapter parses, so it restricts omp to
+// read-only tools and terminates cleanly - what a read-only policy asks for.
+//
+// write is the value that matches workspace-write, on TWO axes rather than one:
+// it permits editing tools while refusing shell execution AND refusing writes to
+// absolute paths outside the working directory. Under write the CLI made nine
+// bash tool calls and left zero markers on disk. That is the same confinement
+// the sibling runtimes give this policy - claude maps workspace-write to
+// --permission-mode acceptEdits, which does not unblock Bash, and codex to
+// --sandbox workspace-write - so yolo here granted strictly more than the policy
+// names, and a truthful `widened` declaration did not make the grant narrower.
+//
+// auto AND the stored-empty case KEEP yolo, deliberately. Their honest analogue
+// would be omitting the flag entirely, the way claude passes no permission-mode
+// for auto, and the measured no-flag row above shows that permits shell and
+// out-of-cwd writes on this host: it reads tools.approvalMode from operator
+// config, so its confinement is a host property this adapter cannot state. That
+// is a separate decision with its own blast radius, and it is not made here.
 func ompApprovalArgs(agent Agent) (string, PermissionPolicyApplication) {
 	switch NormalizeStoredAutonomyPolicy(agent.AutonomyPolicy) {
 	case AutonomyPolicyReadOnly:
 		return "--approval-mode=always-ask", PermissionPolicyApplied
+	case AutonomyPolicyWorkspaceWrite:
+		return "--approval-mode=write", PermissionPolicyApplied
 	case AutonomyPolicyDangerFullAccess:
 		return "--approval-mode=yolo", PermissionPolicyApplied
 	default:

--- a/internal/runtime/omp_test.go
+++ b/internal/runtime/omp_test.go
@@ -3097,7 +3097,7 @@ func TestOmpPolicyArgs(t *testing.T) {
 	}{
 		{AutonomyPolicyAuto, "--approval-mode=yolo"},
 		{AutonomyPolicyReadOnly, "--approval-mode=always-ask"},
-		{AutonomyPolicyWorkspaceWrite, "--approval-mode=yolo"},
+		{AutonomyPolicyWorkspaceWrite, "--approval-mode=write"},
 		{AutonomyPolicyDangerFullAccess, "--approval-mode=yolo"},
 	} {
 		t.Run(tc.policy, func(t *testing.T) {
@@ -3765,10 +3765,16 @@ func TestOmpApprovalModeFollowsTheStoredPolicy(t *testing.T) {
 		{AutonomyPolicyReadOnly, "--approval-mode=always-ask", PermissionPolicyApplied},
 		// Full access IS yolo, so the declaration is honest at `applied`.
 		{AutonomyPolicyDangerFullAccess, "--approval-mode=yolo", PermissionPolicyApplied},
-		// yolo grants more than either of these asked for. `widened` is the
-		// only truthful declaration; `applied` would claim a confinement no
+		// workspace-write maps to write, MEASURED against omp 18.1.15 with the
+		// filesystem as the decider: write lands an editing tool's file, refuses
+		// a shell command (nine bash tool calls, zero markers on disk) and
+		// refuses a write to an absolute path outside the working directory.
+		// That is what this policy asks for and what the sibling runtimes give
+		// it, so `applied` is honest here rather than `widened`.
+		{AutonomyPolicyWorkspaceWrite, "--approval-mode=write", PermissionPolicyApplied},
+		// auto KEEPS yolo, which grants more than it asked for, so `widened` is
+		// the only truthful declaration: `applied` would claim a confinement no
 		// argv performs, and not-applied would hide that a flag was passed.
-		{AutonomyPolicyWorkspaceWrite, "--approval-mode=yolo", PermissionPolicyWidened},
 		{AutonomyPolicyAuto, "--approval-mode=yolo", PermissionPolicyWidened},
 		// An unset policy normalizes to auto, NOT to read-only, so it must not
 		// inherit the restricted argv. This arm is what caught the mapping


### PR DESCRIPTION
## What this changes

`ompApprovalArgs` maps `workspace-write` to `--approval-mode=write` instead of `yolo`. `read-only`, `danger-full-access`, `auto` and the stored-empty case are byte-identical to `main`.

## The measurement, with the filesystem as the decider

Installed `omp 18.1.15`. Same prompt per mode: land a file with an editing tool, then run a SHELL command, then write to an absolute path outside the working directory.

```
mode         in-dir write (tool)   shell command   write outside cwd
always-ask   refused               -               -
write        landed                REFUSED         REFUSED
yolo         landed                landed          landed
(no flag)    -                     landed          landed
```

Under `write` the CLI made **nine bash tool calls and left zero markers on disk**, refusing with:

```
Tool "bash" requires approval but no interactive UI available. Options:
  1. Set tools.approvalMode: yolo in /settings
  2. Add tools.approval.bash: allow to config
  3. Use an interactive U[I]
```

`requires approval` appears 15 times and `no interactive` 14 times in that run.

## Two axes, and the second one is not predictable from the flag name

`yolo` granted more than `workspace-write` names on **two** axes: shell execution **and** writes to absolute paths outside the working directory. I expected only the first; the out-of-workspace write is the one nobody would infer from a flag called `yolo` versus `write`.

## The sibling precedent, which is why `write` is the matching value rather than a guess

```
claude   workspace-write -> --permission-mode acceptEdits   (AGENTS.md: does NOT unblock Bash)
codex    workspace-write -> --sandbox workspace-write
```

## The prior declaration was not wrong, and that is the point

`main` declares this arm `PermissionPolicyWidened`, which **truthfully** described an over-broad grant. A truthful label on an over-broad grant is still an over-broad grant, and disclosure is not mitigation. So the fix is the argv; the declaration becomes `applied` because the confinement is now real.

Worth recording that this passed two readers: I wrote the merged mapping and a reviewer approved it, and both of us treated `write` as a *precision* question rather than a *permission* one. Two readers agreeing is not corroboration when neither ran the thing.

## BLAST RADIUS: this REMOVES a capability three live agents have today

Measured on this host's registry:

```
omp agents by stored policy
  danger-full-access  6   gm-omp-impl, gm-omp-seat, gm-omp-fanout, gm-omp-gate,
                          among-friends-omp, checkin-review-omp     (unchanged)
  auto                5   omp-live, joltra-omp, numbra-omp, keephair-omp,
                          gm-reviewfix-c                            (unchanged, see below)
  workspace-write     3   appkit-omp, omp-router, checkin-builder    <- AFFECTED
```

**`appkit-omp`, `omp-router` and `checkin-builder` lose shell execution and out-of-workspace writes.** If any of them runs `git`, `go`, or any command through a shell tool, it stops being able to after this lands. That is a removal of a capability they have today, not a no-op tightening.

The eight-agent figure that motivated this PR counts `auto` and `workspace-write` together. **This PR touches only the three**, because `auto`'s honest mapping is a separate question: its analogue is omitting the flag, and the measured `(no flag)` row above shows that permits shell and out-of-cwd writes on this host, since `omp` reads `tools.approvalMode` from operator config. That confinement is a host property the adapter cannot state, so choosing it is a different decision with its own five-agent radius, and it is not made here.

## What I did not test

- network access under any mode
- `always-ask` against a shell command (the earlier probe stopped at the write refusal)
- whether `tools.approval.bash: allow` in operator config overrides `--approval-mode`
- single run per mode; the write/yolo split reproduced on the filesystem in both directions, which is stronger than a transcript, but it is not a repeated measurement
- whether the three affected agents actually use shell tools in practice

## Verification

```
mutant: mapping reverted to yolo      -> FAIL "--approval-mode=write" appears 0 times, want exactly 1
mutant: argv write, declared widened  -> FAIL PermissionPolicyApplication = "widened", want "applied"
go build -buildvcs=false ./...          clean
go vet ./internal/runtime/              clean
go test ./internal/runtime/ -count=1    ok
```

Both mutants compile and start from a passing baseline. The declaration and the argv are asserted together, so a change to either alone fails.

## Draft deliberately

This is a live permission change to merged code that removes a capability from three running agents. Sequencing is not mine to choose and no migration or grace period is proposed here. Refs #1721, #2113.

---

## BLOCKED ON #2132's in-place policy verb - do not ready this PR

Five agents have measured or mechanically-necessary shell use and **there is no supported way to grant it deliberately before tightening the default**. Attempted per the owner's phase-2 instruction and refused:

```
checkin-builder  rc=2  "agent type set requires --runtime for new type"
joltra-omp       rc=2  same        numbra-omp  rc=2  same        keephair-omp  rc=2  same
appkit-omp       rc=0  "configured agent type appkit-omp"  -- and the value dispatch reads DID NOT CHANGE
```

`agent type set --policy` writes the config plane; `runtimeAgent(db.Agent)` at `agent_dispatch.go:348` reads the row. `agent type show` then reports `danger-full-access` while `agent show` reports `workspace-write`. That write was reverted; all planes read `workspace-write` again.

The other routes were declined deliberately: `agent start --policy` re-registers and abandons the runtime session (`joltra-omp` holds 106 recorded jobs and a live session), and landing this fix first is the outage the owner explicitly declined.

## Corrected blast radius: 2 dispatched agents, not 8

`--approval-mode` is argv built at dispatch, so an agent whose history is entirely `session-*` attribution rows never receives it:

```
agent            local-* dispatched   session-* recorded
appkit-omp                6                  0        <- AFFECTED
checkin-builder           1                  0        <- AFFECTED
gm-reviewfix-c            0                 11
joltra-omp                0                107
keephair-omp              0                  1
numbra-omp                0                  3
omp-live                  0                  0
omp-router                0                  0
```

The two affected are exactly the two whose shell use was measured first-hand: `checkin-builder` at **612 bash calls in one retained job log**, `appkit-omp` recording `python3 e2e/content_validator_e2e.py -> exit 0`. The three I earlier labelled INFERRED are session-only, which is why no transcript existed to read.

## The three considered and DECLINED for raising, one reason each

- **`omp-router`, `omp-live`**: zero jobs ever. Raising is a declared widening of a paper grant never exercised; if either ever runs and needs shell, the failure is loud, immediate and correctly attributed, and the grant gets made at demonstrated need.
- **`gm-reviewfix-c`**: 11 recorded jobs, zero branches, zero `tests_run`, empty most recent summary. It satisfies the letter of "already has yolo" and there is no evidence it needs shell. Raising a grant is silent and permanent; letting one lapse is loud and reversible.

These three were considered and declined, not overlooked.

---

## UNBLOCKED: the raises are done, so this no longer removes a capability from anyone

#2132's in-place verb landed as `2f67ab7c` and both authorised raises are executed and read back per plane (evidence on #1721):

```
checkin-builder  row: workspace-write -> danger-full-access   rc=0   config_type: none (registry-only)
appkit-omp       row: workspace-write -> danger-full-access   rc=0   config_type: danger-full-access
deployed binary reports both as danger-full-access
```

**Both agents that receive this PR's tightened argv now declare `danger-full-access` deliberately**, so `workspace-write -> write` takes nothing from either. The grant they held by accident of the mapping is now a policy row that says so, which was the point of the ordering.

The three declined agents are unchanged and still declined for the reasons above: `omp-router` and `omp-live` have never run a job, and `gm-reviewfix-c` has 11 recorded jobs with zero command evidence. They fall to `write` and any need becomes a loud, correctly attributed failure at the moment of demonstrated need.

Rebased onto `origin/main` after the base moved for the verb merge; `go build ./...` and `go test ./internal/runtime/ -count=1` both clean at this head.