### PR TITLE
fix(cli): make the worker tick's checkout-lock acquisition symmetric with the poller's (#2135)

### DIFF
--- a/internal/cli/daemon_scheduler.go
+++ b/internal/cli/daemon_scheduler.go
@@ -1806,12 +1806,45 @@ func runEnabledRepoWorkerTicksTracked(ctx context.Context, store *db.Store, work
 			continue
 		}
 		enabled++
+		// SYMMETRIC ACQUISITION (#2135). The poller takes this same per-repo lock
+		// with TryLock and degrades to a recovery-only poll rather than waiting
+		// (daemon_supervision.go:1289). This loop used a BLOCKING Lock(), so the
+		// politeness was one-directional: a poll in progress on repo A stalled this
+		// SEQUENTIAL sweep at A, and every repo behind A got no dispatch at all -
+		// their queued jobs emitted no dispatch_declined event either, because the
+		// selector was never reached.
+		//
+		// Bounding the poll is NOT the remedy and was already tried: #555 bounds it
+		// at daemonPollTimeout (2m) and documents this exact stall. 35 repos x 2m
+		// sequential is ~70 minutes, so shrinking the bound only moves the number.
+		//
+		// The lock's invariant is unchanged - whoever holds it still has exclusive
+		// access to that checkout. What changes is that a LOSER SKIPS instead of
+		// waiting, so contention costs one repo one sweep instead of costing every
+		// repo behind it.
 		lock := locks.For(repo.FullName())
+		held := false
 		if lock != nil {
-			lock.Lock()
+			if forced := skippedRepoTickNeedsLock(repo.FullName()); forced {
+				// STARVATION VALVE. A repo that loses the race every sweep would be
+				// silently late forever while the fleet looked healthy - strictly
+				// worse than the visible fleet-wide lateness this fix removes. After
+				// repoTickSkipForceAfter consecutive skips this repo waits, so it is
+				// delayed at most that many sweeps rather than indefinitely.
+				lock.Lock()
+				held = true
+			} else if lock.TryLock() {
+				held = true
+			}
 		}
+		if lock != nil && !held {
+			skipped := recordRepoTickSkip(repo.FullName())
+			writeLine(stdout, "%s: worker tick skipped, checkout busy (consecutive skips %d of %d before forcing)", repo.FullName(), skipped, repoTickSkipForceAfter)
+			continue
+		}
+		clearRepoTickSkip(repo.FullName())
 		tickErr := runDaemonWorkerTickTracked(ctx, store, worker, workers, false, repo.FullName(), rootFilter, stdout, now, tracker, cand)
-		if lock != nil {
+		if lock != nil && held {
 			lock.Unlock()
 		}
 		if tickErr != nil {

--- a/internal/cli/daemon_scheduler.go
+++ b/internal/cli/daemon_scheduler.go
@@ -1801,6 +1801,10 @@ func runEnabledRepoWorkerTicksTracked(ctx context.Context, store *db.Store, work
 	enabled := 0
 	failed := 0
 	var lastErr error
+	// Repos whose consecutive-skip streak has earned a GUARANTEED turn. They are
+	// collected during the sweep and served after it, so a blocking acquisition
+	// never sits in front of a repo that could have dispatched immediately.
+	var forced []db.Repo
 	for _, repo := range repos {
 		if !repo.Enabled {
 			continue
@@ -1825,21 +1829,30 @@ func runEnabledRepoWorkerTicksTracked(ctx context.Context, store *db.Store, work
 		lock := locks.For(repo.FullName())
 		held := false
 		if lock != nil {
-			if forced := skippedRepoTickNeedsLock(repo.FullName()); forced {
-				// STARVATION VALVE. A repo that loses the race every sweep would be
-				// silently late forever while the fleet looked healthy - strictly
-				// worse than the visible fleet-wide lateness this fix removes. After
-				// repoTickSkipForceAfter consecutive skips this repo waits, so it is
-				// delayed at most that many sweeps rather than indefinitely.
-				lock.Lock()
-				held = true
-			} else if lock.TryLock() {
+			if skippedRepoTickNeedsLock(repo.FullName()) {
+				// STARVATION VALVE, DEFERRED RATHER THAN IN PLACE. A repo that loses
+				// the race every sweep would be silently late forever while the fleet
+				// looked healthy - worse than the visible lateness this fix removes,
+				// because today's version is at least reproducible. So after
+				// repoTickSkipForceAfter consecutive skips the repo gets a GUARANTEED
+				// turn with a blocking acquisition.
+				//
+				// Taking that block HERE would reintroduce head-of-line blocking at a
+				// 1-in-N duty cycle: every repo behind this one would wait exactly as
+				// it does today, once every Nth contended sweep. Deferring it to the
+				// end of the sweep keeps the guarantee and removes the residual
+				// entirely - every other repo dispatches first, then the starved repo
+				// waits as long as it must.
+				forced = append(forced, repo)
+				continue
+			}
+			if lock.TryLock() {
 				held = true
 			}
 		}
 		if lock != nil && !held {
 			skipped := recordRepoTickSkip(repo.FullName())
-			writeLine(stdout, "%s: worker tick skipped, checkout busy (consecutive skips %d of %d before forcing)", repo.FullName(), skipped, repoTickSkipForceAfter)
+			writeLine(stdout, "%s: worker tick skipped, checkout busy (consecutive skips %d of %d before a forced turn)", repo.FullName(), skipped, repoTickSkipForceAfter)
 			continue
 		}
 		clearRepoTickSkip(repo.FullName())
@@ -1851,6 +1864,28 @@ func runEnabledRepoWorkerTicksTracked(ctx context.Context, store *db.Store, work
 			// A cancellation observed mid-sweep is a clean shutdown, not a repo
 			// fault: propagate it immediately so the supervisor treats it as such
 			// (and it never counts toward or masks the escalation streak).
+			if errors.Is(tickErr, context.Canceled) || ctx.Err() != nil {
+				return tickErr
+			}
+			failed++
+			lastErr = tickErr
+			writeLine(stdout, "%s: worker tick error: %v", repo.FullName(), tickErr)
+		}
+	}
+	// THE DEFERRED FORCED TURNS. Served only after every other repo has had its
+	// chance, so the blocking acquisition below can delay nothing but itself.
+	for _, repo := range forced {
+		lock := locks.For(repo.FullName())
+		if lock != nil {
+			lock.Lock()
+		}
+		writeLine(stdout, "%s: worker tick taking a forced turn after %d consecutive skips", repo.FullName(), repoTickSkipForceAfter)
+		clearRepoTickSkip(repo.FullName())
+		tickErr := runDaemonWorkerTickTracked(ctx, store, worker, workers, false, repo.FullName(), rootFilter, stdout, now, tracker, cand)
+		if lock != nil {
+			lock.Unlock()
+		}
+		if tickErr != nil {
 			if errors.Is(tickErr, context.Canceled) || ctx.Err() != nil {
 				return tickErr
 			}

--- a/internal/cli/repo_tick_skips.go
+++ b/internal/cli/repo_tick_skips.go
@@ -1,0 +1,63 @@
+package cli
+
+import "sync"
+
+// repoTickSkipForceAfter bounds how many CONSECUTIVE sweeps a repo may lose the
+// race for its own checkout lock before the worker tick waits for it instead of
+// skipping (#2135).
+//
+// WHY THREE. The symmetric-acquisition fix makes a contended repo skip rather
+// than block, which removes the cross-repo stall - but on its own it introduces a
+// worse failure than the one it fixes: a repo whose poll is slow and whose tick
+// always loses the race would be silently late FOREVER while the fleet looked
+// healthy. Today's bug is at least visible, because every repo is late together.
+//
+// Three is chosen against the two cadences rather than picked: the worker loop
+// ticks on the order of a second, the poller's own per-repo work is bounded at
+// daemonPollTimeout (2m, daemon_scheduler.go), and a poll is only in progress for
+// a fraction of any repo's poll interval. Losing three consecutive sweeps
+// therefore means real contention rather than an unlucky sample, and forcing on
+// the fourth costs one repo one bounded wait instead of an unbounded absence.
+// Lower would force during ordinary contention and re-introduce the stall this
+// fix removes; higher widens the window in which a starving repo is invisible.
+const repoTickSkipForceAfter = 3
+
+// repoTickSkips counts CONSECUTIVE worker-tick skips per repo. It is deliberately
+// observable rather than internal: the question this fix must be able to answer
+// in one query is "which repo is losing the race", and #2117's lesson is that an
+// instrument whose absence is silent localises nothing. The count is logged on
+// every skip with its threshold, so a starving repo names itself in the daemon
+// log rather than requiring an evening of correlation.
+var repoTickSkips = struct {
+	mu     sync.Mutex
+	counts map[string]int
+}{counts: map[string]int{}}
+
+// recordRepoTickSkip increments repo's consecutive-skip count and returns the new
+// value, for logging.
+func recordRepoTickSkip(repo string) int {
+	repoTickSkips.mu.Lock()
+	defer repoTickSkips.mu.Unlock()
+	repoTickSkips.counts[repo]++
+	return repoTickSkips.counts[repo]
+}
+
+// clearRepoTickSkip resets repo's streak. Called when the tick RUNS for that repo,
+// whether it acquired the lock immediately or by forcing, so the counter measures
+// consecutive misses rather than lifetime misses.
+func clearRepoTickSkip(repo string) {
+	repoTickSkips.mu.Lock()
+	defer repoTickSkips.mu.Unlock()
+	delete(repoTickSkips.counts, repo)
+}
+
+// skippedRepoTickNeedsLock reports whether repo has already lost
+// repoTickSkipForceAfter consecutive sweeps and must therefore WAIT for its lock
+// on this one. It is read-only: the streak is cleared by clearRepoTickSkip once
+// the tick actually runs, so a forced acquisition that then runs resets the
+// counter exactly like an uncontended one.
+func skippedRepoTickNeedsLock(repo string) bool {
+	repoTickSkips.mu.Lock()
+	defer repoTickSkips.mu.Unlock()
+	return repoTickSkips.counts[repo] >= repoTickSkipForceAfter
+}

--- a/internal/cli/repo_tick_skips_test.go
+++ b/internal/cli/repo_tick_skips_test.go
@@ -113,9 +113,10 @@ func TestWorkerSweepReachesTheSelectorOnRepoBehindABusyRepo(t *testing.T) {
 		}
 	}
 	uniq := t.Name()
-	// Two jobs on the FREE repo sharing one runtime session, so the second is
-	// declined rather than admitted - a decline is the observable, and it needs
-	// the selector to have run.
+	// Two jobs on the FREE repo. They are ADMITTED and then fail downstream on a
+	// checkout precondition, which is what makes the state transition off `queued`
+	// the observable - see the note at the assertion. The point is only that the
+	// selector had to RUN for this repo for either job to move at all.
 	for i := 0; i < 2; i++ {
 		agent := fmt.Sprintf("lead-%d-%s", i, uniq)
 		task := fmt.Sprintf("task-%d-%s", i, uniq)
@@ -184,6 +185,18 @@ func TestWorkerSweepDefersTheForcedTurnToTheEnd(t *testing.T) {
 			t.Fatalf("UpsertRepo %s: %v", name, err)
 		}
 	}
+	// The free repo needs an OBSERVABLE tick: a clean tick logs nothing, so a
+	// queued job is seeded to produce a per-job dispatch line whose position in
+	// the output can be compared against the forced turn's.
+	uniq := t.Name()
+	agent := "lead-" + uniq
+	task := "task-" + uniq
+	seedDaemonWorkerAgent(t, store, agent, runtime.CodexRuntime, "session-"+uniq, []string{"implement"}, "owner/zzz-free")
+	if err := store.UpsertTask(ctx, db.Task{ID: task, RepoFullName: "owner/zzz-free", State: string(workflow.TaskImplementing), Branch: task, WorktreePath: "/tmp/gitmoot/" + task}); err != nil {
+		t.Fatalf("UpsertTask: %v", err)
+	}
+	enqueueDaemonWorkerJob(t, store, workflow.JobRequest{ID: "job-" + uniq, Agent: agent, Action: "implement", Repo: "owner/zzz-free", Branch: task, TaskID: task})
+
 	locks := &repoCheckoutLocks{}
 	busy := locks.For("owner/aaa-busy")
 	busy.Lock()
@@ -217,7 +230,20 @@ func TestWorkerSweepDefersTheForcedTurnToTheEnd(t *testing.T) {
 	case <-time.After(20 * time.Second):
 		t.Fatal("sweep did not finish after the forced repo's lock was released")
 	}
-	if !strings.Contains(out.String(), "owner/aaa-busy: worker tick taking a forced turn") {
-		t.Fatalf("forced turn was not reported, so a starving repo's guaranteed turn is invisible; output=%q", out.String())
+	logged := out.String()
+	forcedAt := strings.Index(logged, "owner/aaa-busy: worker tick taking a forced turn")
+	if forcedAt < 0 {
+		t.Fatalf("forced turn was not reported, so a starving repo's guaranteed turn is invisible; output=%q", logged)
+	}
+	// THE ORDERING IS THE POINT, not merely that the forced turn happened. A
+	// mutant that serves forced repos FIRST still waits and still logs, so only
+	// the position distinguishes deferral from in-place forcing - and in-place
+	// forcing is what reintroduces head-of-line blocking at a 1-in-N duty cycle.
+	freeAt := strings.Index(logged, "job "+"job-"+uniq)
+	if freeAt < 0 {
+		t.Fatalf("the free repo produced no dispatch line, so this test cannot order anything; output=%q", logged)
+	}
+	if freeAt > forcedAt {
+		t.Fatalf("the forced turn was served BEFORE the free repo's dispatch (forced at %d, free at %d): the blocking acquisition is sitting in front of a repo that could have dispatched immediately, which is the head-of-line blocking this fix removes; output=%q", forcedAt, freeAt, logged)
 	}
 }

--- a/internal/cli/repo_tick_skips_test.go
+++ b/internal/cli/repo_tick_skips_test.go
@@ -3,11 +3,14 @@ package cli
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/gitmoot/gitmoot/internal/db"
+	"github.com/gitmoot/gitmoot/internal/runtime"
+	"github.com/gitmoot/gitmoot/internal/workflow"
 )
 
 // TestWorkerSweepSkipsBusyRepoAndReachesTheRest is #2135's cadence test, and the
@@ -88,5 +91,133 @@ func TestRepoTickSkipForcesLockAfterThreshold(t *testing.T) {
 	clearRepoTickSkip(repo)
 	if skippedRepoTickNeedsLock(repo) {
 		t.Fatal("a repo whose tick ran still demands a blocking acquisition; the counter is measuring lifetime skips rather than consecutive ones")
+	}
+}
+
+// TestWorkerSweepReachesTheSelectorOnRepoBehindABusyRepo is the strong form of
+// the cadence property. "The sweep completed" is weaker than what #2135 claims:
+// it does not prove the SELECTOR ran for the repo behind the busy one, which is
+// the thing that was never happening.
+//
+// The observable is #2117's own instrument, used as a probe. Two jobs on repo B
+// contend for one checkout key, so the selector must DECLINE the second and
+// write a dispatch_declined event. That event can only exist if the selector was
+// reached for repo B in this sweep - which is exactly what a blocking
+// acquisition at repo A prevents.
+func TestWorkerSweepReachesTheSelectorOnRepoBehindABusyRepo(t *testing.T) {
+	ctx := context.Background()
+	store := daemonWorkerStore(t)
+	for _, name := range []string{"aaa-busy", "zzz-free"} {
+		if err := store.UpsertRepo(ctx, db.Repo{Owner: "owner", Name: name, CheckoutPath: t.TempDir(), Enabled: true}); err != nil {
+			t.Fatalf("UpsertRepo %s: %v", name, err)
+		}
+	}
+	uniq := t.Name()
+	// Two jobs on the FREE repo sharing one runtime session, so the second is
+	// declined rather than admitted - a decline is the observable, and it needs
+	// the selector to have run.
+	for i := 0; i < 2; i++ {
+		agent := fmt.Sprintf("lead-%d-%s", i, uniq)
+		task := fmt.Sprintf("task-%d-%s", i, uniq)
+		seedDaemonWorkerAgent(t, store, agent, runtime.CodexRuntime, "session-shared", []string{"implement"}, "owner/zzz-free")
+		if err := store.UpsertTask(ctx, db.Task{ID: task, RepoFullName: "owner/zzz-free", State: string(workflow.TaskImplementing), Branch: task, WorktreePath: "/tmp/gitmoot/" + task}); err != nil {
+			t.Fatalf("UpsertTask: %v", err)
+		}
+		enqueueDaemonWorkerJob(t, store, workflow.JobRequest{ID: fmt.Sprintf("job-%d-%s", i, uniq), Agent: agent, Action: "implement", Repo: "owner/zzz-free", Branch: task, TaskID: task})
+	}
+
+	locks := &repoCheckoutLocks{}
+	busy := locks.For("owner/aaa-busy")
+	busy.Lock()
+	defer busy.Unlock()
+	clearRepoTickSkip("owner/aaa-busy")
+	defer clearRepoTickSkip("owner/aaa-busy")
+
+	var out bytes.Buffer
+	worker := jobWorker{Store: store, Stdout: &out}
+	done := make(chan error, 1)
+	go func() {
+		done <- runEnabledRepoWorkerTicksTracked(ctx, store, worker, 8, "", &out, time.Now().UTC(), locks, nil)
+	}()
+	select {
+	case <-done:
+	case <-time.After(20 * time.Second):
+		t.Fatal("sweep blocked on the busy repo's lock, so the selector was never reached for the repo behind it")
+	}
+
+	// THE OBSERVABLE IS A STATE CHANGE ON REPO B'S JOBS. They can only leave
+	// `queued` if the sweep reached repo B's dispatch, which is precisely what a
+	// blocking acquisition at repo A prevents.
+	//
+	// My first attempt asserted a dispatch_declined event instead, on the theory
+	// that two jobs sharing a runtime session would make the selector decline the
+	// second. It did not: both were ADMITTED and then failed downstream on a
+	// checkout precondition, so no decline was ever written. The failure output
+	// proved the property while the assertion denied it - the observable was
+	// wrong, not the fix.
+	queued, err := store.ListQueuedJobs(ctx)
+	if err != nil {
+		t.Fatalf("ListQueuedJobs: %v", err)
+	}
+	stillQueued := 0
+	for _, job := range queued {
+		if strings.Contains(job.ID, uniq) {
+			stillQueued++
+		}
+	}
+	if stillQueued == 2 {
+		t.Fatalf("both of the free repo's jobs are still queued: the sweep never reached repo B's dispatch, which is the defect #2135 describes; output=%q", out.String())
+	}
+}
+
+// TestWorkerSweepDefersTheForcedTurnToTheEnd pins the residual that the deferred
+// valve exists to remove. Taking the forced blocking acquisition IN PLACE would
+// reintroduce head-of-line blocking at a 1-in-N duty cycle: on that sweep every
+// repo behind the starved one waits exactly as it does today. Deferring keeps the
+// guarantee and removes the residual, so the forced turn must be reported AFTER
+// the free repo's tick rather than before it.
+func TestWorkerSweepDefersTheForcedTurnToTheEnd(t *testing.T) {
+	ctx := context.Background()
+	store := daemonWorkerStore(t)
+	for _, name := range []string{"aaa-busy", "zzz-free"} {
+		if err := store.UpsertRepo(ctx, db.Repo{Owner: "owner", Name: name, CheckoutPath: t.TempDir(), Enabled: true}); err != nil {
+			t.Fatalf("UpsertRepo %s: %v", name, err)
+		}
+	}
+	locks := &repoCheckoutLocks{}
+	busy := locks.For("owner/aaa-busy")
+	busy.Lock()
+	clearRepoTickSkip("owner/aaa-busy")
+	defer clearRepoTickSkip("owner/aaa-busy")
+	// Put the busy repo one skip below the threshold so THIS sweep forces it.
+	for i := 0; i < repoTickSkipForceAfter; i++ {
+		recordRepoTickSkip("owner/aaa-busy")
+	}
+
+	var out bytes.Buffer
+	worker := jobWorker{Store: store, Stdout: &out}
+	done := make(chan error, 1)
+	go func() {
+		done <- runEnabledRepoWorkerTicksTracked(ctx, store, worker, 1, "", &out, time.Now().UTC(), locks, nil)
+	}()
+	// The forced turn must WAIT for the lock, so the sweep cannot finish while it
+	// is held - and crucially it must not finish EARLY either, which would mean
+	// the guarantee was dropped rather than deferred.
+	select {
+	case <-done:
+		t.Fatal("sweep finished while the forced repo's lock was still held: the guaranteed turn was skipped, not deferred")
+	case <-time.After(2 * time.Second):
+	}
+	busy.Unlock()
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("sweep returned %v after the forced turn became available", err)
+		}
+	case <-time.After(20 * time.Second):
+		t.Fatal("sweep did not finish after the forced repo's lock was released")
+	}
+	if !strings.Contains(out.String(), "owner/aaa-busy: worker tick taking a forced turn") {
+		t.Fatalf("forced turn was not reported, so a starving repo's guaranteed turn is invisible; output=%q", out.String())
 	}
 }

--- a/internal/cli/repo_tick_skips_test.go
+++ b/internal/cli/repo_tick_skips_test.go
@@ -1,0 +1,92 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gitmoot/gitmoot/internal/db"
+)
+
+// TestWorkerSweepSkipsBusyRepoAndReachesTheRest is #2135's cadence test, and the
+// property is CADENCE, NOT COMPLETION. Asserting "the job eventually dispatches"
+// passes today, with the bug, at ~78 minutes: the sweep blocks on the busy repo's
+// lock and every repo behind it waits out the poll. So this asserts the sweep
+// COMPLETES while a repo's lock is held by someone else - which it cannot do
+// while the acquisition is a blocking Lock().
+func TestWorkerSweepSkipsBusyRepoAndReachesTheRest(t *testing.T) {
+	ctx := context.Background()
+	store := daemonWorkerStore(t)
+	for _, name := range []string{"aaa-busy", "zzz-free"} {
+		if err := store.UpsertRepo(ctx, db.Repo{Owner: "owner", Name: name, CheckoutPath: t.TempDir(), Enabled: true}); err != nil {
+			t.Fatalf("UpsertRepo %s: %v", name, err)
+		}
+	}
+	// The busy repo sorts FIRST, so a blocking acquisition stalls before the free
+	// repo is ever considered - the ordering is the whole point of the fixture.
+	locks := &repoCheckoutLocks{}
+	busy := locks.For("owner/aaa-busy")
+	busy.Lock()
+	defer busy.Unlock()
+	clearRepoTickSkip("owner/aaa-busy")
+	defer clearRepoTickSkip("owner/aaa-busy")
+
+	var out bytes.Buffer
+	worker := jobWorker{Store: store, Stdout: &out}
+	done := make(chan error, 1)
+	go func() {
+		done <- runEnabledRepoWorkerTicksTracked(ctx, store, worker, 1, "", &out, time.Now().UTC(), locks, nil)
+	}()
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("sweep returned %v, want it to complete past the busy repo", err)
+		}
+	case <-time.After(15 * time.Second):
+		t.Fatal("sweep did not finish while another holder had one repo's checkout lock: it is waiting on that lock, so every repo behind the busy one gets no dispatch this sweep")
+	}
+
+	if !strings.Contains(out.String(), "owner/aaa-busy: worker tick skipped, checkout busy") {
+		t.Fatalf("busy repo did not report a skip, so a starving repo would not name itself in the log; output=%q", out.String())
+	}
+}
+
+// TestRepoTickSkipForcesLockAfterThreshold covers the STARVATION VALVE, which is
+// the arm that would otherwise ship untested - and an untested safety valve is
+// the corpus defect this campaign keeps finding. Without it the fix trades a
+// visible fleet-wide stall for one repo silently late forever.
+func TestRepoTickSkipForcesLockAfterThreshold(t *testing.T) {
+	const repo = "owner/starving"
+	clearRepoTickSkip(repo)
+	defer clearRepoTickSkip(repo)
+
+	if skippedRepoTickNeedsLock(repo) {
+		t.Fatal("a repo with no skips already demands a blocking acquisition; every contended sweep would stall")
+	}
+	for i := 1; i < repoTickSkipForceAfter; i++ {
+		if got := recordRepoTickSkip(repo); got != i {
+			t.Fatalf("skip %d recorded as %d", i, got)
+		}
+		if skippedRepoTickNeedsLock(repo) {
+			t.Fatalf("forced a blocking acquisition after %d skips, before the %d threshold", i, repoTickSkipForceAfter)
+		}
+	}
+	if got := recordRepoTickSkip(repo); got != repoTickSkipForceAfter {
+		t.Fatalf("threshold skip recorded as %d, want %d", got, repoTickSkipForceAfter)
+	}
+	if !skippedRepoTickNeedsLock(repo) {
+		t.Fatalf("after %d consecutive skips the repo still does not force the lock, so it can be starved indefinitely", repoTickSkipForceAfter)
+	}
+
+	// THE STREAK MUST MEASURE CONSECUTIVE MISSES, NOT LIFETIME MISSES. A tick that
+	// runs clears it, so an occasionally-contended repo never accumulates its way
+	// into forcing - otherwise every repo eventually blocks and the fix undoes
+	// itself over time.
+	clearRepoTickSkip(repo)
+	if skippedRepoTickNeedsLock(repo) {
+		t.Fatal("a repo whose tick ran still demands a blocking acquisition; the counter is measuring lifetime skips rather than consecutive ones")
+	}
+}


### PR DESCRIPTION
Addresses gitmoot#2135. **The asymmetry is the defect, not the poll's duration** - please read that before reaching for "just lower the timeout", because that remedy already shipped.

## What was wrong

The poller takes each per-repo checkout lock with `TryLock` and degrades to a recovery-only poll rather than waiting (`daemon_supervision.go:1289`) - it is already polite. The worker tick took the **same** lock with a blocking `Lock()`, with dispatch inside it, in a **sequential** repo loop (`daemon_scheduler.go:1804-1816`).

So politeness was one-directional. A poll in progress on repo A stalled the whole sweep at A, and every repo behind A got no dispatch at all - and their queued jobs emitted **no `dispatch_declined` event** either (gitmoot#2117), because the selector was never reached. That silence is what localised this: a decline names a clause; nothing names the tick.

## The change

A loser **skips** instead of waiting. Contention costs one repo one sweep rather than costing every repo behind it. The lock's invariant is unchanged - whoever holds it still has exclusive access to that checkout.

## Why not just bound the poll

**That remedy already shipped, as #555**, which bounds the poll at `daemonPollTimeout` (2m) and whose comment documents this exact stall. 35 repos x 2m sequential is ~70 minutes against a measured ~78, so shrinking the bound only moves the number.

One detail worth having if you audit the bound: the 2m wraps **only** `PollOnce`. **Corrected after review:** only `store.UpdateRepoPollResult` (`:1341`) is both under the lock and outside that bound. `os.Stat` (`:1275`), `GitHubClient` (`:1286`) and `WorkflowFactory` (`:1287`) all run **before** the lock is acquired at `:1289` - they are unbounded but hold nothing. The distinction separates **lock hold time** (what starves other repos, and what this PR fixes) from **cycle length** (what the ~78-minute measurement captures), and it explains the 432s inter-poll gap better than my original claim did: that gap includes per-repo work that never touches the lock. That is how a measured **432s** gap exceeds a 2-minute bound with nothing violated - a reviewer who asks "is the poll bounded" gets **yes** and stops.

## The starvation valve ships here, not later

Skipping alone would trade a visible fleet-wide stall for **one repo silently late forever while the fleet looked healthy** - strictly worse, because today's version is at least reproducible. After `repoTickSkipForceAfter` (**3**) consecutive skips a repo **waits** for its lock, so it is delayed at most that many sweeps.

Three is derived rather than picked, and the constant carries the reasoning: the worker loop ticks on the order of a second and a poll occupies only a fraction of any repo's interval, so three consecutive misses mean real contention rather than an unlucky sample. Lower would force during ordinary contention and re-introduce the stall; higher widens the window in which a starving repo is invisible.

**And the counter is observable** - #2117's lesson applied to its own successor. Every skip logs the repo, its consecutive count and the threshold, so a starving repo names itself in the daemon log rather than requiring an evening of correlation.

## Tests assert cadence, not completion

"The job eventually dispatches" **passes today, with the bug, at 78 minutes.** So the test asserts the sweep **completes** while another holder owns one repo's lock, with the busy repo sorted **first** so a blocking acquisition stalls before the free repo is ever considered.

Three compiling semantic mutants, all killed from a passing baseline:

| Mutant | Result |
|---|---|
| restore the blocking `Lock()` | sweep hangs; fails on the deadline with "it is waiting on that lock, so every repo behind the busy one gets no dispatch this sweep" |
| remove the force-after-N valve | fails "after 3 consecutive skips the repo still does not force the lock, so it can be starved indefinitely" |
| make the streak lifetime rather than consecutive | fails - and this one matters, because that mutation makes every repo eventually block and undoes the fix over time |

`go build ./...` 0, `go vet ./internal/cli` 0.

## Answering the valve-in-place question, since a reviewer will find it

**The in-place valve reintroduced the bug at a 1-in-N duty cycle, and it is now gone rather than documented.** Taking the forced blocking acquisition at the starved repo's position meant that on that sweep every repo behind it waited exactly as it does today - the precise harm this PR removes, recurring once every Nth contended sweep. Bounded and far better than today, but not zero.

**Forced repos are now collected during the sweep and served after it.** Every other repo dispatches first; the starved repo still gets its guaranteed turn and waits as long as it must. Head-of-line blocking is eliminated rather than rate-limited, and the valve's guarantee is unchanged. The cost is real but small: the loop is now a range over repos plus a second range over a short slice, which still reads as obviously correct in a diff - that was the bar for choosing this over shipping the residual.

## Sweep order is deterministic, which the test depends on

`store.ListRepos` is `SELECT … FROM repos ORDER BY full_name` (`internal/db/store_tasks.go:85-86`). So the fixture's `aaa-busy` sorting before `zzz-free` matches a production **guarantee**, not a lucky map iteration - which matters because the blocking-`Lock()` mutant could otherwise pass on a favourable ordering.

## The test asserts the dispatch property, not sweep completion

"The sweep completed" does not prove the **selector ran** for the repo behind the busy one. The strengthened arm asserts a **state change** on the free repo's jobs: they can only leave `queued` if the sweep reached that repo's dispatch.

**My first observable for this was wrong, and the way it was wrong is worth recording.** I asserted a `dispatch_declined` event, expecting two jobs sharing a runtime session to make the selector decline the second. Both were **admitted** and failed downstream on a checkout precondition, so no decline was ever written - the failure output proved the property while my assertion denied it. The observable was wrong, not the fix.

## The most valuable mutant is the third one

| Mutant | Outcome |
|---|---|
| blocking `Lock()` for `TryLock` | kills **both** cadence arms, the second with "the selector was never reached for the repo behind it" |
| remove the force-after-N valve | fails the starvation arm |
| **lifetime instead of consecutive streak** | fails - **and this is the one that matters most**: a human reviewer would wave it through as equivalent, while it makes every repo eventually block and silently decays this fix back into the bug. A fix that decays is worse than none, because the regression test guarding it still passes |
| forced turn in place instead of deferred | fails the deferral arm |

**Scope of that last kill, stated rather than implied:** it dies because the mutation removes the forced-turn log line along with the deferral, so the test catches it through observability rather than ordering. A mutant that kept the log line and blocked in place would need an explicit ordering assertion to die. The deferral is structurally evident in the diff - a second loop after the first - and I would rather say that than claim a stronger kill than I have.

## Attribution and what is not proven

The live-daemon measurements - 35 repos, mean 134s between polling lines, max 432s, ~78-minute cycle, 74 `context deadline exceeded` in 3h, 94% CPU - are **`phobos`'s from the running process, not mine.** I verified the code that explains them.

**Not proven by me:** I have not reproduced the 78-minute cycle, and the 94% CPU is not established as caused by this rather than coincident with it. Both remain open on the issue.

**Also corrected on the issue, and worth knowing here:** my original filing claimed the registered path had no per-repo bound. That was false - `:1328/:1330` are inside `registeredRepoPoller.pollRepo` and do apply the 2m bound. The retraction is gitmoot#2135's first comment; the fix never depended on the bound being absent.

**Merge note:** `merge_rule: self` for this seat, read from `gitmoot org brief`; exercised only under the six safeguards and only after one substantive independent review at the exact head. I do not self-review.




---

## What this fixes, stated narrowly so a later measurement is not misread

**This fixes DISPATCH cadence, not POLL cadence.** The two are different quantities and were treated as one when the issue was filed:

| Quantity | After this PR |
|---|---|
| **lock hold time** - what starves other repos | fixed: a contended repo is skipped, not waited on |
| **cycle length** - the measured ~78-minute full sweep | **unchanged** |

The poll sweep will still take roughly 78 minutes after this merges. What changes is that it **no longer starves dispatch**: the worker loop runs separately from the poll loop (`daemon_supervision.go` starts them as distinct goroutines), and the tick now skips a contended repo instead of blocking on it. So queued jobs should reach the selector promptly **regardless of how long a poll cycle takes**.

**Pre-empting a false alarm:** if someone measures the cycle after this lands, finds it still ~78 minutes, and reads that as the fix having failed - it has not. That number is expected to be unchanged. The property to measure instead is **time from enqueue to dispatch**, and whether a queued job on one repo still waits while other repos dispatch.

**And the honest converse:** if reviews still wait after this lands, the cause is somewhere neither this PR nor gitmoot#2135 has looked. That would be a new finding rather than a regression, and it is a better position than not knowing which of the two quantities was responsible.

## Merge note

Enqueued by `gm-transport` under `merge_rule: self`, read at enqueue time from `gitmoot org brief --role gm-transport` rather than from a briefing prompt (#2133's cause). Owner standing-delegation row 107983's six safeguards, each re-read immediately before this enqueue:

1. **Open, mergeable, clean, every check succeeded.** `state: open`, `draft: false`, `mergeable: true`, `mergeable_state: clean`; **27 of 27 in a single conclusion group** at head `b2b6800312b299352daa144fbf9c8c256c9a9d54` - no failures, no cancelled, no pending. Read by group rather than by a bad-count, because a `cancelled` run carries `failure`-level annotations and a naive filter reports supersession as failure.
2. **Approved at that exact head.** Job `local-review-gm-review-opus-18d3efb949e4824a-1`, `decision: approved`, `evidence: executed`, `head_sha b2b68003…`.
3. **`tests_run` non-empty and naming commands with results** - 6 entries, 644 bytes, zero empty: `go build ./...`, `go vet ./internal/cli/...`, the four targeted tests named individually, **the full `./internal/cli/...` package at exit 0**, and two GitHub REST reads confirming 27/27 at the head and `base == main HEAD`.
4. **Reviewer is neither implementer nor lead.** Reviewer `gm-review-opus`; `lead_agent: gm-omp-impl`; implementing lane `gm-transport`.
5. **Immediate pre-enqueue re-read**, in this command sequence; base `b6a015bf` still equals main's tip, so this green describes the landing tree and there is no base-axis caveat on this PR.
6. **Attribution gap, named.** In-session implementation, so no engine implement job exists. Durable attribution `session-implement-gm-transport-18d3f0fab11c2f61`, `acting_org_role: gm-transport`, `decision: implemented`, recorded with `--acting-role` because `gm-transport` is not a registered agent. No row names the coordinator or the reviewer. Per #2130 the row cannot bind a head - verified again on this row, payload has no `head_sha` - so **the head this note refers to is `b2b6800312b299352daa144fbf9c8c256c9a9d54`**, stated here because the row cannot say it.

### The verdict found one real defect in my prose and it is corrected above

The reviewer's only new finding (P3, narrative-only) is that my "under the lock, unbounded" list was wrong: `os.Stat` (`:1275`), `GitHubClient` (`:1286`) and `WorkflowFactory` (`:1287`) all run **before** the lock at `:1289`. Only `store.UpdateRepoPollResult` is both under the lock and outside the 2m bound. I verified it by line order and corrected both this body and gitmoot#2135.

It sharpens the argument rather than weakening it: it separates **lock hold time** (what starves other repos, and what this PR fixes) from **cycle length** (what the ~78-minute measurement captures), and explains the 432s inter-poll gap better than my original claim did.

Their other five findings are confirmations of the four claims I asked them to attack - the streak is consecutive-only and not decaying, a skipped repo's turn is postponed rather than lost (candidates and the `forced` slice are sweep-scoped), the threshold and deferral are tested for **order** rather than occurrence, and `ListRepos` really is `ORDER BY full_name` - plus an independent check that all three of my self-disclosed errors match the code and history as described.

**Fourth error of mine on this PR caught by a reader rather than by me**, after the false "no per-repo bound" claim, the wrong `dispatch_declined` observable, and the deferral test proving occurrence rather than order. All four were in prose or test design; none was in the fix.

