### PR TITLE
fix(db): uncorrelate the open-directive predicate so the sweep stops burning a core (#2138)

### DIFF
--- a/internal/db/org_directive_open_predicate_test.go
+++ b/internal/db/org_directive_open_predicate_test.go
@@ -1,0 +1,235 @@
+package db
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+)
+
+// explainPlan returns the query plan for the SHIPPED sql text.
+func explainPlan(t *testing.T, store *Store, sql string, args ...any) string {
+	t.Helper()
+	rows, err := store.db.QueryContext(context.Background(), "EXPLAIN QUERY PLAN "+sql, args...)
+	if err != nil {
+		t.Fatalf("explain: %v", err)
+	}
+	defer rows.Close()
+	var out strings.Builder
+	for rows.Next() {
+		var id, parent, notUsed int
+		var detail string
+		if err := rows.Scan(&id, &parent, &notUsed, &detail); err != nil {
+			t.Fatalf("scan plan row: %v", err)
+		}
+		out.WriteString(detail)
+		out.WriteString("\n")
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("plan rows: %v", err)
+	}
+	return out.String()
+}
+
+// The open-directive predicate must not be CORRELATED (#2138).
+//
+// This is the defect test, and it asserts the shape rather than a duration: a
+// timing bound is flaky and a row count cannot see the difference. The shipped
+// predicate re-scanned every same-workflow sibling note for every candidate,
+// because its comparison literal was built from d.id - measured on the live
+// store as 46,232,418 substr evaluations and 16.96s to return the number 4,
+// twice per pass on a one-minute ticker, which burned a full core forever.
+//
+// SQLite names that shape in its own plan output: the old text produced
+// `CORRELATED SCALAR SUBQUERY`. Materializing the marker set once produces
+// `MATERIALIZE` plus an index probe instead. A mutant restoring the correlated
+// predicate fails here, which no assertion about the returned rows would.
+func TestOpenOrgDirectivePredicateIsNotCorrelated(t *testing.T) {
+	store := openWorkflowTestStore(t)
+	for _, test := range []struct {
+		name string
+		plan string
+	}{
+		{name: "count", plan: explainPlan(t, store, countOpenOrgDirectiveObligationsSQL)},
+		{name: "list", plan: explainPlan(t, store, listOpenOrgDirectiveObligationsSQL, 10)},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			if strings.Contains(strings.ToUpper(test.plan), "CORRELATED") {
+				t.Fatalf("%s plan is correlated per outer row, so cost is quadratic in siblings:\n%s", test.name, test.plan)
+			}
+			// Positive control: absence of "CORRELATED" must mean the marker set
+			// really is built once, not that the planner reported nothing.
+			if !strings.Contains(strings.ToUpper(test.plan), "MATERIALIZE") {
+				t.Fatalf("%s plan does not materialize the marker set, so the absence of CORRELATED proves nothing:\n%s", test.name, test.plan)
+			}
+		})
+	}
+}
+
+// The rewrite derives the target id by TEXT extraction instead of building a
+// per-row literal, and these are the cases where a careless extraction silently
+// changes which directives read as open. Each one is a wrong ANSWER, not a
+// slowdown, so they are the risk the performance fix carries.
+func TestOpenOrgDirectiveTerminalMarkerScoping(t *testing.T) {
+	for _, test := range []struct {
+		name     string
+		marker   func(id int64) (workflow string, body string)
+		wantOpen bool
+	}{
+		{
+			name: "done in the same workflow retires it",
+			marker: func(id int64) (string, string) {
+				return "release/directives", fmt.Sprintf("[org:directive-done id=%d by=worker] finished", id)
+			},
+			wantOpen: false,
+		},
+		{
+			name: "cancel in the same workflow retires it",
+			marker: func(id int64) (string, string) {
+				return "release/directives", fmt.Sprintf("[org:directive-cancel id=%d by=owner] withdrawn", id)
+			},
+			wantOpen: false,
+		},
+		{
+			// The predicate this replaced required r.workflow_id = d.workflow_id.
+			// A first draft of the rewrite dropped that scope, which retired a
+			// directive on a marker belonging to an unrelated workflow.
+			name: "done in a FOREIGN workflow must not retire it",
+			marker: func(id int64) (string, string) {
+				return "unrelated/workflow", fmt.Sprintf("[org:directive-done id=%d by=worker] finished", id)
+			},
+			wantOpen: true,
+		},
+		{
+			// The old text compared '<prefix>' || d.id || ' ', so the id had to be
+			// followed by a space. Extraction must not accept a bare tail.
+			name: "marker with no space after the id must not retire it",
+			marker: func(id int64) (string, string) {
+				return "release/directives", fmt.Sprintf("[org:directive-done id=%d]", id)
+			},
+			wantOpen: true,
+		},
+		{
+			// '007' never equalled '7' under the old text comparison. Casting the
+			// extracted target to an integer would make it match.
+			name: "zero-padded id must not retire the unpadded directive",
+			marker: func(id int64) (string, string) {
+				return "release/directives", fmt.Sprintf("[org:directive-done id=0%d by=worker] finished", id)
+			},
+			wantOpen: true,
+		},
+		{
+			name: "a marker naming a different directive must not retire it",
+			marker: func(id int64) (string, string) {
+				return "release/directives", fmt.Sprintf("[org:directive-done id=%d by=worker] finished", id+9000)
+			},
+			wantOpen: true,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			store := openWorkflowTestStore(t)
+			ctx := context.Background()
+			directive, err := store.InsertWorkflowNote(ctx, WorkflowNote{
+				WorkflowID: "release/directives", Author: "owner",
+				Body: "[org:directive to=worker from=owner wf=release/directives] do the thing",
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			workflowID, body := test.marker(directive.ID)
+			if _, err := store.InsertWorkflowNote(ctx, WorkflowNote{WorkflowID: workflowID, Author: "worker", Body: body}); err != nil {
+				t.Fatal(err)
+			}
+
+			count, err := store.CountOpenOrgDirectiveObligations(ctx)
+			if err != nil {
+				t.Fatal(err)
+			}
+			items, err := store.ListOpenOrgDirectiveObligations(ctx, 10)
+			if err != nil {
+				t.Fatal(err)
+			}
+			wantCount := 0
+			if test.wantOpen {
+				wantCount = 1
+			}
+			if count != wantCount || len(items) != wantCount {
+				t.Fatalf("count=%d list=%d, want %d open for marker %q in %q", count, len(items), wantCount, body, workflowID)
+			}
+		})
+	}
+}
+
+// The ack timestamp was a correlated MIN() per candidate and is now a grouped
+// materialized join, which is the half that measured 21.16s. The earliest of
+// ack/delivered must survive that change, including when both exist.
+//
+// The timestamps are set EXPLICITLY. created_at defaults to CURRENT_TIMESTAMP at
+// one-second granularity, so two notes inserted in the same test tick share a
+// value and MIN == MAX - under which a mutant taking the LATEST marker passes.
+// That is not hypothetical: such a mutant survived the first version of this
+// test, and the fixture was the defect rather than the assertion.
+func TestOpenOrgDirectiveAckTimestampTakesEarliestMarker(t *testing.T) {
+	store := openWorkflowTestStore(t)
+	ctx := context.Background()
+	directive, err := store.InsertWorkflowNote(ctx, WorkflowNote{
+		WorkflowID: "release/directives", Author: "owner",
+		Body: "[org:directive to=worker from=owner wf=release/directives] do the thing",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	const earliest = "2026-09-01 08:00:00"
+	const latest = "2026-09-02 09:30:00"
+	for _, marker := range []struct {
+		body      string
+		createdAt string
+	}{
+		{body: fmt.Sprintf("[org:directive-delivered id=%d by=transport] relayed", directive.ID), createdAt: earliest},
+		{body: fmt.Sprintf("[org:directive-ack id=%d by=worker] seen", directive.ID), createdAt: latest},
+	} {
+		note, err := store.InsertWorkflowNote(ctx, WorkflowNote{WorkflowID: "release/directives", Author: "worker", Body: marker.body})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if _, err := store.db.ExecContext(ctx, `UPDATE workflow_notes SET created_at = ? WHERE id = ?`, marker.createdAt, note.ID); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	items, err := store.ListOpenOrgDirectiveObligations(ctx, 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(items) != 1 || items[0].AckedAt != earliest {
+		t.Fatalf("obligations = %+v, want one row acked at %q (earliest of ack/delivered)", items, earliest)
+	}
+}
+
+// A foreign-workflow ACK must not be attributed either - the same scoping the
+// terminal marker needs, on the other join.
+func TestOpenOrgDirectiveAckIgnoresForeignWorkflow(t *testing.T) {
+	store := openWorkflowTestStore(t)
+	ctx := context.Background()
+	directive, err := store.InsertWorkflowNote(ctx, WorkflowNote{
+		WorkflowID: "release/directives", Author: "owner",
+		Body: "[org:directive to=worker from=owner wf=release/directives] do the thing",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.InsertWorkflowNote(ctx, WorkflowNote{
+		WorkflowID: "unrelated/workflow", Author: "worker",
+		Body: fmt.Sprintf("[org:directive-ack id=%d by=worker] seen", directive.ID),
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	items, err := store.ListOpenOrgDirectiveObligations(ctx, 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(items) != 1 || items[0].AckedAt != "" {
+		t.Fatalf("obligations = %+v, want one row with no ack attributed from a foreign workflow", items)
+	}
+}

--- a/internal/db/workflow_store.go
+++ b/internal/db/workflow_store.go
@@ -1111,6 +1111,108 @@ ORDER BY d.created_at ASC, d.id ASC`, targetRole, targetRole, targetRole)
 	return notes, rows.Err()
 }
 
+// The open-directive predicate, UNCORRELATED (#2138).
+//
+// The obvious spelling - NOT EXISTS whose marker text is built from d.id - is
+// what shipped, and it forces SQLite to rescan every same-workflow sibling note
+// for every candidate, because the comparison literal differs per outer row and
+// no index can serve it. The plan LOOKS indexed (`SEARCH r USING
+// idx_workflow_notes_wid`) and narrows almost nothing: note workflow_id
+// cardinality is 443 distinct over 30,141 rows on the live store, and the
+// largest bucket holds 8,007 - including every open directive. Measured there:
+// 2,887 candidates x 8,007 siblings = 46,232,418 substr evaluations, 16.96s to
+// return the number 4, and the sweep runs this predicate TWICE per pass on a
+// one-minute ticker, so passes overlap and the daemon burns a core forever.
+//
+// The substr calls are NOT the cost: one linear pass over all 30,141 notes
+// doing the same prefix tests measures 0.042s. The CORRELATION is the cost.
+// Materializing the marker set once and anti-joining measures 0.079s for the
+// same answer - 215x - and was proven set-EQUAL in both directions over all
+// 2,887 live candidates before it shipped, rather than compared by count.
+//
+// Two details are load-bearing rather than incidental:
+//
+//   - `wid` is carried and joined. The predicate this replaces required the
+//     marker to live in the SAME workflow_id, so dropping it would retire a
+//     directive on a FOREIGN marker. A first draft did exactly that.
+//   - the target is compared AS TEXT. The old predicate compared
+//     '<prefix>' || d.id || ' ', so 'id=007 ' never matched directive 7 and
+//     still must not; and the instr() guard leaves a marker with no space after
+//     its id unmatched, for the same reason.
+//
+// Cost is now LINEAR in total notes rather than quadratic: 79ms at 30k notes,
+// roughly 0.8s at 10x. That trade was taken deliberately over stamping a
+// terminal column at write time, because there is no Go writer of these markers
+// at all - they arrive as ordinary note bodies - so a write-time stamp would
+// have to infer the same thing from the same text in a place where nothing
+// checks it, and a missed path would be silent and permanent. See #2139.
+const directiveTerminalMarkersCTE = `markers AS MATERIALIZED (
+	SELECT m.workflow_id AS wid,
+		substr(m.body, length('[org:directive-cancel id=') + 1,
+			instr(substr(m.body, length('[org:directive-cancel id=') + 1), ' ') - 1) AS target
+	FROM workflow_notes m
+	WHERE substr(m.body, 1, length('[org:directive-cancel id=')) = '[org:directive-cancel id='
+		AND instr(substr(m.body, length('[org:directive-cancel id=') + 1), ' ') > 1
+	UNION ALL
+	SELECT m.workflow_id,
+		substr(m.body, length('[org:directive-done id=') + 1,
+			instr(substr(m.body, length('[org:directive-done id=') + 1), ' ') - 1)
+	FROM workflow_notes m
+	WHERE substr(m.body, 1, length('[org:directive-done id=')) = '[org:directive-done id='
+		AND instr(substr(m.body, length('[org:directive-done id=') + 1), ' ') > 1
+)`
+
+// directiveAckMarkersCTE is the same rewrite for the ack timestamp the sweep
+// reads alongside the open set. It was a correlated MIN() per candidate row,
+// which is why the LIST half measured 21.16s against the COUNT half's 16.96s.
+const directiveAckMarkersCTE = `acks AS MATERIALIZED (
+	SELECT wid, target, MIN(created_at) AS acked_at FROM (
+		SELECT a.workflow_id AS wid,
+			substr(a.body, length('[org:directive-ack id=') + 1,
+				instr(substr(a.body, length('[org:directive-ack id=') + 1), ' ') - 1) AS target,
+			a.created_at
+		FROM workflow_notes a
+		WHERE substr(a.body, 1, length('[org:directive-ack id=')) = '[org:directive-ack id='
+			AND instr(substr(a.body, length('[org:directive-ack id=') + 1), ' ') > 1
+		UNION ALL
+		SELECT a.workflow_id,
+			substr(a.body, length('[org:directive-delivered id=') + 1,
+				instr(substr(a.body, length('[org:directive-delivered id=') + 1), ' ') - 1),
+			a.created_at
+		FROM workflow_notes a
+		WHERE substr(a.body, 1, length('[org:directive-delivered id=')) = '[org:directive-delivered id='
+			AND instr(substr(a.body, length('[org:directive-delivered id=') + 1), ' ') > 1
+	) GROUP BY wid, target
+)`
+
+// countOpenOrgDirectiveObligationsSQL and listOpenOrgDirectiveObligationsSQL are
+// named so a test can EXPLAIN the SHIPPED text. Asserting on a copy of a query
+// proves nothing about the query that runs (#2138).
+const countOpenOrgDirectiveObligationsSQL = `
+WITH ` + directiveTerminalMarkersCTE + `
+SELECT COUNT(*)
+FROM workflow_notes d
+LEFT JOIN markers k ON k.wid = d.workflow_id AND k.target = CAST(d.id AS TEXT)
+WHERE substr(d.body, 1, length('[org:directive ')) = '[org:directive '
+	AND TRIM(d.directive_parked_at) = ''
+	AND k.target IS NULL`
+
+const listOpenOrgDirectiveObligationsSQL = `
+WITH ` + directiveTerminalMarkersCTE + `,
+` + directiveAckMarkersCTE + `
+SELECT d.id, d.workflow_id, d.author, d.body, d.repo, d.memory_observation_id, d.created_at,
+	d.directive_nudge_count, d.directive_last_nudged_at, d.directive_done_ttl_seconds,
+	d.directive_done_nudge_count, d.directive_exhausted_at,
+	COALESCE(a.acked_at, '')
+FROM workflow_notes d
+LEFT JOIN markers k ON k.wid = d.workflow_id AND k.target = CAST(d.id AS TEXT)
+LEFT JOIN acks a ON a.wid = d.workflow_id AND a.target = CAST(d.id AS TEXT)
+WHERE substr(d.body, 1, length('[org:directive ')) = '[org:directive '
+	AND TRIM(d.directive_parked_at) = ''
+	AND k.target IS NULL
+ORDER BY d.created_at ASC, d.id ASC
+LIMIT ?`
+
 // CountOpenOrgDirectiveObligations returns how many directives are currently
 // open, using the SAME open-predicate as ListOpenOrgDirectiveObligations.
 //
@@ -1120,18 +1222,7 @@ ORDER BY d.created_at ASC, d.id ASC`, targetRole, targetRole, targetRole)
 // second, different mechanism would be worse than reusing the one that works.
 func (s *Store) CountOpenOrgDirectiveObligations(ctx context.Context) (int, error) {
 	var count int
-	err := s.db.QueryRowContext(ctx, `
-SELECT COUNT(*)
-FROM workflow_notes d
-WHERE substr(d.body, 1, length('[org:directive ')) = '[org:directive '
-	AND TRIM(d.directive_parked_at) = ''
-	AND NOT EXISTS (
-		SELECT 1 FROM workflow_notes r
-		WHERE r.workflow_id = d.workflow_id AND (
-			substr(r.body, 1, length('[org:directive-cancel id=' || d.id || ' ')) = '[org:directive-cancel id=' || d.id || ' '
-			OR substr(r.body, 1, length('[org:directive-done id=' || d.id || ' ')) = '[org:directive-done id=' || d.id || ' '
-		)
-	)`).Scan(&count)
+	err := s.db.QueryRowContext(ctx, countOpenOrgDirectiveObligationsSQL).Scan(&count)
 	return count, err
 }
 
@@ -1151,30 +1242,7 @@ func (s *Store) ListOpenOrgDirectiveObligations(ctx context.Context, limit int) 
 	if limit <= 0 {
 		limit = directiveSweepCeiling
 	}
-	rows, err := s.db.QueryContext(ctx, `
-SELECT d.id, d.workflow_id, d.author, d.body, d.repo, d.memory_observation_id, d.created_at,
-	d.directive_nudge_count, d.directive_last_nudged_at, d.directive_done_ttl_seconds,
-	d.directive_done_nudge_count, d.directive_exhausted_at,
-	COALESCE((
-		SELECT MIN(a.created_at) FROM workflow_notes a
-		WHERE a.workflow_id = d.workflow_id
-			AND (
-				substr(a.body, 1, length('[org:directive-ack id=' || d.id || ' ')) = '[org:directive-ack id=' || d.id || ' '
-				OR substr(a.body, 1, length('[org:directive-delivered id=' || d.id || ' ')) = '[org:directive-delivered id=' || d.id || ' '
-			)
-	), '')
-FROM workflow_notes d INDEXED BY idx_workflow_notes_directive_oldest
-WHERE substr(d.body, 1, length('[org:directive ')) = '[org:directive '
-	AND TRIM(d.directive_parked_at) = ''
-	AND NOT EXISTS (
-		SELECT 1 FROM workflow_notes r
-		WHERE r.workflow_id = d.workflow_id AND (
-			substr(r.body, 1, length('[org:directive-cancel id=' || d.id || ' ')) = '[org:directive-cancel id=' || d.id || ' '
-			OR substr(r.body, 1, length('[org:directive-done id=' || d.id || ' ')) = '[org:directive-done id=' || d.id || ' '
-		)
-	)
-ORDER BY d.created_at ASC, d.id ASC
-LIMIT ?`, limit)
+	rows, err := s.db.QueryContext(ctx, listOpenOrgDirectiveObligationsSQL, limit)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/db/workflow_store.go
+++ b/internal/db/workflow_store.go
@@ -1126,9 +1126,21 @@ ORDER BY d.created_at ASC, d.id ASC`, targetRole, targetRole, targetRole)
 //
 // The substr calls are NOT the cost: one linear pass over all 30,141 notes
 // doing the same prefix tests measures 0.042s. The CORRELATION is the cost.
-// Materializing the marker set once and anti-joining measures 0.079s for the
-// same answer - 215x - and was proven set-EQUAL in both directions over all
-// 2,887 live candidates before it shipped, rather than compared by count.
+// Materializing the marker set once and anti-joining was proven set-EQUAL in
+// both directions over all 2,887 live candidates before it shipped, rather than
+// compared by count.
+//
+// THE SPEEDUP IS 24x, AND WHICH ENGINE MEASURED IT MATTERS. Through the shipped
+// modernc pure-Go driver, running these methods against a snapshot of the live
+// store: 38.1s -> 1.58s per sweep pass. The same SQL through the C sqlite3 CLI
+// measures 0.079s, which is 215x - and 215x was published before anyone noticed
+// the benchmark was not the engine that ships. Quote 24x.
+//
+// The explicit `INDEXED BY idx_workflow_notes_directive_oldest` hint on the LIST
+// query was DROPPED here, because the two added LEFT JOINs make the hint a
+// constraint on a plan it no longer describes. Review verified the planner still
+// auto-selects that partial index for the WHERE plus ORDER BY on a synthetic
+// dataset shaped like the live store's cardinality, so the plan is unchanged.
 //
 // Two details are load-bearing rather than incidental:
 //


### PR DESCRIPTION
Fixes #2138. Files: `internal/db/workflow_store.go` and one new test file.

## The defect

The live daemon on this host burned **100% of one core continuously for over two hours**, inside one SQL predicate. Caught in the act rather than inferred: 15 s and 30 s CPU profiles at 99.80% and 98.97% cumulative in `_sqlite3VdbeExec`, 34.16% in `_sqlite3BtreeTableMoveto` with `moveToLeftmost`/`BtreeNext` (sequential scan), and the goroutine parked at `internal/cli/blocked_since.go:482` - the single line `deps.listOpen(ctx, store, deps.sweepWindow(ctx, store))`, which carries both expensive calls.

The open-directive predicate built its comparison text **from `d.id`**:

```sql
substr(r.body, 1, length('[org:directive-done id=' || d.id || ' ')) = '[org:directive-done id=' || d.id || ' '
```

A different literal per outer row, so no index can serve it. **The plan looks indexed and narrows almost nothing** - `SEARCH r USING idx_workflow_notes_wid` - because note `workflow_id` cardinality on the live store is **443 distinct over 30,141 rows**, and the largest bucket holds **8,007**, including every open directive.

| Measure | Value |
| --- | --- |
| outer candidates | 2,887 |
| of those already done or cancelled, re-proved every pass | **2,883** |
| genuinely open | 4 |
| `substr` evaluations per query | **46,232,418** |
| count query, live store | **16.96 s to return the number 4** |

The sweep runs the predicate **twice** per pass (`sweepWindow` to size the window, then `listOpen` re-evaluating it) on a **one-minute** ticker, so a pass costs more than the interval and the loop never stops.

## Why it is not a bulk substr problem

One linear pass over **all 30,141 notes** doing the same prefix tests: **0.042 s**. The `substr` calls are cheap; the **correlation** is the cost. So the predicate did not need a schema change, it needed to stop being correlated. Materialize the marker set once, anti-join it.

## Measured, through the shipped driver

| | before | after |
| --- | --- | --- |
| count | 16.96 s | 0.73 s |
| list | 21.16 s | 0.85 s |
| **per sweep pass** | **38.1 s** | **1.58 s** |

**24x, and that is the figure to quote.** An earlier comment of mine said 215x; that was raw SQL through the C `sqlite3` CLI, and the shipped path is the modernc pure-Go driver, which is most of the remaining cost. The "after" column was produced by running the real `Store` methods against a consistent snapshot of the live database, not by re-typing the SQL.

## Equivalence proven as a set, not a count

Both predicates were run over all 2,887 live candidates and the resulting open-directive ID sets diffed **in both directions**: `in NEW not OLD` = **0**, `in OLD not NEW` = **0**. The shipped methods then returned the same four directives with the same ack timestamps.

**That found a wrong-answer bug in my own first draft.** The original requires the marker to live in the **same `workflow_id`**; the draft dropped that scope, which would have retired a directive on a **foreign** marker. Two details are load-bearing as a result, and both have tests:

- `wid` is carried through the CTE and joined, so a foreign marker does not retire a directive.
- the target is compared **as text**, because the old predicate compared `'<prefix>' || d.id || ' '`, so `id=007 ` never matched directive 7 and still must not.

## The test asserts the plan, not a duration

The defect is quadratic cost with **identical results**, so no assertion about returned rows can see it, and a timing bound would be flaky. SQLite names this shape in its own plan output: the old text produces `CORRELATED SCALAR SUBQUERY`, the new one produces `MATERIALIZE` plus an index probe. The test asserts `CORRELATED` is absent **and** `MATERIALIZE` is present, so the absence cannot pass by the planner reporting nothing.

The positive control is the part that is easy to omit, and it is the same rule as **an empty result is a claim about your instrument, not about the population** - applied to a query plan. Without asserting `MATERIALIZE` is present, a planner that reported *nothing at all* would satisfy "no `CORRELATED` in the output" and the test would pass while proving nothing. The absence is only evidence once the instrument is shown to be reporting.

**Four mutants, each compiling and changing production behaviour, all dead:**

| Mutant | Killed by |
| --- | --- |
| restore the correlated predicate (the bug itself) | plan test |
| drop the same-workflow scope | foreign-marker case |
| compare the target as an integer | zero-padded-id case |
| take the latest ack instead of the earliest | ack timestamp test |

**One mutant is disclosed as invalid rather than counted.** Dropping the `instr(...) > 1` trailing-space guard changes no behaviour: measured in SQLite, a marker with no space after its id extracts as `=` rather than a digit run, because a negative length makes `substr` return the preceding character. The guard is explicit intent, not a load-bearing filter, and that mutant survives by design.

**A test defect of mine that a surviving mutant found.** The first version of the ack test let the latest-ack mutant pass, because `created_at` defaults to `CURRENT_TIMESTAMP` at one-second granularity, so both fixture notes shared a value and `MIN == MAX`. The fixture was the defect, not the assertion; timestamps are now explicit.

## Scope: two of nine sites, deliberately

The same shape is in nine functions across four files. This fixes the **two that were measured burning the core**. The others, with measurements, are tabulated on #2138. Two are worth naming here:

- **`ListUnacknowledgedOrgDirectives` costs 3.52 s per call and has zero production callers** - all eleven references are tests, with a positive control confirming the instrument finds real callers. Disposal of test-only code is a separate judgement.
- **The wake drain measures 5 ms** and stayed at 5 ms when all 2,886 directive-class rows were forced through the clause. I did not predict that and cannot fully explain it; the likely reason is that `EXISTS` short-circuits on the first marker while the sweep's `NOT EXISTS` must prove absence, but that is a hypothesis, not a finding. It is not a second spin source today.

The historical copy in `store_migrations.go` is deliberately untouched: rewriting a shipped migration changes history for every store that already ran it.

## What this does not claim

- **Cost is now linear in total notes, not flat.** 1.58 s at 30k notes, extrapolating to roughly 16 s at 300k. The write-time alternative that would be flat was rejected because there is **no Go writer of these markers at all** - `OrgDirectiveDonePrefix`/`OrgDirectiveCancelPrefix` have zero non-test consumers - so a stamp would have to infer the same thing from the same text somewhere nothing checks it, and a missed path would be silent and permanent. Filed with numbers as #2139.
- **No config change is proposed.** `directive_done_ttl = "1h"` on this host is untouched; #2124 covers the unguarded accessor and stays a separate PR.
- **No claim about deployed behaviour.** The live daemon has not been restarted, so this is verified against a snapshot of its store and its own profiles, not against the running process.

## Deploy notes

Store-layer only, no migration, no schema change, no config change. The daemon picks it up on restart; the spin ends when the new binary runs. `/tmp/cpu.pprof`, `/tmp/cpu2.pprof`, `/tmp/gor.txt`, `/tmp/gor2.txt` and `/tmp/heap.pprof` on this host hold the captured reproduction.



---

## Merge note

Merged by `gm-transport` under `merge_rule: self`, read at merge time from `gitmoot org brief --role gm-transport` rather than from a briefing prompt (#2133).

**Owner deployment decision:** deploy this PR **first**, ahead of the separate `default_branch` fix, because #2138 is starving the daemon's only SQLite connection and had stopped ingestion across all 39 enabled repos. Authorization chain: workflow note **131145**; Grams **gram-1a08cf30317-1394e1-55** and **gram-1a08cf38450-1394e1-56**; the owner selected the "Deploy #2140 first" sequence interactively.

**Reviewed head, stated as a sentence** because `job record --head-sha` is display metadata and is not persisted (#2130): the approved and merged head is `b338483af5f245c878ae0584aab21d5ec94bda02`.

Six safeguards, all re-read immediately before merging:

1. Open, non-draft, `mergeable: true`, `mergeable_state: clean`.
2. 27/27 check-runs in a **single** conclusion group at the reviewed head - read by grouping conclusions, not by trusting a summary label.
3. Approved at that exact head with **non-empty** `tests_run`: 6 entries, 424 bytes, zero empty. Note `evidence: static_only` disagrees with those entries; `tests_run` is the discriminator, and this is the #1247 mislabel in the under-reporting direction.
4. Reviewer `gm-review-opus` is neither the implementer (`gm-transport`) nor the lead (`gm-omp-impl`).
5. Base `4dddf4a8` equals main exactly, so there is no base-axis caveat on this merge. It took three review rounds to get there: main drifted twice under the earlier approvals, and each time the stale green was refused rather than merged.
6. **Attribution gap, named rather than skipped:** this was implemented in-session, so no engine implement job exists. Durable attribution row `session-implement-gm-transport-18d42de22a9856fb`, read back from the store rather than trusted from the CLI echo.

**Three review rounds, and what each found:** round one found the set-equivalence work sound and produced two findings against my prose - the `215x` figure and an undisclosed `INDEXED BY` removal, both since corrected in the source and commit message. Round two confirmed those corrections. Round three independently recomputed the rebase patch-identity claim by sha256 via the GitHub compare API and returned **zero findings**.

**Not claimed:** that 1.58 s per pass is proven headroom for every workload on a single shared connection. It is a 24x reduction in hold time. I asked the reviewer explicitly whether a ~2.6% duty cycle is sufficient and they raised no finding, which is weaker than a measurement and is recorded as such.

Deployment and its post-deploy proof follow separately under the same authorization.
