### PR TITLE
fix(cli): grant the interpreter a script runtime execs, not just the dispatch list (#2141)

### DIFF
--- a/internal/cli/daemon_worker.go
+++ b/internal/cli/daemon_worker.go
@@ -2004,7 +2004,7 @@ func readOnlyRuntimeSandboxGrants(home string, agent runtime.Agent, checkout str
 	// Runtime executables are staged beside the Go toolchain and exposed by
 	// fingerprint-local shims. Grant the PUBLISHED roots the daemon owns, never
 	// the operator PATH roots they were copied from (#1921, ruling 122157).
-	stagedRuntimes, runtimeDiagnostics, err := stageSeatRuntimes(paths)
+	stagedRuntimes, runtimeInterpreters, runtimeDiagnostics, err := stageSeatRuntimes(paths)
 	if err != nil {
 		return grants, err
 	}
@@ -2033,6 +2033,30 @@ func readOnlyRuntimeSandboxGrants(home string, agent runtime.Agent, checkout str
 	grants.runtimeUnavailable = seatRuntimeUnavailable(agent.Runtime, stagedRuntimes, runtimeDiagnostics)
 	for _, shim := range stagedRuntimes {
 		root, err := toolchain.StagedRuntimeRoot(paths.Home, shim)
+		if err != nil {
+			return grants, err
+		}
+		if err := validateStagedToolchainPlacement(root, grants.writes); err != nil {
+			return grants, err
+		}
+		grants.reads = append(grants.reads, root)
+	}
+	// THE EXEC CLOSURE, NOT THE DISPATCH LIST (#2141). seatRuntimeNames
+	// enumerates what the engine can DISPATCH - claude, kimi, codex - and its
+	// own comment says so: "derived from what the engine can start". A script
+	// runtime is not started, it is EXEC'd by an interpreter, and staging
+	// publishes that interpreter into a SIBLING root. The loop above grants
+	// each launcher's own root, so before this the codex launcher was granted
+	// and the node tree it execs was not: the seat received an engine-staged
+	// command it was forbidden to run, and reported exit 126 with no finding.
+	//
+	// Granting RuntimeRoot(paths.Home) wholesale would also fix it and is
+	// refused: that hands a seat exec over every staged runtime including the
+	// ones no dispatch decision chose, which is the widening #1878 and #1921
+	// spent three rounds narrowing away from. Grant exactly what the launcher
+	// execs.
+	for _, interpreter := range runtimeInterpreters {
+		root, err := toolchain.StagedRuntimeRoot(paths.Home, interpreter)
 		if err != nil {
 			return grants, err
 		}

--- a/internal/cli/seat_interpreter_grant_test.go
+++ b/internal/cli/seat_interpreter_grant_test.go
@@ -1,0 +1,136 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/gitmoot/gitmoot/internal/runtime"
+	"github.com/gitmoot/gitmoot/internal/toolchain"
+)
+
+// stageScriptRuntimeFixture builds the codex shape: a packaged script runtime
+// whose entrypoint is executed by a SEPARATE interpreter, so staging publishes
+// two sibling roots. It returns the interpreter's own directory name so the
+// assertion cannot be satisfied by the host's real node.
+func stageScriptRuntimeFixture(t *testing.T, name string) {
+	t.Helper()
+	interpreterDir := t.TempDir()
+	interpreter := filepath.Join(interpreterDir, "probenode")
+	if err := os.WriteFile(interpreter, []byte("#!/bin/sh\nprintf 'ran %s\\n' \"$1\"\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	pkg := filepath.Join(t.TempDir(), "lib", "node_modules", "@openai", name)
+	pkgBin := filepath.Join(pkg, "bin")
+	if err := os.MkdirAll(pkgBin, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(pkg, "package.json"), []byte(`{"name":"@openai/`+name+`"}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	entrypoint := filepath.Join(pkgBin, name+".js")
+	if err := os.WriteFile(entrypoint, []byte("#!/usr/bin/env probenode\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	launcherDir := t.TempDir()
+	if err := os.Symlink(entrypoint, filepath.Join(launcherDir, name)); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", strings.Join([]string{launcherDir, interpreterDir, "/usr/bin", "/bin"}, string(os.PathListSeparator)))
+}
+
+// TestSeatGrantsCoverTheInterpreterAScriptRuntimeExecs pins #2141.
+//
+// A staged script runtime's launcher is a two-line shell script that execs the
+// STAGED interpreter from its own published root - a SIBLING of the launcher's
+// root. Seat setup granted each launcher's own root and nothing else, so the
+// engine handed the seat a command it had itself forbidden: every codex review
+// on this host died with
+//
+//	.bin/codex: exec: .../runtimes/node-<fp>/.bin/node: Permission denied  (126)
+//
+// and produced no finding, so the failure read as a broken reviewer rather than
+// as a missing grant.
+//
+// This drives the production entry, readOnlyRuntimeSandboxGrants, because that
+// is the function that decides what the seat may execute. A test that only
+// asserted stageSeatRuntimes returned an interpreter would pass while the grant
+// list stayed short - the shape of guard this repo has been convicting all
+// week: a population that excludes the case that motivated it.
+func TestSeatGrantsCoverTheInterpreterAScriptRuntimeExecs(t *testing.T) {
+	stageScriptRuntimeFixture(t, "codex")
+	checkout := seatFixtureCheckout(t)
+	home := t.TempDir()
+	agent := runtime.Agent{Name: "gm-review-codex", Runtime: runtime.CodexRuntime, ReadOnlySeat: true}
+
+	grants, err := readOnlyRuntimeSandboxGrants(home, agent, checkout, "gitmoot/gitmoot", true)
+	if err != nil {
+		t.Fatalf("seat setup: %v", err)
+	}
+
+	// Locate the launcher and the interpreter root independently of the grant
+	// list, so the assertion is against the filesystem rather than against the
+	// value under test.
+	seatPaths, err := pathsFromFlag(home)
+	if err != nil {
+		t.Fatalf("resolve seat paths: %v", err)
+	}
+	runtimeRoot := toolchain.RuntimeRoot(seatPaths.Home)
+	entries, err := os.ReadDir(runtimeRoot)
+	if err != nil {
+		t.Fatalf("read staged runtime root: %v", err)
+	}
+	var codexRoot, interpreterRoot string
+	for _, entry := range entries {
+		switch {
+		case strings.HasPrefix(entry.Name(), "codex-"):
+			codexRoot = filepath.Join(runtimeRoot, entry.Name())
+		case strings.HasPrefix(entry.Name(), "probenode-"):
+			interpreterRoot = filepath.Join(runtimeRoot, entry.Name())
+		}
+	}
+	if codexRoot == "" {
+		t.Fatalf("fixture did not stage a codex runtime under %s", runtimeRoot)
+	}
+	if interpreterRoot == "" {
+		t.Fatalf("fixture did not stage the interpreter under %s; the two-root shape this test exists for was not produced", runtimeRoot)
+	}
+	if interpreterRoot == codexRoot {
+		t.Fatal("interpreter and runtime share a root, so this fixture cannot detect the defect")
+	}
+
+	// The launcher must actually reference the interpreter root, or the grant
+	// below would be gratuitous rather than required.
+	launcher, err := os.ReadFile(filepath.Join(codexRoot, ".bin", "codex"))
+	if err != nil {
+		t.Fatalf("read staged launcher: %v", err)
+	}
+	if !strings.Contains(string(launcher), interpreterRoot) {
+		t.Fatalf("staged launcher does not exec the staged interpreter root %s:\n%s", interpreterRoot, launcher)
+	}
+
+	granted := func(root string) bool {
+		for _, read := range grants.reads {
+			if read == root {
+				return true
+			}
+		}
+		return false
+	}
+	if !granted(codexRoot) {
+		t.Errorf("the runtime's own root %s is not granted", codexRoot)
+	}
+	if !granted(interpreterRoot) {
+		t.Fatalf("the interpreter root %s is NOT granted, so the seat cannot exec the launcher the engine staged for it.\ngranted reads: %v", interpreterRoot, grants.reads)
+	}
+
+	// The interpreter must not become PATH-resolvable: granting the exec
+	// closure is not the same as offering the seat a second interpreter by
+	// name, which no dispatch decision chose.
+	for _, env := range grants.env {
+		if strings.HasPrefix(env, "PATH=") && strings.Contains(env, interpreterRoot) {
+			t.Errorf("interpreter root leaked onto the seat PATH: %s", env)
+		}
+	}
+}

--- a/internal/cli/seat_interpreter_grant_test.go
+++ b/internal/cli/seat_interpreter_grant_test.go
@@ -134,3 +134,89 @@ func TestSeatGrantsCoverTheInterpreterAScriptRuntimeExecs(t *testing.T) {
 		}
 	}
 }
+
+// TestSeatGrantsCoverATRANSITIVEInterpreterChain pins the P1 from #2141's
+// review: an interpreter can ITSELF be a script needing a further interpreter.
+//
+// The first version of this fix returned only the IMMEDIATE interpreter, so a
+// three-link chain granted two roots out of three and the seat still exited
+// 126 on the third. The reviewer reproduced that with an executed test rather
+// than arguing it. StageRuntime now returns the full transitive closure.
+//
+// The chain built here is runtime -> mid (a script) -> base (a real binary),
+// which is the shape a packaged interpreter takes when it ships as a wrapper.
+func TestSeatGrantsCoverATRANSITIVEInterpreterChain(t *testing.T) {
+	baseDir := t.TempDir()
+	base := filepath.Join(baseDir, "probebase")
+	if err := os.WriteFile(base, []byte("#!/bin/sh\nprintf 'base ran %s\\n' \"$1\"\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// mid is a SCRIPT interpreter: it needs probebase to run, so staging mid
+	// must in turn stage probebase.
+	midDir := t.TempDir()
+	mid := filepath.Join(midDir, "probemid")
+	if err := os.WriteFile(mid, []byte("#!/usr/bin/env probebase\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	pkg := filepath.Join(t.TempDir(), "lib", "node_modules", "@openai", "codex")
+	pkgBin := filepath.Join(pkg, "bin")
+	if err := os.MkdirAll(pkgBin, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(pkg, "package.json"), []byte(`{"name":"@openai/codex"}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	entrypoint := filepath.Join(pkgBin, "codex.js")
+	if err := os.WriteFile(entrypoint, []byte("#!/usr/bin/env probemid\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	launcherDir := t.TempDir()
+	if err := os.Symlink(entrypoint, filepath.Join(launcherDir, "codex")); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", strings.Join([]string{launcherDir, midDir, baseDir, "/usr/bin", "/bin"}, string(os.PathListSeparator)))
+
+	home := t.TempDir()
+	grants, err := readOnlyRuntimeSandboxGrants(home, runtime.Agent{
+		Name: "gm-review-codex", Runtime: runtime.CodexRuntime, ReadOnlySeat: true,
+	}, seatFixtureCheckout(t), "gitmoot/gitmoot", true)
+	if err != nil {
+		t.Fatalf("seat setup: %v", err)
+	}
+	seatPaths, err := pathsFromFlag(home)
+	if err != nil {
+		t.Fatal(err)
+	}
+	runtimeRoot := toolchain.RuntimeRoot(seatPaths.Home)
+	entries, err := os.ReadDir(runtimeRoot)
+	if err != nil {
+		t.Fatalf("read staged runtime root: %v", err)
+	}
+	want := map[string]string{"codex-": "", "probemid-": "", "probebase-": ""}
+	for _, entry := range entries {
+		for prefix := range want {
+			if strings.HasPrefix(entry.Name(), prefix) {
+				want[prefix] = filepath.Join(runtimeRoot, entry.Name())
+			}
+		}
+	}
+	for prefix, root := range want {
+		if root == "" {
+			t.Fatalf("the fixture did not stage a %s* root under %s; the three-link chain this test exists for was not produced (staged: %v)",
+				prefix, runtimeRoot, entries)
+		}
+	}
+	granted := func(root string) bool {
+		for _, read := range grants.reads {
+			if read == root {
+				return true
+			}
+		}
+		return false
+	}
+	for prefix, root := range want {
+		if !granted(root) {
+			t.Errorf("root %s (%s) is NOT granted, so the seat cannot exec the chain the engine staged: granted reads %v", prefix, root, grants.reads)
+		}
+	}
+}

--- a/internal/cli/seat_staging_barrier_test.go
+++ b/internal/cli/seat_staging_barrier_test.go
@@ -35,7 +35,7 @@ func warmSeatStaging(t *testing.T, home string) {
 	} else if diagnostic != "" {
 		t.Logf("warmSeatStaging: toolchain diagnostic: %s", diagnostic)
 	}
-	if _, diagnostics, err := stageSeatRuntimes(paths); err != nil {
+	if _, _, diagnostics, err := stageSeatRuntimes(paths); err != nil {
 		t.Logf("warmSeatStaging: runtimes not pre-staged (%v); the test window will pay the copy", err)
 	} else {
 		for _, diagnostic := range diagnostics {

--- a/internal/cli/toolchain_seat.go
+++ b/internal/cli/toolchain_seat.go
@@ -121,8 +121,14 @@ var seatRuntimeNames = []string{"claude", "kimi", "codex"}
 // narrowed: the engine copies each runtime's own artifact into a tree it created
 // and grants that. A daemon-owned tree has no operator-writable descendants to
 // appear later, which closes the class rather than its two known instances.
-func stageSeatRuntimes(paths config.Paths) ([]string, []string, error) {
+// It returns the launchers a seat may exec, THE EXEC-CLOSURE ROOTS those
+// launchers additionally require, and diagnostics. The closure is separate from
+// the launcher list on purpose: a launcher belongs on the seat's PATH and an
+// interpreter must NOT, because a seat that can resolve `node` by name gets a
+// second way to run code that no dispatch decision chose (#2141).
+func stageSeatRuntimes(paths config.Paths) ([]string, []string, []string, error) {
 	var staged []string
+	var interpreters []string
 	var diagnostics []string
 	for _, name := range seatRuntimeNames {
 		if resolved, lookupErr := exec.LookPath(name); lookupErr == nil {
@@ -139,20 +145,27 @@ func stageSeatRuntimes(paths config.Paths) ([]string, []string, error) {
 			// as the exit-126 command below rather than leaving it
 			// host-resolvable. That is the whole point: an explicit
 			// unavailability instead of a silent fallback.
-			launcher, stageErr := toolchain.StageRuntime(paths.Home, name, resolved)
+			launcher, interpreter, stageErr := toolchain.StageRuntime(paths.Home, name, resolved)
 			if stageErr == nil {
 				staged = append(staged, launcher)
+				// Only ENGINE-PUBLISHED interpreters need a grant. A system
+				// interpreter is returned as its host path and its root is
+				// already granted, so passing it on would fail containment
+				// resolution for a runtime that is working correctly.
+				if interpreter != "" && toolchain.StagedUnderRuntimeRoot(paths.Home, interpreter) {
+					interpreters = append(interpreters, interpreter)
+				}
 				continue
 			}
 			diagnostics = append(diagnostics, fmt.Sprintf("runtime %s could not be staged, so it is published unavailable rather than left host-resolvable: %v", name, stageErr))
 		}
 		unavailable, err := toolchain.StageUnavailableRuntime(paths.Home, name)
 		if err != nil {
-			return nil, diagnostics, fmt.Errorf("publish unavailable runtime %s: %w", name, err)
+			return nil, nil, diagnostics, fmt.Errorf("publish unavailable runtime %s: %w", name, err)
 		}
 		staged = append(staged, unavailable)
 	}
-	return staged, diagnostics, nil
+	return staged, interpreters, diagnostics, nil
 }
 
 // seatRuntimeUnavailable reports WHY the runtime a seat is about to execute was

--- a/internal/cli/toolchain_seat.go
+++ b/internal/cli/toolchain_seat.go
@@ -145,16 +145,14 @@ func stageSeatRuntimes(paths config.Paths) ([]string, []string, []string, error)
 			// as the exit-126 command below rather than leaving it
 			// host-resolvable. That is the whole point: an explicit
 			// unavailability instead of a silent fallback.
-			launcher, interpreter, stageErr := toolchain.StageRuntime(paths.Home, name, resolved)
+			launcher, closure, stageErr := toolchain.StageRuntime(paths.Home, name, resolved)
 			if stageErr == nil {
 				staged = append(staged, launcher)
-				// Only ENGINE-PUBLISHED interpreters need a grant. A system
-				// interpreter is returned as its host path and its root is
-				// already granted, so passing it on would fail containment
-				// resolution for a runtime that is working correctly.
-				if interpreter != "" && toolchain.StagedUnderRuntimeRoot(paths.Home, interpreter) {
-					interpreters = append(interpreters, interpreter)
-				}
+				// The FULL closure, not the immediate interpreter: an
+				// interpreter can itself be a script needing another. StageRuntime
+				// already filters out system interpreters, whose roots the
+				// sandbox grants unconditionally and which have no staged root.
+				interpreters = append(interpreters, closure...)
 				continue
 			}
 			diagnostics = append(diagnostics, fmt.Sprintf("runtime %s could not be staged, so it is published unavailable rather than left host-resolvable: %v", name, stageErr))

--- a/internal/cli/toolchain_seat_interpreter_test.go
+++ b/internal/cli/toolchain_seat_interpreter_test.go
@@ -57,7 +57,7 @@ func TestStageSeatRuntimesStagesAScriptRuntimesInterpreter(t *testing.T) {
 	t.Setenv("PATH", strings.Join([]string{launcherDir, interpreterDir, "/usr/bin", "/bin"}, string(os.PathListSeparator)))
 
 	paths := config.PathsForHome(t.TempDir())
-	commands, diagnostics, err := stageSeatRuntimes(paths)
+	commands, _, diagnostics, err := stageSeatRuntimes(paths)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -117,7 +117,7 @@ func TestStageSeatRuntimesLeavesSystemInterpretersAlone(t *testing.T) {
 	t.Setenv("PATH", strings.Join([]string{launcherDir, "/usr/bin", "/bin"}, string(os.PathListSeparator)))
 
 	paths := config.PathsForHome(t.TempDir())
-	commands, diagnostics, err := stageSeatRuntimes(paths)
+	commands, _, diagnostics, err := stageSeatRuntimes(paths)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/cli/toolchain_seat_test.go
+++ b/internal/cli/toolchain_seat_test.go
@@ -417,7 +417,7 @@ func TestStageSeatRuntimesCopiesInstalledAndShadowsAbsentRuntimes(t *testing.T) 
 	t.Setenv("PATH", strings.Join(pathEntries, string(os.PathListSeparator)))
 
 	paths := config.PathsForHome(t.TempDir())
-	commands, diagnostics, err := stageSeatRuntimes(paths)
+	commands, _, diagnostics, err := stageSeatRuntimes(paths)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/toolchain/runtime_collect_test.go
+++ b/internal/toolchain/runtime_collect_test.go
@@ -28,7 +28,7 @@ func TestCollectDoesNotRemoveStagedRuntimes(t *testing.T) {
 	if err := os.WriteFile(source, []byte("#!/bin/sh\nprintf 'tool-ran\\n'\n"), 0o755); err != nil {
 		t.Fatal(err)
 	}
-	staged, err := StageRuntime(home, "tool", source)
+	staged, _, err := StageRuntime(home, "tool", source)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/toolchain/runtime_cycle_test.go
+++ b/internal/toolchain/runtime_cycle_test.go
@@ -23,6 +23,25 @@ import (
 // mode being guarded against is non-termination: a plain call would hang the
 // suite rather than fail it, and a stack overflow would take the test binary
 // with it.
+//
+// WHAT THIS TEST DOES AND DOES NOT DISCRIMINATE, measured by isolating each
+// guard rather than asserted (#2142 review, P3):
+//
+//	delete ONLY the revisits loop, keep the depth bound -> PASS
+//	delete ONLY the depth bound, keep the revisits loop -> PASS
+//	delete BOTH                                         -> FAIL at the deadline
+//
+// EITHER GUARD ALONE TERMINATES EVERY CYCLE, so this test proves that the
+// recursion is bounded and does NOT prove that either guard individually is
+// load-bearing. An earlier version of this comment claimed the revisits loop
+// was killed on its own; the mutant behind that claim had deleted both guards,
+// and the reviewer caught it by static trace without running anything.
+//
+// Both are kept deliberately, and the reason is the message rather than
+// termination: the revisits loop stops at the FIRST repeat and says
+// "revisits %q, so it cannot terminate", which names the defect, where the
+// depth bound says "exceeds 8 links", which names the limit. This test accepts
+// either message, which is exactly why it cannot tell them apart.
 func TestStageRuntimeRefusesACyclicInterpreterChain(t *testing.T) {
 	tests := map[string]func(t *testing.T, dir string) string{
 		"self-referential shebang": func(t *testing.T, dir string) string {

--- a/internal/toolchain/runtime_cycle_test.go
+++ b/internal/toolchain/runtime_cycle_test.go
@@ -1,0 +1,106 @@
+package toolchain
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestStageRuntimeRefusesACyclicInterpreterChain pins the P2 from #2141's
+// second review.
+//
+// stageInterpreter recurses into StageRuntime with no visited set and no depth
+// bound, so a self-referential shebang or two scripts naming each other recursed
+// until Go's stack overflowed. A STACK OVERFLOW IS FATAL AND PROCESS-WIDE: one
+// malformed artifact on disk would take down the daemon and every job running in
+// it, not just the seat that staged it. The reviewer reproduced both shapes with
+// a timeout guard and neither returned.
+//
+// The test runs each shape in a goroutine behind a deadline, because the failure
+// mode being guarded against is non-termination: a plain call would hang the
+// suite rather than fail it, and a stack overflow would take the test binary
+// with it.
+func TestStageRuntimeRefusesACyclicInterpreterChain(t *testing.T) {
+	tests := map[string]func(t *testing.T, dir string) string{
+		"self-referential shebang": func(t *testing.T, dir string) string {
+			self := filepath.Join(dir, "selfloop")
+			// Its own shebang names itself, so resolving the interpreter
+			// returns the same file.
+			if err := os.WriteFile(self, []byte("#!"+self+"\n"), 0o755); err != nil {
+				t.Fatal(err)
+			}
+			return self
+		},
+		"two-script mutual cycle": func(t *testing.T, dir string) string {
+			a := filepath.Join(dir, "cyclea")
+			b := filepath.Join(dir, "cycleb")
+			if err := os.WriteFile(a, []byte("#!"+b+"\n"), 0o755); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.WriteFile(b, []byte("#!"+a+"\n"), 0o755); err != nil {
+				t.Fatal(err)
+			}
+			return a
+		},
+	}
+	for name, build := range tests {
+		t.Run(name, func(t *testing.T) {
+			dir := t.TempDir()
+			entry := build(t, dir)
+			type outcome struct {
+				err error
+			}
+			done := make(chan outcome, 1)
+			go func() {
+				_, _, err := StageRuntime(t.TempDir(), "cyclic", entry)
+				done <- outcome{err: err}
+			}()
+			select {
+			case got := <-done:
+				if got.err == nil {
+					t.Fatal("a cyclic interpreter chain staged successfully, which cannot be correct")
+				}
+				if !errors.Is(got.err, ErrRuntimeNotStageable) {
+					t.Fatalf("err = %v, want ErrRuntimeNotStageable", got.err)
+				}
+				if !strings.Contains(got.err.Error(), "revisits") && !strings.Contains(got.err.Error(), "exceeds") {
+					t.Fatalf("refusal does not name the cycle or the bound: %v", got.err)
+				}
+			case <-time.After(20 * time.Second):
+				t.Fatal("StageRuntime did not return on a cyclic interpreter chain: the recursion is unbounded, and in production this ends in a process-wide stack overflow")
+			}
+		})
+	}
+}
+
+// TestStageRuntimeAcceptsARealisticChain is the control: the bound must refuse
+// cycles without refusing the legitimate multi-link chains the transitive
+// closure fix exists to support.
+func TestStageRuntimeAcceptsARealisticChain(t *testing.T) {
+	dir := t.TempDir()
+	base := filepath.Join(dir, "chainbase")
+	if err := os.WriteFile(base, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	prev := base
+	for i := 1; i <= 3; i++ {
+		next := filepath.Join(dir, "chain"+string(rune('a'+i-1)))
+		if err := os.WriteFile(next, []byte("#!"+prev+"\n"), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		prev = next
+	}
+	launcher, closure, err := StageRuntime(t.TempDir(), "chain", prev)
+	if err != nil {
+		t.Fatalf("a legitimate 4-link chain was refused: %v", err)
+	}
+	if launcher == "" {
+		t.Fatal("no launcher for a legitimate chain")
+	}
+	if len(closure) < 3 {
+		t.Fatalf("closure = %d entries, want at least 3 for a 4-link chain: %v", len(closure), closure)
+	}
+}

--- a/internal/toolchain/runtime_launcher.go
+++ b/internal/toolchain/runtime_launcher.go
@@ -97,7 +97,8 @@ func (s *stageSource) stageInterpreter(gitmootHome string) (string, error) {
 	if systemInterpreterRoots(absolute) {
 		return absolute, nil
 	}
-	return StageRuntime(gitmootHome, filepath.Base(candidate), absolute)
+	launcher, _, err := StageRuntime(gitmootHome, filepath.Base(candidate), absolute)
+	return launcher, err
 }
 
 // publish copies the accepted members into the engine root and publishes them by

--- a/internal/toolchain/runtime_launcher.go
+++ b/internal/toolchain/runtime_launcher.go
@@ -36,7 +36,23 @@ func shortDigest(value string) string {
 //   - missing or unreadable shebang: required-but-unstageable, which the caller
 //     turns into an exit-126 command.
 //   - no shebang at all (an ELF binary such as claude or kimi): no interpreter.
-func (s *stageSource) stageInterpreter(gitmootHome string) (string, error) {
+//
+// It returns the interpreter, whether that interpreter was STAGED by this
+// engine, and the interpreter's own transitive closure.
+//
+// THE staged BOOL IS REPORTED BY THE PRODUCER, NOT RE-DERIVED BY THE CALLER
+// (#2141 review, P3). An earlier form had the caller ask
+// StagedUnderRuntimeRoot (SINCE REMOVED - a grep for that name now finds
+// only this sentence), a bool that collapsed two unrelated causes: the
+// EXPECTED "this is a system path, it has no staged root" and a real
+// containment escape. Only this function knows which branch it took, so it
+// says so, and a containment error from the recursive stage now propagates as
+// an error instead of being flattened into false.
+//
+// The closure is transitive because an interpreter can itself be a script:
+// returning only the immediate one leaves a third root ungranted and the seat
+// still exits 126.
+func (s *stageSource) stageInterpreter(gitmootHome string) (string, bool, []string, error) {
 	var entrypoint *os.File
 	for _, member := range s.members {
 		if member.relative == s.entrypoint {
@@ -44,20 +60,20 @@ func (s *stageSource) stageInterpreter(gitmootHome string) (string, error) {
 		}
 	}
 	if entrypoint == nil {
-		return "", fmt.Errorf("%w: entrypoint %q is not among the accepted members", ErrRuntimeNotStageable, s.entrypoint)
+		return "", false, nil, fmt.Errorf("%w: entrypoint %q is not among the accepted members", ErrRuntimeNotStageable, s.entrypoint)
 	}
 	if _, err := entrypoint.Seek(0, io.SeekStart); err != nil {
-		return "", fmt.Errorf("%w: rewind entrypoint: %v", ErrRuntimeNotStageable, err)
+		return "", false, nil, fmt.Errorf("%w: rewind entrypoint: %v", ErrRuntimeNotStageable, err)
 	}
 	header := make([]byte, 256)
 	read, err := entrypoint.Read(header)
 	if err != nil && read == 0 && !errors.Is(err, io.EOF) {
-		return "", fmt.Errorf("%w: read entrypoint header: %v", ErrRuntimeNotStageable, err)
+		return "", false, nil, fmt.Errorf("%w: read entrypoint header: %v", ErrRuntimeNotStageable, err)
 	}
 	header = header[:read]
 	if !strings.HasPrefix(string(header), "#!") {
 		// A binary. Nothing to stage, and the launcher will be a direct link.
-		return "", nil
+		return "", false, nil, nil
 	}
 	line := string(header[2:])
 	if end := strings.IndexAny(line, "\r\n"); end >= 0 {
@@ -65,16 +81,16 @@ func (s *stageSource) stageInterpreter(gitmootHome string) (string, error) {
 	} else if read == len(header) {
 		// The shebang did not terminate inside the header we read, so we cannot
 		// know what it names. Refusing beats guessing.
-		return "", fmt.Errorf("%w: entrypoint shebang exceeds %d bytes and cannot be read completely", ErrRuntimeNotStageable, len(header))
+		return "", false, nil, fmt.Errorf("%w: entrypoint shebang exceeds %d bytes and cannot be read completely", ErrRuntimeNotStageable, len(header))
 	}
 	fields := strings.Fields(line)
 	if len(fields) == 0 {
-		return "", fmt.Errorf("%w: entrypoint declares an empty shebang", ErrRuntimeNotStageable)
+		return "", false, nil, fmt.Errorf("%w: entrypoint declares an empty shebang", ErrRuntimeNotStageable)
 	}
 	candidate := fields[0]
 	if filepath.Base(candidate) == "env" {
 		if len(fields) < 2 {
-			return "", fmt.Errorf("%w: entrypoint shebang %q names no interpreter", ErrRuntimeNotStageable, line)
+			return "", false, nil, fmt.Errorf("%w: entrypoint shebang %q names no interpreter", ErrRuntimeNotStageable, line)
 		}
 		candidate = fields[1]
 	}
@@ -83,22 +99,29 @@ func (s *stageSource) stageInterpreter(gitmootHome string) (string, error) {
 	if !filepath.IsAbs(target) {
 		located, lookErr := exec.LookPath(candidate)
 		if lookErr != nil {
-			return "", fmt.Errorf("%w: entrypoint needs interpreter %q, which cannot be resolved: %v", ErrRuntimeNotStageable, candidate, lookErr)
+			return "", false, nil, fmt.Errorf("%w: entrypoint needs interpreter %q, which cannot be resolved: %v", ErrRuntimeNotStageable, candidate, lookErr)
 		}
 		target = located
 	}
 	absolute, err := filepath.Abs(target)
 	if err != nil {
-		return "", fmt.Errorf("%w: interpreter %q: %v", ErrRuntimeNotStageable, target, err)
+		return "", false, nil, fmt.Errorf("%w: interpreter %q: %v", ErrRuntimeNotStageable, target, err)
 	}
 	// A SYSTEM INTERPRETER STILL GETS AN EXPLICIT LAUNCHER, but no copy: the
 	// sandbox grants those roots unconditionally, and copying /bin/sh would put
 	// an engine copy of the shell ahead of the real one for no gain.
 	if systemInterpreterRoots(absolute) {
-		return absolute, nil
+		// A system interpreter is NOT staged and needs no grant. This is the
+		// arm the collapsed bool used to be asked about.
+		return absolute, false, nil, nil
 	}
-	launcher, _, err := StageRuntime(gitmootHome, filepath.Base(candidate), absolute)
-	return launcher, err
+	// The recursion is what makes the closure transitive: this interpreter's
+	// own interpreters come back here and are propagated to the caller.
+	launcher, nested, err := StageRuntime(gitmootHome, filepath.Base(candidate), absolute)
+	if err != nil {
+		return "", false, nil, err
+	}
+	return launcher, true, nested, nil
 }
 
 // publish copies the accepted members into the engine root and publishes them by

--- a/internal/toolchain/runtime_launcher.go
+++ b/internal/toolchain/runtime_launcher.go
@@ -52,7 +52,7 @@ func shortDigest(value string) string {
 // The closure is transitive because an interpreter can itself be a script:
 // returning only the immediate one leaves a third root ungranted and the seat
 // still exits 126.
-func (s *stageSource) stageInterpreter(gitmootHome string) (string, bool, []string, error) {
+func (s *stageSource) stageInterpreter(gitmootHome string, chain []string) (string, bool, []string, error) {
 	var entrypoint *os.File
 	for _, member := range s.members {
 		if member.relative == s.entrypoint {
@@ -117,7 +117,7 @@ func (s *stageSource) stageInterpreter(gitmootHome string) (string, bool, []stri
 	}
 	// The recursion is what makes the closure transitive: this interpreter's
 	// own interpreters come back here and are propagated to the caller.
-	launcher, nested, err := StageRuntime(gitmootHome, filepath.Base(candidate), absolute)
+	launcher, nested, err := stageRuntimeBounded(gitmootHome, filepath.Base(candidate), absolute, chain)
 	if err != nil {
 		return "", false, nil, err
 	}

--- a/internal/toolchain/runtime_stage.go
+++ b/internal/toolchain/runtime_stage.go
@@ -79,6 +79,30 @@ func RuntimeRoot(gitmootHome string) string {
 // slice is empty for a native binary and for a system interpreter, whose roots
 // the sandbox already grants unconditionally.
 func StageRuntime(gitmootHome string, name string, executable string) (string, []string, error) {
+	return stageRuntimeBounded(gitmootHome, name, executable, nil)
+}
+
+// maxInterpreterChain bounds the interpreter recursion. A real chain is one or
+// two links (a script run by node, or by a wrapper that is itself a script);
+// eight is far past anything a runtime ships and still small enough that the
+// refusal is obviously a defect in the artifact rather than a limit anyone hits.
+const maxInterpreterChain = 8
+
+// stageRuntimeBounded carries the chain of executables already being staged, so
+// the interpreter recursion cannot run forever.
+//
+// WHY THIS EXISTS (#2141 review, P2). The recursion had no visited set and no
+// depth bound. A self-referential shebang, or two scripts naming each other,
+// recursed until Go's stack overflowed - and a stack overflow is a FATAL error
+// that kills the whole process, so one malformed runtime on disk would take
+// down the daemon and every job running in it, not just the seat that staged
+// it. The reviewer reproduced both shapes against this source with a timeout
+// guard; neither returned.
+//
+// The cycle check is keyed on the RESOLVED executable path, which is what the
+// recursion actually revisits: two different names can resolve to one file, and
+// that is exactly the self-loop case.
+func stageRuntimeBounded(gitmootHome string, name string, executable string, chain []string) (string, []string, error) {
 	name = strings.TrimSpace(name)
 	if name == "" || strings.ContainsAny(name, `/\`) || name == "." || name == ".." {
 		return "", nil, fmt.Errorf("%w: %q is not usable as one path component", ErrRuntimeNotStageable, name)
@@ -95,6 +119,15 @@ func StageRuntime(gitmootHome string, name string, executable string) (string, [
 	if err != nil {
 		return "", nil, fmt.Errorf("%w: resolve %q: %v", ErrRuntimeNotStageable, executable, err)
 	}
+	for _, seen := range chain {
+		if seen == resolved {
+			return "", nil, fmt.Errorf("%w: interpreter chain revisits %q, so it cannot terminate", ErrRuntimeNotStageable, resolved)
+		}
+	}
+	if len(chain) >= maxInterpreterChain {
+		return "", nil, fmt.Errorf("%w: interpreter chain for %q exceeds %d links", ErrRuntimeNotStageable, resolved, maxInterpreterChain)
+	}
+	chain = append(append([]string(nil), chain...), resolved)
 	boundary, relative, packaged := runtimeBoundary(resolved)
 	source, err := openStageSource(boundary, relative, packaged)
 	if err != nil {
@@ -111,7 +144,7 @@ func StageRuntime(gitmootHome string, name string, executable string) (string, [
 	// without node is a different artifact when node changes, so the staged
 	// interpreter's own published directory folds into this fingerprint - a
 	// stale launcher can never point at a retired interpreter tree.
-	interpreter, interpreterStaged, nested, err := source.stageInterpreter(gitmootHome)
+	interpreter, interpreterStaged, nested, err := source.stageInterpreter(gitmootHome, chain)
 	if err != nil {
 		return "", nil, err
 	}

--- a/internal/toolchain/runtime_stage.go
+++ b/internal/toolchain/runtime_stage.go
@@ -67,20 +67,25 @@ func RuntimeRoot(gitmootHome string) string {
 // no component of any source path can be a symlink and nothing resolves outside
 // the boundary. The digest and the copy read the SAME descriptors, so the
 // published name describes the published bytes by construction.
-// It returns the staged launcher AND the staged launcher of the interpreter
-// that launcher execs, which is "" for a native binary. THE SECOND VALUE IS THE
-// EXEC CLOSURE AND CALLERS THAT SANDBOX A SEAT MUST GRANT IT (#2141): the
-// launcher is a two-line script that execs the interpreter's own published
-// tree, a SIBLING published root, so a caller granting only this launcher's
-// root has granted a command it cannot run.
-func StageRuntime(gitmootHome string, name string, executable string) (string, string, error) {
+// It returns the staged launcher AND THE FULL TRANSITIVE EXEC CLOSURE: every
+// staged launcher this one reaches by exec, nearest first. Callers that sandbox
+// a seat MUST grant every root in that closure (#2141).
+//
+// TRANSITIVE, NOT IMMEDIATE. The launcher is a two-line script that execs the
+// interpreter's own published tree, a SIBLING published root - and that
+// interpreter can itself be a script needing a third. Returning only the
+// immediate interpreter grants two roots out of three and the seat still exits
+// 126, which is what the #2141 review reproduced with an executed test. The
+// slice is empty for a native binary and for a system interpreter, whose roots
+// the sandbox already grants unconditionally.
+func StageRuntime(gitmootHome string, name string, executable string) (string, []string, error) {
 	name = strings.TrimSpace(name)
 	if name == "" || strings.ContainsAny(name, `/\`) || name == "." || name == ".." {
-		return "", "", fmt.Errorf("%w: %q is not usable as one path component", ErrRuntimeNotStageable, name)
+		return "", nil, fmt.Errorf("%w: %q is not usable as one path component", ErrRuntimeNotStageable, name)
 	}
 	executable = strings.TrimSpace(executable)
 	if executable == "" || !filepath.IsAbs(executable) {
-		return "", "", fmt.Errorf("%w: executable %q must be an absolute path", ErrRuntimeNotStageable, executable)
+		return "", nil, fmt.Errorf("%w: executable %q must be an absolute path", ErrRuntimeNotStageable, executable)
 	}
 	// The RESOLVED target is what runs, and it is what must be copied: a PATH
 	// entry is frequently a symlink into a versioned directory (claude ships
@@ -88,30 +93,35 @@ func StageRuntime(gitmootHome string, name string, executable string) (string, s
 	// copying the link would stage something unrunnable.
 	resolved, err := filepath.EvalSymlinks(executable)
 	if err != nil {
-		return "", "", fmt.Errorf("%w: resolve %q: %v", ErrRuntimeNotStageable, executable, err)
+		return "", nil, fmt.Errorf("%w: resolve %q: %v", ErrRuntimeNotStageable, executable, err)
 	}
 	boundary, relative, packaged := runtimeBoundary(resolved)
 	source, err := openStageSource(boundary, relative, packaged)
 	if err != nil {
-		return "", "", err
+		return "", nil, err
 	}
 	defer source.close()
 
 	fingerprint, err := source.digest()
 	if err != nil {
-		return "", "", err
+		return "", nil, err
 	}
 
 	// THE INTERPRETER IS PART OF THE IDENTITY. A script runtime that cannot run
 	// without node is a different artifact when node changes, so the staged
 	// interpreter's own published directory folds into this fingerprint - a
 	// stale launcher can never point at a retired interpreter tree.
-	interpreter, err := source.stageInterpreter(gitmootHome)
+	interpreter, interpreterStaged, nested, err := source.stageInterpreter(gitmootHome)
 	if err != nil {
-		return "", "", err
+		return "", nil, err
 	}
+	var closure []string
 	if interpreter != "" {
 		fingerprint = shortDigest(fingerprint + "\x00" + interpreter)
+		if interpreterStaged {
+			closure = append(closure, interpreter)
+		}
+		closure = append(closure, nested...)
 	}
 
 	root := RuntimeRoot(gitmootHome)
@@ -125,14 +135,14 @@ func StageRuntime(gitmootHome string, name string, executable string) (string, s
 
 	if _, err := os.Lstat(published); err == nil {
 		if err := validatePublished(published, name, relative, fingerprint); err != nil {
-			return "", "", err
+			return "", nil, err
 		}
-		return launcher, interpreter, nil
+		return launcher, closure, nil
 	}
 	if err := source.publish(root, publishedName, name, relative, interpreter, fingerprint); err != nil {
-		return "", "", err
+		return "", nil, err
 	}
-	return launcher, interpreter, nil
+	return launcher, closure, nil
 }
 
 // RuntimeInterpreter reports the interpreter a staged entrypoint needs, and the
@@ -331,22 +341,6 @@ func StagedRuntimeRoot(gitmootHome string, shim string) (string, error) {
 		return "", fmt.Errorf("%w: runtime shim %q is outside engine runtime root %q", ErrRuntimeNotStageable, shim, RuntimeRoot(gitmootHome))
 	}
 	return root, nil
-}
-
-// StagedUnderRuntimeRoot reports whether path is a launcher the engine
-// published under its own runtime root.
-//
-// IT EXISTS TO SEPARATE THE TWO KINDS OF INTERPRETER StageRuntime CAN REPORT.
-// A packaged script runtime's interpreter is COPIED and published, so its root
-// must be granted to a sandboxed seat. A SYSTEM interpreter (/bin/sh) is
-// returned verbatim and never copied, because "the sandbox grants those roots
-// unconditionally" - asking for its staged root is a category error and fails
-// with "not inside a .bin directory". Callers building grants use this to skip
-// the second kind rather than to swallow the error, which would also hide a
-// genuine containment failure.
-func StagedUnderRuntimeRoot(gitmootHome string, path string) bool {
-	_, err := StagedRuntimeRoot(gitmootHome, path)
-	return err == nil
 }
 
 // runtimeBoundary decides what must be copied for a resolved executable.

--- a/internal/toolchain/runtime_stage.go
+++ b/internal/toolchain/runtime_stage.go
@@ -67,14 +67,20 @@ func RuntimeRoot(gitmootHome string) string {
 // no component of any source path can be a symlink and nothing resolves outside
 // the boundary. The digest and the copy read the SAME descriptors, so the
 // published name describes the published bytes by construction.
-func StageRuntime(gitmootHome string, name string, executable string) (string, error) {
+// It returns the staged launcher AND the staged launcher of the interpreter
+// that launcher execs, which is "" for a native binary. THE SECOND VALUE IS THE
+// EXEC CLOSURE AND CALLERS THAT SANDBOX A SEAT MUST GRANT IT (#2141): the
+// launcher is a two-line script that execs the interpreter's own published
+// tree, a SIBLING published root, so a caller granting only this launcher's
+// root has granted a command it cannot run.
+func StageRuntime(gitmootHome string, name string, executable string) (string, string, error) {
 	name = strings.TrimSpace(name)
 	if name == "" || strings.ContainsAny(name, `/\`) || name == "." || name == ".." {
-		return "", fmt.Errorf("%w: %q is not usable as one path component", ErrRuntimeNotStageable, name)
+		return "", "", fmt.Errorf("%w: %q is not usable as one path component", ErrRuntimeNotStageable, name)
 	}
 	executable = strings.TrimSpace(executable)
 	if executable == "" || !filepath.IsAbs(executable) {
-		return "", fmt.Errorf("%w: executable %q must be an absolute path", ErrRuntimeNotStageable, executable)
+		return "", "", fmt.Errorf("%w: executable %q must be an absolute path", ErrRuntimeNotStageable, executable)
 	}
 	// The RESOLVED target is what runs, and it is what must be copied: a PATH
 	// entry is frequently a symlink into a versioned directory (claude ships
@@ -82,18 +88,18 @@ func StageRuntime(gitmootHome string, name string, executable string) (string, e
 	// copying the link would stage something unrunnable.
 	resolved, err := filepath.EvalSymlinks(executable)
 	if err != nil {
-		return "", fmt.Errorf("%w: resolve %q: %v", ErrRuntimeNotStageable, executable, err)
+		return "", "", fmt.Errorf("%w: resolve %q: %v", ErrRuntimeNotStageable, executable, err)
 	}
 	boundary, relative, packaged := runtimeBoundary(resolved)
 	source, err := openStageSource(boundary, relative, packaged)
 	if err != nil {
-		return "", err
+		return "", "", err
 	}
 	defer source.close()
 
 	fingerprint, err := source.digest()
 	if err != nil {
-		return "", err
+		return "", "", err
 	}
 
 	// THE INTERPRETER IS PART OF THE IDENTITY. A script runtime that cannot run
@@ -102,7 +108,7 @@ func StageRuntime(gitmootHome string, name string, executable string) (string, e
 	// stale launcher can never point at a retired interpreter tree.
 	interpreter, err := source.stageInterpreter(gitmootHome)
 	if err != nil {
-		return "", err
+		return "", "", err
 	}
 	if interpreter != "" {
 		fingerprint = shortDigest(fingerprint + "\x00" + interpreter)
@@ -119,14 +125,14 @@ func StageRuntime(gitmootHome string, name string, executable string) (string, e
 
 	if _, err := os.Lstat(published); err == nil {
 		if err := validatePublished(published, name, relative, fingerprint); err != nil {
-			return "", err
+			return "", "", err
 		}
-		return launcher, nil
+		return launcher, interpreter, nil
 	}
 	if err := source.publish(root, publishedName, name, relative, interpreter, fingerprint); err != nil {
-		return "", err
+		return "", "", err
 	}
-	return launcher, nil
+	return launcher, interpreter, nil
 }
 
 // RuntimeInterpreter reports the interpreter a staged entrypoint needs, and the
@@ -325,6 +331,22 @@ func StagedRuntimeRoot(gitmootHome string, shim string) (string, error) {
 		return "", fmt.Errorf("%w: runtime shim %q is outside engine runtime root %q", ErrRuntimeNotStageable, shim, RuntimeRoot(gitmootHome))
 	}
 	return root, nil
+}
+
+// StagedUnderRuntimeRoot reports whether path is a launcher the engine
+// published under its own runtime root.
+//
+// IT EXISTS TO SEPARATE THE TWO KINDS OF INTERPRETER StageRuntime CAN REPORT.
+// A packaged script runtime's interpreter is COPIED and published, so its root
+// must be granted to a sandboxed seat. A SYSTEM interpreter (/bin/sh) is
+// returned verbatim and never copied, because "the sandbox grants those roots
+// unconditionally" - asking for its staged root is a category error and fails
+// with "not inside a .bin directory". Callers building grants use this to skip
+// the second kind rather than to swallow the error, which would also hide a
+// genuine containment failure.
+func StagedUnderRuntimeRoot(gitmootHome string, path string) bool {
+	_, err := StagedRuntimeRoot(gitmootHome, path)
+	return err == nil
 }
 
 // runtimeBoundary decides what must be copied for a resolved executable.

--- a/internal/toolchain/runtime_stage_boundary_test.go
+++ b/internal/toolchain/runtime_stage_boundary_test.go
@@ -36,7 +36,7 @@ func stageCleanFixtureRuns(t *testing.T) {
 	t.Helper()
 	home := t.TempDir()
 	_, entrypoint := stagedPackageFixture(t)
-	launcher, err := StageRuntime(home, "tool", entrypoint)
+	launcher, _, err := StageRuntime(home, "tool", entrypoint)
 	if err != nil {
 		t.Fatalf("a clean package boundary was refused: %v", err)
 	}
@@ -66,7 +66,7 @@ func TestStageRefusesATreeWithAPrivateAncestor(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	launcher, err := StageRuntime(home, "tool", entrypoint)
+	launcher, _, err := StageRuntime(home, "tool", entrypoint)
 	if !errors.Is(err, ErrRuntimeNotStageable) {
 		t.Fatalf("a tree containing a 0700 directory staged anyway: launcher=%q err=%v", launcher, err)
 	}
@@ -85,7 +85,7 @@ func TestStageRefusesANonWorldReadableMember(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if _, err := StageRuntime(home, "tool", entrypoint); !errors.Is(err, ErrRuntimeNotStageable) {
+	if _, _, err := StageRuntime(home, "tool", entrypoint); !errors.Is(err, ErrRuntimeNotStageable) {
 		t.Fatalf("a tree containing a mode-0600 member staged anyway: %v", err)
 	}
 	assertNoStagedBytes(t, home, "seat-must-not-read-this")
@@ -103,7 +103,7 @@ func TestStageRefusesASymlinkedMember(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if _, err := StageRuntime(home, "tool", entrypoint); !errors.Is(err, ErrRuntimeNotStageable) {
+	if _, _, err := StageRuntime(home, "tool", entrypoint); !errors.Is(err, ErrRuntimeNotStageable) {
 		t.Fatalf("a tree containing an in-root symlink staged anyway: %v", err)
 	}
 	assertNoStagedBytes(t, home, "seat-must-not-read-this")
@@ -150,7 +150,7 @@ func TestStageRefusesASymlinkSwappedBetweenEnumerationAndOpen(t *testing.T) {
 	}
 	t.Cleanup(func() { swapBarrier = nil })
 
-	_, err := StageRuntime(home, "tool", entrypoint)
+	_, _, err := StageRuntime(home, "tool", entrypoint)
 	if !swapped {
 		t.Fatal("the barrier never fired, so this test did not exercise the substitution window")
 	}
@@ -178,7 +178,7 @@ func TestStageRefusesASymlinkSwappedBetweenEnumerationAndOpen(t *testing.T) {
 			t.Fatal(err)
 		}
 	}
-	launcher, controlErr := StageRuntime(controlHome, "tool", controlEntry)
+	launcher, _, controlErr := StageRuntime(controlHome, "tool", controlEntry)
 	if !replaced {
 		t.Fatal("the control barrier never fired")
 	}
@@ -197,13 +197,13 @@ func TestStageRefusesReuseWhenPublishedContentChanged(t *testing.T) {
 	if err := os.WriteFile(source, []byte("#!/bin/sh\nprintf 'v1\\n'\n"), 0o755); err != nil {
 		t.Fatal(err)
 	}
-	launcher, err := StageRuntime(home, "tool", source)
+	launcher, _, err := StageRuntime(home, "tool", source)
 	if err != nil {
 		t.Fatal(err)
 	}
 	// CONTROL FIRST: an untouched published tree is reused and returns the same
 	// launcher, so the refusal below cannot mean "never reuses anything".
-	reused, err := StageRuntime(home, "tool", source)
+	reused, _, err := StageRuntime(home, "tool", source)
 	if err != nil {
 		t.Fatalf("an untouched published tree was not reused: %v", err)
 	}
@@ -222,7 +222,7 @@ func TestStageRefusesReuseWhenPublishedContentChanged(t *testing.T) {
 	if err := os.WriteFile(entrypoint, []byte("#!/bin/sh\nprintf 'substituted\\n'\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := StageRuntime(home, "tool", source); !errors.Is(err, ErrRuntimeNotStageable) {
+	if _, _, err := StageRuntime(home, "tool", source); !errors.Is(err, ErrRuntimeNotStageable) {
 		t.Fatalf("reuse of a published tree whose bytes changed returned %v, want ErrRuntimeNotStageable", err)
 	}
 }

--- a/internal/toolchain/runtime_stage_test.go
+++ b/internal/toolchain/runtime_stage_test.go
@@ -41,7 +41,7 @@ func TestStageRuntimeStagesASelfContainedExecutableWithoutItsProfile(t *testing.
 		t.Fatal(err)
 	}
 
-	staged, err := StageRuntime(home, "kimi", executable)
+	staged, _, err := StageRuntime(home, "kimi", executable)
 	if err != nil {
 		t.Fatalf("StageRuntime: %v", err)
 	}
@@ -119,7 +119,7 @@ func TestStageRuntimeStagesANodePackageBoundary(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	staged, err := StageRuntime(home, "codex", executable)
+	staged, _, err := StageRuntime(home, "codex", executable)
 	if err != nil {
 		t.Fatalf("StageRuntime: %v", err)
 	}
@@ -154,14 +154,14 @@ func TestStageRuntimeRepublishesWhenTheSourceChanges(t *testing.T) {
 	if err := os.WriteFile(executable, []byte("#!/bin/sh\nprintf 'v1\\n'\n"), 0o755); err != nil {
 		t.Fatal(err)
 	}
-	first, err := StageRuntime(home, "claude", executable)
+	first, _, err := StageRuntime(home, "claude", executable)
 	if err != nil {
 		t.Fatal(err)
 	}
 	if err := os.WriteFile(executable, []byte("#!/bin/sh\nprintf 'v2\\n'\n"), 0o755); err != nil {
 		t.Fatal(err)
 	}
-	second, err := StageRuntime(home, "claude", executable)
+	second, _, err := StageRuntime(home, "claude", executable)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -201,7 +201,7 @@ func TestStageRuntimeStagesTheResolvedTargetOfASymlinkedPathEntry(t *testing.T) 
 		t.Fatal(err)
 	}
 
-	staged, err := StageRuntime(home, "claude", link)
+	staged, _, err := StageRuntime(home, "claude", link)
 	if err != nil {
 		t.Fatalf("StageRuntime on a symlinked PATH entry: %v", err)
 	}
@@ -246,7 +246,7 @@ func TestStageRuntimeRefusesCorruptedPublishedCopy(t *testing.T) {
 	if err := os.WriteFile(source, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
 		t.Fatal(err)
 	}
-	staged, err := StageRuntime(home, "claude", source)
+	staged, _, err := StageRuntime(home, "claude", source)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -257,7 +257,7 @@ func TestStageRuntimeRefusesCorruptedPublishedCopy(t *testing.T) {
 	if err := os.Remove(filepath.Join(published, "claude")); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := StageRuntime(home, "claude", source); !errors.Is(err, ErrRuntimeNotStageable) {
+	if _, _, err := StageRuntime(home, "claude", source); !errors.Is(err, ErrRuntimeNotStageable) {
 		t.Fatalf("restaging a corrupted published copy returned %v, want ErrRuntimeNotStageable", err)
 	}
 }
@@ -285,7 +285,7 @@ func TestStageRuntimeReusesAPublishedBinaryRuntime(t *testing.T) {
 	if err := os.WriteFile(source, []byte("\x7fELF\x02\x01\x01 not a script\n"), 0o755); err != nil {
 		t.Fatal(err)
 	}
-	first, err := StageRuntime(home, "claude", source)
+	first, _, err := StageRuntime(home, "claude", source)
 	if err != nil {
 		t.Fatalf("first StageRuntime: %v", err)
 	}
@@ -298,7 +298,7 @@ func TestStageRuntimeReusesAPublishedBinaryRuntime(t *testing.T) {
 	if info.Mode()&os.ModeSymlink == 0 {
 		t.Fatalf("launcher %q has mode %s, want a symlink: this regression covers the symlink-launcher reuse path and a regular launcher no longer exercises it", first, info.Mode())
 	}
-	second, err := StageRuntime(home, "claude", source)
+	second, _, err := StageRuntime(home, "claude", source)
 	if err != nil {
 		t.Fatalf("reusing the published binary runtime: %v", err)
 	}
@@ -335,7 +335,7 @@ func TestStageRuntimeDigestCoversANestedLauncherDirectory(t *testing.T) {
 	if err := os.WriteFile(source, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
 		t.Fatal(err)
 	}
-	staged, err := StageRuntime(home, "codex", source)
+	staged, _, err := StageRuntime(home, "codex", source)
 	if err != nil {
 		t.Fatalf("StageRuntime: %v", err)
 	}
@@ -347,7 +347,7 @@ func TestStageRuntimeDigestCoversANestedLauncherDirectory(t *testing.T) {
 	if _, err := os.Stat(publishedHelper); err != nil {
 		t.Fatalf("a nested %s member was not staged, so the packaged runtime is incomplete: %v", launcherDirName, err)
 	}
-	if _, err := StageRuntime(home, "codex", source); err != nil {
+	if _, _, err := StageRuntime(home, "codex", source); err != nil {
 		t.Fatalf("reusing a package that contains a nested %s directory: %v", launcherDirName, err)
 	}
 	// The engine tree is published read-only, so the tamper needs the directory
@@ -358,7 +358,7 @@ func TestStageRuntimeDigestCoversANestedLauncherDirectory(t *testing.T) {
 	if err := os.Remove(publishedHelper); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := StageRuntime(home, "codex", source); !errors.Is(err, ErrRuntimeNotStageable) {
+	if _, _, err := StageRuntime(home, "codex", source); !errors.Is(err, ErrRuntimeNotStageable) {
 		t.Fatalf("removing a nested %s member left the published digest valid (err = %v); the launcher exclusion must apply to the top level only", launcherDirName, err)
 	}
 }


### PR DESCRIPTION
Fixes #2141. Restores codex-family reviewers on hosts where a script runtime's interpreter is staged into its own published root.

## The defect in one sentence

**A grant derived from a start-list is blind to what the started thing then executes.**

`stageSeatRuntimes` enumerates `seatRuntimeNames = {"claude", "kimi", "codex"}`, and the list's own comment states the mismatch without noticing it: "derived from what the engine can **start** rather than from what happens to be installed". The engine does not start node. It **execs** it.

## Measured on this host

Recorded job diagnostics, verbatim, from two dead reviewers:

```
{"phase":"launched","exit_code":126,"stderr_tail":
 "/root/.gitmoot/runtimes/codex-6cfed7f8fffb3268/.bin/codex: 2: exec:
  /root/.gitmoot/runtimes/node-606c31763a3cb3b6/.bin/node: Permission denied"}
```

The staged launcher execs a **sibling** published root:

```sh
#!/bin/sh
exec '/root/.gitmoot/runtimes/node-606c31763a3cb3b6/.bin/node' \
     '/root/.gitmoot/runtimes/codex-6cfed7f8fffb3268/bin/codex.js' "$@"
```

Staging owns that interpreter deliberately (`runtime_stage.go:103`, so "the kernel never resolves the original absolute shebang"). The grant side never learned: `StageRuntime` computed the interpreter and discarded it, and `readOnlyRuntimeSandboxGrants` maps each shim through `StagedRuntimeRoot`, which resolves a shim to **its own** root. Codex granted, node not.

## The fix, and the one-liner it refuses

`StageRuntime` returns the interpreter it staged; seat setup grants that root.

Granting `toolchain.RuntimeRoot(home)` wholesale also fixes the symptom and is **refused**: it hands a seat exec over every staged runtime including ones no dispatch decision chose, which is the widening #1878 and #1921 spent three rounds narrowing away from. The regression **fails on that mutant too**, so the narrow form is pinned rather than merely the outcome. Pinning the outcome alone would let a future author re-widen the grant while green.

## Two kinds of interpreter, which cost me a round

`stageInterpreter` returns a published launcher for a copied interpreter, and the **bare host path** for a system interpreter such as `/bin/sh`, whose root the sandbox already grants unconditionally. Treating them alike broke `TestSeatSetupReportsWhenTheSeatsOwnRuntimeIsPublishedUnavailable` with `runtime shim "/bin/sh" is not inside a .bin directory` - a runtime that was working correctly.

`StagedUnderRuntimeRoot` separates them by reusing the existing containment check, rather than swallowing `StagedRuntimeRoot`'s error, which would also hide a genuine containment failure.

## A FALSE REPRODUCTION, recorded because it is the most dangerous artifact here

Outside the sandbox, as uid 65534 with `CapEff=0000000000000000`, I produced **the exact recorded string**:

```
sh: 1: /root/.gitmoot/runtimes/node-606c…/.bin/node: Permission denied
exit=126
```

**It is invalid.** Read-only seats do not drop uid: the only `SysProcAttr` on the dispatch path is `Setsid: true` (`daemon_lifecycle.go:1572`), there is no `Credential`/`Setuid`/`Setgid` anywhere in `internal/**`, and confinement is `landlockRuntimeRunner`. The seat runs as the daemon uid, root, and root can exec a `0500 root` file. Right output, wrong mechanism.

Acting on it would have led to a permission change - the one fix that was explicitly forbidden - and it would have looked confirmed. **A reproduction that yields the right output by the wrong mechanism is worse than no reproduction, because it certifies a false model with evidence.** It is the inverse of the false-zero class: not an empty result misread as absence, but a positive result misread as confirmation.

## Tests

`TestSeatGrantsCoverTheInterpreterAScriptRuntimeExecs` drives the production entry `readOnlyRuntimeSandboxGrants`, not `stageSeatRuntimes`, because the grant list is the thing that decides what a seat may execute. A test asserting only that staging returned an interpreter would pass while the grant list stayed short.

It locates both roots from the filesystem independently of the value under test, asserts the staged launcher actually references the interpreter root (so the grant is required rather than gratuitous), asserts both roots are granted, and asserts the interpreter does **not** reach the seat `PATH` - granting an exec closure is not offering a second interpreter by name.

Mutants, run in order with a green baseline first:

```
BASELINE                                   ok   18.576s
MUTANT A  drop the interpreter grant       FAIL
RESTORE   byte-identical to baseline       ok   19.451s
MUTANT B  grant RuntimeRoot(home) instead  FAIL
```

Full suites on this branch: `internal/toolchain` **ok 7.6s**, `internal/cli` **with `-tags e2e`, ok 948.7s**. The tagged lane is used deliberately: an untagged run silently drops the e2e files, which is how a defect escaped me on #2129.

## Scope, stated so nobody reads this as "reviewers fixed"

**This restores codex-family reviewers only.** `claude` and `kimi` fail with a different defect - `resolve ".bin/claude": too many levels of symbolic links`, 68 occurrences each in the daemon journal - which is #1974. `kimi` additionally has no credential configured, so it needs one before it reviews anything even after #1974.

Verification that codex-family reviewers actually return is a live-probe after deploy, not a claim of this PR.
