### PR TITLE
fix(cli): record the remote's default branch, not the local HEAD (#2145)

### DIFF
--- a/internal/cli/agent_dispatch.go
+++ b/internal/cli/agent_dispatch.go
@@ -2063,7 +2063,7 @@ func resolveLocalAgentRepo(ctx context.Context, store *db.Store, repoFlag string
 	// This prevents an ephemeral cwd from becoming repo.CheckoutPath without
 	// silently rebasing local ask/review behavior onto the stored default branch.
 	if strings.TrimSpace(repoFlag) == "" {
-		if cwdRecord, cwdErr := repoRecordForCheckout(ctx, repo, gitutil.NewHostClient(".")); cwdErr == nil {
+		if cwdRecord, _, cwdErr := repoRecordForCheckout(ctx, repo, gitutil.NewHostClient(".")); cwdErr == nil {
 			record.DefaultBranch = cwdRecord.DefaultBranch
 		}
 	}

--- a/internal/cli/agent_dispatch.go
+++ b/internal/cli/agent_dispatch.go
@@ -240,7 +240,7 @@ func dispatchLocalAgentJob(ctx context.Context, store *db.Store, request localAg
 	if err := validateAndTouchActingOrgRole(ctx, store, request.Home, request.ActingOrgRole, request.ExecutionPath); err != nil {
 		return localAgentJobOutput{}, err
 	}
-	repo, record, err := resolveLocalAgentRepo(ctx, store, request.RepoFlag)
+	repo, record, dispatchBranch, persistDefaultBranch, err := resolveLocalAgentRepo(ctx, store, request.RepoFlag, localDispatchJobRunner(request))
 	if err != nil {
 		return localAgentJobOutput{}, err
 	}
@@ -309,7 +309,7 @@ func dispatchLocalAgentJob(ctx context.Context, store *db.Store, request localAg
 			request.ImplementPRValidated = true
 		}
 	}
-	if err := store.UpsertRepo(ctx, record); err != nil {
+	if err := upsertLocalAgentRepo(ctx, store, record, persistDefaultBranch); err != nil {
 		return localAgentJobOutput{}, err
 	}
 	var checkoutPath string
@@ -317,7 +317,7 @@ func dispatchLocalAgentJob(ctx context.Context, store *db.Store, request localAg
 	if agent, blocked, err := readOnlyManagedImplementationBlock(ctx, store, request, repo.FullName()); err != nil {
 		return localAgentJobOutput{}, err
 	} else if blocked {
-		return enqueuePermissionBlockedLocalAgentJob(ctx, store, request, repo.FullName(), record.DefaultBranch, agent.Name, overrideRuntime, overrideRef, orgPolicy)
+		return enqueuePermissionBlockedLocalAgentJob(ctx, store, request, repo.FullName(), dispatchBranch, agent.Name, overrideRuntime, overrideRef, orgPolicy)
 	}
 	agent, releaseAgentReservation, err := resolveLocalDispatchAgent(ctx, store, request, repo.FullName(), record)
 	if err != nil {
@@ -369,7 +369,7 @@ func dispatchLocalAgentJob(ctx context.Context, store *db.Store, request localAg
 		effectiveAgent.ExecBackend = string(execBackend)
 	}
 	if readOnlyImplementationBlocked(request.Action, effectiveAgent) {
-		return enqueuePermissionBlockedLocalAgentJob(ctx, store, request, repo.FullName(), record.DefaultBranch, agent.Name, overrideRuntime, overrideRef, orgPolicy)
+		return enqueuePermissionBlockedLocalAgentJob(ctx, store, request, repo.FullName(), dispatchBranch, agent.Name, overrideRuntime, overrideRef, orgPolicy)
 	}
 	var foregroundContract *runtime.RuntimeContractResult
 	if !request.Background {
@@ -641,7 +641,7 @@ func dispatchLocalAgentJob(ctx context.Context, store *db.Store, request localAg
 		Agent:            agent.Name,
 		Action:           request.Action,
 		Repo:             repo.FullName(),
-		Branch:           firstNonEmpty(request.Branch, record.DefaultBranch),
+		Branch:           firstNonEmpty(request.Branch, dispatchBranch),
 		PullRequest:      request.PullRequest,
 		PullRequestReady: request.PullRequestReady,
 		HeadSHA:          request.HeadSHA,
@@ -2049,32 +2049,45 @@ func formatManagedAgentTime(value time.Time) string {
 	return value.UTC().Format("2006-01-02T15:04:05.000000000Z")
 }
 
-func resolveLocalAgentRepo(ctx context.Context, store *db.Store, repoFlag string) (github.Repository, db.Repo, error) {
-	repo, err := localAgentTargetRepo(ctx, repoFlag)
+func resolveLocalAgentRepo(ctx context.Context, store *db.Store, repoFlag string, runner subprocess.Runner) (github.Repository, db.Repo, string, bool, error) {
+	repo, err := localAgentTargetRepo(ctx, repoFlag, runner)
 	if err != nil {
-		return github.Repository{}, db.Repo{}, err
+		return github.Repository{}, db.Repo{}, "", false, err
 	}
-	record, err := resolveRepoRecord(ctx, store, repo, ".")
+	record, defaultBranchFromRemote, err := resolveRepoRecordWithDefaultSource(ctx, store, repo, ".", runner)
 	if err != nil {
-		return github.Repository{}, db.Repo{}, err
+		return github.Repository{}, db.Repo{}, "", false, err
 	}
+	dispatchBranch := record.DefaultBranch
+	implicitRepo := strings.TrimSpace(repoFlag) == ""
 	// Without --repo, preserve the historical current-checkout branch selection
 	// for the job payload while retaining the registered/stable checkout path.
-	// This prevents an ephemeral cwd from becoming repo.CheckoutPath without
-	// silently rebasing local ask/review behavior onto the stored default branch.
-	if strings.TrimSpace(repoFlag) == "" {
-		if cwdRecord, _, cwdErr := repoRecordForCheckout(ctx, repo, gitutil.NewHostClient(".")); cwdErr == nil {
-			record.DefaultBranch = cwdRecord.DefaultBranch
+	if implicitRepo {
+		if branch, branchErr := jobGitClient(".", runner).CurrentBranch(ctx); branchErr == nil {
+			dispatchBranch = branch
 		}
 	}
-	return repo, record, nil
+	// Explicit repo selection keeps its established fallback behavior. For an
+	// implicit repo, only an origin/HEAD-derived default is safe to persist:
+	// the separately selected current checkout branch belongs to this job.
+	persistDefaultBranch := !implicitRepo || defaultBranchFromRemote
+	return repo, record, dispatchBranch, persistDefaultBranch, nil
 }
 
-func localAgentTargetRepo(ctx context.Context, repoFlag string) (github.Repository, error) {
+// upsertLocalAgentRepo persists checkout metadata while omitting a
+// current-branch fallback that is not authoritative repository-wide.
+func upsertLocalAgentRepo(ctx context.Context, store *db.Store, record db.Repo, persistDefaultBranch bool) error {
+	if !persistDefaultBranch {
+		record.DefaultBranch = ""
+	}
+	return store.UpsertRepo(ctx, record)
+}
+
+func localAgentTargetRepo(ctx context.Context, repoFlag string, runner subprocess.Runner) (github.Repository, error) {
 	if strings.TrimSpace(repoFlag) != "" {
 		return github.ParseRepository(repoFlag)
 	}
-	remote, err := (gitutil.NewHostClient(".")).OriginRemote(ctx)
+	remote, err := jobGitClient(".", runner).OriginRemote(ctx)
 	if err != nil {
 		return github.Repository{}, fmt.Errorf("infer repo from current checkout: %w", err)
 	}

--- a/internal/cli/agent_implement_base_test.go
+++ b/internal/cli/agent_implement_base_test.go
@@ -413,7 +413,7 @@ func TestResolveLocalAgentRepoPreservesRegisteredDefaultBranch(t *testing.T) {
 	if err := store.UpsertRepo(ctx, db.Repo{Owner: "owner", Name: "repo", DefaultBranch: "main", CheckoutPath: checkout, PollInterval: "30s"}); err != nil {
 		t.Fatalf("UpsertRepo: %v", err)
 	}
-	_, record, err := resolveLocalAgentRepo(ctx, store, "owner/repo")
+	_, record, _, _, err := resolveLocalAgentRepo(ctx, store, "owner/repo", subprocess.ExecRunner{})
 	if err != nil {
 		t.Fatalf("resolveLocalAgentRepo: %v", err)
 	}
@@ -422,6 +422,124 @@ func TestResolveLocalAgentRepoPreservesRegisteredDefaultBranch(t *testing.T) {
 	}
 	if branch, err := (gitutil.NewHostClient(checkout)).CurrentBranch(ctx); err != nil || branch != "feature/stale" {
 		t.Fatalf("checkout branch = %q err=%v, want feature/stale", branch, err)
+	}
+}
+
+func TestResolveLocalAgentRepoWithoutFlagUsesCheckoutBranchWithoutChangingRegisteredDefault(t *testing.T) {
+	ctx := context.Background()
+	checkout := t.TempDir()
+	runGit(t, checkout, "init")
+	runGit(t, checkout, "config", "user.email", "gitmoot@example.com")
+	runGit(t, checkout, "config", "user.name", "Gitmoot Test")
+	writeFile(t, filepath.Join(checkout, "README.md"), "main\n")
+	runGit(t, checkout, "add", "README.md")
+	runGit(t, checkout, "commit", "-m", "initial")
+	runGit(t, checkout, "branch", "-m", "main")
+	runGit(t, checkout, "remote", "add", "origin", "https://github.com/owner/repo.git")
+	runGit(t, checkout, "update-ref", "refs/remotes/origin/main", "HEAD")
+	runGit(t, checkout, "symbolic-ref", "refs/remotes/origin/HEAD", "refs/remotes/origin/main")
+	runGit(t, checkout, "switch", "-c", "feature/local")
+	store := openCLIJobStore(t, t.TempDir())
+	defer store.Close()
+	if err := store.UpsertRepo(ctx, db.Repo{Owner: "owner", Name: "repo", DefaultBranch: "main", CheckoutPath: checkout}); err != nil {
+		t.Fatalf("UpsertRepo: %v", err)
+	}
+	t.Chdir(checkout)
+
+	_, record, dispatchBranch, persistDefaultBranch, err := resolveLocalAgentRepo(ctx, store, "", subprocess.ExecRunner{})
+	if err != nil {
+		t.Fatalf("resolveLocalAgentRepo: %v", err)
+	}
+	if dispatchBranch != "feature/local" {
+		t.Fatalf("dispatch branch = %q, want current checkout branch feature/local", dispatchBranch)
+	}
+	if record.DefaultBranch != "main" {
+		t.Fatalf("resolved repo-wide default branch = %q, want main", record.DefaultBranch)
+	}
+	if err := upsertLocalAgentRepo(ctx, store, record, persistDefaultBranch); err != nil {
+		t.Fatalf("upsertLocalAgentRepo: %v", err)
+	}
+	stored, err := store.GetRepo(ctx, "owner/repo")
+	if err != nil || stored.DefaultBranch != "main" {
+		t.Fatalf("stored default branch = %q, err=%v, want main", stored.DefaultBranch, err)
+	}
+}
+
+func TestResolveLocalAgentRepoWithoutFlagPersistsRemoteDefaultForUnregisteredRepo(t *testing.T) {
+	ctx := context.Background()
+	checkout := t.TempDir()
+	runGit(t, checkout, "init")
+	runGit(t, checkout, "config", "user.email", "gitmoot@example.com")
+	runGit(t, checkout, "config", "user.name", "Gitmoot Test")
+	writeFile(t, filepath.Join(checkout, "README.md"), "main\n")
+	runGit(t, checkout, "add", "README.md")
+	runGit(t, checkout, "commit", "-m", "initial")
+	runGit(t, checkout, "branch", "-m", "main")
+	runGit(t, checkout, "remote", "add", "origin", "https://github.com/owner/repo.git")
+	runGit(t, checkout, "update-ref", "refs/remotes/origin/main", "HEAD")
+	runGit(t, checkout, "symbolic-ref", "refs/remotes/origin/HEAD", "refs/remotes/origin/main")
+	runGit(t, checkout, "switch", "-c", "feature/local")
+	store := openCLIJobStore(t, t.TempDir())
+	defer store.Close()
+	t.Chdir(checkout)
+
+	_, record, dispatchBranch, persistDefaultBranch, err := resolveLocalAgentRepo(ctx, store, "", subprocess.ExecRunner{})
+	if err != nil {
+		t.Fatalf("resolveLocalAgentRepo: %v", err)
+	}
+	if dispatchBranch != "feature/local" {
+		t.Fatalf("dispatch branch = %q, want current checkout branch feature/local", dispatchBranch)
+	}
+	if record.DefaultBranch != "main" {
+		t.Fatalf("resolved repo-wide default branch = %q, want remote main", record.DefaultBranch)
+	}
+	if !persistDefaultBranch {
+		t.Fatal("remote-derived default branch was marked unsafe to persist")
+	}
+	if err := upsertLocalAgentRepo(ctx, store, record, persistDefaultBranch); err != nil {
+		t.Fatalf("upsertLocalAgentRepo: %v", err)
+	}
+	stored, err := store.GetRepo(ctx, "owner/repo")
+	if err != nil || stored.DefaultBranch != "main" {
+		t.Fatalf("stored default branch = %q, err=%v, want remote main", stored.DefaultBranch, err)
+	}
+}
+
+func TestResolveLocalAgentRepoWithoutFlagDoesNotPersistCheckoutFallback(t *testing.T) {
+	ctx := context.Background()
+	checkout := t.TempDir()
+	runGit(t, checkout, "init")
+	runGit(t, checkout, "config", "user.email", "gitmoot@example.com")
+	runGit(t, checkout, "config", "user.name", "Gitmoot Test")
+	writeFile(t, filepath.Join(checkout, "README.md"), "main\n")
+	runGit(t, checkout, "add", "README.md")
+	runGit(t, checkout, "commit", "-m", "initial")
+	runGit(t, checkout, "branch", "-m", "main")
+	runGit(t, checkout, "remote", "add", "origin", "https://github.com/owner/repo.git")
+	runGit(t, checkout, "switch", "-c", "feature/local")
+	store := openCLIJobStore(t, t.TempDir())
+	defer store.Close()
+	t.Chdir(checkout)
+
+	_, record, dispatchBranch, persistDefaultBranch, err := resolveLocalAgentRepo(ctx, store, "", subprocess.ExecRunner{})
+	if err != nil {
+		t.Fatalf("resolveLocalAgentRepo: %v", err)
+	}
+	if dispatchBranch != "feature/local" {
+		t.Fatalf("dispatch branch = %q, want current checkout branch feature/local", dispatchBranch)
+	}
+	if record.DefaultBranch != "feature/local" {
+		t.Fatalf("resolved fallback branch = %q, want feature/local", record.DefaultBranch)
+	}
+	if persistDefaultBranch {
+		t.Fatal("current-branch fallback was marked safe to persist")
+	}
+	if err := upsertLocalAgentRepo(ctx, store, record, persistDefaultBranch); err != nil {
+		t.Fatalf("upsertLocalAgentRepo: %v", err)
+	}
+	stored, err := store.GetRepo(ctx, "owner/repo")
+	if err != nil || stored.DefaultBranch != "" {
+		t.Fatalf("stored default branch = %q, err=%v, want empty", stored.DefaultBranch, err)
 	}
 }
 
@@ -439,7 +557,7 @@ func TestResolveLocalAgentRepoSelfHealsDanglingCheckoutForImplementBase(t *testi
 	}
 	runGit(t, primary, "worktree", "remove", "--force", linked)
 
-	_, record, err := resolveLocalAgentRepo(ctx, store, "owner/repo")
+	_, record, _, _, err := resolveLocalAgentRepo(ctx, store, "owner/repo", subprocess.ExecRunner{})
 	if err != nil {
 		t.Fatalf("resolveLocalAgentRepo: %v", err)
 	}
@@ -474,7 +592,7 @@ func TestResolveLocalAgentRepoSelfHealsNonGitCheckout(t *testing.T) {
 		t.Fatalf("recreate non-git checkout directory: %v", err)
 	}
 
-	_, record, err := resolveLocalAgentRepo(ctx, store, "owner/repo")
+	_, record, _, _, err := resolveLocalAgentRepo(ctx, store, "owner/repo", subprocess.ExecRunner{})
 	if err != nil {
 		t.Fatalf("resolveLocalAgentRepo: %v", err)
 	}
@@ -500,7 +618,7 @@ func TestResolveLocalAgentRepoLeavesValidLinkedCheckoutRegistered(t *testing.T) 
 		t.Fatalf("UpsertRepoForce: %v", err)
 	}
 
-	_, record, err := resolveLocalAgentRepo(ctx, store, "owner/repo")
+	_, record, _, _, err := resolveLocalAgentRepo(ctx, store, "owner/repo", subprocess.ExecRunner{})
 	if err != nil {
 		t.Fatalf("resolveLocalAgentRepo: %v", err)
 	}

--- a/internal/cli/daemon_checkout.go
+++ b/internal/cli/daemon_checkout.go
@@ -788,8 +788,19 @@ func repoRecordForCheckout(ctx context.Context, repo github.Repository, client g
 	if remoteRepo.String() != repo.FullName() {
 		return db.Repo{}, fmt.Errorf("current checkout origin is %s, not %s", remoteRepo.String(), repo.FullName())
 	}
+	// THE REMOTE'S DEFAULT, NEVER THE LOCAL HEAD (#2145). This read used
+	// CurrentBranch, so whichever branch the worktree happened to have checked
+	// out when the record was written became the repository's recorded default -
+	// and that field is consumed as the BASE BRANCH by daemon_workflow.go and as
+	// the dispatch branch default by agent_dispatch.go. On this host it had
+	// recorded `fix/lan-address-portability` for a repository whose default is
+	// `master`.
+	//
+	// Left EMPTY when origin/HEAD is unset: UpsertRepo preserves the stored value
+	// against an empty one, so an unreadable remote default keeps whatever was
+	// already recorded instead of overwriting it with a worktree artifact.
 	defaultBranch := ""
-	if branch, err := client.CurrentBranch(ctx); err == nil {
+	if branch, err := client.RemoteDefaultBranch(ctx); err == nil {
 		defaultBranch = branch
 	}
 	return db.Repo{

--- a/internal/cli/daemon_checkout.go
+++ b/internal/cli/daemon_checkout.go
@@ -788,19 +788,33 @@ func repoRecordForCheckout(ctx context.Context, repo github.Repository, client g
 	if remoteRepo.String() != repo.FullName() {
 		return db.Repo{}, fmt.Errorf("current checkout origin is %s, not %s", remoteRepo.String(), repo.FullName())
 	}
-	// THE REMOTE'S DEFAULT, NEVER THE LOCAL HEAD (#2145). This read used
-	// CurrentBranch, so whichever branch the worktree happened to have checked
-	// out when the record was written became the repository's recorded default -
-	// and that field is consumed as the BASE BRANCH by daemon_workflow.go and as
-	// the dispatch branch default by agent_dispatch.go. On this host it had
-	// recorded `fix/lan-address-portability` for a repository whose default is
-	// `master`.
+	// PREFER THE REMOTE'S DEFAULT OVER THE LOCAL HEAD (#2145).
 	//
-	// Left EMPTY when origin/HEAD is unset: UpsertRepo preserves the stored value
-	// against an empty one, so an unreadable remote default keeps whatever was
-	// already recorded instead of overwriting it with a worktree artifact.
+	// This read was CurrentBranch alone, so whichever branch the worktree
+	// happened to have checked out when the record was written became the
+	// repository's recorded default - and that field is consumed as the BASE
+	// BRANCH by daemon_workflow.go and as the dispatch branch default by
+	// agent_dispatch.go. On this host it had recorded
+	// `fix/lan-address-portability` for a repository whose default is `master`,
+	// while the worktree was on a third branch entirely.
+	//
+	// The defect was recording the local HEAD WHEN THE REMOTE DEFAULT WAS
+	// KNOWABLE, so the fix is precedence, not removal: origin/HEAD when it
+	// resolves, the checked-out branch only when it does not.
+	//
+	// The fallback is deliberate and its residual is real. A checkout with an
+	// origin but no origin/HEAD ref - `git init` plus `git remote add`, or a
+	// clone whose head ref was deleted - cannot reveal the remote default
+	// offline, and dropping the value there is worse than an imperfect one:
+	// `gitmoot repo add` would register a repo with no base branch at all, which
+	// `repo doctor` reports as a missing branch and dispatch reads as an empty
+	// default. Such a record keeps a possibly-wrong local branch exactly as
+	// before this change, and pollRepo upgrades it the moment origin/HEAD becomes
+	// resolvable, so the wrong value is now transient rather than permanent.
 	defaultBranch := ""
 	if branch, err := client.RemoteDefaultBranch(ctx); err == nil {
+		defaultBranch = branch
+	} else if branch, err := client.CurrentBranch(ctx); err == nil {
 		defaultBranch = branch
 	}
 	return db.Repo{

--- a/internal/cli/daemon_checkout.go
+++ b/internal/cli/daemon_checkout.go
@@ -772,21 +772,21 @@ func resolveDaemonStartRepo(ctx context.Context, store *db.Store, repo github.Re
 	return resolveRepoRecord(ctx, store, repo, workDir)
 }
 
-func repoRecordForCheckout(ctx context.Context, repo github.Repository, client gitutil.Client) (db.Repo, error) {
+func repoRecordForCheckout(ctx context.Context, repo github.Repository, client gitutil.Client) (db.Repo, bool, error) {
 	root, err := client.Root(ctx)
 	if err != nil {
-		return db.Repo{}, fmt.Errorf("resolve repo checkout: %w", err)
+		return db.Repo{}, false, fmt.Errorf("resolve repo checkout: %w", err)
 	}
 	remote, err := client.OriginRemote(ctx)
 	if err != nil {
-		return db.Repo{}, fmt.Errorf("resolve repo checkout remote: %w", err)
+		return db.Repo{}, false, fmt.Errorf("resolve repo checkout remote: %w", err)
 	}
 	remoteRepo, err := gitutil.ParseGitHubRemote(remote)
 	if err != nil {
-		return db.Repo{}, err
+		return db.Repo{}, false, err
 	}
 	if remoteRepo.String() != repo.FullName() {
-		return db.Repo{}, fmt.Errorf("current checkout origin is %s, not %s", remoteRepo.String(), repo.FullName())
+		return db.Repo{}, false, fmt.Errorf("current checkout origin is %s, not %s", remoteRepo.String(), repo.FullName())
 	}
 	// PREFER THE REMOTE'S DEFAULT OVER THE LOCAL HEAD (#2145).
 	//
@@ -811,9 +811,17 @@ func repoRecordForCheckout(ctx context.Context, repo github.Repository, client g
 	// default. Such a record keeps a possibly-wrong local branch exactly as
 	// before this change, and pollRepo upgrades it the moment origin/HEAD becomes
 	// resolvable, so the wrong value is now transient rather than permanent.
+	// fromRemote is RETURNED rather than re-derived by callers (#2146 review, F2).
+	// An earlier revision had the caller call RemoteDefaultBranch a SECOND time to
+	// learn the provenance, which meant a transient failure of that second
+	// subprocess - git lock contention on an unlocked path, for instance - made a
+	// value that had just been read correctly look unknowable, and discarded it
+	// for that resolve cycle. One read, one answer.
 	defaultBranch := ""
+	fromRemote := false
 	if branch, err := client.RemoteDefaultBranch(ctx); err == nil {
 		defaultBranch = branch
+		fromRemote = true
 	} else if branch, err := client.CurrentBranch(ctx); err == nil {
 		defaultBranch = branch
 	}
@@ -823,5 +831,5 @@ func repoRecordForCheckout(ctx context.Context, repo github.Repository, client g
 		DefaultBranch: defaultBranch,
 		RemoteURL:     remote,
 		CheckoutPath:  root,
-	}, nil
+	}, fromRemote, nil
 }

--- a/internal/cli/daemon_lifecycle.go
+++ b/internal/cli/daemon_lifecycle.go
@@ -1079,7 +1079,7 @@ func preflightDaemonRepoCheckout(ctx context.Context, repo github.Repository, wo
 }
 
 func preflightDaemonRepoCheckoutWithRunner(ctx context.Context, repo github.Repository, workDir string, runner subprocess.Runner) error {
-	_, err := repoRecordForCheckout(ctx, repo, jobGitClient(workDir, runner))
+	_, _, err := repoRecordForCheckout(ctx, repo, jobGitClient(workDir, runner))
 	return err
 }
 

--- a/internal/cli/daemon_supervision.go
+++ b/internal/cli/daemon_supervision.go
@@ -198,6 +198,27 @@ func runSingleRepoSupervisor(ctx context.Context, home string, d daemon.Daemon, 
 	if err := runForeignBootRecoveryOnce(ctx, store, stdout, startupNow, tracker); err != nil {
 		return err
 	}
+	// Reconcile the cached default branch here too (#2145 review, F1).
+	//
+	// pollRepo does this for the fleet, but THIS supervisor never calls pollRepo -
+	// single-repo mode runs startSingleRepoWorkerLoop instead - so without this a
+	// `daemon run --repo owner/repo` deployment could never correct a wrong base
+	// branch, and the claim that a wrong value is transient would be false for
+	// exactly the mode an operator uses to debug one repository.
+	//
+	// Startup-only rather than per tick: this loop ticks far more often than the
+	// fleet poll, the value changes about as often as a repository's default
+	// branch does, and every store call here contends for the daemon's single
+	// SQLite connection (#2145).
+	if record, recErr := store.GetRepo(ctx, d.Repo.FullName()); recErr == nil && strings.TrimSpace(record.CheckoutPath) != "" {
+		if branch, branchErr := gitutil.NewHostClient(record.CheckoutPath).RemoteDefaultBranch(ctx); branchErr == nil {
+			if changed, updateErr := store.UpdateRepoDefaultBranch(ctx, d.Repo.FullName(), branch); updateErr != nil {
+				writeLine(stdout, "%s: default branch reconcile failed: %v", d.Repo.FullName(), updateErr)
+			} else if changed {
+				writeLine(stdout, "%s: default branch reconciled to %s (was %s)", d.Repo.FullName(), branch, record.DefaultBranch)
+			}
+		}
+	}
 	if err := recoverRunningJobsForRepo(ctx, store, stdout, d.Repo.FullName(), rootFilter); err != nil {
 		return err
 	}

--- a/internal/cli/daemon_supervision.go
+++ b/internal/cli/daemon_supervision.go
@@ -15,6 +15,7 @@ import (
 	"github.com/gitmoot/gitmoot/internal/config"
 	"github.com/gitmoot/gitmoot/internal/daemon"
 	"github.com/gitmoot/gitmoot/internal/db"
+	gitutil "github.com/gitmoot/gitmoot/internal/git"
 	"github.com/gitmoot/gitmoot/internal/github"
 	"github.com/gitmoot/gitmoot/internal/pipeline"
 	"github.com/gitmoot/gitmoot/internal/runtime"
@@ -1276,6 +1277,25 @@ func (p registeredRepoPoller) pollRepo(ctx context.Context, repoRecord db.Repo, 
 		message := fmt.Sprintf("registered repo checkout path is unavailable: %s", repoRecord.CheckoutPath)
 		writeLine(p.Stdout, "%s: %s", repoRecord.FullName(), message)
 		return registeredRepoPollResult{LastError: message}, store.UpdateRepoPollResult(ctx, repoRecord.FullName(), lastPollAt, message)
+	}
+	// Self-heal the cached default branch (#2145). The stored value is consumed
+	// as the BASE BRANCH, and it was previously written from the worktree's
+	// CURRENT branch, so existing records can name a feature branch that no
+	// amount of correct writing afterwards would fix - the bad value is already
+	// durable. Reconciling here means a wrong record corrects itself on the next
+	// successful poll instead of requiring a manual store edit.
+	//
+	// Deliberately BEFORE the dry-run return and OUTSIDE the checkout lock: it
+	// only reads a symbolic ref and writes one column, so it must not wait on a
+	// lock held by a running job, and a dry run should still not be silently
+	// operating against a base branch it knows is wrong.
+	if branch, branchErr := gitutil.NewHostClient(repoRecord.CheckoutPath).RemoteDefaultBranch(ctx); branchErr == nil {
+		if changed, updateErr := store.UpdateRepoDefaultBranch(ctx, repoRecord.FullName(), branch); updateErr != nil {
+			writeLine(p.Stdout, "%s: default branch reconcile failed: %v", repoRecord.FullName(), updateErr)
+		} else if changed {
+			writeLine(p.Stdout, "%s: default branch reconciled to %s (was %s)", repoRecord.FullName(), branch, repoRecord.DefaultBranch)
+			repoRecord.DefaultBranch = branch
+		}
 	}
 	// `Workers` is a fleet-wide flag echoed here, not a per-repo pool: no such
 	// pool exists, so printing it as one only misleads (#1758).

--- a/internal/cli/daemon_supervision_test.go
+++ b/internal/cli/daemon_supervision_test.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/gitmoot/gitmoot/internal/config"
+	daemonpkg "github.com/gitmoot/gitmoot/internal/daemon"
 	"github.com/gitmoot/gitmoot/internal/db"
 	"github.com/gitmoot/gitmoot/internal/db/dbtest"
 	"github.com/gitmoot/gitmoot/internal/github"
@@ -892,5 +893,81 @@ func TestPollPassResetsConfigCache(t *testing.T) {
 	}
 	if poller.ConfigCache.memoryDone || poller.ConfigCache.memoryHome != "" {
 		t.Fatalf("config cache survived a poll pass: %+v", poller.ConfigCache)
+	}
+}
+
+type cancelOnTextWriter struct {
+	buffer bytes.Buffer
+	cancel context.CancelFunc
+	needle string
+}
+
+func (w *cancelOnTextWriter) Write(p []byte) (int, error) {
+	n, err := w.buffer.Write(p)
+	if strings.Contains(w.buffer.String(), w.needle) {
+		w.cancel()
+	}
+	return n, err
+}
+
+func TestRunSingleRepoSupervisorReconcilesDefaultBranchAtStartup(t *testing.T) {
+	home := t.TempDir()
+	paths := config.PathsForHome(home)
+	if err := config.Initialize(paths); err != nil {
+		t.Fatalf("Initialize: %v", err)
+	}
+	store, err := dbtest.Open(t, paths.Database)
+	if err != nil {
+		t.Fatalf("Open store: %v", err)
+	}
+	defer store.Close()
+
+	checkout := t.TempDir()
+	runGit(t, checkout, "init")
+	runGit(t, checkout, "config", "user.email", "gitmoot@example.com")
+	runGit(t, checkout, "config", "user.name", "Gitmoot Test")
+	writeFile(t, filepath.Join(checkout, "README.md"), "trunk\n")
+	runGit(t, checkout, "add", "README.md")
+	runGit(t, checkout, "commit", "-m", "initial")
+	runGit(t, checkout, "branch", "-m", "trunk")
+	runGit(t, checkout, "remote", "add", "origin", "https://github.com/owner/repo.git")
+	runGit(t, checkout, "update-ref", "refs/remotes/origin/trunk", "HEAD")
+	runGit(t, checkout, "symbolic-ref", "refs/remotes/origin/HEAD", "refs/remotes/origin/trunk")
+	if err := store.UpsertRepo(context.Background(), db.Repo{
+		Owner: "owner", Name: "repo", DefaultBranch: "wrong",
+		CheckoutPath: checkout, PollInterval: "1h",
+	}); err != nil {
+		t.Fatalf("UpsertRepo: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	output := &cancelOnTextWriter{cancel: cancel, needle: "default branch reconciled to trunk"}
+	done := make(chan error, 1)
+	go func() {
+		done <- runSingleRepoSupervisor(ctx, home, daemonpkg.Daemon{
+			Repo:         github.Repository{Owner: "owner", Name: "repo"},
+			PollInterval: time.Hour,
+			Store:        store,
+		}, store, newDaemonReloadableConfig(time.Hour, 1, false), "", output)
+	}()
+
+	select {
+	case err := <-done:
+		if err != nil && !errors.Is(err, context.Canceled) {
+			t.Fatalf("runSingleRepoSupervisor: %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		cancel()
+		t.Fatal("timed out waiting for startup default-branch reconciliation")
+	}
+	stored, err := store.GetRepo(context.Background(), "owner/repo")
+	if err != nil {
+		t.Fatalf("GetRepo: %v", err)
+	}
+	if stored.DefaultBranch != "trunk" {
+		t.Fatalf("stored default branch = %q, want trunk", stored.DefaultBranch)
+	}
+	if !strings.Contains(output.buffer.String(), "default branch reconciled to trunk (was wrong)") {
+		t.Fatalf("startup output = %q, want reconciliation message", output.buffer.String())
 	}
 }

--- a/internal/cli/host_runner_guard_test.go
+++ b/internal/cli/host_runner_guard_test.go
@@ -91,6 +91,10 @@ var hostRunnerAllowlist = map[string]hostRunnerAllowance{
 		execRunners: 1,
 		reason:      "operator repo registration inspects and repairs the selected host checkout",
 	},
+	"internal/cli/repo.go:repoRecordFromStablePath": {
+		execRunners: 1,
+		reason:      "operator and daemon-start repo resolution inspect a host checkout; backend dispatch calls repoRecordFromStablePathWithDefaultSource with its resolved runner",
+	},
 	"internal/cli/update.go:runDaemonRestartFromExecutable": {
 		rawCommands: 1,
 		reason:      "operator update lifecycle restarts the local daemon executable",

--- a/internal/cli/poll_default_branch_reconcile_test.go
+++ b/internal/cli/poll_default_branch_reconcile_test.go
@@ -1,0 +1,162 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gitmoot/gitmoot/internal/db"
+	"github.com/gitmoot/gitmoot/internal/github"
+)
+
+// pollRepo must correct a cached default branch that names a feature branch
+// (#2145 review, F3).
+//
+// This drives pollRepo itself rather than the helpers underneath it. The review
+// found that all three original tests targeted lower-level functions and NOTHING
+// exercised the reconcile block's wiring - its placement, its store write, or
+// its in-memory update of the record the rest of the poll then uses.
+//
+// The fixture reproduces the live shape exactly: the stored default branch is
+// `fix/lan-address-portability` while the checkout's origin/HEAD resolves to
+// `master`, which is what `jerryfane/herdr` looked like on this host.
+func TestPollRepoReconcilesCachedDefaultBranch(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not installed")
+	}
+	origin := t.TempDir()
+	runGit(t, origin, "init", "-b", "master")
+	runGit(t, origin, "config", "user.email", "gitmoot@example.com")
+	runGit(t, origin, "config", "user.name", "Gitmoot")
+	if err := os.WriteFile(filepath.Join(origin, "README.md"), []byte("# origin\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	runGit(t, origin, "add", "README.md")
+	runGit(t, origin, "commit", "-m", "init")
+	checkout := filepath.Join(t.TempDir(), "clone")
+	runGit(t, t.TempDir(), "clone", origin, checkout)
+	runGit(t, checkout, "checkout", "-b", "fix/lan-address-portability")
+
+	home, paths, store := heartbeatLoopE2EHome(t)
+	ctx := context.Background()
+	repoRecord := db.Repo{
+		Owner: "owner", Name: "repo", CheckoutPath: checkout,
+		DefaultBranch: "fix/lan-address-portability", PollInterval: "30s",
+	}
+	if err := store.UpsertRepo(ctx, repoRecord); err != nil {
+		t.Fatal(err)
+	}
+
+	var out bytes.Buffer
+	poller := defaultRegisteredRepoPoller(store, 1, false, &out, home, paths.Home)
+	poller.GitHubClient = func(string) github.Client { return &cliPollFakeGitHub{} }
+	if _, err := poller.pollRepo(ctx, repoRecord, time.Now().UTC()); err != nil {
+		t.Fatalf("pollRepo returned error: %v", err)
+	}
+
+	stored, err := store.GetRepo(ctx, "owner/repo")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if stored.DefaultBranch != "master" {
+		t.Fatalf("stored default_branch = %q, want master after reconcile", stored.DefaultBranch)
+	}
+	// The correction must be visible to an operator, and must name what it
+	// replaced: a silent store write leaves nobody able to tell a reconcile from
+	// a value that was always right.
+	if !strings.Contains(out.String(), "default branch reconciled to master (was fix/lan-address-portability)") {
+		t.Fatalf("poll output = %q, want a reconcile line naming the old value", out.String())
+	}
+}
+
+// A second pass must not rewrite or re-log. The poll runs every tick, so a
+// reconcile that reports a change every time is indistinguishable from a genuine
+// correction and would bury the real one.
+func TestPollRepoDefaultBranchReconcileIsQuietWhenCorrect(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not installed")
+	}
+	origin := t.TempDir()
+	runGit(t, origin, "init", "-b", "master")
+	runGit(t, origin, "config", "user.email", "gitmoot@example.com")
+	runGit(t, origin, "config", "user.name", "Gitmoot")
+	if err := os.WriteFile(filepath.Join(origin, "README.md"), []byte("# origin\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	runGit(t, origin, "add", "README.md")
+	runGit(t, origin, "commit", "-m", "init")
+	checkout := filepath.Join(t.TempDir(), "clone")
+	runGit(t, t.TempDir(), "clone", origin, checkout)
+
+	home, paths, store := heartbeatLoopE2EHome(t)
+	ctx := context.Background()
+	repoRecord := db.Repo{Owner: "owner", Name: "repo", CheckoutPath: checkout, DefaultBranch: "master", PollInterval: "30s"}
+	if err := store.UpsertRepo(ctx, repoRecord); err != nil {
+		t.Fatal(err)
+	}
+
+	var out bytes.Buffer
+	poller := defaultRegisteredRepoPoller(store, 1, false, &out, home, paths.Home)
+	poller.GitHubClient = func(string) github.Client { return &cliPollFakeGitHub{} }
+	if _, err := poller.pollRepo(ctx, repoRecord, time.Now().UTC()); err != nil {
+		t.Fatalf("pollRepo returned error: %v", err)
+	}
+	if strings.Contains(out.String(), "default branch reconciled") {
+		t.Fatalf("poll output = %q, want no reconcile line when the value is already correct", out.String())
+	}
+}
+
+// preserveRegisteredRepoFields must let a REMOTE-derived default overwrite a
+// stored one, and must not let a FALLBACK value do so (#2145 review, F1).
+//
+// This was the P1: the function kept the stored value whenever it was non-empty,
+// so re-resolving a repository could never correct a wrong base branch. The
+// preserve rule was protective only while the resolved value came from the local
+// HEAD, which is the defect it was compensating for.
+func TestPreserveRegisteredRepoFieldsPrefersRemoteDefault(t *testing.T) {
+	existing := db.Repo{DefaultBranch: "fix/lan-address-portability", PollInterval: "30s", Enabled: true}
+	for _, test := range []struct {
+		name          string
+		resolved      db.Repo
+		remoteDefault string
+		want          string
+	}{
+		{
+			name:          "a remote-derived default overwrites the stored value",
+			resolved:      db.Repo{DefaultBranch: "master"},
+			remoteDefault: "master",
+			want:          "master",
+		},
+		{
+			// origin/HEAD unresolvable: resolved carries the worktree's branch, and
+			// overwriting a stored value with it is the original defect.
+			name:     "a fallback value must not overwrite the stored value",
+			resolved: db.Repo{DefaultBranch: "fix/preview-fork-website-skip"},
+			want:     "fix/lan-address-portability",
+		},
+		{
+			name:     "with nothing stored the fallback is kept rather than dropped",
+			resolved: db.Repo{DefaultBranch: "main"},
+			want:     "main",
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			from := existing
+			if test.want == "main" {
+				from = db.Repo{PollInterval: "30s", Enabled: true}
+			}
+			got := preserveRegisteredRepoFields(test.resolved, from, test.remoteDefault)
+			if got.DefaultBranch != test.want {
+				t.Fatalf("DefaultBranch = %q, want %q", got.DefaultBranch, test.want)
+			}
+			if got.PollInterval != from.PollInterval || got.Enabled != from.Enabled {
+				t.Fatalf("operator-owned fields lost: %+v", got)
+			}
+		})
+	}
+}

--- a/internal/cli/poll_default_branch_reconcile_test.go
+++ b/internal/cli/poll_default_branch_reconcile_test.go
@@ -121,16 +121,16 @@ func TestPollRepoDefaultBranchReconcileIsQuietWhenCorrect(t *testing.T) {
 func TestPreserveRegisteredRepoFieldsPrefersRemoteDefault(t *testing.T) {
 	existing := db.Repo{DefaultBranch: "fix/lan-address-portability", PollInterval: "30s", Enabled: true}
 	for _, test := range []struct {
-		name          string
-		resolved      db.Repo
-		remoteDefault string
-		want          string
+		name       string
+		resolved   db.Repo
+		fromRemote bool
+		want       string
 	}{
 		{
-			name:          "a remote-derived default overwrites the stored value",
-			resolved:      db.Repo{DefaultBranch: "master"},
-			remoteDefault: "master",
-			want:          "master",
+			name:       "a remote-derived default overwrites the stored value",
+			resolved:   db.Repo{DefaultBranch: "master"},
+			fromRemote: true,
+			want:       "master",
 		},
 		{
 			// origin/HEAD unresolvable: resolved carries the worktree's branch, and
@@ -150,7 +150,7 @@ func TestPreserveRegisteredRepoFieldsPrefersRemoteDefault(t *testing.T) {
 			if test.want == "main" {
 				from = db.Repo{PollInterval: "30s", Enabled: true}
 			}
-			got := preserveRegisteredRepoFields(test.resolved, from, test.remoteDefault)
+			got := preserveRegisteredRepoFields(test.resolved, from, test.fromRemote)
 			if got.DefaultBranch != test.want {
 				t.Fatalf("DefaultBranch = %q, want %q", got.DefaultBranch, test.want)
 			}

--- a/internal/cli/repo.go
+++ b/internal/cli/repo.go
@@ -549,11 +549,31 @@ func resolveRepoRecord(ctx context.Context, store *db.Store, repo github.Reposit
 	return repoRecordFromStablePath(ctx, repo, fallbackDir)
 }
 
+// resolveRepoRecordWithDefaultSource reports whether DefaultBranch came from
+// origin/HEAD. Callers that persist an implicitly resolved record need this
+// provenance so a current-branch fallback cannot become repository-wide state.
+func resolveRepoRecordWithDefaultSource(ctx context.Context, store *db.Store, repo github.Repository, fallbackDir string, runner subprocess.Runner) (db.Repo, bool, error) {
+	existing, err := store.GetRepo(ctx, repo.FullName())
+	switch {
+	case err == nil && (strings.TrimSpace(existing.CheckoutPath) != "" || strings.TrimSpace(existing.PrimaryCheckoutPath) != ""):
+		resolved, _, fromRemote, err := resolveRegisteredRepoRecordWithRunnerAndDefaultSource(ctx, store, repo, existing, runner)
+		return resolved, fromRemote, err
+	case err != nil && !errors.Is(err, sql.ErrNoRows):
+		return db.Repo{}, false, err
+	}
+	return repoRecordFromStablePathWithDefaultSource(ctx, repo, fallbackDir, runner)
+}
+
 func resolveRegisteredRepoRecord(ctx context.Context, store *db.Store, repo github.Repository, existing db.Repo) (db.Repo, bool, error) {
 	return resolveRegisteredRepoRecordWithRunner(ctx, store, repo, existing, subprocess.ExecRunner{})
 }
 
 func resolveRegisteredRepoRecordWithRunner(ctx context.Context, store *db.Store, repo github.Repository, existing db.Repo, runner subprocess.Runner) (db.Repo, bool, error) {
+	resolved, healed, _, err := resolveRegisteredRepoRecordWithRunnerAndDefaultSource(ctx, store, repo, existing, runner)
+	return resolved, healed, err
+}
+
+func resolveRegisteredRepoRecordWithRunnerAndDefaultSource(ctx context.Context, store *db.Store, repo github.Repository, existing db.Repo, runner subprocess.Runner) (db.Repo, bool, bool, error) {
 	checkout := strings.TrimSpace(existing.CheckoutPath)
 	var checkoutErr error
 	if checkout != "" {
@@ -563,22 +583,22 @@ func resolveRegisteredRepoRecordWithRunner(ctx context.Context, store *db.Store,
 			if primary == "" {
 				primary, err = jobGitClient(checkout, runner).PrimaryWorktree(ctx)
 				if err != nil {
-					return db.Repo{}, false, fmt.Errorf("resolve primary worktree for %s: %w", repo.FullName(), err)
+					return db.Repo{}, false, false, fmt.Errorf("resolve primary worktree for %s: %w", repo.FullName(), err)
 				}
 				updated, err := store.HealRepoCheckout(ctx, repo.FullName(), checkout, checkout, primary)
 				if err != nil {
-					return db.Repo{}, false, err
+					return db.Repo{}, false, false, err
 				}
 				if !updated {
 					current, err := store.GetRepo(ctx, repo.FullName())
 					if err != nil {
-						return db.Repo{}, false, err
+						return db.Repo{}, false, false, err
 					}
-					return resolveRegisteredRepoRecordWithRunner(ctx, store, repo, current, runner)
+					return resolveRegisteredRepoRecordWithRunnerAndDefaultSource(ctx, store, repo, current, runner)
 				}
 			}
 			resolved.PrimaryCheckoutPath = primary
-			return preserveRegisteredRepoFields(resolved, existing, fromRemote), false, nil
+			return preserveRegisteredRepoFields(resolved, existing, fromRemote), false, fromRemote, nil
 		}
 		checkoutErr = err
 	} else {
@@ -587,37 +607,37 @@ func resolveRegisteredRepoRecordWithRunner(ctx context.Context, store *db.Store,
 
 	primary := strings.TrimSpace(existing.PrimaryCheckoutPath)
 	if primary == "" || sameCheckoutPath(primary, checkout) {
-		return db.Repo{}, false, fmt.Errorf("registered checkout %s for %s is unusable and no distinct primary checkout is available: %w", checkout, repo.FullName(), checkoutErr)
+		return db.Repo{}, false, false, fmt.Errorf("registered checkout %s for %s is unusable and no distinct primary checkout is available: %w", checkout, repo.FullName(), checkoutErr)
 	}
 	resolved, fromRemote, err := repoRecordForCheckout(ctx, repo, jobGitClient(primary, runner))
 	if err != nil {
-		return db.Repo{}, false, fmt.Errorf("registered checkout %s for %s is unusable (%v); verify primary checkout %s: %w", checkout, repo.FullName(), checkoutErr, primary, err)
+		return db.Repo{}, false, false, fmt.Errorf("registered checkout %s for %s is unusable (%v); verify primary checkout %s: %w", checkout, repo.FullName(), checkoutErr, primary, err)
 	}
 	primary, err = jobGitClient(resolved.CheckoutPath, runner).PrimaryWorktree(ctx)
 	if err != nil {
-		return db.Repo{}, false, fmt.Errorf("resolve primary worktree for %s from %s: %w", repo.FullName(), resolved.CheckoutPath, err)
+		return db.Repo{}, false, false, fmt.Errorf("resolve primary worktree for %s from %s: %w", repo.FullName(), resolved.CheckoutPath, err)
 	}
 	if !sameCheckoutPath(primary, resolved.CheckoutPath) {
 		resolved, fromRemote, err = repoRecordForCheckout(ctx, repo, jobGitClient(primary, runner))
 		if err != nil {
-			return db.Repo{}, false, fmt.Errorf("verify resolved primary checkout %s for %s: %w", primary, repo.FullName(), err)
+			return db.Repo{}, false, false, fmt.Errorf("verify resolved primary checkout %s for %s: %w", primary, repo.FullName(), err)
 		}
 	}
 	resolved.PrimaryCheckoutPath = primary
 	resolved = preserveRegisteredRepoFields(resolved, existing, fromRemote)
 	healed, err := store.HealRepoCheckout(ctx, repo.FullName(), checkout, resolved.CheckoutPath, primary)
 	if err != nil {
-		return db.Repo{}, false, err
+		return db.Repo{}, false, false, err
 	}
 	if !healed {
 		current, err := store.GetRepo(ctx, repo.FullName())
 		if err != nil {
-			return db.Repo{}, false, err
+			return db.Repo{}, false, false, err
 		}
-		return resolveRegisteredRepoRecordWithRunner(ctx, store, repo, current, runner)
+		return resolveRegisteredRepoRecordWithRunnerAndDefaultSource(ctx, store, repo, current, runner)
 	}
 	log.Printf("WARNING: %s", repoCheckoutHealMessage(repo.FullName(), checkout, resolved.CheckoutPath))
-	return resolved, true, nil
+	return resolved, true, fromRemote, nil
 }
 
 // preserveRegisteredRepoFields keeps operator-owned fields across a re-resolve.
@@ -665,33 +685,38 @@ func repoRecordFromPath(ctx context.Context, repo github.Repository, path string
 // linked worktrees to their primary. Explicit linked registration is reserved
 // for repo add --force.
 func repoRecordFromStablePath(ctx context.Context, repo github.Repository, path string) (db.Repo, error) {
+	record, _, err := repoRecordFromStablePathWithDefaultSource(ctx, repo, path, subprocess.ExecRunner{})
+	return record, err
+}
+
+func repoRecordFromStablePathWithDefaultSource(ctx context.Context, repo github.Repository, path string, runner subprocess.Runner) (db.Repo, bool, error) {
 	checkout, err := cleanCheckoutPath(path)
 	if err != nil {
-		return db.Repo{}, err
+		return db.Repo{}, false, err
 	}
-	client := gitutil.NewHostClient(checkout)
-	record, _, err := repoRecordForCheckout(ctx, repo, client)
+	client := jobGitClient(checkout, runner)
+	record, fromRemote, err := repoRecordForCheckout(ctx, repo, client)
 	if err != nil {
-		return db.Repo{}, err
+		return db.Repo{}, false, err
 	}
 	primary, err := client.PrimaryWorktree(ctx)
 	if err != nil {
-		return db.Repo{}, fmt.Errorf("resolve primary worktree: %w", err)
+		return db.Repo{}, false, fmt.Errorf("resolve primary worktree: %w", err)
 	}
 	record.PrimaryCheckoutPath = primary
 	linked, err := client.IsLinkedWorktree(ctx)
 	if err != nil {
-		return db.Repo{}, fmt.Errorf("detect linked worktree: %w", err)
+		return db.Repo{}, false, fmt.Errorf("detect linked worktree: %w", err)
 	}
 	if !linked || sameCheckoutPath(record.CheckoutPath, primary) {
-		return record, nil
+		return record, fromRemote, nil
 	}
-	primaryRecord, _, err := repoRecordForCheckout(ctx, repo, gitutil.NewHostClient(primary))
+	primaryRecord, primaryFromRemote, err := repoRecordForCheckout(ctx, repo, jobGitClient(primary, runner))
 	if err != nil {
-		return db.Repo{}, fmt.Errorf("verify primary checkout: %w", err)
+		return db.Repo{}, false, fmt.Errorf("verify primary checkout: %w", err)
 	}
 	primaryRecord.PrimaryCheckoutPath = primary
-	return primaryRecord, nil
+	return primaryRecord, primaryFromRemote, nil
 }
 
 func cleanCheckoutPath(path string) (string, error) {

--- a/internal/cli/repo.go
+++ b/internal/cli/repo.go
@@ -578,7 +578,8 @@ func resolveRegisteredRepoRecordWithRunner(ctx context.Context, store *db.Store,
 				}
 			}
 			resolved.PrimaryCheckoutPath = primary
-			return preserveRegisteredRepoFields(resolved, existing), false, nil
+			remoteDefault, _ := jobGitClient(checkout, runner).RemoteDefaultBranch(ctx)
+			return preserveRegisteredRepoFields(resolved, existing, remoteDefault), false, nil
 		}
 		checkoutErr = err
 	} else {
@@ -604,7 +605,8 @@ func resolveRegisteredRepoRecordWithRunner(ctx context.Context, store *db.Store,
 		}
 	}
 	resolved.PrimaryCheckoutPath = primary
-	resolved = preserveRegisteredRepoFields(resolved, existing)
+	remoteDefault, _ := jobGitClient(primary, runner).RemoteDefaultBranch(ctx)
+	resolved = preserveRegisteredRepoFields(resolved, existing, remoteDefault)
 	healed, err := store.HealRepoCheckout(ctx, repo.FullName(), checkout, resolved.CheckoutPath, primary)
 	if err != nil {
 		return db.Repo{}, false, err
@@ -620,8 +622,27 @@ func resolveRegisteredRepoRecordWithRunner(ctx context.Context, store *db.Store,
 	return resolved, true, nil
 }
 
-func preserveRegisteredRepoFields(resolved, existing db.Repo) db.Repo {
-	if strings.TrimSpace(existing.DefaultBranch) != "" {
+// preserveRegisteredRepoFields keeps operator-owned fields across a re-resolve.
+//
+// remoteDefault is the branch origin/HEAD names, or "" when it could not be
+// read. It is passed EXPLICITLY rather than inferred from resolved, because the
+// decision needs the PROVENANCE of the value and not just the value: a branch
+// derived from the remote is authoritative and must overwrite a stored one,
+// while a branch that fell back to the worktree's current HEAD must never
+// overwrite a stored value that may have come from the remote earlier.
+//
+// This kept the stored DefaultBranch whenever it was non-empty (#2145 review,
+// F1). That was protective while the resolved value came from CurrentBranch - it
+// stopped a worktree artifact overwriting the record - but it also meant a
+// CORRECT remote-derived value could never replace a wrong stored one, so
+// `jerryfane/herdr` kept `fix/lan-address-portability` however often it was
+// re-resolved. THE PRESERVE RULE WAS A WORKAROUND FOR THE DEFECT THIS CHANGE
+// FIXES, and keeping both leaves the record permanently wrong.
+func preserveRegisteredRepoFields(resolved, existing db.Repo, remoteDefault string) db.Repo {
+	switch {
+	case strings.TrimSpace(remoteDefault) != "":
+		resolved.DefaultBranch = strings.TrimSpace(remoteDefault)
+	case strings.TrimSpace(existing.DefaultBranch) != "":
 		resolved.DefaultBranch = existing.DefaultBranch
 	}
 	resolved.PollInterval = existing.PollInterval

--- a/internal/cli/repo.go
+++ b/internal/cli/repo.go
@@ -557,7 +557,7 @@ func resolveRegisteredRepoRecordWithRunner(ctx context.Context, store *db.Store,
 	checkout := strings.TrimSpace(existing.CheckoutPath)
 	var checkoutErr error
 	if checkout != "" {
-		resolved, err := repoRecordForCheckout(ctx, repo, jobGitClient(checkout, runner))
+		resolved, fromRemote, err := repoRecordForCheckout(ctx, repo, jobGitClient(checkout, runner))
 		if err == nil {
 			primary := strings.TrimSpace(existing.PrimaryCheckoutPath)
 			if primary == "" {
@@ -578,8 +578,7 @@ func resolveRegisteredRepoRecordWithRunner(ctx context.Context, store *db.Store,
 				}
 			}
 			resolved.PrimaryCheckoutPath = primary
-			remoteDefault, _ := jobGitClient(checkout, runner).RemoteDefaultBranch(ctx)
-			return preserveRegisteredRepoFields(resolved, existing, remoteDefault), false, nil
+			return preserveRegisteredRepoFields(resolved, existing, fromRemote), false, nil
 		}
 		checkoutErr = err
 	} else {
@@ -590,7 +589,7 @@ func resolveRegisteredRepoRecordWithRunner(ctx context.Context, store *db.Store,
 	if primary == "" || sameCheckoutPath(primary, checkout) {
 		return db.Repo{}, false, fmt.Errorf("registered checkout %s for %s is unusable and no distinct primary checkout is available: %w", checkout, repo.FullName(), checkoutErr)
 	}
-	resolved, err := repoRecordForCheckout(ctx, repo, jobGitClient(primary, runner))
+	resolved, fromRemote, err := repoRecordForCheckout(ctx, repo, jobGitClient(primary, runner))
 	if err != nil {
 		return db.Repo{}, false, fmt.Errorf("registered checkout %s for %s is unusable (%v); verify primary checkout %s: %w", checkout, repo.FullName(), checkoutErr, primary, err)
 	}
@@ -599,14 +598,13 @@ func resolveRegisteredRepoRecordWithRunner(ctx context.Context, store *db.Store,
 		return db.Repo{}, false, fmt.Errorf("resolve primary worktree for %s from %s: %w", repo.FullName(), resolved.CheckoutPath, err)
 	}
 	if !sameCheckoutPath(primary, resolved.CheckoutPath) {
-		resolved, err = repoRecordForCheckout(ctx, repo, jobGitClient(primary, runner))
+		resolved, fromRemote, err = repoRecordForCheckout(ctx, repo, jobGitClient(primary, runner))
 		if err != nil {
 			return db.Repo{}, false, fmt.Errorf("verify resolved primary checkout %s for %s: %w", primary, repo.FullName(), err)
 		}
 	}
 	resolved.PrimaryCheckoutPath = primary
-	remoteDefault, _ := jobGitClient(primary, runner).RemoteDefaultBranch(ctx)
-	resolved = preserveRegisteredRepoFields(resolved, existing, remoteDefault)
+	resolved = preserveRegisteredRepoFields(resolved, existing, fromRemote)
 	healed, err := store.HealRepoCheckout(ctx, repo.FullName(), checkout, resolved.CheckoutPath, primary)
 	if err != nil {
 		return db.Repo{}, false, err
@@ -638,10 +636,10 @@ func resolveRegisteredRepoRecordWithRunner(ctx context.Context, store *db.Store,
 // `jerryfane/herdr` kept `fix/lan-address-portability` however often it was
 // re-resolved. THE PRESERVE RULE WAS A WORKAROUND FOR THE DEFECT THIS CHANGE
 // FIXES, and keeping both leaves the record permanently wrong.
-func preserveRegisteredRepoFields(resolved, existing db.Repo, remoteDefault string) db.Repo {
+func preserveRegisteredRepoFields(resolved, existing db.Repo, resolvedFromRemote bool) db.Repo {
 	switch {
-	case strings.TrimSpace(remoteDefault) != "":
-		resolved.DefaultBranch = strings.TrimSpace(remoteDefault)
+	case resolvedFromRemote && strings.TrimSpace(resolved.DefaultBranch) != "":
+		// keep the remote-derived value already on resolved
 	case strings.TrimSpace(existing.DefaultBranch) != "":
 		resolved.DefaultBranch = existing.DefaultBranch
 	}
@@ -659,7 +657,8 @@ func repoRecordFromPath(ctx context.Context, repo github.Repository, path string
 	if err != nil {
 		return db.Repo{}, err
 	}
-	return repoRecordForCheckout(ctx, repo, gitutil.NewHostClient(checkout))
+	record, _, err := repoRecordForCheckout(ctx, repo, gitutil.NewHostClient(checkout))
+	return record, err
 }
 
 // repoRecordFromStablePath resolves an operator/cwd-provided checkout but pins
@@ -671,7 +670,7 @@ func repoRecordFromStablePath(ctx context.Context, repo github.Repository, path 
 		return db.Repo{}, err
 	}
 	client := gitutil.NewHostClient(checkout)
-	record, err := repoRecordForCheckout(ctx, repo, client)
+	record, _, err := repoRecordForCheckout(ctx, repo, client)
 	if err != nil {
 		return db.Repo{}, err
 	}
@@ -687,7 +686,7 @@ func repoRecordFromStablePath(ctx context.Context, repo github.Repository, path 
 	if !linked || sameCheckoutPath(record.CheckoutPath, primary) {
 		return record, nil
 	}
-	primaryRecord, err := repoRecordForCheckout(ctx, repo, gitutil.NewHostClient(primary))
+	primaryRecord, _, err := repoRecordForCheckout(ctx, repo, gitutil.NewHostClient(primary))
 	if err != nil {
 		return db.Repo{}, fmt.Errorf("verify primary checkout: %w", err)
 	}

--- a/internal/cli/repo_record_default_branch_test.go
+++ b/internal/cli/repo_record_default_branch_test.go
@@ -1,0 +1,91 @@
+package cli
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	gitutil "github.com/gitmoot/gitmoot/internal/git"
+	"github.com/gitmoot/gitmoot/internal/github"
+)
+
+// repoRecordForCheckout must record the REMOTE's default branch, not the branch
+// the worktree happens to be on (#2145).
+//
+// This tests the DEFECT SITE rather than the helper. The git-level test proves
+// RemoteDefaultBranch reads origin/HEAD correctly; it says nothing about which
+// source this function prefers, and a mutant that consults CurrentBranch first
+// and origin/HEAD only as a fallback passes every other test in the package -
+// which is precisely the shape of the bug that was in production.
+func TestRepoRecordForCheckoutPrefersRemoteDefaultOverCheckedOutBranch(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not installed")
+	}
+	origin := t.TempDir()
+	runGit(t, origin, "init", "-b", "master")
+	runGit(t, origin, "config", "user.email", "gitmoot@example.com")
+	runGit(t, origin, "config", "user.name", "Gitmoot")
+	if err := os.WriteFile(filepath.Join(origin, "README.md"), []byte("# origin\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	runGit(t, origin, "add", "README.md")
+	runGit(t, origin, "commit", "-m", "init")
+
+	// Clone locally so origin/HEAD is created, then point origin at the forge URL
+	// the record is validated against. set-url does not disturb refs, so
+	// refs/remotes/origin/HEAD still resolves to origin/master.
+	clone := filepath.Join(t.TempDir(), "clone")
+	runGit(t, t.TempDir(), "clone", origin, clone)
+	runGit(t, clone, "remote", "set-url", "origin", "https://github.com/jerryfane/herdr.git")
+	runGit(t, clone, "checkout", "-b", "fix/lan-address-portability")
+
+	record, err := repoRecordForCheckout(context.Background(),
+		github.Repository{Owner: "jerryfane", Name: "herdr"},
+		gitutil.NewHostClient(clone))
+	if err != nil {
+		t.Fatalf("repoRecordForCheckout returned error: %v", err)
+	}
+	if record.DefaultBranch != "master" {
+		t.Fatalf("DefaultBranch = %q, want master; the worktree is on fix/lan-address-portability and that must not be recorded as the default", record.DefaultBranch)
+	}
+
+	// Control: the worktree really is on the other branch, so the assertion is
+	// distinguishing the two sources rather than passing because they agree.
+	current, err := gitutil.NewHostClient(clone).CurrentBranch(context.Background())
+	if err != nil || current != "fix/lan-address-portability" {
+		t.Fatalf("CurrentBranch = %q err=%v, want the feature branch; fixture does not separate the sources", current, err)
+	}
+}
+
+// With origin/HEAD unresolvable the checked-out branch is the only source, and
+// dropping it would register a repository with no base branch at all - which
+// repo doctor reports as a missing branch and dispatch reads as an empty
+// default. That regression was caught by CI on the first version of this fix.
+func TestRepoRecordForCheckoutFallsBackWhenOriginHeadIsUnset(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not installed")
+	}
+	dir := t.TempDir()
+	runGit(t, dir, "init", "-b", "main")
+	runGit(t, dir, "config", "user.email", "gitmoot@example.com")
+	runGit(t, dir, "config", "user.name", "Gitmoot")
+	if err := os.WriteFile(filepath.Join(dir, "README.md"), []byte("# local\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	runGit(t, dir, "add", "README.md")
+	runGit(t, dir, "commit", "-m", "init")
+	// An origin exists but was never cloned from, so origin/HEAD is absent.
+	runGit(t, dir, "remote", "add", "origin", "https://github.com/jerryfane/herdr.git")
+
+	record, err := repoRecordForCheckout(context.Background(),
+		github.Repository{Owner: "jerryfane", Name: "herdr"},
+		gitutil.NewHostClient(dir))
+	if err != nil {
+		t.Fatalf("repoRecordForCheckout returned error: %v", err)
+	}
+	if record.DefaultBranch != "main" {
+		t.Fatalf("DefaultBranch = %q, want main from the fallback; an empty value registers a repo with no base branch", record.DefaultBranch)
+	}
+}

--- a/internal/cli/repo_record_default_branch_test.go
+++ b/internal/cli/repo_record_default_branch_test.go
@@ -41,11 +41,16 @@ func TestRepoRecordForCheckoutPrefersRemoteDefaultOverCheckedOutBranch(t *testin
 	runGit(t, clone, "remote", "set-url", "origin", "https://github.com/jerryfane/herdr.git")
 	runGit(t, clone, "checkout", "-b", "fix/lan-address-portability")
 
-	record, err := repoRecordForCheckout(context.Background(),
+	record, fromRemote, err := repoRecordForCheckout(context.Background(),
 		github.Repository{Owner: "jerryfane", Name: "herdr"},
 		gitutil.NewHostClient(clone))
 	if err != nil {
 		t.Fatalf("repoRecordForCheckout returned error: %v", err)
+	}
+	// The provenance flag is what lets the caller overwrite a stored value, so a
+	// correct branch reported as a fallback is as broken as a wrong branch.
+	if !fromRemote {
+		t.Fatal("fromRemote = false with origin/HEAD resolvable; the caller would then refuse to correct a stored value")
 	}
 	if record.DefaultBranch != "master" {
 		t.Fatalf("DefaultBranch = %q, want master; the worktree is on fix/lan-address-portability and that must not be recorded as the default", record.DefaultBranch)
@@ -79,11 +84,14 @@ func TestRepoRecordForCheckoutFallsBackWhenOriginHeadIsUnset(t *testing.T) {
 	// An origin exists but was never cloned from, so origin/HEAD is absent.
 	runGit(t, dir, "remote", "add", "origin", "https://github.com/jerryfane/herdr.git")
 
-	record, err := repoRecordForCheckout(context.Background(),
+	record, fromRemote, err := repoRecordForCheckout(context.Background(),
 		github.Repository{Owner: "jerryfane", Name: "herdr"},
 		gitutil.NewHostClient(dir))
 	if err != nil {
 		t.Fatalf("repoRecordForCheckout returned error: %v", err)
+	}
+	if fromRemote {
+		t.Fatal("fromRemote = true with origin/HEAD unset; a fallback value must never be reported as remote-derived")
 	}
 	if record.DefaultBranch != "main" {
 		t.Fatalf("DefaultBranch = %q, want main from the fallback; an empty value registers a repo with no base branch", record.DefaultBranch)

--- a/internal/db/repo_default_branch_test.go
+++ b/internal/db/repo_default_branch_test.go
@@ -1,0 +1,83 @@
+package db
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+)
+
+func openRepoDefaultBranchTestStore(t *testing.T) *Store {
+	t.Helper()
+	store, err := openCachedTestStore(t, filepath.Join(t.TempDir(), "gitmoot.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+	return store
+}
+
+// The cached default branch is consumed as the BASE BRANCH, and it was written
+// from the worktree's CURRENT branch, so records exist naming a feature branch
+// (#2145: jerryfane/herdr held `fix/lan-address-portability` for a repository
+// whose default is `master`). A wrong value is already durable, so the poll must
+// be able to correct it - and must report whether it actually did, or the
+// operator sees a correction logged on every tick forever.
+func TestUpdateRepoDefaultBranchCorrectsAndReportsChange(t *testing.T) {
+	ctx := context.Background()
+	store := openRepoDefaultBranchTestStore(t)
+	if err := store.UpsertRepo(ctx, Repo{
+		Owner: "jerryfane", Name: "herdr",
+		DefaultBranch: "fix/lan-address-portability",
+		RemoteURL:     "https://github.com/jerryfane/herdr.git",
+		CheckoutPath:  "/repo/herdr", PrimaryCheckoutPath: "/repo/herdr",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	changed, err := store.UpdateRepoDefaultBranch(ctx, "jerryfane/herdr", "master")
+	if err != nil || !changed {
+		t.Fatalf("first correction: changed=%v err=%v, want true/nil", changed, err)
+	}
+	repo, err := store.GetRepo(ctx, "jerryfane/herdr")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if repo.DefaultBranch != "master" {
+		t.Fatalf("default_branch = %q, want master", repo.DefaultBranch)
+	}
+
+	// Idempotent: the poll runs every tick, so an unchanged value must report no
+	// change rather than a write.
+	changed, err = store.UpdateRepoDefaultBranch(ctx, "jerryfane/herdr", "master")
+	if err != nil || changed {
+		t.Fatalf("repeat correction: changed=%v err=%v, want false/nil", changed, err)
+	}
+}
+
+// An unreadable origin/HEAD must not blank the base branch. Turning a wrong base
+// into a MISSING base is a worse failure, and it would happen on every repo
+// whose symbolic ref is momentarily unresolvable.
+func TestUpdateRepoDefaultBranchRejectsEmptyRatherThanBlanking(t *testing.T) {
+	ctx := context.Background()
+	store := openRepoDefaultBranchTestStore(t)
+	if err := store.UpsertRepo(ctx, Repo{
+		Owner: "jerryfane", Name: "herdr", DefaultBranch: "master",
+		RemoteURL: "https://github.com/jerryfane/herdr.git", CheckoutPath: "/repo/herdr",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	for _, branch := range []string{"", "   "} {
+		changed, err := store.UpdateRepoDefaultBranch(ctx, "jerryfane/herdr", branch)
+		if err == nil || changed {
+			t.Fatalf("branch %q: changed=%v err=%v, want an error and no change", branch, changed, err)
+		}
+	}
+	repo, err := store.GetRepo(ctx, "jerryfane/herdr")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if repo.DefaultBranch != "master" {
+		t.Fatalf("default_branch = %q, want master preserved", repo.DefaultBranch)
+	}
+}

--- a/internal/db/store_tasks.go
+++ b/internal/db/store_tasks.go
@@ -141,6 +141,31 @@ func (s *Store) UpdateRepoPollResult(ctx context.Context, fullName string, lastP
 	return requireAffected(result, "repo", fullName)
 }
 
+// UpdateRepoDefaultBranch corrects the cached default branch, reporting whether
+// the stored value actually changed so the caller can log a real correction
+// rather than one write per poll (#2145).
+//
+// An EMPTY branch is rejected instead of stored. The column is consumed as the
+// base branch, and blanking it would turn a wrong base into a missing one on
+// every repository whose origin/HEAD is momentarily unreadable.
+func (s *Store) UpdateRepoDefaultBranch(ctx context.Context, fullName string, branch string) (bool, error) {
+	fullName = strings.TrimSpace(fullName)
+	branch = strings.TrimSpace(branch)
+	if branch == "" {
+		return false, errors.New("default branch is required")
+	}
+	result, err := s.db.ExecContext(ctx, `UPDATE repos SET default_branch = ?, updated_at = CURRENT_TIMESTAMP
+		WHERE full_name = ? AND default_branch <> ?`, branch, fullName, branch)
+	if err != nil {
+		return false, err
+	}
+	affected, err := result.RowsAffected()
+	if err != nil {
+		return false, err
+	}
+	return affected > 0, nil
+}
+
 func (s *Store) RemoveRepo(ctx context.Context, fullName string) (bool, error) {
 	result, err := s.db.ExecContext(ctx, `DELETE FROM repos WHERE full_name = ?`, fullName)
 	if err != nil {

--- a/internal/git/client.go
+++ b/internal/git/client.go
@@ -576,6 +576,11 @@ func (c Client) OriginRemote(ctx context.Context) (string, error) {
 // absent one: callers preserve the previously stored value when this yields
 // nothing, whereas a fabricated "main" would silently overwrite a correct record
 // on any repository that uses a different default.
+//
+// The symbolic ref is a LOCAL cache. Git does not update it when the upstream
+// repository renames its default branch; operators must run
+// `git remote set-head origin -a` in the registered checkout. Until then this
+// method deliberately returns the stale cached name rather than guessing.
 func (c Client) RemoteDefaultBranch(ctx context.Context) (string, error) {
 	result, err := c.run(ctx, "symbolic-ref", "--short", "refs/remotes/origin/HEAD")
 	if err != nil {

--- a/internal/git/client.go
+++ b/internal/git/client.go
@@ -582,12 +582,12 @@ func (c Client) OriginRemote(ctx context.Context) (string, error) {
 // `git remote set-head origin -a` in the registered checkout. Until then this
 // method deliberately returns the stale cached name rather than guessing.
 func (c Client) RemoteDefaultBranch(ctx context.Context) (string, error) {
-	result, err := c.run(ctx, "symbolic-ref", "--short", "refs/remotes/origin/HEAD")
+	result, err := c.run(ctx, "symbolic-ref", "refs/remotes/origin/HEAD")
 	if err != nil {
 		return "", err
 	}
 	ref := strings.TrimSpace(result.Stdout)
-	// Defensive, and UNREACHABLE via git: measured, `symbolic-ref --short
+	// Defensive, and UNREACHABLE via git: measured, `symbolic-ref
 	// refs/remotes/origin/HEAD` exits 128 both when the repository has no origin
 	// and after `git remote set-head origin --delete`, so the error return above
 	// fires and this branch cannot be entered. It is kept for consistency with
@@ -596,10 +596,15 @@ func (c Client) RemoteDefaultBranch(ctx context.Context) (string, error) {
 	if ref == "" {
 		return "", errors.New("origin default branch is empty")
 	}
-	// `--short` yields `origin/master`; the stored field holds a branch name.
-	// Only the leading remote name is removed, so a branch whose own name
-	// contains `origin/` survives intact.
-	return strings.TrimPrefix(ref, "origin/"), nil
+	const originRefPrefix = "refs/remotes/origin/"
+	branch, ok := strings.CutPrefix(ref, originRefPrefix)
+	if !ok {
+		return "", fmt.Errorf("origin default branch ref %q is outside %s", ref, originRefPrefix)
+	}
+	if branch == "" {
+		return "", errors.New("origin default branch is empty")
+	}
+	return branch, nil
 }
 
 // OriginRemoteConfigured returns the literal configured origin URL without Git's

--- a/internal/git/client.go
+++ b/internal/git/client.go
@@ -560,6 +560,43 @@ func (c Client) OriginRemote(ctx context.Context) (string, error) {
 	return remote, nil
 }
 
+// RemoteDefaultBranch returns the branch the ORIGIN REMOTE names as its own
+// default, read from the `refs/remotes/origin/HEAD` symbolic ref that clone and
+// `git remote set-head` maintain.
+//
+// It exists because the default branch was previously taken from CurrentBranch
+// (#2145), which is the branch the local worktree happens to have checked out.
+// That is never the repository's default branch except by coincidence: on this
+// host `jerryfane/herdr` had recorded `fix/lan-address-portability` while GitHub
+// reported `master`, and the recorded value is consumed as the BASE BRANCH for
+// advancement and dispatch.
+//
+// An UNSET origin/HEAD is reported as an error rather than guessed. A guess here
+// would be written into the base-branch field, and a wrong base is worse than an
+// absent one: callers preserve the previously stored value when this yields
+// nothing, whereas a fabricated "main" would silently overwrite a correct record
+// on any repository that uses a different default.
+func (c Client) RemoteDefaultBranch(ctx context.Context) (string, error) {
+	result, err := c.run(ctx, "symbolic-ref", "--short", "refs/remotes/origin/HEAD")
+	if err != nil {
+		return "", err
+	}
+	ref := strings.TrimSpace(result.Stdout)
+	// Defensive, and UNREACHABLE via git: measured, `symbolic-ref --short
+	// refs/remotes/origin/HEAD` exits 128 both when the repository has no origin
+	// and after `git remote set-head origin --delete`, so the error return above
+	// fires and this branch cannot be entered. It is kept for consistency with
+	// OriginRemote and OriginRemoteConfigured, which carry the same check. A
+	// mutant replacing it with a guessed default therefore survives by design.
+	if ref == "" {
+		return "", errors.New("origin default branch is empty")
+	}
+	// `--short` yields `origin/master`; the stored field holds a branch name.
+	// Only the leading remote name is removed, so a branch whose own name
+	// contains `origin/` survives intact.
+	return strings.TrimPrefix(ref, "origin/"), nil
+}
+
 // OriginRemoteConfigured returns the literal configured origin URL without Git's
 // url.*.insteadOf rewrite. A disposable clone must preserve the forge-facing URL
 // in its own config even when the source checkout rewrites transport locally.

--- a/internal/git/remote_default_branch_test.go
+++ b/internal/git/remote_default_branch_test.go
@@ -1,0 +1,104 @@
+package git
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+)
+
+// RemoteDefaultBranch must read the REMOTE's default, not the local HEAD.
+//
+// This is the #2145 defect as a test: the caller previously used CurrentBranch,
+// so a clone sitting on a feature branch recorded that branch as the
+// repository's default - and the value is consumed as the base branch. The
+// fixture therefore checks out a feature branch and asserts the remote's default
+// is returned anyway. Under the old CurrentBranch read this returns
+// "fix/lan-address-portability", which is exactly what was found in the store.
+func TestRemoteDefaultBranchIgnoresTheCheckedOutBranch(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not installed")
+	}
+	origin := t.TempDir()
+	runGit(t, origin, "init", "-b", "master")
+	runGit(t, origin, "config", "user.email", "gitmoot@example.com")
+	runGit(t, origin, "config", "user.name", "Gitmoot")
+	if err := os.WriteFile(filepath.Join(origin, "README.md"), []byte("# origin\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	runGit(t, origin, "add", "README.md")
+	runGit(t, origin, "commit", "-m", "init")
+
+	clone := filepath.Join(t.TempDir(), "clone")
+	runGit(t, t.TempDir(), "clone", origin, clone)
+	// The worktree now sits on a branch that is NOT the remote default.
+	runGit(t, clone, "checkout", "-b", "fix/lan-address-portability")
+
+	client := NewHostClient(clone)
+	branch, err := client.RemoteDefaultBranch(context.Background())
+	if err != nil {
+		t.Fatalf("RemoteDefaultBranch returned error: %v", err)
+	}
+	if branch != "master" {
+		t.Fatalf("RemoteDefaultBranch = %q, want master (the remote default, not the checked-out branch)", branch)
+	}
+
+	// Control: the local HEAD really is the other branch, so the assertion above
+	// is distinguishing the two rather than passing because they coincide.
+	current, err := client.CurrentBranch(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if current != "fix/lan-address-portability" {
+		t.Fatalf("CurrentBranch = %q, want the feature branch; fixture does not separate the two values", current)
+	}
+}
+
+// An unset origin/HEAD must ERROR rather than guess. The caller stores the
+// result in the base-branch field and preserves the existing value on an empty
+// read, so a fabricated "main" would silently overwrite a correct record on any
+// repository with a different default.
+func TestRemoteDefaultBranchErrorsWhenOriginHeadIsUnset(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not installed")
+	}
+	dir := t.TempDir()
+	runGit(t, dir, "init", "-b", "main")
+	runGit(t, dir, "config", "user.email", "gitmoot@example.com")
+	runGit(t, dir, "config", "user.name", "Gitmoot")
+	if err := os.WriteFile(filepath.Join(dir, "README.md"), []byte("# no origin\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	runGit(t, dir, "add", "README.md")
+	runGit(t, dir, "commit", "-m", "init")
+
+	// Second arm, and the REALISTIC one: a clone that HAS an origin but whose
+	// origin/HEAD ref has been deleted. `git remote set-head --delete` is the
+	// supported way to reach that state, and it is what a partial or mirrored
+	// clone can look like in production. The no-origin repo above cannot
+	// distinguish "unset" from "no remote".
+	origin := t.TempDir()
+	runGit(t, origin, "init", "-b", "master")
+	runGit(t, origin, "config", "user.email", "gitmoot@example.com")
+	runGit(t, origin, "config", "user.name", "Gitmoot")
+	if err := os.WriteFile(filepath.Join(origin, "README.md"), []byte("# origin\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	runGit(t, origin, "add", "README.md")
+	runGit(t, origin, "commit", "-m", "init")
+	clone := filepath.Join(t.TempDir(), "clone")
+	runGit(t, t.TempDir(), "clone", origin, clone)
+	runGit(t, clone, "remote", "set-head", "origin", "--delete")
+	if deleted, err := NewHostClient(clone).RemoteDefaultBranch(context.Background()); err == nil {
+		t.Fatalf("RemoteDefaultBranch = %q with no error after origin/HEAD was deleted, want an error", deleted)
+	}
+
+	branch, err := NewHostClient(dir).RemoteDefaultBranch(context.Background())
+	if err == nil {
+		t.Fatalf("RemoteDefaultBranch = %q with no error, want an error when origin/HEAD is unset", branch)
+	}
+	if branch != "" {
+		t.Fatalf("RemoteDefaultBranch = %q on error, want empty", branch)
+	}
+}

--- a/internal/git/remote_default_branch_test.go
+++ b/internal/git/remote_default_branch_test.go
@@ -102,3 +102,58 @@ func TestRemoteDefaultBranchErrorsWhenOriginHeadIsUnset(t *testing.T) {
 		t.Fatalf("RemoteDefaultBranch = %q on error, want empty", branch)
 	}
 }
+
+// PRECEDENCE, which is the actual contract (#2145): the remote default wins when
+// origin/HEAD resolves, and the checked-out branch is used only when it does
+// not. Recording the local HEAD *while the remote default was knowable* was the
+// defect; refusing to record anything at all in the unresolvable case was a
+// regression this test also pins, because it left `gitmoot repo add` registering
+// a repository with no base branch, which repo doctor reports as missing.
+func TestRemoteDefaultBranchPrecedenceOverCheckedOutBranch(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not installed")
+	}
+	for _, test := range []struct {
+		name         string
+		deleteHead   bool
+		wantRemote   bool
+		wantFallback string
+	}{
+		{name: "origin/HEAD resolves so the remote default wins", wantRemote: true},
+		{name: "origin/HEAD unset so the checked-out branch is the only source", deleteHead: true, wantFallback: "fix/lan-address-portability"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			origin := t.TempDir()
+			runGit(t, origin, "init", "-b", "master")
+			runGit(t, origin, "config", "user.email", "gitmoot@example.com")
+			runGit(t, origin, "config", "user.name", "Gitmoot")
+			if err := os.WriteFile(filepath.Join(origin, "README.md"), []byte("# origin\n"), 0o644); err != nil {
+				t.Fatal(err)
+			}
+			runGit(t, origin, "add", "README.md")
+			runGit(t, origin, "commit", "-m", "init")
+			clone := filepath.Join(t.TempDir(), "clone")
+			runGit(t, t.TempDir(), "clone", origin, clone)
+			runGit(t, clone, "checkout", "-b", "fix/lan-address-portability")
+			if test.deleteHead {
+				runGit(t, clone, "remote", "set-head", "origin", "--delete")
+			}
+
+			client := NewHostClient(clone)
+			remote, remoteErr := client.RemoteDefaultBranch(context.Background())
+			if test.wantRemote {
+				if remoteErr != nil || remote != "master" {
+					t.Fatalf("RemoteDefaultBranch = %q err=%v, want master", remote, remoteErr)
+				}
+				return
+			}
+			if remoteErr == nil {
+				t.Fatalf("RemoteDefaultBranch = %q, want an error with origin/HEAD deleted", remote)
+			}
+			current, err := client.CurrentBranch(context.Background())
+			if err != nil || current != test.wantFallback {
+				t.Fatalf("CurrentBranch = %q err=%v, want %q as the only available source", current, err, test.wantFallback)
+			}
+		})
+	}
+}

--- a/internal/git/remote_default_branch_test.go
+++ b/internal/git/remote_default_branch_test.go
@@ -55,6 +55,31 @@ func TestRemoteDefaultBranchIgnoresTheCheckedOutBranch(t *testing.T) {
 	}
 }
 
+// Git may lengthen a shortened remote-tracking ref when a local branch collides
+// with it. Reading and stripping the full ref must therefore still return only
+// the remote's branch name.
+func TestRemoteDefaultBranchHandlesShortRefCollision(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not installed")
+	}
+	dir := t.TempDir()
+	runGit(t, dir, "init", "-b", "main")
+	runGit(t, dir, "config", "user.email", "gitmoot@example.com")
+	runGit(t, dir, "config", "user.name", "Gitmoot")
+	runGit(t, dir, "commit", "--allow-empty", "-m", "init")
+	runGit(t, dir, "update-ref", "refs/remotes/origin/main", "HEAD")
+	runGit(t, dir, "symbolic-ref", "refs/remotes/origin/HEAD", "refs/remotes/origin/main")
+	runGit(t, dir, "branch", "origin/main")
+
+	branch, err := NewHostClient(dir).RemoteDefaultBranch(context.Background())
+	if err != nil {
+		t.Fatalf("RemoteDefaultBranch returned error: %v", err)
+	}
+	if branch != "main" {
+		t.Fatalf("RemoteDefaultBranch = %q, want main despite the colliding local ref", branch)
+	}
+}
+
 // An unset origin/HEAD must ERROR rather than guess. The caller stores the
 // result in the base-branch field and preserves the existing value on an empty
 // read, so a fabricated "main" would silently overwrite a correct record on any

--- a/skills/gitmoot/references/CLI.md
+++ b/skills/gitmoot/references/CLI.md
@@ -1417,6 +1417,13 @@ that is behind `origin/<default>`. The error reports the branch and behind
 count and offers both explicit choices: `--base origin/<default>` or
 `--base HEAD`.
 
+The repository-wide default comes from the registered checkout's local
+`origin/HEAD` symbolic ref. Git does not refresh that ref when the upstream
+repository renames its default branch. Run `git remote set-head origin -a` in
+the registered checkout after such a rename; until then Gitmoot treats the
+cached ref as authoritative and may reconcile `repos.default_branch` back to
+the stale name.
+
 `gitmoot agent run`, `ask`, `implement`, and `review` (and `orchestrate`) accept
 an optional `--model <name>` flag that pins the runtime model for that one job,
 overriding the agent's configured default. It is a free-form, runtime-scoped

--- a/website/docs/reference/cli.md
+++ b/website/docs/reference/cli.md
@@ -1104,6 +1104,13 @@ that is behind `origin/<default>`. The error reports the branch and behind
 count and offers both explicit choices: `--base origin/<default>` or
 `--base HEAD`.
 
+The repository-wide default comes from the registered checkout's local
+`origin/HEAD` symbolic ref. Git does not refresh that ref when the upstream
+repository renames its default branch. Run `git remote set-head origin -a` in
+the registered checkout after such a rename; until then Gitmoot treats the
+cached ref as authoritative and may reconcile `repos.default_branch` back to
+the stale name.
+
 `gitmoot agent run`, `ask`, `implement`, and `review` (and `orchestrate`) accept
 an optional `--model <name>` flag that pins the runtime model for that one job,
 overriding the agent's configured default. It is a free-form, runtime-scoped


### PR DESCRIPTION
Part of #2145. Authorization: workflow note 131145; Grams `gram-1a08cf30317-1394e1-55`, `gram-1a08cf38450-1394e1-56`.

**This is the default-branch half of #2145 only.** The poll-starvation half is #2140 and is not in this PR.

## The defect

`repoRecordForCheckout` (`internal/cli/daemon_checkout.go`) derived the stored default branch from **`client.CurrentBranch(ctx)`** - whichever branch the local worktree happened to have checked out when the record was written:

```go
defaultBranch := ""
if branch, err := client.CurrentBranch(ctx); err == nil {
    defaultBranch = branch
}
```

That is never the repository's default branch except by coincidence, and `UpsertRepo` persists it into `repos.default_branch`, which is consumed as the **base branch** by `internal/cli/daemon_workflow.go:535` and `:642`, and as the dispatch branch default by `internal/cli/agent_dispatch.go:644`.

**Observed on this host:** `jerryfane/herdr` had `default_branch = fix/lan-address-portability`; GitHub reports `master`. The checkout was on a *third* branch (`fix/preview-fork-website-skip`) at the time of measurement, which is what shows the recorded value is a frozen artifact of whenever the record was last written rather than a live mirror of anything.

**And there was no correct source available:** GitHub's own `default_branch` field is **never read anywhere in the tree** - zero non-test hits for `default_branch`/`DefaultBranch` under `internal/github/`. Gitmoot had no path to learn a repository's real default branch.

## The fix

Read the **origin remote's own** `refs/remotes/origin/HEAD` symbolic ref, which `git clone` and `git remote set-head` maintain. `git.Client` is a concrete struct with a single implementation, so this adds a method without touching the `github.Client` interface or any fake.

Two deliberate refusals to guess:

- **Unset `origin/HEAD` errors** rather than defaulting to `main`. The value lands in the base-branch field, and callers preserve the previously stored value on an empty read, so a fabricated `main` would silently overwrite a correct record on any repository with a different default.
- **An empty branch is rejected, not stored.** Turning a wrong base into a *missing* base is the worse failure, and it would fire on every repo whose symbolic ref is momentarily unreadable.

**Self-heal on poll.** Existing wrong values are already durable, so correct writing from now on would never fix them. `pollRepo` now reconciles the column on each successful poll and logs only real corrections, placed **before** the dry-run return and **outside** the checkout lock: it reads one symbolic ref and writes one column, so it must not wait on a lock held by a running job, and a dry run should not silently operate against a base it knows is wrong.

Verified against the real checkout, read-only: `git -C /root/herdr-app-2 symbolic-ref --short refs/remotes/origin/HEAD` returns `origin/master`, so the reconcile produces `master`.

## Tests

The git-side test **is the defect**: the fixture clones a repo whose default is `master`, checks out `fix/lan-address-portability` in the clone, and asserts `master` is still returned. It also asserts via `CurrentBranch` that the two values really differ, so the assertion is distinguishing them rather than passing because they coincide.

| Mutant | Compiles | Outcome |
| --- | --- | --- |
| read the local HEAD (`branch --show-current`) - the defect itself | yes | **dead**, fails both git tests |
| accept an empty branch and blank the base | yes | **dead** |
| report `changed` on every call (drop the `<>` guard) | yes | **dead** |
| guess `main` when `origin/HEAD` is unset | yes | **survives, disclosed below** |

**The fourth mutant survives by construction and is disclosed rather than counted.** Its branch is unreachable: measured, `git symbolic-ref --short refs/remotes/origin/HEAD` exits **128** both with no origin at all and after `git remote set-head origin --delete`, printing `fatal: ref refs/remotes/origin/HEAD is not a symbolic ref`. So the error return fires first and the `ref == ""` check cannot be entered. The guard is kept for consistency with `OriginRemote` and `OriginRemoteConfigured`, which carry the same check, and the code says so at the site.

I strengthened the unset test while chasing that mutant - the first version used a repo with **no origin**, which cannot distinguish "unset" from "no remote", so it now also covers a clone that has an origin whose `origin/HEAD` was deleted. That is the realistic production shape. The mutant still survives, for the measured reason above.

## Correction after CI: the first version of this fix was wrong

CI caught a regression I had not, because I ran only the targeted tests locally and never the packages.

Recording **only** the remote default meant a checkout with an origin but **no `origin/HEAD` ref** - `git init` plus `git remote add`, or a clone whose head ref was deleted - registered a repository with **no base branch at all**:

| Failing check | Symptom |
| --- | --- |
| `build / vet / test`, `e2e (tagged)`, `race (internal/cli, shards 1 and 2)` | 4 real failures, not cancellations |
| `TestRunRepoAddListDoctorRemove` | `repo doctor` lost `branch: main` |
| `TestRunAgentAskDispatchesAndStoresResult` | dispatch branch empty |

**The defect was never "consults `CurrentBranch`".** It was consulting `CurrentBranch` *when the remote default was knowable*. So the fix is **precedence**, not removal: `origin/HEAD` when it resolves, the checked-out branch only when it does not, with `pollRepo` upgrading the record the moment `origin/HEAD` becomes resolvable. A wrong value is now **transient rather than permanent**, which is the property that actually mattered.

The residual is stated at the site: a repository whose `origin/HEAD` is never set keeps a possibly-wrong local-branch value, exactly as before this change. That is not an improvement for that case, and it is better than registering no base branch.

**And the test gap was worse than the code gap.** My original tests proved `RemoteDefaultBranch` reads `origin/HEAD` correctly - they said nothing about which source `repoRecordForCheckout` prefers. A mutant consulting `CurrentBranch` first and `origin/HEAD` only as a fallback - **the exact production defect** - passed every test in the package. There is now a test at the defect site, and both mutants die:

| Mutant | Outcome |
| --- | --- |
| invert precedence (local HEAD first) - the production defect | **dead** at the defect site |
| drop the fallback - my own CI regression | **dead** |

Full packages run this time rather than targeted tests: `internal/cli` ok 641s, `internal/db` ok 165s, `internal/git` ok 1.9s, `go vet ./...` clean.

## Review round two: a P1 that falsified this PR's central claim

`gm-review-opus` returned **changes_requested, P1**, with `evidence: executed` and 9 non-empty `tests_run` entries - including independent mutation runs of both my disclosed mutants and manual `git 2.43.0` experiments on `origin/weird` and several crafted invalid symbolic-ref targets.

**The P1 is against the claim I asked them to attack.** I wrote that a wrong value is "transient rather than permanent" because `pollRepo` reconciles it. Two paths make that false:

**F1a - `preserveRegisteredRepoFields` discarded the correction.** It kept the stored `DefaultBranch` whenever it was non-empty, so every re-resolve threw away a correct remote-derived value. `jerryfane/herdr` would have kept `fix/lan-address-portability` however often it was resolved.

That rule was protective *only while the resolved value came from `CurrentBranch`* - it stopped a worktree artifact overwriting the record. **It was a workaround for the exact defect this PR fixes, and keeping both leaves the record permanently wrong.** It now receives the remote default explicitly, because the decision needs the value's **provenance** and not just the value: remote-derived overwrites stored, a fallback never does.

**F1b - single-repo mode never reconciled at all.** `daemon run --repo owner/repo` uses `startSingleRepoWorkerLoop` and never reaches `pollRepo`, so that mode - the one an operator uses to debug a single repository - could not correct a wrong base branch. It now reconciles once at startup. Startup-only rather than per tick, because that loop ticks far more often than the fleet poll and every store call contends for the daemon's single SQLite connection (#2145).

**F3 - the reconcile block had no test.** All three earlier tests targeted helpers; nothing exercised the wiring. The new test drives `pollRepo` with the live shape - stored `fix/lan-address-portability`, a clone whose `origin/HEAD` is `master` - and asserts the store write **and** the operator line that names what it replaced. A second pass must stay quiet, so a per-tick reconcile cannot bury a real correction.

| Mutant | Outcome |
| --- | --- |
| restore the P1: stored value always wins | **dead** |
| let a fallback overwrite a stored value | **dead** |
| drop the `pollRepo` reconcile block | **dead** |
| reconcile writes but never reports | **dead** |

Full packages again: `internal/cli` ok 650s, `internal/db` ok 178s, `internal/git` ok 1.7s, `go vet ./...` clean.

### F2 and F4: answered rather than changed

**F2 (P2)** - `pollRepo` is skipped for disabled repos and returns early when the checkout path is empty or unavailable. Both are real never-revisited windows and I am not closing them here. The checkout-unavailable case **cannot** be reconciled by construction: `origin/HEAD` lives in the checkout, so with no readable checkout there is no source of truth to read. The disabled case is deliberate - a disabled repo is not polled by design, and reconciling it would mean inventing a second scheduling path. The reviewer notes `SetRepoEnabled` has no live caller today, which makes it latent.

**F4 (P3)** - confirmed as self-disclosed: `UpdateRepoDefaultBranch` cannot distinguish a missing repo row from an unchanged value. Both mean "no correction was applied", the caller's only action either way is to not log, and the reviewer classes the race as benign. Distinguishing them would need a second query on the hot path that shares one connection.

## What this does not do

- **Does not fix the poll starvation.** #2145's primary cause is that the org-directive sweep holds the daemon's only SQLite connection (`SetMaxOpenConns(1)`) while the poller blocks in `database/sql.(*DB).conn`; the repair for that is #2140. This PR only stops the base branch being wrong.
- **Does not read GitHub's `default_branch`.** The remote's `origin/HEAD` is the authority used here, which is correct offline and needs no API call or rate budget. Adding a repo-metadata call to the `github.Client` interface would be the alternative and is a larger change than this blocker needs.
- **Does not touch `herdr#185`**, the `merge_gates` row, or any status. herdr#185 remains open and unmerged.


