### PR TITLE
perf(workflow): stop decoding every job payload to compare one worktree path (#2149)

### DIFF
--- a/internal/cli/daemon_reclaim_resilience_test.go
+++ b/internal/cli/daemon_reclaim_resilience_test.go
@@ -491,20 +491,25 @@ END;`); err != nil {
 	}
 }
 
-func TestPrepareDelegationCleanupSkipsDegeneratePath(t *testing.T) {
+func TestDelegationCleanupSkipsDegeneratePathBeforeObligation(t *testing.T) {
 	home := t.TempDir()
 	store := openCLIJobStore(t, home)
 	defer store.Close()
 	job := db.Job{ID: "degenerate-cleanup", Type: "implement"}
 	worker := defaultJobWorker(store, io.Discard, home)
+	now := time.Now().UTC()
 
 	obligation, ok, err := prepareDelegationCleanup(
-		context.Background(), worker, "aged", job, ".", time.Now().UTC())
+		context.Background(), worker, "aged", job, ".", now)
 	if err != nil {
 		t.Fatalf("degenerate path became a reclaim-pass failure: %v", err)
 	}
 	if ok || obligation.ResourceID != "" {
 		t.Fatalf("degenerate path created a cleanup obligation: ok=%v obligation=%+v", ok, obligation)
+	}
+	if err := deferDelegationCleanupSkip(
+		context.Background(), worker, job.ID, ".", db.CleanupReasonTerminalDeferred, now); err != nil {
+		t.Fatalf("filtered degenerate path became a cleanup deferral failure: %v", err)
 	}
 }
 

--- a/internal/cli/daemon_reclaim_resilience_test.go
+++ b/internal/cli/daemon_reclaim_resilience_test.go
@@ -491,6 +491,23 @@ END;`); err != nil {
 	}
 }
 
+func TestPrepareDelegationCleanupSkipsDegeneratePath(t *testing.T) {
+	home := t.TempDir()
+	store := openCLIJobStore(t, home)
+	defer store.Close()
+	job := db.Job{ID: "degenerate-cleanup", Type: "implement"}
+	worker := defaultJobWorker(store, io.Discard, home)
+
+	obligation, ok, err := prepareDelegationCleanup(
+		context.Background(), worker, "aged", job, ".", time.Now().UTC())
+	if err != nil {
+		t.Fatalf("degenerate path became a reclaim-pass failure: %v", err)
+	}
+	if ok || obligation.ResourceID != "" {
+		t.Fatalf("degenerate path created a cleanup obligation: ok=%v obligation=%+v", ok, obligation)
+	}
+}
+
 type failingAgedReclaimManager struct {
 	fakeReclaimWorktreeManager
 	err error

--- a/internal/cli/daemon_scheduler.go
+++ b/internal/cli/daemon_scheduler.go
@@ -283,6 +283,14 @@ func delegationCleanupTargetContained(worker jobWorker, job db.Job, obligation d
 }
 
 func prepareDelegationCleanup(ctx context.Context, worker jobWorker, mode string, job db.Job, path string, now time.Time) (db.CleanupObligation, bool, error) {
+	path = strings.TrimSpace(path)
+	if filepath.Clean(path) == "." {
+		// Candidate discovery is a text prefilter and can return whitespace or
+		// relative spellings of no resource. Skip before obligation persistence:
+		// EnsureCleanupObligation correctly rejects them, but that rejection is
+		// not an operational failure and must not wedge the whole reclaim pass.
+		return db.CleanupObligation{}, false, nil
+	}
 	obligation, err := worker.Store.EnsureCleanupObligation(context.WithoutCancel(ctx), job.ID, path, now)
 	if err != nil {
 		logDelegationReclaimFailure(worker.Stdout, mode, "obligation", job.ID, path, err)

--- a/internal/cli/daemon_scheduler.go
+++ b/internal/cli/daemon_scheduler.go
@@ -251,11 +251,18 @@ func deferDelegationCleanupContention(ctx context.Context, worker jobWorker, mod
 	return nil
 }
 
+func delegationCleanupPathUnavailable(path string) bool {
+	return filepath.Clean(strings.TrimSpace(path)) == "."
+}
+
 // deferDelegationCleanupSkip moves a selected-but-unattempted row behind the
 // bounded host window. The durable next_attempt_at is the fairness cursor: repo
 // filters, session filters, non-final state, and held checkouts must not leave the
 // same 256 rows monopolizing every tick after a daemon restart.
 func deferDelegationCleanupSkip(ctx context.Context, worker jobWorker, jobID, path string, reason db.CleanupObligationReason, now time.Time) error {
+	if delegationCleanupPathUnavailable(path) {
+		return nil
+	}
 	_, err := worker.Store.DeferCleanupObligation(
 		context.WithoutCancel(ctx), jobID, path, reason, now, now.Add(delegationCleanupRetryDelay),
 	)
@@ -284,7 +291,7 @@ func delegationCleanupTargetContained(worker jobWorker, job db.Job, obligation d
 
 func prepareDelegationCleanup(ctx context.Context, worker jobWorker, mode string, job db.Job, path string, now time.Time) (db.CleanupObligation, bool, error) {
 	path = strings.TrimSpace(path)
-	if filepath.Clean(path) == "." {
+	if delegationCleanupPathUnavailable(path) {
 		// Candidate discovery is a text prefilter and can return whitespace or
 		// relative spellings of no resource. Skip before obligation persistence:
 		// EnsureCleanupObligation correctly rejects them, but that rejection is

--- a/internal/db/cleanup_obligations_test.go
+++ b/internal/db/cleanup_obligations_test.go
@@ -148,14 +148,14 @@ func TestMigrationsUpgradeFromPreviousReleasedVersion(t *testing.T) {
 	// every branch that appends a migration, and why the failure reads as "not
 	// appended last" rather than as a merge conflict.
 	//
-	// The marker must name THIS BRANCH'S LAST migration and must be UNIQUE. The
-	// index name is unique to this migration; the bare ALTER would not be,
-	// because the column name also appears in that migration's own prose.
+	// The marker must name THIS BRANCH'S LAST migration and must be UNIQUE.
 	//
 	// It is updated by every branch that appends a migration, which is the point:
 	// the test fails until the new migration is both last and named here, so two
-	// branches cannot each believe theirs is the tail.
-	const branchMigrationMarker = "idx_job_events_provider"
+	// branches cannot each believe theirs is the tail. #2149's index name is
+	// unique to its migration; the bare CREATE INDEX would not be, and neither
+	// would json_extract, which now appears in that migration's own prose.
+	const branchMigrationMarker = "idx_jobs_worktree_path"
 	branchIndex := -1
 	for index, migration := range migrations {
 		if strings.Contains(migration, branchMigrationMarker) {

--- a/internal/db/cleanup_obligations_test.go
+++ b/internal/db/cleanup_obligations_test.go
@@ -148,14 +148,14 @@ func TestMigrationsUpgradeFromPreviousReleasedVersion(t *testing.T) {
 	// every branch that appends a migration, and why the failure reads as "not
 	// appended last" rather than as a merge conflict.
 	//
-	// The marker must name THIS BRANCH'S LAST migration and must be UNIQUE.
+	// The marker must name THIS BRANCH'S LAST migration and must be UNIQUE. The
+	// index name is unique to #1972's migration; the bare ALTER would not be,
+	// because the column name also appears in that migration's own prose.
 	//
 	// It is updated by every branch that appends a migration, which is the point:
 	// the test fails until the new migration is both last and named here, so two
-	// branches cannot each believe theirs is the tail. #2149's index name is
-	// unique to its migration; the bare CREATE INDEX would not be, and neither
-	// would json_extract, which now appears in that migration's own prose.
-	const branchMigrationMarker = "idx_jobs_worktree_path"
+	// branches cannot each believe theirs is the tail.
+	const branchMigrationMarker = "idx_routing_telemetry_fan_out"
 	branchIndex := -1
 	for index, migration := range migrations {
 		if strings.Contains(migration, branchMigrationMarker) {

--- a/internal/db/cleanup_obligations_test.go
+++ b/internal/db/cleanup_obligations_test.go
@@ -149,13 +149,13 @@ func TestMigrationsUpgradeFromPreviousReleasedVersion(t *testing.T) {
 	// appended last" rather than as a merge conflict.
 	//
 	// The marker must name THIS BRANCH'S LAST migration and must be UNIQUE. The
-	// index name is unique to #1972's migration; the bare ALTER would not be,
-	// because the column name also appears in that migration's own prose.
+	// index name is unique to #2161's provider-evidence migration; the bare
+	// ALTER also appears in that migration's explanatory prose.
 	//
 	// It is updated by every branch that appends a migration, which is the point:
 	// the test fails until the new migration is both last and named here, so two
 	// branches cannot each believe theirs is the tail.
-	const branchMigrationMarker = "idx_routing_telemetry_fan_out"
+	const branchMigrationMarker = "idx_job_events_provider"
 	branchIndex := -1
 	for index, migration := range migrations {
 		if strings.Contains(migration, branchMigrationMarker) {

--- a/internal/db/store_jobs.go
+++ b/internal/db/store_jobs.go
@@ -2630,23 +2630,40 @@ func annotateJobInsertConflict(jobID string, err error) error {
 	return fmt.Errorf("%w: %q was not written: %v", ErrJobIDConflict, jobID, err)
 }
 
-// listJobWorktreeRefsSQL is one const so the plan assertion tests the query
-// that actually runs. The expression MUST match idx_jobs_worktree_path
-// character for character, or SQLite silently falls back to a full scan that
-// re-parses every payload, which is exactly the cost #2149 removes. A silent
-// fallback is why the test asserts the PLAN and not a duration.
-const listJobWorktreeRefsSQL = `SELECT id, state, updated_at, created_at,
-	CASE WHEN json_valid(payload) THEN json_extract(payload, '$.worktree_path') END
-	FROM jobs
-	WHERE CASE WHEN json_valid(payload) THEN json_extract(payload, '$.worktree_path') END IS NOT NULL
-	  AND CASE WHEN json_valid(payload) THEN json_extract(payload, '$.worktree_path') END <> ''`
-
-// JobWorktreeRef is the minimum needed to answer "does another job still hold
-// this worktree path": identity, finality, and age. Deliberately NOT a Job.
+// listJobWorktreeRefsSQL selects a SUPERSET of the rows whose payload carries
+// a worktree path, using a text prefilter rather than SQL JSON extraction.
 //
-// #2149: the caller used to take whole Jobs and decode every payload to read
-// one string. Returning a narrow row makes that impossible to reintroduce by
-// accident - there is no payload here to decode.
+// #2149 round two: json_extract IS NOT encoding/json, and review proved the
+// difference is a safety bug rather than a curiosity. With
+// {"worktree_path":"","worktree_path":"/live/path"} Go returns "/live/path"
+// (last duplicate wins) while json_extract returns "". With
+// {"WORKTREE_PATH":"/live/path"} Go returns "/live/path" (field matching is
+// case-insensitive) while json_extract returns NULL. Both payloads are valid
+// JSON. A WHERE clause built on json_extract therefore HIDES rows the old
+// decoder saw, and a hidden row is a live co-owner whose worktree gets
+// reclaimed underneath it.
+//
+// So SQL no longer decides what the path IS. It only drops rows that cannot
+// possibly carry one, and the decode below is plain encoding/json, which is
+// the same package and therefore the same duplicate-key and case-folding
+// rules as ParseJobPayload by construction rather than by agreement.
+//
+// LIKE is case-insensitive for ASCII in SQLite, so a key in any case is
+// caught. Measured on the live store the prefilter selects 4,831 of 15,320
+// rows, which is 69 MORE than the json_extract predicate returned - those 69
+// are exactly the rows the previous version would have dropped.
+//
+// THE ONE GAP, stated rather than hidden: a payload whose KEY is written with
+// JSON escapes, "\u0077orktree_path", would be matched by encoding/json and
+// missed by this prefilter. No writer can produce it - every payload in this
+// table is marshalled by encoding/json, which never escapes a plain ASCII key
+// - and the live store contains zero such rows. If a foreign writer ever
+// appears, this prefilter is where it breaks.
+const listJobWorktreeRefsSQL = `SELECT id, state, updated_at, created_at, payload
+	FROM jobs WHERE payload LIKE '%worktree_path%'`
+
+// JobWorktreeRef is the minimum the reclaim guard needs about another job:
+// identity, finality, and age, plus the path itself.
 type JobWorktreeRef struct {
 	ID           string
 	State        string
@@ -2655,22 +2672,14 @@ type JobWorktreeRef struct {
 	WorktreePath string
 }
 
-// ListJobWorktreeRefs returns every job that records a worktree path, with the
-// path extracted in SQL and no payload read.
+// ListJobWorktreeRefs returns every job that records a non-empty worktree
+// path, decoded with the same rules the caller used to apply itself.
 //
-// WHY EVERY PATH-BEARING ROW RATHER THAN AN EXACT MATCH (#2149). An exact SQL
-// comparison would be a single indexed lookup, but the caller compares
-// filepath.Clean of both sides, so two spellings of one path must match. Every
-// worktree path stored on the profiled host is already clean - measured, 4,763
-// values with zero double slashes, trailing slashes, dot segments or untrimmed
-// values - but "clean today" is a property of the data, not of the schema, and
-// this guard exists to stop an aged row reclaiming a path a live owner still
-// holds. Getting that wrong reclaims someone's worktree, so the comparison
-// stays in Go where Clean applies and SQL only removes rows that can never
-// match: the 69% with no path at all.
-//
-// idx_jobs_worktree_path makes this query covering, so it reads the index and
-// never touches a payload.
+// #2149: the caller loaded every job and decoded every payload to read one
+// field - 15,320 decodes per call on the profiled host, 81% of the daemon's
+// CPU, to build a candidate set that was empty by construction. The decode
+// still happens, but only for rows that mention the key at all, and the
+// caller never sees a payload it might decode again.
 func (s *Store) ListJobWorktreeRefs(ctx context.Context) ([]JobWorktreeRef, error) {
 	rows, err := s.db.QueryContext(ctx, listJobWorktreeRefsSQL)
 	if err != nil {
@@ -2680,9 +2689,23 @@ func (s *Store) ListJobWorktreeRefs(ctx context.Context) ([]JobWorktreeRef, erro
 	var refs []JobWorktreeRef
 	for rows.Next() {
 		var ref JobWorktreeRef
-		if err := rows.Scan(&ref.ID, &ref.State, &ref.UpdatedAt, &ref.CreatedAt, &ref.WorktreePath); err != nil {
+		var payload string
+		if err := rows.Scan(&ref.ID, &ref.State, &ref.UpdatedAt, &ref.CreatedAt, &payload); err != nil {
 			return nil, err
 		}
+		// A payload that does not parse is SKIPPED, matching what the caller
+		// did with a ParseJobPayload error. Silence is correct here: an
+		// unparseable payload records no worktree path to protect.
+		var decoded struct {
+			WorktreePath string `json:"worktree_path"`
+		}
+		if err := json.Unmarshal([]byte(payload), &decoded); err != nil {
+			continue
+		}
+		if strings.TrimSpace(decoded.WorktreePath) == "" {
+			continue
+		}
+		ref.WorktreePath = decoded.WorktreePath
 		refs = append(refs, ref)
 	}
 	return refs, rows.Err()

--- a/internal/db/store_jobs.go
+++ b/internal/db/store_jobs.go
@@ -2629,3 +2629,61 @@ func annotateJobInsertConflict(jobID string, err error) error {
 	}
 	return fmt.Errorf("%w: %q was not written: %v", ErrJobIDConflict, jobID, err)
 }
+
+// listJobWorktreeRefsSQL is one const so the plan assertion tests the query
+// that actually runs. The expression MUST match idx_jobs_worktree_path
+// character for character, or SQLite silently falls back to a full scan that
+// re-parses every payload, which is exactly the cost #2149 removes. A silent
+// fallback is why the test asserts the PLAN and not a duration.
+const listJobWorktreeRefsSQL = `SELECT id, state, updated_at, created_at,
+	CASE WHEN json_valid(payload) THEN json_extract(payload, '$.worktree_path') END
+	FROM jobs
+	WHERE CASE WHEN json_valid(payload) THEN json_extract(payload, '$.worktree_path') END IS NOT NULL
+	  AND CASE WHEN json_valid(payload) THEN json_extract(payload, '$.worktree_path') END <> ''`
+
+// JobWorktreeRef is the minimum needed to answer "does another job still hold
+// this worktree path": identity, finality, and age. Deliberately NOT a Job.
+//
+// #2149: the caller used to take whole Jobs and decode every payload to read
+// one string. Returning a narrow row makes that impossible to reintroduce by
+// accident - there is no payload here to decode.
+type JobWorktreeRef struct {
+	ID           string
+	State        string
+	UpdatedAt    string
+	CreatedAt    string
+	WorktreePath string
+}
+
+// ListJobWorktreeRefs returns every job that records a worktree path, with the
+// path extracted in SQL and no payload read.
+//
+// WHY EVERY PATH-BEARING ROW RATHER THAN AN EXACT MATCH (#2149). An exact SQL
+// comparison would be a single indexed lookup, but the caller compares
+// filepath.Clean of both sides, so two spellings of one path must match. Every
+// worktree path stored on the profiled host is already clean - measured, 4,763
+// values with zero double slashes, trailing slashes, dot segments or untrimmed
+// values - but "clean today" is a property of the data, not of the schema, and
+// this guard exists to stop an aged row reclaiming a path a live owner still
+// holds. Getting that wrong reclaims someone's worktree, so the comparison
+// stays in Go where Clean applies and SQL only removes rows that can never
+// match: the 69% with no path at all.
+//
+// idx_jobs_worktree_path makes this query covering, so it reads the index and
+// never touches a payload.
+func (s *Store) ListJobWorktreeRefs(ctx context.Context) ([]JobWorktreeRef, error) {
+	rows, err := s.db.QueryContext(ctx, listJobWorktreeRefsSQL)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var refs []JobWorktreeRef
+	for rows.Next() {
+		var ref JobWorktreeRef
+		if err := rows.Scan(&ref.ID, &ref.State, &ref.UpdatedAt, &ref.CreatedAt, &ref.WorktreePath); err != nil {
+			return nil, err
+		}
+		refs = append(refs, ref)
+	}
+	return refs, rows.Err()
+}

--- a/internal/db/store_jobs_worktree_refs_test.go
+++ b/internal/db/store_jobs_worktree_refs_test.go
@@ -1,0 +1,89 @@
+package db
+
+import (
+	"context"
+	"testing"
+)
+
+// TestListJobWorktreeRefsReturnsOnlyPathBearingRows covers #2149's query.
+//
+// The reclaim guard used to load every job and decode every payload to read
+// one field. This returns the field itself, and only for rows that have one,
+// so the caller has nothing to decode.
+func TestListJobWorktreeRefsReturnsOnlyPathBearingRows(t *testing.T) {
+	store := openStoreOperationsTestStore(t)
+	ctx := context.Background()
+
+	insert := func(id, state, payload string) {
+		t.Helper()
+		if _, err := store.db.ExecContext(ctx,
+			`INSERT INTO jobs (id, agent, type, state, payload, created_at, updated_at)
+			 VALUES (?,?,?,?,?,?,?)`,
+			id, "a", "review", state, payload, "2026-09-01 00:00:00", "2026-09-02 00:00:00"); err != nil {
+			t.Fatal(err)
+		}
+	}
+	insert("has-path", "succeeded", `{"worktree_path":"/w/one","prompt":"x"}`)
+	insert("no-path", "succeeded", `{"prompt":"x"}`)
+	insert("empty-path", "succeeded", `{"worktree_path":"","prompt":"x"}`)
+	// A payload that is not JSON must be TOLERATED, not rejected. The Go code
+	// this replaces skipped such a row; an unguarded expression index would
+	// have failed this INSERT instead, turning a data oddity into a write
+	// outage. This insert is the regression test for that.
+	insert("not-json", "succeeded", `this is not json at all`)
+
+	refs, err := store.ListJobWorktreeRefs(ctx)
+	if err != nil {
+		t.Fatalf("ListJobWorktreeRefs: %v", err)
+	}
+	if len(refs) != 1 {
+		t.Fatalf("got %d refs, want 1: %+v", len(refs), refs)
+	}
+	got := refs[0]
+	if got.ID != "has-path" || got.WorktreePath != "/w/one" {
+		t.Errorf("ref = %+v, want has-path at /w/one", got)
+	}
+	if got.State != "succeeded" || got.UpdatedAt == "" || got.CreatedAt == "" {
+		t.Errorf("ref = %+v, want the finality and age fields the guard needs", got)
+	}
+}
+
+// TestListJobWorktreeRefsUsesTheCoveringIndex pins the property the fix is
+// for, not merely the result. Without the index this query re-parses every
+// payload in SQLite, which is the cost being removed; measured on live-shaped
+// data that difference was 53ms against 8.5ms, and it grows with the table.
+//
+// Asserting the PLAN rather than a duration, because a timing assertion on a
+// shared runner is a flake generator.
+func TestListJobWorktreeRefsUsesTheCoveringIndex(t *testing.T) {
+	store := openStoreOperationsTestStore(t)
+	ctx := context.Background()
+
+	var id, parent, notused int
+	var plan string
+	if err := store.db.QueryRowContext(ctx, "EXPLAIN QUERY PLAN "+listJobWorktreeRefsSQL).
+		Scan(&id, &parent, &notused, &plan); err != nil {
+		t.Fatalf("EXPLAIN QUERY PLAN: %v", err)
+	}
+	if plan == "" {
+		t.Fatal("empty query plan")
+	}
+	const want = "COVERING INDEX idx_jobs_worktree_path"
+	if !contains(plan, want) {
+		t.Errorf("plan = %q, want it to use %q. Without the covering index every row's payload is parsed again, which is the cost #2149 removes.", plan, want)
+	}
+}
+
+func contains(haystack, needle string) bool {
+	return len(haystack) >= len(needle) && (haystack == needle ||
+		len(needle) == 0 || indexOf(haystack, needle) >= 0)
+}
+
+func indexOf(haystack, needle string) int {
+	for i := 0; i+len(needle) <= len(haystack); i++ {
+		if haystack[i:i+len(needle)] == needle {
+			return i
+		}
+	}
+	return -1
+}

--- a/internal/db/store_jobs_worktree_refs_test.go
+++ b/internal/db/store_jobs_worktree_refs_test.go
@@ -5,85 +5,131 @@ import (
 	"testing"
 )
 
-// TestListJobWorktreeRefsReturnsOnlyPathBearingRows covers #2149's query.
-//
-// The reclaim guard used to load every job and decode every payload to read
-// one field. This returns the field itself, and only for rows that have one,
-// so the caller has nothing to decode.
-func TestListJobWorktreeRefsReturnsOnlyPathBearingRows(t *testing.T) {
-	store := openStoreOperationsTestStore(t)
-	ctx := context.Background()
-
-	insert := func(id, state, payload string) {
-		t.Helper()
-		if _, err := store.db.ExecContext(ctx,
-			`INSERT INTO jobs (id, agent, type, state, payload, created_at, updated_at)
-			 VALUES (?,?,?,?,?,?,?)`,
-			id, "a", "review", state, payload, "2026-09-01 00:00:00", "2026-09-02 00:00:00"); err != nil {
-			t.Fatal(err)
-		}
+func insertWorktreeRefJob(t *testing.T, store *Store, id, state, payload string) {
+	t.Helper()
+	if _, err := store.db.ExecContext(context.Background(),
+		`INSERT INTO jobs (id, agent, type, state, payload, created_at, updated_at)
+		 VALUES (?,?,?,?,?,?,?)`,
+		id, "a", "review", state, payload, "2026-09-01 00:00:00", "2026-09-02 00:00:00"); err != nil {
+		t.Fatalf("insert %s: %v", id, err)
 	}
-	insert("has-path", "succeeded", `{"worktree_path":"/w/one","prompt":"x"}`)
-	insert("no-path", "succeeded", `{"prompt":"x"}`)
-	insert("empty-path", "succeeded", `{"worktree_path":"","prompt":"x"}`)
-	// A payload that is not JSON must be TOLERATED, not rejected. The Go code
-	// this replaces skipped such a row; an unguarded expression index would
-	// have failed this INSERT instead, turning a data oddity into a write
-	// outage. This insert is the regression test for that.
-	insert("not-json", "succeeded", `this is not json at all`)
+}
 
-	refs, err := store.ListJobWorktreeRefs(ctx)
+func refsByID(t *testing.T, store *Store) map[string]JobWorktreeRef {
+	t.Helper()
+	refs, err := store.ListJobWorktreeRefs(context.Background())
 	if err != nil {
 		t.Fatalf("ListJobWorktreeRefs: %v", err)
 	}
-	if len(refs) != 1 {
-		t.Fatalf("got %d refs, want 1: %+v", len(refs), refs)
+	byID := make(map[string]JobWorktreeRef, len(refs))
+	for _, ref := range refs {
+		byID[ref.ID] = ref
 	}
-	got := refs[0]
-	if got.ID != "has-path" || got.WorktreePath != "/w/one" {
-		t.Errorf("ref = %+v, want has-path at /w/one", got)
-	}
-	if got.State != "succeeded" || got.UpdatedAt == "" || got.CreatedAt == "" {
-		t.Errorf("ref = %+v, want the finality and age fields the guard needs", got)
-	}
+	return byID
 }
 
-// TestListJobWorktreeRefsUsesTheCoveringIndex pins the property the fix is
-// for, not merely the result. Without the index this query re-parses every
-// payload in SQLite, which is the cost being removed; measured on live-shaped
-// data that difference was 53ms against 8.5ms, and it grows with the table.
+// TestListJobWorktreeRefsMatchesEncodingJSONNotJSONExtract is the regression
+// for #2149's review finding, and it is a SAFETY test rather than a
+// formatting one.
 //
-// Asserting the PLAN rather than a duration, because a timing assertion on a
-// shared runner is a flake generator.
-func TestListJobWorktreeRefsUsesTheCoveringIndex(t *testing.T) {
+// The first version of this query asked SQLite for the path with
+// json_extract. That is not encoding/json: json_extract returns the FIRST
+// duplicate key and is case-SENSITIVE, while encoding/json keeps the LAST
+// duplicate and matches field names case-insensitively. Both payloads below
+// are valid JSON, and both were dropped by the json_extract predicate while
+// the decoder the caller replaced would have seen them.
+//
+// A dropped row is a co-owner the reclaim guard cannot see. If it is still
+// running, its checkout is deleted underneath it.
+func TestListJobWorktreeRefsMatchesEncodingJSONNotJSONExtract(t *testing.T) {
 	store := openStoreOperationsTestStore(t)
-	ctx := context.Background()
 
-	var id, parent, notused int
-	var plan string
-	if err := store.db.QueryRowContext(ctx, "EXPLAIN QUERY PLAN "+listJobWorktreeRefsSQL).
-		Scan(&id, &parent, &notused, &plan); err != nil {
-		t.Fatalf("EXPLAIN QUERY PLAN: %v", err)
-	}
-	if plan == "" {
-		t.Fatal("empty query plan")
-	}
-	const want = "COVERING INDEX idx_jobs_worktree_path"
-	if !contains(plan, want) {
-		t.Errorf("plan = %q, want it to use %q. Without the covering index every row's payload is parsed again, which is the cost #2149 removes.", plan, want)
-	}
-}
+	// json_extract returns "" for this; encoding/json returns /live/dup.
+	insertWorktreeRefJob(t, store, "duplicate-key", "running",
+		`{"worktree_path":"","worktree_path":"/live/dup"}`)
+	// json_extract returns NULL for this; encoding/json returns /live/case.
+	insertWorktreeRefJob(t, store, "upper-case-key", "running",
+		`{"WORKTREE_PATH":"/live/case"}`)
+	insertWorktreeRefJob(t, store, "canonical", "succeeded",
+		`{"worktree_path":"/plain/one","prompt":"x"}`)
 
-func contains(haystack, needle string) bool {
-	return len(haystack) >= len(needle) && (haystack == needle ||
-		len(needle) == 0 || indexOf(haystack, needle) >= 0)
-}
-
-func indexOf(haystack, needle string) int {
-	for i := 0; i+len(needle) <= len(haystack); i++ {
-		if haystack[i:i+len(needle)] == needle {
-			return i
+	refs := refsByID(t, store)
+	for _, want := range []struct{ id, path string }{
+		{"duplicate-key", "/live/dup"},
+		{"upper-case-key", "/live/case"},
+		{"canonical", "/plain/one"},
+	} {
+		got, ok := refs[want.id]
+		if !ok {
+			t.Errorf("%s is missing: a co-owner invisible to the guard is a worktree deleted underneath a live job", want.id)
+			continue
+		}
+		if got.WorktreePath != want.path {
+			t.Errorf("%s path = %q, want %q (encoding/json semantics, not json_extract's)", want.id, got.WorktreePath, want.path)
 		}
 	}
-	return -1
+}
+
+// TestListJobWorktreeRefsSkipsRowsWithNoUsablePath keeps the query from
+// handing the guard rows it would only discard, and pins that an unparseable
+// payload is skipped rather than failing the call - which is what the caller
+// did with a ParseJobPayload error.
+func TestListJobWorktreeRefsSkipsRowsWithNoUsablePath(t *testing.T) {
+	store := openStoreOperationsTestStore(t)
+
+	insertWorktreeRefJob(t, store, "no-key", "succeeded", `{"prompt":"x"}`)
+	insertWorktreeRefJob(t, store, "empty-value", "succeeded", `{"worktree_path":""}`)
+	insertWorktreeRefJob(t, store, "blank-value", "succeeded", `{"worktree_path":"   "}`)
+	// Mentions the key but only inside a nested object, so the top-level field
+	// is empty. The text prefilter selects it; the decode must discard it.
+	insertWorktreeRefJob(t, store, "nested-only", "succeeded", `{"meta":{"worktree_path":"/nested"}}`)
+	// Not JSON, but it DOES mention the key, so the prefilter selects it and
+	// the decoder is the thing that must cope. The first version of this
+	// fixture omitted the key, so SQL dropped the row and the skip branch was
+	// never reached - its mutant survived, returning an error instead of
+	// skipping, without failing a single test.
+	insertWorktreeRefJob(t, store, "not-json", "succeeded", `{"worktree_path": "/truncated`)
+	insertWorktreeRefJob(t, store, "real", "running", `{"worktree_path":"/real"}`)
+
+	refs := refsByID(t, store)
+	if len(refs) != 1 {
+		t.Fatalf("got %d refs, want only the usable one: %+v", len(refs), refs)
+	}
+	got, ok := refs["real"]
+	if !ok {
+		t.Fatalf("the usable row is missing: %+v", refs)
+	}
+	if got.WorktreePath != "/real" || got.State != "running" {
+		t.Errorf("ref = %+v, want /real in state running", got)
+	}
+	if got.UpdatedAt == "" || got.CreatedAt == "" {
+		t.Errorf("ref = %+v, want the age fields the guard needs to compare against the cutoff", got)
+	}
+}
+
+// TestListJobWorktreeRefsPrefilterIsASuperset pins the property the whole
+// design rests on: SQL must never decide that a row has no path. It may only
+// drop rows that cannot mention one.
+//
+// Asserted by construction rather than by reading the plan: every row whose
+// payload contains the key in ANY case must survive the prefilter and reach
+// the decoder, and the decoder alone decides.
+func TestListJobWorktreeRefsPrefilterIsASuperset(t *testing.T) {
+	store := openStoreOperationsTestStore(t)
+
+	insertWorktreeRefJob(t, store, "mixed-case", "running", `{"WorkTree_Path":"/mixed"}`)
+	insertWorktreeRefJob(t, store, "trailing-ws", "running", `{"worktree_path":"/ws   "}`)
+	// A row with no mention of the key at all is the ONLY thing SQL may drop.
+	insertWorktreeRefJob(t, store, "unrelated", "running", `{"prompt":"nothing here"}`)
+
+	refs := refsByID(t, store)
+	if _, ok := refs["mixed-case"]; !ok {
+		t.Error("a mixed-case key was dropped before the decoder saw it")
+	}
+	if got := refs["trailing-ws"].WorktreePath; got != "/ws   " {
+		t.Errorf("path = %q, want the stored value verbatim: trimming belongs to the caller's comparison, not here", got)
+	}
+	if _, ok := refs["unrelated"]; ok {
+		t.Error("a row that never mentions the key was returned")
+	}
 }

--- a/internal/db/store_migrations.go
+++ b/internal/db/store_migrations.go
@@ -2783,5 +2783,38 @@ CREATE INDEX IF NOT EXISTS idx_routing_telemetry_fan_out ON routing_telemetry(ac
 	`
 ALTER TABLE job_events ADD COLUMN provider TEXT NOT NULL DEFAULT '';
 CREATE INDEX IF NOT EXISTS idx_job_events_provider ON job_events(job_id, id) WHERE provider != '';
+	// #2149: the worktree-path question, answered without reading payloads.
+	//
+	// ReclaimAgedTerminalDelegationWorktreeOutcome asked "does any other job
+	// hold this worktree path" by loading EVERY job row and JSON-decoding
+	// EVERY payload to read one field. On the host that produced the profile
+	// that was 15,320 decodes per call and 81% of the daemon's CPU, to build a
+	// candidate set that is empty by construction: 4,762 distinct paths with a
+	// maximum of ONE row per path.
+	//
+	// The extra columns make the index COVERING for that query, which is the
+	// whole point rather than a micro-optimisation: without them SQLite has
+	// the path but must still visit each row for state and the timestamps, and
+	// measured on live-shaped data that is 53ms against 8.5ms. With them the
+	// query never touches a payload at all.
+	//
+	// json_valid GUARDS THE EXPRESSION, and it is not defensive decoration: an
+	// expression index is evaluated ON WRITE, so a bare json_extract turns a
+	// payload that is not JSON into a failed INSERT. The Go code this replaces
+	// tolerated exactly that - ParseJobPayload returned an error and the row
+	// was skipped - so without the guard this index converts a tolerable data
+	// oddity into a write outage. Caught by a test that inserted a non-JSON
+	// payload, not by review: the live table has zero invalid payloads, so
+	// nothing on this host would have shown it.
+	//
+	// Expression index, not a generated column: no table rewrite on a 400MB
+	// database, and nothing outside SQLite needs to maintain it. It is a plain
+	// json_extract expression, so the sqlite3 CLI can still write this table -
+	// an index over a custom function would have made the database unusable by
+	// any tool that had not registered it.
+	`
+CREATE INDEX IF NOT EXISTS idx_jobs_worktree_path
+	ON jobs(CASE WHEN json_valid(payload) THEN json_extract(payload, '$.worktree_path') END,
+		state, updated_at, created_at, id);
 	`,
 }

--- a/internal/db/store_migrations.go
+++ b/internal/db/store_migrations.go
@@ -2783,38 +2783,5 @@ CREATE INDEX IF NOT EXISTS idx_routing_telemetry_fan_out ON routing_telemetry(ac
 	`
 ALTER TABLE job_events ADD COLUMN provider TEXT NOT NULL DEFAULT '';
 CREATE INDEX IF NOT EXISTS idx_job_events_provider ON job_events(job_id, id) WHERE provider != '';
-	// #2149: the worktree-path question, answered without reading payloads.
-	//
-	// ReclaimAgedTerminalDelegationWorktreeOutcome asked "does any other job
-	// hold this worktree path" by loading EVERY job row and JSON-decoding
-	// EVERY payload to read one field. On the host that produced the profile
-	// that was 15,320 decodes per call and 81% of the daemon's CPU, to build a
-	// candidate set that is empty by construction: 4,762 distinct paths with a
-	// maximum of ONE row per path.
-	//
-	// The extra columns make the index COVERING for that query, which is the
-	// whole point rather than a micro-optimisation: without them SQLite has
-	// the path but must still visit each row for state and the timestamps, and
-	// measured on live-shaped data that is 53ms against 8.5ms. With them the
-	// query never touches a payload at all.
-	//
-	// json_valid GUARDS THE EXPRESSION, and it is not defensive decoration: an
-	// expression index is evaluated ON WRITE, so a bare json_extract turns a
-	// payload that is not JSON into a failed INSERT. The Go code this replaces
-	// tolerated exactly that - ParseJobPayload returned an error and the row
-	// was skipped - so without the guard this index converts a tolerable data
-	// oddity into a write outage. Caught by a test that inserted a non-JSON
-	// payload, not by review: the live table has zero invalid payloads, so
-	// nothing on this host would have shown it.
-	//
-	// Expression index, not a generated column: no table rewrite on a 400MB
-	// database, and nothing outside SQLite needs to maintain it. It is a plain
-	// json_extract expression, so the sqlite3 CLI can still write this table -
-	// an index over a custom function would have made the database unusable by
-	// any tool that had not registered it.
-	`
-CREATE INDEX IF NOT EXISTS idx_jobs_worktree_path
-	ON jobs(CASE WHEN json_valid(payload) THEN json_extract(payload, '$.worktree_path') END,
-		state, updated_at, created_at, id);
 	`,
 }

--- a/internal/workflow/worktree.go
+++ b/internal/workflow/worktree.go
@@ -2364,16 +2364,30 @@ func (e Engine) ReclaimAgedTerminalDelegationWorktreeOutcome(ctx context.Context
 	}
 	// A deterministic path can appear in more than one historical row. Never let
 	// an aged row reclaim it out from under a newer or resumable owner.
-	jobs, err := e.Store.ListJobs(ctx)
+	//
+	// #2149: THIS LOOP WAS 81% OF THE DAEMON'S CPU. It read every job row and
+	// JSON-decoded every payload to compare one field. On the profiled host
+	// that was 15,320 decodes per call, and the candidate set it was building
+	// was empty by construction: 4,762 distinct worktree paths, at most one
+	// row each. Now SQL drops the 69% of rows that record no path at all and
+	// returns the path itself, so no payload is decoded here.
+	//
+	// The COMPARISON DID NOT MOVE. filepath.Clean still decides, in Go, over
+	// every row that has a path, because two spellings of one path must match
+	// and this guard is what stops an aged row reclaiming a live owner's
+	// worktree. Pushing the equality into SQL would have been a single indexed
+	// lookup and measurably faster still; it is not done because SQL cannot
+	// apply Clean, and being wrong here destroys work rather than slowing it.
+	refs, err := e.Store.ListJobWorktreeRefs(ctx)
 	if err != nil {
 		return false, err
 	}
-	for _, other := range jobs {
+	want := filepath.Clean(strings.TrimSpace(payload.WorktreePath))
+	for _, other := range refs {
 		if other.ID == job.ID {
 			continue
 		}
-		otherPayload, err := ParseJobPayload(other.Payload)
-		if err != nil || filepath.Clean(strings.TrimSpace(otherPayload.WorktreePath)) != filepath.Clean(strings.TrimSpace(payload.WorktreePath)) {
+		if filepath.Clean(strings.TrimSpace(other.WorktreePath)) != want {
 			continue
 		}
 		if !IsFinalJobState(other.State) {

--- a/internal/workflow/worktree.go
+++ b/internal/workflow/worktree.go
@@ -2362,6 +2362,14 @@ func (e Engine) ReclaimAgedTerminalDelegationWorktreeOutcome(ctx context.Context
 	if !readOnly && !implement && !fix {
 		return false, nil
 	}
+	path := strings.TrimSpace(payload.WorktreePath)
+	want := filepath.Clean(path)
+	if want == "." {
+		// Empty and degenerate relative spellings are not worktree resources.
+		// Candidate discovery is deliberately a text prefilter, so keep this
+		// filepath-aware rejection at the actuation boundary and skip quietly.
+		return false, nil
+	}
 	// A deterministic path can appear in more than one historical row. Never let
 	// an aged row reclaim it out from under a newer or resumable owner.
 	//
@@ -2382,7 +2390,7 @@ func (e Engine) ReclaimAgedTerminalDelegationWorktreeOutcome(ctx context.Context
 	if err != nil {
 		return false, err
 	}
-	want := filepath.Clean(strings.TrimSpace(payload.WorktreePath))
+
 	for _, other := range refs {
 		if other.ID == job.ID {
 			continue
@@ -2401,7 +2409,6 @@ func (e Engine) ReclaimAgedTerminalDelegationWorktreeOutcome(ctx context.Context
 			return false, nil
 		}
 	}
-	path := strings.TrimSpace(payload.WorktreePath)
 	actuate, err := e.prepareDelegationCleanupObligation(ctx, jobID, job.Type, payload)
 	if err != nil {
 		return false, err

--- a/internal/workflow/worktree_test.go
+++ b/internal/workflow/worktree_test.go
@@ -3065,6 +3065,21 @@ func seedWorktreeOwner(t *testing.T, store *db.Store, jobID, state, worktreePath
 	}
 }
 
+func TestEngineReclaimSkipsDegenerateWorktreePath(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	seedWorktreeOwner(t, store, "fix-degenerate", string(JobSucceeded), ".")
+
+	reclaimed, err := testEngine(store).ReclaimAgedTerminalDelegationWorktreeOutcome(
+		ctx, "fix-degenerate", time.Now().Add(time.Hour))
+	if err != nil {
+		t.Fatalf("degenerate candidate returned an operational error: %v", err)
+	}
+	if reclaimed {
+		t.Fatal("degenerate candidate reported a reclaimed worktree")
+	}
+}
+
 // TestEngineReclaimRefusesWhenAnotherJobStillHoldsThePath is the guard's whole
 // purpose, and it was UNTESTED: a mutant that ignored a non-final co-owner
 // survived the suite.

--- a/internal/workflow/worktree_test.go
+++ b/internal/workflow/worktree_test.go
@@ -3040,3 +3040,116 @@ func gitPackVerifierForTest(t *testing.T) packIndexVerifier {
 	client := gitutil.NewHostClient(t.TempDir())
 	return client.VerifyPackIndex
 }
+
+// seedWorktreeOwner creates a job that records worktreePath, used to build the
+// "another row holds this path" situation the reclaim guard exists for.
+func seedWorktreeOwner(t *testing.T, store *db.Store, jobID, state, worktreePath string) {
+	t.Helper()
+	payload, err := marshalPayload(JobPayload{
+		Repo:         "owner/repo",
+		WorktreePath: worktreePath,
+		FixWorktree:  true,
+	})
+	if err != nil {
+		t.Fatalf("marshalPayload: %v", err)
+	}
+	if err := store.CreateJobWithEvent(context.Background(), db.Job{
+		ID:      jobID,
+		Agent:   "fixer",
+		Type:    "implement",
+		State:   state,
+		Repo:    "owner/repo",
+		Payload: payload,
+	}, db.JobEvent{Kind: state, Message: "seed"}); err != nil {
+		t.Fatalf("CreateJobWithEvent(%s): %v", jobID, err)
+	}
+}
+
+// TestEngineReclaimRefusesWhenAnotherJobStillHoldsThePath is the guard's whole
+// purpose, and it was UNTESTED: a mutant that ignored a non-final co-owner
+// survived the suite.
+//
+// A deterministic worktree path recurs across historical rows. If an aged
+// terminal row reclaims a path a live job still holds, it deletes a running
+// job's checkout. #2149 changed how the co-owners are FOUND - the payloads are
+// no longer decoded - so the property has to be pinned before that change can
+// be trusted, not after.
+func TestEngineReclaimRefusesWhenAnotherJobStillHoldsThePath(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	home := t.TempDir()
+	const agedID = "fix-aged"
+	path, err := FixWorktreePath(home, "owner/repo", agedID)
+	if err != nil {
+		t.Fatalf("FixWorktreePath: %v", err)
+	}
+	if err := os.MkdirAll(path, 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	seedWorktreeOwner(t, store, agedID, string(JobSucceeded), path)
+	// The co-owner is RUNNING, so the aged row must not touch the path.
+	seedWorktreeOwner(t, store, "fix-live-owner", string(JobRunning), path)
+
+	engine := testEngine(store)
+	engine.Home = home
+	engine.WorktreeHasLiveProcess = nil
+	engine.WorktreeLiveness = func(string) (bool, bool) { return false, true }
+
+	reclaimed, err := engine.ReclaimAgedTerminalDelegationWorktreeOutcome(ctx, agedID, time.Now().Add(time.Hour))
+	if err != nil {
+		t.Fatalf("ReclaimAgedTerminalDelegationWorktreeOutcome: %v", err)
+	}
+	if reclaimed {
+		t.Fatal("reclaimed a worktree path another job is still running on")
+	}
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("worktree of a live co-owner was removed: %v", err)
+	}
+}
+
+// TestEngineReclaimMatchesCoOwnersByCleanedPath pins the reason the comparison
+// stays in Go rather than becoming an indexed SQL equality (#2149).
+//
+// Two spellings of one path are the same path. SQL equality would treat them
+// as different and reclaim a live owner's worktree, so the extra rows returned
+// by the query exist precisely so filepath.Clean can decide here.
+func TestEngineReclaimMatchesCoOwnersByCleanedPath(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	home := t.TempDir()
+	const agedID = "fix-aged-clean"
+	path, err := FixWorktreePath(home, "owner/repo", agedID)
+	if err != nil {
+		t.Fatalf("FixWorktreePath: %v", err)
+	}
+	if err := os.MkdirAll(path, 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	seedWorktreeOwner(t, store, agedID, string(JobSucceeded), path)
+	// Same path, different spelling. Textually unequal, semantically identical.
+	//
+	// Built by CONCATENATION on purpose: filepath.Join cleans its own result,
+	// so a fixture using it stores the identical string and proves nothing.
+	// The first version of this test did exactly that and its mutant survived.
+	unclean := path + "/sub/.."
+	if filepath.Clean(unclean) != path {
+		t.Fatalf("fixture is not an alternate spelling: Clean(%q) = %q, want %q", unclean, filepath.Clean(unclean), path)
+	}
+	if unclean == path {
+		t.Fatal("fixture spelling is identical, so this test cannot observe the defect")
+	}
+	seedWorktreeOwner(t, store, "fix-live-unclean", string(JobRunning), unclean)
+
+	engine := testEngine(store)
+	engine.Home = home
+	engine.WorktreeHasLiveProcess = nil
+	engine.WorktreeLiveness = func(string) (bool, bool) { return false, true }
+
+	reclaimed, err := engine.ReclaimAgedTerminalDelegationWorktreeOutcome(ctx, agedID, time.Now().Add(time.Hour))
+	if err != nil {
+		t.Fatalf("ReclaimAgedTerminalDelegationWorktreeOutcome: %v", err)
+	}
+	if reclaimed {
+		t.Fatal("a co-owner spelled differently was not recognised, and its worktree was reclaimed")
+	}
+}


### PR DESCRIPTION
Fixes #2149.

## Profile attribution

The original issue attributed 81% of daemon CPU to `unmarshalPayload` via `db.scanJobs`. The profile supports the first half, not the second:

```
unmarshalPayload                                     13.42s  81.28%
  <- ParseJobPayload                                 12.02s  89.57% of it
    <- ReclaimAgedTerminalDelegationWorktreeOutcome  11.88s  98.84% of that
  <- Engine.mergeGateReviewRequired                   1.40s
db.scanJobs cumulative                               1.61s   9.75%
```

`ReclaimAgedTerminalDelegationWorktreeOutcome` alone accounts for 72.80% of the profile. It listed every job and decoded every payload to compare one field.

Live-store shape at investigation time:

| measure | value |
|---|---:|
| jobs | 15,320 |
| rows with `worktree_path` | 4,762 |
| rows that can never match | 10,558 (69%) |
| distinct stored paths | 4,762 |
| maximum rows sharing a path | 1 |

## Change

`db.ListJobWorktreeRefs` applies a conservative SQL prefilter:

```sql
WHERE payload LIKE '%worktree_path%'
```

It then decodes each surviving payload with Go's standard `encoding/json` semantics into a minimal struct and returns the raw stored path plus the state and timestamps required by the reclamation guard. The workflow layer still trims and `filepath.Clean`s both paths before comparing them.

The prefilter is deliberately a superset for payloads written by this repository:

- SQLite `LIKE` is ASCII case-insensitive, so it retains mixed-case keys that `encoding/json` accepts.
- Duplicate keys are resolved by `encoding/json`, not SQLite JSON functions.
- Malformed matching payloads are skipped, preserving prior behavior.
- Repository writers use `encoding/json`, which does not escape ASCII object-key letters. A manually stored key such as `"\\u0077orktree_path"` would evade the prefilter; the live store contained zero such rows.

No JSON expression index or migration remains.

## Safety correction after review

The first implementation used `json_extract` and reported a 16.4x benchmark. Independent review found that unsafe: Go keeps the later duplicate key and matches field names case-insensitively, while SQLite `json_extract` takes the first exact-case key. That could hide a live co-owner and let reclamation remove its worktree.

This revision removes that implementation completely. The 16.4x result is retracted because it measured the unsafe query.

The safe `LIKE` plus Go decode path measured on a live-shaped 15,320-row fixture:

| implementation | time | payload decodes |
|---|---:|---:|
| prior full scan | ~170 ms | 15,320 |
| safe prefilter | ~82 ms | 4,762 |

That is about **2.1x faster** for the measured shape. The main win is eliminating 10,558 irrelevant decodes while preserving Go JSON and path comparison semantics.

## Regression coverage

Tests cover:

- later duplicate `worktree_path` keys;
- case-insensitive JSON field names;
- malformed payloads that pass the prefilter;
- blank, missing, and nested keys;
- raw path preservation;
- a non-final live co-owner blocking reclaim;
- distinct path spellings that normalize to the same path.

Mutation checks killed reintroducing `json_extract`, changing to case-sensitive `GLOB`, treating malformed candidates as fatal, returning blank paths, trimming in the store layer, ignoring non-final co-owners, and removing path cleaning.

## Verification

- `go build -buildvcs=false ./...`
- `go vet ./...`
- `go test ./internal/db` — 243.154s
- `go test ./internal/workflow` — 138.313s
- `go test ./internal/cli` — 1174.304s

## Deployment

The before profile is `/tmp/cpu_after.pprof` from build `dev-a76d3330`. Deployment and a production re-profile will follow only after exact-head approval and merge, under the owner's recorded authorization.
