### PR TITLE
fix(cli): give omp a read-only seat policy that stages no credential (#1817)

### DIFF
--- a/internal/cli/daemon_worker.go
+++ b/internal/cli/daemon_worker.go
@@ -1657,8 +1657,16 @@ func wrapReadOnlyAdapterRunner(runtimeName string, adapter workflow.DeliveryAdap
 	case *runtime.KimiAdapter:
 		a.Runner = wrap(a.Runner)
 		return a, nil
-	case runtime.OmpAdapter, *runtime.OmpAdapter:
-		return nil, errors.New("read-only seats cannot use omp without an isolated credential broker")
+	case runtime.OmpAdapter:
+		// #1817: omp was the only runtime refused here. The sandbox wrap is the
+		// same for it as for its siblings; what omp needed was a state policy
+		// that stages NO credential and a broker-mode precondition, which
+		// readOnlyOmpSeatStatePolicy now enforces before a seat is built.
+		a.Runner = wrap(a.Runner)
+		return a, nil
+	case *runtime.OmpAdapter:
+		a.Runner = wrap(a.Runner)
+		return a, nil
 	case runtime.ShellAdapter:
 		a.Runner = wrap(a.Runner)
 		return a, nil
@@ -2211,7 +2219,15 @@ func readOnlySeatStatePolicyForRuntime(runtimeName string, userHome string, gate
 	case runtime.ShellRuntime:
 		return readOnlySeatStatePolicy{}, false, nil
 	case runtime.OmpRuntime:
-		return readOnlySeatStatePolicy{}, false, errors.New("read-only seats cannot use omp without an isolated credential broker")
+		// #1817. The refusal that used to live here named a broker as the missing
+		// prerequisite; readOnlyOmpSeatStatePolicy requires exactly that and
+		// stages no credential, so a read-only omp seat is now possible and an
+		// unconfigured one still refuses - with a remedy in the message.
+		policy, err := readOnlyOmpSeatStatePolicy(userHome, ompBrokerEnvLookup)
+		if err != nil {
+			return readOnlySeatStatePolicy{}, false, err
+		}
+		return policy, true, nil
 	default:
 		return readOnlySeatStatePolicy{}, false, fmt.Errorf("read-only seat runtime %q has no isolated state policy", runtimeName)
 	}
@@ -2576,6 +2592,19 @@ func readOnlyRuntimeBaseEnv(runtimeName string, environ []string, githubDir stri
 		allowed["CLAUDE_CONFIG_DIR"] = struct{}{}
 	case runtime.CodexRuntime:
 		allowed["CODEX_HOME"] = struct{}{}
+	case runtime.OmpRuntime:
+		// #1817: omp authenticates through its broker, and the pair is what a
+		// read-only seat is allowed to carry INSTEAD of a credential. This is
+		// the per-runtime env site the policy comment names, so the broker
+		// bearer reaches the seat the same way CLAUDE_CONFIG_DIR does, and the
+		// claude runtime-auth overlay stays claude-only by policy.
+		//
+		// The pair passes through from the daemon environment rather than being
+		// synthesised here: the operator exports it once, readOnlyOmpSeatStatePolicy
+		// refuses the dispatch when it is absent, and nothing in the seat's env
+		// carries a provider key.
+		allowed[ompAuthBrokerURLEnv] = struct{}{}
+		allowed[ompAuthBrokerTokenEnv] = struct{}{}
 	}
 	base := make([]string, 0, len(environ)+2)
 	for _, entry := range environ {

--- a/internal/cli/readonly_seat_omp.go
+++ b/internal/cli/readonly_seat_omp.go
@@ -1,0 +1,112 @@
+package cli
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// The omp read-only seat path (#1817).
+//
+// omp was the ONLY runtime with no read-only seat state policy: both
+// wrapReadOnlyAdapterRunner and readOnlySeatStatePolicyForRuntime refused it
+// outright with "read-only seats cannot use omp without an isolated credential
+// broker", so a registered read-only omp reviewer failed in ~12 seconds with an
+// effective_runtime event and no provider contact. Measured on this host: the
+// same two models answered a direct omp probe from /tmp, which locates the
+// boundary in this wrapper rather than in auth.
+//
+// THE REFUSAL NAMED THE REMEDY AND THE REMEDY EXISTS. omp resolves auth through
+// a BROKER when OMP_AUTH_BROKER_URL and OMP_AUTH_BROKER_TOKEN are both set:
+// its own documentation states that in broker mode "the local SQLite credential
+// store is bypassed and all OAuth refresh / access tokens live on the broker
+// host". That is the isolation this seat needs, and it is the one credentials.go
+// already documents as "how a fleet supplies omp auth without scattering raw
+// keys".
+//
+// So the policy below withholds rather than stages:
+//
+//   - NO credentialFile, NO requiredInputs, NO optionalInputs. prepareReadOnlyRuntimeState
+//     creates the state dir empty and copies ONLY the files a policy lists, so
+//     an empty list means the host's ~/.omp - which holds omp's local credential
+//     store - is never read into the seat. The seat gets a fresh profile.
+//   - stateAtCacheRoot with relativeState home/.omp, because omp finds its
+//     profile under HOME and the sandbox supplies HOME=cacheRoot/home. Same
+//     mechanism kimi uses, for the same reason.
+//   - broker mode is REQUIRED, not preferred. Without it omp would fall back to
+//     the local store, find the seat's fresh empty profile, and fail on auth -
+//     or, worse, a future change staging that store would hand a read-only seat
+//     the owner's provider credentials. Refusing here keeps that from being one
+//     forgotten line away.
+//
+// The pair is INDIVISIBLE and the refusal says which half is missing: omp throws
+// when the URL is set with no token, so a half-configured broker converts into
+// an opaque runtime failure rather than a dispatch-time diagnosis.
+const (
+	ompAuthBrokerURLEnv   = "OMP_AUTH_BROKER_URL"
+	ompAuthBrokerTokenEnv = "OMP_AUTH_BROKER_TOKEN"
+)
+
+// ompBrokerEnvLookup is the seam a test replaces. Production reads the daemon's
+// environment, which is where an operator exports the broker pair.
+var ompBrokerEnvLookup = os.LookupEnv
+
+// readOnlyOmpBrokerEnv returns the broker environment a read-only omp seat needs,
+// or an error naming exactly what is missing.
+//
+// The returned slice is an OVERLAY, not the seat's whole environment: a
+// read-only seat builds its env from a curated allowlist, so the broker pair
+// does not arrive by inheritance and has to be handed over explicitly.
+//
+// What the seat receives is a BROKER BEARER, not a provider credential. That is
+// the whole point of the path: the owner's OAuth refresh tokens stay on the
+// broker host, and the seat holds a token that can be rotated with
+// `omp auth-broker token --regenerate` without touching them.
+func readOnlyOmpBrokerEnv(lookup func(string) (string, bool)) ([]string, error) {
+	if lookup == nil {
+		lookup = ompBrokerEnvLookup
+	}
+	url, _ := lookup(ompAuthBrokerURLEnv)
+	token, _ := lookup(ompAuthBrokerTokenEnv)
+	url = strings.TrimSpace(url)
+	token = strings.TrimSpace(token)
+	switch {
+	case url == "" && token == "":
+		return nil, fmt.Errorf(
+			"read-only seats need omp in broker mode: export %s and %s for the daemon so the seat authenticates through the broker instead of the owner's local credential store",
+			ompAuthBrokerURLEnv, ompAuthBrokerTokenEnv)
+	case url == "":
+		return nil, fmt.Errorf("read-only omp seat has %s but no %s; omp resolves broker mode from the pair", ompAuthBrokerTokenEnv, ompAuthBrokerURLEnv)
+	case token == "":
+		return nil, fmt.Errorf("read-only omp seat has %s but no %s; omp throws when the URL is set and no token is available", ompAuthBrokerURLEnv, ompAuthBrokerTokenEnv)
+	}
+	return []string{
+		ompAuthBrokerURLEnv + "=" + url,
+		ompAuthBrokerTokenEnv + "=" + token,
+	}, nil
+}
+
+// readOnlyOmpSeatStatePolicy is omp's arm of readOnlySeatStatePolicyForRuntime.
+//
+// It returns an error rather than a policy when broker mode is absent, so the
+// refusal happens at dispatch with a remedy in its text instead of as an auth
+// failure after the seat has been built.
+func readOnlyOmpSeatStatePolicy(userHome string, lookup func(string) (string, bool)) (readOnlySeatStatePolicy, error) {
+	if _, err := readOnlyOmpBrokerEnv(lookup); err != nil {
+		return readOnlySeatStatePolicy{}, err
+	}
+	return readOnlySeatStatePolicy{
+		// Resolved but never copied FROM: with no credential file and no inputs,
+		// nothing under this directory is staged. It is set because
+		// prepareReadOnlyRuntimeState resolves the source dir before deciding
+		// what to stage, and an agent may override it with RuntimeConfigDir.
+		defaultSourceDir: filepath.Join(userHome, ".omp"),
+		// omp reads its profile from HOME, so the staged dir has to BE the
+		// seat's HOME/.omp rather than sit under runtime-state.
+		stateAtCacheRoot: true,
+		relativeState:    filepath.Join("home", ".omp"),
+		// Deliberately empty: credentialFile, requiredInputs, optionalInputs.
+		// The broker supplies auth; the seat starts from an empty profile.
+	}, nil
+}

--- a/internal/cli/readonly_seat_omp_test.go
+++ b/internal/cli/readonly_seat_omp_test.go
@@ -1,0 +1,158 @@
+package cli
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/gitmoot/gitmoot/internal/runtime"
+)
+
+func ompBrokerLookup(pairs map[string]string) func(string) (string, bool) {
+	return func(name string) (string, bool) {
+		value, ok := pairs[name]
+		return value, ok
+	}
+}
+
+// TestReadOnlyOmpSeatStagesNoCredentialMaterial is the property the old refusal
+// was standing in for (#1817): a read-only omp seat must not be able to read the
+// owner's omp credential store.
+//
+// prepareReadOnlyRuntimeState copies ONLY the files a policy names -
+// credentialFile, requiredInputs, optionalInputs - into a state dir it creates
+// empty. So the discriminating assertion is that all three are empty, which is
+// what makes the staged profile fresh rather than a copy of ~/.omp.
+//
+// A test that only checked "a policy is returned" would pass with a
+// credentialFile added, which is the one mistake that would hand a read-only
+// reviewer the owner's provider tokens.
+func TestReadOnlyOmpSeatStagesNoCredentialMaterial(t *testing.T) {
+	policy, err := readOnlyOmpSeatStatePolicy("/home/owner", ompBrokerLookup(map[string]string{
+		ompAuthBrokerURLEnv:   "http://127.0.0.1:8765",
+		ompAuthBrokerTokenEnv: "broker-bearer",
+	}))
+	if err != nil {
+		t.Fatalf("broker-configured omp seat refused: %v", err)
+	}
+	if policy.credentialFile != "" {
+		t.Errorf("omp seat policy stages credential file %q; a read-only seat must receive no credential material", policy.credentialFile)
+	}
+	if len(policy.requiredInputs) != 0 {
+		t.Errorf("omp seat policy stages required inputs %v; nothing from the owner's ~/.omp may be copied", policy.requiredInputs)
+	}
+	if len(policy.optionalInputs) != 0 {
+		t.Errorf("omp seat policy stages optional inputs %v; nothing from the owner's ~/.omp may be copied", policy.optionalInputs)
+	}
+	// omp finds its profile under HOME, and the sandbox supplies
+	// HOME=cacheRoot/home. Staging anywhere else leaves omp reading the host
+	// profile instead of the seat's.
+	if !policy.stateAtCacheRoot {
+		t.Error("omp seat policy must stage at the cache root: omp resolves its profile from the sandbox HOME")
+	}
+	if want := filepath.Join("home", ".omp"); policy.relativeState != want {
+		t.Errorf("omp seat state = %q, want %q", policy.relativeState, want)
+	}
+}
+
+// TestReadOnlyOmpSeatRefusesWithoutBrokerMode pins the fail-closed half. Without
+// the broker, omp falls back to its local store, and the seat's fresh profile is
+// empty - so the alternative to refusing is an opaque auth failure after the
+// seat is built, or a future change that stages the owner's store to "fix" it.
+func TestReadOnlyOmpSeatRefusesWithoutBrokerMode(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		pairs map[string]string
+		want  string
+	}{
+		{
+			name:  "neither",
+			pairs: map[string]string{},
+			want:  "broker mode",
+		},
+		{
+			name:  "token only",
+			pairs: map[string]string{ompAuthBrokerTokenEnv: "broker-bearer"},
+			want:  ompAuthBrokerURLEnv,
+		},
+		{
+			name:  "url only",
+			pairs: map[string]string{ompAuthBrokerURLEnv: "http://127.0.0.1:8765"},
+			want:  ompAuthBrokerTokenEnv,
+		},
+		{
+			name:  "blank values are not configuration",
+			pairs: map[string]string{ompAuthBrokerURLEnv: "   ", ompAuthBrokerTokenEnv: ""},
+			want:  "broker mode",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := readOnlyOmpSeatStatePolicy("/home/owner", ompBrokerLookup(tc.pairs))
+			if err == nil {
+				t.Fatalf("omp seat accepted %v; broker mode is required", tc.pairs)
+			}
+			if !strings.Contains(err.Error(), tc.want) {
+				t.Errorf("refusal %q does not name %q; the message has to say which half is missing", err.Error(), tc.want)
+			}
+		})
+	}
+}
+
+// TestReadOnlyOmpSeatOverlayCarriesOnlyTheBrokerPair checks what the seat's
+// environment receives. A read-only seat builds its env from a curated
+// allowlist, so the pair arrives only if handed over - and NOTHING else should
+// be, because any provider key in that overlay is the owner's credential
+// reaching the seat.
+func TestReadOnlyOmpSeatOverlayCarriesOnlyTheBrokerPair(t *testing.T) {
+	overlay, err := readOnlyOmpBrokerEnv(ompBrokerLookup(map[string]string{
+		ompAuthBrokerURLEnv:   "http://127.0.0.1:8765",
+		ompAuthBrokerTokenEnv: "broker-bearer",
+		"ANTHROPIC_API_KEY":   "sk-owner-key",
+		"OPENAI_API_KEY":      "sk-owner-openai",
+	}))
+	if err != nil {
+		t.Fatalf("broker env: %v", err)
+	}
+	if len(overlay) != 2 {
+		t.Fatalf("overlay = %v, want exactly the two broker variables", overlay)
+	}
+	joined := strings.Join(overlay, " ")
+	for _, forbidden := range []string{"ANTHROPIC_API_KEY", "OPENAI_API_KEY", "sk-owner"} {
+		if strings.Contains(joined, forbidden) {
+			t.Errorf("overlay leaks %q: %v", forbidden, overlay)
+		}
+	}
+	if !strings.Contains(joined, ompAuthBrokerURLEnv+"=http://127.0.0.1:8765") {
+		t.Errorf("overlay does not carry the broker url: %v", overlay)
+	}
+	if !strings.Contains(joined, ompAuthBrokerTokenEnv+"=broker-bearer") {
+		t.Errorf("overlay does not carry the broker token: %v", overlay)
+	}
+}
+
+// TestReadOnlySeatPolicyForOmpIsReachable drives the production entry point
+// rather than the helper, because the defect was that this switch refused omp
+// before any policy existed. The arm is what dispatch consults.
+func TestReadOnlySeatPolicyForOmpIsReachable(t *testing.T) {
+	restore := ompBrokerEnvLookup
+	t.Cleanup(func() { ompBrokerEnvLookup = restore })
+	ompBrokerEnvLookup = ompBrokerLookup(map[string]string{
+		ompAuthBrokerURLEnv:   "http://127.0.0.1:8765",
+		ompAuthBrokerTokenEnv: "broker-bearer",
+	})
+	policy, needsState, err := readOnlySeatStatePolicyForRuntime(runtime.OmpRuntime, "/home/owner", false)
+	if err != nil {
+		t.Fatalf("readOnlySeatStatePolicyForRuntime(omp) = %v; omp must resolve a policy in broker mode", err)
+	}
+	if !needsState {
+		t.Fatal("omp must need isolated state: without it the seat reads the host profile")
+	}
+	if policy.credentialFile != "" {
+		t.Errorf("production arm stages credential file %q", policy.credentialFile)
+	}
+
+	ompBrokerEnvLookup = ompBrokerLookup(map[string]string{})
+	if _, _, err := readOnlySeatStatePolicyForRuntime(runtime.OmpRuntime, "/home/owner", false); err == nil {
+		t.Fatal("production arm accepted omp with no broker configured")
+	}
+}

--- a/internal/cli/readonly_seat_omp_test.go
+++ b/internal/cli/readonly_seat_omp_test.go
@@ -156,3 +156,61 @@ func TestReadOnlySeatPolicyForOmpIsReachable(t *testing.T) {
 		t.Fatal("production arm accepted omp with no broker configured")
 	}
 }
+
+// TestReadOnlySeatBaseEnvCarriesTheBrokerPairForOmpOnly drives the function the
+// production seat env is actually built from - readOnlyRuntimeBaseEnv, called at
+// daemon_worker.go:1594 and job_blocker_auth_probe.go:239 with os.Environ().
+//
+// This is the arm a review asked for, and it is the one that would catch the
+// mistake I made first: wiring the pair into readOnlySeatRuntimeAuthEnv, whose
+// outer function returns nil for every non-claude runtime, so the overlay would
+// never have reached the seat. Asserting the POLICY is returned proves nothing
+// about the environment the child process gets.
+//
+// Three properties, and the third is the safety one: the curated allowlist must
+// pass the broker pair for omp, must NOT pass it for another runtime, and must
+// drop provider keys for both.
+func TestReadOnlySeatBaseEnvCarriesTheBrokerPairForOmpOnly(t *testing.T) {
+	environ := []string{
+		"PATH=/usr/bin",
+		"HOME=/home/seat",
+		ompAuthBrokerURLEnv + "=http://127.0.0.1:8765",
+		ompAuthBrokerTokenEnv + "=broker-bearer",
+		"ANTHROPIC_API_KEY=sk-owner-key",
+		"OPENAI_API_KEY=sk-owner-openai",
+	}
+	has := func(entries []string, want string) bool {
+		for _, entry := range entries {
+			if entry == want {
+				return true
+			}
+		}
+		return false
+	}
+
+	ompEnv := readOnlyRuntimeBaseEnv(runtime.OmpRuntime, environ, "/seat/gh")
+	if !has(ompEnv, ompAuthBrokerURLEnv+"=http://127.0.0.1:8765") {
+		t.Errorf("omp seat env lost %s: %v", ompAuthBrokerURLEnv, ompEnv)
+	}
+	if !has(ompEnv, ompAuthBrokerTokenEnv+"=broker-bearer") {
+		t.Errorf("omp seat env lost %s: %v", ompAuthBrokerTokenEnv, ompEnv)
+	}
+
+	// A different runtime must not inherit omp's broker bearer. The allowlist is
+	// per-runtime for exactly this reason.
+	kimiEnv := readOnlyRuntimeBaseEnv(runtime.KimiRuntime, environ, "/seat/gh")
+	if has(kimiEnv, ompAuthBrokerTokenEnv+"=broker-bearer") {
+		t.Errorf("kimi seat env inherited omp's broker token: %v", kimiEnv)
+	}
+
+	// Neither seat may receive a provider key, which is the material the broker
+	// exists to keep off the seat.
+	for name, env := range map[string][]string{"omp": ompEnv, "kimi": kimiEnv} {
+		joined := strings.Join(env, " ")
+		for _, forbidden := range []string{"ANTHROPIC_API_KEY", "OPENAI_API_KEY", "sk-owner"} {
+			if strings.Contains(joined, forbidden) {
+				t.Errorf("%s seat env leaks %q: %v", name, forbidden, env)
+			}
+		}
+	}
+}

--- a/internal/cli/readonly_seat_session_test.go
+++ b/internal/cli/readonly_seat_session_test.go
@@ -177,13 +177,25 @@ func TestQueuedJobRuntimeResourceKeyReadOnlySeat(t *testing.T) {
 // a policy fails here rather than at dispatch.
 func TestReadOnlySeatStatePolicyCoversEveryRegisteredRuntime(t *testing.T) {
 	userHome := t.TempDir()
+	restore := ompBrokerEnvLookup
+	t.Cleanup(func() { ompBrokerEnvLookup = restore })
+	ompBrokerEnvLookup = ompBrokerLookup(map[string]string{
+		ompAuthBrokerURLEnv:   "http://127.0.0.1:8765",
+		ompAuthBrokerTokenEnv: "broker-bearer",
+	})
 	for _, name := range runtime.SupportedRuntimes() {
 		t.Run(name, func(t *testing.T) {
 			policy, needsState, err := readOnlySeatStatePolicyFor(name, userHome, false)
 			switch name {
 			case runtime.OmpRuntime:
-				if err == nil {
-					t.Fatal("omp must be refused: it has no isolated credential broker")
+				if err != nil || !needsState {
+					t.Fatalf("omp needsState=%v err=%v, want a broker-backed isolated state policy", needsState, err)
+				}
+				if policy.relativeState != filepath.Join("home", ".omp") {
+					t.Fatalf("omp relativeState=%q, want %q", policy.relativeState, filepath.Join("home", ".omp"))
+				}
+				if policy.credentialFile != "" || len(policy.requiredInputs) != 0 || len(policy.optionalInputs) != 0 {
+					t.Fatalf("omp policy stages owner material: credential=%q required=%v optional=%v", policy.credentialFile, policy.requiredInputs, policy.optionalInputs)
 				}
 				return
 			case runtime.ShellRuntime:

--- a/internal/cli/sandbox_produce_test.go
+++ b/internal/cli/sandbox_produce_test.go
@@ -951,15 +951,38 @@ func TestStageReadOnlyRuntimeCredentialCopiesOnlyProviderSection(t *testing.T) {
 	}
 }
 
-func TestWrapReadOnlySandboxAdapterRejectsOmpWithoutCredentialBroker(t *testing.T) {
+// TestWrapReadOnlySandboxAdapterOmpRequiresBrokerMode replaces the test that
+// pinned omp's categorical refusal (#1817). The old assertion said a read-only
+// omp seat is rejected, full stop; that was the defect, not the contract. What
+// survives is the fail-closed half, so both arms are asserted here: refused
+// without broker mode, built with it.
+func TestWrapReadOnlySandboxAdapterOmpRequiresBrokerMode(t *testing.T) {
 	checkout := t.TempDir()
 	if err := os.MkdirAll(filepath.Join(checkout, ".git"), 0o700); err != nil {
 		t.Fatal(err)
 	}
 	agent := runtime.Agent{Runtime: runtime.OmpRuntime, ReadOnlySeat: true}
+
+	restore := ompBrokerEnvLookup
+	t.Cleanup(func() { ompBrokerEnvLookup = restore })
+
+	ompBrokerEnvLookup = func(string) (string, bool) { return "", false }
 	_, _, err := wrapReadOnlySandboxAdapter(t.TempDir(), agent, checkout, "", runtime.OmpAdapter{})
-	if err == nil || !strings.Contains(err.Error(), "isolated credential broker") {
-		t.Fatalf("omp read-only seat error = %v", err)
+	if err == nil || !strings.Contains(err.Error(), ompAuthBrokerURLEnv) {
+		t.Fatalf("omp read-only seat without broker mode = %v, want a refusal naming %s", err, ompAuthBrokerURLEnv)
+	}
+
+	ompBrokerEnvLookup = func(name string) (string, bool) {
+		switch name {
+		case ompAuthBrokerURLEnv:
+			return "http://127.0.0.1:8765", true
+		case ompAuthBrokerTokenEnv:
+			return "broker-bearer", true
+		}
+		return "", false
+	}
+	if _, _, err := wrapReadOnlySandboxAdapter(t.TempDir(), agent, checkout, "", runtime.OmpAdapter{}); err != nil {
+		t.Fatalf("omp read-only seat WITH broker mode = %v; the seat must build", err)
 	}
 }
 

--- a/internal/runtime/omp.go
+++ b/internal/runtime/omp.go
@@ -430,21 +430,18 @@ func (a OmpAdapter) preflight() error {
 //     parses; without --mode=json omp prints prose and every job fails extraction.
 //   - `--approval-mode` is ALWAYS present, for DETERMINISM: omitting it inherits
 //     whatever tools.approvalMode the host config carries, which is not
-//     deterministic across machines. Its VALUE now comes from the stored
-//     autonomy policy via ompApprovalArgs (#1721); it was a fixed `yolo` for
-//     every policy until then, so a read-only omp agent ran unrestricted.
-//     Read-only maps to always-ask on the measurement recorded at
-//     ompApprovalArgs; every other policy keeps `yolo` byte-identically.
-//     TWO CLAIMS THIS COMMENT USED TO CARRY WERE WRONG AND ARE CORRECTED
-//     AGAINST THE CODE, because a stale rationale is cited as a reason:
-//     the read-only Landlock wrapper does NOT select only claude and kimi -
-//     wrapReadOnlyAdapterRunner in cli/daemon_worker.go wraps claude, codex,
-//     kimi and shell - and it is not true that "no omp process is ever
-//     confined": that switch has an explicit omp arm which REFUSES a read-only
-//     seat outright ("read-only seats cannot use omp without an isolated
-//     credential broker") rather than running it unconfined. The gap this flag
-//     now closes is the case the seat path never reaches: a non-seat omp
-//     dispatch whose stored policy asked for less than yolo.
+//     deterministic across machines. Its VALUE comes from the stored autonomy
+//     policy via ompApprovalArgs (#1721): read-only maps to `always-ask`,
+//     workspace-write maps to `write`, danger-full-access maps to `yolo`, and
+//     auto or an empty stored policy keeps the historical `yolo` behavior.
+//     Gitmoot-side confinement still differs by dispatch path.
+//     readOnlyImplementationBlocked refuses read-only implementation jobs;
+//     broker-backed read-only seats run through wrapReadOnlyAdapterRunner's
+//     Landlock wrapper after their state policy verifies the broker pair and
+//     stages no owner credential material. A non-seat read-only ask or review
+//     reaches neither boundary, so `always-ask` is its direct tool restriction.
+//     Keeping the flag explicit also prevents any path from inheriting the
+//     host's tools.approvalMode.
 //   - `--no-session` keeps the run in memory: no per-worktree session .jsonl
 //     accretion, and nothing to accidentally resume (v1 never resumes).
 //   - the prompt is exactly ONE token after `--`: multiple positionals become

--- a/internal/runtime/omp_test.go
+++ b/internal/runtime/omp_test.go
@@ -3082,14 +3082,13 @@ func TestOmpSummaryIsFinalAssistantTextNotEnvelope(t *testing.T) {
 //
 // THIS TEST PREVIOUSLY ASSERTED THE OPPOSITE - one fixed `--approval-mode=yolo`
 // for every policy - and its stated reason was "read-only is enforced
-// Gitmoot-side, not by omp's approval tier". That reason does not hold for the
-// dispatch #1721 is about. Gitmoot-side enforcement on omp is exactly two
-// things: readOnlyImplementationBlocked, which covers IMPLEMENT jobs only, and
-// the read-only SEAT arm of wrapReadOnlyAdapterRunner, which refuses omp
-// outright ("read-only seats cannot use omp without an isolated credential
-// broker"). Neither reaches a non-seat read-only ask or review, which ran with
-// unrestricted tools. Dropping the flag entirely is still refused, because an
-// absent flag inherits the host's tools.approvalMode.
+// Gitmoot-side, not by omp's approval tier". Gitmoot-side enforcement depends on
+// the dispatch path: readOnlyImplementationBlocked refuses read-only
+// implementation jobs, and a broker-backed read-only seat receives the
+// Landlock wrapper from wrapReadOnlyAdapterRunner. A non-seat read-only ask or
+// review reaches neither boundary, so it needs `always-ask` to restrict OMP's
+// own tools. Dropping the flag entirely is still refused because an absent flag
+// inherits the host's tools.approvalMode.
 func TestOmpPolicyArgs(t *testing.T) {
 	for _, tc := range []struct {
 		policy string


### PR DESCRIPTION
## What this changes

omp was the **only** runtime with no read-only seat state policy. Both sites refused it outright:

```
daemon_worker.go  wrapReadOnlyAdapterRunner           case OmpAdapter -> errors.New("read-only seats cannot use omp without an isolated credential broker")
daemon_worker.go  readOnlySeatStatePolicyForRuntime    case OmpRuntime -> same error
```

Measured on this host: two registered read-only omp reviewers each failed in **0.2 min** with an `effective_runtime` event and **no provider contact**, while the same two models answered a direct omp probe from `/tmp`. That locates the boundary in this wrapper, not in auth.

## The refusal named the remedy, and the remedy already exists

omp resolves auth through a **broker** when `OMP_AUTH_BROKER_URL` and `OMP_AUTH_BROKER_TOKEN` are both set. omp's own documentation: in broker mode "the local SQLite credential store is bypassed and all OAuth refresh / access tokens live on the broker host". And `internal/cli/credentials.go:67-77` already documents that pair as "how a fleet supplies omp auth without scattering raw keys", noting it is INDIVISIBLE because omp throws when the URL is set with no token.

## So the policy withholds rather than stages

```
credentialFile   ""     requiredInputs  none     optionalInputs  none
stateAtCacheRoot true   relativeState   home/.omp
```

`prepareReadOnlyRuntimeState` creates the state dir empty and copies **only** what a policy lists, so the owner's `~/.omp` - which holds omp's local credential store - is never read into the seat. The seat starts from an empty profile and authenticates through the broker; what it receives is a **broker bearer**, rotatable with `omp auth-broker token --regenerate`, not a provider credential.

Broker mode is **required**, not preferred: without it omp falls back to the local store, finds the seat's empty profile, and fails on auth - or a later change stages that store to "fix" it. Refusing at dispatch keeps that from being one forgotten line away, and the message names which half of the pair is missing.

The pair reaches the seat through `readOnlyRuntimeBaseEnv`, the per-runtime env site the policy comment already names, exactly like `CLAUDE_CONFIG_DIR` and `CODEX_HOME`.

## One existing test replaced rather than re-pinned

`TestWrapReadOnlySandboxAdapterRejectsOmpWithoutCredentialBroker` asserted that a read-only omp seat is rejected, full stop. **That was the defect, not the contract.** Its replacement keeps the surviving half and asserts both arms: refused without broker mode naming `OMP_AUTH_BROKER_URL`, built with it.

## A first attempt was wrong and an existing test caught it

I first wired the pair through `readOnlySeatRuntimeAuthEnv`. `TestSeatRuntimeAuthOverlayIsClaudeOnlyAcrossEverySupportedRuntime` failed, and it was right to: that overlay is claude-only by policy and carries gitmoot's own Claude gateway credential, a different mechanism with an Anthropic upstream. The broker pair belongs in the env allowlist. **That test was left untouched and is green** - I reverted my edit instead of amending its expectation.

## Verification

```
mutant: stage the owner's store (credentialFile: auth.json)
  -> FAIL "omp seat policy stages credential file \"auth.json\"; a read-only seat must receive no credential material"
mutant: drop the broker gate (bypass)
  -> FAIL "omp seat accepted map[]; broker mode is required"
mutant: restore the old categorical refusal in the production arm
  -> FAIL "readOnlySeatStatePolicyForRuntime(omp) = read-only seats cannot use omp ..."

go build -buildvcs=false ./...            clean
go vet ./internal/cli/                    clean
go test ./internal/cli/ -count=1 -timeout 25m   ok 607.693s
```

All three mutants compile and start from a passing baseline.

## Coordination, done before editing

- **gm-integrity (#2142)** confirmed its two `daemon_worker.go` hunks are inside `readOnlyRuntimeSandboxGrants` (~2004, ~2041); neither touches the arms here.
- **gm-findings (#2143)** confirmed its single `daemon_worker.go` line is at ~1977, and that it does not touch `runtime_stage.go` or `seatRuntimeNames`.
- **Adding omp to `seatRuntimeNames` is deliberately NOT in this PR.** That list and `stageSeatRuntimes`' signature are #2142's, which changes the signature to return interpreters; omp goes on top after it merges. gm-integrity's warning is recorded for that follow-up: ask what omp EXECS, not just what dispatches it, and go through `StageRuntime` so the transitive closure is handled.

## What is NOT proven yet, and it is the acceptance gap

The end-to-end ask at `policy=read-only` with effective runtime omp **has not been run**, and it needs two things I do not have authority to do:

1. **A configured broker.** `omp auth-broker status --json` on this host returns `{"ok":false,"reason":"not_configured"}`. Standing one up loads the owner's credentials into a service and exports `OMP_AUTH_BROKER_*` for the daemon - host state and credential material, owner-gated.
2. **A deploy.** The verb-bearing daemon must run a build containing this change; `/root/.local/bin/gitmoot` is `dev-ed5f163f`.

Both registered agents and the repo checkout path are untouched: `gm-review-kimi-omp` and `gm-review-devin-omp` still read `policy=read-only`, `runtime=omp`, models `kimi-code/k3` and `devin/swe-2`, and `checkout_path` is still `/root/gitmoot-checkouts/gitmoot`. Refs #1817.