### PR TITLE
fix(daemon): clear any pending merge-gate status Gitmoot owns, whatever it says (#2148)

### DIFF
--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -32,6 +32,22 @@ const (
 	mergeGateStatusMarker             = "marker"
 	mergeGateStatusObserved           = "observed"
 	mergeGateStatusInactive           = "inactive"
+	// mergeGateStatusCleared means the gate does not apply AND no pending status
+	// Gitmoot owns is left on the head (#2148).
+	//
+	// It is a separate kind from `inactive` on purpose, and the distinction is
+	// what heals existing rows. `inactive` was recorded whenever the gate stopped
+	// applying, including when a pending status Gitmoot had written was left
+	// behind - and the early return on `inactive` then meant no later pass ever
+	// looked at that head again, so the leftover status was permanent. Measured
+	// on this fleet: 4 OPEN pull requests across 4 repositories, each carrying a
+	// different reason text, all reading `mergeable_state: unstable` on green
+	// check-runs.
+	//
+	// Only `cleared` short-circuits now. A legacy `inactive` row is therefore
+	// re-examined exactly once, which costs one combined-status read per affected
+	// head and then upgrades it, instead of requiring a migration.
+	mergeGateStatusCleared = "cleared"
 )
 
 // issueCommentPollOverlap is subtracted from the persisted last-seen cursor when
@@ -1384,7 +1400,14 @@ func (d Daemon) ensureMergeGateStatus(ctx context.Context, pull github.PullReque
 		if applies && (observation.Kind == mergeGateStatusMarker || observation.Kind == mergeGateStatusObserved) {
 			return
 		}
-		if !applies && observation.Kind == mergeGateStatusInactive {
+		// ONLY `cleared` SHORT-CIRCUITS THE NOT-APPLICABLE CASE (#2148).
+		//
+		// `inactive` used to skip here, which is what made a leftover owned
+		// pending status permanent: the head was never looked at again, so the
+		// status Gitmoot itself had written could never be resolved. A legacy
+		// `inactive` row therefore falls through exactly once, costs one
+		// combined-status read, and is upgraded to `cleared` below.
+		if !applies && observation.Kind == mergeGateStatusCleared {
 			return
 		}
 	}
@@ -1418,7 +1441,24 @@ func (d Daemon) ensureMergeGateStatus(ctx context.Context, pull github.PullReque
 		return
 	}
 
-	if found && status.State == "pending" && status.Description == mergeGateUnclearedDescription {
+	// CLEAR ANY PENDING STATUS GITMOOT OWNS, WHATEVER IT SAYS (#2148).
+	//
+	// This matched one literal description, `mergeGateUnclearedDescription`. Every
+	// other pending status Gitmoot writes in this context carries a SPECIFIC
+	// reason - "external CI check ... is pending", "waiting to confirm no external
+	// CI at head ...", "repository has GitHub Actions workflows but no check run
+	// has ..." - and none of them matched, so the clearance branch did not
+	// recognise Gitmoot's own earlier output and fell through. The head then kept
+	// a pending status forever and reported `mergeable_state: unstable` on green
+	// check-runs. Measured before this change: 4 OPEN pull requests across 4
+	// repositories, each with a different reason text.
+	//
+	// Ownership of the context is the right predicate. latestMergeGateStatus only
+	// returns statuses whose context is GitmootMergeGateContext, so a pending one
+	// is ours by construction and ours to resolve once the gate no longer applies.
+	// Matching on message text meant every future reason was unclearable the day
+	// it was introduced.
+	if found && status.State == "pending" {
 		if _, err := d.GitHub.CreateCommitStatus(ctx, github.CommitStatusInput{
 			Repo:        d.Repo,
 			SHA:         headSHA,
@@ -1427,10 +1467,15 @@ func (d Daemon) ensureMergeGateStatus(ctx context.Context, pull github.PullReque
 			Description: mergeGateNotAppliedDescription,
 		}); err != nil {
 			d.logf("merge-gate marker clearance failed for %s#%d at %s: %v", d.Repo.FullName(), pull.Number, headSHA, err)
+			// NOT recorded as cleared: the pending status is still live, so a
+			// later pass must look again rather than short-circuit past it.
 			return
 		}
 	}
-	d.recordMergeGateStatusObservation(ctx, pull.Number, headSHA, mergeGateStatusInactive)
+	// `cleared` rather than `inactive`: reaching here means either there was no
+	// owned pending status, or the write above succeeded. Both are proof that
+	// nothing of ours is outstanding, which is what makes the short-circuit safe.
+	d.recordMergeGateStatusObservation(ctx, pull.Number, headSHA, mergeGateStatusCleared)
 }
 
 func mergeGateMarkerApplies(state string) bool {

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -1327,8 +1327,8 @@ func TestPollOnceAutoMergeDisabledDoesNotPublishMarker(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GetMergeGateStatusObservation returned error: %v", err)
 	}
-	if observation.HeadSHA != "abc123" || observation.Kind != mergeGateStatusInactive {
-		t.Fatalf("status observation = %+v, want inactive current head", observation)
+	if observation.HeadSHA != "abc123" || observation.Kind != mergeGateStatusCleared {
+		t.Fatalf("status observation = %+v, want cleared current head", observation)
 	}
 }
 
@@ -1347,7 +1347,7 @@ func TestPollOnceExternalMergeGateDoesNotPublishMarker(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GetMergeGateStatusObservation returned error: %v", err)
 	}
-	if observation.Kind != mergeGateStatusInactive {
+	if observation.Kind != mergeGateStatusCleared {
 		t.Fatalf("status observation = %+v, want inactive under an external gate", observation)
 	}
 }
@@ -1378,7 +1378,7 @@ func TestPollOnceExternalMergeGateClearsGenericMarker(t *testing.T) {
 	}
 }
 
-func TestPollOnceAwaitingHumanClearsOnlyGenericMarker(t *testing.T) {
+func TestPollOnceAwaitingHumanClearsTheGenericMarker(t *testing.T) {
 	ctx := context.Background()
 	store, client, daemon, _ := newSkippedFanoutPendingGateDaemon(t, workflow.TaskAwaitingHumanMerge)
 	if _, err := client.CreateCommitStatus(ctx, github.CommitStatusInput{
@@ -1415,8 +1415,8 @@ func TestPollOnceAwaitingHumanClearsOnlyGenericMarker(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GetMergeGateStatusObservation returned error: %v", err)
 	}
-	if observation.Kind != mergeGateStatusInactive {
-		t.Fatalf("status observation = %+v, want inactive", observation)
+	if observation.Kind != mergeGateStatusCleared {
+		t.Fatalf("status observation = %+v, want cleared", observation)
 	}
 }
 
@@ -1443,8 +1443,8 @@ func TestPollOnceInactiveTaskPreservesRealGateVerdict(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GetMergeGateStatusObservation returned error: %v", err)
 	}
-	if observation.Kind != mergeGateStatusInactive {
-		t.Fatalf("status observation = %+v, want reconciled inactive head", observation)
+	if observation.Kind != mergeGateStatusCleared {
+		t.Fatalf("status observation = %+v, want reconciled cleared head", observation)
 	}
 }
 
@@ -3823,5 +3823,136 @@ func TestHandlePullRequestWorkflowAttributesFanoutChildrenFromBranchLock(t *test
 	}
 	if payload.ActingOrgRole != "gmc-fanout" {
 		t.Fatalf("daemon-trigger fanout child acting_org_role = %q, want %q; an unattributed fanout child has no owner to wake (#1347)", payload.ActingOrgRole, "gmc-fanout")
+	}
+}
+
+// A REASONED pending status must clear even when an `inactive` observation
+// already exists for that head (#2148).
+//
+// This is the exact production shape. Clearance matched one literal
+// description, so a status carrying a specific reason - here the text that
+// stranded jerryfane/herdr#185 - was not recognised as Gitmoot's own output. The
+// pass then recorded `inactive`, and the early return on `inactive` meant no
+// later pass looked at the head again, so the pending status was PERMANENT and
+// the pull request reported `mergeable_state: unstable` on green check-runs.
+//
+// Measured across this fleet before the fix: 4 OPEN pull requests in 4 separate
+// repositories, each with a different reason text, none of them clearable.
+//
+// Both halves have to hold for the test to mean anything: the status must be
+// rewritten, AND the observation must be upgraded past `inactive` so the head is
+// not re-probed forever.
+func TestPollOnceClearsReasonedPendingStatusDespiteInactiveObservation(t *testing.T) {
+	ctx := context.Background()
+	store, client, daemon, _ := newSkippedFanoutPendingGateDaemon(t, workflow.TaskAwaitingHumanMerge)
+	const reasoned = `external CI check "check (macos-latest)" is pending`
+	if _, err := client.CreateCommitStatus(ctx, github.CommitStatusInput{
+		Repo:        daemon.Repo,
+		SHA:         "abc123",
+		State:       "pending",
+		Context:     workflow.GitmootMergeGateContext,
+		Description: reasoned,
+	}); err != nil {
+		t.Fatalf("seed CreateCommitStatus returned error: %v", err)
+	}
+	// The legacy short-circuit: a head already written off as inactive.
+	if err := store.UpsertMergeGateStatusObservation(ctx, db.MergeGateStatusObservation{
+		RepoFullName: "gitmoot/gitmoot",
+		PullRequest:  7,
+		HeadSHA:      "abc123",
+		Kind:         mergeGateStatusInactive,
+	}); err != nil {
+		t.Fatalf("UpsertMergeGateStatusObservation returned error: %v", err)
+	}
+
+	if err := daemon.PollOnce(ctx); err != nil {
+		t.Fatalf("PollOnce returned error: %v", err)
+	}
+	if len(client.statuses) != 2 {
+		t.Fatalf("statuses = %+v, want the reasoned pending status followed by a not-applied success", client.statuses)
+	}
+	cleared := client.statuses[1]
+	if cleared.State != "success" ||
+		cleared.Context != workflow.GitmootMergeGateContext ||
+		cleared.Description != mergeGateNotAppliedDescription {
+		t.Fatalf("clearance status = %+v, want not-applied success; a pending status in Gitmoot's own context is Gitmoot's to resolve whatever its reason text says", cleared)
+	}
+	observation, err := store.GetMergeGateStatusObservation(ctx, "gitmoot/gitmoot", 7)
+	if err != nil {
+		t.Fatalf("GetMergeGateStatusObservation returned error: %v", err)
+	}
+	if observation.Kind != mergeGateStatusCleared {
+		t.Fatalf("status observation = %+v, want cleared; leaving it inactive is what made the leftover status permanent", observation)
+	}
+}
+
+// CONTROL: with no status of Gitmoot's own on the head, the not-applicable pass
+// must write nothing and still record `cleared`.
+//
+// Without this, the test above could pass for the wrong reason - a change that
+// wrote a success status unconditionally would satisfy it while adding a status
+// to every head Gitmoot does not manage.
+func TestPollOnceRecordsClearedWithoutWritingWhenNoOwnedStatusExists(t *testing.T) {
+	ctx := context.Background()
+	store, client, daemon, _ := newSkippedFanoutPendingGateDaemon(t, workflow.TaskAwaitingHumanMerge)
+
+	if err := daemon.PollOnce(ctx); err != nil {
+		t.Fatalf("PollOnce returned error: %v", err)
+	}
+	if len(client.statuses) != 0 {
+		t.Fatalf("statuses = %+v, want none written when Gitmoot owns no status on the head", client.statuses)
+	}
+	observation, err := store.GetMergeGateStatusObservation(ctx, "gitmoot/gitmoot", 7)
+	if err != nil {
+		t.Fatalf("GetMergeGateStatusObservation returned error: %v", err)
+	}
+	if observation.Kind != mergeGateStatusCleared {
+		t.Fatalf("status observation = %+v, want cleared with nothing outstanding", observation)
+	}
+}
+
+// A FAILED clearance write must not be recorded as cleared (#2148).
+//
+// This exists because a mutant survived: recording `cleared` unconditionally
+// after the write attempt passed every other test in the package. That mutant
+// recreates the original defect in a new form - the head is short-circuited as
+// having nothing outstanding while a pending status Gitmoot owns is still live
+// on it, so no later pass ever looks again.
+//
+// The observation must therefore stay at its prior value so the next pass
+// retries, and the retry is the only thing standing between a transient GitHub
+// failure and a permanently blocked pull request.
+func TestPollOnceFailedClearanceIsNotRecordedAsCleared(t *testing.T) {
+	ctx := context.Background()
+	store, client, daemon, _ := newSkippedFanoutPendingGateDaemon(t, workflow.TaskAwaitingHumanMerge)
+	if _, err := client.CreateCommitStatus(ctx, github.CommitStatusInput{
+		Repo:        daemon.Repo,
+		SHA:         "abc123",
+		State:       "pending",
+		Context:     workflow.GitmootMergeGateContext,
+		Description: `external CI check "check (macos-latest)" is pending`,
+	}); err != nil {
+		t.Fatalf("seed CreateCommitStatus returned error: %v", err)
+	}
+	if err := store.UpsertMergeGateStatusObservation(ctx, db.MergeGateStatusObservation{
+		RepoFullName: "gitmoot/gitmoot",
+		PullRequest:  7,
+		HeadSHA:      "abc123",
+		Kind:         mergeGateStatusInactive,
+	}); err != nil {
+		t.Fatalf("UpsertMergeGateStatusObservation returned error: %v", err)
+	}
+	// The clearance write is the next status call, and it fails.
+	client.statusErrs = []error{errors.New("status bookkeeping unavailable")}
+
+	if err := daemon.PollOnce(ctx); err != nil {
+		t.Fatalf("PollOnce returned error: %v", err)
+	}
+	observation, err := store.GetMergeGateStatusObservation(ctx, "gitmoot/gitmoot", 7)
+	if err != nil {
+		t.Fatalf("GetMergeGateStatusObservation returned error: %v", err)
+	}
+	if observation.Kind == mergeGateStatusCleared {
+		t.Fatalf("status observation = %+v, want it NOT cleared: the pending status is still live, and recording cleared short-circuits every later pass", observation)
 	}
 }


### PR DESCRIPTION
Fixes #2148. Files: `internal/daemon/daemon.go` and `internal/daemon/daemon_test.go`.

Authorization context: this is the residual half of the herdr#185 blocker under owner note 131145; Grams `gram-1a08cf30317-1394e1-55`, `gram-1a08cf38450-1394e1-56`.

## The defect

Clearance of a stale merge-gate marker matched **one literal description**:

```go
if found && status.State == "pending" && status.Description == mergeGateUnclearedDescription {
```

Every other pending status Gitmoot writes in the `gitmoot/merge-gate` context carries a **specific reason** instead. So the clearance branch did not recognise Gitmoot's own earlier output, fell through, and recorded the observation as `inactive` - after which this early return fired on every later pass:

```go
if !applies && observation.Kind == mergeGateStatusInactive { return }
```

Head matches, kind is `inactive`, so it returns **before reading the status again**. The leftover pending status becomes permanent, and with it `mergeable_state: unstable` on a pull request whose check-runs are green. Gitmoot blocks the PR on its own unreadable self-report.

## Fleet scope, measured rather than assumed

57 `inactive` observations exist. 26 belong to open pull requests. Of those, **4 carry a leftover owned pending status** - in 4 different repositories, with 4 different reason texts, none of them the clearable literal:

| Repo | PR | Leftover reason |
| --- | --- | --- |
| `gitmoot/appkit-demo` | 7 | `waiting to confirm no external CI at head f43adf6; grace win...` |
| `themartianapp/keephair` | 54 | `repository has GitHub Actions workflows but no check run has...` |
| `jerryfane/herdr` | 185 | `external CI check "check (macos-latest)" is pending` |
| `jerryfane/herdrup` | 244 | `external CI check "build-and-uitest" is pending` |

So this is general, not one stuck PR. `gm-integrity` independently observed the same shape on PR 2142's previous head while checking their own work, which corroborates it from a second seat.

## The fix

**Ownership of the context is the predicate, not the message text.** `latestMergeGateStatus` only returns statuses whose context is `GitmootMergeGateContext`, so a pending one is ours by construction and ours to resolve once the gate no longer applies. Matching on a literal made every future reason unclearable the day it was introduced - there are already four.

**A new observation kind, `cleared`.** It is the only kind that short-circuits the not-applicable case, and it means *the gate does not apply AND nothing pending of ours is left on the head*. That distinction is what heals the existing rows **without a migration**: a legacy `inactive` row now falls through exactly once, costs one combined-status read, and is upgraded.

**A failed clearance write is not recorded.** If the status write fails, the pending status is still live, so the pass returns without recording and the next one retries.

## Tests

Two firing tests for the exact production shape, plus the control the owner asked for:

- **`TestPollOnceClearsReasonedPendingStatusDespiteInactiveObservation`** - a reasoned pending status (herdr's own text) plus a pre-existing `inactive` observation at the same head. Asserts **both** halves: the status is rewritten, **and** the observation is upgraded past `inactive` so the head is not re-probed forever. Fails on the old code, which short-circuits and never writes.
- **`TestPollOnceRecordsClearedWithoutWritingWhenNoOwnedStatusExists`** - the no-owned-status control. Without it, a change that wrote a success status unconditionally would satisfy the test above while adding a status to every head Gitmoot does not manage.
- **`TestPollOnceFailedClearanceIsNotRecordedAsCleared`** - see below.

Four existing tests asserted `inactive` as the terminal kind. They pinned the old behaviour, so they now assert `cleared`; one test name (`...ClearsOnlyGenericMarker`) described a behaviour that no longer exists and was renamed.

| Mutant | Outcome |
| --- | --- |
| restore the literal-description match (the defect) | **dead** |
| let a legacy `inactive` observation short-circuit again | **dead** |
| write a success status unconditionally, dropping the ownership check | **dead** (two tests) |
| record `cleared` after a **failed** clearance write | **dead**, but only after a new test |

**The fourth mutant survived first, and that is the most useful thing here.** Recording `cleared` regardless of whether the write succeeded passed every other test in the package - and it recreates the original defect in a new form: the head is marked as having nothing outstanding while a pending status Gitmoot owns is still live on it, so no later pass looks again. It now has its own test, which asserts the observation is *not* cleared when the write fails.

`internal/daemon` ok 21.3s, `internal/workflow` ok 143.6s, `go vet ./...` clean.

## What this does not do

- **It does not unblock #2146.** I checked rather than assumed: this clearance path runs only when the gate does **not** apply, and #2146's task state (`changes_requested`) is in `mergeGateMarkerApplies`, so the gate applies and this code cannot fire for it. #2146 is blocked by #2150, a different defect with the same symptom.
- **It does not touch herdr#185**, its `merge_gates` row, or any status by hand. #185 remains open and unmodified; the repair is that the next poll of that repo will now clear the leftover status through the supported path.
- It does not change when a marker is **written**, only when one Gitmoot owns is cleared.
- It does not address `merge_gates` row staleness, which is a separate stream from the status-marker path and which I have not traced.
