### PR TITLE
fix(workflow): hold a head-mismatch approval retryably instead of settling it (#2150)

### DIFF
--- a/internal/workflow/changes_requested_wedge_test.go
+++ b/internal/workflow/changes_requested_wedge_test.go
@@ -175,16 +175,20 @@ func TestApprovalAtSupersededHeadLeavesChangesRequested(t *testing.T) {
 	// A re-review is already open at the newer head; it has not reported yet.
 	seedReviewJob(t, store, "review-pending", "auditor", "head-new", "", JobRunning)
 
-	if err := engine.AdvanceJob(ctx, "review-stale"); err != nil {
-		t.Fatalf("AdvanceJob returned error: %v", err)
+	// The hold is now RETRYABLE (#2150), so it surfaces as an error and writes no
+	// review_advance_held row: the caller's recordAdvanceRetryOnce carries the
+	// message on a single deduped advance_retry marker instead. What must not
+	// change is the DECISION - the objection stands and nothing merges.
+	err := engine.AdvanceJob(ctx, "review-stale")
+	if err == nil {
+		t.Fatal("AdvanceJob returned nil; a head mismatch must be held as retryable rather than settled, or a stale observed head wedges a current approval forever")
+	}
+	if !strings.Contains(err.Error(), "superseded head") {
+		t.Fatalf("hold error = %v, want it to name the superseded head; a silent no-op is what hid #1834", err)
 	}
 	assertTaskState(t, store, "task-9", TaskChangesRequested)
 	if len(gh.merges) != 0 {
 		t.Fatalf("merge calls = %d, want 0: a superseded approval must not merge", len(gh.merges))
-	}
-	reason := heldReason(t, store, "review-stale")
-	if !strings.Contains(reason, "superseded head") {
-		t.Fatalf("held reason = %q, want it to name the superseded head; a silent no-op is what hid #1834", reason)
 	}
 }
 

--- a/internal/workflow/engine_routing_merge.go
+++ b/internal/workflow/engine_routing_merge.go
@@ -535,9 +535,35 @@ func (e Engine) approvalSupersedesChangesRequested(ctx context.Context, payload 
 			payload.Repo, payload.PullRequest), true, nil
 	}
 	if approvingHead != currentHead {
+		// RETRYABLE, NOT SETTLED (#2150). The comparison is sound; the INPUT can be
+		// stale, and settling a stale answer is what wedged two consecutive
+		// approvals on gitmoot/gitmoot#2146.
+		//
+		// `pull_requests.head_sha` is maintained by the repo poll, so a review that
+		// finishes before its repo's next poll sees the PREVIOUS head here. Measured
+		// on that PR, twice in a row: round three approved 946b49de while this read
+		// b5317e68, and round four approved 1c1e0793 while this read 946b49de. Both
+		// times the approving head was the CURRENT one and the cached head was the
+		// superseded one - the comparison was effectively inverted.
+		//
+		// Settling wrote `advance_completed`, and retryPendingJobAdvancements only
+		// re-fires jobs whose latest marker is `advance_retry`, so nothing ever
+		// re-evaluated: the task stayed `changes_requested` across two approvals,
+		// its head kept a pending gitmoot/merge-gate status, and the pull request
+		// reported `mergeable_state: unstable` on green checks with no exit. On this
+		// fleet a review routinely completes inside one poll interval, so that is
+		// the normal ordering rather than a rare race.
+		//
+		// This is the SAME reasoning the missing-row hold above already applies, and
+		// the same shape: a hold that is correct at this instant and wrong to commit
+		// to. A genuinely superseded approval is unaffected - the head comparison
+		// runs again on every retry and still refuses, so it can never approve the
+		// wrong head; it simply re-reads one row per tick instead of being recorded
+		// as finished. recordAdvanceRetryOnce keeps a single `advance_retry` row and
+		// refreshes its message, so retries do not grow the event log.
 		return false, fmt.Sprintf(
-			"approval is bound to head %s but the pull request's current head is %s; an approval at a superseded head does not clear changes_requested",
-			approvingHead, currentHead), false, nil
+			"approval is bound to head %s but the observed pull request head is %s; holding until the observed head catches up, because an approval at a genuinely superseded head must not clear changes_requested",
+			approvingHead, currentHead), true, nil
 	}
 	jobs, err := e.Store.ListJobs(ctx)
 	if err != nil {

--- a/internal/workflow/engine_run_budgets.go
+++ b/internal/workflow/engine_run_budgets.go
@@ -957,9 +957,16 @@ func (e Engine) AdvanceJob(ctx context.Context, jobID string) (retErr error) {
 					// a row per tick is what grew job_events to ~1.8M rows once before.
 					return fmt.Errorf("review approval held: %s", held)
 				}
-				// TERMINAL: a superseded head or a live objection at the current head.
-				// Nothing will change without a new review or a new head, so settle it
-				// with a durable reason instead of retrying forever.
+				// TERMINAL: a live objection at the current head, or an approval with
+				// no head at all. Nothing will change without a new review, so settle
+				// it with a durable reason instead of retrying forever.
+				//
+				// A HEAD MISMATCH IS NO LONGER TERMINAL (#2150). It used to be settled
+				// here, which wedged approvals whose head was actually CURRENT while
+				// the observed row still held the previous one - the normal ordering
+				// when a review finishes inside one poll interval. It is retryable
+				// above now, and a genuinely superseded approval still never admits,
+				// because the head comparison runs again on each re-evaluation.
 				return e.Store.AddJobEvent(ctx, db.JobEvent{
 					JobID:   job.ID,
 					Kind:    "review_advance_held",

--- a/internal/workflow/stale_head_retry_2150_test.go
+++ b/internal/workflow/stale_head_retry_2150_test.go
@@ -1,0 +1,120 @@
+package workflow
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+// THE NORMAL ORDERING (#2150): a review at head N completes before the repo poll
+// refreshes the observed head from N-1.
+//
+// This is the production-path regression. It reproduces the exact sequence
+// measured twice in a row on gitmoot/gitmoot#2146 - round three approved
+// 946b49de while the observed row still held b5317e68, round four approved
+// 1c1e0793 while it held 946b49de - and asserts the properties the fix must
+// have. Under the previous behaviour the first advancement SETTLED, writing
+// advance_completed, and since retryPendingJobAdvancements only re-fires jobs
+// whose latest marker is advance_retry, nothing ever re-evaluated: the task
+// stayed changes_requested across two approvals and the pull request could not
+// be merged.
+func TestStaleObservedHeadHoldsRetryablyThenClearsWhenCacheCatchesUp(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	seedWedgedTask(t, store)
+	seedImplementAttribution(t, store)
+	engine, gh := wedgeEngine(t, store)
+
+	// The observed row is one head behind: the poll has not run since the push.
+	seedObservedPullRequest(t, store, "head-previous")
+	seedReviewJob(t, store, "review-current", "auditor", "head-current", "approved", JobSucceeded)
+
+	// PROPERTY 1: the first advancement holds, and holds RETRYABLY - surfaced as
+	// an error with no settled review_advance_held row, because the caller's
+	// recordAdvanceRetryOnce carries the message on a single deduped marker.
+	firstErr := engine.AdvanceJob(ctx, "review-current")
+	if firstErr == nil {
+		t.Fatal("first AdvanceJob returned nil: a stale observed head was settled, which is the wedge #2150 describes")
+	}
+	if !strings.Contains(firstErr.Error(), "review approval held") {
+		t.Fatalf("first hold error = %v, want a held-approval error", firstErr)
+	}
+	if reason := heldReason(t, store, "review-current"); reason != "" {
+		t.Fatalf("review_advance_held = %q, want none: settling a transient hold is what prevented any retry", reason)
+	}
+	assertTaskState(t, store, "task-9", TaskChangesRequested)
+
+	// PROPERTY 5a: repeated attempts before the cache catches up are idempotent -
+	// same decision, still no settled row, no state change.
+	if err := engine.AdvanceJob(ctx, "review-current"); err == nil {
+		t.Fatal("second AdvanceJob returned nil while the observed head was still stale")
+	}
+	if reason := heldReason(t, store, "review-current"); reason != "" {
+		t.Fatalf("review_advance_held = %q after a repeat attempt, want none", reason)
+	}
+	assertTaskState(t, store, "task-9", TaskChangesRequested)
+
+	// PROPERTY 2: the poll catches up. NO new commit and NO new review.
+	seedObservedPullRequest(t, store, "head-current")
+
+	// PROPERTY 3: the same job, re-advanced by the existing machinery, now clears
+	// changes_requested at the exact approved head.
+	if err := engine.AdvanceJob(ctx, "review-current"); err != nil {
+		t.Fatalf("AdvanceJob after the observed head caught up returned error: %v", err)
+	}
+	if state := taskState(t, store, "task-9"); state == string(TaskChangesRequested) {
+		t.Fatalf("task state = %q, want changes_requested cleared once the approval's head was confirmed current", state)
+	}
+	_ = gh
+}
+
+// PROPERTY 4: a GENUINELY superseded approval must never admit, however many
+// times it is re-evaluated.
+//
+// This is the safety half of the same change. Retrying must not become a way for
+// an old approval to eventually slip through: the head comparison runs again on
+// every attempt, so an approval whose head is not the observed one keeps being
+// refused for as long as that remains true.
+func TestGenuinelySupersededApprovalNeverAdmitsAcrossRetries(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	seedWedgedTask(t, store)
+	seedImplementAttribution(t, store)
+	engine, gh := wedgeEngine(t, store)
+
+	// The observed head is genuinely newer, and it stays that way.
+	seedObservedPullRequest(t, store, "head-new")
+	seedReviewJob(t, store, "review-stale", "auditor", "head-old", "approved", JobSucceeded)
+
+	for attempt := 1; attempt <= 5; attempt++ {
+		err := engine.AdvanceJob(ctx, "review-stale")
+		if err == nil {
+			t.Fatalf("attempt %d admitted a superseded approval", attempt)
+		}
+		if !strings.Contains(err.Error(), "superseded head") {
+			t.Fatalf("attempt %d error = %v, want it to name the superseded head", attempt, err)
+		}
+		assertTaskState(t, store, "task-9", TaskChangesRequested)
+		if len(gh.merges) != 0 {
+			t.Fatalf("attempt %d merge calls = %d, want 0", attempt, len(gh.merges))
+		}
+	}
+
+	// PROPERTY 5b: bounded in the event log. Repeated retries must not append a
+	// row per attempt; the caller keeps one deduped advance_retry marker, and this
+	// path writes no settled row at all. A per-tick row is what grew job_events to
+	// ~1.8M rows once before.
+	events, err := store.ListJobEvents(ctx, "review-stale")
+	if err != nil {
+		t.Fatalf("ListJobEvents returned error: %v", err)
+	}
+	held := 0
+	for _, event := range events {
+		if event.Kind == "review_advance_held" {
+			held++
+		}
+	}
+	if held != 0 {
+		t.Fatalf("review_advance_held rows = %d after 5 attempts, want 0 from this path", held)
+	}
+}


### PR DESCRIPTION
Fixes #2150. Files: `internal/workflow/engine_routing_merge.go`, `internal/workflow/engine_run_budgets.go` (comment), and two test files.

**This is the priority unblocker for #2146**, which is approved at its exact head with executed evidence and cannot be merged. Owner note 131145; Grams `gram-1a08cf30317-1394e1-55`, `gram-1a08cf38450-1394e1-56`.

## The defect

`approvalSupersedesChangesRequested` compares the approving head against `pull_requests.head_sha` and, on a mismatch, returned a **non-retryable** hold. The comparison is sound; the **input** can be stale. That column is maintained by the repo poll, so a review finishing before its repo's next poll sees the **previous** head.

Measured twice consecutively on this very repo:

| Round | Approved head | Head the advancement believed was current | Outcome |
| --- | --- | --- | --- |
| three | `946b49de` | `b5317e68` (previous) | held, settled |
| four | `1c1e0793` | `946b49de` (previous) | held, settled |

Both times the approving head was the **current** one and the cached head was the superseded one, so the comparison was effectively inverted.

**Settling is what made it permanent.** It wrote `advance_completed`, and `retryPendingJobAdvancements` only re-fires jobs whose latest marker is `advance_retry`. So nothing re-evaluated: the task sat at `changes_requested` across two approvals, its head kept a pending `gitmoot/merge-gate` status, and the PR reported `mergeable_state: unstable` on 27/27 green checks **with no exit** - pushing a new head starts a new review that approves and holds the same way. I escaped once by pushing an unrelated fix, which was luck about poll timing, and the next round reproduced it.

I originally filed this as a narrow window. Two-for-two says something stronger: on this fleet a review routinely completes inside one poll interval, so **this is the normal ordering, not a race**.

## The fix, and why it is this shape

One return value: `retryable` becomes `true` for the head mismatch.

**The precedent is immediately above it.** The missing-row branch already applies exactly this reasoning in a comment: *"TRANSIENT: the row appears as soon as the daemon polls the PR, so this hold must be RETRIED, not settled. Settling it silently is the recovery wedge..."*. A head mismatch against a poll-maintained column is the same class: correct at this instant, wrong to commit to.

**The machinery already exists and is already bounded.** The caller routes a retryable hold as an error with **no** job event, because `recordAdvanceRetryOnce` keeps a single `advance_retry` row and refreshes its message - its own comment notes that appending a row per tick once grew `job_events` to ~1.8M rows. So a retry costs one store read per tick and does not grow the log.

**Safety is unchanged.** A genuinely superseded approval never admits: the head comparison re-runs on every re-evaluation and still refuses. Retrying is not a way for an old approval to eventually slip through.

## The five required properties, each asserted

`TestStaleObservedHeadHoldsRetryablyThenClearsWhenCacheCatchesUp` reproduces the normal ordering - observed row one head behind, approval at the current head:

1. **holds safely and retryably** - error surfaced, and **no** `review_advance_held` row written
2. **the cache catches up with no new commit and no review** - only the observed row is updated
3. **the same job then clears `changes_requested`** at the exact approved head
5. **repeats are idempotent** - a second attempt before catch-up changes nothing

`TestGenuinelySupersededApprovalNeverAdmitsAcrossRetries`:

4. **a genuinely superseded approval never admits**, across five attempts, never merges, objection stands every time
5. **bounded** - zero `review_advance_held` rows after five attempts

| Mutant | Outcome |
| --- | --- |
| restore the settle (`advance_completed`) - the defect | **dead**: *"a stale observed head was settled, which is the wedge #2150 describes"* |
| admit on mismatch (the unsafe direction) | **dead** on both safety tests |

`internal/workflow` ok 136.8s, `internal/daemon` ok 16.4s, `go vet ./...` clean.

## Existing test and comment corrected rather than worked around

`TestApprovalAtSupersededHeadLeavesChangesRequested` asserted `AdvanceJob` returned **nil** for a superseded head - that pinned the settling behaviour. It now asserts the retryable error while still asserting the objection stands and nothing merges: the **decision** is what must not change, and it has not.

The call-site comment reading *"TERMINAL: a superseded head or a live objection at the current head"* is corrected, because a head mismatch is no longer terminal there. A comment describing a retracted rule is a false pointer that outlives the change.

## What this does not claim

- **It does not re-read the head from the forge.** Option 1 in the issue would also work and costs an API call per advancement; this takes the cheaper path that the adjacent branch already established, and relies on the poll to refresh the row - which it demonstrably does.
- **It does not order heads.** Nothing here decides which of two SHAs is newer, and option 3 from the issue (lineage comparison) is deliberately refused, because it would weaken exact-head review.
- **It does not bound the superseded case by terminating it.** Such an approval re-evaluates once per tick at the cost of one store read, identically to the pre-existing missing-row hold. "Bounded" here means idempotent in the event log and O(1) per tick, not eventually settled - and I would rather a stuck-forever *hold* than a settled wrong answer.
- **It does not touch herdr#185** or any store row by hand. #185 stays open and unmodified.


---

## Merge note

Merged by `gm-transport` under `merge_rule: self`, read at merge time from `gitmoot org brief --role gm-transport` rather than a briefing prompt (#2133). Owner note **131145**; Grams **gram-1a08cf30317-1394e1-55**, **gram-1a08cf38450-1394e1-56**. Owner directive: make #2150 the priority unblocker for #2146, no safeguard waiver.

**Reviewed and merged head, as a sentence** because `job record --head-sha` is display metadata and is not persisted (#2130): `f3cda27d3d0506e51ec79a344c370f10250254e3`.

Six safeguards, re-read immediately before merging:

1. Open, non-draft, `mergeable: true`, `mergeable_state: clean`, zero commit statuses.
2. 27/27 check-runs in a **single** conclusion group at the reviewed head, read by grouping conclusions rather than trusting a label.
3. Approved at that exact head with **non-empty** `tests_run`: 8 entries, 1129 bytes, zero empty - including two independent mutation runs in an isolated scratch copy.
4. Reviewer `gm-review-opus` is neither the implementer (`gm-transport`) nor the lead (`gm-omp-impl`).
5. Base `f8f0610d` equals main exactly, so there is no base-axis caveat.
6. **Attribution gap, named rather than skipped:** implemented in-session, so no engine implement job exists. Durable row `session-implement-gm-transport-*` recorded with `--acting-role` and read back from the store.

**The reviewer independently reproduced both directions**: reverting the mismatch branch to the settled behaviour fails the regression, and changing it to admit fails the safety test. They also ran a diagnostic-only rerun confirming task state and merge count stay correct under the reverted behaviour, which is what turned their finding below into a wording issue rather than a coverage gap.

## One P3 accepted with a follow-up, not silently

The reviewer found that `TestGenuinelySupersededApprovalNeverAdmitsAcrossRetries` labels its `err == nil` check as "admitted a superseded approval", but `err` is also nil under the **pre-#2150 settle** behaviour even though nothing was admitted. The assertions are correct and they verified the state and merge-count checks independently; the **message** is what misleads, by naming a conclusion the check cannot distinguish on its own.

It is merged as-is deliberately: this PR is the priority unblocker for #2146, which is approved and unmergeable until this lands, and a cosmetic test message does not justify another CI-plus-review cycle on the critical path. **I am fixing the wording in a follow-up rather than leaving it**, because a failure message that names the wrong conclusion is the same class of false pointer this PR's own comment correction addresses.

## Not claimed

- The superseded case now re-evaluates once per tick rather than terminating. Bounded means idempotent in the event log and O(1) per tick, not eventually settled.
- No forge read was added at the advancement boundary; this relies on the poll refreshing the observed row, which it demonstrably does.
- herdr#185 remains open and unmodified.
