### PR TITLE
fix(daemon): recover retained claims after external merge (#2156)

### DIFF
--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -890,6 +890,22 @@ func (d Daemon) reconcileExternallyMergedTasks(ctx context.Context, openPullNumb
 					}
 					continue
 				}
+			} else if canonicalTask.State != string(workflow.TaskReadyToMerge) {
+				// An external merge can become uncertain while the canonical task
+				// is still reviewing. The fresh forge result is authoritative, so
+				// resolve any retained claim atomically before the ordinary merged
+				// transition; otherwise the claim's trigger rejects that transition
+				// on every poll and one old PR blocks the repository forever.
+				if _, recoveredState, recoverErr := d.Store.RecoverClaimedTaskState(ctx, canonicalTask.ID,
+					string(workflow.TaskMerged), "pull_request_merged",
+					fmt.Sprintf("recovered merged pull request #%d from retained task claim", group.number)); recoverErr != nil {
+					if firstErr == nil {
+						firstErr = recoverErr
+					}
+					continue
+				} else {
+					canonicalTask.State = recoveredState
+				}
 			}
 			if closeErr := d.Workflow.HandleReviewPullRequestClosed(ctx, event, true); closeErr != nil {
 				if firstErr == nil {

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -893,18 +893,21 @@ func (d Daemon) reconcileExternallyMergedTasks(ctx context.Context, openPullNumb
 			} else if canonicalTask.State != string(workflow.TaskReadyToMerge) {
 				// An external merge can become uncertain while the canonical task
 				// is still reviewing. The fresh forge result is authoritative, so
-				// resolve any retained claim atomically before the ordinary merged
-				// transition; otherwise the claim's trigger rejects that transition
-				// on every poll and one old PR blocks the repository forever.
-				if _, recoveredState, recoverErr := d.Store.RecoverClaimedTaskState(ctx, canonicalTask.ID,
-					string(workflow.TaskMerged), "pull_request_merged",
-					fmt.Sprintf("recovered merged pull request #%d from retained task claim", group.number)); recoverErr != nil {
+				// release only that retained claim before the ordinary merged
+				// transition. HandleReviewPullRequestClosed must own the transition:
+				// it also releases the branch lock and removes the task worktree.
+				_, currentState, releaseErr := d.Store.ReleaseRetainedTaskStateClaim(ctx,
+					canonicalTask.ID, canonicalTask.State, db.TaskStateClaimKindExternalMergeUncertain)
+				if releaseErr != nil {
 					if firstErr == nil {
-						firstErr = recoverErr
+						firstErr = releaseErr
 					}
 					continue
-				} else {
-					canonicalTask.State = recoveredState
+				}
+				if currentState != canonicalTask.State {
+					// A concurrent transition won the expected-state check. Re-read
+					// the task on the next poll instead of applying this stale branch.
+					continue
 				}
 			}
 			if closeErr := d.Workflow.HandleReviewPullRequestClosed(ctx, event, true); closeErr != nil {

--- a/internal/daemon/external_merge_reconcile_test.go
+++ b/internal/daemon/external_merge_reconcile_test.go
@@ -52,6 +52,67 @@ func TestPollOnceReconcilesExternallyMergedLifecycleTasks(t *testing.T) {
 	}
 }
 
+func TestPollOnceRecoversRetainedClaimForExternallyMergedReviewTask(t *testing.T) {
+	ctx := context.Background()
+	repo := github.Repository{Owner: "owner", Name: "repo"}
+	store := testStore(t)
+	const taskID = "review-pr-7-agent"
+	seedExternalMergeTask(t, store, repo, taskID, "feature/seven", workflow.TaskReviewing, 7)
+
+	token, claimed, current, err := store.ClaimTaskState(ctx, taskID, string(workflow.TaskReviewing),
+		db.TaskStateClaimKindExternalMerge, time.Minute)
+	if err != nil || !claimed || current != string(workflow.TaskReviewing) {
+		t.Fatalf("ClaimTaskState = token %q claimed %v current %q err %v", token, claimed, current, err)
+	}
+	retained, err := store.RetainTaskStateClaim(ctx, taskID, token,
+		string(workflow.TaskReviewing), db.TaskStateClaimKindExternalMergeUncertain)
+	if err != nil || !retained {
+		t.Fatalf("RetainTaskStateClaim = retained %v err %v", retained, err)
+	}
+
+	client := &fakeGitHub{
+		pullsByState:  map[string][]github.PullRequest{"open": nil, "closed": nil},
+		pullsByNumber: map[int64]github.PullRequest{7: mergedPull(7, "feature/seven")},
+		comments:      map[int64][]github.IssueComment{},
+	}
+	engine := workflow.Engine{Store: store}
+	daemon := Daemon{Repo: repo, Store: store, GitHub: client, Workflow: &engine}
+
+	if err := daemon.PollOnce(ctx); err != nil {
+		t.Fatalf("PollOnce with retained merge claim: %v", err)
+	}
+	assertExternalMergeState(t, store, repo.FullName(), taskID, 7, workflow.TaskMerged, "merged")
+	if claimed, err := store.HasTaskStateClaim(ctx, taskID); err != nil || claimed {
+		t.Fatalf("retained claim after merged reconciliation = %v, err=%v; want cleared", claimed, err)
+	}
+	events, err := store.ListTaskEvents(ctx, taskID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	mergedEvents := 0
+	for _, event := range events {
+		if event.Kind == "pull_request_merged" {
+			mergedEvents++
+		}
+	}
+	if mergedEvents != 1 {
+		t.Fatalf("merged task events = %+v, want one pull_request_merged", events)
+	}
+	reconciliation, err := store.BeginPullRequestTerminalReconciliation(ctx, db.PullRequestTerminalReconciliation{
+		RepoFullName: repo.FullName(), PullRequest: 7, HeadSHA: "head-7", OwnerTaskID: taskID,
+	}, []string{taskID})
+	if err != nil || !reconciliation.EffectsCompleted {
+		t.Fatalf("terminal reconciliation = %+v, err=%v; want completed effects", reconciliation, err)
+	}
+	if err := daemon.PollOnce(ctx); err != nil {
+		t.Fatalf("second PollOnce after retained merge claim recovery: %v", err)
+	}
+	events, err = store.ListTaskEvents(ctx, taskID)
+	if err != nil || len(events) != 1 {
+		t.Fatalf("task events after idempotent poll = %+v, err=%v; want one event", events, err)
+	}
+}
+
 func TestBlockedTaskExternalMergeReconcileE2E(t *testing.T) {
 	// PollOnce's reconcile path performs no runtime delivery; the fake GitHub
 	// client and t.TempDir-backed store make this a deterministic no-LLM E2E.

--- a/internal/daemon/external_merge_reconcile_test.go
+++ b/internal/daemon/external_merge_reconcile_test.go
@@ -56,8 +56,25 @@ func TestPollOnceRecoversRetainedClaimForExternallyMergedReviewTask(t *testing.T
 	ctx := context.Background()
 	repo := github.Repository{Owner: "owner", Name: "repo"}
 	store := testStore(t)
-	const taskID = "review-pr-7-agent"
-	seedExternalMergeTask(t, store, repo, taskID, "feature/seven", workflow.TaskReviewing, 7)
+	const (
+		taskID       = "review-pr-7-agent"
+		branch       = "feature/seven"
+		worktreePath = "/tmp/gitmoot-retained-review-worktree"
+	)
+	seedExternalMergeTask(t, store, repo, taskID, branch, workflow.TaskReviewing, 7)
+	task, err := store.GetTask(ctx, taskID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	task.WorktreePath = worktreePath
+	if err := store.UpsertTask(ctx, task); err != nil {
+		t.Fatal(err)
+	}
+	if acquired, err := store.AcquireLock(ctx, db.BranchLock{
+		RepoFullName: repo.FullName(), Branch: branch, Owner: "review-agent",
+	}); err != nil || !acquired {
+		t.Fatalf("AcquireLock = acquired %v err %v", acquired, err)
+	}
 
 	token, claimed, current, err := store.ClaimTaskState(ctx, taskID, string(workflow.TaskReviewing),
 		db.TaskStateClaimKindExternalMerge, time.Minute)
@@ -72,10 +89,11 @@ func TestPollOnceRecoversRetainedClaimForExternallyMergedReviewTask(t *testing.T
 
 	client := &fakeGitHub{
 		pullsByState:  map[string][]github.PullRequest{"open": nil, "closed": nil},
-		pullsByNumber: map[int64]github.PullRequest{7: mergedPull(7, "feature/seven")},
+		pullsByNumber: map[int64]github.PullRequest{7: mergedPull(7, branch)},
 		comments:      map[int64][]github.IssueComment{},
 	}
-	engine := workflow.Engine{Store: store}
+	worktrees := &retainedClaimWorktreeManager{}
+	engine := workflow.Engine{Store: store, DelegationWorktrees: worktrees}
 	daemon := Daemon{Repo: repo, Store: store, GitHub: client, Workflow: &engine}
 
 	if err := daemon.PollOnce(ctx); err != nil {
@@ -85,18 +103,15 @@ func TestPollOnceRecoversRetainedClaimForExternallyMergedReviewTask(t *testing.T
 	if claimed, err := store.HasTaskStateClaim(ctx, taskID); err != nil || claimed {
 		t.Fatalf("retained claim after merged reconciliation = %v, err=%v; want cleared", claimed, err)
 	}
-	events, err := store.ListTaskEvents(ctx, taskID)
-	if err != nil {
-		t.Fatal(err)
+	if _, err := store.GetBranchLock(ctx, repo.FullName(), branch); !errors.Is(err, sql.ErrNoRows) {
+		t.Fatalf("branch lock after merged reconciliation = %v, want absent", err)
 	}
-	mergedEvents := 0
-	for _, event := range events {
-		if event.Kind == "pull_request_merged" {
-			mergedEvents++
-		}
+	task, err = store.GetTask(ctx, taskID)
+	if err != nil || task.WorktreePath != "" {
+		t.Fatalf("task after merged cleanup = %+v err=%v, want empty worktree", task, err)
 	}
-	if mergedEvents != 1 {
-		t.Fatalf("merged task events = %+v, want one pull_request_merged", events)
+	if !reflect.DeepEqual(worktrees.removed, []string{worktreePath}) {
+		t.Fatalf("removed worktrees = %v, want [%s]", worktrees.removed, worktreePath)
 	}
 	reconciliation, err := store.BeginPullRequestTerminalReconciliation(ctx, db.PullRequestTerminalReconciliation{
 		RepoFullName: repo.FullName(), PullRequest: 7, HeadSHA: "head-7", OwnerTaskID: taskID,
@@ -107,10 +122,27 @@ func TestPollOnceRecoversRetainedClaimForExternallyMergedReviewTask(t *testing.T
 	if err := daemon.PollOnce(ctx); err != nil {
 		t.Fatalf("second PollOnce after retained merge claim recovery: %v", err)
 	}
-	events, err = store.ListTaskEvents(ctx, taskID)
-	if err != nil || len(events) != 1 {
-		t.Fatalf("task events after idempotent poll = %+v, err=%v; want one event", events, err)
+	assertExternalMergeState(t, store, repo.FullName(), taskID, 7, workflow.TaskMerged, "merged")
+	if len(worktrees.removed) != 1 {
+		t.Fatalf("second poll removed worktrees=%v, want cleanup exactly once", worktrees.removed)
 	}
+}
+
+type retainedClaimWorktreeManager struct {
+	removed []string
+}
+
+func (*retainedClaimWorktreeManager) AddWorktree(context.Context, string, string, string) error {
+	return errors.New("unexpected AddWorktree")
+}
+
+func (*retainedClaimWorktreeManager) AddDetachedWorktree(context.Context, string, string) error {
+	return errors.New("unexpected AddDetachedWorktree")
+}
+
+func (m *retainedClaimWorktreeManager) RemoveWorktreeForce(_ context.Context, path string) error {
+	m.removed = append(m.removed, path)
+	return nil
 }
 
 func TestBlockedTaskExternalMergeReconcileE2E(t *testing.T) {


### PR DESCRIPTION
Fixes #2156.

A fresh forge read proving a PR merged now releases only a retained `external_merge_uncertain` claim on a non-`ready_to_merge` canonical task before ordinary terminal reconciliation. `HandleReviewPullRequestClosed` remains the owner of the merged state transition, branch-lock release, worktree removal, PR mirror update, and workflow journal. The existing `ready_to_merge` merge-gate path remains unchanged.

Live blocker: merged PR #2131 retained an external-merge-uncertain claim while its task stayed reviewing; every gitmoot repo poll then failed constraint 1811 before ingesting #2146's authorized `/gitmoot merge` command. No live state was hand-edited. Authorized by workflow note 132440.

Review correction at `5f99aa8e63be291992bb86ca1b0a879b997886bf`: the first version atomically pre-moved the task to `merged`, causing normal terminal handling to treat it as already merged and skip branch-lock/worktree cleanup. The corrected production-path regression seeds both resources and proves they are cleaned exactly once, the claim clears, task/PR terminal state completes, terminal effects are durable, and a second poll is idempotent.

Verification:
- `go test -buildvcs=false ./internal/daemon -run '^TestPollOnceRecoversRetainedClaimForExternallyMergedReviewTask$' -count=1 -v`
- `go test -buildvcs=false ./internal/daemon -count=1`
- `go vet ./internal/daemon`
- `git diff --check`

Deploy after merge, then verify PR #2131 terminal reconciliation clears and #2146 slash command is ingested. Keep jerryfane/herdr#185 open and unmodified.