### PR TITLE
feat(runtime): isolate OMP review credentials (#2158)

### DIFF
--- a/docs/adapters.md
+++ b/docs/adapters.md
@@ -148,6 +148,21 @@ then executes it, and that `--plan-yolo-into` selects the execution model with
 the `smol` role as the default. Gitmoot verifies the installed flags and records
 the requested plan shape; it cannot verify omp's internal phase transitions.
 
+Read-only OMP review and ask seats do not inherit profile auth or ambient
+provider keys. They require `OMP_AUTH_BROKER_URL` as an HTTPS or loopback HTTP
+origin, an owner-only token file named by `OMP_AUTH_BROKER_TOKEN_FILE`, and a
+provider-qualified effective model.
+An upstream `OMP_AUTH_BROKER_TOKEN` in the daemon environment is refused
+because the runtime requires seat-readable `/proc`. Gitmoot writes a random
+job-local token and loopback URL only into the seat's minimal `config.yml`; no
+broker secret enters the child environment. The proxy filters credentials and
+usage to that provider, forwards only credential refreshes, and does not expose
+shared broker writes. The daemon-staged OMP binary runs under the normal
+read-only Landlock wrapper with job-private `PI_CONFIG_DIR` and
+`PI_CODING_AGENT_DIR` roots. Missing or unsafe broker configuration refuses
+before runtime staging; an unqualified effective model refuses before OMP
+launches. The proxy and state are removed after delivery.
+
 Startup stores the session id from the NDJSON header line, but delivery never
 uses it: omp is stateless in v1 and never passes `--resume`, `--continue`, or
 `--fork`. That is a correctness requirement, not a simplification —

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -458,19 +458,37 @@ Fixes:
   condition recorded `failed`, and 25 of 29 measured refusal deaths were
   re-dispatched into the identical wall, one agent eleven times. Find them with
   `gitmoot job list --state blocked`.
-- A read-only seat (every `review`/`ask` job under the read-only autonomy
-  policy) does NOT authenticate with the ambient credential: it stages a
-  SNAPSHOT of its runtime config dir (`payload.runtime_config_dir`, else the
-  daemon's `CLAUDE_CONFIG_DIR`, else `~/.claude`) and carries the resolved
-  `runtime-auth.env` overlay. When that snapshot is already expired the job
-  records one `readonly_seat_credential_expired` event naming the expiry, the
-  refresh-token state and whether an overlay was available — read it with
-  `gitmoot job events <job-id>` before treating the runtime's own "OAuth session
-  expired and could not be refreshed" wording as an account problem. It never
-  refuses the job. `gitmoot doctor` and `gitmoot auth probe claude` both report
-  that seat credential beside the ambient one, and doctor FAILS (non-zero exit)
-  when it is expired with no refresh token, since every read-only seat job on
-  that runtime will fail until the account is re-logged in.
+- A Claude read-only seat (every `review`/`ask` job under the read-only
+  autonomy policy) does not rely only on its staged credential snapshot. It
+  stages the runtime config dir (`payload.runtime_config_dir`,
+  else the daemon's `CLAUDE_CONFIG_DIR`, else `~/.claude`) and also carries the
+  resolved `runtime-auth.env` overlay. When that snapshot is already expired
+  the job records one `readonly_seat_credential_expired` event naming the
+  expiry, the refresh-token state and whether an overlay was available — read
+  it with `gitmoot job events <job-id>` before treating the runtime's own
+  "OAuth session expired and could not be refreshed" wording as an account
+  problem. It never refuses the job. `gitmoot doctor` and `gitmoot auth probe
+  claude` both report that seat credential beside the ambient one, and doctor
+  FAILS (non-zero exit) when it is expired with no refresh token, since every
+  read-only seat job on that runtime will fail until the account is re-logged
+  in.
+- An OMP read-only seat uses no operator profile or ambient provider key. Set
+  `OMP_AUTH_BROKER_URL` to an HTTPS or loopback HTTP origin and point
+  `OMP_AUTH_BROKER_TOKEN_FILE` at an owner-only regular file; the daemon refuses
+  `OMP_AUTH_BROKER_TOKEN` because every seat must read `/proc` for runtime
+  startup. The job's effective model must be provider-qualified, such as
+  `kimi-code/k3`. Gitmoot writes a random job-local token and loopback URL only
+  into the seat's minimal `config.yml`; no broker secret enters the child
+  environment. The proxy exposes only that provider, forwards refreshes only,
+  and keeps broker writes local to the disposable client. The daemon-staged OMP
+  binary receives job-private `PI_CONFIG_DIR` and `PI_CODING_AGENT_DIR` roots.
+  Missing or unsafe broker configuration refuses before staging; an unqualified
+  effective model refuses before OMP launches. The state and proxy are removed
+  at the job boundary.
+  When broker and clients share an OS account, run `auth-broker serve` with a
+  dedicated relative `PI_CONFIG_DIR` and point `OMP_AUTH_BROKER_TOKEN_FILE` at
+  that directory's `auth-broker.token`. Otherwise both roles use
+  `~/.omp/auth-broker.token`, so a client token can invalidate the service.
 - A kimi credential that goes blank mid-session is REPORTED, not repaired
   (#1856). Kimi's credential (`~/.kimi-code/credentials/kimi-code.json`) has
   been observed blanked IN PLACE after a failed refresh: still-valid JSON, 136

--- a/internal/cli/daemon_worker.go
+++ b/internal/cli/daemon_worker.go
@@ -1534,9 +1534,52 @@ type readOnlySandboxGrants struct {
 	toolchainUnavailable string
 }
 
+type readOnlyOmpBrokerSession struct {
+	mu       sync.Mutex
+	config   readOnlyOmpBrokerConfig
+	stateDir string
+	broker   *readOnlyOmpBrokerProxy
+}
+
+func (s *readOnlyOmpBrokerSession) prepare(model string) (string, error) {
+	provider, err := readOnlyOmpProvider(model)
+	if err != nil {
+		return "", err
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.broker != nil {
+		if provider != s.broker.provider {
+			return "", fmt.Errorf("read-only omp job model provider %q is outside the broker scope %q", provider, s.broker.provider)
+		}
+		return provider, nil
+	}
+	broker, err := startReadOnlyOmpBrokerProxy(s.config, model)
+	if err != nil {
+		return "", err
+	}
+	if err := broker.writeConfig(s.stateDir); err != nil {
+		return "", errors.Join(err, broker.close())
+	}
+	s.broker = broker
+	return provider, nil
+}
+
+func (s *readOnlyOmpBrokerSession) close() error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.broker == nil {
+		return nil
+	}
+	err := s.broker.close()
+	s.broker = nil
+	return err
+}
+
 type readOnlyRuntimeAdapter struct {
 	runtime.Adapter
 	cleanupRoot string
+	ompSession  *readOnlyOmpBrokerSession
 }
 
 func (a readOnlyRuntimeAdapter) PermissionPolicyApplication(agent runtime.Agent) runtime.PermissionPolicyApplication {
@@ -1544,22 +1587,46 @@ func (a readOnlyRuntimeAdapter) PermissionPolicyApplication(agent runtime.Agent)
 }
 
 func (a readOnlyRuntimeAdapter) Deliver(ctx context.Context, agent runtime.Agent, job runtime.Job) (runtime.Result, error) {
+	if a.ompSession != nil {
+		model := runtime.EffectiveModel(agent, job)
+		provider, err := readOnlyOmpProvider(model)
+		if err != nil {
+			return runtime.Result{}, err
+		}
+		if job.Plan {
+			planProvider, err := readOnlyOmpProvider(job.PlanInto)
+			if err != nil {
+				return runtime.Result{}, fmt.Errorf("read-only omp plan execution model: %w", err)
+			}
+			if planProvider != provider {
+				return runtime.Result{}, fmt.Errorf("read-only omp plan execution provider %q is outside the broker scope %q", planProvider, provider)
+			}
+		}
+		if _, err := a.ompSession.prepare(model); err != nil {
+			return runtime.Result{}, err
+		}
+	}
 	// Mailbox repair turns reuse this adapter. Keep its isolated credentials and
 	// session state until RunJob returns; the worker owns job-boundary cleanup.
 	return a.Adapter.Deliver(ctx, agent, job)
 }
 
 func (a readOnlyRuntimeAdapter) cleanup() error {
+	var cleanupErrors []error
+	if a.ompSession != nil {
+		if err := a.ompSession.close(); err != nil {
+			cleanupErrors = append(cleanupErrors, fmt.Errorf("stop read-only omp broker: %w", err))
+		}
+	}
 	// The prompt can move or rewrite anything under the job-private writable
 	// cache. Delete that entire root so renamed credentials cannot escape cleanup;
 	// never synchronize untrusted state back to the shared runtime profile.
-	if a.cleanupRoot == "" {
-		return nil
+	if a.cleanupRoot != "" {
+		if err := os.RemoveAll(a.cleanupRoot); err != nil {
+			cleanupErrors = append(cleanupErrors, fmt.Errorf("remove read-only seat cache: %w", err))
+		}
 	}
-	if err := os.RemoveAll(a.cleanupRoot); err != nil {
-		return fmt.Errorf("remove read-only seat cache: %w", err)
-	}
-	return nil
+	return errors.Join(cleanupErrors...)
 }
 
 // reviewRepo is the repo of the JOB being run, which is what the seat's
@@ -1571,25 +1638,47 @@ func wrapReadOnlySandboxAdapter(home string, agent runtime.Agent, checkout strin
 		return adapter, readOnlySeatSetup{}, nil
 	}
 	_, gatewayMode := adapter.(modelGatewayRuntimeAdapter)
+	// Resolve credentials before creating or publishing any seat state. Claude
+	// receives its authoritative overlay. OMP reads its upstream token from an
+	// owner-only file now, but starts its provider-filtered proxy only when
+	// Deliver has the job's effective model.
+	var (
+		seatAuthEnv []string
+		ompConfig   *readOnlyOmpBrokerConfig
+	)
+	var err error
+	if agent.Runtime == runtime.OmpRuntime {
+		config, configErr := readOnlySeatOmpBrokerConfig(os.Environ())
+		if configErr != nil {
+			return nil, readOnlySeatSetup{}, configErr
+		}
+		ompConfig = &config
+	} else {
+		seatAuthEnv, err = readOnlySeatRuntimeAuthEnv(home, agent.Runtime, gatewayMode)
+	}
+	if err != nil {
+		return nil, readOnlySeatSetup{}, err
+	}
 	grants, err := readOnlyRuntimeSandboxGrants(home, agent, checkout, reviewRepo, gatewayMode)
 	if err != nil {
 		return nil, readOnlySeatSetup{}, err
 	}
-	// A seat's env is rebuilt from scratch, which DROPPED the runtime auth the
-	// non-seat path injects (runtimeJobRunnerWithAuth appends
-	// runtimeAuthInjectionEnv onto the curated BaseEnv). The seat was therefore
-	// left with nothing but its staged credential snapshot, and once that
-	// snapshot expired every claude review failed with "OAuth session expired and
-	// could not be refreshed" while `gitmoot auth probe claude` stayed green,
-	// because the probe reads the resolved auth the seat never received. Inject
-	// the same overlay here so a seat authenticates exactly like every other job.
+	setup := readOnlySeatSetup{dropped: grants.dropped, runtimeUnavailable: grants.runtimeUnavailable, toolchainUnavailable: grants.toolchainUnavailable}
+	var ompSession *readOnlyOmpBrokerSession
+	if ompConfig != nil {
+		if grants.stateDir == "" {
+			cleanupErr := os.RemoveAll(grants.cacheRoot)
+			return nil, setup, errors.Join(errors.New("read-only omp broker requires isolated runtime state"), cleanupErr)
+		}
+		ompSession = &readOnlyOmpBrokerSession{config: *ompConfig, stateDir: grants.stateDir}
+	}
+	// A seat's env is rebuilt from scratch. Claude therefore needs the same
+	// resolved runtime-auth overlay as every other Claude job. OMP's proxy token
+	// exists only in its job-private config; its upstream bearer, operator
+	// profile, and ambient provider keys remain outside the child environment.
+	//
 	// Gateway mode is excluded: there the gateway holds the credential and the
 	// seat is deliberately given none.
-	seatAuthEnv, err := readOnlySeatRuntimeAuthEnv(home, agent.Runtime, gatewayMode)
-	if err != nil {
-		return nil, readOnlySeatSetup{}, err
-	}
-	setup := readOnlySeatSetup{dropped: grants.dropped, runtimeUnavailable: grants.runtimeUnavailable, toolchainUnavailable: grants.toolchainUnavailable}
 	wrap := func(runner subprocess.Runner) subprocess.Runner {
 		baseEnv := readOnlyRuntimeBaseEnv(agent.Runtime, os.Environ(), filepath.Join(grants.cacheRoot, "gh"))
 		curated := graftRuntimeBaseRunner(runner, subprocess.CuratedGroupRunner{
@@ -1607,7 +1696,8 @@ func wrapReadOnlySandboxAdapter(home string, agent runtime.Agent, checkout strin
 	if err != nil {
 		// Staging and narrowing are already done at this point, so the
 		// withheld list is reported even though the wrap failed.
-		return nil, setup, err
+		cleanupErr := os.RemoveAll(grants.cacheRoot)
+		return nil, setup, errors.Join(err, cleanupErr)
 	}
 	if grants.stateDir == "" {
 		return wrapped, setup, nil
@@ -1617,11 +1707,13 @@ func wrapReadOnlySandboxAdapter(home string, agent runtime.Agent, checkout strin
 		// The narrowing already happened, so report it even though delivery
 		// cannot be built: a withheld credential is news whether or not the
 		// wrap succeeds.
-		return nil, setup, fmt.Errorf("read-only Landlock sandbox returned incompatible %T adapter", wrapped)
+		cleanupErr := os.RemoveAll(grants.cacheRoot)
+		return nil, setup, errors.Join(fmt.Errorf("read-only Landlock sandbox returned incompatible %T adapter", wrapped), cleanupErr)
 	}
 	return readOnlyRuntimeAdapter{
 		Adapter:     runtimeAdapter,
 		cleanupRoot: grants.cacheRoot,
+		ompSession:  ompSession,
 	}, setup, nil
 }
 
@@ -1657,8 +1749,12 @@ func wrapReadOnlyAdapterRunner(runtimeName string, adapter workflow.DeliveryAdap
 	case *runtime.KimiAdapter:
 		a.Runner = wrap(a.Runner)
 		return a, nil
-	case runtime.OmpAdapter, *runtime.OmpAdapter:
-		return nil, errors.New("read-only seats cannot use omp without an isolated credential broker")
+	case runtime.OmpAdapter:
+		a.Runner = wrap(a.Runner)
+		return a, nil
+	case *runtime.OmpAdapter:
+		a.Runner = wrap(a.Runner)
+		return a, nil
 	case runtime.ShellAdapter:
 		a.Runner = wrap(a.Runner)
 		return a, nil
@@ -2004,7 +2100,7 @@ func readOnlyRuntimeSandboxGrants(home string, agent runtime.Agent, checkout str
 	// Runtime executables are staged beside the Go toolchain and exposed by
 	// fingerprint-local shims. Grant the PUBLISHED roots the daemon owns, never
 	// the operator PATH roots they were copied from (#1921, ruling 122157).
-	stagedRuntimes, runtimeInterpreters, runtimeDiagnostics, err := stageSeatRuntimes(paths)
+	stagedRuntimes, runtimeInterpreters, runtimeDiagnostics, err := stageSeatRuntimes(paths, agent.Runtime)
 	if err != nil {
 		return grants, err
 	}
@@ -2158,8 +2254,10 @@ type readOnlySeatStatePolicy struct {
 	// is only correct for a file that cannot carry a third-party credential.
 	inputNarrowers map[string]func([]byte) (narrowedConfig, error)
 	// stateEnv names the environment variable that points the runtime at the
-	// staged dir. Empty when the runtime finds it through HOME.
-	stateEnv string
+	// staged dir. stateRootEnv names a config-root variable whose value the
+	// runtime resolves relative to HOME. Empty when HOME alone locates state.
+	stateEnv     string
+	stateRootEnv string
 }
 
 // readOnlySeatStatePolicyFor returns the staging policy for a runtime. The
@@ -2235,7 +2333,15 @@ func readOnlySeatStatePolicyForRuntime(runtimeName string, userHome string, gate
 	case runtime.ShellRuntime:
 		return readOnlySeatStatePolicy{}, false, nil
 	case runtime.OmpRuntime:
-		return readOnlySeatStatePolicy{}, false, errors.New("read-only seats cannot use omp without an isolated credential broker")
+		// OMP authenticates only through the separately validated scoped proxy.
+		// Its writable config, database, snapshot cache and logs need fresh
+		// job-private roots, but no file from the operator's OMP profile is staged.
+		return readOnlySeatStatePolicy{
+			defaultSourceDir: filepath.Join(userHome, ".omp", "agent"),
+			relativeState:    filepath.Join(".omp", "agent"),
+			stateEnv:         "PI_CODING_AGENT_DIR",
+			stateRootEnv:     "PI_CONFIG_DIR",
+		}, true, nil
 	default:
 		return readOnlySeatStatePolicy{}, false, fmt.Errorf("read-only seat runtime %q has no isolated state policy", runtimeName)
 	}
@@ -2314,6 +2420,16 @@ func prepareReadOnlyRuntimeState(agent runtime.Agent, cacheRoot string, gatewayM
 	var stateEnv []string
 	if policy.stateEnv != "" {
 		stateEnv = append(stateEnv, policy.stateEnv+"="+stateDir)
+	}
+	if policy.stateRootEnv != "" {
+		rootFromHome, err := filepath.Rel(filepath.Join(cacheRoot, "home"), filepath.Dir(stateDir))
+		if err != nil {
+			return "", nil, nil, fmt.Errorf("resolve isolated runtime config root: %w", err)
+		}
+		if filepath.IsAbs(rootFromHome) {
+			return "", nil, nil, errors.New("isolated runtime config root did not resolve relative to HOME")
+		}
+		stateEnv = append(stateEnv, policy.stateRootEnv+"="+rootFromHome)
 	}
 	return stateDir, stateEnv, dropped, nil
 }

--- a/internal/cli/readonly_omp_broker.go
+++ b/internal/cli/readonly_omp_broker.go
@@ -1,0 +1,467 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"crypto/rand"
+	"crypto/subtle"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const (
+	readOnlyOmpBrokerBodyLimit  = 16 << 20
+	readOnlyOmpBrokerTokenLimit = 16 << 10
+)
+
+type readOnlyOmpBrokerConfig struct {
+	url   string
+	token string
+}
+
+type readOnlyOmpBrokerProxy struct {
+	server        *http.Server
+	listener      net.Listener
+	client        *http.Client
+	upstream      readOnlyOmpBrokerConfig
+	downstreamKey string
+	provider      string
+}
+
+func readOnlySeatOmpBrokerConfig(environ []string) (readOnlyOmpBrokerConfig, error) {
+	const (
+		urlName       = "OMP_AUTH_BROKER_URL"
+		tokenName     = "OMP_AUTH_BROKER_TOKEN"
+		tokenFileName = "OMP_AUTH_BROKER_TOKEN_FILE"
+	)
+	var config readOnlyOmpBrokerConfig
+	var tokenFile, ambientToken string
+	for _, entry := range environ {
+		name, value, ok := strings.Cut(entry, "=")
+		if !ok {
+			continue
+		}
+		switch name {
+		case urlName:
+			config.url = strings.TrimSpace(value)
+		case tokenName:
+			ambientToken = strings.TrimSpace(value)
+		case tokenFileName:
+			tokenFile = strings.TrimSpace(value)
+		}
+	}
+	if ambientToken != "" {
+		return readOnlyOmpBrokerConfig{}, fmt.Errorf("read-only omp seat refuses %s in the daemon environment because /proc exposes it; put the token in a mode-0600 file named by %s", tokenName, tokenFileName)
+	}
+	var missing []string
+	if config.url == "" {
+		missing = append(missing, urlName)
+	}
+	if tokenFile == "" {
+		missing = append(missing, tokenFileName)
+	}
+	if len(missing) != 0 {
+		return readOnlyOmpBrokerConfig{}, fmt.Errorf("read-only omp seat requires an isolated auth broker; set %s in the daemon environment", strings.Join(missing, " and "))
+	}
+	parsed, err := url.Parse(config.url)
+	validOrigin := err == nil &&
+		(parsed.Scheme == "http" || parsed.Scheme == "https") &&
+		parsed.Host != "" &&
+		parsed.User == nil &&
+		(parsed.Path == "" || parsed.Path == "/") &&
+		parsed.RawPath == "" &&
+		parsed.RawQuery == "" &&
+		parsed.Fragment == ""
+	if validOrigin && parsed.Scheme == "http" {
+		hostIP := net.ParseIP(parsed.Hostname())
+		validOrigin = parsed.Hostname() == "localhost" || (hostIP != nil && hostIP.IsLoopback())
+	}
+	if !validOrigin {
+		return readOnlyOmpBrokerConfig{}, errors.New("read-only omp seat requires OMP_AUTH_BROKER_URL to be an HTTPS or loopback HTTP origin without credentials, path, query, or fragment")
+	}
+	config.token, err = readOnlyOmpBrokerToken(tokenFile)
+	if err != nil {
+		return readOnlyOmpBrokerConfig{}, err
+	}
+	config.url = strings.TrimRight(config.url, "/")
+	return config, nil
+}
+
+func readOnlyOmpBrokerToken(path string) (string, error) {
+	if !filepath.IsAbs(path) {
+		return "", errors.New("read-only omp seat requires OMP_AUTH_BROKER_TOKEN_FILE to be an absolute path")
+	}
+	before, err := os.Lstat(path)
+	if err != nil {
+		return "", fmt.Errorf("inspect OMP_AUTH_BROKER_TOKEN_FILE: %w", err)
+	}
+	if !before.Mode().IsRegular() || before.Mode().Perm()&0o077 != 0 {
+		return "", errors.New("read-only omp seat requires OMP_AUTH_BROKER_TOKEN_FILE to be an owner-only regular file (0600 or stricter)")
+	}
+	file, err := os.Open(path)
+	if err != nil {
+		return "", fmt.Errorf("open OMP_AUTH_BROKER_TOKEN_FILE: %w", err)
+	}
+	defer file.Close()
+	after, err := file.Stat()
+	if err != nil || !os.SameFile(before, after) ||
+		!after.Mode().IsRegular() || after.Mode().Perm()&0o077 != 0 {
+		return "", errors.New("OMP_AUTH_BROKER_TOKEN_FILE changed while opening")
+	}
+	data, err := io.ReadAll(io.LimitReader(file, readOnlyOmpBrokerTokenLimit+1))
+	if err != nil || len(data) > readOnlyOmpBrokerTokenLimit {
+		return "", errors.New("read OMP_AUTH_BROKER_TOKEN_FILE: token is unavailable or too large")
+	}
+	token := strings.TrimSpace(string(data))
+	if token == "" || strings.ContainsAny(token, " \t\r\n") {
+		return "", errors.New("OMP_AUTH_BROKER_TOKEN_FILE contains an invalid token")
+	}
+	return token, nil
+}
+
+func readOnlyOmpProvider(model string) (string, error) {
+	model = strings.TrimSpace(model)
+	provider, modelID, ok := strings.Cut(model, "/")
+	if !ok || provider == "" || modelID == "" || strings.ContainsAny(provider, " \t\r\n") {
+		return "", fmt.Errorf("read-only omp seat requires a provider-qualified model such as provider/model; got %q", model)
+	}
+	return provider, nil
+}
+
+func startReadOnlyOmpBrokerProxy(config readOnlyOmpBrokerConfig, model string) (*readOnlyOmpBrokerProxy, error) {
+	provider, err := readOnlyOmpProvider(model)
+	if err != nil {
+		return nil, err
+	}
+	keyBytes := make([]byte, 32)
+	if _, err := rand.Read(keyBytes); err != nil {
+		return nil, fmt.Errorf("generate read-only omp broker token: %w", err)
+	}
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		return nil, fmt.Errorf("listen for read-only omp broker: %w", err)
+	}
+	transport := http.DefaultTransport.(*http.Transport).Clone()
+	transport.Proxy = nil
+	proxy := &readOnlyOmpBrokerProxy{
+		listener: listener,
+		client: &http.Client{
+			Transport: transport,
+			Timeout:   35 * time.Second,
+			CheckRedirect: func(*http.Request, []*http.Request) error {
+				return http.ErrUseLastResponse
+			},
+		},
+		upstream:      config,
+		downstreamKey: base64.RawURLEncoding.EncodeToString(keyBytes),
+		provider:      provider,
+	}
+	proxy.server = &http.Server{
+		Handler:           proxy,
+		ReadHeaderTimeout: 5 * time.Second,
+		WriteTimeout:      40 * time.Second,
+		IdleTimeout:       40 * time.Second,
+	}
+	go func() {
+		_ = proxy.server.Serve(listener)
+	}()
+	return proxy, nil
+}
+
+func (p *readOnlyOmpBrokerProxy) writeConfig(stateDir string) error {
+	configPath := filepath.Join(stateDir, "config.yml")
+	file, err := os.OpenFile(configPath, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o600)
+	if err != nil {
+		return fmt.Errorf("create read-only omp broker config: %w", err)
+	}
+	body := fmt.Sprintf(
+		"auth:\n  broker:\n    url: %s\n    token: %s\n",
+		strconv.Quote("http://"+p.listener.Addr().String()),
+		strconv.Quote(p.downstreamKey),
+	)
+	if _, err := io.WriteString(file, body); err != nil {
+		file.Close()
+		return fmt.Errorf("write read-only omp broker config: %w", err)
+	}
+	if err := file.Close(); err != nil {
+		return fmt.Errorf("close read-only omp broker config: %w", err)
+	}
+	return nil
+}
+
+func (p *readOnlyOmpBrokerProxy) close() error {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	err := p.server.Shutdown(ctx)
+	p.client.CloseIdleConnections()
+	if errors.Is(err, http.ErrServerClosed) {
+		return nil
+	}
+	return err
+}
+
+func (p *readOnlyOmpBrokerProxy) ServeHTTP(w http.ResponseWriter, request *http.Request) {
+	if request.URL.Path == "/v1/healthz" && request.Method == http.MethodGet {
+		writeOmpBrokerJSON(w, http.StatusOK, map[string]any{"ok": true, "version": "gitmoot-scoped"})
+		return
+	}
+	if !p.authorized(request.Header.Get("Authorization")) {
+		writeOmpBrokerJSON(w, http.StatusUnauthorized, map[string]any{"error": "unauthorized"})
+		return
+	}
+
+	switch {
+	case request.Method == http.MethodGet && request.URL.Path == "/v1/snapshot/stream":
+		// OMP permanently falls back to conditional snapshot polling after this
+		// sentinel. Filtering an unbounded SSE stream would add a second protocol
+		// parser to a credential boundary for no functional gain.
+		writeOmpBrokerJSON(w, http.StatusNotFound, map[string]any{"error": "stream unsupported by scoped broker"})
+	case request.Method == http.MethodGet && request.URL.Path == "/v1/snapshot":
+		p.forward(w, request, "credentials", nil)
+	case request.Method == http.MethodGet && request.URL.Path == "/v1/usage":
+		p.forward(w, request, "reports", nil)
+	case request.Method == http.MethodGet && request.URL.Path == "/v1/credentials/disabled":
+		query := request.URL.Query()
+		query.Set("provider", p.provider)
+		request.URL.RawQuery = query.Encode()
+		p.forward(w, request, "disabled", nil)
+	case request.Method == http.MethodPost && request.URL.Path == "/v1/usage/observed":
+		body, err := readOmpBrokerBody(request.Body)
+		if err != nil || !brokerBodyUsesOnlyProvider(body, p.provider, true) {
+			writeOmpBrokerJSON(w, http.StatusForbidden, map[string]any{"error": "provider outside seat scope"})
+			return
+		}
+		// A reviewer cannot write client identity or usage into the shared vault.
+		// A local success preserves OMP's best-effort accounting path.
+		writeOmpBrokerJSON(w, http.StatusOK, map[string]any{"ok": true})
+	case request.Method == http.MethodPost && request.URL.Path == "/v1/usage/stale":
+		// Invalidating every broker client's usage cache is outside a seat's
+		// authority. OMP treats this notification as best-effort.
+		writeOmpBrokerJSON(w, http.StatusOK, map[string]any{"ok": true})
+	default:
+		credentialID, action, ok := ompBrokerCredentialRoute(request.Method, request.URL.Path)
+		if !ok || !p.credentialAllowed(request.Context(), credentialID) {
+			writeOmpBrokerJSON(w, http.StatusForbidden, map[string]any{"error": "broker route outside seat scope"})
+			return
+		}
+		body, err := readOmpBrokerBody(request.Body)
+		if err != nil {
+			writeOmpBrokerJSON(w, http.StatusBadRequest, map[string]any{"error": "request body too large"})
+			return
+		}
+		if len(body) != 0 && !brokerBodyUsesOnlyProvider(body, p.provider, false) {
+			writeOmpBrokerJSON(w, http.StatusForbidden, map[string]any{"error": "provider outside seat scope"})
+			return
+		}
+		if action != "refresh" {
+			// Disable/block writes would mutate a shared credential or its
+			// availability for every agent. Keep them local to this disposable
+			// client by acknowledging without forwarding.
+			writeOmpBrokerJSON(w, http.StatusOK, map[string]any{"ok": true})
+			return
+		}
+		p.forward(w, request, "entry", body)
+	}
+}
+
+func (p *readOnlyOmpBrokerProxy) authorized(header string) bool {
+	const prefix = "Bearer "
+	if !strings.HasPrefix(header, prefix) {
+		return false
+	}
+	provided := strings.TrimSpace(strings.TrimPrefix(header, prefix))
+	if len(provided) != len(p.downstreamKey) {
+		return false
+	}
+	return subtle.ConstantTimeCompare([]byte(provided), []byte(p.downstreamKey)) == 1
+}
+
+func ompBrokerCredentialRoute(method, path string) (int64, string, bool) {
+	parts := strings.Split(strings.Trim(path, "/"), "/")
+	if len(parts) != 4 || parts[0] != "v1" || parts[1] != "credential" {
+		return 0, "", false
+	}
+	allowed := (method == http.MethodPost && (parts[3] == "refresh" || parts[3] == "disable" || parts[3] == "block")) ||
+		(method == http.MethodDelete && parts[3] == "blocks")
+	if !allowed {
+		return 0, "", false
+	}
+	id, err := strconv.ParseInt(parts[2], 10, 64)
+	return id, parts[3], err == nil && id > 0
+}
+
+func (p *readOnlyOmpBrokerProxy) credentialAllowed(ctx context.Context, credentialID int64) bool {
+	request, err := http.NewRequestWithContext(ctx, http.MethodGet, p.upstream.url+"/v1/snapshot", nil)
+	if err != nil {
+		return false
+	}
+	request.Header.Set("Authorization", "Bearer "+p.upstream.token)
+	response, err := p.client.Do(request)
+	if err != nil {
+		return false
+	}
+	defer response.Body.Close()
+	if response.StatusCode != http.StatusOK {
+		return false
+	}
+	body, err := io.ReadAll(io.LimitReader(response.Body, readOnlyOmpBrokerBodyLimit+1))
+	if err != nil || len(body) > readOnlyOmpBrokerBodyLimit {
+		return false
+	}
+	var snapshot struct {
+		Credentials []struct {
+			ID       int64  `json:"id"`
+			Provider string `json:"provider"`
+		} `json:"credentials"`
+	}
+	if json.Unmarshal(body, &snapshot) != nil {
+		return false
+	}
+	for _, credential := range snapshot.Credentials {
+		if credential.ID == credentialID {
+			return credential.Provider == p.provider
+		}
+	}
+	return false
+}
+
+func (p *readOnlyOmpBrokerProxy) forward(w http.ResponseWriter, incoming *http.Request, responseField string, body []byte) {
+	var reader io.Reader
+	if body != nil {
+		reader = bytes.NewReader(body)
+	} else if incoming.Body != nil {
+		reader = incoming.Body
+	}
+	upstreamRequest, err := http.NewRequestWithContext(incoming.Context(), incoming.Method, p.upstream.url+incoming.URL.RequestURI(), reader)
+	if err != nil {
+		writeOmpBrokerJSON(w, http.StatusBadGateway, map[string]any{"error": "upstream request failed"})
+		return
+	}
+	upstreamRequest.Header.Set("Authorization", "Bearer "+p.upstream.token)
+	for _, name := range []string{"Accept", "Content-Type", "If-None-Match", "OMP-Auth-Broker-Capabilities"} {
+		if value := incoming.Header.Get(name); value != "" {
+			upstreamRequest.Header.Set(name, value)
+		}
+	}
+	response, err := p.client.Do(upstreamRequest)
+	if err != nil {
+		writeOmpBrokerJSON(w, http.StatusBadGateway, map[string]any{"error": "upstream broker unavailable"})
+		return
+	}
+	defer response.Body.Close()
+	if response.StatusCode == http.StatusNotModified || response.StatusCode == http.StatusNoContent {
+		w.WriteHeader(response.StatusCode)
+		return
+	}
+	responseBody, err := io.ReadAll(io.LimitReader(response.Body, readOnlyOmpBrokerBodyLimit+1))
+	if err != nil || len(responseBody) > readOnlyOmpBrokerBodyLimit {
+		writeOmpBrokerJSON(w, http.StatusBadGateway, map[string]any{"error": "upstream broker response too large"})
+		return
+	}
+	if response.StatusCode < 200 || response.StatusCode >= 300 {
+		writeOmpBrokerJSON(w, response.StatusCode, map[string]any{"error": "upstream broker request failed"})
+		return
+	}
+	responseBody, err = filterOmpBrokerPayload(responseBody, p.provider, responseField)
+	if err != nil {
+		writeOmpBrokerJSON(w, http.StatusBadGateway, map[string]any{"error": "upstream broker response invalid"})
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("Content-Length", strconv.Itoa(len(responseBody)))
+	w.WriteHeader(response.StatusCode)
+	_, _ = w.Write(responseBody)
+}
+
+func filterOmpBrokerPayload(body []byte, provider, responseField string) ([]byte, error) {
+	var object map[string]any
+	if err := json.Unmarshal(body, &object); err != nil {
+		return nil, err
+	}
+	if responseField == "entry" {
+		entry, ok := object[responseField].(map[string]any)
+		if !ok || entry["provider"] != provider {
+			return nil, errors.New("broker returned an invalid scoped credential")
+		}
+		return json.Marshal(object)
+	}
+	items, ok := object[responseField].([]any)
+	if !ok {
+		return nil, fmt.Errorf("broker response omitted %q array", responseField)
+	}
+	filtered := items[:0]
+	for _, item := range items {
+		record, ok := item.(map[string]any)
+		if ok && record["provider"] == provider {
+			filtered = append(filtered, item)
+		}
+	}
+	object[responseField] = filtered
+	return json.Marshal(object)
+}
+
+func brokerBodyUsesOnlyProvider(body []byte, provider string, requireProvider bool) bool {
+	if len(bytes.TrimSpace(body)) == 0 {
+		return !requireProvider
+	}
+	var value any
+	if json.Unmarshal(body, &value) != nil {
+		return false
+	}
+	seen := false
+	var visit func(any) bool
+	visit = func(current any) bool {
+		switch typed := current.(type) {
+		case map[string]any:
+			for key, child := range typed {
+				if key == "provider" || key == "providerKey" {
+					text, ok := child.(string)
+					if !ok || text != provider {
+						return false
+					}
+					seen = true
+				}
+				if !visit(child) {
+					return false
+				}
+			}
+		case []any:
+			for _, child := range typed {
+				if !visit(child) {
+					return false
+				}
+			}
+		}
+		return true
+	}
+	return visit(value) && (!requireProvider || seen)
+}
+
+func readOmpBrokerBody(body io.ReadCloser) ([]byte, error) {
+	if body == nil {
+		return nil, nil
+	}
+	defer body.Close()
+	data, err := io.ReadAll(io.LimitReader(body, readOnlyOmpBrokerBodyLimit+1))
+	if err != nil || len(data) > readOnlyOmpBrokerBodyLimit {
+		return nil, errors.New("broker request body too large")
+	}
+	return data, nil
+}
+
+func writeOmpBrokerJSON(w http.ResponseWriter, status int, value any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(value)
+}

--- a/internal/cli/readonly_omp_broker_test.go
+++ b/internal/cli/readonly_omp_broker_test.go
@@ -1,0 +1,230 @@
+package cli
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/gitmoot/gitmoot/internal/runtime"
+)
+
+func TestReadOnlyOmpBrokerProxyFiltersProviderAndProtectsUpstreamToken(t *testing.T) {
+	const upstreamToken = "upstream-vault-token"
+	var selectedRefreshes atomic.Int32
+	var foreignRefreshes atomic.Int32
+	var usageReports atomic.Int32
+	var credentialWrites atomic.Int32
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, request *http.Request) {
+		if request.Header.Get("Authorization") != "Bearer "+upstreamToken {
+			writeOmpBrokerJSON(w, http.StatusUnauthorized, map[string]any{"error": "bad upstream token"})
+			return
+		}
+		switch request.URL.Path {
+		case "/v1/snapshot":
+			writeOmpBrokerJSON(w, http.StatusOK, map[string]any{
+				"generation": 4, "generatedAt": 1, "serverNowMs": 1,
+				"refresher": map[string]any{"enabled": true, "intervalMs": 1, "skewMs": 1, "nextSweepInMs": 1},
+				"credentials": []any{
+					map[string]any{"id": 11, "provider": "kimi-code", "credential": map[string]any{"type": "api_key", "key": "selected-access"}, "identityKey": "kimi"},
+					map[string]any{"id": 22, "provider": "anthropic", "credential": map[string]any{"type": "oauth", "access": "foreign-access"}, "identityKey": "claude"},
+				},
+			})
+		case "/v1/usage":
+			writeOmpBrokerJSON(w, http.StatusOK, map[string]any{"generatedAt": 1, "reports": []any{
+				map[string]any{"provider": "kimi-code", "limits": []any{}},
+				map[string]any{"provider": "anthropic", "limits": []any{}, "metadata": map[string]any{"account": "foreign"}},
+			}})
+		case "/v1/credential/11/refresh":
+			selectedRefreshes.Add(1)
+			writeOmpBrokerJSON(w, http.StatusOK, map[string]any{"entry": map[string]any{"id": 11, "provider": "kimi-code", "credential": map[string]any{"type": "oauth", "access": "selected-refreshed"}}})
+		case "/v1/credential/22/refresh":
+			foreignRefreshes.Add(1)
+			writeOmpBrokerJSON(w, http.StatusOK, map[string]any{"entry": map[string]any{"id": 22, "provider": "anthropic", "credential": map[string]any{"type": "oauth", "access": "foreign-refreshed"}}})
+		case "/v1/credential/11/disable":
+			credentialWrites.Add(1)
+			writeOmpBrokerJSON(w, http.StatusOK, map[string]any{"ok": true})
+		case "/v1/usage/observed":
+			usageReports.Add(1)
+			writeOmpBrokerJSON(w, http.StatusOK, map[string]any{"ok": true})
+		default:
+			writeOmpBrokerJSON(w, http.StatusNotFound, map[string]any{"error": "not found"})
+		}
+	}))
+	defer upstream.Close()
+
+	proxy, err := startReadOnlyOmpBrokerProxy(readOnlyOmpBrokerConfig{url: upstream.URL, token: upstreamToken}, "kimi-code/k3")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer proxy.close()
+	proxyURL := "http://" + proxy.listener.Addr().String()
+	proxyToken := proxy.downstreamKey
+	if proxyToken == "" || proxyToken == upstreamToken {
+		t.Fatalf("downstream token was empty or reused the upstream vault token")
+	}
+
+	request := func(method, path, token, body string) (int, string) {
+		t.Helper()
+		req, err := http.NewRequest(method, proxyURL+path, strings.NewReader(body))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if token != "" {
+			req.Header.Set("Authorization", "Bearer "+token)
+		}
+		if body != "" {
+			req.Header.Set("Content-Type", "application/json")
+		}
+		response, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer response.Body.Close()
+		data, err := io.ReadAll(response.Body)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return response.StatusCode, string(data)
+	}
+
+	if status, _ := request(http.MethodGet, "/v1/snapshot", "wrong", ""); status != http.StatusUnauthorized {
+		t.Fatalf("wrong downstream token status = %d, want 401", status)
+	}
+	status, snapshot := request(http.MethodGet, "/v1/snapshot", proxyToken, "")
+	if status != http.StatusOK || !strings.Contains(snapshot, "selected-access") || strings.Contains(snapshot, "anthropic") || strings.Contains(snapshot, "foreign-access") {
+		t.Fatalf("filtered snapshot status=%d body=%s", status, snapshot)
+	}
+	status, usage := request(http.MethodGet, "/v1/usage", proxyToken, "")
+	if status != http.StatusOK || !strings.Contains(usage, "kimi-code") || strings.Contains(usage, "anthropic") || strings.Contains(usage, "foreign") {
+		t.Fatalf("filtered usage status=%d body=%s", status, usage)
+	}
+	if status, _ := request(http.MethodGet, "/v1/snapshot/stream", proxyToken, ""); status != http.StatusNotFound {
+		t.Fatalf("snapshot stream status = %d, want OMP fallback sentinel 404", status)
+	}
+	if status, _ := request(http.MethodPost, "/v1/credential/22/refresh", proxyToken, ""); status != http.StatusForbidden || foreignRefreshes.Load() != 0 {
+		t.Fatalf("foreign refresh status=%d upstreamCalls=%d", status, foreignRefreshes.Load())
+	}
+	status, refreshed := request(http.MethodPost, "/v1/credential/11/refresh", proxyToken, "")
+	if status != http.StatusOK || selectedRefreshes.Load() != 1 || !strings.Contains(refreshed, "selected-refreshed") {
+		t.Fatalf("selected refresh status=%d calls=%d body=%s", status, selectedRefreshes.Load(), refreshed)
+	}
+	foreignUsage := `{"installId":"seat","entries":[{"provider":"anthropic","model":"claude"}]}`
+	if status, _ := request(http.MethodPost, "/v1/usage/observed", proxyToken, foreignUsage); status != http.StatusForbidden || usageReports.Load() != 0 {
+		t.Fatalf("foreign usage status=%d upstreamCalls=%d", status, usageReports.Load())
+	}
+	selectedUsage := `{"installId":"seat","entries":[{"provider":"kimi-code","model":"k3"}]}`
+	if status, _ := request(http.MethodPost, "/v1/usage/observed", proxyToken, selectedUsage); status != http.StatusOK || usageReports.Load() != 0 {
+		t.Fatalf("selected usage status=%d upstreamCalls=%d, want local acknowledgement", status, usageReports.Load())
+	}
+	if status, _ := request(http.MethodPost, "/v1/credential/11/disable", proxyToken, `{"cause":"seat"}`); status != http.StatusOK || credentialWrites.Load() != 0 {
+		t.Fatalf("selected disable status=%d upstreamCalls=%d, want local acknowledgement", status, credentialWrites.Load())
+	}
+}
+
+func TestReadOnlyOmpBrokerPayloadFilteringFailsClosed(t *testing.T) {
+	if _, err := filterOmpBrokerPayload([]byte(`{"generation":1}`), "kimi-code", "credentials"); err == nil {
+		t.Fatal("snapshot without credentials array was accepted")
+	}
+	if _, err := filterOmpBrokerPayload([]byte(`{"entry":{"id":22,"provider":"anthropic"}}`), "kimi-code", "entry"); err == nil {
+		t.Fatal("foreign refresh result was accepted")
+	}
+	filtered, err := filterOmpBrokerPayload([]byte(`{"credentials":[{"id":11,"provider":"kimi-code"},{"id":22,"provider":"anthropic"}]}`), "kimi-code", "credentials")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(filtered), "anthropic") || !strings.Contains(string(filtered), "kimi-code") {
+		t.Fatalf("filtered payload escaped provider scope: %s", filtered)
+	}
+}
+
+func TestReadOnlyOmpBrokerRequiresQualifiedAndStableEffectiveProvider(t *testing.T) {
+	for _, model := range []string{"", "k3", "/k3", "kimi-code/"} {
+		if _, err := readOnlyOmpProvider(model); err == nil {
+			t.Fatalf("model %q was accepted without a stable provider scope", model)
+		}
+	}
+	if provider, err := readOnlyOmpProvider("kimi-code/k3"); err != nil || provider != "kimi-code" {
+		t.Fatalf("qualified model provider=%q err=%v", provider, err)
+	}
+
+	session := &readOnlyOmpBrokerSession{
+		config:   readOnlyOmpBrokerConfig{url: "http://127.0.0.1:1", token: "upstream"},
+		stateDir: t.TempDir(),
+	}
+	defer session.close()
+	adapter := readOnlyRuntimeAdapter{Adapter: &cliWorkerFakeAdapter{}, ompSession: session}
+	_, err := adapter.Deliver(
+		context.Background(),
+		runtime.Agent{Model: "kimi-code/k3"},
+		runtime.Job{Model: "anthropic/claude-opus-5"},
+	)
+	if err != nil || session.broker == nil || session.broker.provider != "anthropic" {
+		t.Fatalf("job override broker=%v err=%v, want anthropic scope", session.broker, err)
+	}
+	if _, err := adapter.Deliver(context.Background(), runtime.Agent{Model: "kimi-code/k3"}, runtime.Job{}); err == nil || !strings.Contains(err.Error(), "outside the broker scope") {
+		t.Fatalf("cross-provider repair turn error = %v", err)
+	}
+	_, err = adapter.Deliver(
+		context.Background(),
+		runtime.Agent{Model: "anthropic/claude-opus-5"},
+		runtime.Job{Plan: true, PlanInto: "kimi-code/k3"},
+	)
+	if err == nil || !strings.Contains(err.Error(), "plan execution provider") {
+		t.Fatalf("cross-provider plan override error = %v", err)
+	}
+}
+
+func TestReadOnlyOmpBrokerConfigRejectsUnsafeURL(t *testing.T) {
+	tokenFile := filepath.Join(t.TempDir(), "broker-token")
+	if err := os.WriteFile(tokenFile, []byte("token\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	for _, brokerURL := range []string{
+		"file:///tmp/broker",
+		"http://user:secret@127.0.0.1:8765",
+		"http://127.0.0.1:8765/path",
+		"http://127.0.0.1:8765?token=leak",
+		"http://example.com",
+	} {
+		_, err := readOnlySeatOmpBrokerConfig([]string{
+			"OMP_AUTH_BROKER_URL=" + brokerURL,
+			"OMP_AUTH_BROKER_TOKEN_FILE=" + tokenFile,
+		})
+		if err == nil {
+			t.Fatalf("unsafe broker URL %q was accepted", brokerURL)
+		}
+	}
+
+	config, err := readOnlySeatOmpBrokerConfig([]string{
+		"OMP_AUTH_BROKER_URL=http://127.0.0.1:8765/",
+		"OMP_AUTH_BROKER_TOKEN_FILE=" + tokenFile,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if config.url != "http://127.0.0.1:8765" || config.token != "token" {
+		t.Fatalf("normalized broker config = url:%q token-loaded:%v", config.url, config.token != "")
+	}
+	if _, err := readOnlySeatOmpBrokerConfig([]string{
+		"OMP_AUTH_BROKER_URL=http://127.0.0.1:8765",
+		"OMP_AUTH_BROKER_TOKEN=token",
+		"OMP_AUTH_BROKER_TOKEN_FILE=" + tokenFile,
+	}); err == nil || !strings.Contains(err.Error(), "/proc") {
+		t.Fatalf("ambient upstream broker token was not refused: %v", err)
+	}
+	if err := os.Chmod(tokenFile, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := readOnlySeatOmpBrokerConfig([]string{
+		"OMP_AUTH_BROKER_URL=http://127.0.0.1:8765",
+		"OMP_AUTH_BROKER_TOKEN_FILE=" + tokenFile,
+	}); err == nil || !strings.Contains(err.Error(), "owner-only") {
+		t.Fatalf("insecure token file was accepted: %v", err)
+	}
+}

--- a/internal/cli/readonly_seat_credential.go
+++ b/internal/cli/readonly_seat_credential.go
@@ -169,15 +169,23 @@ func readOnlySeatCredentialPreflight(agent runtime.Agent, sourceDir string, gate
 	)
 }
 
-// readOnlySeatRuntimeAuthEnv resolves the runtime auth a seat must carry: the
-// same overlay runtimeJobRunnerWithAuth injects for every other job, which the
-// seat path rebuilt its environment without.
+// readOnlySeatRuntimeAuthEnv resolves whether the daemon has the credential
+// route a seat needs. Claude receives the same authoritative overlay as every
+// other Claude job. OMP returns only its non-secret configured endpoint for the
+// preflight below; wrapReadOnlySandboxAdapter separately exchanges the token
+// file for a provider-scoped job token before constructing the child environment.
 //
-// It bootstraps first, exactly as runtimeJobRunnerWithAuth does. Reading
+// It bootstraps Claude first, exactly as runtimeJobRunnerWithAuth does. Reading
 // runtime-auth.env alone returned an empty overlay on a host that authenticates
 // from ambient credentials and had never written that file.
 func readOnlySeatRuntimeAuthEnv(home string, runtimeName string, gatewayMode bool) ([]string, error) {
-	if gatewayMode || runtimeName != runtime.ClaudeRuntime {
+	if gatewayMode {
+		return nil, nil
+	}
+	if runtimeName == runtime.OmpRuntime {
+		return readOnlySeatOmpBrokerEnv(os.Environ())
+	}
+	if runtimeName != runtime.ClaudeRuntime {
 		return nil, nil
 	}
 	paths, err := pathsFromFlag(home)
@@ -187,12 +195,26 @@ func readOnlySeatRuntimeAuthEnv(home string, runtimeName string, gatewayMode boo
 	return readOnlySeatRuntimeAuthEnvForPaths(paths, runtimeName, gatewayMode)
 }
 
+func readOnlySeatOmpBrokerEnv(environ []string) ([]string, error) {
+	config, err := readOnlySeatOmpBrokerConfig(environ)
+	if err != nil {
+		return nil, err
+	}
+	return []string{"OMP_AUTH_BROKER_URL=" + config.url}, nil
+}
+
 // readOnlySeatRuntimeAuthEnvForPaths is the same lookup for a caller that has
 // already resolved its paths. Handing paths.Home to the flag-taking variant
 // re-resolves a DIFFERENT home, which is the mistake that made the operator
 // checks read the wrong overlay (#1810 review, round 3).
 func readOnlySeatRuntimeAuthEnvForPaths(paths config.Paths, runtimeName string, gatewayMode bool) ([]string, error) {
-	if gatewayMode || runtimeName != runtime.ClaudeRuntime {
+	if gatewayMode {
+		return nil, nil
+	}
+	if runtimeName == runtime.OmpRuntime {
+		return readOnlySeatOmpBrokerEnv(os.Environ())
+	}
+	if runtimeName != runtime.ClaudeRuntime {
 		return nil, nil
 	}
 	if _, err := bootstrapRuntimeAuth(paths.Home, runtimeAuthEnvLookup, runtimeAuthLogf); err != nil {

--- a/internal/cli/readonly_seat_credential_test.go
+++ b/internal/cli/readonly_seat_credential_test.go
@@ -722,46 +722,115 @@ func TestSeatAuthProbeFailsOpenOnEveryUndecidableOutcome(t *testing.T) {
 	}
 }
 
-// The overlay is claude-only BY POLICY, not by "codex happens to be excluded".
-// Round 3 measured a mutant widening it to kimi surviving, because the test
-// named codex instead of enumerating the runtimes.
-func TestSeatRuntimeAuthOverlayIsClaudeOnlyAcrossEverySupportedRuntime(t *testing.T) {
+// Auth overlays are runtime-scoped BY POLICY, not because one neighboring
+// runtime happens to be excluded. Enumerate the registry so adding a runtime
+// cannot silently inherit Claude or OMP credentials.
+func TestSeatRuntimeAuthOverlayIsRuntimeScopedAcrossEverySupportedRuntime(t *testing.T) {
 	home := t.TempDir()
 	configured := t.TempDir()
 	writeClaudeCredential(t, configured, time.Now().Add(time.Hour).UnixMilli(), "refresh")
+	tokenFile := filepath.Join(t.TempDir(), "omp-broker-token")
+	if err := os.WriteFile(tokenFile, []byte("seat-broker-token\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
 	t.Setenv("CLAUDE_CONFIG_DIR", configured)
 	t.Setenv("CLAUDE_CODE_OAUTH_TOKEN", "seat-overlay-token")
+	t.Setenv("OMP_AUTH_BROKER_URL", "http://127.0.0.1:8765")
+	t.Setenv("OMP_AUTH_BROKER_TOKEN", "")
+	t.Setenv("OMP_AUTH_BROKER_TOKEN_FILE", tokenFile)
 	supported := runtime.SupportedRuntimes()
 	if len(supported) < 2 {
 		t.Fatalf("SupportedRuntimes() = %v, expected the full runtime set", supported)
 	}
 	sawClaude := false
+	sawOmp := false
 	for _, name := range supported {
 		env, err := readOnlySeatRuntimeAuthEnv(home, name, false)
 		if err != nil {
 			t.Fatalf("readOnlySeatRuntimeAuthEnv(%s): %v", name, err)
 		}
-		if name == runtime.ClaudeRuntime {
+		switch name {
+		case runtime.ClaudeRuntime:
 			sawClaude = true
-			if len(env) == 0 {
-				t.Fatalf("claude lost its runtime-auth overlay: %v", env)
+			if len(env) == 0 || containsEnvPrefix(env, "OMP_AUTH_BROKER_") {
+				t.Fatalf("claude runtime auth = %v, want only its resolved overlay", redactEnvNames(env))
 			}
-			continue
-		}
-		if len(env) != 0 {
-			t.Fatalf("runtime %q received a claude overlay (%d entries): the overlay is claude-only by policy", name, len(env))
+		case runtime.OmpRuntime:
+			sawOmp = true
+			if len(env) != 1 ||
+				!containsEnv(env, "OMP_AUTH_BROKER_URL=http://127.0.0.1:8765") ||
+				containsEnvPrefix(env, "OMP_AUTH_BROKER_TOKEN") ||
+				containsEnvPrefix(env, runtime.ClaudeOAuthTokenEnv+"=") {
+				t.Fatalf("omp runtime preflight = %v, want only the non-secret broker endpoint", redactEnvNames(env))
+			}
+		default:
+			if len(env) != 0 {
+				t.Fatalf("runtime %q received another runtime's auth: %v", name, redactEnvNames(env))
+			}
 		}
 	}
-	if !sawClaude {
-		t.Fatalf("SupportedRuntimes() = %v, missing claude; the policy assertion measured nothing", supported)
+	if !sawClaude || !sawOmp {
+		t.Fatalf("SupportedRuntimes() = %v, sawClaude=%v sawOmp=%v", supported, sawClaude, sawOmp)
 	}
-	// Gateway mode withholds it from claude too.
+	// Gateway mode withholds auth from the child process.
 	gatewayEnv, err := readOnlySeatRuntimeAuthEnv(home, runtime.ClaudeRuntime, true)
 	if err != nil {
 		t.Fatal(err)
 	}
 	if len(gatewayEnv) != 0 {
 		t.Fatalf("gateway-mode claude seat received an overlay: %v", redactEnvNames(gatewayEnv))
+	}
+}
+
+func TestReadOnlySeatOmpBrokerEnvRequiresSecureTokenFile(t *testing.T) {
+	tokenFile := filepath.Join(t.TempDir(), "broker-token")
+	if err := os.WriteFile(tokenFile, []byte("broker-token\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	for _, test := range []struct {
+		name        string
+		environ     []string
+		wantMissing []string
+	}{
+		{name: "both missing", wantMissing: []string{"OMP_AUTH_BROKER_URL", "OMP_AUTH_BROKER_TOKEN_FILE"}},
+		{name: "URL missing", environ: []string{"OMP_AUTH_BROKER_TOKEN_FILE=" + tokenFile}, wantMissing: []string{"OMP_AUTH_BROKER_URL"}},
+		{name: "token file missing", environ: []string{"OMP_AUTH_BROKER_URL=http://127.0.0.1:8765"}, wantMissing: []string{"OMP_AUTH_BROKER_TOKEN_FILE"}},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			_, err := readOnlySeatOmpBrokerEnv(test.environ)
+			if err == nil {
+				t.Fatal("incomplete broker configuration was accepted")
+			}
+			for _, name := range test.wantMissing {
+				if !strings.Contains(err.Error(), name) {
+					t.Fatalf("error %q does not name missing %s", err, name)
+				}
+			}
+		})
+	}
+
+	if _, err := readOnlySeatOmpBrokerEnv([]string{
+		"OMP_AUTH_BROKER_URL=http://127.0.0.1:8765",
+		"OMP_AUTH_BROKER_TOKEN=must-not-enter-daemon-environ",
+		"OMP_AUTH_BROKER_TOKEN_FILE=" + tokenFile,
+	}); err == nil {
+		t.Fatal("ambient upstream token was accepted")
+	}
+	env, err := readOnlySeatOmpBrokerEnv([]string{
+		"OPENAI_API_KEY=must-not-cross",
+		"OMP_PROFILE=operator",
+		"OMP_AUTH_BROKER_URL=http://127.0.0.1:8765",
+		"OMP_AUTH_BROKER_TOKEN_FILE=" + tokenFile,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(env) != 1 ||
+		!containsEnv(env, "OMP_AUTH_BROKER_URL=http://127.0.0.1:8765") ||
+		containsEnvPrefix(env, "OMP_AUTH_BROKER_TOKEN") ||
+		containsEnvPrefix(env, "OPENAI_API_KEY=") ||
+		containsEnvPrefix(env, "OMP_PROFILE=") {
+		t.Fatalf("broker preflight env = %v, want only the non-secret endpoint", redactEnvNames(env))
 	}
 }
 

--- a/internal/cli/readonly_seat_session_test.go
+++ b/internal/cli/readonly_seat_session_test.go
@@ -182,8 +182,16 @@ func TestReadOnlySeatStatePolicyCoversEveryRegisteredRuntime(t *testing.T) {
 			policy, needsState, err := readOnlySeatStatePolicyFor(name, userHome, false)
 			switch name {
 			case runtime.OmpRuntime:
-				if err == nil {
-					t.Fatal("omp must be refused: it has no isolated credential broker")
+				if err != nil || !needsState {
+					t.Fatalf("omp needsState=%v err=%v, want isolated writable state", needsState, err)
+				}
+				if policy.relativeState != filepath.Join(".omp", "agent") ||
+					policy.stateEnv != "PI_CODING_AGENT_DIR" ||
+					policy.stateRootEnv != "PI_CONFIG_DIR" {
+					t.Fatalf("omp state policy = %+v, want job-private OMP state and config roots", policy)
+				}
+				if policy.credentialFile != "" || len(policy.requiredInputs) != 0 || len(policy.optionalInputs) != 0 {
+					t.Fatalf("omp policy stages operator profile inputs: %+v", policy)
 				}
 				return
 			case runtime.ShellRuntime:

--- a/internal/cli/readonly_seat_temp_worker_test.go
+++ b/internal/cli/readonly_seat_temp_worker_test.go
@@ -24,9 +24,9 @@ import (
 // survives into a path that never wrapped it. A read-only seat therefore ran
 // outside Landlock and outside this PR's staging policy.
 //
-// The observable is the staging the wrap performs: with the wrap in place the
-// seat's isolated runtime state exists on disk under the config home. Without
-// it, nothing is staged, because nothing on the fork path ever asks.
+// The observable is the fail-closed wrapper refusal. The fake delivery adapter
+// cannot be Landlock-wrapped, so reaching that refusal proves the fork path
+// applied the sandbox policy before any runtime launch.
 func TestTempWorkerForkStillSandboxesAReadOnlySeat(t *testing.T) {
 	ctx := context.Background()
 	home := t.TempDir()
@@ -129,8 +129,8 @@ func TestTempWorkerForkStillSandboxesAReadOnlySeat(t *testing.T) {
 	}
 
 	// The fake adapter cannot be Landlock-wrapped, so the wrap REFUSING it is
-	// itself proof the fork path now asks - and the staging below happens inside
-	// that same call, before the refusal.
+	// proof the fork path now asks. The private state is removed with the failed
+	// setup rather than left behind as a second, stale observable.
 	wrapAttempted := false
 	for _, event := range events {
 		if strings.Contains(event.Message, "read-only Landlock sandbox") {
@@ -140,34 +140,4 @@ func TestTempWorkerForkStillSandboxesAReadOnlySeat(t *testing.T) {
 	if !wrapAttempted {
 		t.Error("no evidence the fork path applied the read-only sandbox wrap")
 	}
-
-	staged := stagedSeatStateUnder(t, home)
-	if staged == "" {
-		t.Fatalf("the forked read-only seat staged no isolated runtime state under %q: it ran outside the sandbox and outside the staging policy", home)
-	}
-	contents, err := os.ReadFile(staged)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !strings.Contains(string(contents), "gpt-5") {
-		t.Errorf("staged seat config = %q, want the host model setting", contents)
-	}
-}
-
-// stagedSeatStateUnder finds a staged seat config.toml anywhere under home. The
-// cache root is chosen by the isolated-tool-cache grant, so the test asks
-// whether staging HAPPENED rather than hard-coding where.
-func stagedSeatStateUnder(t *testing.T, home string) string {
-	t.Helper()
-	var found string
-	_ = filepath.WalkDir(home, func(path string, entry os.DirEntry, err error) error {
-		if err != nil || entry.IsDir() || found != "" {
-			return nil //nolint:nilerr // an unreadable subtree is not a result
-		}
-		if filepath.Base(path) == "config.toml" && strings.Contains(path, "runtime-state") {
-			found = path
-		}
-		return nil
-	})
-	return found
 }

--- a/internal/cli/sandbox_produce_test.go
+++ b/internal/cli/sandbox_produce_test.go
@@ -6,11 +6,14 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net/http"
 	"os"
 	"path/filepath"
 	"reflect"
+	"strconv"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/gitmoot/gitmoot/internal/config"
 	"github.com/gitmoot/gitmoot/internal/credgw"
@@ -951,15 +954,162 @@ func TestStageReadOnlyRuntimeCredentialCopiesOnlyProviderSection(t *testing.T) {
 	}
 }
 
-func TestWrapReadOnlySandboxAdapterRejectsOmpWithoutCredentialBroker(t *testing.T) {
+func TestWrapReadOnlySandboxAdapterRejectsOmpBeforeStagingWithoutCredentialBroker(t *testing.T) {
 	checkout := t.TempDir()
 	if err := os.MkdirAll(filepath.Join(checkout, ".git"), 0o700); err != nil {
 		t.Fatal(err)
 	}
-	agent := runtime.Agent{Runtime: runtime.OmpRuntime, ReadOnlySeat: true}
-	_, _, err := wrapReadOnlySandboxAdapter(t.TempDir(), agent, checkout, "", runtime.OmpAdapter{})
-	if err == nil || !strings.Contains(err.Error(), "isolated credential broker") {
+	t.Setenv("OMP_AUTH_BROKER_URL", "")
+	t.Setenv("OMP_AUTH_BROKER_TOKEN", "")
+	t.Setenv("OMP_AUTH_BROKER_TOKEN_FILE", "")
+	configHome := t.TempDir()
+	_, _, err := wrapReadOnlySandboxAdapter(configHome, runtime.Agent{
+		Runtime: runtime.OmpRuntime, ReadOnlySeat: true,
+	}, checkout, "", runtime.OmpAdapter{})
+	if err == nil ||
+		!strings.Contains(err.Error(), "OMP_AUTH_BROKER_URL") ||
+		!strings.Contains(err.Error(), "OMP_AUTH_BROKER_TOKEN_FILE") {
 		t.Fatalf("omp read-only seat error = %v", err)
+	}
+	entries, readErr := os.ReadDir(configHome)
+	if readErr != nil || len(entries) != 0 {
+		t.Fatalf("broker refusal staged state under %q: entries=%v err=%v", configHome, entries, readErr)
+	}
+}
+
+func TestWrapReadOnlySandboxAdapterUsesScopedBrokerAndPrivateOmpState(t *testing.T) {
+	configHome := t.TempDir()
+	checkout := filepath.Join(t.TempDir(), "review-worktree")
+	if err := os.MkdirAll(filepath.Join(checkout, ".git"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	hostProfile := filepath.Join(t.TempDir(), "operator-omp")
+	if err := os.MkdirAll(hostProfile, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(hostProfile, "agent.db"), []byte("host sessions and credentials"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	runtimeDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(runtimeDir, runtime.OmpRuntime), []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	tokenFile := filepath.Join(t.TempDir(), "broker-token")
+	if err := os.WriteFile(tokenFile, []byte("seat-broker-token\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("OMP_AUTH_BROKER_URL", "http://127.0.0.1:8765")
+	t.Setenv("OMP_AUTH_BROKER_TOKEN", "")
+	t.Setenv("OMP_AUTH_BROKER_TOKEN_FILE", tokenFile)
+	t.Setenv("OPENAI_API_KEY", "must-not-cross")
+	t.Setenv("ANTHROPIC_API_KEY", "must-not-cross")
+	t.Setenv("OMP_PROFILE", "operator")
+	t.Setenv("PI_PROFILE", "operator")
+	t.Setenv("PI_CODING_AGENT_DIR", hostProfile)
+
+	wrapped, _, err := wrapReadOnlySandboxAdapter(configHome, runtime.Agent{
+		Runtime: runtime.OmpRuntime, Model: "kimi-code/k3", ReadOnlySeat: true, RuntimeConfigDir: hostProfile,
+	}, checkout, "", runtime.OmpAdapter{Runner: subprocess.GroupRunner{}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	stateAdapter, ok := wrapped.(readOnlyRuntimeAdapter)
+	if !ok {
+		t.Fatalf("wrapped adapter = %T, want readOnlyRuntimeAdapter", wrapped)
+	}
+	stateDir := filepath.Join(stateAdapter.cleanupRoot, "runtime-state", ".omp", "agent")
+	if entries, err := os.ReadDir(stateDir); err != nil || len(entries) != 0 {
+		t.Fatalf("isolated OMP state before delivery = %q entries=%v err=%v, want empty", stateDir, entries, err)
+	}
+	if _, err := stateAdapter.ompSession.prepare("kimi-code/k3"); err != nil {
+		t.Fatalf("prepare job-scoped OMP broker: %v", err)
+	}
+	entries, err := os.ReadDir(stateDir)
+	if err != nil || len(entries) != 1 || entries[0].Name() != "config.yml" {
+		t.Fatalf("isolated OMP state = %q entries=%v err=%v, want only scoped config", stateDir, entries, err)
+	}
+	brokerURL := "http://" + stateAdapter.ompSession.broker.listener.Addr().String()
+	brokerToken := stateAdapter.ompSession.broker.downstreamKey
+	configPath := filepath.Join(stateDir, "config.yml")
+	configData, err := os.ReadFile(configPath)
+	if err != nil ||
+		!strings.Contains(string(configData), brokerURL) ||
+		!strings.Contains(string(configData), brokerToken) ||
+		strings.Contains(string(configData), "seat-broker-token") ||
+		strings.Contains(string(configData), "127.0.0.1:8765") {
+		t.Fatalf("job-private OMP config did not contain only the scoped route: %q err=%v", configData, err)
+	}
+	if info, err := os.Stat(configPath); err != nil || info.Mode().Perm() != 0o600 {
+		t.Fatalf("job-private OMP config mode = %v err=%v, want 0600", info, err)
+	}
+	ompAdapter, ok := stateAdapter.Adapter.(runtime.OmpAdapter)
+	if !ok {
+		t.Fatalf("inner adapter = %T, want runtime.OmpAdapter", stateAdapter.Adapter)
+	}
+	runner, ok := ompAdapter.Runner.(subprocess.WrappingRunner)
+	if !ok {
+		t.Fatalf("wrapped runner = %T, want subprocess.WrappingRunner", ompAdapter.Runner)
+	}
+	if !runner.ReadOnlyWorkdir || len(runner.WritablePaths) != 1 || runner.WritablePaths[0] != stateAdapter.cleanupRoot {
+		t.Fatalf("OMP sandbox workdir/write grants = readOnly:%v writes:%v", runner.ReadOnlyWorkdir, runner.WritablePaths)
+	}
+	if containsPath(runner.ReadablePaths, hostProfile) || containsPath(runner.ReadableFiles, filepath.Join(hostProfile, "agent.db")) {
+		t.Fatalf("OMP sandbox reads expose operator profile: dirs=%v files=%v", runner.ReadablePaths, runner.ReadableFiles)
+	}
+	if envValue(runner.Env, "PI_CODING_AGENT_DIR") != stateDir ||
+		envValue(runner.Env, "PI_CONFIG_DIR") != filepath.Join("..", "runtime-state", ".omp") {
+		t.Fatalf("OMP sandbox env lacks isolated state roots: %v", redactEnvNames(runner.Env))
+	}
+	for _, forbidden := range []string{
+		"OPENAI_API_KEY=", "ANTHROPIC_API_KEY=", "OMP_PROFILE=", "PI_PROFILE=",
+		"OMP_AUTH_BROKER_URL=", "OMP_AUTH_BROKER_TOKEN=", "OMP_AUTH_BROKER_TOKEN_FILE=",
+	} {
+		if containsEnvPrefix(runner.Env, forbidden) {
+			t.Fatalf("OMP sandbox env contains forbidden %s", strings.TrimSuffix(forbidden, "="))
+		}
+	}
+	base, ok := runner.Inner.(subprocess.CuratedGroupRunner)
+	if !ok {
+		t.Fatalf("sandbox inner = %T, want CuratedGroupRunner", runner.Inner)
+	}
+	for _, forbidden := range []string{"OMP_AUTH_BROKER_URL=", "OMP_AUTH_BROKER_TOKEN=", "OMP_AUTH_BROKER_TOKEN_FILE="} {
+		if containsEnvPrefix(base.BaseEnv, forbidden) {
+			t.Fatalf("OMP curated base exposes broker config: %v", redactEnvNames(base.BaseEnv))
+		}
+	}
+	if probe := sandbox.SandboxProbe(); probe.Supported {
+		for _, path := range []string{
+			tokenFile,
+			filepath.Join("/proc", strconv.Itoa(os.Getpid()), "root", tokenFile),
+		} {
+			readResult, readErr := runner.Run(context.Background(), checkout, "/usr/bin/cat", path)
+			if readErr == nil || strings.Contains(readResult.Stdout, "seat-broker-token") {
+				t.Fatalf("OMP sandbox read upstream broker token through %q: err=%v output=%q", path, readErr, readResult.Stdout)
+			}
+		}
+	}
+	var stagedOmp string
+	for _, dir := range filepath.SplitList(envValue(runner.Env, "PATH")) {
+		candidate := filepath.Join(dir, runtime.OmpRuntime)
+		if info, statErr := os.Stat(candidate); statErr == nil && info.Mode().IsRegular() {
+			stagedOmp = candidate
+			break
+		}
+	}
+	if stagedOmp == "" || pathWithin(stagedOmp, runtimeDir) {
+		t.Fatalf("OMP PATH did not resolve an engine-owned staged copy: %q", stagedOmp)
+	}
+	if err := stateAdapter.cleanup(); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(stateAdapter.cleanupRoot); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("isolated OMP state survived cleanup: %v", err)
+	}
+	client := http.Client{Timeout: 250 * time.Millisecond}
+	response, requestErr := client.Get(brokerURL + "/v1/healthz")
+	if requestErr == nil {
+		response.Body.Close()
+		t.Fatal("job-local OMP broker remained reachable after cleanup")
 	}
 }
 

--- a/internal/cli/seat_staging_barrier_test.go
+++ b/internal/cli/seat_staging_barrier_test.go
@@ -35,7 +35,7 @@ func warmSeatStaging(t *testing.T, home string) {
 	} else if diagnostic != "" {
 		t.Logf("warmSeatStaging: toolchain diagnostic: %s", diagnostic)
 	}
-	if _, _, diagnostics, err := stageSeatRuntimes(paths); err != nil {
+	if _, _, diagnostics, err := stageSeatRuntimes(paths, ""); err != nil {
 		t.Logf("warmSeatStaging: runtimes not pre-staged (%v); the test window will pay the copy", err)
 	} else {
 		for _, diagnostic := range diagnostics {

--- a/internal/cli/toolchain_seat.go
+++ b/internal/cli/toolchain_seat.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/gitmoot/gitmoot/internal/config"
+	"github.com/gitmoot/gitmoot/internal/runtime"
 	"github.com/gitmoot/gitmoot/internal/toolchain"
 )
 
@@ -88,22 +89,21 @@ func unavailableSeatToolchain(paths config.Paths, diagnostic string) (string, []
 	return root, env, diagnostic, nil
 }
 
-// seatRuntimeNames are the runtimes a read-only seat may need to LAUNCH. Each is
-// a runtime this engine dispatches jobs to, so the list is derived from what the
-// engine can start rather than from what happens to be installed on a host.
-var seatRuntimeNames = []string{"claude", "kimi", "codex"}
+// seatRuntimeNames are the provider CLIs every read-only seat may need as a
+// sibling runtime. OMP is different: it is a routing harness capable of
+// launching more agents, so it is staged only when OMP is the selected runtime.
+var seatRuntimeNames = []string{runtime.ClaudeRuntime, runtime.KimiRuntime, runtime.CodexRuntime}
 
-// stageSeatRuntimes materialises one engine-owned command for every runtime
-// class the engine can dispatch. Each INSTALLED runtime becomes a copied
-// artifact; each missing or unstageable one becomes an explicit exit-126 command
-// so inherited PATH entries cannot route around the policy.
+// stageSeatRuntimes materialises engine-owned commands for the provider runtime
+// set and, when selected, OMP. Each installed runtime becomes a copied artifact;
+// each missing or unstageable one becomes an explicit exit-126 command so
+// inherited PATH entries cannot route around the policy.
 //
-// EVERY INSTALLED RUNTIME IS STAGED, not only the seat's own. A seat's prompt
-// may legitimately invoke a sibling runtime, and contract item 5 of ruling
-// 122157 requires the actual installed Claude, Kimi and Codex to LAUNCH from
-// staged copies - "a design that merely turns all four into MISSING is not
-// accepted". Copies are content-addressed, so the second seat wanting the same
-// runtime reuses the first seat's tree instead of copying again.
+// EVERY INSTALLED PROVIDER RUNTIME IS STAGED, not only the seat's own. A seat's
+// prompt may legitimately invoke a sibling provider runtime, and contract item
+// 5 of ruling 122157 requires the actual installed Claude, Kimi and Codex to
+// LAUNCH from staged copies. Copies are content-addressed, so the second seat
+// wanting the same runtime reuses the first seat's tree instead of copying again.
 //
 // WHY COPIES AND NOT GRANTS (#1921 review rounds 1-3, ruling 122157). Three
 // rounds tried to make a recursive Landlock grant over the OPERATOR's install
@@ -126,11 +126,15 @@ var seatRuntimeNames = []string{"claude", "kimi", "codex"}
 // the launcher list on purpose: a launcher belongs on the seat's PATH and an
 // interpreter must NOT, because a seat that can resolve `node` by name gets a
 // second way to run code that no dispatch decision chose (#2141).
-func stageSeatRuntimes(paths config.Paths) ([]string, []string, []string, error) {
+func stageSeatRuntimes(paths config.Paths, selectedRuntime string) ([]string, []string, []string, error) {
+	names := seatRuntimeNames
+	if strings.TrimSpace(selectedRuntime) == runtime.OmpRuntime {
+		names = append(append([]string(nil), seatRuntimeNames...), runtime.OmpRuntime)
+	}
 	var staged []string
 	var interpreters []string
 	var diagnostics []string
-	for _, name := range seatRuntimeNames {
+	for _, name := range names {
 		if resolved, lookupErr := exec.LookPath(name); lookupErr == nil {
 			// STAGING NOW OWNS THE WHOLE ARTIFACT, INTERPRETER INCLUDED. The
 			// engine reads the entrypoint's shebang from the descriptor it will

--- a/internal/cli/toolchain_seat_interpreter_test.go
+++ b/internal/cli/toolchain_seat_interpreter_test.go
@@ -57,7 +57,7 @@ func TestStageSeatRuntimesStagesAScriptRuntimesInterpreter(t *testing.T) {
 	t.Setenv("PATH", strings.Join([]string{launcherDir, interpreterDir, "/usr/bin", "/bin"}, string(os.PathListSeparator)))
 
 	paths := config.PathsForHome(t.TempDir())
-	commands, _, diagnostics, err := stageSeatRuntimes(paths)
+	commands, _, diagnostics, err := stageSeatRuntimes(paths, "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -117,7 +117,7 @@ func TestStageSeatRuntimesLeavesSystemInterpretersAlone(t *testing.T) {
 	t.Setenv("PATH", strings.Join([]string{launcherDir, "/usr/bin", "/bin"}, string(os.PathListSeparator)))
 
 	paths := config.PathsForHome(t.TempDir())
-	commands, _, diagnostics, err := stageSeatRuntimes(paths)
+	commands, _, diagnostics, err := stageSeatRuntimes(paths, "")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/cli/toolchain_seat_test.go
+++ b/internal/cli/toolchain_seat_test.go
@@ -417,7 +417,7 @@ func TestStageSeatRuntimesCopiesInstalledAndShadowsAbsentRuntimes(t *testing.T) 
 	t.Setenv("PATH", strings.Join(pathEntries, string(os.PathListSeparator)))
 
 	paths := config.PathsForHome(t.TempDir())
-	commands, _, diagnostics, err := stageSeatRuntimes(paths)
+	commands, _, diagnostics, err := stageSeatRuntimes(paths, "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -443,6 +443,47 @@ func TestStageSeatRuntimesCopiesInstalledAndShadowsAbsentRuntimes(t *testing.T) 
 		if runErr != nil || strings.TrimSpace(string(output)) != name+"-ran" {
 			t.Errorf("installed runtime %q did not launch from its staged copy: err=%v output=%q", name, runErr, output)
 		}
+	}
+}
+
+func TestStageSeatRuntimesAddsOmpOnlyWhenSelected(t *testing.T) {
+	runtimeDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(runtimeDir, runtime.OmpRuntime), []byte("#!/bin/sh\nprintf 'omp-ran\\n'\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", runtimeDir)
+
+	without, _, _, err := stageSeatRuntimes(config.PathsForHome(t.TempDir()), "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, command := range without {
+		if filepath.Base(command) == runtime.OmpRuntime {
+			t.Fatalf("unselected OMP was published to a provider seat: %v", without)
+		}
+	}
+
+	paths := config.PathsForHome(t.TempDir())
+	with, _, diagnostics, err := stageSeatRuntimes(paths, runtime.OmpRuntime)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(diagnostics) != 0 {
+		t.Fatalf("selected OMP staging diagnostics = %v", diagnostics)
+	}
+	var ompCommand string
+	for _, command := range with {
+		if filepath.Base(command) == runtime.OmpRuntime {
+			ompCommand = command
+			break
+		}
+	}
+	if ompCommand == "" || !pathWithin(ompCommand, toolchain.RuntimeRoot(paths.Home)) {
+		t.Fatalf("selected OMP command = %q, want daemon-owned staged path", ompCommand)
+	}
+	output, err := exec.Command(ompCommand).CombinedOutput()
+	if err != nil || strings.TrimSpace(string(output)) != "omp-ran" {
+		t.Fatalf("staged OMP command failed: err=%v output=%q", err, output)
 	}
 }
 

--- a/skills/gitmoot/references/CLI.md
+++ b/skills/gitmoot/references/CLI.md
@@ -992,11 +992,22 @@ an omp seat:
   manufacture diversity the merge gate would trust. The exclusion is symmetric: a
   registered omp seat is never picked as another runtime's cross-family reviewer
   either. Per-seat provider declaration is issue #1436.
-- **Authentication is per profile.** Authenticate omp once interactively (or
-  export the provider key the daemon should use, or point it at an auth broker),
-  then restart the Gitmoot daemon so it inherits the credential. The daemon must
-  also see the binary: its `PATH` comes from the systemd EnvironmentFile, not a
-  login shell.
+- **Authentication depends on the seat policy.** Ordinary omp jobs use the
+  profile, provider keys, or auth broker visible to the daemon. Read-only review
+  and ask seats require `OMP_AUTH_BROKER_URL` as an HTTPS or loopback HTTP
+  origin, an owner-only token file named by `OMP_AUTH_BROKER_TOKEN_FILE`, and a
+  provider-qualified effective model such as `kimi-code/k3`. An upstream
+  `OMP_AUTH_BROKER_TOKEN` in the daemon environment
+  is refused because the runtime requires seat-readable `/proc`. Gitmoot writes
+  the random job-local token and loopback URL only into the seat's minimal
+  `config.yml`; no broker secret enters the child environment. The proxy exposes
+  only that provider, forwards credential refreshes, and keeps shared broker
+  writes out of reach. Gitmoot drops the operator profile and ambient provider
+  keys, runs a daemon-staged OMP binary, and supplies job-private
+  `PI_CONFIG_DIR` and `PI_CODING_AGENT_DIR` roots. Missing or unsafe broker
+  configuration refuses before runtime staging; an unqualified effective model
+  refuses before OMP launches. Restart the daemon after changing its broker
+  environment; its `PATH` also comes from the systemd EnvironmentFile.
 
 `agent start`, `agent subscribe`, and `agent type set` accept an optional
 `--model <name>` flag that sets the agent's default runtime model. It is a

--- a/website/docs/operations/troubleshooting.md
+++ b/website/docs/operations/troubleshooting.md
@@ -317,10 +317,10 @@ deferral is a first-class `job.deferred` emitted instead of `job.failed`. A job
 that "failed then reappeared as queued" is the deferral working; only act when
 the retry budget is spent and the job stays failed.
 
-A read-only seat (every `review`/`ask` job under the read-only autonomy policy)
-does NOT authenticate with the ambient credential: it stages a SNAPSHOT of its
+A Claude read-only seat (every `review`/`ask` job under the read-only autonomy
+policy) does not rely only on its staged credential snapshot. It stages the
 runtime config dir (`payload.runtime_config_dir`, else the daemon's
-`CLAUDE_CONFIG_DIR`, else `~/.claude`) and carries the resolved
+`CLAUDE_CONFIG_DIR`, else `~/.claude`) and also carries the resolved
 `runtime-auth.env` overlay. When that snapshot is already expired the job records
 one `readonly_seat_credential_expired` event naming the expiry, the refresh-token
 state and whether an overlay was available; read it with `gitmoot job events
@@ -330,6 +330,25 @@ be refreshed" wording as an account problem. It never refuses the job.
 beside the ambient one, and doctor FAILS (non-zero exit) when it is expired with
 no refresh token, since every read-only seat job on that runtime will fail until
 the account is re-logged in.
+
+An OMP read-only seat uses no operator profile or ambient provider key. Set
+`OMP_AUTH_BROKER_URL` to an HTTPS or loopback HTTP origin and point
+`OMP_AUTH_BROKER_TOKEN_FILE` at an owner-only regular file; the daemon refuses
+an upstream `OMP_AUTH_BROKER_TOKEN` because every seat must read `/proc` for
+runtime startup. The job's effective model must
+be provider-qualified, such as `kimi-code/k3`. Gitmoot writes a random
+job-local token and loopback URL only into the seat's minimal `config.yml`; no
+broker secret enters the child environment. The proxy exposes only that
+provider, forwards refreshes only, and keeps broker writes local to the
+disposable client. The daemon-staged OMP binary receives job-private
+`PI_CONFIG_DIR` and `PI_CODING_AGENT_DIR` roots. Missing or unsafe broker
+configuration refuses before staging; an unqualified effective model refuses
+before OMP launches. The state and proxy are removed at the job boundary.
+
+When broker and clients share an OS account, run `auth-broker serve` with a
+dedicated relative `PI_CONFIG_DIR` and point `OMP_AUTH_BROKER_TOKEN_FILE` at that
+directory's `auth-broker.token`. Otherwise both roles use
+`~/.omp/auth-broker.token`, so a client token can invalidate the service.
 
 A kimi credential that goes blank mid-session is REPORTED, not repaired (#1856).
 Kimi's credential (`~/.kimi-code/credentials/kimi-code.json`) has been observed
@@ -881,6 +900,7 @@ What the seat stages, per runtime:
 | claude | `~/.claude` | `.credentials.json`, narrowed to `claudeAiOauth` and checked for usability. Nothing is staged in gateway mode, where the gateway supplies the credential. |
 | codex | `~/.codex` | `auth.json`, plus `config.toml` when present - NARROWED, see below |
 | kimi | `~/.kimi-code` | `config.toml` (REQUIRED), `credentials/kimi-code.json` |
+| omp | none | No operator profile input is staged. The daemon reads its upstream token from the owner-only file named by `OMP_AUTH_BROKER_TOKEN_FILE`. A minimal job-private `config.yml` holds the random token and loopback URL for a proxy filtered to the provider in the required `provider/model` selector. `PI_CONFIG_DIR` and `PI_CODING_AGENT_DIR` both resolve inside the disposable state root. |
 
 ### Why the staged codex config.toml is not a copy
 

--- a/website/docs/reference/runtime-adapters.md
+++ b/website/docs/reference/runtime-adapters.md
@@ -364,6 +364,22 @@ provider environment keys, and the binary's install path, because a daemon that
 cannot see the binary and a daemon that cannot see a credential are the two
 failure modes operators actually hit.
 
+Read-only OMP review and ask seats are stricter regardless of `env_curation`.
+They require `OMP_AUTH_BROKER_URL` as an HTTPS or loopback HTTP origin, an
+owner-only token file named by `OMP_AUTH_BROKER_TOKEN_FILE`, and a
+provider-qualified effective model such as `kimi-code/k3`. An upstream
+`OMP_AUTH_BROKER_TOKEN` in the daemon environment
+is refused because the runtime requires seat-readable `/proc`. Gitmoot writes
+the random job-local token and loopback URL only into the seat's minimal
+`config.yml`; no broker secret enters the child environment. The proxy filters
+credentials and usage to that provider, forwards only credential refreshes, and
+acknowledges disable/block/accounting writes locally rather than mutating the
+shared broker. The seat receives no upstream token, profile path, or ambient
+provider key. Its daemon-staged OMP binary uses job-private `PI_CONFIG_DIR` and
+`PI_CODING_AGENT_DIR` roots; the proxy and state are removed after delivery.
+Missing or unsafe broker configuration refuses before runtime staging; an
+unqualified effective model refuses before OMP launches.
+
 Child-environment curation is **off by default**, and with it off omp inherits
 the daemon's whole environment exactly like every other runtime. When
 `[credentials] env_curation = true` is enabled, omp's curated allowlist is


### PR DESCRIPTION
Fixes #2158.

Authorization: owner workflow note 132481.

## Change
- require an HTTPS or loopback HTTP OMP auth-broker origin plus an owner-only token file; refuse a daemon-env bearer that a seat could read through `/proc`
- create a random per-job loopback proxy token and filter broker credentials, usage, refreshes, and mutations to the effective model provider
- stage OMP only for OMP seats, under the existing read-only Landlock wrapper and job-private `PI_CONFIG_DIR` / `PI_CODING_AGENT_DIR`
- remove the proxy and private state at the job boundary, including wrapper failures
- document the daemon prerequisite in both docs trees and the packaged skill

The token-file requirement replaces the issue's original direct token pair after the `/proc` exposure was reproduced; issue #2158 now records the corrected boundary.

## Verification
- focused broker, staging, state, and Landlock tests: pass
- real OMP/Kimi request through the production read-only wrapper and live broker: pass (`LANDLOCK_BROKER_OK`); direct token-file and `/proc/<parent>/root` reads denied
- `go build -buildvcs=false ./...`: pass
- `go generate ./... && git diff --exit-code`: pass
- `go vet ./...`: pass
- website `npm run build`: pass after temporarily escaping the pre-existing unrelated raw `<owner/repo>` MDX at `website/docs/reference/cli.md:2912`; that workaround was restored and is not in this PR
- full `internal/cli` suite reached the host disk dispatch guard at 4.86–4.87% free (minimum 5%), causing unrelated pipeline/worker tests to remain queued; the changed focused paths pass

## Deploy
After merge, deploy both host binaries from the exact main tip, restart `gitmoot-daemon` and `gitmoot-dashboard-web` only with zero engine-dispatched running/queued jobs, then run an OMP exact-head review and verify the public dashboard binary/API.