### PR TITLE
feat(org): wake seats on review verdicts by default

### DIFF
--- a/internal/cli/event_rule_sink.go
+++ b/internal/cli/event_rule_sink.go
@@ -313,7 +313,9 @@ func (s *eventRuleSink) evaluateRules(ctx context.Context, event events.Event, r
 		return s.completeWakeOutbox(ctx, event, db.WakeOutboxStateFailed, "organization registry unavailable", errors.New("organization registry unavailable"))
 	}
 	isAddressedNoteWake := event.Type == events.EventOrgReply || event.Type == events.EventOrgDirective || event.Type == events.EventOrgFact
-	deduplicateAddressedWake := isAddressedNoteWake || containsEventRuleKind(kinds, eventRuleKindReviewVerdict)
+	// Addressed note events are coalesced across their matching routes. Verdict
+	// events only coalesce review-verdict routes; a job-terminal route remains a
+	// separate operator-requested notification with its own prompt.
 	replyHandled := false
 	addressedWakeHandled := map[string]bool{}
 	for _, rule := range rules {
@@ -329,9 +331,11 @@ func (s *eventRuleSink) evaluateRules(ctx context.Context, event events.Event, r
 			continue
 		}
 		observer := rule.Scope == db.EventRuleScopeObserver
-		// Addressed note and review-verdict rules notify a role once even when an
-		// operator already configured a route that overlaps a provisioned default.
-		// Observer rules remain independent copies.
+		deduplicateAddressedWake := isAddressedNoteWake ||
+			strings.EqualFold(strings.TrimSpace(rule.OnKind), eventRuleKindReviewVerdict)
+		// Addressed note rules and duplicate review-verdict rules notify a role
+		// once. Other kinds matching the same verdict event and observer rules
+		// remain independent copies.
 		wakeRole := strings.ToLower(strings.TrimSpace(rule.WakeRole))
 		if deduplicateAddressedWake && !observer && addressedWakeHandled[wakeRole] {
 			continue

--- a/internal/cli/event_rule_sink.go
+++ b/internal/cli/event_rule_sink.go
@@ -313,8 +313,9 @@ func (s *eventRuleSink) evaluateRules(ctx context.Context, event events.Event, r
 		return s.completeWakeOutbox(ctx, event, db.WakeOutboxStateFailed, "organization registry unavailable", errors.New("organization registry unavailable"))
 	}
 	isAddressedNoteWake := event.Type == events.EventOrgReply || event.Type == events.EventOrgDirective || event.Type == events.EventOrgFact
+	deduplicateAddressedWake := isAddressedNoteWake || containsEventRuleKind(kinds, eventRuleKindReviewVerdict)
 	replyHandled := false
-	addressedReplyHandled := false
+	addressedWakeHandled := map[string]bool{}
 	for _, rule := range rules {
 		// #1942 review P2: rules are processed SERIALLY, each spending its own
 		// probe/prompt budget, so a command that has stopped waiting can release the
@@ -328,10 +329,11 @@ func (s *eventRuleSink) evaluateRules(ctx context.Context, event events.Event, r
 			continue
 		}
 		observer := rule.Scope == db.EventRuleScopeObserver
-		// Preserve the existing one-attempt-per-target behavior for duplicate
-		// addressed reply rules while allowing every observer rule to see the
-		// directed event independently.
-		if isAddressedNoteWake && !observer && addressedReplyHandled {
+		// Addressed note and review-verdict rules notify a role once even when an
+		// operator already configured a route that overlaps a provisioned default.
+		// Observer rules remain independent copies.
+		wakeRole := strings.ToLower(strings.TrimSpace(rule.WakeRole))
+		if deduplicateAddressedWake && !observer && addressedWakeHandled[wakeRole] {
 			continue
 		}
 		pane, ok := s.resolveRolePane(ctx, cfg, rule.WakeRole)
@@ -411,14 +413,13 @@ func (s *eventRuleSink) evaluateRules(ctx context.Context, event events.Event, r
 		// recording it here is what lets a multi-rule config extend the wait
 		// instead of being abandoned on a bound sized for a single rule.
 		s.progress.Add(1)
-		// A coalesced reply batch still gives its addressed target one attempt per
-		// window. Observer rules are independent copies and do not consume that
-		// target attempt.
+		// Coalesced addressed wakes give each target role one attempt per event.
+		// Observer rules are independent copies and do not consume that attempt.
 		if isAddressedNoteWake {
 			replyHandled = true
-			if !observer {
-				addressedReplyHandled = true
-			}
+		}
+		if deduplicateAddressedWake && !observer {
+			addressedWakeHandled[wakeRole] = true
 		}
 	}
 	if isAddressedNoteWake && !replyHandled {

--- a/internal/cli/event_rule_sink_test.go
+++ b/internal/cli/event_rule_sink_test.go
@@ -963,6 +963,7 @@ pane="w1:p3"
 	}
 	defer store.Close()
 	for _, rule := range []db.EventRule{
+		{ID: "requester-terminal", OnKind: "job-terminal", WakeRole: "requester", Scope: db.EventRuleScopeAddressed, Enabled: true},
 		{ID: "author", OnKind: eventRuleKindReviewVerdict, WakeRole: "author", Scope: db.EventRuleScopeAddressed, Enabled: true},
 		{ID: "requester", OnKind: eventRuleKindReviewVerdict, WakeRole: "requester", Scope: db.EventRuleScopeAddressed, Enabled: true},
 		{ID: "requester-duplicate", OnKind: eventRuleKindReviewVerdict, WakeRole: "requester", Scope: db.EventRuleScopeAddressed, Enabled: true},
@@ -986,9 +987,27 @@ pane="w1:p3"
 		ReviewDecision:  "approved",
 	})
 
+	requesterPrompts := make([]string, 0, 2)
+	for i, pane := range wake.panes {
+		if pane == "w1:p4" {
+			requesterPrompts = append(requesterPrompts, wake.prompts[i])
+		}
+	}
 	sort.Strings(wake.panes)
-	if got, want := fmt.Sprint(wake.panes), "[w1:p1 w1:p3 w1:p4]"; got != want {
+	if got, want := fmt.Sprint(wake.panes), "[w1:p1 w1:p3 w1:p4 w1:p4]"; got != want {
 		t.Fatalf("woken panes = %s, want %s", got, want)
+	}
+	if len(requesterPrompts) != 2 {
+		t.Fatalf("requester prompts = %d, want generic and verdict-specific prompts", len(requesterPrompts))
+	}
+	hasVerdictPrompt := false
+	hasGenericPrompt := false
+	for _, prompt := range requesterPrompts {
+		hasVerdictPrompt = hasVerdictPrompt || strings.Contains(prompt, "review verdict approved")
+		hasGenericPrompt = hasGenericPrompt || strings.Contains(prompt, "job-terminal event")
+	}
+	if !hasVerdictPrompt || !hasGenericPrompt {
+		t.Fatalf("requester prompts = %q, want generic and verdict-specific prompts", requesterPrompts)
 	}
 }
 

--- a/internal/cli/event_rule_sink_test.go
+++ b/internal/cli/event_rule_sink_test.go
@@ -965,6 +965,7 @@ pane="w1:p3"
 	for _, rule := range []db.EventRule{
 		{ID: "author", OnKind: eventRuleKindReviewVerdict, WakeRole: "author", Scope: db.EventRuleScopeAddressed, Enabled: true},
 		{ID: "requester", OnKind: eventRuleKindReviewVerdict, WakeRole: "requester", Scope: db.EventRuleScopeAddressed, Enabled: true},
+		{ID: "requester-duplicate", OnKind: eventRuleKindReviewVerdict, WakeRole: "requester", Scope: db.EventRuleScopeAddressed, Enabled: true},
 		{ID: "other", OnKind: eventRuleKindReviewVerdict, WakeRole: "other", Scope: db.EventRuleScopeAddressed, Enabled: true},
 		{ID: "auditor", OnKind: eventRuleKindReviewVerdict, WakeRole: "auditor", Scope: db.EventRuleScopeObserver, Enabled: true},
 	} {

--- a/internal/cli/org.go
+++ b/internal/cli/org.go
@@ -161,7 +161,7 @@ func printOrgUsage(w io.Writer) {
 	fmt.Fprintln(w, "  gitmoot org interrupts [--window 24h|7d|0] [--json] [--home DIR]")
 }
 
-var orgSeatDefaultRouteKinds = []string{"blocked", "directive", "escalation", "fact", "reply"}
+var orgSeatDefaultRouteKinds = []string{"blocked", "directive", "escalation", "fact", "reply", "review-verdict"}
 
 const orgSeatExternalTimeout = 10 * time.Second
 

--- a/internal/cli/org_seat_test.go
+++ b/internal/cli/org_seat_test.go
@@ -113,7 +113,8 @@ func TestOrgSeatAddEndsGreenOnRealityValidation(t *testing.T) {
 		"route org-seat-worker-escalation created",
 		"route org-seat-worker-fact created",
 		"route org-seat-worker-reply created",
-		"ok role worker pane=w1:p2 enabled_routes=5",
+		"route org-seat-worker-review-verdict created",
+		"ok role worker pane=w1:p2 enabled_routes=6",
 	} {
 		if !strings.Contains(stdout.String(), want) {
 			t.Fatalf("seat add output missing %q:\n%s", want, stdout.String())
@@ -128,8 +129,8 @@ func TestOrgSeatAddEndsGreenOnRealityValidation(t *testing.T) {
 		t.Fatalf("worker role = %+v, present=%t", worker, ok)
 	}
 	rules := listOrgSeatTestRules(t, paths)
-	if len(rules) != 6 {
-		t.Fatalf("event rules = %+v, want owner route plus five worker routes", rules)
+	if len(rules) != 7 {
+		t.Fatalf("event rules = %+v, want owner route plus six worker routes", rules)
 	}
 
 	// Re-running add is the repair path and must not duplicate owned routes.
@@ -137,11 +138,111 @@ func TestOrgSeatAddEndsGreenOnRealityValidation(t *testing.T) {
 	stderr.Reset()
 	code = runOrg([]string{"seat", "add", "worker", "--pane", "Worker", "--home", home}, &stdout, &stderr)
 	if code != 0 || !strings.Contains(stdout.String(), "route org-seat-worker-reply existed") ||
-		!strings.Contains(stdout.String(), "ok role worker pane=w1:p2 enabled_routes=5") {
+		!strings.Contains(stdout.String(), "ok role worker pane=w1:p2 enabled_routes=6") {
 		t.Fatalf("second seat add code=%d out=%q err=%q", code, stdout.String(), stderr.String())
 	}
-	if got := len(listOrgSeatTestRules(t, paths)); got != 6 {
-		t.Fatalf("event rules after repair = %d, want 6", got)
+	if got := len(listOrgSeatTestRules(t, paths)); got != 7 {
+		t.Fatalf("event rules after repair = %d, want 7", got)
+	}
+}
+
+func TestOrgSeatAddCleanDatabaseCreatesPersistentReviewVerdictRoute(t *testing.T) {
+	home := t.TempDir()
+	paths := config.PathsForHome(home)
+	if err := os.MkdirAll(filepath.Dir(paths.ConfigFile), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(paths.ConfigFile, []byte(`
+[org.roles."owner"]
+scope = ["*"]
+merge_rule = "owner"
+pane = "Owner"
+`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	panes := []org.LivePane{
+		{PaneID: "w1:p1", Label: "Owner"},
+		{PaneID: "w1:p2", Label: "Worker"},
+	}
+	withOrgSeatFixtureProvider(t, &panes)
+
+	var stdout, stderr bytes.Buffer
+	if code := runOrg([]string{"seat", "add", "worker", "--pane", "Worker", "--home", home}, &stdout, &stderr); code != 0 {
+		t.Fatalf("seat add code=%d out=%q err=%q", code, stdout.String(), stderr.String())
+	}
+
+	store, err := dbtest.Open(t, paths.Database)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rules, err := store.ListEventRules(context.Background())
+	if err != nil {
+		store.Close()
+		t.Fatal(err)
+	}
+	if err := store.Close(); err != nil {
+		t.Fatal(err)
+	}
+	want := db.EventRule{
+		ID: "org-seat-worker-review-verdict", OnKind: "review-verdict", WakeRole: "worker",
+		Scope: db.EventRuleScopeAddressed, Enabled: true,
+	}
+	if !slices.ContainsFunc(rules, func(rule db.EventRule) bool { return sameOrgSeatRule(rule, want) }) {
+		t.Fatalf("review verdict route missing after database reopen: %+v", rules)
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	if code := runOrg([]string{"events", "rule", "rm", "--home", home, want.ID}, &stdout, &stderr); code != 0 {
+		t.Fatalf("remove review wake opt-out code=%d out=%q err=%q", code, stdout.String(), stderr.String())
+	}
+	store, err = dbtest.Open(t, paths.Database)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rules, err = store.ListEventRules(context.Background())
+	if err != nil {
+		store.Close()
+		t.Fatal(err)
+	}
+	if err := store.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if slices.ContainsFunc(rules, func(rule db.EventRule) bool { return rule.ID == want.ID }) {
+		t.Fatalf("review verdict route returned after explicit opt-out and database reopen: %+v", rules)
+	}
+}
+
+func TestOrgSeatAddRepairsMissingReviewVerdictRoute(t *testing.T) {
+	home, paths, panes := setupOrgSeatTestHome(t)
+	withOrgSeatFixtureProvider(t, &panes)
+
+	var stdout, stderr bytes.Buffer
+	if code := runOrg([]string{"seat", "add", "worker", "--pane", "Worker", "--home", home}, &stdout, &stderr); code != 0 {
+		t.Fatalf("initial seat add code=%d out=%q err=%q", code, stdout.String(), stderr.String())
+	}
+	store, err := dbtest.Open(t, paths.Database)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := store.DeleteEventRule(context.Background(), "org-seat-worker-review-verdict"); err != nil {
+		store.Close()
+		t.Fatal(err)
+	}
+	if err := store.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	if code := runOrg([]string{"seat", "add", "worker", "--pane", "Worker", "--home", home}, &stdout, &stderr); code != 0 {
+		t.Fatalf("repair seat add code=%d out=%q err=%q", code, stdout.String(), stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "route org-seat-worker-review-verdict created") {
+		t.Fatalf("repair output missing review route creation:\n%s", stdout.String())
+	}
+	if got := len(listOrgSeatTestRules(t, paths)); got != 7 {
+		t.Fatalf("event rules after review route repair = %d, want 7", got)
 	}
 }
 
@@ -255,7 +356,7 @@ func TestOrgSeatBindingSurvivesLabelRename(t *testing.T) {
 	stdout.Reset()
 	stderr.Reset()
 	if code := runOrg([]string{"validate", "--home", home}, &stdout, &stderr); code != 0 ||
-		!strings.Contains(stdout.String(), "ok 2 roles, 2 live panes, 6 enabled routes") {
+		!strings.Contains(stdout.String(), "ok 2 roles, 2 live panes, 7 enabled routes") {
 		t.Fatalf("validate after rename code=%d out=%q err=%q", code, stdout.String(), stderr.String())
 	}
 }
@@ -268,7 +369,7 @@ func TestOrgSeatAddCreatesUnboundThenBinds(t *testing.T) {
 	code := runOrg([]string{"seat", "add", "worker", "--home", home}, &stdout, &stderr)
 	if code != 0 || !strings.Contains(stdout.String(), `role worker created pane=""`) ||
 		!strings.Contains(stdout.String(), "role worker is unbound") ||
-		!strings.Contains(stdout.String(), "ok role worker unbound enabled_routes=5") {
+		!strings.Contains(stdout.String(), "ok role worker unbound enabled_routes=6") {
 		t.Fatalf("unbound seat add code=%d out=%q err=%q", code, stdout.String(), stderr.String())
 	}
 	cfg, err := config.LoadOrg(paths)
@@ -279,8 +380,8 @@ func TestOrgSeatAddCreatesUnboundThenBinds(t *testing.T) {
 	if !ok || worker.Pane != "" {
 		t.Fatalf("unbound worker role = %+v, present=%t", worker, ok)
 	}
-	if got := len(listOrgSeatTestRules(t, paths)); got != 6 {
-		t.Fatalf("routes after unbound creation = %d, want 6", got)
+	if got := len(listOrgSeatTestRules(t, paths)); got != 7 {
+		t.Fatalf("routes after unbound creation = %d, want 7", got)
 	}
 	stdout.Reset()
 	stderr.Reset()
@@ -303,13 +404,13 @@ func TestOrgSeatAddCreatesUnboundThenBinds(t *testing.T) {
 	if !ok || worker.Pane != "w1:p2" {
 		t.Fatalf("bound worker role = %+v, present=%t", worker, ok)
 	}
-	if got := len(listOrgSeatTestRules(t, paths)); got != 6 {
-		t.Fatalf("routes after bind = %d, want 6", got)
+	if got := len(listOrgSeatTestRules(t, paths)); got != 7 {
+		t.Fatalf("routes after bind = %d, want 7", got)
 	}
 	stdout.Reset()
 	stderr.Reset()
 	if code := runOrg([]string{"validate", "--home", home}, &stdout, &stderr); code != 0 ||
-		!strings.Contains(stdout.String(), "ok 2 roles, 2 live panes, 6 enabled routes") {
+		!strings.Contains(stdout.String(), "ok 2 roles, 2 live panes, 7 enabled routes") {
 		t.Fatalf("validate bound seat code=%d out=%q err=%q", code, stdout.String(), stderr.String())
 	}
 }
@@ -363,8 +464,8 @@ func TestOrgSeatAddRejectsPolicyChangesForExistingRole(t *testing.T) {
 			if !ok || worker.Pane != "" || len(worker.Scope) != 1 || worker.Scope[0] != "*" {
 				t.Fatalf("worker changed after rejected policy flag: %+v, present=%t", worker, ok)
 			}
-			if got := len(listOrgSeatTestRules(t, paths)); got != 6 {
-				t.Fatalf("routes after rejected policy flag = %d, want 6", got)
+			if got := len(listOrgSeatTestRules(t, paths)); got != 7 {
+				t.Fatalf("routes after rejected policy flag = %d, want 7", got)
 			}
 		})
 	}
@@ -396,8 +497,8 @@ func TestOrgSeatAddAcceptsMatchingPolicyFlagsForExistingRole(t *testing.T) {
 		worker.MergeRule != "none" || worker.Pane != "w1:p2" {
 		t.Fatalf("worker after matching retry = %+v, present=%t", worker, ok)
 	}
-	if got := len(listOrgSeatTestRules(t, paths)); got != 6 {
-		t.Fatalf("routes after matching retry = %d, want 6", got)
+	if got := len(listOrgSeatTestRules(t, paths)); got != 7 {
+		t.Fatalf("routes after matching retry = %d, want 7", got)
 	}
 }
 
@@ -488,7 +589,7 @@ func TestOrgSeatAddSucceedsWithAnotherUnboundRole(t *testing.T) {
 	stdout.Reset()
 	stderr.Reset()
 	code := runOrg([]string{"seat", "add", "other", "--pane", "w1:p2", "--home", home}, &stdout, &stderr)
-	if code != 0 || !strings.Contains(stdout.String(), "ok role other pane=w1:p2 enabled_routes=5") {
+	if code != 0 || !strings.Contains(stdout.String(), "ok role other pane=w1:p2 enabled_routes=6") {
 		t.Fatalf("bound other add code=%d out=%q err=%q", code, stdout.String(), stderr.String())
 	}
 	stdout.Reset()
@@ -528,8 +629,8 @@ func TestOrgSeatAddRebindsUnresolvedConfiguredPane(t *testing.T) {
 	if !ok || worker.Pane != "w1:p2" || worker.Parent != "owner" || worker.MergeRule != "owner" {
 		t.Fatalf("rebound worker = %+v, present=%t", worker, ok)
 	}
-	if got := len(listOrgSeatTestRules(t, paths)); got != 6 {
-		t.Fatalf("routes after rebind = %d, want 6", got)
+	if got := len(listOrgSeatTestRules(t, paths)); got != 7 {
+		t.Fatalf("routes after rebind = %d, want 7", got)
 	}
 }
 
@@ -554,7 +655,7 @@ func TestOrgSeatAddRejectsAmbiguousConfiguredPaneRebind(t *testing.T) {
 	if !ok || worker.Pane != "Worker" {
 		t.Fatalf("ambiguous rebind changed worker = %+v, present=%t", worker, ok)
 	}
-	if got := len(listOrgSeatTestRules(t, paths)); got != 6 {
+	if got := len(listOrgSeatTestRules(t, paths)); got != 7 {
 		t.Fatalf("ambiguous rebind changed routes: %d", got)
 	}
 }
@@ -791,7 +892,7 @@ func TestOrgSeatRemoveRefusesUnshippedBranchWork(t *testing.T) {
 	if _, ok := cfg.Role("worker"); !ok {
 		t.Fatal("branch-check mutant removed worker role")
 	}
-	if got := len(listOrgSeatTestRules(t, paths)); got != 6 {
+	if got := len(listOrgSeatTestRules(t, paths)); got != 7 {
 		t.Fatalf("branch refusal changed routes: %d", got)
 	}
 }
@@ -886,8 +987,8 @@ func TestOrgSeatRemoveStalePaneIDFailsClosed(t *testing.T) {
 	if !ok || worker.Pane != "w1:p9" {
 		t.Fatalf("stale worker changed after refused removal = %+v, present=%t", worker, ok)
 	}
-	if got := len(listOrgSeatTestRules(t, paths)); got != 6 {
-		t.Fatalf("routes after stale removal refusal = %d, want 6", got)
+	if got := len(listOrgSeatTestRules(t, paths)); got != 7 {
+		t.Fatalf("routes after stale removal refusal = %d, want 7", got)
 	}
 }
 
@@ -920,7 +1021,7 @@ func TestOrgSeatRemoveAmbiguousPaneLabelFailsClosed(t *testing.T) {
 	} else if _, ok := cfg.Role("worker"); !ok {
 		t.Fatal("ambiguous removal deleted worker")
 	}
-	if got := len(listOrgSeatTestRules(t, paths)); got != 6 {
+	if got := len(listOrgSeatTestRules(t, paths)); got != 7 {
 		t.Fatalf("ambiguous removal changed routes: %d", got)
 	}
 
@@ -981,7 +1082,7 @@ func TestOrgSeatRemoveConfiguredPaneProviderOutageFailsClosed(t *testing.T) {
 	} else if _, ok := cfg.Role("worker"); !ok {
 		t.Fatal("provider outage removal deleted worker")
 	}
-	if got := len(listOrgSeatTestRules(t, paths)); got != 6 {
+	if got := len(listOrgSeatTestRules(t, paths)); got != 7 {
 		t.Fatalf("provider outage removal changed routes: %d", got)
 	}
 }
@@ -1013,7 +1114,7 @@ func TestOrgSeatRemoveClosesPaneAndEndsWithValidation(t *testing.T) {
 	}
 	for _, want := range []string{
 		"pane w1:p2 closed",
-		"role worker removed with 5 wake routes",
+		"role worker removed with 6 wake routes",
 		"ok role worker absent owned_routes=0",
 	} {
 		if !strings.Contains(stdout.String(), want) {
@@ -1146,8 +1247,8 @@ func TestOrgSeatRemoveRestoresOwnedStateWhenPaneCloseFails(t *testing.T) {
 	if _, ok := cfg.Role("worker"); !ok {
 		t.Fatal("worker role was not restored after pane-close failure")
 	}
-	if got := len(listOrgSeatTestRules(t, paths)); got != 6 {
-		t.Fatalf("routes after pane-close rollback = %d, want 6", got)
+	if got := len(listOrgSeatTestRules(t, paths)); got != 7 {
+		t.Fatalf("routes after pane-close rollback = %d, want 7", got)
 	}
 }
 
@@ -1417,7 +1518,7 @@ func TestOrgSeatRemoveForceStillFailsClosedOnProviderOutage(t *testing.T) {
 	if _, ok := cfg.Role("worker"); !ok {
 		t.Fatal("a provider outage under --force removed the role anyway")
 	}
-	if got := len(listOrgSeatTestRules(t, paths)); got != 6 {
+	if got := len(listOrgSeatTestRules(t, paths)); got != 7 {
 		t.Fatalf("a provider outage under --force changed routes: %d", got)
 	}
 }

--- a/skills/gitmoot/references/CLI.md
+++ b/skills/gitmoot/references/CLI.md
@@ -1775,6 +1775,10 @@ filter. Remove one by its stable ID with `org events rule rm` to quiet that kind
 this is destructive and re-running `seat add` recreates it. There is currently
 no non-destructive event-rule disable verb.
 
+After upgrading an existing installation, re-run `org seat add <role>` for each
+seat to provision default routes introduced by the new release, including
+`review-verdict`. The repair preserves the seat's existing policy and routes.
+
 The registry uses `[org] enforce = "warn"|"block"` and
 `[org.roles."name"]` entries with `parent`, `scope`, `merge_rule`, an optional
 cosmetic `display_name`, an optional `model` runtime pin, an optional per-role

--- a/skills/gitmoot/references/CLI.md
+++ b/skills/gitmoot/references/CLI.md
@@ -1703,8 +1703,9 @@ claimed by any role; each failure includes category counts and a reason.
 
 `gitmoot org seat add <name> [--pane ID_OR_LABEL] [--parent ROLE]
 [--scope REPO,...] [--merge-rule owner|self|none] [--home DIR]` creates or
-repairs a role and installs addressed `reply`, `blocked`, `directive`,
-`escalation`, and `fact` routes with stable IDs `org-seat-<name>-<kind>`.
+repairs a role and installs addressed `reply`, `review-verdict`, `blocked`,
+`directive`, `escalation`, and `fact` routes with stable IDs
+`org-seat-<name>-<kind>`.
 
 With `--pane`, Gitmoot resolves a literal live pane id first, then a unique
 exact live label, and stores the resolved pane id. Existing label-based commands
@@ -1719,10 +1720,10 @@ resolving, for example after Herdr recreates a pane with a new id, the same
 command can rebind the role to a live unclaimed pane while preserving its policy
 and routes. A configured binding that still resolves is immutable. An ambiguous
 label binding must be disambiguated in Herdr before rebinding. Every successful
-add validates the affected role and five routes. Bound creation and repair also
+add validates the affected role and six routes. Bound creation and repair also
 validate the live binding without making unrelated intentionally unbound roles
 decide the exit code. Unbound creation reports the deferred bind command and an
-`ok role NAME unbound enabled_routes=5` verdict. The global `org validate` command
+`ok role NAME unbound enabled_routes=6` verdict. The global `org validate` command
 continues to report every unbound role until it is attached.
 
 For a new non-owner seat, the acting role comes from `GITMOOT_ORG_ROLE` and

--- a/skills/gitmoot/references/CLI.md
+++ b/skills/gitmoot/references/CLI.md
@@ -1770,7 +1770,7 @@ those panes separately before forcing the removal. `--force` does not weaken
 anything else: a pane that DOES resolve is still refused when its branch check
 fails, and a provider error still fails closed rather than being forced through.
 
-The five provisioned routes are enabled, addressed, and have an empty match
+The six provisioned routes are enabled, addressed, and have an empty match
 filter. Remove one by its stable ID with `org events rule rm` to quiet that kind;
 this is destructive and re-running `seat add` recreates it. There is currently
 no non-destructive event-rule disable verb.

--- a/website/docs/reference/cli.md
+++ b/website/docs/reference/cli.md
@@ -1594,6 +1594,10 @@ filter. Remove one by its stable ID with `org events rule rm` to quiet that kind
 this is destructive and re-running `seat add` recreates it. There is currently
 no non-destructive event-rule disable verb.
 
+After upgrading an existing installation, re-run `org seat add <role>` for each
+seat to provision default routes introduced by the new release, including
+`review-verdict`. The repair preserves the seat's existing policy and routes.
+
 `gitmoot org recycle <role> --kind <kind> --handoff "<note>" [--pane <id>]
 [--json] [--home <dir>]` journals a typed handoff in the role-lifecycle workflow
 `org/<role>`, builds the successor's boot prompt from `org brief` plus that

--- a/website/docs/reference/cli.md
+++ b/website/docs/reference/cli.md
@@ -1589,7 +1589,7 @@ those panes separately before forcing the removal. `--force` does not weaken
 anything else: a pane that DOES resolve is still refused when its branch check
 fails, and a provider error still fails closed rather than being forced through.
 
-The five provisioned routes are enabled, addressed, and have an empty match
+The six provisioned routes are enabled, addressed, and have an empty match
 filter. Remove one by its stable ID with `org events rule rm` to quiet that kind;
 this is destructive and re-running `seat add` recreates it. There is currently
 no non-destructive event-rule disable verb.

--- a/website/docs/reference/cli.md
+++ b/website/docs/reference/cli.md
@@ -1522,8 +1522,9 @@ at enqueue.
 
 `gitmoot org seat add <name> [--pane ID_OR_LABEL] [--parent ROLE]
 [--scope REPO,...] [--merge-rule owner|self|none] [--home DIR]` creates or
-repairs a role and installs addressed `reply`, `blocked`, `directive`,
-`escalation`, and `fact` routes with stable IDs `org-seat-<name>-<kind>`.
+repairs a role and installs addressed `reply`, `review-verdict`, `blocked`,
+`directive`, `escalation`, and `fact` routes with stable IDs
+`org-seat-<name>-<kind>`.
 
 With `--pane`, Gitmoot resolves a literal live pane id first, then a unique
 exact live label, and stores the resolved pane id. Existing label-based commands
@@ -1538,10 +1539,10 @@ resolving, for example after Herdr recreates a pane with a new id, the same
 command can rebind the role to a live unclaimed pane while preserving its policy
 and routes. A configured binding that still resolves is immutable. An ambiguous
 label binding must be disambiguated in Herdr before rebinding. Every successful
-add validates the affected role and five routes. Bound creation and repair also
+add validates the affected role and six routes. Bound creation and repair also
 validate the live binding without making unrelated intentionally unbound roles
 decide the exit code. Unbound creation reports the deferred bind command and an
-`ok role NAME unbound enabled_routes=5` verdict. The global `org validate` command
+`ok role NAME unbound enabled_routes=6` verdict. The global `org validate` command
 continues to report every unbound role until it is attached.
 
 For a new non-owner seat, the acting role comes from `GITMOOT_ORG_ROLE` and


### PR DESCRIPTION
## Summary
- add `review-verdict` to every new organization seat's addressed default routes
- repair the missing default route when `gitmoot org seat add` is rerun for an existing seat
- document the sixth default route

## Verification
- `go test ./internal/cli -run '^TestOrgSeat' -count=1`
- focused review-verdict routing tests
- persistent event-rule tests
- Herdr prompt bridge tests
- clean-home CLI smoke: new unbound seat created `org-seat-worker-review-verdict`

Authority: owner workflow note 137629. No merge or deployment authorization.