### PR TITLE
fix(daemon): promptly settle dead runtime jobs

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -549,18 +549,19 @@ Fixes:
   writes nothing to the tasks table. Inspect it with `gitmoot job events
   <parent-job-id>` (`job events` has no `--json` flag). `gitmoot job show
   <parent-job-id> --json` is valid but does not include event history.
-- A job stuck in `running` is recovered automatically once it shows no lease
-  progress past the staleness window (default 30m; tune with the
-  `GITMOOT_STALE_RUNNING_AFTER` environment variable; the smallest honored value
-  is 1m — below-1m, malformed, or non-positive values are rejected in favor of
-  the 30m default rather than clamped, #560). This window is a same-boot crash
-  backstop, not a timeout: a job holding a runtime session lock whose lease has
-  not elapsed is left running regardless of the window (its real timeout has not
-  passed). After a **reboot** you do not wait it out at all — the kernel boot id
-  changes, so on its next startup and every tick the daemon immediately requeues
-  every job claimed on the previous boot and reclaims its stranded runtime session
-  lock, regardless of any unexpired lease (#651). Boot-aware recovery is Linux
-  only; elsewhere recovery falls back to the lease/age window above.
+- A job whose recorded runtime PID is dead is failed after the PID and job log
+  stay unchanged across two 30-second observations. Gitmoot then cancels only
+  that tracked delivery, which lets its normal runtime and worktree cleanup
+  finish without interrupting healthy sibling jobs. The terminal event retains
+  a redacted transcript tail; partial runtime usage is recorded when the adapter
+  reported it before exit.
+- Legacy running rows with no runtime PID still use the conservative stale-job
+  recovery path: no lease progress past the staleness window (default 30m,
+  configurable with `GITMOOT_STALE_RUNNING_AFTER`; minimum 1m) plus frozen log
+  evidence. This is a crash backstop, not a job timeout. After a **reboot**, the
+  kernel boot id changes, so the daemon immediately requeues jobs claimed on the
+  previous boot and reclaims their runtime-session locks (#651). Boot-aware
+  recovery is Linux-only.
 - A backlog of `blocked` jobs (each paused awaiting a human) never clears on its
   own. Dismiss one with `gitmoot job cancel <job-id>` (cancel now abandons a
   `blocked` job as well as a `queued`/`running` one; #631), or clear a stale

--- a/internal/cli/daemon_dispatch_tracked.go
+++ b/internal/cli/daemon_dispatch_tracked.go
@@ -93,6 +93,8 @@ type inflightDispatch struct {
 	repo        string
 	checkoutKey string
 	runtimeKey  string
+	runCtx      context.Context
+	cancelRun   context.CancelFunc
 }
 
 // inflightJobTracker owns the cross-tick in-flight job accounting and
@@ -131,7 +133,7 @@ type inflightJobTracker struct {
 // finite.
 func newInflightJobTracker(ctx context.Context) *inflightJobTracker {
 	runCtx, cancel := context.WithCancel(context.WithoutCancel(ctx))
-	return &inflightJobTracker{
+	tracker := &inflightJobTracker{
 		runCtx:    runCtx,
 		cancelRun: cancel,
 		jobs:      map[string]inflightDispatch{},
@@ -140,8 +142,10 @@ func newInflightJobTracker(ctx context.Context) *inflightJobTracker {
 		perRepo:   map[string]int{},
 		poolRuns:  map[string]bool{},
 		errs:      map[string][]error{},
-		liveness:  newDaemonLivenessSweep(),
 	}
+	tracker.liveness = newDaemonLivenessSweep()
+	tracker.liveness.cancelJob = tracker.cancelJob
+	return tracker
 }
 
 // jobContext returns the context dispatched jobs must run on: cancelled ONLY
@@ -151,6 +155,21 @@ func newInflightJobTracker(ctx context.Context) *inflightJobTracker {
 func (t *inflightJobTracker) jobContext(fallback context.Context) context.Context {
 	if t == nil {
 		return fallback
+	}
+	return t.runCtx
+}
+
+// trackedJobContext returns one job's child context. The liveness reaper can
+// cancel this context without interrupting healthy siblings; drain still
+// cancels their shared parent when its shutdown budget expires.
+func (t *inflightJobTracker) trackedJobContext(jobID string, fallback context.Context) context.Context {
+	if t == nil {
+		return fallback
+	}
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if dispatch, ok := t.jobs[jobID]; ok && dispatch.runCtx != nil {
+		return dispatch.runCtx
 	}
 	return t.runCtx
 }
@@ -183,7 +202,8 @@ func (t *inflightJobTracker) beginWithin(hostCap int, jobID, repo, checkoutKey, 
 			return false
 		}
 	}
-	t.jobs[jobID] = inflightDispatch{repo: repo, checkoutKey: checkoutKey, runtimeKey: runtimeKey}
+	jobCtx, cancelJob := context.WithCancel(t.runCtx)
+	t.jobs[jobID] = inflightDispatch{repo: repo, checkoutKey: checkoutKey, runtimeKey: runtimeKey, runCtx: jobCtx, cancelRun: cancelJob}
 	if checkoutKey != "" {
 		t.checkouts[checkoutKey]++
 	}
@@ -192,6 +212,23 @@ func (t *inflightJobTracker) beginWithin(hostCap int, jobID, repo, checkoutKey, 
 	}
 	t.perRepo[repo]++
 	t.wg.Add(1)
+	return true
+}
+
+// cancelJob interrupts one tracked delivery after the durable liveness
+// transition wins. It does not release accounting: the worker's normal defer
+// owns that cleanup once cancellation unwinds the runtime and worktree.
+func (t *inflightJobTracker) cancelJob(jobID string) bool {
+	if t == nil {
+		return false
+	}
+	t.mu.Lock()
+	dispatch, exists := t.jobs[jobID]
+	t.mu.Unlock()
+	if !exists || dispatch.cancelRun == nil {
+		return false
+	}
+	dispatch.cancelRun()
 	return true
 }
 
@@ -207,6 +244,9 @@ func (t *inflightJobTracker) end(jobID string) {
 		return
 	}
 	delete(t.jobs, jobID)
+	if dispatch.cancelRun != nil {
+		dispatch.cancelRun()
+	}
 	decrementCount(t.checkouts, dispatch.checkoutKey)
 	decrementCount(t.runtimes, dispatch.runtimeKey)
 	decrementCount(t.perRepo, dispatch.repo)
@@ -842,7 +882,6 @@ func dispatchQueuedJobsTracked(ctx context.Context, worker jobWorker, limit int,
 	seedCheckouts, seedRuntimes := tracker.seeds()
 	queued, remaining := selectRunnableQueuedJobsSeeded(ctx, worker.Store, eligible, slots, policy, seedCheckouts, seedRuntimes)
 	explainHeldBackJobs(ctx, worker, tracker, remaining)
-	runCtx := tracker.jobContext(ctx)
 	for _, job := range queued {
 		job := job
 		if !worker.Admission.Reserve(job.ID, func() admissionEstimate { return worker.admissionEstimate(ctx, job) }) {
@@ -858,6 +897,7 @@ func dispatchQueuedJobsTracked(ctx context.Context, worker jobWorker, limit int,
 			worker.Admission.Release(job.ID)
 			continue
 		}
+		runCtx := tracker.trackedJobContext(job.ID, ctx)
 		go func() {
 			defer tracker.end(job.ID)
 			defer worker.Admission.Release(job.ID)

--- a/internal/cli/daemon_liveness.go
+++ b/internal/cli/daemon_liveness.go
@@ -28,6 +28,12 @@ const (
 	runtimePIDIdentityMismatch
 )
 
+// daemonDeadRuntimeReapAfter gives the normal worker settlement path its
+// bounded terminal-write window before recovery intervenes. A process proven
+// dead cannot resume work, so it must not inherit the 30m/45m silence policy
+// used for legacy rows with no process identity.
+const daemonDeadRuntimeReapAfter = 30 * time.Second
+
 type livenessLogSample struct {
 	size             int64
 	modified         time.Time
@@ -38,12 +44,13 @@ type livenessLogSample struct {
 // daemonLivenessSweep retains one prior transcript observation per candidate.
 // A single stat can never turn temporary silence into a terminal verdict.
 type daemonLivenessSweep struct {
-	mu       sync.Mutex
-	samples  map[string]livenessLogSample
-	stat     func(string) (os.FileInfo, error)
-	probe    func(int, string) runtimePIDState
-	identity func(int) string
-	signal   func(int, syscall.Signal) error
+	mu        sync.Mutex
+	samples   map[string]livenessLogSample
+	stat      func(string) (os.FileInfo, error)
+	probe     func(int, string) runtimePIDState
+	identity  func(int) string
+	signal    func(int, syscall.Signal) error
+	cancelJob func(string) bool
 }
 
 func newDaemonLivenessSweep() *daemonLivenessSweep {
@@ -116,13 +123,18 @@ func configuredDaemonQuietKillAfter(home string, stdout io.Writer) time.Duration
 }
 
 // sweepRunningJobLiveness is the recurring same-boot crash detector. Startup
-// and foreign-boot recovery stay separate: this path only fails a job after
-// age, byte-progress, and runtime-process evidence converge.
+// and foreign-boot recovery stay separate. Rows with a recorded dead PID use a
+// short, two-sample confirmation window; legacy rows still require the original
+// stale-age, byte-progress, and lease evidence.
 func (s *daemonLivenessSweep) sweepRunningJobLiveness(ctx context.Context, store *db.Store, stdout io.Writer, paths config.Paths, now time.Time, staleAfter, quietAfter time.Duration, repoFilter, rootFilter string) error {
 	if s == nil {
 		return nil
 	}
-	jobs, err := store.ListRunningJobsUpdatedBefore(ctx, now.Add(-staleAfter))
+	candidateAge := staleAfter
+	if candidateAge <= 0 || candidateAge > daemonDeadRuntimeReapAfter {
+		candidateAge = daemonDeadRuntimeReapAfter
+	}
+	jobs, err := store.ListRunningJobsUpdatedBefore(ctx, now.Add(-candidateAge))
 	if err != nil {
 		return err
 	}
@@ -134,7 +146,11 @@ func (s *daemonLivenessSweep) sweepRunningJobLiveness(ctx context.Context, store
 			return err
 		}
 	}
-	s.prune(now, 4*quietAfter)
+	pruneAfter := 4 * quietAfter
+	if minimum := 4 * daemonDeadRuntimeReapAfter; pruneAfter < minimum {
+		pruneAfter = minimum
+	}
+	s.prune(now, pruneAfter)
 	return nil
 }
 
@@ -148,26 +164,20 @@ func (s *daemonLivenessSweep) evaluate(ctx context.Context, store *db.Store, std
 		s.forget(job.ID)
 		return nil
 	}
-	requiredQuiet := quietAfter
+
 	legacy := payload.RuntimePID <= 0
+	requiredAge := staleAfter
+	requiredQuiet := quietAfter
+	stableFor := daemonWorkerLoopInterval
 	if legacy {
 		requiredQuiet = 2 * quietAfter
-	}
-	if now.Sub(info.ModTime()) < requiredQuiet {
-		s.remember(job.ID, livenessLogSample{size: info.Size(), modified: info.ModTime(), observed: now})
-		return nil
-	}
-
-	previous, stable := s.previousStable(job.ID, info, now)
-	if !stable {
-		return nil
-	}
-
-	if !legacy {
+	} else {
 		switch s.probe(payload.RuntimePID, payload.RuntimePIDStartTime) {
 		case runtimePIDLive:
+			s.forget(job.ID)
 			return nil // absolute veto: a quiet, thinking runtime remains live
 		case runtimePIDIdentityMismatch:
+			previous, _ := s.previousStable(job.ID, info, now, daemonWorkerLoopInterval)
 			if !previous.identityReported {
 				_ = store.AddJobEvent(ctx, db.JobEvent{
 					JobID: job.ID,
@@ -180,11 +190,30 @@ func (s *daemonLivenessSweep) evaluate(ctx context.Context, store *db.Store, std
 			}
 			return nil
 		case runtimePIDUnknown:
+			s.forget(job.ID)
 			return nil
 		case runtimePIDDead:
-			// All three required legs are named in the terminal event below.
+			requiredAge = daemonDeadRuntimeReapAfter
+			requiredQuiet = daemonDeadRuntimeReapAfter
+			stableFor = daemonDeadRuntimeReapAfter
 		}
-	} else {
+	}
+
+	updatedAt := parseJobTimeMillis(job.UpdatedAt)
+	if updatedAt == 0 {
+		updatedAt = parseJobTimeMillis(job.CreatedAt)
+	}
+	if updatedAt == 0 || now.Sub(time.UnixMilli(updatedAt)) < requiredAge {
+		s.forget(job.ID)
+		return nil
+	}
+
+	_, stable := s.previousStable(job.ID, info, now, stableFor)
+	if now.Sub(info.ModTime()) < requiredQuiet || !stable {
+		return nil
+	}
+
+	if legacy {
 		leaseHeld, leaseErr := runtimeOwnerLeaseHeld(ctx, store, job.ID, now)
 		if leaseErr != nil {
 			return leaseErr
@@ -199,14 +228,17 @@ func (s *daemonLivenessSweep) evaluate(ctx context.Context, store *db.Store, std
 	runtimePGID := payload.RuntimePGID
 	processLeg := "legacy row has no runtime PID and holds no runtime lease"
 	if !legacy {
-		processLeg = fmt.Sprintf("runtime pid %d is dead (recorded starttime %s)", runtimePID, runtimeStart)
+		processLeg = fmt.Sprintf("runtime pid %d is dead (recorded starttime %s) across two samples for %s", runtimePID, runtimeStart, stableFor)
 	}
-	message := fmt.Sprintf("liveness predicate satisfied: updated_at frozen past %s; job log byte-frozen for %s across two samples; %s", staleAfter, requiredQuiet, processLeg)
+	message := fmt.Sprintf("liveness predicate satisfied: updated_at frozen past %s; job log byte-frozen for %s across two samples; %s", requiredAge, requiredQuiet, processLeg)
 	transitioned, err := failRecoveredRunningJob(ctx, store, stdout, now, job, message)
 	if err != nil {
 		return err
 	}
 	if transitioned {
+		if s.cancelJob != nil {
+			s.cancelJob(job.ID)
+		}
 		if !legacy {
 			s.killRecordedRuntimeGroup(ctx, store, job.ID, runtimePID, runtimePGID, runtimeStart)
 		}
@@ -248,14 +280,17 @@ func (s *daemonLivenessSweep) killRecordedRuntimeGroup(ctx context.Context, stor
 	}
 }
 
-func (s *daemonLivenessSweep) previousStable(jobID string, info os.FileInfo, now time.Time) (livenessLogSample, bool) {
+func (s *daemonLivenessSweep) previousStable(jobID string, info os.FileInfo, now time.Time, stableFor time.Duration) (livenessLogSample, bool) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	previous, ok := s.samples[jobID]
 	current := livenessLogSample{size: info.Size(), modified: info.ModTime(), observed: now, identityReported: previous.identityReported}
+	unchanged := ok && previous.size == current.size && previous.modified.Equal(current.modified)
+	if unchanged {
+		current.observed = previous.observed
+	}
 	s.samples[jobID] = current
-	stable := ok && previous.size == current.size && previous.modified.Equal(current.modified) && now.Sub(previous.observed) >= daemonWorkerLoopInterval
-	return current, stable
+	return current, unchanged && now.Sub(previous.observed) >= stableFor
 }
 
 func (s *daemonLivenessSweep) remember(jobID string, sample livenessLogSample) {

--- a/internal/cli/daemon_liveness_test.go
+++ b/internal/cli/daemon_liveness_test.go
@@ -59,7 +59,7 @@ func livenessTestJob(t *testing.T, id string, pid int) (context.Context, config.
 
 func runLivenessSamples(t *testing.T, sweep *daemonLivenessSweep, ctx context.Context, store *db.Store, paths config.Paths, now time.Time, quiet time.Duration) {
 	t.Helper()
-	for _, at := range []time.Time{now, now.Add(daemonWorkerLoopInterval)} {
+	for _, at := range []time.Time{now, now.Add(daemonDeadRuntimeReapAfter)} {
 		if err := sweep.sweepRunningJobLiveness(ctx, store, io.Discard, paths, at, 30*time.Minute, quiet, "owner/repo", ""); err != nil {
 			t.Fatalf("sweep at %s: %v", at, err)
 		}
@@ -120,6 +120,70 @@ func TestDaemonLivenessSweepDeadPIDFrozenLogFails(t *testing.T) {
 	}
 }
 
+func TestDaemonLivenessSweepPromptlyCancelsOnlyDeadTrackedJob(t *testing.T) {
+	ctx, paths, store, _, quiet := livenessTestJob(t, "dead-recent", 4242)
+	now := time.Now().UTC().Add(2 * daemonDeadRuntimeReapAfter)
+	logPath := transcript.JobLogPath(paths.Logs, "dead-recent")
+	frozenAt := now.Add(-daemonDeadRuntimeReapAfter - time.Second)
+	if err := os.Chtimes(logPath, frozenAt, frozenAt); err != nil {
+		t.Fatal(err)
+	}
+
+	tracker := newInflightJobTracker(context.Background())
+	if !tracker.beginWithin(0, "dead-recent", "owner/repo", "dead-checkout", "dead-runtime") {
+		t.Fatal("dead job admission refused")
+	}
+	if !tracker.beginWithin(0, "healthy-sibling", "owner/other", "healthy-checkout", "healthy-runtime") {
+		t.Fatal("healthy sibling admission refused")
+	}
+	deadCtx := tracker.trackedJobContext("dead-recent", context.Background())
+	healthyCtx := tracker.trackedJobContext("healthy-sibling", context.Background())
+	cleaned := make(chan struct{})
+	go func() {
+		<-deadCtx.Done()
+		tracker.end("dead-recent")
+		close(cleaned)
+	}()
+	defer tracker.end("healthy-sibling")
+
+	sweep := tracker.liveness
+	sweep.probe = func(int, string) runtimePIDState { return runtimePIDDead }
+	for elapsed := time.Duration(0); elapsed < daemonDeadRuntimeReapAfter; elapsed += daemonWorkerLoopInterval {
+		if err := sweep.sweepRunningJobLiveness(ctx, store, io.Discard, paths, now.Add(elapsed), 30*time.Minute, quiet, "owner/repo", ""); err != nil {
+			t.Fatal(err)
+		}
+		select {
+		case <-deadCtx.Done():
+			t.Fatalf("dead job cancelled after %s, before the confirmation window", elapsed)
+		default:
+		}
+	}
+	if err := sweep.sweepRunningJobLiveness(ctx, store, io.Discard, paths, now.Add(daemonDeadRuntimeReapAfter), 30*time.Minute, quiet, "owner/repo", ""); err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case <-cleaned:
+	case <-time.After(2 * time.Second):
+		t.Fatal("dead job context was not cancelled after recovery transition")
+	}
+	select {
+	case <-healthyCtx.Done():
+		t.Fatal("dead-job recovery cancelled a healthy sibling")
+	default:
+	}
+
+	job, err := store.GetJob(ctx, "dead-recent")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if job.State != string(workflow.JobFailed) {
+		t.Fatalf("recent dead job state = %q, want failed", job.State)
+	}
+	if tracker.inflightJob("dead-recent") {
+		t.Fatal("dead job remained in tracker after cancellation cleanup")
+	}
+}
+
 func TestDaemonLivenessSweepLivePIDVetoesFrozenLog(t *testing.T) {
 	ctx, paths, store, now, quiet := livenessTestJob(t, "live", os.Getpid())
 	sweep := newDaemonLivenessSweep()
@@ -137,7 +201,7 @@ func TestDaemonLivenessSweepLivePIDVetoesFrozenLog(t *testing.T) {
 func TestDaemonLivenessSweepQuietThresholdVetoes(t *testing.T) {
 	ctx, paths, store, now, quiet := livenessTestJob(t, "recent", 4242)
 	path := transcript.JobLogPath(paths.Logs, "recent")
-	recent := now.Add(-quiet + time.Minute)
+	recent := now.Add(time.Second) // output arrives between the two dead-PID samples
 	if err := os.Chtimes(path, recent, recent); err != nil {
 		t.Fatal(err)
 	}

--- a/internal/cli/daemon_scheduler.go
+++ b/internal/cli/daemon_scheduler.go
@@ -2429,13 +2429,10 @@ func runQueuedJobsForRepoPoolTracked(ctx context.Context, worker jobWorker, limi
 	// ctx is the SIGNAL context and governs this pass's own accept/requery loop:
 	// on shutdown it must stop selecting, querying and dispatching promptly.
 	//
-	// deliveryCtx governs the JOBS this pass dispatches, and must SURVIVE the
-	// shutdown signal so in-flight work can finish while the tracker's drain
-	// waits for it. Only the two runPoolJobRecovered calls below may use it.
-	//
-	// A nil tracker returns ctx unchanged, which is what keeps the untracked
-	// runQueuedJobsForRepoPool byte-identical to the historical pool.
-	deliveryCtx := tracker.jobContext(ctx)
+	// Each dispatched job gets a child of the tracker's shutdown-surviving
+	// context after admission. That lets the liveness reaper interrupt one dead
+	// runtime without cancelling healthy siblings. A nil tracker falls back to
+	// ctx, preserving the historical untracked pool path.
 
 	type finished struct {
 		jobID        string
@@ -2661,6 +2658,7 @@ func runQueuedJobsForRepoPoolTracked(ctx context.Context, worker jobWorker, limi
 						worker.Admission.Release(job.ID)
 						continue
 					}
+					deliveryCtx := tracker.trackedJobContext(job.ID, ctx)
 					inflightCheckouts[checkoutKey] = true
 					if runtimeKey != "" {
 						inflightRuntimes[runtimeKey] = true
@@ -2788,6 +2786,7 @@ func runQueuedJobsForRepoPoolTracked(ctx context.Context, worker jobWorker, limi
 						_ = jobGitClient(iso.repoCheckout, iso.runner).RemoveWorktreeForce(context.WithoutCancel(ctx), iso.worktreePath)
 						continue
 					}
+					deliveryCtx := tracker.trackedJobContext(iso.job.ID, ctx)
 					inflightCheckouts[iso.checkoutKey] = true
 					if iso.runtimeKey != "" {
 						inflightRuntimes[iso.runtimeKey] = true

--- a/internal/cli/daemon_scheduler_test.go
+++ b/internal/cli/daemon_scheduler_test.go
@@ -4318,7 +4318,7 @@ func TestDaemonWorkerTickRunsLivenessSweep(t *testing.T) {
 	tracker := newInflightJobTracker(ctx)
 	tracker.liveness.probe = func(int, string) runtimePIDState { return runtimePIDDead }
 
-	for _, at := range []time.Time{now, now.Add(daemonWorkerLoopInterval)} {
+	for _, at := range []time.Time{now, now.Add(daemonDeadRuntimeReapAfter)} {
 		if err := runDaemonWorkerTickTracked(ctx, store, worker, 0, false, "", "", io.Discard, at, tracker, nil); err != nil {
 			t.Fatalf("runDaemonWorkerTickTracked(%s): %v", at, err)
 		}

--- a/internal/db/store_jobs.go
+++ b/internal/db/store_jobs.go
@@ -731,7 +731,7 @@ func (s *Store) CountJobsByOrgRoleSince(ctx context.Context, since time.Time) (m
 // must never time it out and requeue it (which would try to Deliver work the
 // engine never owned). Engine-driven jobs default externally_driven = 0, so their
 // reaping is byte-identical.
-const listRunningJobsUpdatedBeforeSQL = `SELECT id, agent, type, state, payload, model, parent_job_id, delegation_id, delegation_depth, delegated_by, root_killed, input_tokens, output_tokens
+const listRunningJobsUpdatedBeforeSQL = `SELECT id, agent, type, state, payload, model, parent_job_id, delegation_id, delegation_depth, delegated_by, root_killed, input_tokens, output_tokens, created_at, updated_at
 		FROM jobs WHERE state = 'running' AND externally_driven = 0 AND updated_at < ? ORDER BY updated_at`
 
 // ListRunningJobsUpdatedBefore returns the running jobs whose updated_at predates
@@ -743,9 +743,9 @@ const listRunningJobsUpdatedBeforeSQL = `SELECT id, agent, type, state, payload,
 // reason ListQueuedJobs inlines 'queued': SQLite only applies a partial index when
 // it can prove the query's WHERE implies the index's predicate, which a bound
 // `state = ?` prevents (EXPLAIN QUERY PLAN falls back to a scan + temp b-tree).
-// The sole caller (recoverRunningJobsBeforeForRepoSkipping) processes each row
-// independently and does not depend on the ordering; updated_at is fixed-width
-// 'YYYY-MM-DD HH:MM:SS' so lexical order equals chronological order.
+// Recovery callers process each row independently and do not depend on the
+// ordering. created_at and updated_at are returned because the liveness evaluator
+// applies a shorter age bound only when a recorded runtime PID is proven dead.
 func (s *Store) ListRunningJobsUpdatedBefore(ctx context.Context, before time.Time) ([]Job, error) {
 	rows, err := s.db.QueryContext(ctx, listRunningJobsUpdatedBeforeSQL, before.UTC().Format("2006-01-02 15:04:05"))
 	if err != nil {
@@ -756,7 +756,7 @@ func (s *Store) ListRunningJobsUpdatedBefore(ctx context.Context, before time.Ti
 	var jobs []Job
 	for rows.Next() {
 		var job Job
-		if err := rows.Scan(&job.ID, &job.Agent, &job.Type, &job.State, &job.Payload, &job.Model, &job.ParentJobID, &job.DelegationID, &job.DelegationDepth, &job.DelegatedBy, &job.RootKilled, &job.InputTokens, &job.OutputTokens); err != nil {
+		if err := rows.Scan(&job.ID, &job.Agent, &job.Type, &job.State, &job.Payload, &job.Model, &job.ParentJobID, &job.DelegationID, &job.DelegationDepth, &job.DelegatedBy, &job.RootKilled, &job.InputTokens, &job.OutputTokens, &job.CreatedAt, &job.UpdatedAt); err != nil {
 			return nil, err
 		}
 		jobs = append(jobs, job)

--- a/internal/db/store_test.go
+++ b/internal/db/store_test.go
@@ -3453,6 +3453,11 @@ func TestListRunningJobsUpdatedBeforeOrder(t *testing.T) {
 		t.Fatalf("ListRunningJobsUpdatedBefore returned error: %v", err)
 	}
 	wantIDs := []string{"job-2", "job-3", "job-1"}
+	wantUpdatedAt := map[string]string{
+		"job-1": "2026-01-30 00:00:00",
+		"job-2": "2026-01-10 00:00:00",
+		"job-3": "2026-01-20 00:00:00",
+	}
 	if len(got) != len(wantIDs) {
 		t.Fatalf("returned %d jobs, want %d: %+v", len(got), len(wantIDs), got)
 	}
@@ -3462,6 +3467,9 @@ func TestListRunningJobsUpdatedBeforeOrder(t *testing.T) {
 		}
 		if job.State != "running" {
 			t.Fatalf("job[%d].State = %q, want running only", i, job.State)
+		}
+		if job.CreatedAt == "" || job.UpdatedAt != wantUpdatedAt[job.ID] {
+			t.Fatalf("job[%d] timestamps = created %q updated %q, want populated created_at and updated_at %q", i, job.CreatedAt, job.UpdatedAt, wantUpdatedAt[job.ID])
 		}
 	}
 

--- a/internal/workflow/mailbox.go
+++ b/internal/workflow/mailbox.go
@@ -1748,6 +1748,19 @@ func (m Mailbox) deliver(ctx context.Context, adapter DeliveryAdapter, agent run
 		delivery.RuntimeDefaultEffort = m.RuntimeDefaultEffort(agent.Runtime)
 	}
 	result, err := adapter.Deliver(ctx, agent, delivery)
+	// A successful adapter return ends runtime-process supervision. Clear its
+	// identity before produce/review checks and other settlement work: the runtime
+	// process has exited normally, so a dead PID no longer proves the job is
+	// orphaned. Leaving it recorded would let the daemon's prompt dead-process
+	// reaper cancel legitimate post-delivery work.
+	if err == nil && payload.RuntimePID > 0 {
+		payload.RuntimePID = 0
+		payload.RuntimePIDStartTime = ""
+		payload.RuntimePGID = 0
+		if saveErr := m.savePayload(ctx, job.ID, *payload); saveErr != nil {
+			return "", "", false, nil, fmt.Errorf("clear completed runtime identity: %w", saveErr)
+		}
+	}
 	// Record the adapter's own evidence of the plan shape it dispatched, so a
 	// reader can tell a plan run from a normal one without re-deriving it from the
 	// argv. Written before the error branch: a plan run that failed is still a plan
@@ -1773,43 +1786,49 @@ func (m Mailbox) deliver(ctx context.Context, adapter DeliveryAdapter, agent run
 	// liveness sweep needs the exact process that produced the retained transcript;
 	// terminal transitions clear it atomically with settlement below.
 	// Record best-effort runtime token usage so the per-root delegation token
-	// budget (#338 Part B) can sum a tree's cost. Usage accounting must never fail
-	// a delivery, so every write error here is swallowed.
-	if err == nil {
-		inTok, outTok := result.InputTokens, result.OutputTokens
-		// codex reports SESSION-CUMULATIVE counts on a resumed thread (#661): the
-		// session's whole running total, not this job's usage. When the adapter flags
-		// them cumulative, convert to this job's per-session delta keyed by the
-		// runtime session (runtime+ref) before persisting. Only a concrete, stable
-		// ref names a session we can key on; an empty or "last" ref does not, so —
-		// as today — it contributes 0 rather than being mis-attributed. A false flag
-		// (fresh/single-use, and every non-codex runtime) skips the delta table
-		// entirely and records the count verbatim (#664).
-		if result.CumulativeUsage && agent.RuntimeRef != "" && agent.RuntimeRef != runtime.LastRef {
-			inTok, outTok, _ = m.store.RecordRuntimeSessionUsageDelta(ctx, agent.Runtime+":"+agent.RuntimeRef, result.InputTokens, result.OutputTokens)
-		} else if result.CumulativeUsage {
-			inTok, outTok = 0, 0
-		} else if agent.Runtime == runtime.CodexRuntime && result.RefreshedRuntimeRef != "" && result.RefreshedRuntimeRef != runtime.LastRef {
-			// A fresh codex delivery reports PER-JOB (non-cumulative) usage and skips the
-			// delta table by design (#664), so the runtime_session_usage baseline for its
-			// thread is never seeded. But a fresh codex delivery ALSO adopts its concrete
-			// thread in-memory for same-job repair (#665): if turn 1 is malformed, the
-			// repair delivery resumes that thread, reports SESSION-CUMULATIVE usage, and
-			// (turn1+turn2) would delta against a ZERO baseline — re-counting turn 1 on
-			// top of the verbatim record below (#669 interaction). SEED the baseline with
-			// turn 1's counts, keyed byte-identically to the key the repair path computes
-			// from the adopted ref (runtime+RefreshedRuntimeRef), so a repair delta =
-			// (turn1+turn2)-turn1 = turn2. The returned delta is discarded; the verbatim
-			// UpdateJobUsage below records this turn. Errors are swallowed like the delta
-			// call — usage accounting never fails a delivery.
-			_, _, _ = m.store.RecordRuntimeSessionUsageDelta(ctx, agent.Runtime+":"+result.RefreshedRuntimeRef, result.InputTokens, result.OutputTokens)
-		}
-		// Only persist when a positive count remains so runtimes that report nothing
-		// (e.g. the shell runtime) or a delta that resolved to 0 leave the columns at
-		// their 0 default rather than taking a no-op write.
-		if inTok > 0 || outTok > 0 {
-			_ = m.store.UpdateJobUsage(ctx, job.ID, inTok, outTok)
-		}
+	// budget (#338 Part B) can sum a tree's cost. Failed runtimes are billed too:
+	// adapters return whatever usage their partial output proved before exit.
+	// Usage accounting must never fail a delivery, so every write error here is
+	// swallowed.
+	usageCtx := ctx
+	if err != nil {
+		var cancel context.CancelFunc
+		usageCtx, cancel = terminalWriteContext(ctx)
+		defer cancel()
+	}
+	inTok, outTok := result.InputTokens, result.OutputTokens
+	// codex reports SESSION-CUMULATIVE counts on a resumed thread (#661): the
+	// session's whole running total, not this job's usage. When the adapter flags
+	// them cumulative, convert to this job's per-session delta keyed by the
+	// runtime session (runtime+ref) before persisting. Only a concrete, stable
+	// ref names a session we can key on; an empty or "last" ref does not, so —
+	// as today — it contributes 0 rather than being mis-attributed. A false flag
+	// (fresh/single-use, and every non-codex runtime) skips the delta table
+	// entirely and records the count verbatim (#664).
+	if result.CumulativeUsage && agent.RuntimeRef != "" && agent.RuntimeRef != runtime.LastRef {
+		inTok, outTok, _ = m.store.RecordRuntimeSessionUsageDelta(usageCtx, agent.Runtime+":"+agent.RuntimeRef, result.InputTokens, result.OutputTokens)
+	} else if result.CumulativeUsage {
+		inTok, outTok = 0, 0
+	} else if agent.Runtime == runtime.CodexRuntime && result.RefreshedRuntimeRef != "" && result.RefreshedRuntimeRef != runtime.LastRef {
+		// A fresh codex delivery reports PER-JOB (non-cumulative) usage and skips the
+		// delta table by design (#664), so the runtime_session_usage baseline for its
+		// thread is never seeded. But a fresh codex delivery ALSO adopts its concrete
+		// thread in-memory for same-job repair (#665): if turn 1 is malformed, the
+		// repair delivery resumes that thread, reports SESSION-CUMULATIVE usage, and
+		// (turn1+turn2) would delta against a ZERO baseline — re-counting turn 1 on
+		// top of the verbatim record below (#669 interaction). SEED the baseline with
+		// turn 1's counts, keyed byte-identically to the key the repair path computes
+		// from the adopted ref (runtime+RefreshedRuntimeRef), so a repair delta =
+		// (turn1+turn2)-turn1 = turn2. The returned delta is discarded; the verbatim
+		// UpdateJobUsage below records this turn. Errors are swallowed like the delta
+		// call — usage accounting never fails a delivery.
+		_, _, _ = m.store.RecordRuntimeSessionUsageDelta(usageCtx, agent.Runtime+":"+result.RefreshedRuntimeRef, result.InputTokens, result.OutputTokens)
+	}
+	// Only persist when a positive count remains so runtimes that report nothing
+	// (e.g. the shell runtime) or a delta that resolved to 0 leave the columns at
+	// their 0 default rather than taking a no-op write.
+	if inTok > 0 || outTok > 0 {
+		_ = m.store.UpdateJobUsage(usageCtx, job.ID, inTok, outTok)
 	}
 	diag := failureDiagnosticsFromSession(result.SessionDiag)
 	if strings.TrimSpace(result.Summary) != "" {

--- a/internal/workflow/mailbox_test.go
+++ b/internal/workflow/mailbox_test.go
@@ -2,6 +2,7 @@ package workflow
 
 import (
 	"context"
+	"errors"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -175,7 +176,7 @@ func TestMailboxPersistsRuntimeIdentityUntilTerminal(t *testing.T) {
 	}
 }
 
-func TestMailboxKeepsRuntimePIDThroughProduceCheckUntilTerminal(t *testing.T) {
+func TestMailboxClearsRuntimePIDBeforeProduceCheck(t *testing.T) {
 	ctx := context.Background()
 	store := openTestStore(t)
 	dir := t.TempDir()
@@ -218,11 +219,8 @@ func TestMailboxKeepsRuntimePIDThroughProduceCheckUntilTerminal(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ParseJobPayload during produce check: %v", err)
 	}
-	if stored.State != string(JobRunning) || payload.RuntimePID != os.Getpid() || payload.RuntimePIDStartTime == "" {
-		t.Fatalf("produce check window = state %q pid %d start %q, want last runtime identity retained", stored.State, payload.RuntimePID, payload.RuntimePIDStartTime)
-	}
-	if live, known := RuntimeProcessLiveness(payload.RuntimePID, payload.RuntimePIDStartTime); !live || !known {
-		t.Fatalf("produce-check runtime liveness = (%v, %v), want retained live identity", live, known)
+	if stored.State != string(JobRunning) || payload.RuntimePID != 0 || payload.RuntimePIDStartTime != "" || payload.RuntimePGID != 0 {
+		t.Fatalf("produce check window = state %q pid %d pgid %d start %q, want running with completed runtime identity cleared", stored.State, payload.RuntimePID, payload.RuntimePGID, payload.RuntimePIDStartTime)
 	}
 	if err := os.WriteFile(release, []byte("go"), 0o600); err != nil {
 		t.Fatalf("release produce check: %v", err)
@@ -899,6 +897,37 @@ func TestMailboxDeliverDeltasCumulativeUsage(t *testing.T) {
 	}
 	if jobB.InputTokens != 500 || jobB.OutputTokens != 50 {
 		t.Fatalf("job-b usage = (%d, %d), want (500, 50) — only the per-session delta, not the 1500/150 cumulative", jobB.InputTokens, jobB.OutputTokens)
+	}
+}
+
+func TestMailboxDeliverRecordsPartialUsageFromFailedRuntime(t *testing.T) {
+	ctx := context.Background()
+	runCtx, cancelRun := context.WithCancel(ctx)
+	defer cancelRun()
+	store := openTestStore(t)
+	mailbox := Mailbox{store: store, resolveDeliveryWorktree: ExcludedDeliveryWorktreeResolver("test_explicit_no_worktree")}
+	agent := runtime.Agent{Name: "reviewer", Runtime: runtime.OmpRuntime, RuntimeRef: "fresh:runtime", RepoScope: "gitmoot/gitmoot", Role: "reviewer"}
+	crash := errors.New("runtime exited before agent_end")
+	adapter := &fakeDelivery{
+		err:         crash,
+		errorResult: runtime.Result{InputTokens: 8833, OutputTokens: 144, Raw: "partial transcript"},
+		onDeliver:   cancelRun,
+	}
+	if _, err := mailbox.Enqueue(ctx, JobRequest{ID: "failed-usage", Agent: "reviewer", Action: "review", Repo: "gitmoot/gitmoot"}); err != nil {
+		t.Fatalf("Enqueue: %v", err)
+	}
+	if _, err := mailbox.Run(runCtx, "failed-usage", agent, adapter); err == nil {
+		t.Fatal("Run succeeded despite runtime crash")
+	}
+	job, err := store.GetJob(ctx, "failed-usage")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if job.State != string(JobFailed) {
+		t.Fatalf("failed runtime job state = %q, want failed", job.State)
+	}
+	if job.InputTokens != 8833 || job.OutputTokens != 144 {
+		t.Fatalf("failed runtime usage = (%d, %d), want (8833, 144)", job.InputTokens, job.OutputTokens)
 	}
 }
 
@@ -2027,6 +2056,7 @@ type fakeDelivery struct {
 	onDeliver             func()
 	pid                   int
 	err                   error
+	errorResult           runtime.Result
 }
 
 func (f *fakeDelivery) Deliver(_ context.Context, agent runtime.Agent, job runtime.Job) (runtime.Result, error) {
@@ -2048,14 +2078,11 @@ func (f *fakeDelivery) Deliver(_ context.Context, agent runtime.Agent, job runti
 		f.onDeliver()
 	}
 	if f.err != nil {
-		// A REAL adapter populates plan evidence on its FAILURE returns too — omp
-		// sets Result.PlanMode on both the non-zero-exit and parse-error paths,
-		// because a plan run that died is still a plan run. Returning a zero Result
-		// here made the mailbox's write-before-the-error-branch behaviour
-		// unobservable, so a mutation that recorded evidence only on success could
-		// not be killed by any test. The double has to honour the contract it
-		// stands in for.
-		return runtime.Result{PlanMode: runtime.PlanModeDescriptor(job.Plan, job.PlanInto)}, f.err
+		// A REAL adapter returns partial usage and plan evidence on failure. OMP
+		// accumulates both before reporting a non-zero exit or truncated stream.
+		result := f.errorResult
+		result.PlanMode = runtime.PlanModeDescriptor(job.Plan, job.PlanInto)
+		return result, f.err
 	}
 	index := len(f.prompts) - 1
 	result := runtime.Result{}


### PR DESCRIPTION
Fixes #2163.

## What changed
- inspect recorded runtime PIDs after 30 seconds instead of waiting for the legacy 30m/45m stale thresholds
- require a dead PID and unchanged transcript across two 30-second observations
- cancel only the affected tracked job so its runtime/worktree cleanup unwinds without interrupting siblings
- retain timestamps needed by the liveness evaluator
- persist partial token usage returned by failed runtimes

## Verification
- focused cli/workflow/db regression set passes
- isolated real daemon smoke: a running review row with a dead PID and frozen partial transcript transitioned to `failed` after the confirmation window and recorded `job_recovery_failed`
- `git diff --check` passes

The broad affected-package command reached the repository's 10-minute test timeout in unrelated pipeline tests; `internal/workflow` and `internal/db` completed successfully, while the relevant `internal/cli` regression was rerun and passes.