### PR TITLE
fix(org): preserve review obligations across seat exits

### DIFF
--- a/internal/cli/agent.go
+++ b/internal/cli/agent.go
@@ -375,6 +375,7 @@ type agentRunOptions struct {
 	repo                    string
 	jsonOutput              bool
 	background              bool
+	foreground              bool
 	typeName                string
 	action                  string
 	model                   string
@@ -497,6 +498,9 @@ func runAgentReview(args []string, stdout, stderr io.Writer) int {
 	if options.prNumber <= 0 {
 		fmt.Fprintln(stderr, "agent review requires --pr number")
 		return 2
+	}
+	if strings.TrimSpace(options.orgRole) != "" && !options.foreground {
+		options.background = true
 	}
 	output, exit := dispatchAgentCommand(options, "review", "explicit agent review", "agent_review", stdout, stderr)
 	if exit != 0 {
@@ -677,6 +681,8 @@ func parseAgentRunOptions(command string, args []string, stderr io.Writer) (agen
 			return agentRunOptions{}, false
 		case arg == "--background":
 			options.background = true
+		case arg == "--foreground":
+			options.foreground = true
 		case arg == "--json":
 			options.jsonOutput = true
 		case arg == "--skip-native-review-fanout":
@@ -761,6 +767,14 @@ func parseAgentRunOptions(command string, args []string, stderr io.Writer) (agen
 	}
 	if options.agent == "" || options.message == "" {
 		fmt.Fprintf(stderr, "%s requires exactly one agent and one message\n", label)
+		return agentRunOptions{}, false
+	}
+	if options.background && options.foreground {
+		fmt.Fprintf(stderr, "%s: --background and --foreground are mutually exclusive\n", label)
+		return agentRunOptions{}, false
+	}
+	if options.foreground && command != "review" {
+		fmt.Fprintf(stderr, "%s: --foreground is only supported for agent review\n", label)
 		return agentRunOptions{}, false
 	}
 	normalizedRecipe, err := validateRecipeID(options.recipe)
@@ -901,7 +915,8 @@ func printAgentRunUsage(w io.Writer, command string) {
 	case "orchestrate":
 		fmt.Fprintln(w, "  gitmoot orchestrate <agent> \"message\" [--repo owner/repo] [--task task-id] [--pr number] [--head-sha sha] [--branch branch] [--draft|--ready] [--type type] [--action ask|review|implement] [--model model] [--effort effort] [--workflow id] [--org-role role] [--runtime rt] [--session ref] [--recipe id] [--skip-native-review-fanout] [--home path] [--json]")
 	case "review":
-		fmt.Fprintln(w, "  gitmoot agent review <name> \"message\" --repo owner/repo --pr number [--lead implementer] [--head-sha sha] [--branch branch] [--background] [--type type] [--action review] [--model model] [--effort effort] [--workflow id] [--org-role role] [--runtime rt] [--session ref] [--home path] [--json]")
+		fmt.Fprintln(w, "  gitmoot agent review <name> \"message\" --repo owner/repo --pr number [--lead implementer] [--head-sha sha] [--branch branch] [--background|--foreground] [--type type] [--action review] [--model model] [--effort effort] [--workflow id] [--org-role role] [--runtime rt] [--session ref] [--home path] [--json]")
+		fmt.Fprintln(w, "  Reviews attributed with --org-role queue for daemon ownership by default; --foreground keeps synchronous execution.")
 	case "implement":
 		fmt.Fprintln(w, "  gitmoot agent implement <name> \"message\" [--repo owner/repo] [--task task-id] [--pr number] [--base ref] [--head-sha sha] [--branch branch] [--draft|--ready] [--background] [--type type] [--action implement] [--model model] [--effort effort] [--workflow id] [--org-role role] [--runtime rt] [--session ref] [--skip-native-review-fanout] [--home path] [--json]")
 	default:

--- a/internal/cli/agent_dispatch_test.go
+++ b/internal/cli/agent_dispatch_test.go
@@ -19,6 +19,81 @@ import (
 	"github.com/gitmoot/gitmoot/internal/workflow"
 )
 
+func TestOrgRoleReviewCLIQueuesForDaemonOwnership(t *testing.T) {
+	home := t.TempDir()
+	paths := config.PathsForHome(home)
+	if err := config.Initialize(paths); err != nil {
+		t.Fatal(err)
+	}
+	file, err := os.OpenFile(paths.ConfigFile, os.O_APPEND|os.O_WRONLY, 0o600)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := file.WriteString(`
+[org]
+enforce = "warn"
+[org.roles."owner"]
+scope = ["*"]
+[org.roles."joltra"]
+parent = "owner"
+scope = ["owner/repo"]
+`); err != nil {
+		file.Close()
+		t.Fatal(err)
+	}
+	if err := file.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	store := openCLIJobStore(t, home)
+	defer store.Close()
+	checkout, _, head := readonlyReviewWorktreeGitCheckout(t)
+	seedReviewDispatchFixture(t, store, checkout)
+	replaceDiskGuardMeasurement(t, func(string) (diskFilesystemUsage, error) {
+		return diskFilesystemUsage{TotalBytes: 20 << 30, FreeBytes: 10 << 30}, nil
+	})
+	adapter := installReviewLeadTestAdapter(t, `{"gitmoot_result":{"decision":"approved","summary":"looks good","findings":[],"changes_made":[],"tests_run":["inspection"],"needs":[],"delegations":[]}}`)
+	previousGitHubFactory := newAgentDispatchGitHubClient
+	newAgentDispatchGitHubClient = func(string) github.Client { return githubtest.NoopClient{} }
+	t.Cleanup(func() { newAgentDispatchGitHubClient = previousGitHubFactory })
+
+	args := []string{
+		"reviewer", "Review this exact head.", "--repo", "owner/repo", "--pr", "12",
+		"--head-sha", head, "--branch", "feature/review", "--lead", "implementer",
+		"--org-role", "joltra", "--home", home,
+	}
+	var stdout, stderr bytes.Buffer
+	code := runAgentReview(args, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("review exit=%d stdout=%q stderr=%q", code, stdout.String(), stderr.String())
+	}
+	jobs, err := store.ListJobs(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(jobs) != 1 || jobs[0].State != string(workflow.JobQueued) {
+		t.Fatalf("jobs = %+v, want one daemon-owned queued review", jobs)
+	}
+	for _, want := range []string{"state: queued", "next: gitmoot job watch"} {
+		if !strings.Contains(stdout.String(), want) {
+			t.Fatalf("stdout = %q, want %q", stdout.String(), want)
+		}
+	}
+	if adapter.calls != 0 {
+		t.Fatalf("background review invoked runtime %d times, want zero", adapter.calls)
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	code = runAgentReview(append(args, "--foreground"), &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("foreground review exit=%d stdout=%q stderr=%q", code, stdout.String(), stderr.String())
+	}
+	if adapter.calls != 1 {
+		t.Fatalf("explicit foreground review invoked runtime %d times, want one", adapter.calls)
+	}
+}
+
 // buildLocalAgentJobOutput must render a terminally-succeeded implement job into
 // the same populated output the success path returns, so the advance-error
 // recovery branch can surface the persisted result instead of discarding it.

--- a/internal/cli/agent_test.go
+++ b/internal/cli/agent_test.go
@@ -4534,3 +4534,13 @@ func TestCompensatePolicyWriteFailureRollsConfigBack(t *testing.T) {
 		}
 	})
 }
+
+func TestReviewExecutionModeRejectsConflictingFlags(t *testing.T) {
+	var stderr bytes.Buffer
+	_, ok := parseAgentRunOptions("review", []string{
+		"reviewer", "review it", "--background", "--foreground", "--repo", "owner/repo", "--pr", "7",
+	}, &stderr)
+	if ok || !strings.Contains(stderr.String(), "mutually exclusive") {
+		t.Fatalf("ok=%t stderr=%q, want conflicting mode refusal", ok, stderr.String())
+	}
+}

--- a/internal/cli/awaited_fact_test.go
+++ b/internal/cli/awaited_fact_test.go
@@ -3,6 +3,8 @@ package cli
 import (
 	"bytes"
 	"context"
+	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -14,6 +16,20 @@ import (
 	"github.com/gitmoot/gitmoot/internal/db/dbtest"
 	"github.com/gitmoot/gitmoot/internal/workflow"
 )
+
+func insertAwaitedFactWakeForTest(t *testing.T, store *db.Store, payload db.AwaitedFactWakePayload) {
+	t.Helper()
+	encoded, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := store.InsertWakeOutbox(
+		context.Background(), db.WakeOutboxSourceAwaitedFact, string(encoded),
+		db.WakeOutboxKindFact, []string{payload.WaiterRole},
+	); err != nil {
+		t.Fatal(err)
+	}
+}
 
 func TestAwaitedFactExpiryRemainsQueryableAndAddressesParent(t *testing.T) {
 	root := t.TempDir()
@@ -93,6 +109,167 @@ func TestAwaitedFactOutboxIsAddressedDeliveryWithoutReceiptCeremony(t *testing.T
 	prompt := eventRuleWakePrompt("fact", event)
 	if !strings.Contains(prompt, "awaited fact for lane") || strings.Contains(prompt, " ack ") || strings.Contains(prompt, " done ") {
 		t.Fatalf("fact prompt = %q, want delivery-only prompt without receipt ceremony", prompt)
+	}
+}
+
+func TestFailedReviewFactWakeRequiresRetryOrExplicitBlocker(t *testing.T) {
+	payload := `{"id":8,"waiter_role":"lane","subject_kind":"review_verdict","subject_key":"acme/widget#46@head","state":"review_failed","job_id":"review-8","detail":"review job review-8 failed without an exact-head verdict"}`
+	event, err := wakeOutboxEvent([]db.WakeOutboxObligation{{
+		ID: 2, SourceKind: db.WakeOutboxSourceAwaitedFact, SourceID: payload,
+		TargetRole: "lane", CoalesceKey: "fact:lane", CreatedAt: time.Now().UTC().Format(time.RFC3339Nano),
+	}}, time.Now().UTC())
+	if err != nil {
+		t.Fatal(err)
+	}
+	prompt := eventRuleWakePrompt("fact", event)
+	for _, want := range []string{"review-8 failed", "org await list --role lane --state waiting", "Retry the exact-head review", "record a blocker naming its owner and next trigger"} {
+		if !strings.Contains(prompt, want) {
+			t.Fatalf("failed-review prompt = %q, want %q", prompt, want)
+		}
+	}
+}
+
+func TestFactWakeBatchPrioritizesReviewFailureOverOlderCompletion(t *testing.T) {
+	now := time.Now().UTC()
+	event, err := wakeOutboxEvent([]db.WakeOutboxObligation{
+		{
+			ID: 2, SourceKind: db.WakeOutboxSourceAwaitedFact,
+			SourceID:   `{"id":8,"waiter_role":"lane","subject_kind":"review_verdict","subject_key":"acme/widget#45@old","state":"satisfied"}`,
+			TargetRole: "lane", CoalesceKey: "fact:lane", CreatedAt: now.Add(-time.Second).Format(time.RFC3339Nano),
+		},
+		{
+			ID: 3, SourceKind: db.WakeOutboxSourceAwaitedFact,
+			SourceID:   `{"id":9,"waiter_role":"lane","subject_kind":"review_verdict","subject_key":"acme/widget#46@head","state":"review_failed","job_id":"review-9","detail":"review job review-9 failed without an exact-head verdict"}`,
+			TargetRole: "lane", CoalesceKey: "fact:lane", CreatedAt: now.Format(time.RFC3339Nano),
+		},
+	}, now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if event.JobID != "awaited-fact:9" || event.Cause != "awaited_fact_review_failed" {
+		t.Fatalf("fact event identity = %q cause=%q, want actionable failed fact", event.JobID, event.Cause)
+	}
+	prompt := eventRuleWakePrompt("fact", event)
+	for _, want := range []string{"review-9 failed", "is satisfied", "Retry the exact-head review"} {
+		if !strings.Contains(prompt, want) {
+			t.Fatalf("coalesced fact prompt = %q, want %q", prompt, want)
+		}
+	}
+}
+
+func TestFactWakeBatchSuppressesFailureSupersededBySuccess(t *testing.T) {
+	now := time.Now().UTC()
+	event, err := wakeOutboxEvent([]db.WakeOutboxObligation{
+		{
+			ID: 2, SourceKind: db.WakeOutboxSourceAwaitedFact,
+			SourceID:   `{"id":9,"waiter_role":"lane","subject_kind":"review_verdict","subject_key":"acme/widget#46@head","state":"review_failed","job_id":"review-9","lifecycle_generation":0,"detail":"review job review-9 failed without an exact-head verdict"}`,
+			TargetRole: "lane", CoalesceKey: "fact:lane", CreatedAt: now.Add(-time.Second).Format(time.RFC3339Nano),
+		},
+		{
+			ID: 3, SourceKind: db.WakeOutboxSourceAwaitedFact,
+			SourceID:   `{"id":9,"waiter_role":"lane","subject_kind":"review_verdict","subject_key":"acme/widget#46@head","state":"satisfied"}`,
+			TargetRole: "lane", CoalesceKey: "fact:lane", CreatedAt: now.Format(time.RFC3339Nano),
+		},
+	}, now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if event.JobID != "awaited-fact:9" || event.Cause != "awaited_fact_satisfied" {
+		t.Fatalf("fact event identity = %q cause=%q, want latest satisfied fact", event.JobID, event.Cause)
+	}
+	prompt := eventRuleWakePrompt("fact", event)
+	if !strings.Contains(prompt, "is satisfied") || strings.Contains(prompt, "Retry the exact-head review") ||
+		strings.Contains(prompt, "review-9 failed") {
+		t.Fatalf("coalesced fact prompt = %q, want only the latest satisfied state", prompt)
+	}
+}
+
+func TestFactWakeDrainReducesOneFactAcrossBatchLimit(t *testing.T) {
+	store, sink, wake, _ := replyWakeTestHarness(t, []replyWakeTestRole{{"owner", "w1:p0"}, {"lane", "w1:p1"}})
+	ctx := context.Background()
+	if err := store.AddEventRule(ctx, db.EventRule{
+		ID: "fact-lane", OnKind: db.WakeOutboxKindFact, WakeRole: "lane",
+		Scope: db.EventRuleScopeAddressed, Enabled: true,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	insertAwaitedFactWakeForTest(t, store, db.AwaitedFactWakePayload{
+		ID: 9, WaiterRole: "lane", SubjectKind: db.AwaitedFactSubjectReviewVerdict,
+		SubjectKey: "acme/widget#46@head", State: "review_failed", JobID: "review-9",
+		Detail: "review job review-9 failed without an exact-head verdict",
+	})
+	for index := range replyWakeMaxCoalescedItems - 1 {
+		insertAwaitedFactWakeForTest(t, store, db.AwaitedFactWakePayload{
+			ID: int64(100 + index), WaiterRole: "lane", SubjectKind: db.AwaitedFactSubjectReviewVerdict,
+			SubjectKey: fmt.Sprintf("acme/widget#%d@head", 100+index), State: db.AwaitedFactStateSatisfied,
+		})
+	}
+	insertAwaitedFactWakeForTest(t, store, db.AwaitedFactWakePayload{
+		ID: 9, WaiterRole: "lane", SubjectKind: db.AwaitedFactSubjectReviewVerdict,
+		SubjectKey: "acme/widget#46@head", State: db.AwaitedFactStateSatisfied,
+	})
+
+	drainReplyWakeAfterAllRowsAreDue(t, store, sink)
+	if wake.promptCalls != replyWakeMaxCoalescedItems {
+		t.Fatalf("prompt calls = %d, want one per current fact (%d)", wake.promptCalls, replyWakeMaxCoalescedItems)
+	}
+	for _, prompt := range wake.prompts {
+		if strings.Contains(prompt, "Retry the exact-head review") || strings.Contains(prompt, "review-9 failed") {
+			t.Fatalf("stale failure escaped cross-batch reduction: %q", prompt)
+		}
+	}
+	pending, err := store.ListWakeOutbox(ctx, db.WakeOutboxStatePending)
+	if err != nil || len(pending) != 0 {
+		t.Fatalf("pending fact wakes = %+v err=%v, want none", pending, err)
+	}
+	delivered, err := store.ListWakeOutbox(ctx, db.WakeOutboxStateDelivered)
+	if err != nil {
+		t.Fatal(err)
+	}
+	currentDelivered := false
+	for _, row := range delivered {
+		var payload db.AwaitedFactWakePayload
+		if err := json.Unmarshal([]byte(row.SourceID), &payload); err != nil {
+			t.Fatal(err)
+		}
+		if payload.ID == 9 {
+			currentDelivered = payload.State == db.AwaitedFactStateSatisfied
+		}
+	}
+	if !currentDelivered {
+		t.Fatalf("delivered fact rows = %+v, want fact 9's current satisfied lifecycle as survivor", delivered)
+	}
+}
+
+func TestFactWakeDrainDeliversDistinctFailuresSeparately(t *testing.T) {
+	store, sink, wake, _ := replyWakeTestHarness(t, []replyWakeTestRole{{"owner", "w1:p0"}, {"lane", "w1:p1"}})
+	ctx := context.Background()
+	if err := store.AddEventRule(ctx, db.EventRule{
+		ID: "fact-lane", OnKind: db.WakeOutboxKindFact, WakeRole: "lane",
+		Scope: db.EventRuleScopeAddressed, Enabled: true,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	for index, jobID := range []string{"review-alpha", "review-beta"} {
+		insertAwaitedFactWakeForTest(t, store, db.AwaitedFactWakePayload{
+			ID: int64(index + 1), WaiterRole: "lane", SubjectKind: db.AwaitedFactSubjectReviewVerdict,
+			SubjectKey: fmt.Sprintf("acme/widget#%d@head", index+1), State: "review_failed", JobID: jobID,
+			Detail: fmt.Sprintf("review job %s failed without an exact-head verdict; %s", jobID, strings.Repeat("detail ", 60)),
+		})
+	}
+
+	drainReplyWakeAfterAllRowsAreDue(t, store, sink)
+	if wake.promptCalls != 2 {
+		t.Fatalf("prompt calls = %d, want one per unresolved failure", wake.promptCalls)
+	}
+	for _, jobID := range []string{"review-alpha", "review-beta"} {
+		found := false
+		for _, prompt := range wake.prompts {
+			found = found || strings.Contains(prompt, jobID)
+		}
+		if !found {
+			t.Fatalf("prompts = %+v, want distinct failure %s", wake.prompts, jobID)
+		}
 	}
 }
 

--- a/internal/cli/daemon_liveness_test.go
+++ b/internal/cli/daemon_liveness_test.go
@@ -120,6 +120,58 @@ func TestDaemonLivenessSweepDeadPIDFrozenLogFails(t *testing.T) {
 	}
 }
 
+func TestDaemonLivenessFailureWakesExactHeadReviewWaiter(t *testing.T) {
+	ctx, paths, store, now, quiet := livenessTestJob(t, "dead-review", 4242)
+	job, err := store.GetJob(ctx, "dead-review")
+	if err != nil {
+		t.Fatal(err)
+	}
+	payload, err := daemonJobPayload(job)
+	if err != nil {
+		t.Fatal(err)
+	}
+	payload.PullRequest = 42
+	payload.HeadSHA = "head-dead"
+	encoded, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := store.UpdateJobPayload(ctx, job.ID, string(encoded)); err != nil {
+		t.Fatal(err)
+	}
+	key, err := db.ReviewVerdictSubjectKey("owner/repo", 42, "head-dead")
+	if err != nil {
+		t.Fatal(err)
+	}
+	fact, _, err := store.SubscribeAwaitedFact(ctx, db.AwaitedFactSubscription{
+		WaiterRole: "joltra", SubjectKind: db.AwaitedFactSubjectReviewVerdict,
+		SubjectKey: key, Deadline: now.Add(time.Hour),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	sweep := newDaemonLivenessSweep()
+	sweep.probe = func(int, string) runtimePIDState { return runtimePIDDead }
+	runLivenessSamples(t, sweep, ctx, store, paths, now, quiet)
+
+	got, err := store.GetAwaitedFact(ctx, fact.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.State != db.AwaitedFactStateWaiting {
+		t.Fatalf("fact state = %q, want waiting until a verdict lands", got.State)
+	}
+	outbox, err := store.ListWakeOutbox(ctx, db.WakeOutboxStatePending)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(outbox) != 1 || outbox[0].TargetRole != "joltra" ||
+		!strings.Contains(outbox[0].SourceID, `"state":"review_failed"`) {
+		t.Fatalf("liveness failure wake = %+v", outbox)
+	}
+}
+
 func TestDaemonLivenessSweepPromptlyCancelsOnlyDeadTrackedJob(t *testing.T) {
 	ctx, paths, store, _, quiet := livenessTestJob(t, "dead-recent", 4242)
 	now := time.Now().UTC().Add(2 * daemonDeadRuntimeReapAfter)

--- a/internal/cli/daemon_result_test.go
+++ b/internal/cli/daemon_result_test.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"context"
+	"errors"
 	"io"
 	"strings"
 	"testing"
@@ -11,6 +12,55 @@ import (
 	"github.com/gitmoot/gitmoot/internal/runtime"
 	"github.com/gitmoot/gitmoot/internal/workflow"
 )
+
+func TestFinishQueuedReviewFailureWakesExactHeadWaiter(t *testing.T) {
+	ctx := context.Background()
+	store := daemonWorkerStore(t)
+	key, err := db.ReviewVerdictSubjectKey("acme/widget", 2165, "head-preflight")
+	if err != nil {
+		t.Fatal(err)
+	}
+	fact, _, err := store.SubscribeAwaitedFact(ctx, db.AwaitedFactSubscription{
+		WaiterRole: "lane", SubjectKind: db.AwaitedFactSubjectReviewVerdict,
+		SubjectKey: key, Deadline: time.Now().UTC().Add(time.Hour),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	payload := mustJobPayload(t, workflow.JobPayload{
+		Repo: "acme/widget", PullRequest: 2165, HeadSHA: "head-preflight",
+		WorkflowID: "preflight-review",
+	})
+	if err := store.CreateJobWithEvent(ctx, db.Job{
+		ID: "review-preflight", Agent: "reviewer", Type: "review",
+		State: string(workflow.JobQueued), Payload: payload,
+	}, db.JobEvent{Kind: string(workflow.JobQueued), Message: "queued"}); err != nil {
+		t.Fatal(err)
+	}
+	job, err := store.GetJob(ctx, "review-preflight")
+	if err != nil {
+		t.Fatal(err)
+	}
+	worker := jobWorker{Store: store, Stdout: io.Discard}
+	if err := worker.finishQueuedJob(ctx, job, workflow.JobFailed, errors.New("adapter preflight failed")); err != nil {
+		t.Fatal(err)
+	}
+	gotFact, err := store.GetAwaitedFact(ctx, fact.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if gotFact.State != db.AwaitedFactStateWaiting {
+		t.Fatalf("awaited fact state = %q, want waiting", gotFact.State)
+	}
+	outbox, err := store.ListWakeOutbox(ctx, db.WakeOutboxStatePending)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(outbox) != 1 || outbox[0].TargetRole != "lane" ||
+		!strings.Contains(outbox[0].SourceID, `"state":"review_failed"`) {
+		t.Fatalf("preflight failure wake = %+v", outbox)
+	}
+}
 
 type deadlineBlockingAdapter struct{}
 

--- a/internal/cli/event_rule_sink.go
+++ b/internal/cli/event_rule_sink.go
@@ -827,6 +827,12 @@ func eventRuleWakePrompt(kind string, event events.Event) string {
 	}
 	if strings.EqualFold(strings.TrimSpace(kind), db.WakeOutboxKindFact) {
 		detail := truncateForWake(strings.TrimSpace(event.Detail), 320)
+		if strings.HasPrefix(event.Cause, "awaited_fact_review_") {
+			return fmt.Sprintf(
+				"gitmoot awaited fact for %s: %s. Inspect current waits with: gitmoot org await list --role %s --state waiting. Retry the exact-head review; if no reviewer runtime works, record a blocker naming its owner and next trigger before idling",
+				event.WakeTargetRole, detail, event.WakeTargetRole,
+			)
+		}
 		return fmt.Sprintf("gitmoot awaited fact for %s: %s", event.WakeTargetRole, detail)
 	}
 	// event.Detail is already redacted and absolute-path-scrubbed by

--- a/internal/cli/org_overview.go
+++ b/internal/cli/org_overview.go
@@ -36,6 +36,9 @@ type orgSharedState struct {
 	blockedLoaded   bool
 	livePresence    map[string]db.RoleLivePresence
 	liveLoaded      bool
+	awaitedFacts    map[string][]db.AwaitedFact
+	awaitedFactsErr error
+	awaitedLoaded   bool
 	unavailable     map[string]db.OrgRoleUnavailable
 }
 
@@ -193,6 +196,42 @@ func (shared *orgSharedState) loadBlockedEpisodes(ctx context.Context) ([]db.Blo
 	return episodes, nil
 }
 
+func (shared *orgSharedState) loadWaitingAwaitedFacts(ctx context.Context) (map[string][]db.AwaitedFact, error) {
+	if shared.awaitedLoaded {
+		return shared.awaitedFacts, shared.awaitedFactsErr
+	}
+	shared.awaitedLoaded = true
+	facts, err := shared.Store.ListAwaitedFacts(ctx, "", db.AwaitedFactStateWaiting)
+	if err != nil {
+		shared.awaitedFactsErr = err
+		shared.Warnings = append(shared.Warnings, fmt.Sprintf("awaited-fact blockers unavailable: %v", err))
+		return nil, err
+	}
+	shared.awaitedFacts = make(map[string][]db.AwaitedFact)
+	for _, fact := range facts {
+		role := strings.ToLower(strings.TrimSpace(fact.WaiterRole))
+		if role != "" {
+			shared.awaitedFacts[role] = append(shared.awaitedFacts[role], fact)
+		}
+	}
+	return shared.awaitedFacts, nil
+}
+
+func awaitedFactBlockerDetail(role string, facts []db.AwaitedFact) string {
+	if len(facts) == 0 {
+		return ""
+	}
+	fact := facts[0]
+	detail := fmt.Sprintf(
+		"owner=%s; awaiting %s %s; next_trigger=satisfaction or deadline %s",
+		role, fact.SubjectKind, fact.SubjectKey, fact.Deadline,
+	)
+	if len(facts) > 1 {
+		return fmt.Sprintf("%d unresolved waits; oldest: %s", len(facts), detail)
+	}
+	return detail
+}
+
 // loadJobCounts caches the indexed queued/running counts for one overview
 // projection. Presence and recycle enrichment share the same snapshot.
 func (shared *orgSharedState) loadJobCounts(ctx context.Context) (map[string]map[string]int, error) {
@@ -216,6 +255,7 @@ func buildOrgStatusRows(ctx context.Context, shared *orgSharedState, src orgLive
 		return nil, &orgLiveSourceError{err: err}
 	}
 	roles := loadOrgRoster(ctx, shared.Store, shared.Config).Members()
+	waitingByRole, _ := shared.loadWaitingAwaitedFacts(ctx)
 	rows := make([]orgStatusOutput, 0, len(roles))
 	observedNow := time.Now().UTC()
 	for _, role := range roles {
@@ -238,6 +278,18 @@ func buildOrgStatusRows(ctx context.Context, shared *orgSharedState, src orgLive
 				State:    org.StateUnavailable,
 				Detail:   fmt.Sprintf("⚠ UNAVAILABLE reason=%s until=%s", incident.Reason, unavailableUntil),
 				Activity: live.Activity,
+			}
+		}
+		if _, unavailable := shared.unavailable[role.Name]; !unavailable {
+			if facts := waitingByRole[role.Name]; len(facts) > 0 {
+				switch live.State {
+				case org.StateIdle, org.StateDone, org.StateUnknown:
+					live = org.RoleLiveState{
+						State:    org.StateBlocked,
+						Detail:   awaitedFactBlockerDetail(role.Name, facts),
+						Activity: live.Activity,
+					}
+				}
 			}
 		}
 		seen := shared.Presence[role.Name]

--- a/internal/cli/org_overview_test.go
+++ b/internal/cli/org_overview_test.go
@@ -78,6 +78,55 @@ func TestStoreOrgLiveSourcePersistedFreshness(t *testing.T) {
 	}
 }
 
+func TestOrgStatusShowsIdleRoleWithUnresolvedWaitAsBlocked(t *testing.T) {
+	_, paths := setupOrgHome(t)
+	store, err := dbtest.Open(t, paths.Database)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+
+	ctx := context.Background()
+	key, err := db.ReviewVerdictSubjectKey("owner/repo", 42, "head-42")
+	if err != nil {
+		t.Fatal(err)
+	}
+	deadline := time.Now().UTC().Add(2 * time.Hour)
+	if _, _, err := store.SubscribeAwaitedFact(ctx, db.AwaitedFactSubscription{
+		WaiterRole:  "review",
+		SubjectKind: db.AwaitedFactSubjectReviewVerdict,
+		SubjectKey:  key,
+		Deadline:    deadline,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	shared, err := loadOrgSharedState(ctx, paths, store, time.Now().UTC())
+	if err != nil {
+		t.Fatal(err)
+	}
+	rows, err := buildOrgStatusRows(ctx, &shared, func(context.Context, config.OrgConfig) (map[string]org.RoleLiveState, time.Time, string, error) {
+		return map[string]org.RoleLiveState{"review": {State: org.StateIdle}}, time.Now().UTC(), "test", nil
+	}, "chart", false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, row := range rows {
+		if row.Role != "review" {
+			continue
+		}
+		if row.ProviderState != org.StateBlocked {
+			t.Fatalf("review state = %q, want blocked", row.ProviderState)
+		}
+		for _, want := range []string{"owner=review", "awaiting review_verdict", "next_trigger=satisfaction or deadline"} {
+			if !strings.Contains(row.ProviderDetail, want) {
+				t.Fatalf("review detail = %q, want %q", row.ProviderDetail, want)
+			}
+		}
+		return
+	}
+	t.Fatal("review role missing from status rows")
+}
+
 func TestLoadOrgSharedStateMissedWakeAgeOut(t *testing.T) {
 	_, paths := setupOrgHome(t)
 	file, err := os.OpenFile(paths.ConfigFile, os.O_APPEND|os.O_WRONLY, 0o600)
@@ -207,8 +256,13 @@ recycle_after = "1ns"
 	if !foundRecyclable {
 		t.Fatal("recyclable role missing from rows")
 	}
-	if len(shared.Warnings) != 1 || !strings.Contains(shared.Warnings[0], "active-jobs counts unavailable") {
-		t.Fatalf("warnings = %+v, want one active-jobs warning", shared.Warnings)
+	if len(shared.Warnings) != 2 ||
+		!strings.Contains(shared.Warnings[0], "awaited-fact blockers unavailable") ||
+		!strings.Contains(shared.Warnings[1], "active-jobs counts unavailable") {
+		t.Fatalf("warnings = %+v, want awaited-fact and active-jobs warnings", shared.Warnings)
+	}
+	if shared.awaitedFactsErr == nil {
+		t.Fatal("awaited-fact failure was not cached")
 	}
 	cachedErr := shared.jobCountsErr
 	if cachedErr == nil {

--- a/internal/cli/reply_wake_outbox.go
+++ b/internal/cli/reply_wake_outbox.go
@@ -152,6 +152,17 @@ func drainReplyWakeOutboxWithHealth(ctx context.Context, store wakeOutboxStore, 
 			// let role-level coalescing mark another directive delivered unseen.
 			key += "\x00" + entry.SourceID + "\x00" + entry.DirectivePhase
 		}
+		if entry.SourceKind == db.WakeOutboxSourceAwaitedFact {
+			var payload db.AwaitedFactWakePayload
+			if err := json.Unmarshal([]byte(entry.SourceID), &payload); err != nil {
+				return replyWakeOutboxHealth{}, fmt.Errorf("decode awaited fact wake outbox group for row %d: %w", entry.ID, err)
+			}
+			// Each awaited fact is its own obligation stream. Mixing distinct
+			// facts can truncate one action from the only prompt that carries it;
+			// keeping every lifecycle of one fact together also lets a later
+			// success suppress its earlier failed-attempt wake before delivery.
+			key += fmt.Sprintf("\x00fact:%d", payload.ID)
+		}
 		groups[key] = append(groups[key], entry)
 	}
 	if resolve == nil {
@@ -183,6 +194,9 @@ func drainReplyWakeOutboxWithHealth(ctx context.Context, store wakeOutboxStore, 
 			// only removes a later interrupt. The batch event still names every
 			// member's retrieval command, so collapsing loses no note.
 			end := min(start+replyWakeMaxCoalescedItems, len(items))
+			if items[start].SourceKind == db.WakeOutboxSourceAwaitedFact {
+				end = len(items)
+			}
 
 			batch := items[start:end]
 			event, err := wakeOutboxEvent(batch, now)
@@ -206,16 +220,23 @@ func drainReplyWakeOutboxWithHealth(ctx context.Context, store wakeOutboxStore, 
 				// later can deliver the same batch; nothing is silently erased.
 				break
 			}
-			ids := make([]int64, 0, len(batch))
-			for _, entry := range batch {
-				ids = append(ids, entry.ID)
+			survivor := 0
+			if batch[0].SourceKind == db.WakeOutboxSourceAwaitedFact {
+				survivor = len(batch) - 1
 			}
-			// The oldest row SURVIVES as the delivered obligation: it is the one
-			// wakeOutboxEvent identifies as `oldest id`, and ids[0] is that row.
-			// The WHOLE batch travels to the outcome (#1982): a delivered wake
-			// supersedes the rest into the survivor, while a retryable failure
-			// returns them all to pending so the next attempt re-coalesces every
-			// note instead of losing the ones a survivor carried.
+			ids := make([]int64, 0, len(batch))
+			ids = append(ids, batch[survivor].ID)
+			for index, entry := range batch {
+				if index != survivor {
+					ids = append(ids, entry.ID)
+				}
+			}
+			// Generic batches keep their oldest row as the delivered survivor.
+			// A single-fact batch instead survives on its newest lifecycle row,
+			// matching the current state wakeOutboxEvent rendered after reducing
+			// older attempts. The whole batch still travels to the outcome:
+			// delivery supersedes the rest, while retryable failure returns all
+			// rows to pending so the next attempt can reduce them again.
 			claimed, err := store.ClaimWakeOutbox(ctx, ids[0], ids[1:], now)
 			if err != nil {
 				return replyWakeOutboxHealth{}, err
@@ -569,14 +590,54 @@ func wakeOutboxEvent(batch []db.WakeOutboxObligation, now time.Time) (events.Eve
 			return events.Event{}, fmt.Errorf("decode escalation wake outbox event for row %d: %w", oldest.ID, err)
 		}
 	case db.WakeOutboxSourceAwaitedFact:
-		var payload db.AwaitedFactWakePayload
-		if err := json.Unmarshal([]byte(oldest.SourceID), &payload); err != nil {
-			return events.Event{}, fmt.Errorf("decode awaited fact wake outbox event for row %d: %w", oldest.ID, err)
+		payloads := make([]db.AwaitedFactWakePayload, 0, len(batch))
+		latestByFact := make(map[int64]int, len(batch))
+		for _, entry := range batch {
+			var payload db.AwaitedFactWakePayload
+			if err := json.Unmarshal([]byte(entry.SourceID), &payload); err != nil {
+				return events.Event{}, fmt.Errorf("decode awaited fact wake outbox event for row %d: %w", entry.ID, err)
+			}
+			payloads = append(payloads, payload)
+			latestByFact[payload.ID] = len(payloads) - 1
 		}
-		detail := fmt.Sprintf("awaited %s %s for %s is %s", payload.SubjectKind, payload.SubjectKey, payload.WaiterRole, payload.State)
-		if len(batch) > 1 {
-			detail = fmt.Sprintf("%d awaited facts ready; oldest: %s", len(batch), detail)
+		current := make([]db.AwaitedFactWakePayload, 0, len(payloads))
+		for index, payload := range payloads {
+			if latestByFact[payload.ID] == index {
+				current = append(current, payload)
+			}
 		}
+		actionable := -1
+		for index, payload := range current {
+			if strings.HasPrefix(payload.State, "review_") {
+				actionable = index
+				break
+			}
+		}
+		lead := 0
+		if actionable >= 0 {
+			lead = actionable
+		}
+		ordered := make([]db.AwaitedFactWakePayload, 0, len(current))
+		ordered = append(ordered, current[lead])
+		ordered = append(ordered, current[:lead]...)
+		ordered = append(ordered, current[lead+1:]...)
+		details := make([]string, 0, len(ordered))
+		for _, payload := range ordered {
+			detail := fmt.Sprintf("awaited %s %s for %s is %s", payload.SubjectKind, payload.SubjectKey, payload.WaiterRole, payload.State)
+			if extra := strings.TrimSpace(payload.Detail); extra != "" {
+				if strings.HasPrefix(payload.State, "review_") {
+					detail = extra + "; " + detail
+				} else {
+					detail += "; " + extra
+				}
+			}
+			details = append(details, detail)
+		}
+		detail := details[0]
+		if len(details) > 1 {
+			detail = fmt.Sprintf("%d awaited facts ready: %s", len(details), strings.Join(details, "; "))
+		}
+		payload := current[lead]
 		factID := fmt.Sprintf("awaited-fact:%d", payload.ID)
 		event = events.NewEvent(
 			events.EventOrgFact,

--- a/internal/cockpit/herdr_org.go
+++ b/internal/cockpit/herdr_org.go
@@ -268,7 +268,10 @@ func mapHerdrAgentStatus(raw string) org.RoleLiveState {
 	case string(org.StateBlocked):
 		return org.RoleLiveState{State: org.StateBlocked}
 	case string(org.StateDone):
-		return org.RoleLiveState{State: org.StateDone}
+		// Herdr's "done" is an attention bit, not workflow completion: it means
+		// the pane is idle and its last completed turn has not been viewed. Gitmoot
+		// must not expose that as completion of the role's durable obligations.
+		return org.RoleLiveState{State: org.StateIdle, Detail: "Herdr pane is idle with an unseen completed turn"}
 	case "":
 		return org.RoleLiveState{State: org.StateUnknown, Detail: "Herdr pane has no agent_status"}
 	default:

--- a/internal/cockpit/herdr_org_test.go
+++ b/internal/cockpit/herdr_org_test.go
@@ -49,7 +49,7 @@ func TestHerdrOrgProviderSnapshotMapping(t *testing.T) {
 		t.Fatalf("snapshot metadata = %+v", snapshot)
 	}
 	wants := map[string]org.LifecycleState{
-		"owner": org.StateWorking, "review": org.StateBlocked, "done": org.StateDone,
+		"owner": org.StateWorking, "review": org.StateBlocked, "done": org.StateIdle,
 		"idle": org.StateIdle, "future": org.StateUnknown, "duplicate": org.StateUnknown,
 		"missing": org.StateUnknown, "whitespace-label": org.StateUnknown, "whitespace-status": org.StateUnknown,
 		"pending-working": org.StateInputPending, "pending-idle": org.StateInputPending, "pending-unknown": org.StateInputPending,
@@ -139,7 +139,7 @@ func TestHerdrOrgProviderPresenceWakePaneBindingParity(t *testing.T) {
 		{name: "empty binding", binding: "", wantState: org.StateUnknown, wantDetail: "Herdr pane binding is unset"},
 		{name: "binding matching one label", binding: "unique-label", wantPane: "w1:p1", wantState: org.StateWorking, wantOK: true},
 		{name: "binding matching multiple labels", binding: "duplicate-label", wantState: org.StateUnknown, wantAmbiguous: true},
-		{name: "literal pane id", binding: "w1:p4", wantPane: "w1:p4", wantState: org.StateDone, wantOK: true},
+		{name: "literal pane id", binding: "w1:p4", wantPane: "w1:p4", wantState: org.StateIdle, wantOK: true},
 		{name: "literal pane id precedes duplicate labels", binding: "w1:p8", wantPane: "w1:p8", wantState: org.StateWorking, wantOK: true},
 		{name: "absent literal pane id", binding: "w9:p9", wantState: org.StateUnknown},
 		{name: "binding matching nothing", binding: "missing-label", wantState: org.StateUnknown},
@@ -208,7 +208,7 @@ func TestHerdrOrgProviderSnapshotPaneBindings(t *testing.T) {
 	}
 	wants := map[string]org.LifecycleState{
 		"idle-role": org.StateIdle, "working-role": org.StateWorking,
-		"blocked-role": org.StateBlocked, "done-role": org.StateDone,
+		"blocked-role": org.StateBlocked, "done-role": org.StateIdle,
 		"pending-role": org.StateInputPending,
 		"literal-role": org.StateWorking, "missing-role": org.StateUnknown,
 		"ambiguous-role": org.StateUnknown, "empty-id-role": org.StateUnknown,

--- a/internal/db/awaited_facts.go
+++ b/internal/db/awaited_facts.go
@@ -48,11 +48,14 @@ type AwaitedFactSubscription struct {
 // always produced by the same constructor used by subscriptions and review
 // producers; delivery never restates it from separate fields.
 type AwaitedFactWakePayload struct {
-	ID          int64  `json:"id"`
-	WaiterRole  string `json:"waiter_role"`
-	SubjectKind string `json:"subject_kind"`
-	SubjectKey  string `json:"subject_key"`
-	State       string `json:"state"`
+	ID                  int64  `json:"id"`
+	WaiterRole          string `json:"waiter_role"`
+	SubjectKind         string `json:"subject_kind"`
+	SubjectKey          string `json:"subject_key"`
+	State               string `json:"state"`
+	JobID               string `json:"job_id,omitempty"`
+	LifecycleGeneration int64  `json:"lifecycle_generation,omitempty"`
+	Detail              string `json:"detail,omitempty"`
 }
 
 // ReviewVerdictSubjectKey is the single source of truth for a review wait's
@@ -411,17 +414,58 @@ func reviewVerdictFact(jobID, agent, state, payload string, blockingSeverity fun
 	return reviewVerdictObservation{repo: decoded.Repo, pullRequest: decoded.PullRequest, headSHA: decoded.HeadSHA, detail: detail}, true
 }
 
-func resolveAwaitedReviewFactTx(ctx context.Context, tx *sql.Tx, jobID, agent, jobType, state, payload string, blockingSeverity func(repo string) string, now time.Time) error {
+func resolveStoredAwaitedReviewFactTx(ctx context.Context, tx *sql.Tx, jobID, state string, blockingSeverity func(repo string) string, now time.Time) error {
+	switch state {
+	case "succeeded", "failed", "blocked", "cancelled":
+	default:
+		return nil
+	}
+	var agent, jobType, payload string
+	var lifecycleGeneration int64
+	if err := tx.QueryRowContext(ctx, `
+SELECT agent, type, payload, lifecycle_generation
+FROM jobs
+WHERE id = ?`, jobID).Scan(&agent, &jobType, &payload, &lifecycleGeneration); err != nil {
+		return err
+	}
+	return resolveAwaitedReviewFactTx(
+		ctx, tx, jobID, agent, jobType, state, payload, lifecycleGeneration,
+		blockingSeverity, now,
+	)
+}
+
+func resolveAwaitedReviewFactTx(ctx context.Context, tx *sql.Tx, jobID, agent, jobType, state, payload string, lifecycleGeneration int64, blockingSeverity func(repo string) string, now time.Time) error {
 	if strings.TrimSpace(jobType) != "review" {
 		return nil
 	}
-	fact, ok := reviewVerdictFact(jobID, agent, state, payload, blockingSeverity)
-	if !ok {
+	var fact reviewVerdictObservation
+	noticeState := ""
+	var key string
+	switch state {
+	case "succeeded":
+		var ok bool
+		fact, ok = reviewVerdictFact(jobID, agent, state, payload, blockingSeverity)
+		if !ok {
+			return nil
+		}
+		var err error
+		key, err = ReviewVerdictSubjectKey(fact.repo, fact.pullRequest, fact.headSHA)
+		if err != nil {
+			return nil
+		}
+	case "failed", "blocked", "cancelled":
+		var decoded reviewVerdictPayload
+		if err := json.Unmarshal([]byte(payload), &decoded); err != nil {
+			return nil
+		}
+		var err error
+		key, err = ReviewVerdictSubjectKey(decoded.Repo, decoded.PullRequest, decoded.HeadSHA)
+		if err != nil {
+			return nil
+		}
+		noticeState = "review_" + state
+	default:
 		return nil
-	}
-	key, err := ReviewVerdictSubjectKey(fact.repo, fact.pullRequest, fact.headSHA)
-	if err != nil {
-		return err
 	}
 	rows, err := tx.QueryContext(ctx, `
 SELECT id, waiter_role
@@ -447,8 +491,28 @@ ORDER BY id`, AwaitedFactSubjectReviewVerdict, key)
 	if err := rows.Close(); err != nil {
 		return err
 	}
+	if len(targets) == 0 {
+		return nil
+	}
+
+	if state == "succeeded" {
+		for _, target := range targets {
+			if _, err := satisfyAwaitedFactTx(ctx, tx, target.id, target.role, AwaitedFactSubjectReviewVerdict, key, fact.detail, now); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+
+	detail := fmt.Sprintf(
+		"review job %s %s without an exact-head verdict; the awaited fact remains unresolved",
+		strings.TrimSpace(jobID), state,
+	)
 	for _, target := range targets {
-		if _, err := satisfyAwaitedFactTx(ctx, tx, target.id, target.role, AwaitedFactSubjectReviewVerdict, key, fact.detail, now); err != nil {
+		if err := insertAwaitedFactNoticeWakeTx(
+			ctx, tx, target.id, target.role, target.role, AwaitedFactSubjectReviewVerdict, key,
+			noticeState, jobID, lifecycleGeneration, detail,
+		); err != nil {
 			return err
 		}
 	}
@@ -468,11 +532,63 @@ WHERE id = ? AND state = 'waiting'`, detail, stamp, stamp, id)
 	if err != nil || affected == 0 {
 		return false, err
 	}
+	if err := supersedePendingAwaitedFactWakesTx(ctx, tx, id, AwaitedFactStateSatisfied, now); err != nil {
+		return false, err
+	}
 	return true, insertAwaitedFactWakeTx(ctx, tx, id, waiterRole, waiterRole, subjectKind, subjectKey, AwaitedFactStateSatisfied)
 }
 
+func supersedePendingAwaitedFactWakesTx(ctx context.Context, tx *sql.Tx, factID int64, terminalState string, now time.Time) error {
+	rows, err := tx.QueryContext(ctx, `
+SELECT id, source_id
+FROM wake_outbox
+WHERE source_kind = ? AND state = ?`,
+		WakeOutboxSourceAwaitedFact, WakeOutboxStatePending,
+	)
+	if err != nil {
+		return err
+	}
+	var stale []int64
+	for rows.Next() {
+		var id int64
+		var sourceID string
+		if err := rows.Scan(&id, &sourceID); err != nil {
+			rows.Close()
+			return err
+		}
+		var payload AwaitedFactWakePayload
+		if json.Unmarshal([]byte(sourceID), &payload) == nil && payload.ID == factID {
+			stale = append(stale, id)
+		}
+	}
+	if err := rows.Close(); err != nil {
+		return err
+	}
+	stamp := now.UTC().Format(time.RFC3339Nano)
+	reason := fmt.Sprintf("awaited fact %d reached %s before wake delivery", factID, terminalState)
+	for _, id := range stale {
+		if _, err := tx.ExecContext(ctx, `
+UPDATE wake_outbox
+SET state = ?, last_error = ?, finished_at = ?, updated_at = ?
+WHERE id = ? AND state = ?`,
+			WakeOutboxStateSuperseded, reason, stamp, stamp, id, WakeOutboxStatePending,
+		); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 func insertAwaitedFactWakeTx(ctx context.Context, tx *sql.Tx, id int64, waiterRole, targetRole, subjectKind, subjectKey, state string) error {
-	payload, err := json.Marshal(AwaitedFactWakePayload{ID: id, WaiterRole: waiterRole, SubjectKind: subjectKind, SubjectKey: subjectKey, State: state})
+	return insertAwaitedFactNoticeWakeTx(ctx, tx, id, waiterRole, targetRole, subjectKind, subjectKey, state, "", 0, "")
+}
+
+func insertAwaitedFactNoticeWakeTx(ctx context.Context, tx *sql.Tx, id int64, waiterRole, targetRole, subjectKind, subjectKey, state, jobID string, lifecycleGeneration int64, detail string) error {
+	payload, err := json.Marshal(AwaitedFactWakePayload{
+		ID: id, WaiterRole: waiterRole, SubjectKind: subjectKind, SubjectKey: subjectKey,
+		State: state, JobID: strings.TrimSpace(jobID), LifecycleGeneration: lifecycleGeneration,
+		Detail: strings.TrimSpace(detail),
+	})
 	if err != nil {
 		return err
 	}
@@ -568,6 +684,9 @@ WHERE id = ? AND state = 'waiting'`, stamp, stamp, id)
 	}
 	affected, err := result.RowsAffected()
 	if err != nil || affected == 0 {
+		return false, err
+	}
+	if err := supersedePendingAwaitedFactWakesTx(ctx, tx, id, AwaitedFactStateExpired, now); err != nil {
 		return false, err
 	}
 	if err := insertAwaitedFactWakeTx(ctx, tx, id, fact.WaiterRole, escalationRole, fact.SubjectKind, fact.SubjectKey, AwaitedFactStateExpired); err != nil {

--- a/internal/db/awaited_facts_test.go
+++ b/internal/db/awaited_facts_test.go
@@ -138,6 +138,146 @@ func TestSubscribeAwaitedFactRecheckRejectsOldHead(t *testing.T) {
 	}
 }
 
+func TestFailedReviewWakesWaiterWithoutResolvingExactHeadFact(t *testing.T) {
+	store := openAwaitedFactTestStore(t)
+	ctx := context.Background()
+	fact := subscribeReviewFact(t, store, "lane", "acme/widget", 45, "head-failed")
+	payload := `{"repo":"acme/widget","pull_request":45,"head_sha":"head-failed"}`
+	if err := store.CreateJobWithEvent(ctx, Job{
+		ID: "review-crashed", Agent: "reviewer", Type: "review", State: "running",
+		Repo: "acme/widget", PullRequest: 45, Payload: payload,
+	}, JobEvent{Kind: "running", Message: "started"}); err != nil {
+		t.Fatal(err)
+	}
+	changed, err := store.TransitionJobStatePayloadWithEvent(
+		ctx, "review-crashed", "running", "failed", payload,
+		JobEvent{Kind: "failed", Message: "runtime process died"},
+	)
+	if err != nil || !changed {
+		t.Fatalf("failed transition changed=%t err=%v", changed, err)
+	}
+	if state := awaitedFactState(t, store, fact.ID); state != AwaitedFactStateWaiting {
+		t.Fatalf("awaited fact state = %q, want waiting", state)
+	}
+	outbox, err := store.ListWakeOutbox(ctx, WakeOutboxStatePending)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(outbox) != 1 || outbox[0].TargetRole != "lane" || outbox[0].CoalesceKey != "fact:lane" {
+		t.Fatalf("failed review wake = %+v", outbox)
+	}
+	var wake AwaitedFactWakePayload
+	if err := json.Unmarshal([]byte(outbox[0].SourceID), &wake); err != nil {
+		t.Fatal(err)
+	}
+	if wake.ID != fact.ID || wake.State != "review_failed" || wake.JobID != "review-crashed" ||
+		!strings.Contains(wake.Detail, "without an exact-head verdict") {
+		t.Fatalf("failed review wake payload = %+v", wake)
+	}
+}
+
+func TestFailedReviewRetryCreatesDistinctWakePerLifecycle(t *testing.T) {
+	store := openAwaitedFactTestStore(t)
+	ctx := context.Background()
+	fact := subscribeReviewFact(t, store, "lane", "acme/widget", 45, "head-retry")
+	payload := `{"repo":"acme/widget","pull_request":45,"head_sha":"head-retry"}`
+	if err := store.CreateJobWithEvent(ctx, Job{
+		ID: "review-retry", Agent: "reviewer", Type: "review", State: "running",
+		Repo: "acme/widget", PullRequest: 45, Payload: payload,
+	}, JobEvent{Kind: "running", Message: "started"}); err != nil {
+		t.Fatal(err)
+	}
+	changed, err := store.TransitionJobStatePayloadWithEvent(
+		ctx, "review-retry", "running", "failed", payload,
+		JobEvent{Kind: "failed", Message: "first runtime failure"},
+	)
+	if err != nil || !changed {
+		t.Fatalf("first failure changed=%t err=%v", changed, err)
+	}
+	changed, err = store.TransitionJobStateWithEvent(
+		ctx, "review-retry", "failed", "queued",
+		JobEvent{Kind: "retry", Message: "retrying"},
+	)
+	if err != nil || !changed {
+		t.Fatalf("retry changed=%t err=%v", changed, err)
+	}
+	retried, err := store.GetJob(ctx, "review-retry")
+	if err != nil {
+		t.Fatal(err)
+	}
+	changed, err = store.TransitionJobStateWithEventAtGeneration(
+		ctx, "review-retry", "queued", retried.LifecycleGeneration, "failed",
+		JobEvent{Kind: "failed", Message: "preflight failed again"},
+	)
+	if err != nil || !changed {
+		t.Fatalf("second failure changed=%t err=%v", changed, err)
+	}
+	if state := awaitedFactState(t, store, fact.ID); state != AwaitedFactStateWaiting {
+		t.Fatalf("awaited fact state = %q, want waiting", state)
+	}
+	outbox, err := store.ListWakeOutbox(ctx, WakeOutboxStatePending)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(outbox) != 2 {
+		t.Fatalf("failed review wakes = %+v, want one per lifecycle", outbox)
+	}
+	generations := make(map[int64]bool, len(outbox))
+	for _, row := range outbox {
+		var wake AwaitedFactWakePayload
+		if err := json.Unmarshal([]byte(row.SourceID), &wake); err != nil {
+			t.Fatal(err)
+		}
+		generations[wake.LifecycleGeneration] = true
+	}
+	if !generations[0] || !generations[1] {
+		t.Fatalf("wake lifecycle generations = %+v, want 0 and 1", generations)
+	}
+}
+
+func TestFailedReviewWakeIsRetiredWhenFactExpiresToParent(t *testing.T) {
+	store := openAwaitedFactTestStore(t)
+	ctx := context.Background()
+	fact := subscribeReviewFact(t, store, "lane", "acme/widget", 45, "head-expired")
+	payload := `{"repo":"acme/widget","pull_request":45,"head_sha":"head-expired"}`
+	if err := store.CreateJobWithEvent(ctx, Job{
+		ID: "review-expired", Agent: "reviewer", Type: "review", State: "running",
+		Repo: "acme/widget", PullRequest: 45, Payload: payload,
+	}, JobEvent{Kind: "running", Message: "started"}); err != nil {
+		t.Fatal(err)
+	}
+	changed, err := store.TransitionJobStatePayloadWithEvent(
+		ctx, "review-expired", "running", "failed", payload,
+		JobEvent{Kind: "failed", Message: "runtime failed"},
+	)
+	if err != nil || !changed {
+		t.Fatalf("failed transition changed=%t err=%v", changed, err)
+	}
+	expired, err := store.ExpireAwaitedFact(ctx, fact.ID, "owner", time.Now().UTC())
+	if err != nil || !expired {
+		t.Fatalf("expiry changed=%t err=%v", expired, err)
+	}
+	pending, err := store.ListWakeOutbox(ctx, WakeOutboxStatePending)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(pending) != 1 || pending[0].TargetRole != "owner" ||
+		!strings.Contains(pending[0].SourceID, `"state":"expired"`) {
+		t.Fatalf("pending wakes = %+v, want only parent expiry", pending)
+	}
+	superseded, err := store.ListWakeOutbox(ctx, WakeOutboxStateSuperseded)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(superseded) != 1 || superseded[0].TargetRole != "lane" ||
+		!strings.Contains(superseded[0].SourceID, `"state":"review_failed"`) {
+		t.Fatalf("superseded wakes = %+v, want retired waiter failure", superseded)
+	}
+	if state := awaitedFactState(t, store, fact.ID); state != AwaitedFactStateExpired {
+		t.Fatalf("awaited fact state = %q, want expired", state)
+	}
+}
+
 func TestAwaitedFactProducerCommitSatisfiesExactHead(t *testing.T) {
 	store := openAwaitedFactTestStore(t)
 	ctx := context.Background()

--- a/internal/db/store_jobs.go
+++ b/internal/db/store_jobs.go
@@ -128,7 +128,7 @@ func createJobWithEventTx(ctx context.Context, tx *sql.Tx, s *Store, job Job, ev
 			return err
 		}
 	}
-	return resolveAwaitedReviewFactTx(ctx, tx, job.ID, job.Agent, job.Type, job.State, job.Payload, s.blockingSeverityFor, time.Now().UTC())
+	return resolveAwaitedReviewFactTx(ctx, tx, job.ID, job.Agent, job.Type, job.State, job.Payload, 0, s.blockingSeverityFor, time.Now().UTC())
 }
 
 // ErrAdvanceOwnershipLost is returned when an irreversible write is refused because
@@ -850,6 +850,9 @@ func (s *Store) TransitionJobStateWithEvent(ctx context.Context, id string, from
 	if _, err := tx.ExecContext(ctx, `INSERT INTO job_events(job_id, kind, message) VALUES (?, ?, ?)`, event.JobID, event.Kind, event.Message); err != nil {
 		return false, err
 	}
+	if err := resolveStoredAwaitedReviewFactTx(ctx, tx, id, to, s.blockingSeverityFor, time.Now().UTC()); err != nil {
+		return false, err
+	}
 	return true, tx.Commit()
 }
 
@@ -903,6 +906,9 @@ func (s *Store) TransitionJobStateWithEventAtGeneration(ctx context.Context, id 
 			return false, err
 		}
 	}
+	if err := resolveStoredAwaitedReviewFactTx(ctx, tx, id, to, s.blockingSeverityFor, time.Now().UTC()); err != nil {
+		return false, err
+	}
 	return true, tx.Commit()
 }
 
@@ -949,11 +955,7 @@ func (s *Store) TransitionJobStatePayloadWithEventAtGeneration(ctx context.Conte
 			return false, err
 		}
 	}
-	var agent, jobType string
-	if err := tx.QueryRowContext(ctx, `SELECT agent, type FROM jobs WHERE id = ?`, id).Scan(&agent, &jobType); err != nil {
-		return false, err
-	}
-	if err := resolveAwaitedReviewFactTx(ctx, tx, id, agent, jobType, to, payload, s.blockingSeverityFor, time.Now().UTC()); err != nil {
+	if err := resolveStoredAwaitedReviewFactTx(ctx, tx, id, to, s.blockingSeverityFor, time.Now().UTC()); err != nil {
 		return false, err
 	}
 	return true, tx.Commit()
@@ -1118,11 +1120,7 @@ func (s *Store) TransitionJobStatePayloadWithEvent(ctx context.Context, id strin
 			return false, err
 		}
 	}
-	var agent, jobType string
-	if err := tx.QueryRowContext(ctx, `SELECT agent, type FROM jobs WHERE id = ?`, id).Scan(&agent, &jobType); err != nil {
-		return false, err
-	}
-	if err := resolveAwaitedReviewFactTx(ctx, tx, id, agent, jobType, to, payload, s.blockingSeverityFor, time.Now().UTC()); err != nil {
+	if err := resolveStoredAwaitedReviewFactTx(ctx, tx, id, to, s.blockingSeverityFor, time.Now().UTC()); err != nil {
 		return false, err
 	}
 	return true, tx.Commit()
@@ -1177,11 +1175,7 @@ func (s *Store) TransitionJobStatePayloadUsageWithEvent(ctx context.Context, id 
 			return false, err
 		}
 	}
-	var agent, jobType string
-	if err := tx.QueryRowContext(ctx, `SELECT agent, type FROM jobs WHERE id = ?`, id).Scan(&agent, &jobType); err != nil {
-		return false, err
-	}
-	if err := resolveAwaitedReviewFactTx(ctx, tx, id, agent, jobType, to, payload, s.blockingSeverityFor, time.Now().UTC()); err != nil {
+	if err := resolveStoredAwaitedReviewFactTx(ctx, tx, id, to, s.blockingSeverityFor, time.Now().UTC()); err != nil {
 		return false, err
 	}
 	return true, tx.Commit()
@@ -1396,11 +1390,7 @@ func (s *Store) UpdateJobPayloadAndStateWithEvent(ctx context.Context, id string
 	if _, err := tx.ExecContext(ctx, `INSERT INTO job_events(job_id, kind, message) VALUES (?, ?, ?)`, event.JobID, event.Kind, event.Message); err != nil {
 		return err
 	}
-	var agent, jobType string
-	if err := tx.QueryRowContext(ctx, `SELECT agent, type FROM jobs WHERE id = ?`, id).Scan(&agent, &jobType); err != nil {
-		return err
-	}
-	if err := resolveAwaitedReviewFactTx(ctx, tx, id, agent, jobType, state, payload, s.blockingSeverityFor, time.Now().UTC()); err != nil {
+	if err := resolveStoredAwaitedReviewFactTx(ctx, tx, id, state, s.blockingSeverityFor, time.Now().UTC()); err != nil {
 		return err
 	}
 	return tx.Commit()

--- a/skills/gitmoot/references/CLI.md
+++ b/skills/gitmoot/references/CLI.md
@@ -1218,6 +1218,11 @@ gitmoot agent run lead --repo owner/repo --effort xhigh "Implement this task."
 gitmoot job watch <job-id>
 ```
 
+`agent review` with `--org-role` queues the job for daemon ownership by default.
+This keeps a review running if the calling seat or its command runner exits.
+Use `--foreground` only when synchronous ownership is intentional. Unattributed
+reviews retain their synchronous default; `--background` remains accepted.
+
 `agent run --action ask|review|implement` explicitly selects the job action and
 wins before the usual inference order (`--task` -> implement, then
 `--pr`/review `--head-sha` -> review, then message heuristics). `--type <name>`

--- a/website/docs/reference/cli.md
+++ b/website/docs/reference/cli.md
@@ -905,6 +905,11 @@ gitmoot agent run lead --repo owner/repo --effort xhigh "Implement this task."
 gitmoot job watch <job-id>
 ```
 
+`agent review` with `--org-role` queues the job for daemon ownership by default.
+This keeps a review running if the calling seat or its command runner exits.
+Use `--foreground` only when synchronous ownership is intentional. Unattributed
+reviews retain their synchronous default; `--background` remains accepted.
+
 `agent run --action ask|review|implement` explicitly selects the job action and
 wins before the usual inference order (`--task` -> implement, then
 `--pr`/review `--head-sha` -> review, then message heuristics). `--type <name>`


### PR DESCRIPTION
## Problem
Herdr `done` means an idle pane with an unseen completed turn, but Gitmoot exposed it as workflow completion. Exact-head review jobs launched synchronously by org seats were also owned by the caller process; the Joltra attempts died at the caller's roughly two-minute command boundary, across OMP and native Codex. Liveness recovery then failed the job without waking the still-waiting exact-head review obligation.

## Change
- normalize Herdr `done` to workflow `idle`
- show idle/unknown roles with live awaited facts as blocked, including owner and next trigger
- make `agent review --org-role` daemon-owned by default; add explicit `--foreground`
- wake exact-head fact waiters when a review fails, blocks, or is cancelled without resolving the fact
- retain exact-head waiting state until a real verdict lands

## Verification
- targeted lifecycle, liveness, CLI ownership, and wake tests pass
- `go test ./skills` passes
- `go build ./cmd/gitmoot` passes
- fixed binary reports no false `done` states for the affected campaign roles

Authorized by owner directive 142323.