### PR TITLE
fix(runtime): allow OMP tools in read-only seats

### DIFF
--- a/docs/adapters.md
+++ b/docs/adapters.md
@@ -131,14 +131,16 @@ omp -p --mode=json --approval-mode=<policy> --no-session \
 `--plan-yolo` appears if and only if the job asked for plan mode (`plan` /
 `plan_into` on the job payload), with `--plan-yolo-into` pinning the model the
 execution phase runs on. `plan_into` must be one non-flag model selector with no
-internal whitespace or control characters. It is orthogonal to
-`--approval-mode`, whose value comes from the agent's autonomy policy
-(`read-only` maps to `always-ask`, every other policy to `yolo`) and is
-unchanged by plan mode. `plan_into`
-without `plan`, malformed targets, and a plan request routed to any non-omp
-runtime are refused before dispatch — a plan-gated brief never silently
-degrades into an ordinary implementation. Runtime preflight requires the two
-plan flags only for plan requests; an ordinary omp job does not require them.
+internal whitespace or control characters. For ordinary non-seat deliveries,
+`--approval-mode` comes from the agent's autonomy policy (`read-only` maps to
+`always-ask`, `workspace-write` to `write`, and every other policy to `yolo`)
+and is unchanged by plan mode. A kernel-enforced `ReadOnlySeat` overrides that
+mapping with `yolo`, declared `widened`, so shell and test tools can run while
+the daemon's Landlock wrapper remains the write boundary. `plan_into` without
+`plan`, malformed targets, and a plan request routed to any non-omp runtime are
+refused before dispatch — a plan-gated brief never silently degrades into an
+ordinary implementation. Runtime preflight requires the two plan flags only for
+plan requests; an ordinary omp job does not require them.
 
 This behavior description is grounded in a versioned CLI declaration, not an
 internal transition Gitmoot can observe. On `omp/17.2.4`, run

--- a/internal/runtime/omp.go
+++ b/internal/runtime/omp.go
@@ -579,15 +579,17 @@ func ompArgs(agent Agent, model string, thinking string, maxTime string, plan bo
 // ompWorkspaceArgs grants the agent's produce paths as additional workspace roots,
 // writable first then readable — the same ordering kimi uses. These are
 // cooperative visibility hints for omp's own file layer and NOT an enforcement
-// boundary: --add-dir does not make the readable subset read-only, and omp gets no
-// Landlock confinement underneath either (that wrapper selects by runtime name and
-// wraps only claude/kimi). TWO gates keep a read-only omp agent from writing, and
-// they cover disjoint job shapes: readOnlyImplementationBlocked refuses an
-// implement-typed job (it returns false for every other type), and the mailbox
-// plan gate refuses a plan-mode job of ANY type. Before that second gate existed,
-// an `ask` job carrying plan was a write bypass on a read-only seat — plan mode
-// auto-executes and upstream adds the write tool — so if you add a third path that
-// can end in a write, it needs its own gate here; neither existing one will cover it.
+// boundary: --add-dir does not make the readable subset read-only. Ordinary
+// non-seat read-only deliveries rely on omp's always-ask mode. A ReadOnlySeat is
+// different: the daemon wraps omp in its kernel-enforced Landlock domain, and
+// ompApprovalArgs uses yolo so headless shell and test tools can run inside that
+// boundary. Two additional gates refuse write-shaped work for read-only agents:
+// readOnlyImplementationBlocked refuses an implement-typed job (it returns false
+// for every other type), and the mailbox plan gate refuses a plan-mode job of ANY
+// type. Before that second gate existed, an `ask` job carrying plan was a write
+// bypass — plan mode auto-executes and upstream adds the write tool — so if you
+// add a third path that can end in a write, it needs its own gate here; neither
+// existing one will cover it.
 func ompWorkspaceArgs(agent Agent) []string {
 	var args []string
 	for _, path := range agent.WritablePaths {

--- a/internal/runtime/omp.go
+++ b/internal/runtime/omp.go
@@ -126,8 +126,8 @@ func (a OmpAdapter) PermissionPolicyApplication(agent Agent) PermissionPolicyApp
 //
 // always-ask returns isError:true with "requires approval but no interactive UI
 // available" for bash and write WITHOUT the write landing, and still exits 0
-// with a full agent_end envelope this adapter parses, so it restricts omp to
-// read-only tools and terminates cleanly - what a read-only policy asks for.
+// with a full agent_end envelope this adapter parses. That is required for
+// non-seat read-only jobs, which have no external filesystem boundary.
 //
 // write is the value that matches workspace-write, on TWO axes rather than one:
 // it permits editing tools while refusing shell execution AND refusing writes to
@@ -144,7 +144,16 @@ func (a OmpAdapter) PermissionPolicyApplication(agent Agent) PermissionPolicyApp
 // out-of-cwd writes on this host: it reads tools.approvalMode from operator
 // config, so its confinement is a host property this adapter cannot state. That
 // is a separate decision with its own blast radius, and it is not made here.
+//
+// A ReadOnlySeat is different: Gitmoot has already put the process inside its
+// kernel-enforced Landlock domain. OMP must use yolo there so headless shell and
+// test tools can execute; Landlock, not OMP's interactive approval UI, remains
+// the read-only boundary. Like the sibling adapters, report this as widened
+// because OMP itself is no longer applying the stored restriction.
 func ompApprovalArgs(agent Agent) (string, PermissionPolicyApplication) {
+	if agent.ReadOnlySeat {
+		return "--approval-mode=yolo", PermissionPolicyWidened
+	}
 	switch NormalizeStoredAutonomyPolicy(agent.AutonomyPolicy) {
 	case AutonomyPolicyReadOnly:
 		return "--approval-mode=always-ask", PermissionPolicyApplied

--- a/internal/runtime/omp_test.go
+++ b/internal/runtime/omp_test.go
@@ -3120,6 +3120,38 @@ func TestOmpPolicyArgs(t *testing.T) {
 	}
 }
 
+// TestOmpDeliverReadOnlySeatDefersApprovalToLandlock drives the production
+// Deliver argv path. A read-only seat is already inside Gitmoot's kernel
+// sandbox, so OMP must not ask an unavailable interactive UI before running
+// shell/tests. Non-seat read-only delivery still relies on OMP for confinement.
+func TestOmpDeliverReadOnlySeatDefersApprovalToLandlock(t *testing.T) {
+	for _, tc := range []struct {
+		name         string
+		readOnlySeat bool
+		wantFlag     string
+		wantProperty PermissionPolicyApplication
+	}{
+		{"kernel-enforced seat", true, "--approval-mode=yolo", PermissionPolicyWidened},
+		{"unsandboxed non-seat", false, "--approval-mode=always-ask", PermissionPolicyApplied},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			runner := &fakeRunner{results: []subprocess.Result{{Stdout: ompStreamOK}}}
+			adapter := OmpAdapter{Runner: runner, Dir: "/repo"}
+			agent := ompTestAgent()
+			agent.AutonomyPolicy = AutonomyPolicyReadOnly
+			agent.ReadOnlySeat = tc.readOnlySeat
+
+			if _, err := adapter.Deliver(context.Background(), agent, Job{Prompt: "run the review checks"}); err != nil {
+				t.Fatalf("Deliver: %v", err)
+			}
+			runner.want(t, 0, "omp", "-p", "--mode=json", tc.wantFlag, "--no-session", "--", "run the review checks")
+			if got := adapter.PermissionPolicyApplication(agent); got != tc.wantProperty {
+				t.Fatalf("PermissionPolicyApplication = %q, want %q", got, tc.wantProperty)
+			}
+		})
+	}
+}
+
 // TestOmpPromptQuotingHazards: the prompt must land as ONE token immediately after
 // `--`, byte-identical, whatever it looks like. Kills the fleet's known scar
 // class: a prompt reparsed as a flag (leading `-` exits 2), as an attachment

--- a/skills/gitmoot/references/CLI.md
+++ b/skills/gitmoot/references/CLI.md
@@ -976,16 +976,19 @@ an omp seat:
   the run, the envelope is complete and only the final answer is missing, so the
   parser reads the FINAL assistant message rather than the last one that carried
   text — an earlier work note is never handed back as the job's answer.
-- **`--policy` selects the `--approval-mode` value,** and the flag is always
-  present for **determinism** - omitting it would inherit whatever
+- **`--policy` selects the ordinary `--approval-mode` value,** and the flag is
+  always present for **determinism** - omitting it would inherit whatever
   `tools.approvalMode` the host config carries. `read-only` maps to
   `always-ask`, `workspace-write` maps to `write`, and `auto` plus
   `danger-full-access` map to `yolo`. Measured on omp 17.2.4 headless,
   `always-ask` lets `read`/`grep`/`glob` succeed and refuses
   `bash`/`write`, with the process exiting 0 and a full `agent_end`, so it
-  **restricts** omp rather than breaking it (#1721). The adapter declares the
-  relationship it produced: `applied` for the three explicit policies and
-  `widened` for `auto`.
+  **restricts** omp rather than breaking it (#1721). A kernel-enforced
+  `ReadOnlySeat` is the exception: Gitmoot wraps the delivery in Landlock and
+  passes `yolo` so headless shell and test tools can run. The adapter declares
+  that override `widened`; Landlock remains the write boundary. Non-seat
+  `read-only` keeps `always-ask`. The other three explicit policy mappings are
+  declared `applied`, while `auto` is `widened`.
 - **OMP cross-family independence uses runtime-reported upstream-provider
   evidence.** A successful delivery whose final runtime message identifies its
   provider and model records that provider in the append-only event ledger; the

--- a/website/docs/reference/cli.md
+++ b/website/docs/reference/cli.md
@@ -750,16 +750,19 @@ the daemon runs under. What that changes in practice:
   mid-work** — by the `--max-time` deadline or the provider's output cap, where
   the envelope is complete and only the final answer is missing — fails loudly
   rather than reporting an empty success.
-- **`--policy` selects the `--approval-mode` value,** and the flag is always
-  present for **determinism** - omitting it would inherit whatever
+- **`--policy` selects the ordinary `--approval-mode` value,** and the flag is
+  always present for **determinism** - omitting it would inherit whatever
   `tools.approvalMode` the host config carries. `read-only` maps to
   `always-ask`, `workspace-write` maps to `write`, and `auto` plus
   `danger-full-access` map to `yolo`. Measured on omp 17.2.4 headless,
   `always-ask` lets `read`/`grep`/`glob` succeed and refuses
   `bash`/`write`, with the process exiting 0 and a full `agent_end`, so it
-  **restricts** omp rather than breaking it (#1721). The adapter declares the
-  relationship it produced: `applied` for the three explicit policies and
-  `widened` for `auto`.
+  **restricts** omp rather than breaking it (#1721). A kernel-enforced
+  `ReadOnlySeat` is the exception: Gitmoot wraps the delivery in Landlock and
+  passes `yolo` so headless shell and test tools can run. The adapter declares
+  that override `widened`; Landlock remains the write boundary. Non-seat
+  `read-only` keeps `always-ask`. The other three explicit policy mappings are
+  declared `applied`, while `auto` is `widened`.
 - **OMP cross-family independence uses runtime-reported upstream-provider
   evidence.** A successful delivery whose final runtime message identifies its
   provider and model records that provider in the append-only event ledger; the

--- a/website/docs/reference/runtime-adapters.md
+++ b/website/docs/reference/runtime-adapters.md
@@ -229,10 +229,10 @@ have been billed for a message whose `message_end` never reached stdout.
 
 ### Autonomy policies
 
-| `--policy` | omp argument | Effect |
+| `--policy` | ordinary omp argument | Effect |
 |---|---|---|
 | `read-only` | `--approval-mode=always-ask` | restricts omp to read tools; declared `applied` |
-| `workspace-write` | `--approval-mode=yolo` | declared `widened`: yolo grants more than asked |
+| `workspace-write` | `--approval-mode=write` | permits edit tools but refuses shell and out-of-worktree writes; declared `applied` |
 | `danger-full-access` | `--approval-mode=yolo` | declared `applied` |
 | `auto` (default) | `--approval-mode=yolo` | declared `widened` |
 
@@ -257,15 +257,18 @@ terminates cleanly — which is what a read-only policy wants. omp 17.2.4 has no
 now passes `always-ask`.
 :::
 
-Read-only therefore stays enforced **Gitmoot-side**, exactly as it is for Kimi:
-the `implement` **capability** is refused at `agent start` and `agent subscribe`
-when the agent carries `auto`/empty or `read-only`, and an implement **job** for
-such an agent is refused again at dispatch — both at CLI enqueue and in the
-daemon. Treat the runtime-level approval flag as advisory and the Gitmoot gate as
-the boundary. (Landlock is not a second layer here: the sandbox wrapper selects
-by runtime **name** and wraps only Claude and Kimi, so no omp process is ever
-confined by it. omp separately does not advertise `produce`, which is why it
-never reaches the produce-stage wrapper either.)
+For ordinary, non-seat deliveries, read-only stays enforced **Gitmoot-side** and
+by omp's `always-ask` mode. The `implement` **capability** is refused at
+`agent start` and `agent subscribe` when the agent carries `auto`/empty or
+`read-only`, and an implement **job** for such an agent is refused again at
+dispatch — both at CLI enqueue and in the daemon.
+
+A kernel-enforced `ReadOnlySeat` is the exception. Gitmoot wraps every such omp
+delivery in its Landlock sandbox and passes `--approval-mode=yolo`, declared
+`widened`, so headless shell and test tools can run. Landlock, rather than omp's
+interactive approval UI, is then the write boundary. Ordinary non-seat
+`read-only` deliveries retain `always-ask`; omp still does not advertise
+`produce`, so it never reaches the separate produce-stage wrapper.
 
 ### Plan mode
 


### PR DESCRIPTION
## Problem

Headless OMP reviews stored as `read-only` receive `--approval-mode=always-ask`. Shell and test tool calls then return `requires approval but no interactive UI available`, even though Gitmoot has already placed a `ReadOnlySeat` inside its kernel-enforced Landlock domain.

Authority: durable directive 146790 in `gitmoot/review-fix-campaign`.

## Change

- Map OMP `ReadOnlySeat` deliveries to `--approval-mode=yolo`, matching the existing externally-sandboxed Codex/Claude pattern.
- Keep `PermissionPolicyWidened`: OMP itself is not the confinement boundary; Landlock is.
- Preserve `--approval-mode=always-ask` for unsandboxed/non-seat read-only jobs.
- Add a production `Deliver` argv regression covering both sides.

## Verification

- Pre-fix actual OMP reproduction: `--approval-mode=always-ask` returned `Tool "bash" requires approval but no interactive UI available` and did not run `printf`.
- `go test -buildvcs=false ./internal/runtime -count=1`
- Focused runtime approval tests passed.
- Focused CLI OMP broker/Landlock wiring tests passed.
- `go vet ./internal/runtime`
- Actual modified-tree OMP/Landlock review-seat smoke passed: OMP `devin/swe-2` used bash to run `go test -buildvcs=false ./internal/runtime -run ^TestOmpDeliverReadOnlySeatDefersApprovalToLandlock$ -count=1` inside `wrapReadOnlySandboxAdapter`; the command passed while the worktree remained read-only.

No merge or deployment is authorized or performed.